### PR TITLE
fix: enable branch coverage in coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-cargo-coverage-
       - name: Generate coverage report
         run: |
-          cargo +nightly llvm-cov --workspace --html --locked --remap-path-prefix
+          cargo +nightly llvm-cov --workspace --html --branch --locked --remap-path-prefix
           cargo +nightly llvm-cov --workspace --json --no-run --locked --output-path target/llvm-cov/html/coverage.json
       - name: Add badge JSON
         run: |


### PR DESCRIPTION
## Summary

Add `--branch` flag to `cargo llvm-cov` so branch coverage is instrumented. Without it, the Branch Coverage column shows `- (0/0)` for all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)