### PR TITLE
refactor: batch quick-wins (#260, #261, #265, #266)

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -326,7 +326,7 @@ impl InProcessDaemon {
             if repos.contains_key(&path) {
                 continue;
             }
-            let (registry, repo_slug) = crate::providers::discovery::detect_providers_with_mode(
+            let (registry, repo_slug) = crate::providers::discovery::detect_providers(
                 &path,
                 &config,
                 Arc::clone(&runner),
@@ -1218,7 +1218,7 @@ impl DaemonHandle for InProcessDaemon {
         }
 
         // Create the model outside the lock (spawns provider detection and refresh)
-        let (registry, repo_slug) = crate::providers::discovery::detect_providers_with_mode(
+        let (registry, repo_slug) = crate::providers::discovery::detect_providers(
             &path,
             &self.config,
             Arc::clone(&self.runner),

--- a/crates/flotilla-core/src/providers/discovery.rs
+++ b/crates/flotilla-core/src/providers/discovery.rs
@@ -169,27 +169,6 @@ pub async fn detect_providers(
     repo_root: &Path,
     config: &ConfigStore,
     runner: Arc<dyn CommandRunner>,
-) -> (ProviderRegistry, Option<String>) {
-    detect_providers_inner(repo_root, config, runner, false).await
-}
-
-/// Like [`detect_providers`] but accepts a `follower` flag.
-///
-/// When `follower` is true, external providers are stripped after discovery
-/// so the daemon only reports local state.
-pub async fn detect_providers_with_mode(
-    repo_root: &Path,
-    config: &ConfigStore,
-    runner: Arc<dyn CommandRunner>,
-    follower: bool,
-) -> (ProviderRegistry, Option<String>) {
-    detect_providers_inner(repo_root, config, runner, follower).await
-}
-
-async fn detect_providers_inner(
-    repo_root: &Path,
-    config: &ConfigStore,
-    runner: Arc<dyn CommandRunner>,
     follower: bool,
 ) -> (ProviderRegistry, Option<String>) {
     let mut registry = ProviderRegistry::new();
@@ -799,7 +778,7 @@ mod tests {
                 .build(),
         );
 
-        let (registry, slug) = detect_providers(&repo, &config, runner).await;
+        let (registry, slug) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.vcs.is_empty());
         assert!(!registry.checkout_managers.is_empty());
         assert_eq!(slug, None);
@@ -817,7 +796,7 @@ mod tests {
                 .tool_exists("claude", false)
                 .build(),
         );
-        let (registry, _) = detect_providers(&repo, &config, runner).await;
+        let (registry, _) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.vcs.contains_key("git"));
     }
 
@@ -839,7 +818,7 @@ mod tests {
                 .build(),
         );
 
-        let (registry, slug) = detect_providers(&repo, &config, runner).await;
+        let (registry, slug) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.code_review.contains_key("github"));
         assert!(registry.issue_trackers.contains_key("github"));
         assert_eq!(slug, Some("owner/repo".to_string()));
@@ -863,7 +842,7 @@ mod tests {
                 .build(),
         );
 
-        let (registry, slug) = detect_providers(&repo, &config, runner).await;
+        let (registry, slug) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.code_review.is_empty());
         assert!(registry.issue_trackers.is_empty());
         assert_eq!(slug, Some("owner/repo".to_string()));
@@ -887,7 +866,7 @@ mod tests {
                 .build(),
         );
 
-        let (registry, slug) = detect_providers(&repo, &config, runner).await;
+        let (registry, slug) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.code_review.is_empty());
         assert!(registry.issue_trackers.is_empty());
         assert_eq!(slug, None);
@@ -911,7 +890,7 @@ mod tests {
                 .build(),
         );
 
-        let (registry, slug) = detect_providers(&repo, &config, runner).await;
+        let (registry, slug) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.code_review.is_empty());
         assert!(registry.issue_trackers.is_empty());
         assert_eq!(slug, Some("owner/repo".to_string()));
@@ -932,7 +911,7 @@ mod tests {
                     .build(),
             );
 
-            let (registry, _) = detect_providers(&repo, &config, runner).await;
+            let (registry, _) = detect_providers(&repo, &config, runner, false).await;
             assert_eq!(
                 registry.cloud_agents.contains_key("claude"),
                 should_register
@@ -960,7 +939,7 @@ mod tests {
                     .tool_exists("claude", false)
                     .build(),
             );
-            let (registry, _) = detect_providers(&repo, &config, runner).await;
+            let (registry, _) = detect_providers(&repo, &config, runner, false).await;
             assert!(registry.cloud_agents.contains_key("cursor"));
         }
         std::env::remove_var("CURSOR_API_KEY");
@@ -978,7 +957,7 @@ mod tests {
                     .tool_exists("claude", false)
                     .build(),
             );
-            let (registry, _) = detect_providers(&repo, &config, runner).await;
+            let (registry, _) = detect_providers(&repo, &config, runner, false).await;
             assert!(!registry.cloud_agents.contains_key("cursor"));
         }
 
@@ -995,7 +974,7 @@ mod tests {
                     .tool_exists("claude", false)
                     .build(),
             );
-            let (registry, _) = detect_providers(&repo, &config, runner).await;
+            let (registry, _) = detect_providers(&repo, &config, runner, false).await;
             assert!(!registry.cloud_agents.contains_key("cursor"));
         }
     }
@@ -1013,7 +992,7 @@ mod tests {
                 .build(),
         );
         let runner_dyn: Arc<dyn CommandRunner> = runner.clone();
-        let (registry, _) = detect_providers(&repo, &config, runner_dyn).await;
+        let (registry, _) = detect_providers(&repo, &config, runner_dyn, false).await;
         assert!(!registry.checkout_managers.is_empty());
         assert_eq!(runner.exists_call_count("wt"), 0);
     }
@@ -1031,7 +1010,7 @@ mod tests {
                 .build(),
         );
         let runner_dyn: Arc<dyn CommandRunner> = runner.clone();
-        let (registry, _) = detect_providers(&repo, &config, runner_dyn).await;
+        let (registry, _) = detect_providers(&repo, &config, runner_dyn, false).await;
         assert!(!registry.checkout_managers.is_empty());
         assert_eq!(runner.exists_call_count("wt"), 1);
     }
@@ -1049,7 +1028,7 @@ mod tests {
                 .build(),
         );
         let runner_dyn: Arc<dyn CommandRunner> = runner.clone();
-        let (registry, _) = detect_providers(&repo, &config, runner_dyn).await;
+        let (registry, _) = detect_providers(&repo, &config, runner_dyn, false).await;
         assert!(!registry.checkout_managers.is_empty());
         assert_eq!(runner.exists_call_count("wt"), 1);
     }
@@ -1079,7 +1058,7 @@ mod tests {
                     .tool_exists("claude", false)
                     .build(),
             );
-            let (registry, _) = detect_providers(&repo, &config, runner).await;
+            let (registry, _) = detect_providers(&repo, &config, runner, false).await;
             assert!(registry.cloud_agents.contains_key("codex"));
         }
 
@@ -1096,7 +1075,7 @@ mod tests {
                     .tool_exists("claude", false)
                     .build(),
             );
-            let (registry, _) = detect_providers(&repo, &config, runner).await;
+            let (registry, _) = detect_providers(&repo, &config, runner, false).await;
             assert!(!registry.cloud_agents.contains_key("codex"));
         }
 
@@ -1122,7 +1101,7 @@ mod tests {
                 .build(),
         );
 
-        let (registry, slug) = detect_providers(&repo, &config, runner).await;
+        let (registry, slug) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.code_review.contains_key("github"));
         assert!(registry.issue_trackers.contains_key("github"));
         assert_eq!(slug, Some("owner/repo".to_string()));
@@ -1151,7 +1130,7 @@ mod tests {
                 .build(),
         );
 
-        let (registry, slug) = detect_providers(&repo, &config, runner).await;
+        let (registry, slug) = detect_providers(&repo, &config, runner, false).await;
         assert!(registry.code_review.contains_key("github"));
         assert!(registry.issue_trackers.contains_key("github"));
         assert_eq!(slug, Some("upstream/repo".to_string()));

--- a/crates/flotilla-protocol/src/host.rs
+++ b/crates/flotilla-protocol/src/host.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use tracing::warn;
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
@@ -18,14 +19,20 @@ impl HostName {
 
     /// Create a HostName from the local machine's hostname.
     /// Uses `gethostname` crate (already a dependency in flotilla-core).
+    /// The result is cached so `gethostname()` is only called once.
     pub fn local() -> Self {
-        let name = gethostname::gethostname()
-            .into_string()
-            .unwrap_or_else(|os| {
-                warn!(hostname = ?os, "hostname is not valid UTF-8, falling back to \"localhost\"");
-                "localhost".to_string()
-            });
-        Self(name)
+        static HOSTNAME: OnceLock<HostName> = OnceLock::new();
+        HOSTNAME
+            .get_or_init(|| {
+                let name = gethostname::gethostname()
+                    .into_string()
+                    .unwrap_or_else(|os| {
+                        warn!(hostname = ?os, "hostname is not valid UTF-8, falling back to \"localhost\"");
+                        "localhost".to_string()
+                    });
+                Self(name)
+            })
+            .clone()
     }
 }
 

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -588,56 +588,6 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
     use test_support::*;
-    use tokio::sync::broadcast;
-
-    struct TestDaemon {
-        tx: broadcast::Sender<DaemonEvent>,
-    }
-
-    impl TestDaemon {
-        fn new() -> Self {
-            let (tx, _) = broadcast::channel(1);
-            Self { tx }
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl DaemonHandle for TestDaemon {
-        fn subscribe(&self) -> broadcast::Receiver<DaemonEvent> {
-            self.tx.subscribe()
-        }
-
-        async fn get_state(&self, _repo: &Path) -> Result<Snapshot, String> {
-            Err("stub".into())
-        }
-
-        async fn list_repos(&self) -> Result<Vec<RepoInfo>, String> {
-            Ok(vec![])
-        }
-
-        async fn execute(&self, _repo: &Path, _command: Command) -> Result<u64, String> {
-            Ok(1)
-        }
-
-        async fn refresh(&self, _repo: &Path) -> Result<(), String> {
-            Ok(())
-        }
-
-        async fn add_repo(&self, _path: &Path) -> Result<(), String> {
-            Ok(())
-        }
-
-        async fn remove_repo(&self, _path: &Path) -> Result<(), String> {
-            Ok(())
-        }
-
-        async fn replay_since(
-            &self,
-            _last_seen: &HashMap<PathBuf, u64>,
-        ) -> Result<Vec<DaemonEvent>, String> {
-            Ok(vec![])
-        }
-    }
 
     // -- CommandQueue --
 
@@ -719,7 +669,7 @@ mod tests {
         )
         .unwrap();
 
-        let daemon: Arc<dyn DaemonHandle> = Arc::new(TestDaemon::new());
+        let daemon: Arc<dyn DaemonHandle> = Arc::new(test_support::StubDaemon::new());
         let config = Arc::new(ConfigStore::with_base(dir.path()));
         let app = App::new(
             daemon,
@@ -733,7 +683,7 @@ mod tests {
     #[test]
     fn persist_layout_writes_current_ui_state() {
         let dir = tempdir().unwrap();
-        let daemon: Arc<dyn DaemonHandle> = Arc::new(TestDaemon::new());
+        let daemon: Arc<dyn DaemonHandle> = Arc::new(test_support::StubDaemon::new());
         let config = Arc::new(ConfigStore::with_base(dir.path()));
         let mut app = App::new(
             daemon,

--- a/crates/flotilla-tui/src/app/test_support.rs
+++ b/crates/flotilla-tui/src/app/test_support.rs
@@ -19,14 +19,14 @@ use super::{App, DirEntry, TuiRepoModel, UiMode};
 // Re-export shared builders so unit tests can use `test_support::checkout_item` etc.
 pub(crate) use super::test_builders::*;
 
-struct StubDaemon {
+pub(crate) struct StubDaemon {
     tx: broadcast::Sender<DaemonEvent>,
 }
 
 static STUB_APP_CONFIG_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 impl StubDaemon {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let (tx, _) = broadcast::channel(1);
         Self { tx }
     }

--- a/crates/flotilla-tui/src/ui.rs
+++ b/crates/flotilla-tui/src/ui.rs
@@ -1400,4 +1400,43 @@ mod tests {
         let position = resolve_preview_position(Rect::new(0, 0, 160, 40), RepoViewLayout::Zoom);
         assert_eq!(position, None);
     }
+
+    #[test]
+    fn auto_neither_viable_falls_back_to_right() {
+        // 60x10: right_preview_width = 24 (< MIN_PREVIEW_WIDTH 32),
+        //        below_preview_height = 4 (< MIN_PREVIEW_HEIGHT 6)
+        // Both layouts are non-viable, so fallback to Right.
+        let result = resolve_auto_preview_position(Rect::new(0, 0, 60, 10));
+        assert_eq!(result, ResolvedPreviewPosition::Right);
+    }
+
+    #[test]
+    fn auto_only_right_viable() {
+        // 210x10: right_preview_width = 84 (>= 32), right_table_width = 126 (>= 50) → viable
+        //         below_preview_height = 4 (< 6) → not viable
+        let result = resolve_auto_preview_position(Rect::new(0, 0, 210, 10));
+        assert_eq!(result, ResolvedPreviewPosition::Right);
+    }
+
+    #[test]
+    fn auto_only_below_viable() {
+        // 60x40: right_preview_width = 24 (< 32) → not viable
+        //        below_preview_height = 16 (>= 6), below_table_height = 24 (>= 8) → viable
+        let result = resolve_auto_preview_position(Rect::new(0, 0, 60, 40));
+        assert_eq!(result, ResolvedPreviewPosition::Below);
+    }
+
+    #[test]
+    fn auto_both_viable_wide_prefers_right() {
+        // 160x40: both viable, aspect_ratio = 4.0 (>= 2.0) → Right
+        let result = resolve_auto_preview_position(Rect::new(0, 0, 160, 40));
+        assert_eq!(result, ResolvedPreviewPosition::Right);
+    }
+
+    #[test]
+    fn auto_both_viable_tall_prefers_below() {
+        // 90x50: both viable, aspect_ratio = 1.8 (< 2.0) → Below
+        let result = resolve_auto_preview_position(Rect::new(0, 0, 90, 50));
+        assert_eq!(result, ResolvedPreviewPosition::Below);
+    }
 }

--- a/examples/debug_sessions.rs
+++ b/examples/debug_sessions.rs
@@ -27,7 +27,7 @@ async fn main() {
     println!("\n=== Step 1: Build ProviderRegistry ===");
     let config = ConfigStore::new();
     let runner: Arc<dyn CommandRunner> = Arc::new(ProcessCommandRunner);
-    let (registry, repo_slug) = detect_providers(&repo_root, &config, runner).await;
+    let (registry, repo_slug) = detect_providers(&repo_root, &config, runner, false).await;
     println!("  checkout_managers: {}", registry.checkout_managers.len());
     println!("  code_review: {}", registry.code_review.len());
     println!("  issue_trackers: {}", registry.issue_trackers.len());


### PR DESCRIPTION
## Summary

- **#266** Collapse `detect_providers` / `detect_providers_with_mode` into a single `detect_providers(..., follower: bool)` function
- **#265** Cache `HostName::local()` with `OnceLock` to avoid repeated `gethostname()` syscalls
- **#261** Deduplicate `TestDaemon` / `StubDaemon` — make `StubDaemon` `pub(crate)` and remove the duplicate
- **#260** Add tests for all four `resolve_auto_preview_position` match arms (including the `(false, false)` fallback)

Net: -25 lines, 880 tests pass, clippy clean.

Closes #260, closes #261, closes #265, closes #266.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets --locked -- -D warnings` — no warnings
- [x] `cargo test --workspace --locked` — 880 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)