### PR TITLE
fix: add --workspace and --remap-path-prefix to coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,8 +57,8 @@ jobs:
             ${{ runner.os }}-cargo-coverage-
       - name: Generate coverage report
         run: |
-          cargo +nightly llvm-cov --html --locked
-          cargo +nightly llvm-cov --json --no-run --locked --output-path target/llvm-cov/html/coverage.json
+          cargo +nightly llvm-cov --workspace --html --locked --remap-path-prefix
+          cargo +nightly llvm-cov --workspace --json --no-run --locked --output-path target/llvm-cov/html/coverage.json
       - name: Add badge JSON
         run: |
           PERCENT=$(jq -r '.data[0].totals.lines.percent | floor' target/llvm-cov/html/coverage.json)


### PR DESCRIPTION
## Summary

- Add `--workspace` so all crates are instrumented (was only covering `src/main.rs`)
- Add `--remap-path-prefix` to strip CI runner absolute paths from the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)