### PR TITLE
fix: proportional column widths and consistent worktree padding

### DIFF
--- a/crates/flotilla-tui/src/ui.rs
+++ b/crates/flotilla-tui/src/ui.rs
@@ -327,9 +327,9 @@ fn render_unified_table(model: &TuiModel, ui: &mut UiState, frame: &mut Frame, a
 
     let widths = [
         Constraint::Length(3), // icon
-        Constraint::Min(6),    // Path (capped at 30 after layout)
-        Constraint::Fill(1),   // Description (absorbs remaining space)
-        Constraint::Min(8),    // Branch (shrinks before fixed columns)
+        Constraint::Fill(1),   // Path
+        Constraint::Fill(2),   // Description
+        Constraint::Fill(1),   // Branch
         Constraint::Length(3), // WT
         Constraint::Length(3), // WS
         Constraint::Length(4), // PR
@@ -340,11 +340,7 @@ fn render_unified_table(model: &TuiModel, ui: &mut UiState, frame: &mut Frame, a
 
     let inner_width = area.width.saturating_sub(2 + HIGHLIGHT_SYMBOL_WIDTH);
     let col_areas = Layout::horizontal(widths).split(Rect::new(0, 0, inner_width, 1));
-    let mut col_widths: Vec<u16> = col_areas.iter().map(|r| r.width).collect();
-    // Cap Path column (index 1) at 30 — ratatui doesn't support Min+Max on one column.
-    if col_widths.len() > 1 {
-        col_widths[1] = col_widths[1].min(30);
-    }
+    let col_widths: Vec<u16> = col_areas.iter().map(|r| r.width).collect();
 
     // Build rows from active repo (immutable borrows)
     let rm = model.active();

--- a/crates/flotilla-tui/src/ui_helpers.rs
+++ b/crates/flotilla-tui/src/ui_helpers.rs
@@ -138,12 +138,16 @@ pub fn shorten_path(path: &Path, repo_root: &Path, col_width: usize) -> String {
         .unwrap_or(0);
     let ideal_padding = main_display.len().saturating_sub(repo_name_len);
 
+    // Cap padding so it never exceeds half the column — leaves room for the name
+    // even after the caller truncates.  Crucially this is independent of the name
+    // length, so every worktree at the same depth gets identical indentation.
+    let padding = ideal_padding.min(col_width / 2);
+
     // Under repo root (e.g. .worktrees/feat-auth, sub/dir)
     if let Ok(rel) = path.strip_prefix(repo_root) {
         let s = rel.to_string_lossy();
         if !s.is_empty() {
             let name = s.into_owned();
-            let padding = ideal_padding.min(col_width.saturating_sub(name.len()));
             return format!("{:padding$}{name}", "");
         }
     }
@@ -164,7 +168,6 @@ pub fn shorten_path(path: &Path, repo_root: &Path, col_width: usize) -> String {
                 .strip_prefix(&root_name)
                 .unwrap_or(&path_name)
                 .to_string();
-            let padding = ideal_padding.min(col_width.saturating_sub(name.len()));
             return format!("{:padding$}{name}", "");
         }
     }
@@ -419,19 +422,19 @@ mod tests {
 
     #[test]
     fn shorten_path_worktree_narrow_column() {
-        // Narrow column — padding shrinks so name still fits.
+        // Narrow column — padding is consistent (capped at col/2), caller truncates.
         let root = Path::new("/dev/project");
         let wt = Path::new("/dev/project/.worktrees/feat-auth");
-        // name = ".worktrees/feat-auth" (20 chars), col = 22, padding = 2
-        assert_eq!(shorten_path(wt, root, 22), "  .worktrees/feat-auth");
+        // ideal_padding = 5, col/2 = 11 → padding = 5 (same as wide)
+        assert_eq!(shorten_path(wt, root, 22), "     .worktrees/feat-auth");
     }
 
     #[test]
     fn shorten_path_worktree_very_narrow() {
-        // Very narrow — no padding, name alone.
+        // Very narrow — padding capped at col/2 = 5, still consistent indent.
         let root = Path::new("/dev/project");
         let wt = Path::new("/dev/project/.worktrees/feat-auth");
-        assert_eq!(shorten_path(wt, root, 10), ".worktrees/feat-auth");
+        assert_eq!(shorten_path(wt, root, 10), "     .worktrees/feat-auth");
     }
 
     #[test]

--- a/crates/flotilla-tui/tests/snapshots/snapshots__action_menu.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__action_menu.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__branch_input_generating_popup.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__branch_input_generating_popup.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__debug_panel_with_correlation_details.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__debug_panel_with_correlation_details.snap
@@ -4,9 +4,9 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││Description: Feature branch checkout          │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││Description: Feature branch checkout          │
 │      ── Checkouts ──                                                 ││Branch: feat-xyz                              │
-│▸  ○       feat- Feature bra feat-xyz   ✓                             ││                                              │
+│▸  ○       fea Feature branch  feat-xyz ✓                             ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__delete_confirm_safe_to_delete.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__delete_confirm_safe_to_delete.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__empty_state.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__empty_state.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | empty | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__file_picker_popup.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__file_picker_popup.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__help_screen.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__help_screen.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                       ┌ Help ────────────────────────────────────────────────────────────────┐                       │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__issue_search_mode_status_bar.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__issue_search_mode_status_bar.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__preview_change_request.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__preview_change_request.snap
@@ -4,9 +4,9 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││Description: Refactor auth module             │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││Description: Refactor auth module             │
 │      ── Pull Requests ──                                             ││Branch: feat-auth                             │
-│▸  ⊙             Refactor au feat-auth          #77                   ││PR #77: Refactor auth module                  │
+│▸  ⊙           Refactor auth m feat-aut         #77                   ││PR #77: Refactor auth module                  │
 │                                                                      ││State: Open                                   │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__preview_issue.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__preview_issue.snap
@@ -4,9 +4,9 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││Description: Fix login timeout bug            │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││Description: Fix login timeout bug            │
 │      ── Issues ──                                                    ││Issue #25: Fix login timeout bug []           │
-│▸  ◇             Fix login t —                            #25         ││                                              │
+│▸  ◇           Fix login timeo —                          #25         ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__preview_session.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__preview_session.snap
@@ -4,9 +4,9 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││Description: Debug API endpoints              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││Description: Debug API endpoints              │
 │      ── Sessions ──                                                  ││Branch: feat/session-branch                   │
-│▸  ▶             Debug API e feat/sessi              ▶                ││Session: Debug API endpoints                  │
+│▸  ▶           Debug API endpo feat/ses              ▶                ││Session: Debug API endpoints                  │
 │                                                                      ││Status: Running                               │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__selected_item_preview.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__selected_item_preview.snap
@@ -4,11 +4,11 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││Description: checkout feat-dashboard          │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││Description: checkout feat-dashboard          │
 │      ── Checkouts ──                                                 ││Branch: feat-dashboard                        │
-│▸  ○  feat-dashb checkout fe feat-dashb ✓                             ││Path: /test/my-project/feat-dashboard         │
+│▸  ○       fea checkout feat-d feat-das ✓                             ││Path: /test/my-project/feat-dashboard         │
 │      ── Pull Requests ──                                             ││                                              │
-│   ⊙             Build analy feat-dashb         #99                   ││                                              │
+│   ⊙           Build analytics feat-das         #99                   ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__single_repo_empty_table.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__single_repo_empty_table.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__single_repo_with_items.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__single_repo_with_items.snap
@@ -4,15 +4,15 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││Description: checkout feat-login              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││Description: checkout feat-login              │
 │      ── Checkouts ──                                                 ││Branch: feat-login                            │
-│▸  ○     feat-lo checkout fe feat-login ✓                             ││Path: /test/my-project/feat-login             │
+│▸  ○       fea checkout feat-l feat-log ✓                             ││Path: /test/my-project/feat-login             │
 │      ── Sessions ──                                                  ││                                              │
-│   ◆             session s1  feat/sessi              ◆                ││                                              │
+│   ◆           session s1      feat/ses              ◆                ││                                              │
 │      ── Pull Requests ──                                             ││                                              │
-│   ⊙             Add login p feat-login         #42                   ││                                              │
+│   ⊙           Add login page  feat-log         #42                   ││                                              │
 │      ── Issues ──                                                    ││                                              │
-│   ◇             Users need  —                            #10         ││                                              │
+│   ◇           Users need auth —                          #10         ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__status_bar_with_error.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__status_bar_with_error.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__status_bar_with_multiple_in_flight_commands.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__status_bar_with_multiple_in_flight_commands.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | my-project | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │

--- a/crates/flotilla-tui/tests/snapshots/snapshots__tab_bar_multiple_repos.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__tab_bar_multiple_repos.snap
@@ -4,7 +4,7 @@ expression: output
 ---
  ⚓  flotilla  | alpha | beta | gamma | [+]
 ┌─────────────────────────────────────────────────────────────────── ⚙ ┐┌ Preview ─────────────────────────────────────┐
-│      Path       Description Branch     WT  WS  PR   SS   Issues Git  ││                                              │
+│      Path     Description     Branch   WT  WS  PR   SS   Issues Git  ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │
 │                                                                      ││                                              │


### PR DESCRIPTION
## Summary
- Path, Description, and Branch columns now use `Fill(1:2:1)` instead of `Min(6)`/`Min(8)` + `Fill(1)`, which starved Path and Branch to their minimums
- Removed `.min(30)` content cap on Path that only truncated text without affecting layout
- Worktree path padding is now independent of name length so all worktrees at the same depth align uniformly

## Test plan
- [x] All snapshot tests updated and passing
- [x] Visually verified in running TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)