### PR TITLE
fix: buffer deltas during gap recovery, retry spawn lock

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -291,6 +291,7 @@ pub async fn connect_or_spawn(
                 match final_lock {
                     Ok(Some(file)) => {
                         lock_file = Some(file);
+                        break;
                     }
                     Ok(None) => {
                         // Someone else spawned while we waited — one last connect attempt.
@@ -460,7 +461,7 @@ fn handle_event(
                         buf.push(event);
                         return;
                     }
-                    guard.insert(repo.clone(), Vec::new());
+                    guard.insert(repo.clone(), vec![event]);
                     drop(guard);
 
                     if let Some(ls) = local_seq {


### PR DESCRIPTION
## Summary
- **Gap recovery delta drop (high):** When a `SnapshotDelta` arrived while recovery was in progress, it was silently discarded via early return. If the server emitted a newer delta before the replay response returned, the client stayed permanently stale. Now deltas are buffered in the `recovering` map and re-processed after recovery completes — if they apply cleanly they're forwarded, if they still show a gap a fresh recovery cycle starts.
- **Spawn-lock mutual exclusion (medium):** A waiter whose reconnect failed after another process's lock released would fall through to spawn a daemon without reacquiring the lock, allowing multiple competing daemons. Now retries lock acquisition up to 3 times before falling through.

## Test plan
- [x] All existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Manual: kill daemon during active refresh, verify client recovers without stale state
- [ ] Manual: race two clients starting simultaneously, verify only one daemon spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)