### PR TITLE
fix: prevent peer checkout duplication from merged last_snapshot

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -190,10 +190,6 @@ struct SnapshotBuildContext<'a> {
     host_name: &'a HostName,
 }
 
-fn build_repo_snapshot(ctx: SnapshotBuildContext<'_>) -> Snapshot {
-    build_repo_snapshot_with_peers(ctx, None)
-}
-
 /// Build a proto Snapshot, optionally merging peer provider data before correlation.
 fn build_repo_snapshot_with_peers(ctx: SnapshotBuildContext<'_>, peer_overlay: Option<&[(HostName, ProviderData)]>) -> Snapshot {
     let SnapshotBuildContext { repo_identity, path, seq, local_providers, errors, provider_health, cache, search_results, host_name } = ctx;
@@ -1802,6 +1798,7 @@ impl DaemonHandle for InProcessDaemon {
     async fn replay_since(&self, last_seen: &HashMap<flotilla_protocol::RepoIdentity, u64>) -> Result<Vec<DaemonEvent>, String> {
         let repos = self.repos.read().await;
         let order = self.repo_order.read().await;
+        let peer_overlay = self.peer_providers.read().await;
         let mut events = Vec::new();
 
         for identity in order.iter() {
@@ -1813,18 +1810,22 @@ impl DaemonHandle for InProcessDaemon {
             if state.seq == 0 {
                 continue;
             }
+            let peers = peer_overlay.get(identity);
             let snapshot = || {
-                build_repo_snapshot(SnapshotBuildContext {
-                    repo_identity: state.identity.clone(),
-                    path: state.preferred_path(),
-                    seq: state.seq,
-                    local_providers: &state.last_local_providers,
-                    errors: &state.last_snapshot.errors,
-                    provider_health: &state.last_snapshot.provider_health,
-                    cache: &state.issue_cache,
-                    search_results: &state.search_results,
-                    host_name: &self.host_name,
-                })
+                build_repo_snapshot_with_peers(
+                    SnapshotBuildContext {
+                        repo_identity: state.identity.clone(),
+                        path: state.preferred_path(),
+                        seq: state.seq,
+                        local_providers: &state.last_local_providers,
+                        errors: &state.last_snapshot.errors,
+                        provider_health: &state.last_snapshot.provider_health,
+                        cache: &state.issue_cache,
+                        search_results: &state.search_results,
+                        host_name: &self.host_name,
+                    },
+                    peers.map(|p| p.as_slice()),
+                )
             };
 
             match last_seen.get(&state.identity) {
@@ -2244,17 +2245,20 @@ mod tests {
         })]);
 
         let default_snap = RefreshSnapshot::default();
-        let snap = build_repo_snapshot(SnapshotBuildContext {
-            repo_identity: fallback_repo_identity(Path::new("/tmp/repo")),
-            path: Path::new("/tmp/repo"),
-            seq: 7,
-            local_providers: &default_snap.providers,
-            errors: &default_snap.errors,
-            provider_health: &default_snap.provider_health,
-            cache: &cache,
-            search_results: &None,
-            host_name: &HostName::local(),
-        });
+        let snap = build_repo_snapshot_with_peers(
+            SnapshotBuildContext {
+                repo_identity: fallback_repo_identity(Path::new("/tmp/repo")),
+                path: Path::new("/tmp/repo"),
+                seq: 7,
+                local_providers: &default_snap.providers,
+                errors: &default_snap.errors,
+                provider_health: &default_snap.provider_health,
+                cache: &cache,
+                search_results: &None,
+                host_name: &HostName::local(),
+            },
+            None,
+        );
         assert_eq!(snap.seq, 7);
         assert_eq!(snap.issue_total, Some(5));
         assert!(snap.issue_has_more);

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -520,6 +520,63 @@ async fn replay_since_returns_empty_when_up_to_date() {
     assert!(events.is_empty(), "should be empty when up to date");
 }
 
+/// replay_since must include peer provider data, just like get_state and live
+/// broadcasts. A late-subscribing or reconnecting client should see the same
+/// merged view (local + peer checkouts with correct host attribution) as a
+/// client that was connected from the start.
+#[tokio::test]
+async fn replay_since_includes_peer_checkouts_with_correct_host() {
+    let (_temp, repo, daemon, _identity) = daemon_for_git_repo("git@github.com:owner/repo.git").await;
+    let mut rx = daemon.subscribe();
+
+    // Initial refresh
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut rx).await;
+
+    // Use a peer host name that won't collide with the local hostname
+    let peer_host = HostName::new("remote-peer-host");
+    let peer_checkout_path = HostPath::new(peer_host.clone(), "/srv/remote/repo");
+    let mut peer_data = ProviderData::default();
+    peer_data.checkouts.insert(peer_checkout_path.clone(), Checkout {
+        branch: "peer-feature".into(),
+        is_main: false,
+        trunk_ahead_behind: None,
+        remote_ahead_behind: None,
+        working_tree: None,
+        last_commit: None,
+        correlation_keys: vec![],
+        association_keys: vec![],
+    });
+
+    daemon.set_peer_providers(&repo, vec![(peer_host.clone(), peer_data)]).await;
+    let _ = recv_event(&mut rx).await;
+
+    // Trigger refresh so poll_snapshots stores updated state
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut rx).await;
+
+    // Simulate a new client connecting — replay_since with empty last_seen
+    let events = daemon.replay_since(&HashMap::new()).await.expect("replay_since");
+
+    let snap = events
+        .iter()
+        .find_map(|e| match e {
+            DaemonEvent::SnapshotFull(s) if s.repo == repo => Some(s),
+            _ => None,
+        })
+        .expect("should have a SnapshotFull for our repo");
+
+    // Peer checkout must be present, attributed to its real host (not local)
+    assert!(
+        snap.providers.checkouts.contains_key(&peer_checkout_path),
+        "replay snapshot must include peer checkout under remote-peer-host, got keys: {:?}",
+        snap.providers.checkouts.keys().collect::<Vec<_>>()
+    );
+
+    // No ghost checkout under local host
+    let local_host = HostName::local();
+    let ghost = HostPath::new(local_host, PathBuf::from("/srv/remote/repo"));
+    assert!(!snap.providers.checkouts.contains_key(&ghost), "replay snapshot must not re-attribute peer checkout to local host");
+}
+
 #[tokio::test]
 async fn add_and_remove_repo_updates_state_and_emits_events() {
     let temp = tempfile::tempdir().unwrap();
@@ -719,8 +776,8 @@ async fn get_state_does_not_reattribute_peer_checkouts_after_poll() {
     // Initial refresh — populates last_snapshot with local-only data
     let _ = trigger_refresh_and_recv(&daemon, &repo, &mut rx).await;
 
-    let peer_host = HostName::new("kiwi");
-    let peer_checkout_path = HostPath::new(peer_host.clone(), "/srv/kiwi/repo");
+    let peer_host = HostName::new("remote-peer-host");
+    let peer_checkout_path = HostPath::new(peer_host.clone(), "/srv/remote/repo");
     let mut peer_data = ProviderData::default();
     peer_data.checkouts.insert(peer_checkout_path.clone(), Checkout {
         branch: "peer-feature".into(),
@@ -753,7 +810,7 @@ async fn get_state_does_not_reattribute_peer_checkouts_after_poll() {
 
     // The peer checkout must NOT appear re-attributed to the local host
     let local_host = HostName::local();
-    let ghost_checkout = HostPath::new(local_host, PathBuf::from("/srv/kiwi/repo"));
+    let ghost_checkout = HostPath::new(local_host, PathBuf::from("/srv/remote/repo"));
     assert!(!snapshot.providers.checkouts.contains_key(&ghost_checkout), "peer checkout must not be re-stamped as a local checkout");
 }
 
@@ -767,8 +824,8 @@ async fn set_peer_providers_after_poll_does_not_duplicate_checkouts() {
     // Initial refresh
     let _ = trigger_refresh_and_recv(&daemon, &repo, &mut rx).await;
 
-    let peer_host = HostName::new("kiwi");
-    let peer_checkout_path = HostPath::new(peer_host.clone(), "/srv/kiwi/repo");
+    let peer_host = HostName::new("remote-peer-host");
+    let peer_checkout_path = HostPath::new(peer_host.clone(), "/srv/remote/repo");
     let make_peer_data = |branch: &str| {
         let mut pd = ProviderData::default();
         pd.checkouts.insert(peer_checkout_path.clone(), Checkout {
@@ -802,7 +859,7 @@ async fn set_peer_providers_after_poll_does_not_duplicate_checkouts() {
     assert_eq!(peer_count, 1, "peer should have exactly 1 checkout, got {peer_count}");
 
     let local_host = HostName::local();
-    let ghost_checkout = HostPath::new(local_host, PathBuf::from("/srv/kiwi/repo"));
+    let ghost_checkout = HostPath::new(local_host, PathBuf::from("/srv/remote/repo"));
     assert!(
         !snapshot.providers.checkouts.contains_key(&ghost_checkout),
         "peer path must not appear as a local checkout after poll + repeated peer updates"


### PR DESCRIPTION
## Summary

- The identity refactor (`1c4a204`) changed `poll_snapshots` to store merged (local + peer) data in `state.last_snapshot`. When `broadcast_snapshot_inner`, `get_state`, or `replay_since` read this as a base, `normalize_local_provider_hosts` re-stamped all checkouts (including peer ones) with the local hostname, then `merge_provider_data` added the real peer checkouts again — creating ghost duplicates attributed to the wrong host.
- Separated `local_providers` from errors/health in `SnapshotBuildContext` so callers always pass `state.last_local_providers` (local-only) instead of `state.last_snapshot.providers` (merged).
- Made `last_snapshot` itself store local-only data, matching the pre-refactor invariant.
- Fixed `replay_since` to merge peer data (it previously passed no peer overlay, so late subscribers got local-only snapshots — buggy both before and after the first fix).
- Removed the unused `build_repo_snapshot` wrapper; all paths now consistently use `build_repo_snapshot_with_peers(local_providers, peer_overlay)`.

## Test plan

- [x] Unit test: `build_repo_snapshot_with_peers_does_not_duplicate_from_merged_base` — directly verifies the double-merge bug with merged base data
- [x] Integration test: `get_state_does_not_reattribute_peer_checkouts_after_poll` — end-to-end with refresh cycle
- [x] Integration test: `set_peer_providers_after_poll_does_not_duplicate_checkouts` — repeated peer updates after poll
- [x] Integration test: `replay_since_includes_peer_checkouts_with_correct_host` — late subscriber gets peer data with correct host attribution
- [x] All 1349 workspace tests pass, clippy clean, fmt clean
- [ ] Manual test: verify no checkout flapping between hosts (feta/kiwi/udder) in the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)