### PR TITLE
test: unit tests for app/mod.rs, github.rs, and cursor.rs

### DIFF
--- a/crates/flotilla-core/src/providers/code_review/github.rs
+++ b/crates/flotilla-core/src/providers/code_review/github.rs
@@ -359,107 +359,50 @@ mod tests {
     // --- parse_state tests ---
 
     #[test]
-    fn parse_state_all_variants() {
-        assert_eq!(
-            GitHubCodeReview::parse_state("OPEN"),
-            ChangeRequestStatus::Open
-        );
-        assert_eq!(
-            GitHubCodeReview::parse_state("DRAFT"),
-            ChangeRequestStatus::Draft
-        );
-        assert_eq!(
-            GitHubCodeReview::parse_state("MERGED"),
-            ChangeRequestStatus::Merged
-        );
-        assert_eq!(
-            GitHubCodeReview::parse_state("CLOSED"),
-            ChangeRequestStatus::Closed
-        );
-    }
-
-    #[test]
-    fn parse_state_case_insensitive() {
-        assert_eq!(
-            GitHubCodeReview::parse_state("open"),
-            ChangeRequestStatus::Open
-        );
-        assert_eq!(
-            GitHubCodeReview::parse_state("Merged"),
-            ChangeRequestStatus::Merged
-        );
-    }
-
-    #[test]
-    fn parse_state_unknown_defaults_to_open() {
-        assert_eq!(
-            GitHubCodeReview::parse_state("unknown"),
-            ChangeRequestStatus::Open
-        );
-        assert_eq!(GitHubCodeReview::parse_state(""), ChangeRequestStatus::Open);
+    fn parse_state_cases() {
+        let cases = [
+            ("OPEN", ChangeRequestStatus::Open),
+            ("DRAFT", ChangeRequestStatus::Draft),
+            ("MERGED", ChangeRequestStatus::Merged),
+            ("CLOSED", ChangeRequestStatus::Closed),
+            ("open", ChangeRequestStatus::Open),
+            ("Merged", ChangeRequestStatus::Merged),
+            ("unknown", ChangeRequestStatus::Open),
+            ("", ChangeRequestStatus::Open),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(GitHubCodeReview::parse_state(input), expected, "{input}");
+        }
     }
 
     // --- parse_linked_issues tests ---
 
     #[test]
-    fn parse_linked_issues_fixes_keyword() {
-        assert_eq!(GitHubCodeReview::parse_linked_issues("Fixes #7"), vec!["7"]);
-    }
-
-    #[test]
-    fn parse_linked_issues_closes_keyword() {
-        assert_eq!(
-            GitHubCodeReview::parse_linked_issues("Closes #42"),
-            vec!["42"]
-        );
-    }
-
-    #[test]
-    fn parse_linked_issues_resolves_keyword() {
-        assert_eq!(
-            GitHubCodeReview::parse_linked_issues("Resolves #100"),
-            vec!["100"]
-        );
-    }
-
-    #[test]
-    fn parse_linked_issues_multiple_keywords() {
-        let result = GitHubCodeReview::parse_linked_issues("Fixes #1, Closes #2, Resolves #3");
-        assert_eq!(result, vec!["1", "2", "3"]);
-    }
-
-    #[test]
-    fn parse_linked_issues_case_insensitive() {
-        assert_eq!(GitHubCodeReview::parse_linked_issues("FIXES #5"), vec!["5"]);
-        assert_eq!(
-            GitHubCodeReview::parse_linked_issues("closes #6"),
-            vec!["6"]
-        );
-    }
-
-    #[test]
-    fn parse_linked_issues_deduplicates() {
-        let result = GitHubCodeReview::parse_linked_issues("Fixes #7\nCloses #7");
-        assert_eq!(result, vec!["7"]);
-    }
-
-    #[test]
-    fn parse_linked_issues_no_matches() {
-        assert!(GitHubCodeReview::parse_linked_issues("Just a description").is_empty());
-        assert!(GitHubCodeReview::parse_linked_issues("").is_empty());
-    }
-
-    #[test]
-    fn parse_linked_issues_missing_hash() {
-        assert!(GitHubCodeReview::parse_linked_issues("Fixes 7").is_empty());
-    }
-
-    #[test]
-    fn parse_linked_issues_embedded_in_text() {
-        let result = GitHubCodeReview::parse_linked_issues(
-            "This PR fixes #12 by updating the parser.\nAlso closes #34.",
-        );
-        assert_eq!(result, vec!["12", "34"]);
+    fn parse_linked_issues_cases() {
+        let cases = [
+            ("Fixes #7", vec!["7"]),
+            ("Closes #42", vec!["42"]),
+            ("Resolves #100", vec!["100"]),
+            ("Fixes #1, Closes #2, Resolves #3", vec!["1", "2", "3"]),
+            ("FIXES #5", vec!["5"]),
+            ("closes #6", vec!["6"]),
+            ("Fixes #7\nCloses #7", vec!["7"]),
+            ("Just a description", vec![]),
+            ("", vec![]),
+            ("Fixes 7", vec![]),
+            (
+                "This PR fixes #12 by updating the parser.\nAlso closes #34.",
+                vec!["12", "34"],
+            ),
+        ];
+        for (input, expected) in cases {
+            let expected: Vec<String> = expected.into_iter().map(str::to_string).collect();
+            assert_eq!(
+                GitHubCodeReview::parse_linked_issues(input),
+                expected,
+                "{input}"
+            );
+        }
     }
 
     // --- gh_pr_to_change_request tests ---
@@ -475,17 +418,22 @@ mod tests {
         GitHubCodeReview::new("github".into(), "owner/repo".into(), api, runner)
     }
 
-    #[test]
-    fn gh_pr_to_change_request_basic() {
-        let provider = provider_with_empty_replay();
-        let pr = GhPr {
-            number: 42,
+    fn gh_pr(number: i64) -> GhPr {
+        GhPr {
+            number,
             title: "Add feature".into(),
             head_ref_name: "feat/add-feature".into(),
             state: "OPEN".into(),
-            body: Some("Fixes #7".into()),
+            body: None,
             is_draft: false,
-        };
+        }
+    }
+
+    #[test]
+    fn gh_pr_to_change_request_basic() {
+        let provider = provider_with_empty_replay();
+        let mut pr = gh_pr(42);
+        pr.body = Some("Fixes #7".into());
         let (id, cr) = provider.gh_pr_to_change_request(&pr);
         assert_eq!(id, "42");
         assert_eq!(cr.title, "Add feature");
@@ -508,14 +456,10 @@ mod tests {
     #[test]
     fn gh_pr_to_change_request_draft_overrides_open() {
         let provider = provider_with_empty_replay();
-        let pr = GhPr {
-            number: 10,
-            title: "WIP".into(),
-            head_ref_name: "wip-branch".into(),
-            state: "OPEN".into(),
-            body: None,
-            is_draft: true,
-        };
+        let mut pr = gh_pr(10);
+        pr.title = "WIP".into();
+        pr.head_ref_name = "wip-branch".into();
+        pr.is_draft = true;
         let (_, cr) = provider.gh_pr_to_change_request(&pr);
         assert_eq!(cr.status, ChangeRequestStatus::Draft);
         assert!(cr.association_keys.is_empty());
@@ -524,14 +468,11 @@ mod tests {
     #[test]
     fn gh_pr_to_change_request_merged_not_affected_by_draft() {
         let provider = provider_with_empty_replay();
-        let pr = GhPr {
-            number: 20,
-            title: "Done".into(),
-            head_ref_name: "done-branch".into(),
-            state: "MERGED".into(),
-            body: None,
-            is_draft: true,
-        };
+        let mut pr = gh_pr(20);
+        pr.title = "Done".into();
+        pr.head_ref_name = "done-branch".into();
+        pr.state = "MERGED".into();
+        pr.is_draft = true;
         let (_, cr) = provider.gh_pr_to_change_request(&pr);
         assert_eq!(cr.status, ChangeRequestStatus::Merged);
     }
@@ -539,14 +480,10 @@ mod tests {
     #[test]
     fn gh_pr_to_change_request_issues_from_title_and_body() {
         let provider = provider_with_empty_replay();
-        let pr = GhPr {
-            number: 30,
-            title: "Fixes #1".into(),
-            head_ref_name: "fix".into(),
-            state: "OPEN".into(),
-            body: Some("Also closes #2".into()),
-            is_draft: false,
-        };
+        let mut pr = gh_pr(30);
+        pr.title = "Fixes #1".into();
+        pr.head_ref_name = "fix".into();
+        pr.body = Some("Also closes #2".into());
         let (_, cr) = provider.gh_pr_to_change_request(&pr);
         assert!(cr
             .association_keys
@@ -559,14 +496,10 @@ mod tests {
     #[test]
     fn gh_pr_to_change_request_deduplicates_issues_across_title_and_body() {
         let provider = provider_with_empty_replay();
-        let pr = GhPr {
-            number: 31,
-            title: "Fixes #5".into(),
-            head_ref_name: "fix".into(),
-            state: "OPEN".into(),
-            body: Some("Closes #5".into()),
-            is_draft: false,
-        };
+        let mut pr = gh_pr(31);
+        pr.title = "Fixes #5".into();
+        pr.head_ref_name = "fix".into();
+        pr.body = Some("Closes #5".into());
         let (_, cr) = provider.gh_pr_to_change_request(&pr);
         let issue_refs: Vec<_> = cr
             .association_keys

--- a/crates/flotilla-core/src/providers/coding_agent/cursor.rs
+++ b/crates/flotilla-core/src/providers/coding_agent/cursor.rs
@@ -242,6 +242,22 @@ impl super::CloudAgentService for CursorCodingAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::coding_agent::CloudAgentService;
+
+    fn cursor_agent(status: &str, repository: &str, branch: &str) -> CursorAgent {
+        CursorAgent {
+            id: "bc-1".to_string(),
+            name: "Session".to_string(),
+            status: status.to_string(),
+            created_at: "2026-01-01T00:00:00.000Z".to_string(),
+            source: CursorSource {
+                repository: repository.to_string(),
+            },
+            target: CursorTarget {
+                branch_name: branch.to_string(),
+            },
+        }
+    }
 
     #[test]
     fn repo_slug_from_cursor_repository_cases() {
@@ -251,130 +267,61 @@ mod tests {
             ("git@github.com:owner/repo.git", Some("owner/repo")),
             ("git@github.com:owner/repo", Some("owner/repo")),
             ("owner/repo", Some("owner/repo")),
+            ("http://github.com/owner/repo", Some("owner/repo")),
+            ("https://github.com/owner/repo/", Some("owner/repo")),
+            ("  owner/repo  ", Some("owner/repo")),
             ("", None),
             ("repo-only", None),
         ];
         for (input, expected) in cases {
             assert_eq!(
                 repo_slug_from_cursor_repository(input),
-                expected.map(str::to_string)
+                expected.map(str::to_string),
+                "{input}"
             );
         }
     }
 
     #[test]
-    fn cursor_agent_maps_status_and_branch() {
-        let make = |status: &str| CursorAgent {
-            id: "bc-1".to_string(),
-            name: "Session".to_string(),
-            status: status.to_string(),
-            created_at: "2026-01-01T00:00:00.000Z".to_string(),
-            source: CursorSource {
-                repository: "github.com/owner/repo".to_string(),
-            },
-            target: CursorTarget {
-                branch_name: "feature/one".to_string(),
-            },
-        };
+    fn cursor_agent_maps_status_branch_and_repo() {
+        let status_cases = [
+            ("CREATING", SessionStatus::Running),
+            ("RUNNING", SessionStatus::Running),
+            ("FINISHED", SessionStatus::Idle),
+            ("STOPPED", SessionStatus::Idle),
+            ("FAILED", SessionStatus::Idle),
+            ("EXPIRED", SessionStatus::Idle),
+            ("UNKNOWN_STATUS", SessionStatus::Idle),
+        ];
+        for (status, expected) in status_cases {
+            assert_eq!(
+                cursor_agent(status, "", "").session_status(),
+                expected,
+                "{status}"
+            );
+        }
 
-        assert_eq!(make("CREATING").session_status(), SessionStatus::Running);
-        assert_eq!(make("RUNNING").session_status(), SessionStatus::Running);
-        assert_eq!(make("FINISHED").session_status(), SessionStatus::Idle);
-        assert_eq!(make("STOPPED").session_status(), SessionStatus::Idle);
-        assert_eq!(make("FAILED").session_status(), SessionStatus::Idle);
-        assert_eq!(make("EXPIRED").session_status(), SessionStatus::Idle);
-
-        let agent = make("RUNNING");
+        let agent = cursor_agent("RUNNING", "github.com/owner/repo", "feature/one");
         assert_eq!(agent.branch(), Some("feature/one"));
         assert_eq!(agent.repo_slug(), Some("owner/repo".to_string()));
     }
 
     #[test]
     fn cursor_agent_empty_branch_returns_none() {
-        let agent = CursorAgent {
-            id: "a-1".to_string(),
-            name: String::new(),
-            status: "RUNNING".to_string(),
-            created_at: String::new(),
-            source: CursorSource {
-                repository: String::new(),
-            },
-            target: CursorTarget {
-                branch_name: String::new(),
-            },
-        };
+        let agent = cursor_agent("RUNNING", "", "");
         assert!(agent.branch().is_none());
     }
 
     #[test]
     fn cursor_agent_repo_slug_delegates() {
-        let agent = CursorAgent {
-            id: "a-2".to_string(),
-            name: String::new(),
-            status: "FINISHED".to_string(),
-            created_at: String::new(),
-            source: CursorSource {
-                repository: "https://github.com/owner/repo.git".to_string(),
-            },
-            target: CursorTarget {
-                branch_name: String::new(),
-            },
-        };
+        let agent = cursor_agent("FINISHED", "https://github.com/owner/repo.git", "");
         assert_eq!(agent.repo_slug(), Some("owner/repo".to_string()));
     }
 
     #[test]
     fn cursor_agent_empty_repo_returns_none() {
-        let agent = CursorAgent {
-            id: "a-3".to_string(),
-            name: String::new(),
-            status: "RUNNING".to_string(),
-            created_at: String::new(),
-            source: CursorSource {
-                repository: String::new(),
-            },
-            target: CursorTarget {
-                branch_name: String::new(),
-            },
-        };
+        let agent = cursor_agent("RUNNING", "", "");
         assert!(agent.repo_slug().is_none());
-    }
-
-    #[test]
-    fn cursor_agent_unknown_status_defaults_to_idle() {
-        let agent = CursorAgent {
-            id: "a-4".to_string(),
-            name: String::new(),
-            status: "UNKNOWN_STATUS".to_string(),
-            created_at: String::new(),
-            source: CursorSource::default(),
-            target: CursorTarget::default(),
-        };
-        assert_eq!(agent.session_status(), SessionStatus::Idle);
-    }
-
-    #[test]
-    fn repo_slug_http_without_tls() {
-        assert_eq!(
-            repo_slug_from_cursor_repository("http://github.com/owner/repo"),
-            Some("owner/repo".to_string()),
-        );
-    }
-
-    #[test]
-    fn repo_slug_trailing_slashes() {
-        assert_eq!(
-            repo_slug_from_cursor_repository("https://github.com/owner/repo/"),
-            Some("owner/repo".to_string()),
-        );
-    }
-
-    #[test]
-    fn repo_slug_whitespace_trimmed() {
-        assert_eq!(
-            repo_slug_from_cursor_repository("  owner/repo  "),
-            Some("owner/repo".to_string()),
-        );
     }
 
     struct MockHttpClient;
@@ -389,11 +336,14 @@ mod tests {
         }
     }
 
+    fn cursor_service() -> CursorCodingAgent {
+        let http: Arc<dyn crate::providers::HttpClient> = Arc::new(MockHttpClient);
+        CursorCodingAgent::new("cursor".into(), http)
+    }
+
     #[tokio::test]
     async fn archive_session_returns_error() {
-        use crate::providers::coding_agent::CloudAgentService;
-        let http: Arc<dyn crate::providers::HttpClient> = Arc::new(MockHttpClient);
-        let agent = CursorCodingAgent::new("cursor".into(), http);
+        let agent = cursor_service();
         let result = agent.archive_session("any-id").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not supported"));
@@ -401,18 +351,14 @@ mod tests {
 
     #[tokio::test]
     async fn attach_command_formats_resume() {
-        use crate::providers::coding_agent::CloudAgentService;
-        let http: Arc<dyn crate::providers::HttpClient> = Arc::new(MockHttpClient);
-        let agent = CursorCodingAgent::new("cursor".into(), http);
+        let agent = cursor_service();
         let cmd = agent.attach_command("sess-42").await.unwrap();
         assert_eq!(cmd, "agent --resume sess-42");
     }
 
     #[tokio::test]
     async fn display_name_returns_expected() {
-        use crate::providers::coding_agent::CloudAgentService;
-        let http: Arc<dyn crate::providers::HttpClient> = Arc::new(MockHttpClient);
-        let agent = CursorCodingAgent::new("cursor".into(), http);
+        let agent = cursor_service();
         assert_eq!(agent.display_name(), "Cursor Cloud Agents");
     }
 }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -504,11 +504,11 @@ mod tests {
 
     #[test]
     fn from_repo_info_builds_correct_model() {
-        let info = vec![
+        let repos_info = vec![
             repo_info("/tmp/repo-a", "repo-a", RepoLabels::default()),
             repo_info("/tmp/repo-b", "repo-b", RepoLabels::default()),
         ];
-        let model = TuiModel::from_repo_info(info);
+        let model = TuiModel::from_repo_info(repos_info);
         assert_eq!(model.repos.len(), 2);
         assert_eq!(model.repo_order.len(), 2);
         assert_eq!(model.active_repo, 0);
@@ -519,11 +519,11 @@ mod tests {
 
     #[test]
     fn from_repo_info_preserves_order() {
-        let info = vec![
+        let repos_info = vec![
             repo_info("/z", "z", RepoLabels::default()),
             repo_info("/a", "a", RepoLabels::default()),
         ];
-        let model = TuiModel::from_repo_info(info);
+        let model = TuiModel::from_repo_info(repos_info);
         assert_eq!(model.repo_order[0], PathBuf::from("/z"));
         assert_eq!(model.repo_order[1], PathBuf::from("/a"));
     }
@@ -544,11 +544,7 @@ mod tests {
 
     #[test]
     fn format_error_status_single_error() {
-        let errors = vec![ProviderError {
-            category: "code_review".into(),
-            provider: "github".into(),
-            message: "rate limited".into(),
-        }];
+        let errors = vec![provider_error("code_review", "github", "rate limited")];
         let msg = format_error_status(&errors, Path::new("/tmp/my-repo")).unwrap();
         assert!(msg.contains("my-repo"));
         assert!(msg.contains("code_review"));
@@ -558,27 +554,19 @@ mod tests {
 
     #[test]
     fn format_error_status_suppresses_issues_disabled() {
-        let errors = vec![ProviderError {
-            category: "issues".into(),
-            provider: "github".into(),
-            message: "repo has disabled issues".into(),
-        }];
+        let errors = vec![provider_error(
+            "issues",
+            "github",
+            "repo has disabled issues",
+        )];
         assert!(format_error_status(&errors, Path::new("/repo")).is_none());
     }
 
     #[test]
     fn format_error_status_mixed_suppressed_and_real() {
         let errors = vec![
-            ProviderError {
-                category: "issues".into(),
-                provider: "github".into(),
-                message: "repo has disabled issues".into(),
-            },
-            ProviderError {
-                category: "vcs".into(),
-                provider: "git".into(),
-                message: "not a git repo".into(),
-            },
+            provider_error("issues", "github", "repo has disabled issues"),
+            provider_error("vcs", "git", "not a git repo"),
         ];
         let msg = format_error_status(&errors, Path::new("/repo")).unwrap();
         assert!(msg.contains("not a git repo"));
@@ -587,11 +575,7 @@ mod tests {
 
     #[test]
     fn format_error_status_empty_provider_no_suffix() {
-        let errors = vec![ProviderError {
-            category: "vcs".into(),
-            provider: String::new(),
-            message: "error".into(),
-        }];
+        let errors = vec![provider_error("vcs", "", "error")];
         let msg = format_error_status(&errors, Path::new("/r")).unwrap();
         assert!(!msg.contains("()"));
     }
@@ -599,43 +583,19 @@ mod tests {
     #[test]
     fn format_error_status_multiple_errors_joined() {
         let errors = vec![
-            ProviderError {
-                category: "vcs".into(),
-                provider: "git".into(),
-                message: "err1".into(),
-            },
-            ProviderError {
-                category: "cr".into(),
-                provider: "gh".into(),
-                message: "err2".into(),
-            },
+            provider_error("vcs", "git", "err1"),
+            provider_error("cr", "gh", "err2"),
         ];
         let msg = format_error_status(&errors, Path::new("/r")).unwrap();
         assert!(msg.contains("; "));
     }
 
-    // -- apply_snapshot --
-
-    fn make_snapshot(repo: &Path, work_items: Vec<WorkItem>) -> Snapshot {
-        Snapshot {
-            seq: 1,
-            repo: repo.to_path_buf(),
-            work_items,
-            providers: ProviderData::default(),
-            provider_health: HashMap::new(),
-            errors: vec![],
-            issue_total: None,
-            issue_has_more: false,
-            issue_search_results: None,
-        }
-    }
-
     #[test]
     fn apply_snapshot_updates_provider_data() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let snap = make_snapshot(&repo, vec![]);
+        let snap = snapshot(&repo);
         app.apply_snapshot(snap);
         assert!(!app.model.repos[&repo].loading);
     }
@@ -643,9 +603,9 @@ mod tests {
     #[test]
     fn apply_snapshot_updates_issue_metadata() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let mut snap = make_snapshot(&repo, vec![]);
+        let mut snap = snapshot(&repo);
         snap.issue_has_more = true;
         snap.issue_total = Some(42);
         snap.issue_search_results = Some(vec![]);
@@ -660,9 +620,9 @@ mod tests {
     #[test]
     fn apply_snapshot_maps_provider_health_to_statuses() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let mut snap = make_snapshot(&repo, vec![]);
+        let mut snap = snapshot(&repo);
         snap.provider_health.insert(
             "vcs".into(),
             HashMap::from([("git".into(), true), ("wt".into(), false)]),
@@ -682,14 +642,10 @@ mod tests {
     #[test]
     fn apply_snapshot_sets_error_status_message() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let mut snap = make_snapshot(&repo, vec![]);
-        snap.errors = vec![ProviderError {
-            category: "cr".into(),
-            provider: "gh".into(),
-            message: "fail".into(),
-        }];
+        let mut snap = snapshot(&repo);
+        snap.errors = vec![provider_error("cr", "gh", "fail")];
         app.apply_snapshot(snap);
 
         assert!(app.model.status_message.is_some());
@@ -699,10 +655,10 @@ mod tests {
     #[test]
     fn apply_snapshot_clears_status_on_no_errors() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
         app.model.status_message = Some("old error".into());
 
-        let snap = make_snapshot(&repo, vec![]);
+        let snap = snapshot(&repo);
         app.apply_snapshot(snap);
 
         assert!(app.model.status_message.is_none());
@@ -711,22 +667,22 @@ mod tests {
     #[test]
     fn apply_snapshot_unknown_repo_is_noop() {
         let mut app = stub_app();
-        let snap = make_snapshot(Path::new("/nonexistent"), vec![]);
+        let snap = snapshot(Path::new("/nonexistent"));
         app.apply_snapshot(snap);
     }
 
     #[test]
     fn apply_snapshot_requests_initial_issue_fetch() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let snap = make_snapshot(&repo, vec![]);
+        let snap = snapshot(&repo);
         app.apply_snapshot(snap);
 
         let cmd = app.proto_commands.take_next();
         assert!(matches!(cmd, Some(Command::SetIssueViewport { .. })));
         // Second snapshot should NOT queue another
-        let snap2 = make_snapshot(&repo, vec![]);
+        let snap2 = snapshot(&repo);
         app.apply_snapshot(snap2);
         assert!(app.proto_commands.take_next().is_none());
     }
@@ -737,12 +693,13 @@ mod tests {
         let inactive_repo = app.model.repo_order[1].clone();
 
         // First snapshot to establish baseline providers
-        let snap1 = make_snapshot(&inactive_repo, vec![]);
+        let snap1 = snapshot(&inactive_repo);
         app.apply_snapshot(snap1);
 
         // Second snapshot with different providers
-        let mut snap2 = make_snapshot(&inactive_repo, vec![checkout_item("feat", "/wt", false)]);
+        let mut snap2 = snapshot(&inactive_repo);
         snap2.seq = 2;
+        snap2.work_items = vec![checkout_item("feat", "/wt", false)];
         let mut different_providers = ProviderData::default();
         different_providers.checkouts.insert(
             PathBuf::from("/wt"),
@@ -768,19 +725,12 @@ mod tests {
     #[test]
     fn apply_delta_updates_issue_metadata() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let delta = SnapshotDelta {
-            seq: 2,
-            prev_seq: 1,
-            repo: repo.clone(),
-            changes: vec![],
-            work_items: vec![],
-            issue_total: Some(10),
-            issue_has_more: true,
-            issue_search_results: None,
-        };
-        app.apply_delta(delta);
+        let mut change = delta(&repo, vec![]);
+        change.issue_total = Some(10);
+        change.issue_has_more = true;
+        app.apply_delta(change);
 
         let rm = &app.model.repos[&repo];
         assert_eq!(rm.issue_total, Some(10));
@@ -791,39 +741,26 @@ mod tests {
     #[test]
     fn apply_delta_unknown_repo_is_noop() {
         let mut app = stub_app();
-        let delta = SnapshotDelta {
-            seq: 1,
-            prev_seq: 0,
-            repo: PathBuf::from("/nonexistent"),
-            changes: vec![],
-            work_items: vec![],
-            issue_total: None,
-            issue_has_more: false,
-            issue_search_results: None,
-        };
-        app.apply_delta(delta);
+        let mut change = delta(Path::new("/nonexistent"), vec![]);
+        change.seq = 1;
+        change.prev_seq = 0;
+        app.apply_delta(change);
     }
 
     #[test]
     fn apply_delta_provider_health_added() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let delta = SnapshotDelta {
-            seq: 2,
-            prev_seq: 1,
-            repo: repo.clone(),
-            changes: vec![flotilla_protocol::Change::ProviderHealth {
+        let change = delta(
+            &repo,
+            vec![flotilla_protocol::Change::ProviderHealth {
                 category: "vcs".into(),
                 provider: "git".into(),
                 op: flotilla_protocol::EntryOp::Added(true),
             }],
-            work_items: vec![],
-            issue_total: None,
-            issue_has_more: false,
-            issue_search_results: None,
-        };
-        app.apply_delta(delta);
+        );
+        app.apply_delta(change);
 
         assert_eq!(
             app.model.provider_statuses[&(repo.clone(), "vcs".into(), "git".into())],
@@ -835,7 +772,7 @@ mod tests {
     #[test]
     fn apply_delta_provider_health_removed() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
         app.model
             .repos
@@ -846,21 +783,15 @@ mod tests {
             .or_default()
             .insert("git".into(), true);
 
-        let delta = SnapshotDelta {
-            seq: 2,
-            prev_seq: 1,
-            repo: repo.clone(),
-            changes: vec![flotilla_protocol::Change::ProviderHealth {
+        let change = delta(
+            &repo,
+            vec![flotilla_protocol::Change::ProviderHealth {
                 category: "vcs".into(),
                 provider: "git".into(),
                 op: flotilla_protocol::EntryOp::Removed,
             }],
-            work_items: vec![],
-            issue_total: None,
-            issue_has_more: false,
-            issue_search_results: None,
-        };
-        app.apply_delta(delta);
+        );
+        app.apply_delta(change);
 
         assert!(!app.model.repos[&repo].provider_health.contains_key("vcs"));
     }
@@ -868,25 +799,15 @@ mod tests {
     #[test]
     fn apply_delta_errors_changed_updates_status() {
         let mut app = stub_app();
-        let repo = app.model.repo_order[0].clone();
+        let repo = active_repo_path(&app);
 
-        let delta = SnapshotDelta {
-            seq: 2,
-            prev_seq: 1,
-            repo: repo.clone(),
-            changes: vec![flotilla_protocol::Change::ErrorsChanged(vec![
-                ProviderError {
-                    category: "cr".into(),
-                    provider: "gh".into(),
-                    message: "broken".into(),
-                },
+        let change = delta(
+            &repo,
+            vec![flotilla_protocol::Change::ErrorsChanged(vec![
+                provider_error("cr", "gh", "broken"),
             ])],
-            work_items: vec![],
-            issue_total: None,
-            issue_has_more: false,
-            issue_search_results: None,
-        };
-        app.apply_delta(delta);
+        );
+        app.apply_delta(change);
 
         assert!(app
             .model
@@ -901,11 +822,9 @@ mod tests {
         let mut app = stub_app_with_repos(2);
         let inactive_repo = app.model.repo_order[1].clone();
 
-        let delta = SnapshotDelta {
-            seq: 2,
-            prev_seq: 1,
-            repo: inactive_repo.clone(),
-            changes: vec![flotilla_protocol::Change::Session {
+        let change = delta(
+            &inactive_repo,
+            vec![flotilla_protocol::Change::Session {
                 key: "s1".into(),
                 op: flotilla_protocol::EntryOp::Added(flotilla_protocol::CloudAgentSession {
                     title: "new session".into(),
@@ -915,12 +834,8 @@ mod tests {
                     correlation_keys: vec![],
                 }),
             }],
-            work_items: vec![],
-            issue_total: None,
-            issue_has_more: false,
-            issue_search_results: None,
-        };
-        app.apply_delta(delta);
+        );
+        app.apply_delta(change);
 
         assert!(app.ui.repo_ui[&inactive_repo].has_unseen_changes);
     }
@@ -930,21 +845,15 @@ mod tests {
         let mut app = stub_app_with_repos(2);
         let inactive_repo = app.model.repo_order[1].clone();
 
-        let delta = SnapshotDelta {
-            seq: 2,
-            prev_seq: 1,
-            repo: inactive_repo.clone(),
-            changes: vec![flotilla_protocol::Change::ProviderHealth {
+        let change = delta(
+            &inactive_repo,
+            vec![flotilla_protocol::Change::ProviderHealth {
                 category: "vcs".into(),
                 provider: "git".into(),
                 op: flotilla_protocol::EntryOp::Added(true),
             }],
-            work_items: vec![],
-            issue_total: None,
-            issue_has_more: false,
-            issue_search_results: None,
-        };
-        app.apply_delta(delta);
+        );
+        app.apply_delta(change);
 
         assert!(!app.ui.repo_ui[&inactive_repo].has_unseen_changes);
     }

--- a/crates/flotilla-tui/src/app/test_support.rs
+++ b/crates/flotilla-tui/src/app/test_support.rs
@@ -6,7 +6,10 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use flotilla_core::config::ConfigStore;
 use flotilla_core::daemon::DaemonHandle;
 use flotilla_core::data::{GroupEntry, GroupedWorkItems};
-use flotilla_protocol::{Command, DaemonEvent, RepoInfo, RepoLabels, Snapshot, WorkItem};
+use flotilla_protocol::{
+    Change, Command, DaemonEvent, ProviderData, ProviderError, RepoInfo, RepoLabels, Snapshot,
+    SnapshotDelta, WorkItem,
+};
 use tokio::sync::broadcast;
 use tui_input::Input;
 
@@ -79,6 +82,45 @@ pub(crate) fn stub_app_with_repos(count: usize) -> App {
         })
         .collect();
     stub_app_with_repo_infos(repos_info)
+}
+
+pub(crate) fn active_repo_path(app: &App) -> PathBuf {
+    app.model.repo_order[app.model.active_repo].clone()
+}
+
+pub(crate) fn provider_error(category: &str, provider: &str, message: &str) -> ProviderError {
+    ProviderError {
+        category: category.into(),
+        provider: provider.into(),
+        message: message.into(),
+    }
+}
+
+pub(crate) fn snapshot(repo: &Path) -> Snapshot {
+    Snapshot {
+        seq: 1,
+        repo: repo.to_path_buf(),
+        work_items: vec![],
+        providers: ProviderData::default(),
+        provider_health: HashMap::new(),
+        errors: vec![],
+        issue_total: None,
+        issue_has_more: false,
+        issue_search_results: None,
+    }
+}
+
+pub(crate) fn delta(repo: &Path, changes: Vec<Change>) -> SnapshotDelta {
+    SnapshotDelta {
+        seq: 2,
+        prev_seq: 1,
+        repo: repo.to_path_buf(),
+        changes,
+        work_items: vec![],
+        issue_total: None,
+        issue_has_more: false,
+        issue_search_results: None,
+    }
 }
 
 pub(crate) fn default_repo_model(labels: RepoLabels) -> TuiRepoModel {

--- a/docs/superpowers/plans/2026-03-11-test-consolidation.md
+++ b/docs/superpowers/plans/2026-03-11-test-consolidation.md
@@ -1,0 +1,130 @@
+# Test Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate duplicated setup and assertions in the newly added Rust tests while preserving behavior and coverage.
+
+**Architecture:** Keep the refactor test-only. Use case tables for parser tests, local builders for repeated provider structs, and shared TUI test helpers for snapshot/delta/error setup so the tests read as behavior checks instead of fixture assembly.
+
+**Tech Stack:** Rust, `cargo test`, existing repo test helpers
+
+---
+
+## Chunk 1: Provider Test Consolidation
+
+### Task 1: Refactor GitHub code review tests
+
+**Files:**
+- Modify: `crates/flotilla-core/src/providers/code_review/github.rs`
+- Test: `crates/flotilla-core/src/providers/code_review/github.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace duplicated parser checks with table-driven tests and add a compact `GhPr` builder while keeping behavior assertions intact.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --locked -p flotilla-core providers::code_review::github::tests`
+Expected: one or more tests fail until helper extraction is complete.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Refactor only the test module. Do not change production code.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --locked -p flotilla-core providers::code_review::github::tests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+Commit together with the other test-consolidation tasks once all verification passes.
+
+### Task 2: Refactor Cursor coding agent tests
+
+**Files:**
+- Modify: `crates/flotilla-core/src/providers/coding_agent/cursor.rs`
+- Test: `crates/flotilla-core/src/providers/coding_agent/cursor.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace repeated `CursorAgent` and `CursorCodingAgent` construction with small helpers and combine parser-like cases where it improves readability.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --locked -p flotilla-core providers::coding_agent::cursor::tests`
+Expected: one or more tests fail until helper extraction is complete.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Refactor only the test module. Do not change production code.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --locked -p flotilla-core providers::coding_agent::cursor::tests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+Commit together with the other test-consolidation tasks once all verification passes.
+
+## Chunk 2: TUI Test Support Consolidation
+
+### Task 3: Add shared app test helpers
+
+**Files:**
+- Modify: `crates/flotilla-tui/src/app/test_support.rs`
+- Modify: `crates/flotilla-tui/src/app/mod.rs`
+- Test: `crates/flotilla-tui/src/app/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Refactor the app tests to call helper constructors for snapshots, deltas, and provider errors.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --locked -p flotilla-tui app::tests`
+Expected: one or more tests fail until helper extraction is complete.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add focused test helpers to `test_support.rs` and update the tests to use them.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --locked -p flotilla-tui app::tests`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+Commit together with the other test-consolidation tasks once all verification passes.
+
+## Chunk 3: Verification And Commit
+
+### Task 4: Run full sandbox-safe verification
+
+**Files:**
+- Modify: none
+- Test: workspace
+
+- [ ] **Step 1: Run the workspace tests**
+
+Run:
+
+```bash
+mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Review git diff**
+
+Run: `git diff --stat`
+Expected: only the intended test/doc refactor files are changed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-11-test-consolidation-design.md docs/superpowers/plans/2026-03-11-test-consolidation.md crates/flotilla-core/src/providers/code_review/github.rs crates/flotilla-core/src/providers/coding_agent/cursor.rs crates/flotilla-tui/src/app/mod.rs crates/flotilla-tui/src/app/test_support.rs
+git commit -m "test: consolidate new coverage"
+```

--- a/docs/superpowers/specs/2026-03-11-test-consolidation-design.md
+++ b/docs/superpowers/specs/2026-03-11-test-consolidation-design.md
@@ -1,0 +1,38 @@
+# Test Consolidation Design
+
+**Goal:** Reduce duplication in the newly added Rust tests without changing production behavior or weakening coverage.
+
+## Scope
+
+This refactor is limited to test code in:
+
+- `crates/flotilla-core/src/providers/code_review/github.rs`
+- `crates/flotilla-core/src/providers/coding_agent/cursor.rs`
+- `crates/flotilla-tui/src/app/mod.rs`
+- `crates/flotilla-tui/src/app/test_support.rs`
+
+No production logic changes are in scope.
+
+## Approach
+
+Use narrow, local helpers where setup repetition obscures intent:
+
+- Convert parser-style tests to table-driven case arrays.
+- Add small builders for repeated test fixtures (`GhPr`, `CursorAgent`, `CursorCodingAgent`).
+- Move repeated `Snapshot`, `SnapshotDelta`, and `ProviderError` setup into `app/test_support.rs`.
+
+Keep tests that verify distinct behavior as separate functions. The goal is consolidation, not over-abstraction.
+
+## Constraints
+
+- Preserve current assertions and behavioral coverage.
+- Keep helpers test-local or test-support-local.
+- Avoid introducing generic utilities that make tests harder to read than the duplicated setup they replace.
+
+## Verification
+
+Run:
+
+```bash
+mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests
+```


### PR DESCRIPTION
## Summary
- **app/mod.rs** (28.9% → ~85%): 37 tests covering CommandQueue, TuiModel construction, `format_error_status`, `apply_snapshot`/`apply_delta` state transitions, repo add/remove lifecycle, daemon events, and convenience accessors
- **code_review/github.rs** (53% → ~90%): 17 tests for `parse_state`, `parse_linked_issues`, and `gh_pr_to_change_request` pure functions
- **coding_agent/cursor.rs** (50% → ~80%): 10 tests for CursorAgent helpers, repo slug edge cases, and async trait methods (`archive_session`, `attach_command`, `display_name`)

Targets [#162](https://github.com/rjwittams/flotilla/issues/162) — these three files were identified as the fastest path to 85% overall coverage (~192 lines needed).

## Test plan
- [x] `cargo test --workspace --locked` — 718 passed, 0 failed
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)