### PR TITLE
fix: ensure parent dirs exist before shpool daemon file operations

### DIFF
--- a/crates/flotilla-core/src/providers/terminal/shpool.rs
+++ b/crates/flotilla-core/src/providers/terminal/shpool.rs
@@ -250,6 +250,15 @@ impl ShpoolTerminalPool {
             return;
         }
 
+        // Ensure the parent directory exists before creating the socket,
+        // log file, or pid file.
+        if let Some(parent) = socket_path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!(path = %parent.display(), err = %e, "failed to create shpool state dir");
+                return;
+            }
+        }
+
         let socket_str = socket_path.display().to_string();
         let config_str = config_path.display().to_string();
         let log_path = socket_path.with_file_name("daemonized-shpool.log");


### PR DESCRIPTION
## Summary
- Adds `create_dir_all` for the shpool state subdirectory in `start_daemon()` before creating the socket, log file, or pid file
- Matches the existing pattern already used in `write_config()`

Closes #518

## Test plan
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` passes
- [x] `cargo test --workspace --locked` passes
- [ ] Manual: verify shpool starts cleanly on a fresh state dir (no pre-existing `shpool/` subdirectory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)