### PR TITLE
fix: resolve remote checkout removal by using target_host

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -143,15 +143,15 @@ pub async fn build_plan(
             .await
         }
 
-        CommandAction::RemoveCheckout { checkout } => match resolve_checkout_branch(&checkout, &providers_data, &local_host) {
+        CommandAction::RemoveCheckout { checkout } => match resolve_checkout_branch(&checkout, &providers_data, &target_host) {
             Ok(branch) => {
                 let deleted_paths: Vec<HostPath> = providers_data
                     .checkouts
                     .iter()
-                    .filter(|(hp, co)| co.branch == branch && hp.host == local_host)
+                    .filter(|(hp, co)| co.branch == branch && hp.host == target_host)
                     .map(|(hp, _)| hp.clone())
                     .collect();
-                Ok(build_remove_checkout_plan(branch, deleted_paths, local_host))
+                Ok(build_remove_checkout_plan(branch, deleted_paths, target_host))
             }
             Err(message) => Err(CommandValue::Error { message }),
         },

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -1084,6 +1084,35 @@ async fn remove_checkout_failure() {
     assert_error_eq(result, "cannot remove trunk");
 }
 
+#[tokio::test]
+async fn remove_checkout_resolves_for_remote_host() {
+    let remote = HostName::new("remote-box");
+    let remote_hp = HostPath::new(remote.clone(), PathBuf::from("/repo/wt-feat"));
+    let mut data = empty_data();
+    data.checkouts.insert(remote_hp, TestCheckout::new("feat").build());
+
+    let config_base = config_base();
+    let plan = build_plan(
+        command_with_host("remote-box", remove_checkout_action("feat")),
+        RepoExecutionContext { identity: repo_identity(), root: repo_root() },
+        Arc::new(empty_registry()),
+        Arc::new(data),
+        config_base.clone(),
+        test_attachable_store(&config_base),
+        None,
+        local_host(),
+    )
+    .await;
+
+    let plan = plan.expect("build_plan should succeed for remote checkout");
+    assert_eq!(plan.steps.len(), 1);
+    assert_eq!(plan.steps[0].host, StepExecutionContext::Host(HostName::new("remote-box")));
+    assert!(
+        matches!(&plan.steps[0].action, StepAction::RemoveCheckout { branch, .. } if branch == "feat"),
+        "step should be RemoveCheckout for branch feat"
+    );
+}
+
 // -----------------------------------------------------------------------
 // Tests: RemoveCheckout — terminal cleanup
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `build_plan` for `RemoveCheckout` was using `local_host` (the daemon receiving the command) instead of `target_host` (from `command.host`) when looking up checkouts in `providers_data`. Remote checkouts are keyed under the remote host name, so the filter `hp.host == local_host` never matched — causing "checkout not found" on every remote deletion attempt.
- Fixed all three occurrences in the `RemoveCheckout` arm: the `resolve_checkout_branch` call, the `deleted_paths` filter, and the step host in `build_remove_checkout_plan`.
- Added a test that verifies `build_plan` succeeds for a checkout owned by a remote host (confirmed it fails without the fix).

## Test plan

- [x] New test `remove_checkout_resolves_for_remote_host` passes
- [x] Verified test fails without the fix ("checkout not found: feat")
- [x] Full `cargo test --workspace --locked` passes
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] `cargo +nightly-2026-03-12 fmt --check` clean
- [ ] Manual: remove a remote checkout from a multi-host TUI session

🤖 Generated with [Claude Code](https://claude.com/claude-code)