### PR TITLE
fix: drop --branch flag (crashes nightly llvm-cov)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,9 @@ jobs:
             ${{ runner.os }}-cargo-coverage-
       - name: Generate coverage report
         run: |
-          cargo +nightly llvm-cov --workspace --html --branch --locked --remap-path-prefix
+          # NOTE: --branch crashes llvm-cov (SIGSEGV from --show-mcdc in nightly LLVM).
+          # Revisit when upstream is fixed.
+          cargo +nightly llvm-cov --workspace --html --locked --remap-path-prefix
           cargo +nightly llvm-cov --workspace --json --no-run --locked --output-path target/llvm-cov/html/coverage.json
       - name: Add badge JSON
         run: |


### PR DESCRIPTION
## Summary

Reverts the `--branch` flag added in #69. It causes `cargo-llvm-cov` to pass `--show-mcdc` to `llvm-cov show`, which triggers a SIGSEGV in the nightly LLVM toolchain. Reproduces on both Linux (CI) and macOS (local).

Left a comment noting we should revisit when upstream fixes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)