### PR TITLE
docs: use repo-local TMPDIR for sandbox cargo commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.codex-tmp/
 .idea/
 __pycache__/
 .playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,9 @@
 ## Test Command Defaults
 
 - Normal environment: `cargo test --workspace --locked`
-- Restricted Codex sandbox (socket bind/listen blocked): `cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
+- Restricted Codex sandbox (socket bind/listen blocked): `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
 
-Use the sandbox-safe command when `CODEX_SANDBOX` is set or socket-bind tests are expected to fail with `Operation not permitted`.
+Use the sandbox-safe command when `CODEX_SANDBOX` is set or socket-bind tests are expected to fail with `Operation not permitted`. The repo-local `TMPDIR` avoids native build failures from crates like `aws-lc-sys` under the sandbox.
 
 ## Cursor Cloud specific instructions
 
@@ -33,6 +33,7 @@ The app auto-detects git, GitHub (`gh` CLI), Claude, and terminal multiplexers f
 | Lint (format) | `cargo fmt --check` |
 | Lint (clippy) | `cargo clippy --all-targets --locked -- -D warnings` |
 | Test | `cargo test --workspace --locked` |
+| Test (sandbox) | `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests` |
 | Run | `cargo run -- --repo-root /workspace` |
 
 ### Gotchas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ cargo run                            # run, auto-detect repo from cwd
 
 Before pushing, always run `cargo fmt`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`.
 
+In the Codex sandbox, prefer `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests` so native dependencies can create temp files and socket-bind tests stay skipped.
+
 ## Architecture
 
 Provider-based plugin system with data correlation:


### PR DESCRIPTION
## Summary
- document the sandbox-safe cargo test command with a repo-local `TMPDIR`
- explain why the repo-local temp dir is needed for native dependencies like `aws-lc-sys`
- ignore `.codex-tmp/` so the workaround does not dirty the worktree

## Testing
- not run (docs and gitignore changes only)