### PR TITLE
fix: handle tracking remotes with / in name and clamp help scroll

### DIFF
--- a/crates/flotilla-core/src/providers/discovery.rs
+++ b/crates/flotilla-core/src/providers/discovery.rs
@@ -32,8 +32,24 @@ async fn tracking_remote_url(repo_root: &Path, runner: &dyn CommandRunner) -> Op
     )
     .ok()?;
     let upstream = upstream.trim();
-    // upstream looks like "origin/main" — the remote name is the first segment
-    let remote_name = upstream.split('/').next()?;
+    let remotes_output = run!(runner, "git", &["remote"], repo_root).ok()?;
+    let remotes: Vec<&str> = remotes_output
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect();
+    // upstream looks like "origin/main" or "team/origin/main". Match it against
+    // configured remotes and prefer the longest prefix to handle remotes containing '/'.
+    let remote_name = remotes
+        .into_iter()
+        .filter(|remote| {
+            upstream == *remote
+                || upstream
+                    .strip_prefix(remote)
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+        })
+        .max_by_key(|remote| remote.len())
+        .or_else(|| upstream.split('/').next())?;
     if remote_name.is_empty() {
         return None;
     }
@@ -563,6 +579,7 @@ mod tests {
                 &["rev-parse", "--abbrev-ref", "@{upstream}"],
                 Ok("upstream/main\n".to_string()),
             )
+            .on_run("git", &["remote"], Ok("origin\nupstream\n".to_string()))
             .on_run(
                 "git",
                 &["remote", "get-url", "upstream"],
@@ -575,6 +592,31 @@ mod tests {
             Some("https://github.com/upstream/repo.git".to_string())
         );
         assert!(runner.saw_cwd(repo_root));
+    }
+
+    #[tokio::test]
+    async fn first_remote_prefers_tracking_remote_with_slash_in_name_over_origin() {
+        let repo_root = Path::new("/tmp/repo-root");
+        let runner = DiscoveryMockRunner::builder()
+            .on_run(
+                "git",
+                &["rev-parse", "--abbrev-ref", "@{upstream}"],
+                Ok("team/origin/main\n".to_string()),
+            )
+            .on_run("git", &["remote"], Ok("origin\nteam/origin\n".to_string()))
+            .on_run(
+                "git",
+                &["remote", "get-url", "origin"],
+                Ok("https://github.com/wrong/repo.git\n".to_string()),
+            )
+            .on_run(
+                "git",
+                &["remote", "get-url", "team/origin"],
+                Ok("https://github.com/team/repo.git\n".to_string()),
+            )
+            .build();
+        let url = first_remote_url(repo_root, &runner).await;
+        assert_eq!(url, Some("https://github.com/team/repo.git".to_string()));
     }
 
     #[tokio::test]
@@ -1044,6 +1086,7 @@ mod tests {
                     &["rev-parse", "--abbrev-ref", "@{upstream}"],
                     Ok("upstream/main\n".to_string()),
                 )
+                .on_run("git", &["remote"], Ok("origin\nupstream\n".to_string()))
                 .on_run(
                     "git",
                     &["remote", "get-url", "upstream"],

--- a/crates/flotilla-tui/src/ui.rs
+++ b/crates/flotilla-tui/src/ui.rs
@@ -822,7 +822,7 @@ fn render_delete_confirm(model: &TuiModel, ui: &UiState, frame: &mut Frame) {
     frame.render_widget(paragraph, area);
 }
 
-fn render_help(model: &TuiModel, ui: &UiState, frame: &mut Frame) {
+fn render_help(model: &TuiModel, ui: &mut UiState, frame: &mut Frame) {
     if !matches!(ui.mode, UiMode::Help) {
         return;
     }
@@ -891,7 +891,8 @@ fn render_help(model: &TuiModel, ui: &UiState, frame: &mut Frame) {
     let total_lines = help_text.len() as u16;
     let inner_height = area.height.saturating_sub(2); // borders
     let max_scroll = total_lines.saturating_sub(inner_height);
-    let scroll = ui.help_scroll.min(max_scroll);
+    ui.help_scroll = ui.help_scroll.min(max_scroll);
+    let scroll = ui.help_scroll;
 
     let has_more_below = scroll < max_scroll;
     let has_more_above = scroll > 0;

--- a/crates/flotilla-tui/tests/snapshots.rs
+++ b/crates/flotilla-tui/tests/snapshots.rs
@@ -76,6 +76,14 @@ fn help_screen() {
 }
 
 #[test]
+fn help_screen_clamps_scroll_state_after_render() {
+    let mut harness = TestHarness::single_repo("my-project").with_mode(UiMode::Help);
+    harness.ui.help_scroll = u16::MAX;
+    let _ = harness.render_to_string();
+    assert!(harness.ui.help_scroll < u16::MAX);
+}
+
+#[test]
 fn action_menu() {
     let mut harness = TestHarness::single_repo("my-project").with_mode(UiMode::ActionMenu {
         items: vec![


### PR DESCRIPTION
## Summary

Follow-up to #216 — these fixes were developed but not pushed before the squash merge.

- **Remote name with `/`**: `tracking_remote_url` now matches the upstream ref against configured remotes using longest-prefix matching, so remote names like `team/origin` are handled correctly instead of being truncated by naive `split('/').next()`.
- **Help scroll clamp**: `help_scroll` is now clamped in-place during render, so reverse scrolling works immediately after overscrolling past the end.

## Test plan

- [x] New test: `first_remote_prefers_tracking_remote_with_slash_in_name_over_origin`
- [x] New test: `help_screen_clamps_scroll_state_after_render`
- [x] Existing `first_remote_prefers_tracking_remote` updated with `git remote` mock
- [x] All 730 tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)