### PR TITLE
fix: action menu clobbering DeleteConfirm and BranchInput modes

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -340,7 +340,9 @@ impl App {
                 *index = item_idx;
             }
             self.execute_menu_action();
-            self.ui.mode = UiMode::Normal;
+            if matches!(self.ui.mode, UiMode::ActionMenu { .. }) {
+                self.ui.mode = UiMode::Normal;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- `handle_menu_key` unconditionally set `UiMode::Normal` after executing an action, overwriting `DeleteConfirm` and `BranchInput` modes that `resolve_and_push` had just set
- Delete worktree and generate branch name silently failed when triggered from the action menu (shortcut keys `d`/`n` were unaffected)
- Fix: only reset to Normal if the mode is still `ActionMenu`

## Test plan

- [x] `cargo check` / `cargo test` / `cargo clippy` clean
- [ ] Manual: select a non-trunk worktree, open action menu, choose "Remove worktree" — confirmation dialog should appear
- [ ] Manual: select an issue, open action menu, choose "Generate branch name" — branch input should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)