### PR TITLE
refactor: rename IntoChannelLabel to ChannelLabeler (#222)

### DIFF
--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -51,14 +51,13 @@ pub enum ChannelRequest<'a> {
     Http { method: &'a str, url: &'a str },
 }
 
-#[allow(clippy::wrong_self_convention)]
-pub trait IntoChannelLabel {
-    fn into_channel_label(&self, request: &ChannelRequest) -> ChannelLabel;
+pub trait ChannelLabeler {
+    fn label_for(&self, request: &ChannelRequest) -> ChannelLabel;
 }
 
 pub struct DefaultLabeler;
-impl IntoChannelLabel for DefaultLabeler {
-    fn into_channel_label(&self, request: &ChannelRequest) -> ChannelLabel {
+impl ChannelLabeler for DefaultLabeler {
+    fn label_for(&self, request: &ChannelRequest) -> ChannelLabel {
         match request {
             ChannelRequest::Command { cmd, args } => match args.first() {
                 Some(sub) if !sub.is_empty() => ChannelLabel::Command(format!("{} {}", cmd, sub)),
@@ -71,8 +70,8 @@ impl IntoChannelLabel for DefaultLabeler {
 }
 
 pub struct TaskId(pub &'static str);
-impl IntoChannelLabel for TaskId {
-    fn into_channel_label(&self, request: &ChannelRequest) -> ChannelLabel {
+impl ChannelLabeler for TaskId {
+    fn label_for(&self, request: &ChannelRequest) -> ChannelLabel {
         match request {
             ChannelRequest::Command { .. } => ChannelLabel::Command(self.0.into()),
             ChannelRequest::GhApi { .. } => ChannelLabel::GhApi(self.0.into()),
@@ -183,8 +182,8 @@ macro_rules! run {
             cmd: __cmd,
             args: __args,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $labeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $labeler.label_for(&__request);
         $runner.run(__cmd, __args, $cwd, &__label).await
     }};
     ($runner:expr, $cmd:expr, $args:expr, $cwd:expr $(,)?) => {{
@@ -194,8 +193,8 @@ macro_rules! run {
             cmd: __cmd,
             args: __args,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $crate::providers::DefaultLabeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $crate::providers::DefaultLabeler.label_for(&__request);
         $runner.run(__cmd, __args, $cwd, &__label).await
     }};
 }
@@ -209,8 +208,8 @@ macro_rules! run_output {
             cmd: __cmd,
             args: __args,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $labeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $labeler.label_for(&__request);
         $runner.run_output(__cmd, __args, $cwd, &__label).await
     }};
     ($runner:expr, $cmd:expr, $args:expr, $cwd:expr $(,)?) => {{
@@ -220,8 +219,8 @@ macro_rules! run_output {
             cmd: __cmd,
             args: __args,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $crate::providers::DefaultLabeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $crate::providers::DefaultLabeler.label_for(&__request);
         $runner.run_output(__cmd, __args, $cwd, &__label).await
     }};
 }
@@ -235,8 +234,8 @@ macro_rules! gh_api_get {
             method: "GET",
             endpoint: __endpoint,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $labeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $labeler.label_for(&__request);
         $api.get(__endpoint, $repo_root, &__label).await
     }};
     ($api:expr, $endpoint:expr, $repo_root:expr $(,)?) => {{
@@ -245,8 +244,8 @@ macro_rules! gh_api_get {
             method: "GET",
             endpoint: __endpoint,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $crate::providers::DefaultLabeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $crate::providers::DefaultLabeler.label_for(&__request);
         $api.get(__endpoint, $repo_root, &__label).await
     }};
 }
@@ -260,8 +259,8 @@ macro_rules! gh_api_get_with_headers {
             method: "GET",
             endpoint: __endpoint,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $labeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $labeler.label_for(&__request);
         $api.get_with_headers(__endpoint, $repo_root, &__label)
             .await
     }};
@@ -271,8 +270,8 @@ macro_rules! gh_api_get_with_headers {
             method: "GET",
             endpoint: __endpoint,
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $crate::providers::DefaultLabeler.into_channel_label(&__request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $crate::providers::DefaultLabeler.label_for(&__request);
         $api.get_with_headers(__endpoint, $repo_root, &__label)
             .await
     }};
@@ -287,8 +286,8 @@ macro_rules! http_execute {
             method: __request.method().as_str(),
             url: __request.url().as_str(),
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $labeler.into_channel_label(&__chan_request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $labeler.label_for(&__chan_request);
         $http.execute(__request, &__label).await
     }};
     ($http:expr, $request:expr $(,)?) => {{
@@ -297,8 +296,8 @@ macro_rules! http_execute {
             method: __request.method().as_str(),
             url: __request.url().as_str(),
         };
-        use $crate::providers::IntoChannelLabel as _;
-        let __label = $crate::providers::DefaultLabeler.into_channel_label(&__chan_request);
+        use $crate::providers::ChannelLabeler as _;
+        let __label = $crate::providers::DefaultLabeler.label_for(&__chan_request);
         $http.execute(__request, &__label).await
     }};
 }

--- a/crates/flotilla-core/src/providers/replay.rs
+++ b/crates/flotilla-core/src/providers/replay.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 
 use super::github_api::{GhApi, GhApiResponse};
 use super::{
-    ChannelLabel, ChannelRequest, CommandOutput, CommandRunner, DefaultLabeler, IntoChannelLabel,
+    ChannelLabel, ChannelLabeler, ChannelRequest, CommandOutput, CommandRunner, DefaultLabeler,
 };
 
 /// A single recorded interaction with an external system.
@@ -69,19 +69,19 @@ impl Interaction {
                     cmd,
                     args: &args_refs,
                 };
-                DefaultLabeler.into_channel_label(&request)
+                DefaultLabeler.label_for(&request)
             }
             Interaction::GhApi { label: Some(l), .. } => ChannelLabel::GhApi(l.clone()),
             Interaction::GhApi {
                 method, endpoint, ..
             } => {
                 let request = ChannelRequest::GhApi { method, endpoint };
-                DefaultLabeler.into_channel_label(&request)
+                DefaultLabeler.label_for(&request)
             }
             Interaction::Http { label: Some(l), .. } => ChannelLabel::Http(l.clone()),
             Interaction::Http { method, url, .. } => {
                 let request = ChannelRequest::Http { method, url };
-                DefaultLabeler.into_channel_label(&request)
+                DefaultLabeler.label_for(&request)
             }
         }
     }
@@ -814,7 +814,7 @@ impl CommandRunner for RecordingRunner {
         let result = self.inner.run(cmd, args, cwd, label).await;
 
         let request = ChannelRequest::Command { cmd, args };
-        let default = DefaultLabeler.into_channel_label(&request);
+        let default = DefaultLabeler.label_for(&request);
         let explicit = explicit_label(label, &default);
 
         let (stdout, stderr, exit_code) = match &result {
@@ -845,7 +845,7 @@ impl CommandRunner for RecordingRunner {
         let result = self.inner.run_output(cmd, args, cwd, label).await;
 
         let request = ChannelRequest::Command { cmd, args };
-        let default = DefaultLabeler.into_channel_label(&request);
+        let default = DefaultLabeler.label_for(&request);
         let explicit = explicit_label(label, &default);
 
         match &result {
@@ -910,7 +910,7 @@ impl GhApi for RecordingGhApi {
             method: "GET",
             endpoint,
         };
-        let default = DefaultLabeler.into_channel_label(&request);
+        let default = DefaultLabeler.label_for(&request);
         let explicit = explicit_label(label, &default);
 
         match &result {
@@ -954,7 +954,7 @@ impl GhApi for RecordingGhApi {
             method: "GET",
             endpoint,
         };
-        let default = DefaultLabeler.into_channel_label(&request);
+        let default = DefaultLabeler.label_for(&request);
         let explicit = explicit_label(label, &default);
 
         match &result {
@@ -1045,7 +1045,7 @@ impl super::HttpClient for RecordingHttpClient {
             method: &method,
             url: &url,
         };
-        let default = DefaultLabeler.into_channel_label(&chan_request);
+        let default = DefaultLabeler.label_for(&chan_request);
         let explicit = explicit_label(label, &default);
 
         let result = self.inner.execute(request, label).await;
@@ -1590,7 +1590,7 @@ interactions:
             args: &["branch", "--list"],
         };
         assert_eq!(
-            DefaultLabeler.into_channel_label(&request),
+            DefaultLabeler.label_for(&request),
             ChannelLabel::Command("git branch".into())
         );
     }
@@ -1602,7 +1602,7 @@ interactions:
             args: &[],
         };
         assert_eq!(
-            DefaultLabeler.into_channel_label(&request),
+            DefaultLabeler.label_for(&request),
             ChannelLabel::Command("git".into())
         );
     }
@@ -1615,7 +1615,7 @@ interactions:
             args: &["rev-list", "--left-right", "--count", "HEAD...main"],
         };
         assert_eq!(
-            TaskId("trunk-ab").into_channel_label(&request),
+            TaskId("trunk-ab").label_for(&request),
             ChannelLabel::Command("trunk-ab".into())
         );
     }

--- a/docs/superpowers/specs/2026-03-10-recorder-replayer-sync-barriers-design.md
+++ b/docs/superpowers/specs/2026-03-10-recorder-replayer-sync-barriers-design.md
@@ -162,6 +162,6 @@ The loader detects which format by checking for `rounds:` vs `interactions:` at 
 
 ## Out of Scope
 
-- Explicit channel label overrides / `IntoChannelLabel` trait (future).
+- Explicit channel label overrides / `ChannelLabeler` trait (future).
 - Automatic barrier detection from async boundaries.
 - Migration tool to convert flat fixtures to round-based format.


### PR DESCRIPTION
## Summary
- Renames `IntoChannelLabel` trait to `ChannelLabeler` and method `into_channel_label` to `label_for`
- Removes `#[allow(clippy::wrong_self_convention)]` suppression
- The method takes `&self` so the `into_` prefix was misleading per clippy conventions

Closes #222

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy --all-targets --locked -- -D warnings` passes (no suppression needed)
- [x] `cargo test --locked --workspace` passes
- [x] `cargo fmt -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)