### PR TITLE
chore: add gh setup hook for Claude Code web sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,5 +59,18 @@
       "Bash(curl * | sh)",
       "Bash(curl * | bash)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y gh-setup-hooks",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a SessionStart hook to install `gh` CLI in Claude Code web environments via `npx -y gh-setup-hooks`

## Test plan
- [ ] Verify gh is available in a Claude Code web session on the changedirection fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)