### PR TITLE
fix: workspace launch after checkout creation fails silently

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -455,26 +455,21 @@ pub async fn execute(
     local_host: &HostName,
 ) -> CommandResult {
     match action {
-        CommandAction::CreateWorkspaceForCheckout { checkout_path } => {
-            let host_key = HostPath::new(local_host.clone(), checkout_path.clone());
-            if let Some(co) = providers_data.checkouts.get(&host_key).cloned() {
-                info!(branch = %co.branch, "entering workspace");
-                if let Some((_, ws_mgr)) = &registry.workspace_manager {
-                    if select_existing_workspace(ws_mgr.as_ref(), &checkout_path).await {
-                        return CommandResult::Ok;
-                    }
-                    let mut config = workspace_config(&repo.root, &co.branch, &checkout_path, "claude", config_base);
-                    if let Some((_, tp)) = &registry.terminal_pool {
-                        resolve_terminal_pool(&mut config, tp.as_ref()).await;
-                    }
-                    if let Err(e) = ws_mgr.create_workspace(&config).await {
-                        return CommandResult::Error { message: e };
-                    }
+        CommandAction::CreateWorkspaceForCheckout { checkout_path, label } => {
+            info!(%label, "entering workspace");
+            if let Some((_, ws_mgr)) = &registry.workspace_manager {
+                if select_existing_workspace(ws_mgr.as_ref(), &checkout_path).await {
+                    return CommandResult::Ok;
                 }
-                CommandResult::Ok
-            } else {
-                CommandResult::Error { message: format!("checkout not found: {}", checkout_path.display()) }
+                let mut config = workspace_config(&repo.root, &label, &checkout_path, "claude", config_base);
+                if let Some((_, tp)) = &registry.terminal_pool {
+                    resolve_terminal_pool(&mut config, tp.as_ref()).await;
+                }
+                if let Err(e) = ws_mgr.create_workspace(&config).await {
+                    return CommandResult::Error { message: e };
+                }
             }
+            CommandResult::Ok
         }
 
         CommandAction::CreateWorkspaceFromPreparedTerminal { target_host, branch, checkout_path, commands } => {
@@ -1391,12 +1386,13 @@ mod tests {
     #[tokio::test]
     async fn create_workspace_for_checkout_success_without_ws_manager() {
         let registry = empty_registry();
-        let mut data = empty_data();
+        let data = empty_data();
         let path = PathBuf::from("/repo/wt-feat");
-        data.checkouts.insert(hp("/repo/wt-feat"), make_checkout("feat", "/repo/wt-feat"));
         let runner = runner_ok();
 
-        let result = run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path: path }, &registry, &data, &runner).await;
+        let result =
+            run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path: path, label: "feat".into() }, &registry, &data, &runner)
+                .await;
 
         assert_ok(result);
     }
@@ -1419,43 +1415,28 @@ mod tests {
     async fn create_workspace_for_checkout_success_with_ws_manager() {
         let mut registry = empty_registry();
         registry.workspace_manager = Some((desc("cmux"), Arc::new(MockWorkspaceManager::succeeding())));
-        let mut data = empty_data();
+        let data = empty_data();
         let path = PathBuf::from("/repo/wt-feat");
-        data.checkouts.insert(hp("/repo/wt-feat"), make_checkout("feat", "/repo/wt-feat"));
         let runner = runner_ok();
 
-        let result = run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path: path }, &registry, &data, &runner).await;
+        let result =
+            run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path: path, label: "feat".into() }, &registry, &data, &runner)
+                .await;
 
         assert_ok(result);
-    }
-
-    #[tokio::test]
-    async fn create_workspace_for_checkout_not_found() {
-        let registry = empty_registry();
-        let data = empty_data();
-        let runner = runner_ok();
-
-        let result = run_execute(
-            CommandAction::CreateWorkspaceForCheckout { checkout_path: PathBuf::from("/nonexistent") },
-            &registry,
-            &data,
-            &runner,
-        )
-        .await;
-
-        assert_error_contains(result, "checkout not found");
     }
 
     #[tokio::test]
     async fn create_workspace_for_checkout_ws_manager_fails() {
         let mut registry = empty_registry();
         registry.workspace_manager = Some((desc("cmux"), Arc::new(MockWorkspaceManager::failing("ws creation failed"))));
-        let mut data = empty_data();
+        let data = empty_data();
         let path = PathBuf::from("/repo/wt-feat");
-        data.checkouts.insert(hp("/repo/wt-feat"), make_checkout("feat", "/repo/wt-feat"));
         let runner = runner_ok();
 
-        let result = run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path: path }, &registry, &data, &runner).await;
+        let result =
+            run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path: path, label: "feat".into() }, &registry, &data, &runner)
+                .await;
 
         assert_error_eq(result, "ws creation failed");
     }
@@ -1542,7 +1523,8 @@ mod tests {
         data.checkouts.insert(hp("/repo/wt-feat"), make_checkout("feat", "/repo/wt-feat"));
         let runner = runner_ok();
 
-        let result = run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path }, &registry, &data, &runner).await;
+        let result =
+            run_execute(CommandAction::CreateWorkspaceForCheckout { checkout_path, label: "feat".into() }, &registry, &data, &runner).await;
 
         assert_ok(result);
         let calls = ws_mgr.calls.lock().await;

--- a/crates/flotilla-core/src/providers/vcs/fixtures/git_create_remote_branch.yaml
+++ b/crates/flotilla-core/src/providers/vcs/fixtures/git_create_remote_branch.yaml
@@ -56,7 +56,7 @@ interactions:
   - add
   - -b
   - feature/remote-only
-  - '{repo}/../repo.feature-remote-only'
+  - '{repo}.feature-remote-only'
   - origin/feature/remote-only
   cwd: '{repo}'
   stdout: ''
@@ -71,7 +71,7 @@ interactions:
   - '--left-right'
   - '--count'
   - HEAD...main
-  cwd: '{repo}/../repo.feature-remote-only'
+  cwd: '{repo}.feature-remote-only'
   stdout: "1\t0\n"
   stderr: null
   exit_code: 0
@@ -84,7 +84,7 @@ interactions:
   - '--left-right'
   - '--count'
   - HEAD...origin/feature/remote-only
-  cwd: '{repo}/../repo.feature-remote-only'
+  cwd: '{repo}.feature-remote-only'
   stdout: "0\t0\n"
   stderr: null
   exit_code: 0
@@ -94,7 +94,7 @@ interactions:
   args:
   - status
   - '--porcelain'
-  cwd: '{repo}/../repo.feature-remote-only'
+  cwd: '{repo}.feature-remote-only'
   stdout: ''
   stderr: null
   exit_code: 0
@@ -105,7 +105,7 @@ interactions:
   - log
   - '-1'
   - "--format=%h\t%s"
-  cwd: '{repo}/../repo.feature-remote-only'
+  cwd: '{repo}.feature-remote-only'
   stdout: "abc1234\tremote-only work\n"
   stderr: null
   exit_code: 0
@@ -116,7 +116,7 @@ interactions:
   - config
   - '--get-regexp'
   - branch\.feature/remote-only\.flotilla\.issues\.
-  cwd: '{repo}/../repo.feature-remote-only'
+  cwd: '{repo}.feature-remote-only'
   stdout: null
   stderr: ''
   exit_code: 1
@@ -128,7 +128,7 @@ interactions:
   - log
   - '-1'
   - '--format=%s'
-  cwd: '{repo}/../repo.feature-remote-only'
+  cwd: '{repo}.feature-remote-only'
   stdout: "remote-only work\n"
   stderr: null
   exit_code: 0

--- a/crates/flotilla-core/src/providers/vcs/git_worktree.rs
+++ b/crates/flotilla-core/src/providers/vcs/git_worktree.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     sync::Arc,
 };
 
@@ -10,6 +10,21 @@ use crate::{
     config::CheckoutsConfig,
     providers::{run, types::*, CommandRunner, TaskId},
 };
+
+/// Resolve `.` and `..` components in-place without touching the filesystem.
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for c in path.components() {
+        match c {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
 
 pub struct GitCheckoutManager {
     config: CheckoutsConfig,
@@ -25,6 +40,10 @@ impl GitCheckoutManager {
     }
 
     /// Render the worktree path template for a given repo and branch.
+    ///
+    /// The result is normalized to resolve `.` and `..` components so that the
+    /// returned path matches what `git worktree list` reports (which always
+    /// returns canonical absolute paths).
     fn render_worktree_path(&self, repo_root: &Path, branch: &str) -> Result<PathBuf, String> {
         let repo_name = repo_root.file_name().map(|n| n.to_string_lossy().to_string()).unwrap_or_else(|| "repo".to_string());
 
@@ -38,7 +57,8 @@ impl GitCheckoutManager {
             .map_err(|e| format!("failed to render worktree path: {e}"))?;
 
         let path = PathBuf::from(rendered.trim());
-        Ok(if path.is_absolute() { path } else { repo_root.join(&path) })
+        let absolute = if path.is_absolute() { path } else { repo_root.join(&path) };
+        Ok(normalize_path(&absolute))
     }
 
     /// Parse `git worktree list --porcelain` output into (path, branch) tuples.
@@ -326,7 +346,7 @@ branch refs/heads/feature
         let repo = Path::new("/home/user/myrepo");
 
         let path = mgr.render_worktree_path(repo, "feature/my-branch").unwrap();
-        assert_eq!(path, PathBuf::from("/home/user/myrepo/../myrepo.feature-my-branch"));
+        assert_eq!(path, PathBuf::from("/home/user/myrepo.feature-my-branch"));
     }
 
     #[test]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -46,6 +46,7 @@ pub struct Command {
 pub enum CommandAction {
     CreateWorkspaceForCheckout {
         checkout_path: PathBuf,
+        label: String,
     },
     CreateWorkspaceFromPreparedTerminal {
         target_host: crate::HostName,
@@ -281,7 +282,7 @@ mod tests {
             Command {
                 host: None,
                 context_repo: Some(RepoSelector::Identity(repo_identity())),
-                action: CommandAction::CreateWorkspaceForCheckout { checkout_path: PathBuf::from("/repo/wt") },
+                action: CommandAction::CreateWorkspaceForCheckout { checkout_path: PathBuf::from("/repo/wt"), label: "feat-x".into() },
             },
             Command { host: None, context_repo: None, action: CommandAction::SelectWorkspace { ws_ref: "ws://1".into() } },
             Command {
@@ -447,7 +448,7 @@ mod tests {
             Command {
                 host: None,
                 context_repo: None,
-                action: CommandAction::CreateWorkspaceForCheckout { checkout_path: PathBuf::from("/tmp") },
+                action: CommandAction::CreateWorkspaceForCheckout { checkout_path: PathBuf::from("/tmp"), label: "ws".into() },
             },
             Command {
                 host: Some(HostName::new("desktop")),

--- a/crates/flotilla-tui/src/app/intent.rs
+++ b/crates/flotilla-tui/src/app/intent.rs
@@ -100,11 +100,13 @@ impl Intent {
                 item.workspace_refs.first().map(|ws_ref| app.repo_command(CommandAction::SelectWorkspace { ws_ref: ws_ref.clone() }))
             }
             Intent::CreateWorkspace => item.checkout_key().map(|p| {
+                let label =
+                    item.branch.clone().unwrap_or_else(|| p.path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default());
                 let command = app.item_host_repo_command(CommandAction::PrepareTerminalForCheckout { checkout_path: p.path.clone() }, item);
                 if command.host.is_some() {
                     command
                 } else {
-                    app.repo_command(CommandAction::CreateWorkspaceForCheckout { checkout_path: p.path.clone() })
+                    app.repo_command(CommandAction::CreateWorkspaceForCheckout { checkout_path: p.path.clone(), label })
                 }
             }),
             Intent::RemoveCheckout => {
@@ -586,9 +588,10 @@ mod tests {
         let cmd = Intent::CreateWorkspace.resolve(&item, &app);
         assert!(cmd.is_some());
         match cmd.unwrap() {
-            Command { host, action: CommandAction::CreateWorkspaceForCheckout { checkout_path }, .. } => {
+            Command { host, action: CommandAction::CreateWorkspaceForCheckout { checkout_path, label }, .. } => {
                 assert_eq!(host, None);
-                assert_eq!(checkout_path, PathBuf::from("/tmp/feat-x"))
+                assert_eq!(checkout_path, PathBuf::from("/tmp/feat-x"));
+                assert_eq!(label, "feat/x");
             }
             other => panic!("expected CreateWorkspaceForCheckout, got {other:?}"),
         }

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -1597,7 +1597,7 @@ mod tests {
         app.action_enter();
         let (cmd, _) = app.proto_commands.take_next().unwrap();
         match cmd {
-            Command { action: CommandAction::CreateWorkspaceForCheckout { checkout_path }, .. } => {
+            Command { action: CommandAction::CreateWorkspaceForCheckout { checkout_path, .. }, .. } => {
                 assert_eq!(checkout_path, PathBuf::from("/tmp/a"));
             }
             other => panic!("expected CreateWorkspaceForCheckout, got {:?}", other),

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -394,13 +394,16 @@ impl App {
                     // go through the PrepareTerminal → TerminalPrepared flow instead.
                     let is_local = self.model.my_host.as_ref().is_some_and(|my| *my == host);
                     let auto_workspace = match (&result, is_local) {
-                        (CommandResult::CheckoutCreated { path, .. }, true) => Some(path.clone()),
+                        (CommandResult::CheckoutCreated { branch, path }, true) => Some((path.clone(), branch.clone())),
                         _ => None,
                     };
                     executor::handle_result(result, self);
-                    if let Some(checkout_path) = auto_workspace {
+                    if let Some((checkout_path, label)) = auto_workspace {
                         self.proto_commands.push(
-                            self.repo_command_for_identity(repo_identity, CommandAction::CreateWorkspaceForCheckout { checkout_path }),
+                            self.repo_command_for_identity(repo_identity, CommandAction::CreateWorkspaceForCheckout {
+                                checkout_path,
+                                label,
+                            }),
                         );
                     }
 
@@ -1507,7 +1510,7 @@ mod tests {
         let (cmd, _) = app.proto_commands.take_next().expect("should queue workspace creation");
         assert_eq!(cmd.context_repo, Some(RepoSelector::Identity(repo_identity)));
         match cmd.action {
-            CommandAction::CreateWorkspaceForCheckout { checkout_path: p } => assert_eq!(p, checkout_path),
+            CommandAction::CreateWorkspaceForCheckout { checkout_path: p, .. } => assert_eq!(p, checkout_path),
             other => panic!("expected CreateWorkspaceForCheckout, got {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary

- **Timing race**: `CreateWorkspaceForCheckout` looked up the checkout in `providers_data`, but the refresh cycle hadn't discovered the newly-created checkout yet (~555ms lag vs ~17ms round-trip)
- **Path mismatch**: the worktree path template produced `../` paths that didn't match the canonical paths from `git worktree list`, and `HostPath` uses exact `PathBuf` equality
- Adds a `label` field to `CreateWorkspaceForCheckout` so the executor no longer needs the `providers_data` lookup — the caller decides the workspace display name (tab/window label in zellij/tmux/cmux)
- Normalizes worktree template paths to resolve `..` components

## Test plan

- [x] `cargo test --workspace --locked` — 1348 tests pass, 0 failures
- [x] `cargo clippy --all-targets --locked -- -D warnings` — clean
- [x] `cargo +nightly-2026-03-12 fmt --check` — clean
- [ ] Manual: create a checkout via the TUI and verify workspace tab appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)