### PR TITLE
fix: catppuccin shimmer contrast

### DIFF
--- a/crates/flotilla-tui/src/theme.rs
+++ b/crates/flotilla-tui/src/theme.rs
@@ -156,8 +156,8 @@ impl Theme {
             text: p.text.into(),
             subtext: p.subtext0.into(),
             // Shimmer
-            shimmer_base: p.yellow.into(),
-            shimmer_highlight: p.rosewater.into(),
+            shimmer_base: p.peach.into(),
+            shimmer_highlight: p.yellow.into(),
             // Bar chrome
             bar_bg: p.crust.into(),
             key_hint: p.peach.into(),


### PR DESCRIPTION
## Summary

- Catppuccin mocha shimmer was using `yellow` RGB(249,226,175) as base and `rosewater` RGB(245,224,220) as highlight — delta of only (-4, -2, +45), making the sweeping band invisible
- Changed to `peach` RGB(250,179,135) → `yellow` RGB(249,226,175) which gives a visible orange-to-yellow sweep
- Classic theme was unaffected (already has strong contrast: dark gold → bright yellow)

## Test plan

- [x] All flotilla-tui tests pass
- [x] Clippy clean, fmt clean
- [ ] Manual: trigger an action in catppuccin theme, verify shimmer band is visible on the in-flight row

🤖 Generated with [Claude Code](https://claude.com/claude-code)