### PR TITLE
refactor: remove host assumptions from claude, codex, and cmux detectors (#472)

### DIFF
--- a/crates/flotilla-core/src/providers/discovery/detectors/claude.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/claude.rs
@@ -25,9 +25,9 @@ impl HostDetector for ClaudeDetector {
             };
         }
 
-        // 2. Check known installation locations via runner (not local filesystem)
-        let known_paths: Vec<PathBuf> = env.get("HOME").into_iter().map(|h| PathBuf::from(h).join(".claude/local/claude")).collect();
-        for path in known_paths {
+        // 2. Check known installation location via runner (not local filesystem)
+        if let Some(home) = env.get("HOME") {
+            let path = PathBuf::from(home).join(".claude/local/claude");
             let path_str = path.to_str().unwrap_or("");
             if let Ok(output) = run!(runner, path_str, &["--version"], Path::new(".")) {
                 return match parse_first_dotted_version(&output) {

--- a/crates/flotilla-core/src/providers/discovery/detectors/cmux.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/cmux.rs
@@ -33,7 +33,8 @@ impl HostDetector for CmuxDetector {
         if runner.exists("cmux", &["list-sessions", "--format=json"]).await {
             assertions.push(EnvironmentAssertion::binary("cmux", "cmux"));
         } else {
-            // 3. Fall back to the macOS app-bundle path, checked via runner
+            // 3. Fall back to the macOS app-bundle path — runs the binary to confirm
+            //    it's functional, not just present on disk
             if runner.exists(CMUX_APP_BUNDLE_BIN, &["list-sessions", "--format=json"]).await {
                 assertions.push(EnvironmentAssertion::binary("cmux", CMUX_APP_BUNDLE_BIN));
             }

--- a/crates/flotilla-core/src/providers/discovery/detectors/codex.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/codex.rs
@@ -34,7 +34,10 @@ impl HostDetector for CodexAuthDetector {
         };
         let auth_path = home.join("auth.json");
         // Check existence via runner (test -f) rather than local filesystem
-        if runner.exists("test", &["-f", &auth_path.to_string_lossy()]).await {
+        let Some(path_str) = auth_path.to_str() else {
+            return vec![]; // non-UTF-8 path — can't pass to runner
+        };
+        if runner.exists("test", &["-f", path_str]).await {
             vec![EnvironmentAssertion::auth_file("codex", auth_path)]
         } else {
             vec![]


### PR DESCRIPTION
## Summary

- **Claude detector:** resolve `~/.claude/local/claude` fallback from `env.get("HOME")` instead of `dirs::home_dir()`. Run binary via runner instead of `path.is_file()` on daemon host.
- **Codex detector:** resolve `~/.codex` fallback from `env.get("HOME")` instead of `dirs::home_dir()`. Check `auth.json` existence via `runner.exists("test", &["-f", ...])` instead of `path.exists()`.
- **Cmux detector:** check app-bundle binary via `runner.exists()` instead of `path.exists()`. Correct behavior in containers where the macOS app bundle won't exist.

All detector tests now use mock runners and env vars — no filesystem dependency.

Phase B PR 2 of #472 (parent: #442).

## Test plan

- [x] All existing tests pass (1923 tests, 0 failures)
- [x] New tests: claude fallback via HOME, codex via HOME, cmux app-bundle fallback, cmux nothing
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)