### PR TITLE
fix: disable ANSI in daemon tracing when stderr is not a terminal

### DIFF
--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{io::IsTerminal, path::Path, sync::Arc, time::Duration};
 
 use flotilla_core::{config::ConfigStore, path_context::DaemonHostPath, providers::discovery::DiscoveryRuntime};
 use tracing::info;
@@ -14,7 +14,12 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
             .from_env_lossy(),
         |f, d| f.add_directive(d.parse().expect("valid directive")),
     );
-    tracing_subscriber::fmt().with_writer(std::io::stderr).with_env_filter(filter).try_init().ok();
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_ansi(std::io::stderr().is_terminal())
+        .with_env_filter(filter)
+        .try_init()
+        .ok();
 
     let timeout = if timeout_secs == 0 { Duration::from_secs(u64::MAX) } else { Duration::from_secs(timeout_secs) };
 


### PR DESCRIPTION
## Summary

- Adds `with_ansi(std::io::stderr().is_terminal())` to the daemon's tracing subscriber so ANSI escape codes are only emitted when stderr is a real terminal
- Prevents garbled log output when daemon stderr is redirected to a file or pipe

## Test plan

- [ ] `cargo clippy` and `cargo test` pass
- [ ] Daemon logs to terminal still have color
- [ ] Daemon logs redirected to file no longer contain escape sequences

🤖 Generated with [Claude Code](https://claude.com/claude-code)