### PR TITLE
fix: use path-based selector for checkout removal

### DIFF
--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -352,10 +352,12 @@ impl App {
         if let Some(cmd) = intent.resolve(item, self) {
             match intent {
                 Intent::RemoveCheckout => {
+                    let checkout_path = item.checkout_key().map(|hp| hp.path.clone());
                     let widget = crate::widgets::delete_confirm::DeleteConfirmWidget::new(
                         item.terminal_keys.clone(),
                         item.identity.clone(),
                         self.item_execution_host(item),
+                        checkout_path,
                     );
                     self.widget_stack.push(Box::new(widget));
                 }
@@ -1283,7 +1285,8 @@ mod tests {
     // ── handle_delete_confirm_key (via widget stack) ────────────────
 
     fn push_delete_confirm_widget(app: &mut App, branch: &str) {
-        let mut widget = crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None);
+        let mut widget =
+            crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None, None);
         widget.update_info(CheckoutStatus {
             branch: branch.into(),
             change_request_status: None,
@@ -1330,7 +1333,7 @@ mod tests {
     fn delete_confirm_attaches_pending_context() {
         let mut app = stub_app();
         let item = make_work_item("a");
-        let mut widget = crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], item.identity.clone(), None);
+        let mut widget = crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], item.identity.clone(), None, None);
         widget.update_info(CheckoutStatus {
             branch: "feat/a".into(),
             change_request_status: None,
@@ -1355,6 +1358,7 @@ mod tests {
             vec![],
             WorkItemIdentity::Session("test".into()),
             Some(hostname.clone()),
+            None,
         );
         widget.update_info(CheckoutStatus {
             branch: "feat/x".into(),
@@ -1376,7 +1380,7 @@ mod tests {
     fn delete_confirm_ignores_while_loading() {
         let mut app = stub_app();
         // Loading widget — no info yet
-        let widget = crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None);
+        let widget = crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None, None);
         app.widget_stack.push(Box::new(widget));
         app.handle_key(key(KeyCode::Char('y')));
         // Widget should still be on the stack (Consumed, not Finished)
@@ -1640,7 +1644,8 @@ mod tests {
     #[test]
     fn delete_confirm_y_with_no_info_does_not_push_command() {
         let mut app = stub_app();
-        let mut widget = crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None);
+        let mut widget =
+            crate::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None, None);
         widget.loading = false; // not loading, but no info either
         app.widget_stack.push(Box::new(widget));
         app.handle_key(key(KeyCode::Char('y')));

--- a/crates/flotilla-tui/src/widgets/action_menu.rs
+++ b/crates/flotilla-tui/src/widgets/action_menu.rs
@@ -52,7 +52,9 @@ impl ActionMenuWidget {
                     Some(my_host) if self.item.host != *my_host => Some(self.item.host.clone()),
                     _ => None,
                 };
-                let widget = DeleteConfirmWidget::new(self.item.terminal_keys.clone(), self.item.identity.clone(), remote_host);
+                let checkout_path = self.item.checkout_key().map(|hp| hp.path.clone());
+                let widget =
+                    DeleteConfirmWidget::new(self.item.terminal_keys.clone(), self.item.identity.clone(), remote_host, checkout_path);
                 let pending_ctx =
                     PendingActionContext { identity: self.item.identity.clone(), description: entry.intent.label(labels), repo_identity };
                 ctx.commands.push_with_context(entry.command.clone(), Some(pending_ctx));

--- a/crates/flotilla-tui/src/widgets/delete_confirm.rs
+++ b/crates/flotilla-tui/src/widgets/delete_confirm.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use flotilla_protocol::{
     CheckoutSelector, CheckoutStatus, Command, CommandAction, HostName, ManagedTerminalId, RepoSelector, WorkItemIdentity,
 };
@@ -23,11 +25,17 @@ pub struct DeleteConfirmWidget {
     pub terminal_keys: Vec<ManagedTerminalId>,
     pub identity: WorkItemIdentity,
     pub remote_host: Option<HostName>,
+    pub checkout_path: Option<PathBuf>,
 }
 
 impl DeleteConfirmWidget {
-    pub fn new(terminal_keys: Vec<ManagedTerminalId>, identity: WorkItemIdentity, remote_host: Option<HostName>) -> Self {
-        Self { info: None, loading: true, terminal_keys, identity, remote_host }
+    pub fn new(
+        terminal_keys: Vec<ManagedTerminalId>,
+        identity: WorkItemIdentity,
+        remote_host: Option<HostName>,
+        checkout_path: Option<PathBuf>,
+    ) -> Self {
+        Self { info: None, loading: true, terminal_keys, identity, remote_host, checkout_path }
     }
 
     /// Update the checkout status info after the async fetch completes.
@@ -50,10 +58,11 @@ impl InteractiveWidget for DeleteConfirmWidget {
                         description: format!("Remove {}", info.branch),
                         repo_identity: ctx.model.active_repo_identity().clone(),
                     };
-                    let action = CommandAction::RemoveCheckout {
-                        checkout: CheckoutSelector::Query(info.branch.clone()),
-                        terminal_keys: self.terminal_keys.clone(),
+                    let checkout = match &self.checkout_path {
+                        Some(path) => CheckoutSelector::Path(path.clone()),
+                        None => CheckoutSelector::Query(info.branch.clone()),
                     };
+                    let action = CommandAction::RemoveCheckout { checkout, terminal_keys: self.terminal_keys.clone() };
                     let command = Command {
                         host: self.remote_host.clone(),
                         context_repo: Some(RepoSelector::Identity(ctx.model.active_repo_identity().clone())),
@@ -177,7 +186,7 @@ mod tests {
     use crate::app::test_support::TestWidgetHarness;
 
     fn make_widget() -> DeleteConfirmWidget {
-        DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None)
+        DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None, None)
     }
 
     fn make_widget_with_info(branch: &str) -> DeleteConfirmWidget {
@@ -239,7 +248,7 @@ mod tests {
     #[test]
     fn delete_confirm_attaches_pending_context() {
         let identity = WorkItemIdentity::Session("custom-id".into());
-        let mut widget = DeleteConfirmWidget::new(vec![], identity.clone(), None);
+        let mut widget = DeleteConfirmWidget::new(vec![], identity.clone(), None, None);
         widget.update_info(CheckoutStatus {
             branch: "feat/a".into(),
             change_request_status: None,
@@ -262,7 +271,7 @@ mod tests {
     #[test]
     fn delete_confirm_routes_to_remote_host_when_set() {
         let hostname = HostName::new("feta");
-        let mut widget = DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), Some(hostname.clone()));
+        let mut widget = DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), Some(hostname.clone()), None);
         widget.update_info(CheckoutStatus {
             branch: "feat/x".into(),
             change_request_status: None,
@@ -326,6 +335,33 @@ mod tests {
         let outcome = widget.handle_action(Action::Confirm, &mut ctx);
         assert!(matches!(outcome, Outcome::Finished));
         assert!(harness.commands.take_next().is_none());
+    }
+
+    #[test]
+    fn delete_confirm_uses_path_selector_when_checkout_path_set() {
+        let mut widget =
+            DeleteConfirmWidget::new(vec![], WorkItemIdentity::Session("test".into()), None, Some(PathBuf::from("/tmp/feat-x")));
+        widget.update_info(CheckoutStatus {
+            branch: "feat/x".into(),
+            change_request_status: None,
+            merge_commit_sha: None,
+            unpushed_commits: vec![],
+            has_uncommitted: false,
+            uncommitted_files: vec![],
+            base_detection_warning: None,
+        });
+        let mut harness = TestWidgetHarness::new();
+        let mut ctx = harness.ctx();
+
+        widget.handle_action(Action::Confirm, &mut ctx);
+
+        let (cmd, _) = harness.commands.take_next().expect("expected command");
+        match cmd {
+            Command { action: CommandAction::RemoveCheckout { checkout, .. }, .. } => {
+                assert_eq!(checkout, CheckoutSelector::Path(PathBuf::from("/tmp/feat-x")));
+            }
+            other => panic!("expected RemoveCheckout, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/flotilla-tui/tests/snapshots.rs
+++ b/crates/flotilla-tui/tests/snapshots.rs
@@ -382,7 +382,7 @@ fn delete_confirm_widget(
     identity: WorkItemIdentity,
     remote_host: Option<HostName>,
 ) -> Box<dyn flotilla_tui::widgets::InteractiveWidget> {
-    let mut widget = flotilla_tui::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], identity, remote_host);
+    let mut widget = flotilla_tui::widgets::delete_confirm::DeleteConfirmWidget::new(vec![], identity, remote_host, None);
     widget.update_info(info);
     Box::new(widget)
 }
@@ -620,6 +620,7 @@ fn delete_confirm_widget_renders_on_short_terminals_without_overflow() {
     let mut widget = flotilla_tui::widgets::delete_confirm::DeleteConfirmWidget::new(
         vec![],
         WorkItemIdentity::Checkout(HostPath::new(HostName::local(), PathBuf::from("/test/my-project/feat/a"))),
+        None,
         None,
     );
     widget.update_info(flotilla_protocol::CheckoutStatus {


### PR DESCRIPTION
## Summary
- **Bug:** Removing a worktree checkout with `main` checked out produced an "ambiguous selector" error because `DeleteConfirmWidget` used `CheckoutSelector::Query(branch_name)` — a fuzzy `contains()` match that could hit multiple checkouts
- **Fix:** Store the exact checkout path from the `WorkItem` at widget construction and use `CheckoutSelector::Path` for precise matching, falling back to `Query` only for the CLI path where no `WorkItem` is available

## Test plan
- [x] New test: `delete_confirm_uses_path_selector_when_checkout_path_set`
- [x] All 649 flotilla-tui unit tests pass
- [x] clippy clean, fmt clean
- [ ] Manual: remove a worktree that has `main` checked out — should no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)