### PR TITLE
fix: filter expired Cursor agent sessions

### DIFF
--- a/crates/flotilla-core/src/providers/coding_agent/cursor.rs
+++ b/crates/flotilla-core/src/providers/coding_agent/cursor.rs
@@ -110,7 +110,8 @@ impl CursorAgent {
     fn session_status(&self) -> SessionStatus {
         match self.status.as_str() {
             "CREATING" | "RUNNING" => SessionStatus::Running,
-            "FINISHED" | "STOPPED" | "FAILED" | "EXPIRED" => SessionStatus::Idle,
+            "EXPIRED" => SessionStatus::Expired,
+            "FINISHED" | "STOPPED" | "FAILED" => SessionStatus::Idle,
             _ => SessionStatus::Idle,
         }
     }
@@ -196,6 +197,7 @@ impl super::CloudAgentService for CursorCodingAgent {
         let provider_name = &self.provider_name;
         Ok(agents
             .into_iter()
+            .filter(|a| a.session_status() != SessionStatus::Expired)
             .filter(|a| a.repo_slug().is_some_and(|r| r == *slug))
             .map(|a| {
                 let mut correlation_keys = vec![CorrelationKey::SessionRef(
@@ -290,7 +292,7 @@ mod tests {
             ("FINISHED", SessionStatus::Idle),
             ("STOPPED", SessionStatus::Idle),
             ("FAILED", SessionStatus::Idle),
-            ("EXPIRED", SessionStatus::Idle),
+            ("EXPIRED", SessionStatus::Expired),
             ("UNKNOWN_STATUS", SessionStatus::Idle),
         ];
         for (status, expected) in status_cases {

--- a/crates/flotilla-protocol/src/provider_data.rs
+++ b/crates/flotilla-protocol/src/provider_data.rs
@@ -108,6 +108,7 @@ pub enum SessionStatus {
     Running,
     Idle,
     Archived,
+    Expired,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -326,6 +327,7 @@ mod tests {
             SessionStatus::Running,
             SessionStatus::Idle,
             SessionStatus::Archived,
+            SessionStatus::Expired,
         ] {
             assert_roundtrip(&status);
         }

--- a/crates/flotilla-tui/src/ui_helpers.rs
+++ b/crates/flotilla-tui/src/ui_helpers.rs
@@ -61,7 +61,7 @@ pub fn session_status_display(status: &SessionStatus) -> &'static str {
     match status {
         SessionStatus::Running => "▶",
         SessionStatus::Idle => "◆",
-        SessionStatus::Archived => "○",
+        SessionStatus::Archived | SessionStatus::Expired => "○",
     }
 }
 
@@ -311,6 +311,7 @@ mod tests {
         assert_eq!(session_status_display(&SessionStatus::Running), "▶");
         assert_eq!(session_status_display(&SessionStatus::Idle), "◆");
         assert_eq!(session_status_display(&SessionStatus::Archived), "○");
+        assert_eq!(session_status_display(&SessionStatus::Expired), "○");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `SessionStatus::Expired` variant to distinguish expired sessions from idle/archived
- Maps Cursor API's `EXPIRED` status to the new variant (was previously `Idle`)
- Filters expired sessions in the Cursor provider so they don't clutter the work item list

Confirmed via API that 5 of 6 Cursor sessions were `EXPIRED` — they were all showing as idle work items.

Closes #228

Follow-up: #245 will let archived/expired sessions flow to the UI behind a show/hide toggle.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Existing status mapping tests updated for `Expired`
- [x] Roundtrip and display tests cover new variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)