### PR TITLE
chore: add sandbox latency note to socket roundtrip test

### DIFF
--- a/crates/flotilla-daemon/tests/socket_roundtrip.rs
+++ b/crates/flotilla-daemon/tests/socket_roundtrip.rs
@@ -37,7 +37,8 @@ async fn socket_roundtrip() {
         let _ = server.run().await;
     });
 
-    // Wait for socket to appear
+    // Wait for socket to appear.
+    // Note: sandboxed environments can introduce extra startup latency here.
     for _ in 0..20 {
         if socket_path.exists() {
             break;


### PR DESCRIPTION
## Summary

- Adds a comment noting that sandboxed environments (e.g. Codex) can introduce extra startup latency in the socket roundtrip test

🤖 Generated with [Claude Code](https://claude.com/claude-code)