### PR TITLE
[codex] fix issue-row actions and branch naming fallbacks

### DIFF
--- a/crates/flotilla-core/src/data.rs
+++ b/crates/flotilla-core/src/data.rs
@@ -393,9 +393,11 @@ fn group_to_work_item(providers: &ProviderData, group: &CorrelatedGroup, group_i
     let description = pr_title.or(session_title).or(agent_title).or_else(|| branch.clone()).or(set_description).unwrap_or_default();
 
     let source = match &anchor {
-        CorrelatedAnchor::Checkout(co) => {
-            co.host_path().map(|path| path.host.to_string()).or_else(|| co.key.host_name().map(ToString::to_string))
-        }
+        CorrelatedAnchor::Checkout(co) => co
+            .host_path()
+            .map(|path| path.host.to_string())
+            .or_else(|| co.key.host_name().map(ToString::to_string))
+            .or_else(|| host.as_ref().map(ToString::to_string)),
         CorrelatedAnchor::AttachableSet(id) => providers.attachable_sets.get(id).and_then(|set| {
             set.checkout
                 .as_ref()

--- a/crates/flotilla-core/src/data/tests.rs
+++ b/crates/flotilla-core/src/data/tests.rs
@@ -226,6 +226,32 @@ fn host_falls_back_to_checkout_host_provenance_when_key_has_host_id() {
 }
 
 #[test]
+fn checkout_source_falls_back_to_provider_host_for_environment_qualified_paths() {
+    let checkout_key = flotilla_protocol::qualified_path::QualifiedPath::environment(
+        flotilla_protocol::EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new("peer-host-id")),
+        "/repos/feat-remote",
+    );
+    let mut providers = ProviderData::default();
+    providers.checkouts.insert(checkout_key.clone(), Checkout {
+        branch: "feat-remote".into(),
+        is_main: false,
+        trunk_ahead_behind: None,
+        remote_ahead_behind: None,
+        working_tree: None,
+        last_commit: None,
+        correlation_keys: vec![CorrelationKey::Branch("feat-remote".into()), CorrelationKey::CheckoutPath(checkout_key.clone())],
+        association_keys: vec![],
+        host_name: Some(flotilla_protocol::HostName::new("follower")),
+        environment_id: checkout_key.environment_id().cloned(),
+    });
+
+    let grouped = crate::data::correlate(&providers).0;
+    let checkout = grouped.iter().find(|item| item.branch() == Some("feat-remote")).expect("correlated checkout");
+
+    assert_eq!(checkout.source(), Some("follower"));
+}
+
+#[test]
 fn is_main_checkout_true() {
     let wi = checkout_item("/repos/main", Some("main"), true);
     assert!(wi.is_main_checkout());

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -742,14 +742,16 @@ impl StepResolver for ExecutorStepResolver {
                 Ok(StepOutcome::Completed)
             }
             StepAction::ArchiveSession { session_id } => {
-                let session_actions = ReadOnlySessionActionService::new(self.registry.as_ref(), self.providers_data.as_ref());
+                let session_actions =
+                    ReadOnlySessionActionService::new(&self.repo.root, self.registry.as_ref(), self.providers_data.as_ref());
                 match session_actions.archive_session_result(&session_id).await {
                     CommandValue::Error { message } => Err(message),
                     result => Ok(StepOutcome::CompletedWith(result)),
                 }
             }
             StepAction::GenerateBranchName { issue_keys } => {
-                let session_actions = ReadOnlySessionActionService::new(self.registry.as_ref(), self.providers_data.as_ref());
+                let session_actions =
+                    ReadOnlySessionActionService::new(&effective_repo_root, effective_registry.as_ref(), effective_providers_data.as_ref());
                 Ok(StepOutcome::CompletedWith(session_actions.generate_branch_name_result(&issue_keys).await))
             }
             StepAction::PrepareWorkspace { checkout_path: explicit_path, label, display_host } => {

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -743,7 +743,7 @@ impl StepResolver for ExecutorStepResolver {
             }
             StepAction::ArchiveSession { session_id } => {
                 let session_actions =
-                    ReadOnlySessionActionService::new(&self.repo.root, self.registry.as_ref(), self.providers_data.as_ref());
+                    ReadOnlySessionActionService::new(&effective_repo_root, effective_registry.as_ref(), effective_providers_data.as_ref());
                 match session_actions.archive_session_result(&session_id).await {
                     CommandValue::Error { message } => Err(message),
                     result => Ok(StepOutcome::CompletedWith(result)),

--- a/crates/flotilla-core/src/executor/session_actions.rs
+++ b/crates/flotilla-core/src/executor/session_actions.rs
@@ -77,10 +77,17 @@ impl<'a> ReadOnlySessionActionService<'a> {
             .collect();
 
         info!(requested_issue_count = issue_keys.len(), resolved_issue_count = issues.len(), "generating branch name");
-        let branch_result = if issues.is_empty() {
-            None
-        } else if let Some(ai) = self.registry.ai_utilities.preferred() {
-            let context: Vec<String> = issues.iter().map(|(id, issue)| self.format_branch_issue_context(id, issue)).collect();
+        let branch_result = if let Some(ai) = self.registry.ai_utilities.preferred() {
+            let context: Vec<String> = issue_keys
+                .iter()
+                .map(|id| {
+                    issues
+                        .iter()
+                        .find(|(issue_id, _)| issue_id == id)
+                        .map(|(_, issue)| self.format_branch_issue_context(id, issue))
+                        .unwrap_or_else(|| format!("issue {id}"))
+                })
+                .collect();
             let prompt_text = if context.len() == 1 { context[0].clone() } else { context.join("; ") };
             Some(ai.generate_branch_name(&prompt_text).await)
         } else {
@@ -99,10 +106,10 @@ impl<'a> ReadOnlySessionActionService<'a> {
                 CommandValue::BranchNameGenerated { name, issue_ids: issue_id_pairs }
             }
             None => {
-                if issues.is_empty() {
-                    warn!("using fallback branch name without resolved issue context");
-                } else {
+                if !issues.is_empty() {
                     warn!("using fallback branch name without AI provider");
+                } else {
+                    warn!("using fallback branch name without resolved issue context");
                 }
                 let fallback: Vec<String> = issue_keys.iter().map(|id| format!("issue-{id}")).collect();
                 let name = fallback.join("-");
@@ -123,7 +130,7 @@ impl<'a> ReadOnlySessionActionService<'a> {
                 match tracker.fetch_issues_by_id(self.repo_root.as_path(), &missing).await {
                     Ok(fetched) => {
                         for (id, issue) in fetched {
-                            resolved.entry(id).or_insert(issue);
+                            resolved.insert(id, issue);
                         }
                     }
                     Err(error) => {

--- a/crates/flotilla-core/src/executor/session_actions.rs
+++ b/crates/flotilla-core/src/executor/session_actions.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
-use flotilla_protocol::{CommandValue, HostName};
+use flotilla_protocol::{provider_data::Issue, CommandValue, HostName};
 use tracing::{info, warn};
 
 use super::WorkspaceOrchestrator;
@@ -16,6 +16,7 @@ use crate::{
 };
 
 pub(super) struct ReadOnlySessionActionService<'a> {
+    repo_root: &'a ExecutionEnvironmentPath,
     registry: &'a ProviderRegistry,
     providers_data: &'a ProviderData,
 }
@@ -36,8 +37,8 @@ pub(super) struct TeleportFlow<'a> {
 }
 
 impl<'a> ReadOnlySessionActionService<'a> {
-    pub(super) fn new(registry: &'a ProviderRegistry, providers_data: &'a ProviderData) -> Self {
-        Self { registry, providers_data }
+    pub(super) fn new(repo_root: &'a ExecutionEnvironmentPath, registry: &'a ProviderRegistry, providers_data: &'a ProviderData) -> Self {
+        Self { repo_root, registry, providers_data }
     }
 
     pub(super) async fn archive_session_result(&self, session_id: &str) -> CommandValue {
@@ -61,20 +62,25 @@ impl<'a> ReadOnlySessionActionService<'a> {
     }
 
     pub(super) async fn generate_branch_name_result(&self, issue_keys: &[String]) -> CommandValue {
-        let issues: Vec<(String, String)> = issue_keys
+        let issues = self.resolve_branch_name_issues(issue_keys).await;
+
+        let issue_id_pairs: Vec<(String, String)> = issue_keys
             .iter()
-            .filter_map(|key| self.providers_data.issues.get(key.as_str()).map(|issue| (key.clone(), issue.title.clone())))
+            .map(|id| {
+                let provider = issues
+                    .iter()
+                    .find(|(issue_id, _)| issue_id == id)
+                    .map(|(_, issue)| self.provider_name_for_issue(issue))
+                    .unwrap_or_else(|| self.default_issue_provider_name());
+                (provider, id.clone())
+            })
             .collect();
 
-        let issue_id_pairs: Vec<(String, String)> = {
-            let provider =
-                self.registry.issue_trackers.preferred_name().map(|name| name.to_string()).unwrap_or_else(|| "issues".to_string());
-            issues.iter().map(|(id, _title)| (provider.clone(), id.clone())).collect()
-        };
-
-        info!(issue_count = issue_keys.len(), "generating branch name");
-        let branch_result = if let Some(ai) = self.registry.ai_utilities.preferred() {
-            let context: Vec<String> = issues.iter().map(|(id, title)| format!("{} #{}", title, id)).collect();
+        info!(requested_issue_count = issue_keys.len(), resolved_issue_count = issues.len(), "generating branch name");
+        let branch_result = if issues.is_empty() {
+            None
+        } else if let Some(ai) = self.registry.ai_utilities.preferred() {
+            let context: Vec<String> = issues.iter().map(|(id, issue)| self.format_branch_issue_context(id, issue)).collect();
             let prompt_text = if context.len() == 1 { context[0].clone() } else { context.join("; ") };
             Some(ai.generate_branch_name(&prompt_text).await)
         } else {
@@ -88,16 +94,65 @@ impl<'a> ReadOnlySessionActionService<'a> {
             }
             Some(Err(error)) => {
                 warn!(%error, "using fallback branch name after AI failure");
-                let fallback: Vec<String> = issues.iter().map(|(id, _)| format!("issue-{}", id)).collect();
+                let fallback: Vec<String> = issue_keys.iter().map(|id| format!("issue-{id}")).collect();
                 let name = fallback.join("-");
                 CommandValue::BranchNameGenerated { name, issue_ids: issue_id_pairs }
             }
             None => {
-                warn!("using fallback branch name without AI provider");
-                let fallback: Vec<String> = issues.iter().map(|(id, _)| format!("issue-{}", id)).collect();
+                if issues.is_empty() {
+                    warn!("using fallback branch name without resolved issue context");
+                } else {
+                    warn!("using fallback branch name without AI provider");
+                }
+                let fallback: Vec<String> = issue_keys.iter().map(|id| format!("issue-{id}")).collect();
                 let name = fallback.join("-");
                 CommandValue::BranchNameGenerated { name, issue_ids: issue_id_pairs }
             }
+        }
+    }
+
+    async fn resolve_branch_name_issues(&self, issue_keys: &[String]) -> Vec<(String, Issue)> {
+        let mut resolved: HashMap<String, Issue> = issue_keys
+            .iter()
+            .filter_map(|key| self.providers_data.issues.get(key.as_str()).cloned().map(|issue| (key.clone(), issue)))
+            .collect();
+
+        let missing: Vec<String> = issue_keys.iter().filter(|key| !resolved.contains_key(key.as_str())).cloned().collect();
+        if !missing.is_empty() {
+            if let Some(tracker) = self.registry.issue_trackers.preferred() {
+                match tracker.fetch_issues_by_id(self.repo_root.as_path(), &missing).await {
+                    Ok(fetched) => {
+                        for (id, issue) in fetched {
+                            resolved.entry(id).or_insert(issue);
+                        }
+                    }
+                    Err(error) => {
+                        warn!(%error, missing_issue_count = missing.len(), "failed to fetch missing issues for branch naming");
+                    }
+                }
+            }
+        }
+
+        issue_keys.iter().filter_map(|key| resolved.get(key.as_str()).cloned().map(|issue| (key.clone(), issue))).collect()
+    }
+
+    fn format_branch_issue_context(&self, id: &str, issue: &Issue) -> String {
+        if issue.labels.is_empty() {
+            format!("{} #{}", issue.title, id)
+        } else {
+            format!("{} #{} [{}]", issue.title, id, issue.labels.join(", "))
+        }
+    }
+
+    fn default_issue_provider_name(&self) -> String {
+        self.registry.issue_trackers.preferred_name().map(|name| name.to_string()).unwrap_or_else(|| "issues".to_string())
+    }
+
+    fn provider_name_for_issue(&self, issue: &Issue) -> String {
+        if issue.provider_name.is_empty() {
+            self.default_issue_provider_name()
+        } else {
+            issue.provider_name.clone()
         }
     }
 }
@@ -115,7 +170,7 @@ impl<'a> TeleportSessionActionService<'a> {
         terminal_manager: Option<&'a TerminalManager>,
     ) -> Self {
         Self {
-            read_only: ReadOnlySessionActionService::new(registry, providers_data),
+            read_only: ReadOnlySessionActionService::new(repo_root, registry, providers_data),
             repo_root,
             config_base,
             attachable_store,

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -1763,6 +1763,24 @@ async fn generate_branch_name_unknown_issue_key_uses_requested_ids() {
     assert_branch_name_generated(result, "issue-nonexistent", &[("issues", "nonexistent")]);
 }
 
+#[tokio::test]
+async fn generate_branch_name_unknown_issue_key_still_uses_ai_context() {
+    let mut registry = empty_registry();
+    registry.ai_utilities.insert("claude", desc("claude"), Arc::new(MockAiUtility::succeeding("feat/from-placeholder")));
+    let data = empty_data();
+    let runner = runner_ok();
+
+    let result = run_build_plan_to_completion(
+        CommandAction::GenerateBranchName { issue_keys: vec!["nonexistent".to_string()] },
+        registry,
+        data,
+        runner,
+    )
+    .await;
+
+    assert_branch_name_generated(result, "feat/from-placeholder", &[("issues", "nonexistent")]);
+}
+
 // -----------------------------------------------------------------------
 // Tests: TeleportSession
 // -----------------------------------------------------------------------

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -208,7 +208,20 @@ impl ChangeRequestTracker for MockChangeRequestTracker {
 }
 
 /// A mock IssueProvider provider.
-struct MockIssueProvider;
+struct MockIssueProvider {
+    fetched_by_id: tokio::sync::Mutex<Vec<Vec<String>>>,
+    fetched_issues: Vec<(String, Issue)>,
+}
+
+impl MockIssueProvider {
+    fn empty() -> Self {
+        Self { fetched_by_id: tokio::sync::Mutex::new(Vec::new()), fetched_issues: Vec::new() }
+    }
+
+    fn with_fetched_issues(fetched_issues: Vec<(String, Issue)>) -> Self {
+        Self { fetched_by_id: tokio::sync::Mutex::new(Vec::new()), fetched_issues }
+    }
+}
 
 #[async_trait]
 impl IssueProvider for MockIssueProvider {
@@ -217,6 +230,11 @@ impl IssueProvider for MockIssueProvider {
     }
     async fn open_in_browser(&self, _repo_root: &Path, _id: &str) -> Result<(), String> {
         Ok(())
+    }
+
+    async fn fetch_issues_by_id(&self, _repo_root: &Path, ids: &[String]) -> Result<Vec<(String, Issue)>, String> {
+        self.fetched_by_id.lock().await.push(ids.to_vec());
+        Ok(self.fetched_issues.iter().filter(|(id, _)| ids.iter().any(|requested| requested == id)).cloned().collect())
     }
 }
 
@@ -1487,7 +1505,7 @@ async fn open_issue_no_provider() {
 #[tokio::test]
 async fn open_issue_with_provider() {
     let mut registry = empty_registry();
-    registry.issue_trackers.insert("github", desc("github"), Arc::new(MockIssueProvider));
+    registry.issue_trackers.insert("github", desc("github"), Arc::new(MockIssueProvider::empty()));
     let runner = runner_ok();
 
     let result = run_build_plan_to_completion(CommandAction::OpenIssue { id: "10".to_string() }, registry, empty_data(), runner).await;
@@ -1640,7 +1658,7 @@ async fn archive_session_agent_fails() {
 async fn generate_branch_name_ai_success() {
     let mut registry = empty_registry();
     registry.ai_utilities.insert("claude", desc("claude"), Arc::new(MockAiUtility::succeeding("feat/add-login")));
-    registry.issue_trackers.insert("github", desc("github"), Arc::new(MockIssueProvider));
+    registry.issue_trackers.insert("github", desc("github"), Arc::new(MockIssueProvider::empty()));
     let mut data = empty_data();
     data.issues.insert("42".to_string(), TestIssue::new("Add login feature").build());
     let runner = runner_ok();
@@ -1685,7 +1703,7 @@ async fn generate_branch_name_no_ai_provider_uses_fallback() {
 async fn generate_branch_name_multiple_issues() {
     let mut registry = empty_registry();
     registry.ai_utilities.insert("claude", desc("claude"), Arc::new(MockAiUtility::succeeding("feat/login-and-signup")));
-    registry.issue_trackers.insert("github", desc("github"), Arc::new(MockIssueProvider));
+    registry.issue_trackers.insert("github", desc("github"), Arc::new(MockIssueProvider::empty()));
     let mut data = empty_data();
     data.issues.insert("1".to_string(), TestIssue::new("Login feature").build());
     data.issues.insert("2".to_string(), TestIssue::new("Signup feature").build());
@@ -1703,7 +1721,33 @@ async fn generate_branch_name_multiple_issues() {
 }
 
 #[tokio::test]
-async fn generate_branch_name_unknown_issue_key() {
+async fn generate_branch_name_fetches_missing_issue_details() {
+    let mut registry = empty_registry();
+    registry.ai_utilities.insert("claude", desc("claude"), Arc::new(MockAiUtility::succeeding("feat/from-fetched-issue")));
+    let fetched_issue = Issue {
+        title: "Fix login redirect".to_string(),
+        labels: vec!["bug".to_string(), "auth".to_string()],
+        association_keys: vec![],
+        provider_name: "github".to_string(),
+        provider_display_name: "GitHub".to_string(),
+    };
+    registry.issue_trackers.insert(
+        "github",
+        desc("github"),
+        Arc::new(MockIssueProvider::with_fetched_issues(vec![("42".to_string(), fetched_issue)])),
+    );
+    let data = empty_data();
+    let runner = runner_ok();
+
+    let result =
+        run_build_plan_to_completion(CommandAction::GenerateBranchName { issue_keys: vec!["42".to_string()] }, registry, data, runner)
+            .await;
+
+    assert_branch_name_generated(result, "feat/from-fetched-issue", &[("github", "42")]);
+}
+
+#[tokio::test]
+async fn generate_branch_name_unknown_issue_key_uses_requested_ids() {
     let registry = empty_registry();
     let data = empty_data();
     let runner = runner_ok();
@@ -1716,8 +1760,7 @@ async fn generate_branch_name_unknown_issue_key() {
     )
     .await;
 
-    // No issues found, so empty fallback
-    assert_branch_name_generated(result, "", &[]);
+    assert_branch_name_generated(result, "issue-nonexistent", &[("issues", "nonexistent")]);
 }
 
 // -----------------------------------------------------------------------

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -496,7 +496,7 @@ async fn daemon_for_cwd() -> (tempfile::TempDir, PathBuf, Arc<InProcessDaemon>) 
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(repo.join(".git")).expect("create .git dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, fake_discovery(false), HostName::local()).await;
     (temp, repo, daemon)
 }
@@ -505,7 +505,7 @@ async fn daemon_for_plain_dir() -> (tempfile::TempDir, PathBuf, Arc<InProcessDae
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, fake_discovery(false), HostName::local()).await;
     (temp, repo, daemon)
 }
@@ -514,9 +514,15 @@ async fn daemon_for_plain_dir_with_discovery(discovery: DiscoveryRuntime) -> (te
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, discovery, HostName::local()).await;
     (temp, repo, daemon)
+}
+
+fn test_config_store(config_dir: PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(config_dir))
 }
 
 fn static_ssh_test_discovery(runner: Arc<dyn CommandRunner>) -> DiscoveryRuntime {
@@ -1908,7 +1914,7 @@ async fn archive_session_can_be_cancelled_while_provider_call_is_in_flight() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(repo.join(".git")).expect("create .git dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let agent = Arc::new(SlowCloudAgent::new());
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, slow_cloud_agent_discovery(Arc::clone(&agent)), HostName::local()).await;
     let mut rx = daemon.subscribe();
@@ -1970,7 +1976,7 @@ async fn generate_branch_name_can_be_cancelled_while_provider_call_is_in_flight(
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(repo.join(".git")).expect("create .git dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let utility = Arc::new(SlowAiUtility::new());
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, slow_ai_discovery(Arc::clone(&utility)), HostName::local()).await;
     let mut rx = daemon.subscribe();

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -229,24 +229,19 @@ impl App {
         let multi_selected = page.multi_selected.clone();
         let mut all_issue_keys: Vec<String> = Vec::new();
 
-        // Collect issues from multi-selected items
-        for item in page.table.all_items() {
-            if multi_selected.contains(&item.identity) {
-                all_issue_keys.extend(item.issue_keys.iter().cloned());
+        for selected in &multi_selected {
+            if let Some(issue_keys) = page.table.issue_keys_for_identity(selected) {
+                all_issue_keys.extend(issue_keys);
             }
         }
 
         // Also include current selection if not already in multi_selected
-        match self.selected_row_cloned() {
-            Some(OwnedSelectedRow::WorkItem(ref item)) => {
-                if !multi_selected.contains(&item.identity) {
-                    all_issue_keys.extend(item.issue_keys.iter().cloned());
+        if let Some(selected_identity) = page.table.selected_identity() {
+            if !multi_selected.contains(&selected_identity) {
+                if let Some(issue_keys) = page.table.issue_keys_for_identity(&selected_identity) {
+                    all_issue_keys.extend(issue_keys);
                 }
             }
-            Some(OwnedSelectedRow::IssueRow(row)) => {
-                all_issue_keys.push(row.id);
-            }
-            None => {}
         }
 
         all_issue_keys.sort();
@@ -262,8 +257,11 @@ impl App {
     }
 
     fn dispatch_if_available(&mut self, intent: Intent) {
-        // dispatch only applies to WorkItem rows (intents operate on WorkItem)
-        let Some(item) = self.selected_work_item().cloned() else {
+        let Some(item) = (match self.selected_row_cloned() {
+            Some(OwnedSelectedRow::WorkItem(item)) => Some(*item),
+            Some(OwnedSelectedRow::IssueRow(row)) => Some(self.work_item_for_issue_row(&row)),
+            None => None,
+        }) else {
             return;
         };
         let my_node_id = self.model.my_node_id().cloned();
@@ -388,9 +386,11 @@ impl App {
     }
 
     pub(super) fn open_action_menu(&mut self) {
-        // Action menu only applies to WorkItem rows; IssueRows have no
-        // Intent-based actions beyond the built-in Enter behaviour.
-        let Some(item) = self.selected_work_item().cloned() else {
+        let Some(item) = (match self.selected_row_cloned() {
+            Some(OwnedSelectedRow::WorkItem(item)) => Some(*item),
+            Some(OwnedSelectedRow::IssueRow(row)) => Some(self.work_item_for_issue_row(&row)),
+            None => None,
+        }) else {
             return;
         };
 

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -25,6 +25,33 @@ fn hp(path: &str) -> HostPath {
     HostPath::new(HostName::local(), PathBuf::from(path))
 }
 
+fn native_issue_row(id: &str) -> crate::widgets::section_table::IssueRow {
+    crate::widgets::section_table::IssueRow {
+        id: id.to_string(),
+        issue: flotilla_protocol::provider_data::Issue {
+            title: format!("Issue {id}"),
+            labels: vec![],
+            association_keys: vec![],
+            provider_name: "github".into(),
+            provider_display_name: "GitHub".into(),
+        },
+    }
+}
+
+fn setup_native_issue_rows(app: &mut App, issue_ids: &[&str]) {
+    let repo_key = app.model.repo_order[app.model.active_repo].clone();
+    if let Some(handle) = app.repo_data.get(&repo_key) {
+        handle.mutate(|d| {
+            d.work_items.clear();
+            d.issue_rows = issue_ids.iter().map(|id| native_issue_row(id)).collect();
+            d.issue_section_label = "Issues".into();
+        });
+    }
+    if let Some(page) = app.screen.repo_pages.get_mut(&repo_key) {
+        page.reconcile_if_changed();
+    }
+}
+
 /// Read the active RepoPage's selected flat index.
 fn active_selection(app: &App) -> Option<usize> {
     let identity = &app.model.repo_order[app.model.active_repo];
@@ -1388,6 +1415,56 @@ fn action_enter_multi_select_without_issues_clears() {
     let identity = app.model.repo_order[0].clone();
     let page = app.screen.repo_pages.get(&identity).expect("page exists");
     assert!(page.multi_selected.is_empty());
+}
+
+#[test]
+fn action_enter_multi_select_generates_branch_name_for_native_issue_rows() {
+    let mut app = stub_app();
+    setup_native_issue_rows(&mut app, &["ISSUE-1", "ISSUE-2"]);
+
+    let identity = app.model.repo_order[0].clone();
+    let page = app.screen.repo_pages.get_mut(&identity).expect("page exists");
+    page.multi_selected.insert(WorkItemIdentity::Issue("ISSUE-1".into()));
+    page.multi_selected.insert(WorkItemIdentity::Issue("ISSUE-2".into()));
+
+    app.action_enter();
+
+    assert_eq!(app.screen.modal_stack.len(), 1);
+    assert_eq!(
+        app.screen.modal_stack.last().expect("modal stack non-empty").binding_mode(),
+        KeyBindingMode::from(BindingModeId::BranchInput)
+    );
+    let (cmd, _) = app.proto_commands.take_next().expect("expected command");
+    match cmd {
+        Command { action: CommandAction::GenerateBranchName { issue_keys }, .. } => {
+            assert_eq!(issue_keys, vec!["ISSUE-1".to_string(), "ISSUE-2".to_string()]);
+        }
+        other => panic!("expected GenerateBranchName, got {:?}", other),
+    }
+
+    let page = app.screen.repo_pages.get(&identity).expect("page exists");
+    assert!(page.multi_selected.is_empty());
+}
+
+#[test]
+fn dispatch_generate_branch_name_from_native_issue_row() {
+    let mut app = stub_app();
+    setup_native_issue_rows(&mut app, &["ISSUE-1"]);
+
+    app.dispatch_if_available(Intent::GenerateBranchName);
+
+    assert_eq!(app.screen.modal_stack.len(), 1);
+    assert_eq!(
+        app.screen.modal_stack.last().expect("modal stack non-empty").binding_mode(),
+        KeyBindingMode::from(BindingModeId::BranchInput)
+    );
+    let (cmd, _) = app.proto_commands.take_next().expect("expected command");
+    match cmd {
+        Command { action: CommandAction::GenerateBranchName { issue_keys }, .. } => {
+            assert_eq!(issue_keys, vec!["ISSUE-1".to_string()]);
+        }
+        other => panic!("expected GenerateBranchName, got {:?}", other),
+    }
 }
 
 // ── delete_confirm_y_with_no_info ────────────────────────────────

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -526,6 +526,27 @@ impl App {
         }
     }
 
+    pub(super) fn work_item_for_issue_row(&self, row: &IssueRow) -> WorkItem {
+        WorkItem {
+            kind: flotilla_protocol::WorkItemKind::Issue,
+            identity: WorkItemIdentity::Issue(row.id.clone()),
+            node_id: self.model.my_node_id().cloned().unwrap_or_else(|| NodeId::new("issue-row")),
+            branch: None,
+            description: row.issue.title.clone(),
+            checkout: None,
+            change_request_key: None,
+            session_key: None,
+            issue_keys: vec![row.id.clone()],
+            workspace_refs: vec![],
+            is_main_checkout: false,
+            debug_group: vec![],
+            source: (!row.issue.provider_display_name.is_empty()).then(|| row.issue.provider_display_name.clone()),
+            terminal_keys: vec![],
+            attachable_set_id: None,
+            agent_keys: vec![],
+        }
+    }
+
     pub fn repo_path_for_identity(&self, identity: &RepoIdentity) -> Option<PathBuf> {
         self.model.repos.get(identity).map(|repo| repo.path.clone())
     }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -530,6 +530,8 @@ impl App {
         WorkItem {
             kind: flotilla_protocol::WorkItemKind::Issue,
             identity: WorkItemIdentity::Issue(row.id.clone()),
+            // Issue rows are synthesized from the local repo view, so the local
+            // node id should already be known; this fallback is only a safety net.
             node_id: self.model.my_node_id().cloned().unwrap_or_else(|| NodeId::new("issue-row")),
             branch: None,
             description: row.issue.title.clone(),

--- a/crates/flotilla-tui/src/widgets/columns.rs
+++ b/crates/flotilla-tui/src/widgets/columns.rs
@@ -1,5 +1,5 @@
 use flotilla_core::data::SectionKind;
-use flotilla_protocol::WorkItem;
+use flotilla_protocol::{HostName, WorkItem};
 use ratatui::{layout::Constraint, style::Style, text::Span};
 
 use super::section_table::{ColumnDef, IssueRow, RenderCtx};
@@ -31,11 +31,17 @@ fn checkout_columns() -> Vec<ColumnDef<WorkItem>> {
         source_column(),
         col("Path", Constraint::Fill(1), |item, ctx| {
             let text = if let Some(hp) = item.checkout_key() {
-                let host_name = hp.host_name();
-                let is_local = host_name.is_none() || ctx.my_host.is_none() || ctx.my_host == host_name;
+                let display_host = item
+                    .checkout
+                    .as_ref()
+                    .and_then(|checkout| checkout.host_path())
+                    .map(|path| path.host.clone())
+                    .or_else(|| item.source.as_ref().map(HostName::new))
+                    .or_else(|| hp.host_name().cloned());
+                let is_local = display_host.as_ref().is_none_or(|host| ctx.my_host.is_none() || ctx.my_host == Some(host));
                 let (repo_root, home_dir) = if is_local {
                     (ctx.repo_root.to_path_buf(), dirs::home_dir())
-                } else if let Some(host_name) = host_name {
+                } else if let Some(host_name) = display_host.as_ref() {
                     let root = ctx.host_repo_roots.get(host_name).cloned().unwrap_or_else(|| hp.path.clone());
                     let home = ctx.host_home_dirs.get(host_name).map(|p| p.to_path_buf());
                     (root, home)

--- a/crates/flotilla-tui/src/widgets/repo_page.rs
+++ b/crates/flotilla-tui/src/widgets/repo_page.rs
@@ -182,7 +182,7 @@ impl RepoPage {
         // Query-driven issues go into a native IssueRow section.
         self.table.update_issue_section(data.issue_section_label.clone(), data.issue_rows.clone());
 
-        let current_identities: HashSet<WorkItemIdentity> = self.table.all_items().map(|item| item.identity.clone()).collect();
+        let current_identities: HashSet<WorkItemIdentity> = self.table.all_identities().collect();
         self.multi_selected.retain(|id| current_identities.contains(id));
         self.pending_actions.retain(|id, _| current_identities.contains(id));
     }
@@ -264,9 +264,7 @@ impl RepoPage {
     }
 
     fn toggle_multi_select(&mut self) {
-        // Multi-select only applies to WorkItem rows (which have identities).
-        if let Some(item) = self.table.selected_work_item() {
-            let identity = item.identity.clone();
+        if let Some(identity) = self.table.selected_identity() {
             if !self.multi_selected.remove(&identity) {
                 self.multi_selected.insert(identity);
             }
@@ -274,8 +272,8 @@ impl RepoPage {
     }
 
     pub fn select_all(&mut self) {
-        for item in self.table.all_items() {
-            self.multi_selected.insert(item.identity.clone());
+        for identity in self.table.all_identities() {
+            self.multi_selected.insert(identity);
         }
     }
 }

--- a/crates/flotilla-tui/src/widgets/repo_page/tests.rs
+++ b/crates/flotilla-tui/src/widgets/repo_page/tests.rs
@@ -1,4 +1,4 @@
-use flotilla_protocol::{CloudAgentSession, ProviderData, RepoLabels, SessionStatus, WorkItemIdentity};
+use flotilla_protocol::{provider_data::Issue, CloudAgentSession, ProviderData, RepoLabels, SessionStatus, WorkItemIdentity};
 
 use super::*;
 use crate::app::test_support::{issue_item, session_item, TestWidgetHarness};
@@ -17,6 +17,33 @@ fn test_repo_data(items: Vec<WorkItem>) -> Shared<RepoData> {
         work_items: items,
         issue_rows: Vec::new(),
         issue_section_label: String::new(),
+        loading: false,
+    })
+}
+
+fn native_issue_row(id: &str) -> IssueRow {
+    IssueRow {
+        id: id.to_string(),
+        issue: Issue {
+            title: format!("Issue {id}"),
+            labels: vec![],
+            association_keys: vec![],
+            provider_name: "github".into(),
+            provider_display_name: "GitHub".into(),
+        },
+    }
+}
+
+fn test_repo_data_with_issue_rows(issue_rows: Vec<IssueRow>) -> Shared<RepoData> {
+    Shared::new(RepoData {
+        path: PathBuf::from("/tmp/test-repo"),
+        providers: Arc::new(ProviderData::default()),
+        labels: RepoLabels::default(),
+        provider_names: HashMap::new(),
+        provider_health: HashMap::new(),
+        work_items: Vec::new(),
+        issue_rows,
+        issue_section_label: "Issues".into(),
         loading: false,
     })
 }
@@ -98,6 +125,23 @@ fn reconcile_prunes_stale_multi_select() {
 
     // Remove item 3 from the data.
     data.mutate(|d| d.work_items.retain(|i| i.identity != WorkItemIdentity::Issue("3".into())));
+
+    page.reconcile_if_changed();
+    assert_eq!(page.multi_selected.len(), 1);
+    assert!(page.multi_selected.contains(&WorkItemIdentity::Issue("1".into())));
+    assert!(!page.multi_selected.contains(&WorkItemIdentity::Issue("3".into())));
+}
+
+#[test]
+fn reconcile_prunes_stale_native_issue_row_multi_select() {
+    let data = test_repo_data_with_issue_rows(vec![native_issue_row("1"), native_issue_row("2"), native_issue_row("3")]);
+    let mut page = RepoPage::new(test_repo_identity(), data.clone(), RepoViewLayout::Auto);
+    page.reconcile_if_changed();
+
+    page.multi_selected.insert(WorkItemIdentity::Issue("1".into()));
+    page.multi_selected.insert(WorkItemIdentity::Issue("3".into()));
+
+    data.mutate(|d| d.issue_rows.retain(|row| row.id != "3"));
 
     page.reconcile_if_changed();
     assert_eq!(page.multi_selected.len(), 1);
@@ -356,11 +400,45 @@ fn toggle_multi_select_adds_and_removes() {
     assert!(page.multi_selected.is_empty());
 }
 
+#[test]
+fn toggle_multi_select_adds_and_removes_native_issue_rows() {
+    let data = test_repo_data_with_issue_rows(vec![native_issue_row("1"), native_issue_row("2")]);
+    let mut page = RepoPage::new(test_repo_identity(), data, RepoViewLayout::Auto);
+    page.reconcile_if_changed();
+    let mut harness = TestWidgetHarness::new();
+
+    {
+        let mut ctx = harness.ctx();
+        page.handle_action(Action::ToggleMultiSelect, &mut ctx);
+    }
+    assert!(page.multi_selected.contains(&WorkItemIdentity::Issue("1".into())));
+
+    {
+        let mut ctx = harness.ctx();
+        page.handle_action(Action::ToggleMultiSelect, &mut ctx);
+    }
+    assert!(page.multi_selected.is_empty());
+}
+
 // ── select_all ──
 
 #[test]
 fn select_all_selects_all_items() {
     let mut page = page_with_items(vec![issue_item("1"), issue_item("2"), issue_item("3")]);
+
+    page.select_all();
+
+    assert_eq!(page.multi_selected.len(), 3);
+    assert!(page.multi_selected.contains(&WorkItemIdentity::Issue("1".into())));
+    assert!(page.multi_selected.contains(&WorkItemIdentity::Issue("2".into())));
+    assert!(page.multi_selected.contains(&WorkItemIdentity::Issue("3".into())));
+}
+
+#[test]
+fn select_all_selects_native_issue_rows() {
+    let data = test_repo_data_with_issue_rows(vec![native_issue_row("1"), native_issue_row("2"), native_issue_row("3")]);
+    let mut page = RepoPage::new(test_repo_identity(), data, RepoViewLayout::Auto);
+    page.reconcile_if_changed();
 
     page.select_all();
 

--- a/crates/flotilla-tui/src/widgets/split_table.rs
+++ b/crates/flotilla-tui/src/widgets/split_table.rs
@@ -485,9 +485,45 @@ impl SplitTable {
     }
 
     /// Convenience: identity of the currently selected item. Returns `None`
-    /// for `IssueRow` selections (they have no `WorkItemIdentity`).
+    /// when nothing is selected.
     pub fn selected_identity(&self) -> Option<WorkItemIdentity> {
-        self.selected_work_item().map(|item| item.identity.clone())
+        match self.selected_row()? {
+            SelectedRow::WorkItem(item) => Some(item.identity.clone()),
+            SelectedRow::Issue(row) => Some(WorkItemIdentity::Issue(row.id.clone())),
+        }
+    }
+
+    /// Iterate all selectable identities across all sections.
+    pub fn all_identities(&self) -> impl Iterator<Item = WorkItemIdentity> + '_ {
+        self.sections.iter().flat_map(|(_, section)| match section {
+            AnySection::WorkItems(t) => t.items.iter().map(|item| item.identity.clone()).collect::<Vec<_>>(),
+            AnySection::Issues(t) => t.items.iter().map(|row| WorkItemIdentity::Issue(row.id.clone())).collect::<Vec<_>>(),
+        })
+    }
+
+    /// Issue keys associated with the given identity, whether it comes from a
+    /// work-item-backed row or a native issue row.
+    pub fn issue_keys_for_identity(&self, identity: &WorkItemIdentity) -> Option<Vec<String>> {
+        match identity {
+            WorkItemIdentity::Issue(issue_id) => {
+                for (_, section) in &self.sections {
+                    match section {
+                        AnySection::Issues(t) => {
+                            if t.items.iter().any(|row| &row.id == issue_id) {
+                                return Some(vec![issue_id.clone()]);
+                            }
+                        }
+                        AnySection::WorkItems(t) => {
+                            if let Some(item) = t.items.iter().find(|item| &item.identity == identity) {
+                                return Some(item.issue_keys.clone());
+                            }
+                        }
+                    }
+                }
+                None
+            }
+            _ => self.all_items().find(|item| &item.identity == identity).map(|item| item.issue_keys.clone()),
+        }
     }
 
     /// Total number of items across all sections (both `WorkItem` and `IssueRow`).
@@ -563,10 +599,14 @@ impl SplitTable {
             if let AnySection::WorkItems(table) = section {
                 for item in &table.items {
                     if item.is_main_checkout {
-                        if let Some(co) = item.checkout_key() {
-                            if let Some(host_name) = co.host_name() {
-                                host_repo_roots.insert(host_name.clone(), co.path.clone());
+                        if let Some(checkout) = item.checkout.as_ref() {
+                            if let Some(host_path) = checkout.host_path() {
+                                host_repo_roots.insert(host_path.host.clone(), host_path.path.clone());
+                                continue;
                             }
+                        }
+                        if let (Some(source), Some(co)) = (item.source.as_ref(), item.checkout_key()) {
+                            host_repo_roots.insert(HostName::new(source), co.path.clone());
                         }
                     }
                 }
@@ -682,7 +722,19 @@ impl SplitTable {
                                 prev_source: prev_source.as_deref(),
                             };
 
-                            render_generic_data_row(frame, item, &table.columns, &render_ctx, is_selected, y, area.x, area.width, theme);
+                            let is_multi_selected = multi_selected.contains(&WorkItemIdentity::Issue(item.id.clone()));
+                            render_generic_data_row(
+                                frame,
+                                item,
+                                &table.columns,
+                                &render_ctx,
+                                is_selected,
+                                is_multi_selected,
+                                y,
+                                area.x,
+                                area.width,
+                                theme,
+                            );
                         }
                         prev_source = Some(item.issue.provider_display_name.clone());
                         flat_row += 1;
@@ -895,7 +947,7 @@ fn render_column_headers_generic<T>(columns: &[ColumnDef<T>], col_widths: &[u16]
     frame.render_widget(line, area);
 }
 
-/// Render a single data row for any `ColumnDef<T>` section (no pending/multi-select support).
+/// Render a single data row for any `ColumnDef<T>` section.
 #[allow(clippy::too_many_arguments)]
 fn render_generic_data_row<T>(
     frame: &mut Frame,
@@ -903,6 +955,7 @@ fn render_generic_data_row<T>(
     columns: &[ColumnDef<T>],
     ctx: &RenderCtx,
     is_selected: bool,
+    is_multi_selected: bool,
     y: u16,
     area_x: u16,
     area_width: u16,
@@ -930,6 +983,14 @@ fn render_generic_data_row<T>(
     let line = Line::from(spans);
     frame.render_widget(line, Rect::new(area_x, y, area_width, 1));
 
+    if is_multi_selected {
+        let buf = frame.buffer_mut();
+        for cx in area_x..area_x + area_width {
+            if let Some(cell) = buf.cell_mut(Position::new(cx, y)) {
+                cell.set_bg(theme.multi_select_bg);
+            }
+        }
+    }
     if is_selected {
         let buf = frame.buffer_mut();
         for cx in area_x..area_x + area_width {


### PR DESCRIPTION
## Summary
- make branch-name generation keep the originally requested issue IDs and fetch missing issue details from the preferred tracker before asking AI for a name
- preserve checkout host/source information for environment-qualified paths so remote checkout rows render against the right host context
- treat native TUI issue rows like selectable actionable items so multi-select, action menus, and branch-name generation work consistently across issue sections

## Why
These fixes address two related gaps in repo-scoped issue workflows. Branch-name generation could lose issue context when the current provider snapshot did not already contain every requested issue, and native issue rows in the TUI did not participate in the same action and multi-select paths as work-item rows. Remote checkout path rendering also lacked a reliable host fallback in some environment-qualified cases.

## Impact
Issue-driven workflows stay usable even when the issue metadata has to be fetched lazily, and users can generate branches directly from native issue rows or issue-row multi-select without falling back to work-item-backed sections. Remote checkout rows also show paths relative to the correct host root more reliably.

## Root Cause
The executor only consulted in-memory issue data when building branch-name context and derived fallback issue/provider pairs from resolved issues rather than the user-requested IDs. In the TUI, several selection and intent paths were hard-wired to `WorkItem` rows and ignored native `IssueRow` identities.

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked` *(fails in this sandbox on existing machine-identity-dependent tests: `host_identity::tests::resolve_local_node_id_uses_machine_scoped_identity_dir`, `in_process::tests::get_repo_providers_uses_preferred_root_environment_host_discovery_for_non_local_direct_repo`)*
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-core --locked generate_branch_name`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-core --locked checkout_source_falls_back_to_provider_host_for_environment_qualified_paths`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-tui --locked app::key_handlers::tests`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-tui --locked widgets::repo_page::tests`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-tui --locked widgets::split_table::tests`