### PR TITLE
fix: use context_repo for FetchCheckoutStatus repo resolution

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -485,15 +485,7 @@ impl InProcessDaemon {
             CommandAction::Checkout { repo, .. } => self.resolve_repo_selector(repo).await,
             CommandAction::RemoveCheckout { checkout, .. } => self.resolve_checkout_selector(checkout).await.map(|(repo, _)| repo),
             CommandAction::Refresh { repo: Some(selector) } => self.resolve_repo_selector(selector).await,
-            CommandAction::FetchCheckoutStatus { checkout_path: Some(path), .. } => {
-                let repos = self.repos.read().await;
-                repos
-                    .keys()
-                    .find(|repo_root| path.starts_with(repo_root))
-                    .cloned()
-                    .ok_or_else(|| format!("repo not tracked: {}", path.display()))
-            }
-            CommandAction::FetchCheckoutStatus { checkout_path: None, .. }
+            CommandAction::FetchCheckoutStatus { .. }
             | CommandAction::OpenChangeRequest { .. }
             | CommandAction::CloseChangeRequest { .. }
             | CommandAction::OpenIssue { .. }


### PR DESCRIPTION
## Summary
- Fixes worktree deletion hanging on "Loading safety info..." (now shows error thanks to earlier fix on main)
- Root cause: `resolve_repo_for_command` introduced in #316 used `starts_with` path matching for `FetchCheckoutStatus`, which fails for git worktrees (checkout paths are siblings of the repo root, not children)
- Fix: use `context_repo` (the active repo root) like all other context-dependent commands

## Test plan
- [ ] Delete a worktree from a repo launched from a git worktree (e.g. `flotilla.sandbox-tests-slow`)
- [ ] Delete a worktree from a repo launched from the main checkout
- [ ] Verify safety info popup loads correctly in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)