### PR TITLE
fix: global providers table uses worst-wins status across repos

### DIFF
--- a/crates/flotilla-tui/src/ui.rs
+++ b/crates/flotilla-tui/src/ui.rs
@@ -959,6 +959,17 @@ fn render_config_screen(model: &TuiModel, ui: &mut UiState, frame: &mut Frame, a
     render_event_log(ui, frame, chunks[1]);
 }
 
+/// Return the worse of two provider statuses (Error > Ok > None).
+fn worse_status(a: Option<ProviderStatus>, b: Option<ProviderStatus>) -> Option<ProviderStatus> {
+    match (a, b) {
+        (Some(ProviderStatus::Error), _) | (_, Some(ProviderStatus::Error)) => {
+            Some(ProviderStatus::Error)
+        }
+        (Some(ProviderStatus::Ok), _) | (_, Some(ProviderStatus::Ok)) => Some(ProviderStatus::Ok),
+        _ => None,
+    }
+}
+
 fn render_global_status(model: &TuiModel, frame: &mut Frame, area: Rect) {
     // Collect providers across all repos: (category_key, provider_name) → status.
     let categories = [
@@ -972,7 +983,9 @@ fn render_global_status(model: &TuiModel, frame: &mut Frame, area: Rect) {
         ("Terminal pool", "terminal_pool"),
     ];
 
-    // Collect unique (category, provider_name) pairs with their best-known status.
+    // Collect unique (category, provider_name) pairs with worst-wins status.
+    // If a provider is healthy in repo A but failing in repo B, the global
+    // view should surface the failure (Error > Ok > None).
     struct ProviderEntry {
         name: String,
         status: Option<ProviderStatus>,
@@ -985,17 +998,19 @@ fn render_global_status(model: &TuiModel, frame: &mut Frame, area: Rect) {
             if let Some(pnames) = rm.provider_names.get(key) {
                 let entries = by_category.entry(key).or_default();
                 for pname in pnames {
-                    if entries.iter().any(|e| e.name == *pname) {
-                        continue;
-                    }
                     let status = model
                         .provider_statuses
                         .get(&(path.clone(), key.to_string(), pname.clone()))
                         .copied();
-                    entries.push(ProviderEntry {
-                        name: pname.clone(),
-                        status,
-                    });
+                    if let Some(existing) = entries.iter_mut().find(|e| e.name == *pname) {
+                        // Worst-wins: Error beats Ok beats None.
+                        existing.status = worse_status(existing.status, status);
+                    } else {
+                        entries.push(ProviderEntry {
+                            name: pname.clone(),
+                            status,
+                        });
+                    }
                 }
             }
         }

--- a/crates/flotilla-tui/tests/snapshots.rs
+++ b/crates/flotilla-tui/tests/snapshots.rs
@@ -283,6 +283,18 @@ fn providers_overlay() {
 }
 
 #[test]
+fn config_screen_cross_repo_worst_wins() {
+    let mut harness = TestHarness::multi_repo(&["alpha", "beta"])
+        .with_mode(UiMode::Config)
+        .with_provider_names("alpha", vec![("code_review", "GitHub")])
+        .with_provider_names("beta", vec![("code_review", "GitHub")])
+        .with_provider_status("alpha", "code_review", "GitHub", ProviderStatus::Ok)
+        .with_provider_status("beta", "code_review", "GitHub", ProviderStatus::Error);
+    let output = harness.render_to_string();
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn debug_panel_with_correlation_details() {
     let mut item = support::checkout_item("feat-xyz", "/test/my-project/feat-xyz", false);
     item.description = "Feature branch checkout".into();

--- a/crates/flotilla-tui/tests/snapshots/snapshots__config_screen_cross_repo_worst_wins.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__config_screen_cross_repo_worst_wins.snap
@@ -1,0 +1,35 @@
+---
+source: crates/flotilla-tui/tests/snapshots.rs
+assertion_line: 294
+expression: output
+---
+ ⚓  flotilla  | alpha | beta | [+]
+┌ Providers ───────────────────────────────────────────────────────────┐┌ Event Log ───────────────────────────── INFO ┐
+│Role             Provider                 Status                      ││                                              │
+│VCS              —                                                    ││                                              │
+│Checkout mgr     —                                                    ││                                              │
+│Code review      GitHub                   ✗                           ││                                              │
+│Issue tracker    —                                                    ││                                              │
+│Cloud agents     —                                                    ││                                              │
+│AI utility       —                                                    ││                                              │
+│Workspace mgr    —                                                    ││                                              │
+│Terminal pool    —                                                    ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+│                                                                      ││                                              │
+└──────────────────────────────────────────────────────────────────────┘└──────────────────────────────────────────────┘
+ j/k:scroll log  [/]:switch tab  ?:help  q:quit


### PR DESCRIPTION
## Summary
- Global providers table now aggregates status across repos using worst-wins (Error > Ok > None) instead of silently showing only the first repo's status
- Adds `worse_status()` helper and snapshot test covering cross-repo status aggregation

Fixes #196

## Test plan
- [x] New `config_screen_cross_repo_worst_wins` snapshot test: GitHub Ok in alpha + Error in beta → shows ✗
- [x] All 656 existing tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)