### PR TITLE
chore: pin all nightly toolchain usage to nightly-2026-03-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-03-12
           components: rustfmt
-      - run: cargo +nightly fmt --check
+      - run: cargo +nightly-2026-03-12 fmt --check
 
   clippy:
     name: Clippy

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,8 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-03-12
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: actions/cache@v4
@@ -52,15 +53,15 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-coverage-nightly-2026-03-12-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-coverage-
+            ${{ runner.os }}-cargo-coverage-nightly-2026-03-12-
       - name: Generate coverage report
         run: |
           # NOTE: --branch crashes llvm-cov (SIGSEGV from --show-mcdc in nightly LLVM).
           # Revisit when upstream is fixed.
-          cargo +nightly llvm-cov --workspace --html --locked --remap-path-prefix
-          cargo +nightly llvm-cov --workspace --json --no-run --locked --output-path target/llvm-cov/html/coverage.json
+          cargo +nightly-2026-03-12 llvm-cov --workspace --html --locked --remap-path-prefix
+          cargo +nightly-2026-03-12 llvm-cov --workspace --json --no-run --locked --output-path target/llvm-cov/html/coverage.json
       - name: Add badge JSON
         run: |
           PERCENT=$(jq -r '.data[0].totals.lines.percent | floor' target/llvm-cov/html/coverage.json)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ The app auto-detects git, GitHub (`gh` CLI), Claude, and terminal multiplexers f
 |------|---------|
 | Build | `cargo build --locked` |
 | Lint (format) | `cargo fmt --check` |
-| Lint (format, repo convention) | `cargo +nightly fmt --check` |
+| Lint (format, repo convention) | `cargo +nightly-2026-03-12 fmt --check` |
 | Lint (clippy) | `cargo clippy --all-targets --locked -- -D warnings` |
 | Test | `cargo test --workspace --locked` |
 | Test (sandbox) | `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests` |
@@ -42,7 +42,7 @@ The app auto-detects git, GitHub (`gh` CLI), Claude, and terminal multiplexers f
 ### Gotchas
 
 - `cargo build` without `--locked` may update `Cargo.lock`; use `--locked` for reproducible builds.
-- Repo formatting follows `cargo +nightly fmt`; `cargo fmt` may not match the checked-in style on stable.
+- Repo formatting follows `cargo +nightly-2026-03-12 fmt`; `cargo fmt` may not match the checked-in style on stable.
 - The TUI needs a real terminal (TTY). Use `cargo run` inside a terminal emulator, not piped.
 
 ## Testing Providers with Record/Replay

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,18 @@ We are in a **no backwards compatibility** phase. Protocol types, snapshot forma
 ## Quick Reference
 
 ```bash
-cargo build                          # build
-cargo test                           # all tests
-cargo clippy                         # lint
-cargo +nightly fmt                   # format (nightly required for import grouping)
-cargo dylint --all -- --all-targets  # custom lints (requires cargo-dylint + dylint-link)
-cargo run -- --repo-root /path       # run with explicit repo
-cargo run                            # run, auto-detect repo from cwd
+cargo build                                    # build
+cargo test                                     # all tests
+cargo clippy                                   # lint
+cargo +nightly-2026-03-12 fmt                  # format (pinned nightly, see rustfmt.toml)
+cargo dylint --all -- --all-targets             # custom lints (requires cargo-dylint + dylint-link)
+cargo run -- --repo-root /path                 # run with explicit repo
+cargo run                                      # run, auto-detect repo from cwd
 ```
 
-Before pushing, always run `cargo +nightly fmt`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`.
+Before pushing, always run `cargo +nightly-2026-03-12 fmt`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked`.
+
+**Nightly toolchain:** All nightly-dependent tools (rustfmt, llvm-cov, Dylint) are pinned to `nightly-2026-03-12`. Install with `rustup toolchain install nightly-2026-03-12 --component rustfmt llvm-tools-preview`.
 
 In the Codex sandbox, prefer `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests` so native dependencies can create temp files and socket-bind tests stay skipped.
 
@@ -108,7 +110,7 @@ Union-find over `CorrelationKey` values (`Branch`, `CheckoutPath`, `ChangeReques
 - **Errors**: Provider methods return `Result<T, String>`. App-level uses `color_eyre::Result`.
 - **Async**: `async-trait` for provider traits, `tokio::join!` for parallel refresh.
 - **Enums over bools**: Prefer enum variants for state (e.g. `UiMode`, `Intent`, `WorkItemKind`).
-- **Formatting**: `cargo +nightly fmt` — uses `max_width=140`, `imports_granularity="Crate"`, `group_imports="StdExternalCrate"`. See `rustfmt.toml`.
+- **Formatting**: `cargo +nightly-2026-03-12 fmt` — uses `max_width=140`, `imports_granularity="Crate"`, `group_imports="StdExternalCrate"`. See `rustfmt.toml`.
 - **Inline paths**: Prefer `use` imports over long inline `crate::`/`self::`/`super::` paths (>3 segments). Enforced by a Dylint lint (`cargo dylint --all -- --all-targets`). Config in `dylint.toml`.
 - **Imports**: std first, external crates, then `use crate::...`.
 - **Adding dependencies is fine** when they solve a real problem — don't reinvent the wheel.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,7 @@
 # Wider lines, fewer chain/arg explosions.
-# Requires nightly rustfmt: `cargo +nightly fmt`
-# CI uses nightly for fmt; stable silently ignores the unstable keys.
+# Requires nightly rustfmt: `cargo +nightly-2026-03-12 fmt`
+# All nightly usage is pinned to nightly-2026-03-12 (CI, coverage, Dylint).
+# Stable silently ignores the unstable keys below.
 
 max_width = 140
 # "Max" sets all sub-widths (chain, fn_call, attr, array, struct_lit,


### PR DESCRIPTION
## Summary
- Pin CI fmt job and coverage job to `nightly-2026-03-12` (were using unpinned `@nightly`)
- Dylint job and lints `rust-toolchain` were already pinned — no change needed
- Update CLAUDE.md, AGENTS.md, and rustfmt.toml to document the pinned version consistently
- Add install command for contributors: `rustup toolchain install nightly-2026-03-12 --component rustfmt llvm-tools-preview`

## Test plan
- [x] `cargo +nightly-2026-03-12 fmt --check` passes locally
- [ ] CI Format job passes with pinned toolchain
- [ ] Coverage job passes with pinned toolchain

🤖 Generated with [Claude Code](https://claude.com/claude-code)