### PR TITLE
docs: convoy, workflow, and tiller control plane design

### DIFF
--- a/docs/superpowers/specs/2026-04-13-convoy-and-control-plane-design.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-and-control-plane-design.md
@@ -147,8 +147,9 @@ name: review-and-fix
 tasks:
   - name: implement
     processes:
-      - role: agent
-        command: "{main_command}"
+      - role: coding-agent
+        selector:
+          capability: code
       - role: build
         command: "cargo watch -x check"
 
@@ -156,7 +157,8 @@ tasks:
     depends_on: [implement]
     processes:
       - role: reviewer
-        command: "claude --review"
+        selector:
+          capability: code-review
       - role: tests
         command: "cargo test --watch"
 ```
@@ -293,6 +295,8 @@ A convoy stage might reference external state ("wait for PR status = merged") by
 ## Correlation
 
 Convoy data feeds into the existing provider data / correlation engine as just another data source. The convoy controller doesn't need to know about correlation — it emits items with the right keys (Branch, CheckoutPath, etc.), and the correlation engine groups them with independently-discovered PRs, branches, and other items downstream. This means convoy integration with the current model is thin: convoys produce `ProviderData` items, correlation handles the rest. The exact long-term shape of correlation is a separate concern.
+
+**Key emission timing:** Correlation keys like `CheckoutPath` aren't known until task provisioning completes. During provisioning, the convoy item and the checkout item may appear as separate work items. They merge on the next refresh cycle once the checkout exists and its keys are visible. This is the same pattern as existing provider discovery — providers report what currently exists, refresh cycles update correlation. No special incremental-update mechanism is needed.
 
 ## Deferred Design Questions
 

--- a/docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md
@@ -1,0 +1,306 @@
+# Convoy, Workflow, and Tiller Control Plane Design
+
+## Context
+
+Flotilla currently manages development workspaces through a provider-based model: providers discover and report items (checkouts, PRs, sessions, terminals), a correlation engine groups them into work items, and users interact via TUI/CLI. The `AttachableSet` is the closest thing to a "unit of work" — a group of terminals sharing a host, checkout, and environment.
+
+This document captures the design direction for three interrelated concepts:
+
+1. **Convoy** — the new primary unit of work, replacing AttachableSet
+2. **Workflow** — a DAG of tasks that a convoy executes
+3. **Tiller** — a minimal k8s-style control plane that manages these as resources
+
+## Tiller: Micro Control Plane
+
+### What It Is
+
+Tiller is a minimal control plane implementing a subset of the Kubernetes API model: named objects, declared desired state, observed status, labels, reconciliation loops. It is not a k8s fork — it's a small server that speaks enough of the same language that k8s tooling and client libraries work where practical.
+
+### Design Goals
+
+- **Small.** Single binary, Rust. SQLite for state.
+- **Workload-agnostic.** Manages resources, not containers specifically.
+- **Subsettable.** Higher-level systems choose which resource types and controllers they need.
+- **Discoverable.** Agents report what exists as first-class objects.
+- **Growable.** Start on a single machine with UDS, extend to remote nodes, migrate to real k8s.
+
+### Controller API Abstraction
+
+The key architectural decision: controllers are written against a `ResourceClient` trait, not against a specific backing store. The same controller logic can run on:
+
+```
+ConvoyController, EnvironmentController, etc.
+         |
+    ResourceClient trait  (get/list/watch/create/update/delete)
+         |
+    +----+----------------+------------------+
+    |                     |                  |
+InProcessTiller      TillerHTTP         K8sREST
+(SQLite, same       (UDS/TCP to        (raw REST calls,
+ process)            tiller server)      real k8s cluster)
+```
+
+- **InProcessTiller**: Zero-dependency laptop case. Runs inside the flotilla daemon. SQLite-backed.
+- **TillerHTTP**: Standalone tiller server, REST over UDS/SSH/TCP.
+- **K8sREST**: Real k8s cluster via raw REST calls (reqwest + serde). Teams or power users.
+
+We prefer raw REST over kube-rs for the k8s backend. The `ResourceClient` trait should reflect plain REST semantics (what Tiller would eventually expose), not kube-rs's `Api<T>` abstractions. For prototyping a single-node controller loop, a simple watch-and-react loop is clearer than kube-rs's reconciler framework. We already have reqwest and serde.
+
+This means prototyping on real k8s is viable — raw REST is the first `ResourceClient` implementation, InProcessTiller comes later with scope defined by actual usage rather than speculation.
+
+### Transport
+
+- Local: REST over Unix domain socket. No TLS overhead.
+- Remote (current plan): UDS forwarded over SSH.
+- Remote (future): TCP with TLS.
+- No gRPC. JSON over HTTP. Debuggable with curl.
+
+### State
+
+SQLite. resourceVersion derived from rowid. Atomic multi-resource updates via transactions.
+
+### API Shape
+
+Standard k8s URL structure:
+
+```
+/apis/{group}/{version}/{resource}
+/apis/{group}/{version}/{resource}/{name}
+/apis/{group}/{version}/{resource}/{name}/status
+```
+
+Watch via SSE or chunked transfer. resourceVersion maps to SQLite rowid.
+
+### kubectl Compatibility
+
+A basic subset: `get`, `apply`, `describe`, `delete`, `logs`. Requires discovery endpoints and enough metadata for kubectl to format output.
+
+Open question: how much unnecessary discovery/negotiation kubectl does per invocation.
+
+### What Tiller Skips
+
+- Full k8s API compatibility (admission webhooks, version conversion, aggregation)
+- RBAC (auth at transport layer)
+- Networking model (no pod IPs, Services, Ingress)
+- etcd (SQLite instead)
+- Scheduler (direct node assignment initially)
+- Built-in workload types (Deployment, ReplicaSet) — domain of the system built on top
+
+## Convoy: The Primary Unit of Work
+
+### The Fundamental Shift
+
+**Before:** Branch -> Checkout -> (terminals appear) -> work happens
+**After:** Convoy -> (creates branches, checkouts, environments, agents as needed) -> work happens
+
+The convoy is the intent. Everything else is infrastructure it provisions. This is the spec/status split — the convoy spec says what to achieve, a controller reconciles reality toward it.
+
+### Convoy Resource
+
+```
+Convoy {
+    name: String,                    // explicit, meaningful name
+    workflow: WorkflowRef,           // which template (or inline definition)
+    status: ConvoyPhase,             // Pending -> Active -> Completed/Failed
+    tasks: Vec<TaskStatus>,          // current state of each task in the DAG
+}
+```
+
+A convoy is a named, user-created workflow instance. The name is explicit and meaningful (eventually could be AI-generated, similar to the existing branch name generation, or come from an initial planning conversation with an agent).
+
+### Relationship to AttachableSet
+
+Today's `AttachableSet` is a degenerate convoy — a convoy with a single task:
+
+| AttachableSet field | Convoy equivalent |
+|---------------------|-------------------|
+| `id` (UUID) | Convoy name (meaningful string) |
+| `host_affinity` | Task-level: which host the task runs on |
+| `checkout` | Task-level: which checkout the task works against |
+| `environment_id` | Task-level: which container/sandbox |
+| `template_identity` | `workflow` reference |
+| `members` (terminals) | Task's processes |
+
+The critical difference: **host, checkout, and environment are Task-level properties, not Convoy-level.** A convoy can have tasks running on different hosts, different checkouts, different environments — sequentially or concurrently.
+
+### Migration Path
+
+Build Convoy as the first Tiller resource (option B). The current `AttachableSet` and `AttachableStoreApi` continue working during transition. Once convoys subsume all AttachableSet functionality, the old store is removed. No "two models" period for new work — convoys are born on the new model.
+
+## Workflow: The DAG Shape
+
+### WorkflowTemplate Resource
+
+A reusable definition of the DAG shape, separate from any convoy instance:
+
+```yaml
+# .flotilla/workflows/review-and-fix.yaml
+name: review-and-fix
+tasks:
+  - name: implement
+    processes:
+      - role: agent
+        command: "{main_command}"
+      - role: build
+        command: "cargo watch -x check"
+
+  - name: review
+    depends_on: [implement]
+    processes:
+      - role: reviewer
+        command: "claude --review"
+      - role: tests
+        command: "cargo test --watch"
+```
+
+Templates define **what runs and in what order**. They do not specify where — host, checkout, and environment are resolved at launch time when the convoy is instantiated.
+
+### Task: The Placement Unit
+
+A task is a node in the workflow DAG. All processes within a task share the same host, checkout, and environment. This is the scheduling/placement unit.
+
+```
+TaskDefinition {
+    name: String,
+    depends_on: Vec<String>,         // DAG edges
+    processes: Vec<ProcessDefinition>,
+}
+```
+
+### DAG Edges
+
+For now, dependency edges mean **sequencing only**: task B starts after task A completes. Future possibilities (data flow, environment inheritance) are deferred.
+
+### Task Lifecycle
+
+```
+Pending -> Ready -> Launching -> Running -> Completed
+                                         -> Failed
+                                         -> Cancelled
+```
+
+- **Pending**: dependencies not yet satisfied
+- **Ready**: all dependencies completed, eligible to launch
+- **Launching**: resources being provisioned (environment, checkout, terminals)
+- **Running**: processes active, user can interact
+- **Completed/Failed/Cancelled**: terminal states
+
+For now, task completion is explicit — the user marks it done in the TUI, or process exit triggers a status change. Eventually agents will be able to mark their own task complete via a CLI command.
+
+### Process: What Actually Runs
+
+```
+ProcessDefinition {
+    role: String,                    // "coding-agent", "dev-server", "reviewer"
+    command: String,                 // template-resolved command
+}
+```
+
+A process is the logical thing ("coding agent on this checkout"). A terminal is how it's presented and interacted with. The process definition is resolved at launch time through the terminal pool and presentation manager.
+
+Communication between processes within a task is not specified — for now, the user interacts with them via terminals. Future work may add explicit inter-process channels.
+
+### Relationship to Current WorkspaceTemplate
+
+Today's `WorkspaceTemplate` conflates two things:
+
+- **Content** (roles + commands) = process definitions for a single task
+- **Layout** (pane arrangement) = presentation manager configuration
+
+In convoy terms: content moves into `WorkflowTemplate` task definitions, layout moves to `PresentationManager` config. A single-task workflow with a layout section is backwards-compatible with today's workspace templates.
+
+## Presentation Flow
+
+### How the Presentation Manager Surfaces Convoy Tasks
+
+The presentation manager (currently `WorkspaceManager`) already receives fully-resolved `Vec<(role, command_string)>` pairs and a layout template. It doesn't know or care where the commands came from. The existing flow through `WorkspaceAttachRequest` → `resolve_template` → `PaneLayout` → create panes works unchanged for convoy tasks.
+
+For a single convoy task becoming Ready:
+
+```
+Task becomes Ready
+  → Controller resolves each ProcessDefinition through hop chain
+  → Produces Vec<(role, command_string)>     ← same shape as today
+  → Hands to PresentationManager with layout config
+  → Panes created, user interacts
+```
+
+### Task Transitions
+
+When task A completes and task B becomes Ready, the presentation needs to update. Options:
+
+- **Reconfigure existing workspace** — add/replace panes for the new task's processes. Better UX (user stays in one context), but needs a new `update_workspace`/`add_panes` capability on the presentation manager trait.
+- **Create new workspace** — simpler, but disorienting context switch.
+
+Reconfiguration is the preferred direction.
+
+### Convoy TUI Pane
+
+A default convoy presentation could include a flotilla TUI pane focused on the convoy — showing task DAG progression alongside the terminal processes. This would be another process in the layout (e.g. `flotilla tui --convoy <name>`) running in its own pane, displaying task status, allowing the user to mark tasks complete, and navigating to process terminals.
+
+## Provider Type Mapping
+
+### Types That Become Convoy Sub-Resources (Created by Controllers)
+
+These are things a convoy controller creates as it provisions tasks:
+
+- **Environment** (from `EnvironmentProvider`)
+- **Checkout** (from `CheckoutManager`)
+- **Terminal sessions** (from `TerminalPool`)
+- **Agent sessions** (from `CloudAgentService`)
+- **Presentation/workspace** (from `WorkspaceManager`, renamed to `PresentationManager`)
+
+### Types That Remain Read-Only Context
+
+These don't need to be k8s resources to be useful — the convoy controller references them:
+
+- PRs / change requests
+- Issues
+- Branches (remote)
+- Commit info, working tree status
+
+A convoy stage might reference external state ("wait for PR status = merged") by querying the existing provider, not by watching a k8s resource.
+
+## Correlation
+
+Convoy data feeds into the existing provider data / correlation engine as just another data source. The convoy controller doesn't need to know about correlation — it emits items with the right keys (Branch, CheckoutPath, etc.), and the correlation engine groups them with independently-discovered PRs, branches, and other items downstream. This means convoy integration with the current model is thin: convoys produce `ProviderData` items, correlation handles the rest. The exact long-term shape of correlation is a separate concern.
+
+## Deferred Design Questions
+
+These are real and important but orthogonal to the core convoy lifecycle:
+
+### Agent-Planned Workflows
+Agents should eventually be able to plan and modify workflow DAGs dynamically — replanning based on discovery, adding stages for progressive PRs, etc. For now, workflow templates are static.
+
+### Multi-Branch Convoys
+A workflow stage might cut a PR, get approval, then fork new branches for subsequent work. When the PR merges/squashes, downstream stages need to rebase/cherry-pick. This requires convoy-level branch management that doesn't exist yet.
+
+### Agent Configuration
+Process definitions will eventually need richer agent configuration: system prompt injection, permission policies (e.g. turn off permission checking if sandboxed), hooks/skills setup, config preparation. For now, `role + command` is sufficient.
+
+### Inter-Convoy Coordination
+Convoys are independent for now. Future work may need coordination between convoys (e.g. "this convoy depends on that convoy's output").
+
+### Nesting / Sub-Convoys
+A tempting model: "sub-convoy is-a stage" for scheduling purposes. Deferred because without concrete use cases driving it, we'd be speculating on the composition contract. The alternative — a convoy stage whose completion condition is "this other convoy completed" — gives inter-convoy coordination without nesting, and the pattern can be formalized later if it's common enough.
+
+### Task as Independent Resource vs Convoy Sub-Status
+In k8s terms: Argo makes each task its own resource (a Pod), giving independent watch/status. For flotilla's first cut, tasks-as-convoy-status is simpler — no need to watch tasks independently yet, avoids N-resources-per-convoy explosion. Can be promoted to independent resources later if needed.
+
+## Naming
+
+| Old | New |
+|-----|-----|
+| AttachableSet | Convoy (the workflow instance) |
+| AttachableSet members | Task processes |
+| WorkspaceTemplate | WorkflowTemplate (DAG) + PresentationConfig (layout) |
+| WorkspaceManager | PresentationManager |
+
+## Open Questions
+
+- **kubectl overhead**: How chatty is kubectl per invocation? Is the discovery tax acceptable?
+- **Discovered resource schema**: How to represent objects with observed state but no declared spec?
+- **Node agent liveness**: Heartbeat model, timeout policy, disconnect behavior.
+- **Dynamic vs static type registration**: CRD-like runtime registration vs compiled-in types?
+- **Label/field selector query language**: How much of k8s selector syntax to support?
+- **Prototyping strategy**: Start with real k8s (raw REST, standalone prototype) to validate the resource model, then build InProcessTiller once the API surface is known from actual usage.

--- a/docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md
@@ -303,4 +303,5 @@ In k8s terms: Argo makes each task its own resource (a Pod), giving independent 
 - **Node agent liveness**: Heartbeat model, timeout policy, disconnect behavior.
 - **Dynamic vs static type registration**: CRD-like runtime registration vs compiled-in types?
 - **Label/field selector query language**: How much of k8s selector syntax to support?
-- **Prototyping strategy**: Start with real k8s (raw REST, standalone prototype) to validate the resource model, then build InProcessTiller once the API surface is known from actual usage.
+- **Prototyping strategy**: Start with real k8s via minikube (raw REST, standalone prototype) to validate the resource model, then build the in-process Rust/SQLite resource server once the API surface is known from actual usage. k3s is Linux-only (no macOS support), and Go's goroutine stack model prevents embedding any Go-based k8s components as a library — the in-process resource server must be a Rust reimplementation of the required k8s API subset.
+- **Naming**: The in-process resource server is a flotilla subsystem, not a separate project. Use `flotilla-resources` or a `resources` module rather than a branded name. "Tiller" collides with Helm 2's deprecated in-cluster component.

--- a/docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md
@@ -1,4 +1,4 @@
-# Convoy, Workflow, and Tiller Control Plane Design
+# Convoy, Workflow, and Control Plane Design
 
 ## Context
 
@@ -8,13 +8,13 @@ This document captures the design direction for three interrelated concepts:
 
 1. **Convoy** — the new primary unit of work, replacing AttachableSet
 2. **Workflow** — a DAG of tasks that a convoy executes
-3. **Tiller** — a minimal k8s-style control plane that manages these as resources
+3. **flotilla-cp** — a minimal k8s-style control plane that manages these as resources
 
-## Tiller: Micro Control Plane
+## flotilla-cp: Micro Control Plane
 
 ### What It Is
 
-Tiller is a minimal control plane implementing a subset of the Kubernetes API model: named objects, declared desired state, observed status, labels, reconciliation loops. It is not a k8s fork — it's a small server that speaks enough of the same language that k8s tooling and client libraries work where practical.
+flotilla-cp is a minimal control plane implementing a subset of the Kubernetes API model: named objects, declared desired state, observed status, labels, reconciliation loops. It is not a k8s fork — it's a small server that speaks enough of the same language that k8s tooling and client libraries work where practical.
 
 ### Design Goals
 
@@ -35,18 +35,18 @@ ConvoyController, EnvironmentController, etc.
          |
     +----+----------------+------------------+
     |                     |                  |
-InProcessTiller      TillerHTTP         K8sREST
+InProcess             flotilla-cp-http       K8sREST
 (SQLite, same       (UDS/TCP to        (raw REST calls,
  process)            tiller server)      real k8s cluster)
 ```
 
-- **InProcessTiller**: Zero-dependency laptop case. Runs inside the flotilla daemon. SQLite-backed.
-- **TillerHTTP**: Standalone tiller server, REST over UDS/SSH/TCP.
+- **InProcess**: Zero-dependency laptop case. Runs inside the flotilla daemon. SQLite-backed.
+- **flotilla-cp-http**: Standalone flotilla-cp server, REST over UDS/SSH/TCP.
 - **K8sREST**: Real k8s cluster via raw REST calls (reqwest + serde). Teams or power users.
 
-We prefer raw REST over kube-rs for the k8s backend. The `ResourceClient` trait should reflect plain REST semantics (what Tiller would eventually expose), not kube-rs's `Api<T>` abstractions. For prototyping a single-node controller loop, a simple watch-and-react loop is clearer than kube-rs's reconciler framework. We already have reqwest and serde.
+We prefer raw REST over kube-rs for the k8s backend. The `ResourceClient` trait should reflect plain REST semantics (what flotilla-cp would eventually expose), not kube-rs's `Api<T>` abstractions. For prototyping a single-node controller loop, a simple watch-and-react loop is clearer than kube-rs's reconciler framework. We already have reqwest and serde.
 
-This means prototyping on real k8s is viable — raw REST is the first `ResourceClient` implementation, InProcessTiller comes later with scope defined by actual usage rather than speculation.
+This means prototyping on real k8s is viable — raw REST is the first `ResourceClient` implementation, in-process flotilla-cp comes later with scope defined by actual usage rather than speculation.
 
 ### Transport
 
@@ -61,15 +61,17 @@ SQLite. resourceVersion derived from rowid. Atomic multi-resource updates via tr
 
 ### API Shape
 
-Standard k8s URL structure:
+Standard k8s namespaced URL structure:
 
 ```
-/apis/{group}/{version}/{resource}
-/apis/{group}/{version}/{resource}/{name}
-/apis/{group}/{version}/{resource}/{name}/status
+/apis/{group}/{version}/namespaces/{namespace}/{resource}
+/apis/{group}/{version}/namespaces/{namespace}/{resource}/{name}
+/apis/{group}/{version}/namespaces/{namespace}/{resource}/{name}/status
 ```
 
-Watch via SSE or chunked transfer. resourceVersion maps to SQLite rowid.
+All resources are namespaced. Single-user/laptop case uses a default namespace (`flotilla`). Scales to per-user or per-team namespaces on shared clusters.
+
+Watch via chunked HTTP transfer with newline-delimited JSON events (matching k8s watch semantics, required for kubectl compatibility). resourceVersion maps to SQLite rowid. Watches are scoped to a single resource type — per-table rowids are not globally monotonic across types, which is acceptable since clients typically watch one resource type at a time. A global sequence table can be added later if cross-type watch is needed.
 
 ### kubectl Compatibility
 
@@ -77,7 +79,7 @@ A basic subset: `get`, `apply`, `describe`, `delete`, `logs`. Requires discovery
 
 Open question: how much unnecessary discovery/negotiation kubectl does per invocation.
 
-### What Tiller Skips
+### What flotilla-cp Skips
 
 - Full k8s API compatibility (admission webhooks, version conversion, aggregation)
 - RBAC (auth at transport layer)
@@ -94,6 +96,12 @@ Open question: how much unnecessary discovery/negotiation kubectl does per invoc
 **After:** Convoy -> (creates branches, checkouts, environments, agents as needed) -> work happens
 
 The convoy is the intent. Everything else is infrastructure it provisions. This is the spec/status split — the convoy spec says what to achieve, a controller reconciles reality toward it.
+
+### Impact on Commands and Execution
+
+Today's command executor does imperative orchestration: create environment, then create checkout, then start terminals, then bind workspace — multi-step sequences with error handling at each point. In the controller model, a command becomes a single resource write (create/update a Convoy, Task, or sub-resource), and controllers reconcile the desired state into reality. The orchestration complexity moves from the executor into controller reconciliation loops, where it's easier to reason about (watch resource, compare desired vs actual, take one action, repeat).
+
+The existing `StepPlan` DAG pattern is not replaced — the same DAG progression model applies to both step plans and convoy workflows. What simplifies is the *executor layer*: instead of commands encoding multi-step procedures, they become thin resource mutations.
 
 ### Convoy Resource
 
@@ -125,7 +133,7 @@ The critical difference: **host, checkout, and environment are Task-level proper
 
 ### Migration Path
 
-Build Convoy as the first Tiller resource (option B). The current `AttachableSet` and `AttachableStoreApi` continue working during transition. Once convoys subsume all AttachableSet functionality, the old store is removed. No "two models" period for new work — convoys are born on the new model.
+Build Convoy as the first flotilla-cp resource (option B). The current `AttachableSet` and `AttachableStoreApi` continue working during transition. Once convoys subsume all AttachableSet functionality, the old store is removed. No "two models" period for new work — convoys are born on the new model.
 
 ## Workflow: The DAG Shape
 
@@ -185,16 +193,37 @@ Pending -> Ready -> Launching -> Running -> Completed
 - **Running**: processes active, user can interact
 - **Completed/Failed/Cancelled**: terminal states
 
-For now, task completion is explicit — the user marks it done in the TUI, or process exit triggers a status change. Eventually agents will be able to mark their own task complete via a CLI command.
+**Failure policy (v1):** Fail fast — any task failure halts the convoy. Running sibling tasks are cancelled. No retries. Supervision strategies (retry, continue siblings, escalate) are future work.
+
+Task completion is always explicit — via TUI action or CLI command. Process exits do not automatically complete or fail a task (a crashed process can be restarted without affecting task state). Eventually agents will be able to mark their own task complete via a CLI command.
 
 ### Process: What Actually Runs
 
+Processes come in two kinds:
+
+**Agent processes** — resolved via a selector. The template declares what capability is needed; policy resolves it to a concrete agent + options at launch time.
+
+```yaml
+processes:
+  - role: coding-agent
+    selector:
+      capability: code
+  - role: reviewer
+    selector:
+      capability: code-review
 ```
-ProcessDefinition {
-    role: String,                    // "coding-agent", "dev-server", "reviewer"
-    command: String,                 // template-resolved command
-}
+
+**Tool processes** — literal commands, no resolution needed.
+
+```yaml
+processes:
+  - role: build
+    command: "cargo watch -x check"
+  - role: dev-server
+    command: "cargo run --example server"
 ```
+
+**Selector resolution (v1):** A simple lookup from capability to concrete command, configured in repo config or global defaults. E.g. `capability: code → claude`, `capability: code-review → claude --review`. Future: a policy agent (Quartermaster) resolves selectors using environment context — remaining credits/allowances, known caches, off-peak scheduling, provisioning target capabilities (sandbox quality, platform tools).
 
 A process is the logical thing ("coding agent on this checkout"). A terminal is how it's presented and interacted with. The process definition is resolved at launch time through the terminal pool and presentation manager.
 
@@ -207,7 +236,7 @@ Today's `WorkspaceTemplate` conflates two things:
 - **Content** (roles + commands) = process definitions for a single task
 - **Layout** (pane arrangement) = presentation manager configuration
 
-In convoy terms: content moves into `WorkflowTemplate` task definitions, layout moves to `PresentationManager` config. A single-task workflow with a layout section is backwards-compatible with today's workspace templates.
+In convoy terms: content moves into `WorkflowTemplate` task definitions, layout moves to `PresentationManager` config. A single-task workflow with a layout section is backwards-compatible with today's workspace templates. Template variable substitution (`{main_command}`) is replaced by the selector model — templates declare capabilities, resolution is external.
 
 ## Presentation Flow
 
@@ -304,4 +333,4 @@ In k8s terms: Argo makes each task its own resource (a Pod), giving independent 
 - **Dynamic vs static type registration**: CRD-like runtime registration vs compiled-in types?
 - **Label/field selector query language**: How much of k8s selector syntax to support?
 - **Prototyping strategy**: Start with real k8s via minikube (raw REST, standalone prototype) to validate the resource model, then build the in-process Rust/SQLite resource server once the API surface is known from actual usage. k3s is Linux-only (no macOS support), and Go's goroutine stack model prevents embedding any Go-based k8s components as a library — the in-process resource server must be a Rust reimplementation of the required k8s API subset.
-- **Naming**: The in-process resource server is a flotilla subsystem, not a separate project. Use `flotilla-resources` or a `resources` module rather than a branded name. "Tiller" collides with Helm 2's deprecated in-cluster component.
+- **Naming**: The control plane is `flotilla-cp`. The in-process resource server is a flotilla subsystem (`flotilla-resources` crate or `resources` module).

--- a/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
@@ -1,0 +1,210 @@
+# Convoy Implementation — Brainstorm Prompts
+
+These are self-contained prompts for future brainstorm sessions, ordered by dependency. Reference the design doc at `docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md` for full context.
+
+## Dependency Graph
+
+```
+1. ResourceClient trait + k8s REST prototype
+   2. WorkflowTemplate resource (depends on 1)
+3. Convoy resource + controller (depends on 1, 2)
+4. Task provisioning / policy (depends on 3)
+5. Presentation integration + PresentationManager rename (depends on 3)
+6. TUI convoy view (depends on 3)
+7. AttachableSet migration (depends on 3-6)
+```
+
+## Design Decisions
+
+### kube-rs vs raw REST
+
+We prefer **raw REST calls** (reqwest + serde) over kube-rs for the k8s backend. Reasons:
+- kube-rs is a heavy dependency with opinions about async runtime
+- The `ResourceClient` trait should reflect plain REST semantics (what Tiller would eventually expose), not kube-rs's `Api<T>` abstractions
+- For prototyping a single-node controller loop, a simple `loop { watch, react }` is clearer than kube-rs's reconciler framework
+- We already have reqwest and serde
+
+### Pure k8s prototype (stages 1-4)
+
+Stages 1 through 4 should be prototyped as a standalone project against real k8s, using pure k8s primitives. The goal is to understand the CRD/controller model with real tooling feedback (`kubectl get convoys`, watch events). This prototype is separate from the flotilla codebase — it validates the resource model before integrating.
+
+Task provisioning (stage 4) is where the interesting policy question lives: should tasks create k8s-native sub-resources (Pods for containerized agents, Jobs for one-shot tasks) and let built-in k8s controllers handle lifecycle? Or should our controller manage everything directly? This is a deployment policy choice — the same convoy controller should work either way. The prototype will help answer this by trying both.
+
+### Correlation is downstream
+
+Convoy data feeds into the existing provider data / correlation engine as just another data source. The convoy doesn't need to know about correlation — it emits items with appropriate keys, and the correlation engine groups them with independently-discovered PRs, branches, etc. This means convoy integration with the current model is thin: convoys produce `ProviderData` items, correlation handles the rest. The exact shape of correlation in the long term is a separate concern.
+
+---
+
+## 1. ResourceClient Trait and k8s REST Backend
+
+**Goal:** Define the `ResourceClient` trait that convoy controllers use, and implement it against real k8s via raw REST calls.
+
+**Context:** Flotilla's convoy system needs a k8s-style resource API (get/list/watch/create/update/delete with resourceVersion). Controllers are written against a trait so they can run against k8s REST (prototyping), a future TillerHTTP backend, or InProcessTiller (zero-dependency laptop case). See the Tiller design doc for the full vision.
+
+This should be prototyped as a **standalone project** outside the flotilla codebase — a minimal Rust binary that registers CRDs and does CRUD + watch against a local k8s cluster (kind/k3s).
+
+**Key questions:**
+- What's the minimal trait surface that convoy controllers actually need? Start from usage, not from "what k8s has."
+- How does watch work in the trait? The k8s watch API returns newline-delimited JSON with ADDED/MODIFIED/DELETED events. Streaming iterator? Async channel?
+- How are resource types represented? Generic `ResourceClient<T: Resource>` with serde, or runtime-typed with serde_json::Value?
+- Resource metadata subset: name, namespace, resourceVersion, labels are likely needed. Annotations? Generation/observedGeneration?
+- Error model: Conflict (resourceVersion mismatch), NotFound, etc. What does the trait's error type look like?
+- How much k8s discovery/negotiation is needed for raw REST? CRD registration, API group discovery, OpenAPI — what's the minimum to make `kubectl get convoys` work?
+
+**Constraints:**
+- The trait must be testable with an in-memory implementation (tests shouldn't need a running cluster).
+- Must support watch (convoy controller needs to react to status changes).
+- Keep it minimal — we can add methods as controllers need them.
+- Use reqwest + serde, not kube-rs.
+
+**Starting point:** k8s API reference for custom resources. The k8s watch protocol. Look at `AttachableStoreApi` in `crates/flotilla-core/src/attachable/store.rs` for the current CRUD pattern we're replacing.
+
+---
+
+## 2. WorkflowTemplate Resource
+
+**Goal:** Define the WorkflowTemplate resource type — the reusable DAG definition that convoys instantiate.
+
+**Context:** A WorkflowTemplate defines the shape of a workflow: named tasks, their process definitions (role + command), and dependency edges between tasks. It's a pure data resource (no controller needed). Templates don't specify where things run (host/checkout/environment) — that's resolved at convoy launch time.
+
+Today's `WorkspaceTemplate` (`.flotilla/workspace.yaml`) defines content (roles + commands) and layout (pane arrangement) for a single task. WorkflowTemplate generalizes this to a DAG of tasks. Single-task workflows should be backwards-compatible with the workspace template experience.
+
+Part of the standalone k8s prototype from stage 1.
+
+**Key questions:**
+- What's the YAML format? How does it relate to/differ from the existing workspace.yaml?
+- How do single-task workflows degrade gracefully to the current workspace template experience?
+- Where do templates live? `.flotilla/workflows/` in repo? Global config? Both with precedence? As k8s resources (like ConfigMaps)?
+- How are process definitions expressed? Just `role + command` for now, but what's the extension point for future agent configuration (system prompts, permissions, hooks)?
+- How are DAG edges expressed? `depends_on: [task_name]` is simple — is it sufficient?
+- How does template rendering/variable substitution work? Current `WorkspaceTemplate::render()` does simple `{var}` replacement.
+- Validation: what makes a template invalid? (cycles in DAG, duplicate task names, missing dependency references)
+
+**Starting point:** Read `crates/flotilla-core/src/template.rs` for the current `WorkspaceTemplate`. Read the convoy design doc's WorkflowTemplate section. Look at Argo Workflow's template model for comparison (useful reference, but we want something lighter).
+
+---
+
+## 3. Convoy Resource and Controller
+
+**Goal:** Define the Convoy resource type and build a minimal controller that manages convoy lifecycle through the workflow DAG.
+
+**Context:** A Convoy is a named workflow instance. It references a WorkflowTemplate, tracks task states, and advances through the DAG as tasks complete. This is the core of the new model — it replaces the "branch -> checkout -> terminals" interaction loop with "convoy -> (provisions everything needed) -> work happens."
+
+Part of the standalone k8s prototype. The controller should be a simple reconciliation loop: watch convoy resources, compare desired state (workflow DAG) against observed state (task statuses), take action.
+
+**Key questions:**
+- Convoy spec: what fields? Name, workflow reference, per-task overrides (host/checkout/environment bindings)?
+- Convoy status: task states, overall phase, timestamps?
+- How is a convoy created? For the prototype: `kubectl apply`. For flotilla: CLI command, TUI action, eventually agent-initiated.
+- The controller reconciliation loop: what does it watch, what does it do on each tick?
+  - Convoy created -> mark root tasks as Ready
+  - Task marked Ready -> (hand off to task provisioning, brainstorm 4)
+  - Task completed -> check dependents, mark newly-unblocked tasks as Ready
+  - All tasks completed -> mark convoy Completed
+- How does task completion work? Initially explicit (CLI command, status patch). Eventually agents mark their own tasks complete.
+- Should tasks be sub-resources of the convoy (status fields) or independent resources? Status fields are simpler for now. Independent resources give you watch/status per task but add complexity.
+- How does the controller get started? In the prototype: standalone binary. In flotilla: part of the daemon.
+- This controller pattern should eventually replace much of the current command/step/executor complexity. How does the reconciliation model compare to the current `StepPlan` execution?
+
+**Dependencies:** ResourceClient trait (brainstorm 1), WorkflowTemplate (brainstorm 2).
+
+**Starting point:** Read `crates/flotilla-core/src/executor/workspace.rs` for the current orchestration flow. Read `crates/flotilla-core/src/step.rs` for the current step execution model that convoys would replace. Read the convoy design doc.
+
+---
+
+## 4. Task Provisioning and Policy
+
+**Goal:** When a convoy task becomes Ready, provision the infrastructure it needs. Determine the policy boundary: what does the convoy controller create directly vs. what does it delegate to other controllers?
+
+**Context:** This is where the convoy controller creates real things. The interesting question is the policy layer: should the controller create k8s-native resources (Pods, Jobs) and let built-in controllers handle lifecycle? Or create flotilla-specific resources and manage them directly?
+
+For example, a task needing a containerized coding agent could:
+- **k8s-native**: Create a Pod spec -> k8s schedules it -> container runs agent -> controller watches Pod status
+- **flotilla-managed**: Controller calls EnvironmentProvider + TerminalPool directly -> creates terminal sessions -> watches terminal status
+
+The k8s-native path gives you scheduling, restarts, resource limits for free. The flotilla-managed path works on a laptop without k8s. The convoy controller shouldn't care which — it creates a "task execution" resource and watches its status. The policy layer decides how that resolves.
+
+**Key questions:**
+- What's the provisioning sequence for a task? Environment first, then checkout accessibility, then processes?
+- The policy boundary: what abstraction separates "what the task needs" from "how it's provided"? Is this just the ResourceClient creating different resource types depending on policy?
+- For the k8s prototype: try creating Pods for tasks. What works well? What's awkward?
+- For the laptop case: the same task definition should resolve to local processes via TerminalPool. How does the policy switch work?
+- Host assignment: explicit in convoy spec? Defaulted? Eventually scheduled?
+- Failure handling: provisioning fails — what happens to the task? Retry? Mark failed? Propagate to convoy?
+- How does this relate to the current executor's command flow? The `WorkspaceOrchestrator` does: ensure environment -> ensure checkout -> ensure terminals -> bind to workspace. Is this the same sequence, just expressed as resource creation + reconciliation?
+
+**Dependencies:** Convoy resource + controller (brainstorm 3).
+
+**Starting point:** Read `crates/flotilla-core/src/executor/workspace.rs` (WorkspaceOrchestrator), `crates/flotilla-core/src/executor/session_actions.rs`, `crates/flotilla-core/src/hop_chain/`, and `crates/flotilla-core/src/step.rs`.
+
+---
+
+## 5. Presentation Integration and PresentationManager Rename
+
+**Goal:** Rename WorkspaceManager to PresentationManager, and connect convoy tasks to the presentation layer so users can see and interact with running processes.
+
+**Context:** The presentation manager already receives fully-resolved `Vec<(role, command_string)>` pairs and a layout template — it doesn't care where commands came from. For a single convoy task, the existing `WorkspaceAttachRequest` -> `resolve_template` -> `PaneLayout` -> create panes path works unchanged.
+
+The new parts are:
+- **Rename**: WorkspaceManager -> PresentationManager throughout the codebase. Mechanical but touches many files. The user-facing concept of "workspace" (tmux/zellij workspace) may stay — the rename is internal.
+- **Task transitions**: when task A completes and task B starts, the presentation should update (add/replace panes rather than creating a new workspace).
+- **Convoy TUI pane**: a flotilla TUI instance focused on the convoy, running as a pane in the presentation alongside terminal processes, showing task DAG progression.
+
+**Key questions:**
+- Reconfigure vs replace: when a new task starts, should the existing workspace gain new panes, or should a new workspace replace it? Reconfiguration needs new `update_workspace`/`add_panes` on the trait.
+- What does the presentation layout look like for a multi-task convoy? One workspace for the whole convoy? One per task?
+- How does the flotilla TUI pane work? It's another process in the layout — `flotilla tui --convoy <name>`? How does it get convoy state?
+- Layout config: per-task? Convoy-level? Both with defaults?
+- Should user-facing terminology stay as "workspace" while the internal trait is "PresentationManager"?
+
+**Dependencies:** Convoy resource + controller (brainstorm 3).
+
+**Starting point:** Read `crates/flotilla-core/src/providers/workspace/mod.rs` (resolve_template, build_pane_layout, WorkspaceManager trait), `crates/flotilla-core/src/providers/workspace/cmux.rs` (create_workspace implementation). Grep for `workspace_manager` in config and binding strings.
+
+---
+
+## 6. TUI Convoy View
+
+**Goal:** Add convoy-aware views to the flotilla TUI — showing convoy status, task DAG progression, and navigating to task processes.
+
+**Context:** Today the TUI shows work items (correlated groups of checkouts, PRs, sessions, terminals). The convoy becomes the primary object the user works with. The TUI needs to show:
+
+- Convoy list (like work item table but convoy-focused)
+- Convoy detail: task DAG with status indicators (Pending/Ready/Running/Completed)
+- Task detail: processes, their terminal status, links to attach
+- Convoy creation flow (eventually)
+
+There's also the "convoy pane" concept from brainstorm 5: a flotilla TUI instance running inside the presentation workspace, showing convoy progression alongside terminal processes.
+
+Convoy data feeds into the TUI through the normal provider data / snapshot path. The convoy controller produces items that become part of `ProviderData`, and correlation groups them with related work items (PRs, branches) downstream. The TUI doesn't need special convoy awareness in the correlation layer — it just needs to display convoy-shaped data well.
+
+**Key questions:**
+- Does the convoy view replace the work item table, supplement it, or is it a different tab/mode?
+- How does the TUI get convoy state? Through the existing snapshot/provider data path? Or a dedicated convoy watch?
+- What does the DAG visualization look like in a terminal? Simple list with indentation and status icons? Actual graph rendering?
+- Task interaction: how does the user mark a task complete? Action menu? Keybinding?
+- How does "attach to process terminal" work from the convoy view?
+- The convoy-as-TUI-pane: is this `flotilla tui --filter convoy=<name>`? A separate subcommand?
+
+**Dependencies:** Convoy resource + controller (brainstorm 3).
+
+**Starting point:** Read `crates/flotilla-tui/src/widgets/repo_page.rs`, `crates/flotilla-tui/src/app/mod.rs`, `crates/flotilla-core/src/data.rs` (work item building).
+
+---
+
+## 7. AttachableSet Migration
+
+**Goal:** Migrate existing AttachableSet functionality to convoys, then remove the old model.
+
+**Context:** Once convoys handle the full lifecycle (create, provision, present, tear down), AttachableSet becomes redundant. Today's AttachableSet is a convoy with a single task — the migration should be straightforward once the convoy model is solid.
+
+**Key questions:**
+- Can migration be gradual? (new code paths create convoys, old code paths still create AttachableSets, both coexist temporarily)
+- What happens to persisted AttachableSet state in `~/.config/flotilla/attachables/registry.json`? Auto-migrate on startup? Clean break?
+- The binding system (`ProviderBinding`) — does it have a convoy equivalent, or do native resource references replace it entirely?
+- What correlation keys do convoys emit? The existing `CorrelationKey::AttachableSet(id)` needs a convoy equivalent, but the exact shape depends on how correlation evolves. Keep it simple: convoy tasks emit the same keys their sub-resources would (Branch, CheckoutPath, etc.) and correlation groups them naturally.
+
+**Dependencies:** All previous brainstorms (3-6) should be solid before migrating.
+
+**Starting point:** Read `crates/flotilla-core/src/attachable/` (full module), `crates/flotilla-core/src/providers/correlation.rs`.

--- a/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
@@ -20,7 +20,7 @@ These are self-contained prompts for future brainstorm sessions, ordered by depe
 
 We prefer **raw REST calls** (reqwest + serde) over kube-rs for the k8s backend. Reasons:
 - kube-rs is a heavy dependency with opinions about async runtime
-- The `ResourceClient` trait should reflect plain REST semantics (what Tiller would eventually expose), not kube-rs's `Api<T>` abstractions
+- The `ResourceClient` trait should reflect plain REST semantics (what flotilla-cp would eventually expose), not kube-rs's `Api<T>` abstractions
 - For prototyping a single-node controller loop, a simple `loop { watch, react }` is clearer than kube-rs's reconciler framework
 - kube-rs doesn't provide leader election (community crate, no fencing) — not needed for single-node anyway
 - We already have reqwest and serde
@@ -49,7 +49,7 @@ Convoy data feeds into the existing provider data / correlation engine as just a
 
 **Goal:** Define the `ResourceClient` trait that convoy controllers use, and implement it against real k8s via raw REST calls.
 
-**Context:** Flotilla's convoy system needs a k8s-style resource API (get/list/watch/create/update/delete with resourceVersion). Controllers are written against a trait so they can run against k8s REST (prototyping), a future TillerHTTP backend, or InProcessTiller (zero-dependency laptop case). See the Tiller design doc for the full vision.
+**Context:** Flotilla's convoy system needs a k8s-style resource API (get/list/watch/create/update/delete with resourceVersion). Controllers are written against a trait so they can run against k8s REST (prototyping), a future flotilla-cpHTTP backend, or InProcessflotilla-cp (zero-dependency laptop case). See the flotilla-cp design doc for the full vision.
 
 This should be prototyped as a **standalone project** outside the flotilla codebase — a minimal Rust binary that registers CRDs and does CRUD + watch against a local k8s cluster (minikube). k3s is not viable (Linux-only); Go's goroutine stack model prevents embedding any Go-based k8s API server as a library, so the production in-process resource server will be a Rust/SQLite reimplementation of the required subset.
 

--- a/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
@@ -1,18 +1,20 @@
 # Convoy Implementation — Brainstorm Prompts
 
-These are self-contained prompts for future brainstorm sessions, ordered by dependency. Reference the design doc at `docs/superpowers/specs/2026-04-13-convoy-and-tiller-design.md` for full context.
+These are self-contained prompts for future brainstorm sessions, ordered by dependency. Reference the design doc at `docs/superpowers/specs/2026-04-13-convoy-and-control-plane-design.md` for full context.
 
 ## Dependency Graph
 
 ```
 1. ResourceClient trait + k8s REST prototype
-   2. WorkflowTemplate resource (depends on 1)
-3. Convoy resource + controller (depends on 1, 2)
-4. Task provisioning / policy (depends on 3)
-5. Presentation integration + PresentationManager rename (depends on 3)
-6. TUI convoy view (depends on 3)
-7. AttachableSet migration (depends on 3-6)
+2. WorkflowTemplate resource                   depends on: 1
+3. Convoy resource + controller                 depends on: 1, 2
+4. Task provisioning / policy                   depends on: 3
+5. Presentation integration + rename            depends on: 3
+6. TUI convoy view                              depends on: 3
+7. AttachableSet migration                      depends on: 3, 4, 5, 6
 ```
+
+Stages 4, 5, and 6 can run in parallel once 3 is complete.
 
 ## Design Decisions
 

--- a/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
@@ -22,7 +22,16 @@ We prefer **raw REST calls** (reqwest + serde) over kube-rs for the k8s backend.
 - kube-rs is a heavy dependency with opinions about async runtime
 - The `ResourceClient` trait should reflect plain REST semantics (what Tiller would eventually expose), not kube-rs's `Api<T>` abstractions
 - For prototyping a single-node controller loop, a simple `loop { watch, react }` is clearer than kube-rs's reconciler framework
+- kube-rs doesn't provide leader election (community crate, no fencing) — not needed for single-node anyway
 - We already have reqwest and serde
+
+### Hand-written CRD YAML over macro generation
+
+CRD specs are written as plain YAML, not generated from Rust derive macros (e.g. kube-rs `#[derive(CustomResource)]`). Reasons:
+- CRD YAML diffs are readable — you see exactly what changed in the schema
+- Macro-generated CRD output is opaque — derive attribute changes don't show the actual schema effect
+- k8s CRD specs are full of `x-kubernetes-*` annotations and structural schema requirements that fight macro generation
+- Hand-written YAML is debuggable with `kubectl apply --dry-run` and standard k8s tooling
 
 ### Pure k8s prototype (stages 1-4)
 

--- a/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
@@ -51,7 +51,7 @@ Convoy data feeds into the existing provider data / correlation engine as just a
 
 **Context:** Flotilla's convoy system needs a k8s-style resource API (get/list/watch/create/update/delete with resourceVersion). Controllers are written against a trait so they can run against k8s REST (prototyping), a future TillerHTTP backend, or InProcessTiller (zero-dependency laptop case). See the Tiller design doc for the full vision.
 
-This should be prototyped as a **standalone project** outside the flotilla codebase — a minimal Rust binary that registers CRDs and does CRUD + watch against a local k8s cluster (kind/k3s).
+This should be prototyped as a **standalone project** outside the flotilla codebase — a minimal Rust binary that registers CRDs and does CRUD + watch against a local k8s cluster (minikube). k3s is not viable (Linux-only); Go's goroutine stack model prevents embedding any Go-based k8s API server as a library, so the production in-process resource server will be a Rust/SQLite reimplementation of the required subset.
 
 **Key questions:**
 - What's the minimal trait surface that convoy controllers actually need? Start from usage, not from "what k8s has."


### PR DESCRIPTION
## Summary
- Design doc for the convoy resource model (replacing AttachableSet as the primary unit of work), workflow DAG templates, and Tiller micro control plane with ResourceClient trait abstraction
- Sequenced brainstorm prompts for incremental implementation (7 stages from ResourceClient trait through AttachableSet migration)
- Key decisions: raw REST over kube-rs, pure k8s prototype for stages 1-4, correlation as downstream concern

## Test plan
- [ ] Design review — no code changes