### PR TITLE
[codex] implement convoy resource stage 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1077,9 +1077,9 @@ checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -1285,6 +1285,8 @@ dependencies = [
  "serde_yml",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2088,9 +2090,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -3621,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_helpers"
@@ -4265,9 +4267,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -4330,9 +4332,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",

--- a/crates/flotilla-core/src/host_identity.rs
+++ b/crates/flotilla-core/src/host_identity.rs
@@ -771,6 +771,8 @@ mod tests {
         let base = tempfile::tempdir().unwrap();
         let machine_runner = crate::providers::discovery::test_support::DiscoveryMockRunner::builder()
             .on_run("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"], Ok("\"IOPlatformUUID\" = \"machine-uuid\"\n".into()))
+            .on_run("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"], Ok("\"IOPlatformUUID\" = \"machine-uuid\"\n".into()))
+            .on_run("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"], Ok("\"IOPlatformUUID\" = \"machine-uuid\"\n".into()))
             .build();
 
         let node_id_1 = resolve_local_node_id(base.path(), None, &machine_runner).await.unwrap();

--- a/crates/flotilla-core/src/host_identity.rs
+++ b/crates/flotilla-core/src/host_identity.rs
@@ -770,6 +770,8 @@ mod tests {
     async fn resolve_local_node_id_uses_machine_scoped_identity_dir() {
         let base = tempfile::tempdir().unwrap();
         let machine_runner = crate::providers::discovery::test_support::DiscoveryMockRunner::builder()
+            // This test resolves the machine UUID once per `resolve_local_node_id()` call and
+            // once more when asserting the scoped identity directory path directly.
             .on_run("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"], Ok("\"IOPlatformUUID\" = \"machine-uuid\"\n".into()))
             .on_run("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"], Ok("\"IOPlatformUUID\" = \"machine-uuid\"\n".into()))
             .on_run("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"], Ok("\"IOPlatformUUID\" = \"machine-uuid\"\n".into()))

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -525,15 +525,13 @@ fn snapshot_includes_linked_issues_when_populated() {
 async fn get_repo_providers_uses_preferred_root_environment_host_discovery_for_non_local_direct_repo() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
+    let config_base = temp.path().join("config");
     std::fs::create_dir_all(&repo).expect("create repo dir");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
 
-    let daemon = InProcessDaemon::new(
-        vec![],
-        Arc::new(ConfigStore::with_base(temp.path().join("config"))),
-        fake_discovery(false),
-        HostName::local(),
-    )
-    .await;
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
 
     daemon
         .replace_local_environment_bag_for_test(EnvironmentBag::new().with(EnvironmentAssertion::env_var("LOCAL_MARKER", "local")))

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -547,7 +547,8 @@ fn static_ssh_test_discovery_with_env_and_detectors(
 
 fn write_static_environment_config(config_dir: &Path, contents: &str) {
     std::fs::create_dir_all(config_dir).expect("create config dir");
-    std::fs::write(config_dir.join("daemon.toml"), contents).expect("write daemon config");
+    let rendered = if contents.contains("machine_id") { contents.to_owned() } else { format!("machine_id = \"test-machine\"\n{contents}") };
+    std::fs::write(config_dir.join("daemon.toml"), rendered).expect("write daemon config");
 }
 
 async fn daemon_for_plain_dir_with_local_environment_id(local_environment_id: &str) -> (tempfile::TempDir, PathBuf, Arc<InProcessDaemon>) {
@@ -555,12 +556,12 @@ async fn daemon_for_plain_dir_with_local_environment_id(local_environment_id: &s
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
     let config_dir = temp.path().join("config");
-    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    let config = test_config_store(config_dir.clone());
     let discovery = fake_discovery(false);
-    let machine_state_dir = flotilla_core::host_identity::resolve_local_environment_state_dir(&config_dir, None, &*discovery.runner).await;
+    let machine_state_dir =
+        flotilla_core::host_identity::resolve_local_environment_state_dir(&config_dir, Some("test-machine"), &*discovery.runner).await;
     std::fs::create_dir_all(&machine_state_dir).expect("create machine-scoped state dir");
     std::fs::write(machine_state_dir.join("environment-id"), format!("{local_environment_id}\n")).expect("seed environment id");
-    let config = Arc::new(ConfigStore::with_base(config_dir));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, discovery, HostName::local()).await;
     (temp, repo, daemon)
 }
@@ -1305,7 +1306,7 @@ async fn daemon_for_fake_repo() -> (tempfile::TempDir, PathBuf, Arc<InProcessDae
     let mut discovery = fake_vcs_discovery(state);
     discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, discovery, HostName::local()).await;
     let identity = daemon.tracked_repo_identity_for_path(&repo).await.expect("identity");
     (temp, repo, daemon, identity)
@@ -1327,7 +1328,7 @@ async fn daemon_for_duplicate_fake_repos() -> (tempfile::TempDir, PathBuf, PathB
         vec![Box::new(FakeCheckoutManagerFactory::new(state_a)), Box::new(FakeCheckoutManagerFactory::new(state_b))];
     discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo_a.clone(), repo_b.clone()], config, discovery, HostName::local()).await;
     (temp, repo_a, repo_b, daemon)
 }
@@ -1550,13 +1551,8 @@ async fn daemon_uses_persisted_local_environment_id() {
 
     drop(daemon);
 
-    let restarted = InProcessDaemon::new(
-        vec![repo],
-        Arc::new(ConfigStore::with_base(temp.path().join("config"))),
-        fake_discovery(false),
-        HostName::local(),
-    )
-    .await;
+    let restarted =
+        InProcessDaemon::new(vec![repo], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
     assert_eq!(restarted.local_environment_id().as_str(), "test-local-environment-id");
 }
 
@@ -1570,8 +1566,7 @@ async fn daemon_uses_config_machine_id_for_local_node_identity_storage() {
     std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"override-machine\"\n").expect("write daemon config");
 
     let daemon =
-        InProcessDaemon::new(vec![repo], Arc::new(ConfigStore::with_base(config_dir.clone())), fake_discovery(false), HostName::local())
-            .await;
+        InProcessDaemon::new(vec![repo], Arc::new(ConfigStore::with_base(&config_dir)), fake_discovery(false), HostName::local()).await;
 
     assert!(
         config_dir.join("identity/override-machine/node.key").exists(),
@@ -1593,13 +1588,8 @@ async fn daemon_uses_persisted_fingerprint_backed_node_id() {
     std::fs::create_dir_all(&config_dir).expect("create config dir");
 
     let discovery = fake_discovery(false);
-    let daemon = InProcessDaemon::new(
-        vec![repo.clone()],
-        Arc::new(ConfigStore::with_base(config_dir.clone())),
-        discovery,
-        HostName::new("display-host"),
-    )
-    .await;
+    let daemon =
+        InProcessDaemon::new(vec![repo.clone()], test_config_store(config_dir.clone()), discovery, HostName::new("display-host")).await;
 
     let first_node_id = daemon.node_id().clone();
     assert_eq!(first_node_id.as_str().len(), 32, "node id should be a 16-byte hex fingerprint");
@@ -1609,7 +1599,7 @@ async fn daemon_uses_persisted_fingerprint_backed_node_id() {
 
     let restarted = InProcessDaemon::new(
         vec![repo],
-        Arc::new(ConfigStore::with_base(config_dir.clone())),
+        test_config_store(config_dir.clone()),
         fake_discovery(false),
         HostName::new("renamed-display-host"),
     )
@@ -1751,8 +1741,7 @@ async fn provisioned_repo_refresh_stamps_discovered_checkout_environment_id() {
     discovery.factories.checkout_managers.push(Box::new(FakeCheckoutManagerFactory::new(state)));
 
     let runner = Arc::new(DiscoveryMockRunner::builder().build());
-    let daemon =
-        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(temp.path().join("config"))), discovery, HostName::local()).await;
+    let daemon = InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
     let environment_id = EnvironmentId::new("provisioned-checkout-env");
     let handle: EnvironmentHandle = Arc::new(TestProvisionedEnvironment {
         id: environment_id.clone(),
@@ -2266,7 +2255,7 @@ async fn list_hosts_uses_environment_scoped_counts_for_multiple_hosts_on_same_no
     discovery.factories.checkout_managers =
         vec![Box::new(FakeCheckoutManagerFactory::new(state_a)), Box::new(FakeCheckoutManagerFactory::new(state_b))];
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo_a.clone(), repo_b.clone()], config, discovery, HostName::local()).await;
     let peer = test_node("shared-peer");
     let env_a = EnvironmentId::host(HostId::new("shared-peer-host-a"));
@@ -2794,7 +2783,7 @@ async fn add_and_remove_repo_updates_state_and_emits_events() {
     let repo = temp.path().join("new-repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::local()).await;
     let mut rx = daemon.subscribe();
 
@@ -2912,7 +2901,7 @@ async fn adding_local_clone_promotes_remote_only_identity_to_local_execution() {
     let remote = temp.path().join("origin.git");
     let _ = init_git_repo_with_local_bare_remote(&local_repo, &remote);
     let identity = test_repo_identity();
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![], config, local_bare_remote_discovery(), HostName::local()).await;
 
     daemon.add_virtual_repo(identity.clone(), PathBuf::from("/remote/desktop/owner/repo"), vec![], 0).await.expect("add virtual repo");
@@ -3291,7 +3280,8 @@ async fn in_process_daemon_correlates_workspace_into_one_remote_checkout_item() 
 
 #[tokio::test]
 async fn execute_on_untracked_repo_returns_error_without_started_event() {
-    let config = Arc::new(ConfigStore::with_base(tempfile::tempdir().expect("tempdir").path()));
+    let config_tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(config_tmp.path().to_path_buf());
     let daemon = InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::local()).await;
     let mut rx = daemon.subscribe();
     let repo = std::path::PathBuf::from("/tmp/does-not-exist-for-daemon-test");
@@ -3322,7 +3312,8 @@ async fn execute_on_untracked_repo_returns_error_without_started_event() {
 
 #[tokio::test]
 async fn untrack_missing_repo_returns_error_without_started_event() {
-    let config = Arc::new(ConfigStore::with_base(tempfile::tempdir().expect("tempdir").path()));
+    let config_tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(config_tmp.path().to_path_buf());
     let daemon = InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::local()).await;
     let mut rx = daemon.subscribe();
     let repo = std::path::PathBuf::from("/tmp/does-not-exist-for-daemon-test");
@@ -3359,7 +3350,7 @@ async fn refresh_all_command_refreshes_every_tracked_repo() {
     std::fs::create_dir_all(&repo_a).unwrap();
     std::fs::create_dir_all(&repo_b).unwrap();
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo_a.clone(), repo_b.clone()], config, fake_discovery(false), HostName::local()).await;
     let mut rx = daemon.subscribe();
 
@@ -3489,7 +3480,8 @@ async fn checkout_target_branch_and_fresh_branch_are_distinct_errors() {
 
 #[tokio::test]
 async fn follower_mode_flag_is_stored() {
-    let config = Arc::new(ConfigStore::with_base(tempfile::tempdir().expect("tempdir").path()));
+    let config_tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(config_tmp.path().to_path_buf());
     let leader = InProcessDaemon::new(vec![], config.clone(), fake_discovery(false), HostName::local()).await;
     assert!(!leader.is_follower(), "default daemon should not be follower");
 
@@ -3503,7 +3495,7 @@ async fn follower_mode_skips_external_providers() {
     let repo = temp.path().to_path_buf();
     init_git_repo(&repo);
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, git_process_discovery(true), HostName::local()).await;
 
     assert!(daemon.is_follower());
@@ -3530,7 +3522,8 @@ async fn follower_mode_skips_external_providers() {
 
 #[tokio::test]
 async fn add_virtual_repo_emits_repo_tracked_then_snapshot_and_is_queryable() {
-    let config = Arc::new(ConfigStore::with_base(tempfile::tempdir().expect("tempdir").path()));
+    let config_tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(config_tmp.path().to_path_buf());
     let daemon = InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::local()).await;
     let mut rx = daemon.subscribe();
 
@@ -3602,7 +3595,8 @@ async fn add_virtual_repo_emits_repo_tracked_then_snapshot_and_is_queryable() {
 
 #[tokio::test]
 async fn add_virtual_repo_is_idempotent() {
-    let config = Arc::new(ConfigStore::with_base(tempfile::tempdir().expect("tempdir").path()));
+    let config_tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(config_tmp.path().to_path_buf());
     let daemon = InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::local()).await;
 
     let synthetic_path = PathBuf::from("<remote>/desktop/home/dev/repo");
@@ -3654,7 +3648,7 @@ async fn get_repo_detail_returns_provider_health_and_errors() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(
         vec![repo.clone()],
         config,
@@ -3708,7 +3702,7 @@ async fn add_repo_uses_manager_backed_local_environment_for_repo_identity() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon =
         InProcessDaemon::new(vec![], config, fake_discovery_with_provider_set(FakeDiscoveryProviders::new()), HostName::local()).await;
 
@@ -3736,7 +3730,7 @@ async fn add_repo_uses_manager_backed_local_environment_for_provider_discovery()
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let terminal_pool: Arc<dyn TerminalPool> = Arc::new(FakeTerminalPool::new());
     let mut discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
     discovery
@@ -4083,7 +4077,7 @@ async fn linked_issue_pinning_fetches_and_broadcasts_missing_issues() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(flotilla_core::config::ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon =
         flotilla_core::in_process::InProcessDaemon::new(vec![repo.clone()], config, discovery, flotilla_protocol::HostName::local()).await;
 
@@ -4177,7 +4171,7 @@ async fn attachable_set_cascade_deletes_on_checkout_removal() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(flotilla_core::config::ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = flotilla_core::in_process::InProcessDaemon::new(vec![repo.clone()], config, discovery, HostName::local()).await;
     let mut rx = daemon.subscribe();
 
@@ -4270,7 +4264,7 @@ async fn two_commands_can_run_concurrently() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(repo.join(".git")).expect("create .git dir");
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let agent = Arc::new(SlowCloudAgent::new());
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, slow_cloud_agent_discovery(Arc::clone(&agent)), HostName::local()).await;
     let mut rx = daemon.subscribe();

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -91,9 +91,15 @@ async fn empty_daemon() -> (tempfile::TempDir, Arc<InProcessDaemon>) {
 
 async fn empty_daemon_named(host_name: &str) -> (tempfile::TempDir, Arc<InProcessDaemon>) {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::new(host_name)).await;
     (tmp, daemon)
+}
+
+fn test_config_store(config_dir: PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(config_dir))
 }
 
 type RoutingState = (
@@ -317,7 +323,7 @@ async fn dispatch_repo_query_methods_round_trip() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, fake_discovery(false), HostName::new("local")).await;
     daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh repo");
 
@@ -699,7 +705,7 @@ async fn remote_command_mutations_route_remote_step_requests() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     let repo_identity = init_git_repo_with_remote(&repo, "git@github.com:owner/repo.git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, git_process_discovery(false), HostName::new("local")).await;
     daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh repo");
 
@@ -784,7 +790,7 @@ async fn remote_command_remote_step_events_remap_to_presentation_command_id_and_
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     let repo_identity = init_git_repo_with_remote(&repo, "git@github.com:owner/repo.git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, git_process_discovery(false), HostName::new("local")).await;
     daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh repo");
 
@@ -884,7 +890,7 @@ async fn remote_checkout_completion_runs_workspace_step_on_presentation_host() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     init_git_repo_with_remote(&repo, "git@github.com:owner/repo.git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let workspace_manager = Arc::new(FakeWorkspaceManager::new());
     let discovery =
         fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_workspace_manager(workspace_manager.clone() as Arc<_>));
@@ -1056,7 +1062,7 @@ async fn remote_checkout_failure_with_empty_response_still_stops_local_workspace
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     init_git_repo_with_remote(&repo, "git@github.com:owner/repo.git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let workspace_manager = Arc::new(FakeWorkspaceManager::new());
     let discovery =
         fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_workspace_manager(workspace_manager.clone() as Arc<_>));
@@ -1298,7 +1304,7 @@ async fn cancel_active_remote_segment_routes_remote_step_cancel_and_finishes_com
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     let repo_identity = init_git_repo_with_remote(&repo, "git@github.com:owner/repo.git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, git_process_discovery(false), HostName::new("local")).await;
     daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh repo");
 
@@ -1452,7 +1458,7 @@ async fn cancel_disconnect_of_active_remote_segment_finishes_pending_command() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     let repo_identity = init_git_repo_with_remote(&repo, "git@github.com:owner/repo.git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, git_process_discovery(false), HostName::new("local")).await;
     daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh repo");
 
@@ -1649,7 +1655,7 @@ async fn execute_forwarded_command_proxies_lifecycle_and_response() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     std::fs::create_dir_all(repo.join(".git")).expect("create .git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, fake_discovery(false), HostName::new("local")).await;
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let pending_remote_commands = Arc::new(Mutex::new(HashMap::new()));
@@ -1747,7 +1753,7 @@ async fn execute_forwarded_prepare_terminal_returns_terminal_prepared() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("remote-root").join("repo");
     let repo_identity = init_git_repo_with_remote(&repo, "git@github.com:owner/repo.git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, git_process_discovery(false), HostName::new("local")).await;
     daemon.refresh(&flotilla_protocol::RepoSelector::Path(repo.clone())).await.expect("refresh repo");
 
@@ -1913,7 +1919,7 @@ async fn execute_forwarded_checkout_resolves_repo_identity_across_different_root
     let repo_identity = init_git_repo_with_remote(&remote_repo, "git@github.com:owner/repo.git");
     init_git_repo_with_remote(&requester_repo, "git@github.com:owner/repo.git");
 
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![remote_repo.clone()], config, git_process_discovery(false), HostName::new("local")).await;
     daemon.refresh(&flotilla_protocol::RepoSelector::Path(remote_repo.clone())).await.expect("refresh repo");
 
@@ -1965,7 +1971,7 @@ async fn execute_forwarded_checkout_resolves_repo_identity_across_different_root
 #[tokio::test]
 async fn take_peer_data_rx_returns_some_once() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let mut server = DaemonServer::new(vec![], config, fake_discovery(false), tmp.path().join("test.sock"), Duration::from_secs(60))
         .await
         .expect("create daemon server");
@@ -1979,7 +1985,7 @@ async fn daemon_server_does_not_replay_configured_peers_without_host_environment
     let tmp = tempfile::tempdir().expect("tempdir");
     let base = tmp.path().join("config");
     std::fs::create_dir_all(&base).expect("create config directory");
-    std::fs::write(base.join("daemon.toml"), "host_name = \"local\"\n").expect("write daemon config");
+    std::fs::write(base.join("daemon.toml"), "machine_id = \"test-machine\"\nhost_name = \"local\"\n").expect("write daemon config");
     std::fs::write(
             base.join("hosts.toml"),
             "[hosts.udder]\nhostname = \"udder\"\ndaemon_socket = \"/tmp/udder.sock\"\n\n[hosts.feta]\nhostname = \"feta\"\ndaemon_socket = \"/tmp/feta.sock\"\n",
@@ -2596,7 +2602,7 @@ async fn peer_manager_initialized_from_config() {
     std::fs::create_dir_all(&base).expect("create config directory");
 
     // Write daemon config with a custom host name
-    std::fs::write(base.join("daemon.toml"), "host_name = \"test-host\"\n").expect("write daemon config");
+    std::fs::write(base.join("daemon.toml"), "machine_id = \"test-machine\"\nhost_name = \"test-host\"\n").expect("write daemon config");
 
     // Write hosts config with one peer
     std::fs::write(
@@ -2619,7 +2625,7 @@ async fn peer_manager_initialized_from_config() {
 #[tokio::test]
 async fn peer_manager_default_when_no_config() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let server = DaemonServer::new(vec![], config, fake_discovery(false), tmp.path().join("test.sock"), Duration::from_secs(60))
         .await
         .expect("create daemon server");
@@ -2634,6 +2640,7 @@ async fn daemon_server_new_returns_error_for_invalid_hosts_config() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let base = tmp.path().join("config");
     std::fs::create_dir_all(&base).expect("create config directory");
+    std::fs::write(base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
     std::fs::write(
         base.join("hosts.toml"),
         "[hosts.remote]\nhostname = \"10.0.0.5\"\nexpected_host_name = [\ndaemon_socket = \"/tmp/daemon.sock\"\n",
@@ -2654,7 +2661,7 @@ async fn daemon_server_new_returns_error_for_invalid_daemon_config() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let base = tmp.path().join("config");
     std::fs::create_dir_all(&base).expect("create config directory");
-    std::fs::write(base.join("daemon.toml"), "environments = 123\n").expect("write invalid daemon config");
+    std::fs::write(base.join("daemon.toml"), "machine_id = \"test-machine\"\nenvironments = 123\n").expect("write invalid daemon config");
 
     let config = Arc::new(ConfigStore::with_base(&base));
     let result = DaemonServer::new(vec![], config, fake_discovery(false), tmp.path().join("test.sock"), Duration::from_secs(60)).await;
@@ -3033,7 +3040,7 @@ async fn set_peer_providers_rejects_stale_version() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo = tmp.path().join("repo");
     std::fs::create_dir_all(repo.join(".git")).expect("create .git");
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, fake_discovery(false), HostName::new("local")).await;
 
     let fresh_peers = vec![(NodeInfo::new(NodeId::new("hostB"), "hostB"), ProviderData {

--- a/crates/flotilla-daemon/tests/multi_host.rs
+++ b/crates/flotilla-daemon/tests/multi_host.rs
@@ -80,8 +80,15 @@ async fn wait_for_local_checkout(daemon: &Arc<InProcessDaemon>, repo: &std::path
     .await
     .expect("timeout waiting for local checkout providers")
 }
+
+fn test_config_store(config_dir: PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(config_dir))
+}
+
 async fn empty_daemon_with_host(temp: &tempfile::TempDir, host: &str) -> Arc<InProcessDaemon> {
-    let config = Arc::new(ConfigStore::with_base(temp.path().join(format!("config-{host}"))));
+    let config = test_config_store(temp.path().join(format!("config-{host}")));
     InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::new(host)).await
 }
 // ---------------------------------------------------------------------------
@@ -222,7 +229,7 @@ async fn daemon_snapshot_has_correct_host_attribution() {
     let repo = temp.path().to_path_buf();
     std::fs::create_dir_all(repo.join(".git")).expect("create .git dir");
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, fake_discovery(false), HostName::local()).await;
 
     // Subscribe first, then trigger a refresh so the snapshot cannot race ahead.
@@ -264,14 +271,14 @@ async fn remote_checkout_replication_attributes_checkout_to_follower_host() {
 
     let leader = InProcessDaemon::new(
         vec![leader_repo.clone()],
-        Arc::new(ConfigStore::with_base(temp.path().join("leader-config"))),
+        test_config_store(temp.path().join("leader-config")),
         git_process_discovery(false),
         HostName::new("leader"),
     )
     .await;
     let follower = InProcessDaemon::new(
         vec![follower_repo.clone()],
-        Arc::new(ConfigStore::with_base(temp.path().join("follower-config"))),
+        test_config_store(temp.path().join("follower-config")),
         git_process_discovery(false),
         HostName::new("follower"),
     )
@@ -326,7 +333,7 @@ async fn daemon_snapshot_includes_follower_checkout_overlay() {
     let repo = temp.path().to_path_buf();
     std::fs::create_dir_all(repo.join(".git")).expect("create .git dir");
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, fake_discovery(false), HostName::local()).await;
 
     let follower_host = HostName::new("follower");
@@ -618,7 +625,7 @@ async fn follower_mode_has_only_local_providers() {
     let repo = temp.path().to_path_buf();
     init_git_repo(&repo);
 
-    let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+    let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo], config, git_process_discovery(true), HostName::local()).await;
 
     assert!(daemon.is_follower(), "daemon should be in follower mode");

--- a/crates/flotilla-daemon/tests/peer_connect_flow.rs
+++ b/crates/flotilla-daemon/tests/peer_connect_flow.rs
@@ -25,6 +25,12 @@ fn test_node_id(name: &str) -> NodeId {
     NodeId::new(format!("node-{name}"))
 }
 
+fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(config_dir))
+}
+
 /// Peer sender that captures messages and signals a `Notify` on each send,
 /// allowing tests to wait deterministically instead of sleeping.
 struct NotifyPeerSender {
@@ -70,7 +76,7 @@ async fn peer_connect_triggers_local_state_send() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo_path = tmp.path().join("repo");
     init_git_repo(&repo_path);
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let host_a = HostName::new("host-a");
     let _host_b = HostName::new("host-b");
     let node_b = test_node_id("host-b");
@@ -111,7 +117,7 @@ async fn peer_reconnect_resends_local_state() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let repo_path = tmp.path().join("repo");
     init_git_repo(&repo_path);
-    let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
+    let config = test_config_store(tmp.path().join("config"));
     let host_a = HostName::new("host-a");
     let _host_b = HostName::new("host-b");
     let node_b = test_node_id("host-b");

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -13,9 +13,15 @@ use flotilla_core::{
 use flotilla_daemon::server::test_support::{spawn_in_memory_request_topology, spawn_in_memory_request_topology_stateful};
 use flotilla_protocol::{provider_data::Issue, Command, CommandAction, CommandValue, HostName, RepoSelector};
 
+fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(config_dir))
+}
+
 async fn empty_daemon_named(host_name: &str) -> Arc<InProcessDaemon> {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let config = Arc::new(ConfigStore::with_base(tmp.keep()));
+    let config = test_config_store(tmp.keep());
     InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::new(host_name)).await
 }
 
@@ -93,7 +99,7 @@ async fn remote_issue_query_returns_results() {
     let follower_tmp = tempfile::tempdir().expect("tempdir");
     let follower_repo = follower_tmp.path().join("repo");
     init_git_repo_with_remote(&follower_repo, "git@github.com:owner/repo.git");
-    let follower_config = Arc::new(ConfigStore::with_base(follower_tmp.path().join("config")));
+    let follower_config = test_config_store(follower_tmp.path().join("config"));
     let follower_discovery = fake_discovery_with_provider_set(
         FakeDiscoveryProviders::new().with_issue_query_service(Arc::clone(&mock_service) as Arc<dyn IssueQueryService>),
     );

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -15,8 +15,8 @@ serde_yml = "0.0.12"
 base64 = "0.22"
 bytes = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tempfile = "3"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -14,6 +14,8 @@ reqwest = { version = "0.13.2", default-features = false, features = ["json", "q
 serde_yml = "0.0.12"
 base64 = "0.22"
 bytes = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/flotilla-resources/examples/convoy_controller.rs
+++ b/crates/flotilla-resources/examples/convoy_controller.rs
@@ -1,8 +1,8 @@
 use std::{env, path::PathBuf, time::Duration};
 
 use flotilla_resources::{
-    apply_status_patch, ensure_crd, ensure_namespace, reconcile, Convoy, HttpBackend, ResourceBackend, WatchEvent, WatchStart,
-    WorkflowTemplate,
+    apply_status_patch, ensure_crd, ensure_namespace, reconcile, Convoy, HttpBackend, ResourceBackend, ResourceError, WatchEvent,
+    WatchStart, WorkflowTemplate,
 };
 use futures::StreamExt;
 use tracing::{error, info, warn};
@@ -22,7 +22,11 @@ async fn reconcile_and_apply(
 ) -> Result<(), flotilla_resources::ResourceError> {
     let convoy = convoys.get(name).await?;
     let template = if convoy.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_none() {
-        Some(templates.get(&convoy.spec.workflow_ref).await?)
+        match templates.get(&convoy.spec.workflow_ref).await {
+            Ok(template) => Some(template),
+            Err(ResourceError::NotFound { .. }) => None,
+            Err(err) => return Err(err),
+        }
     } else {
         None
     };

--- a/crates/flotilla-resources/examples/convoy_controller.rs
+++ b/crates/flotilla-resources/examples/convoy_controller.rs
@@ -1,0 +1,117 @@
+use std::{env, path::PathBuf, time::Duration};
+
+use flotilla_resources::{
+    apply_status_patch, ensure_crd, ensure_namespace, reconcile, Convoy, HttpBackend, ResourceBackend, WatchEvent, WatchStart,
+    WorkflowTemplate,
+};
+use futures::StreamExt;
+use tracing::{error, info, warn};
+
+fn kubeconfig_path() -> PathBuf {
+    if let Ok(path) = env::var("KUBECONFIG") {
+        return PathBuf::from(path);
+    }
+    let home = env::var("HOME").expect("HOME must be set when KUBECONFIG is unset");
+    PathBuf::from(home).join(".kube/config")
+}
+
+async fn reconcile_and_apply(
+    convoys: &flotilla_resources::TypedResolver<Convoy>,
+    templates: &flotilla_resources::TypedResolver<WorkflowTemplate>,
+    name: &str,
+) -> Result<(), flotilla_resources::ResourceError> {
+    let convoy = convoys.get(name).await?;
+    let template = if convoy.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_none() {
+        Some(templates.get(&convoy.spec.workflow_ref).await?)
+    } else {
+        None
+    };
+    let outcome = reconcile(&convoy, template.as_ref(), chrono::Utc::now());
+    if let Some(patch) = outcome.patch {
+        info!(convoy = %name, ?patch, "applying convoy patch");
+        apply_status_patch(convoys, name, &patch).await?;
+    }
+    for event in outcome.events {
+        info!(convoy = %name, ?event, "convoy reconcile event");
+    }
+    Ok(())
+}
+
+async fn resync_all(
+    convoys: &flotilla_resources::TypedResolver<Convoy>,
+    templates: &flotilla_resources::TypedResolver<WorkflowTemplate>,
+) -> Result<(), flotilla_resources::ResourceError> {
+    let listed = convoys.list().await?;
+    for convoy in listed.items {
+        reconcile_and_apply(convoys, templates, &convoy.metadata.name).await?;
+    }
+    Ok(())
+}
+
+fn parse_namespace() -> String {
+    let mut args = env::args().skip(1);
+    let mut namespace = "flotilla".to_string();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--namespace" => {
+                namespace = args.next().expect("--namespace requires a value");
+            }
+            other => panic!("unexpected argument: {other}"),
+        }
+    }
+    namespace
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt().with_target(false).init();
+
+    let namespace = parse_namespace();
+    let backend = HttpBackend::from_kubeconfig(kubeconfig_path())?;
+    ensure_namespace(&backend, &namespace).await?;
+    ensure_crd(&backend, include_str!("../src/crds/workflow_template.crd.yaml")).await?;
+    ensure_crd(&backend, include_str!("../src/crds/convoy.crd.yaml")).await?;
+
+    let backend = ResourceBackend::Http(backend);
+    let convoys = backend.clone().using::<Convoy>(&namespace);
+    let templates = backend.using::<WorkflowTemplate>(&namespace);
+
+    let listed = convoys.list().await?;
+    for convoy in &listed.items {
+        reconcile_and_apply(&convoys, &templates, &convoy.metadata.name).await?;
+    }
+
+    let mut watch = convoys.watch(WatchStart::FromVersion(listed.resource_version)).await?;
+    let mut resync = tokio::time::interval(Duration::from_secs(60));
+
+    loop {
+        tokio::select! {
+            maybe_event = watch.next() => {
+                match maybe_event {
+                    Some(Ok(WatchEvent::Added(convoy) | WatchEvent::Modified(convoy))) => {
+                        if let Err(err) = reconcile_and_apply(&convoys, &templates, &convoy.metadata.name).await {
+                            error!(convoy = %convoy.metadata.name, %err, "convoy reconcile failed");
+                        }
+                    }
+                    Some(Ok(WatchEvent::Deleted(convoy))) => {
+                        info!(convoy = %convoy.metadata.name, "convoy deleted");
+                    }
+                    Some(Err(err)) => {
+                        warn!(%err, "convoy watch error; waiting for next resync");
+                    }
+                    None => {
+                        warn!("convoy watch stream ended");
+                        break;
+                    }
+                }
+            }
+            _ = resync.tick() => {
+                if let Err(err) = resync_all(&convoys, &templates).await {
+                    warn!(%err, "convoy resync failed");
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -1,8 +1,8 @@
 use std::{env, path::PathBuf};
 
 use flotilla_resources::{
-    ensure_crd, ensure_namespace, validate, HttpBackend, InputMeta, ResourceBackend, WatchEvent, WatchStart, WorkflowTemplate,
-    WorkflowTemplateSpec,
+    ensure_crd, ensure_namespace, validate, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, HttpBackend, InputMeta, InputValue,
+    ResourceBackend, WatchEvent, WatchStart, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use futures::StreamExt;
 use serde::Deserialize;
@@ -38,6 +38,19 @@ fn updated_workflow_spec() -> WorkflowTemplateSpec {
     spec
 }
 
+fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
+    ConvoySpec {
+        workflow_ref: workflow_ref.to_string(),
+        inputs: [
+            ("feature".to_string(), InputValue::String("Retry logic for the poller".to_string())),
+            ("branch".to_string(), InputValue::String("fix-bug-123".to_string())),
+        ]
+        .into_iter()
+        .collect(),
+        placement_policy: Some("laptop-docker".to_string()),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let kubeconfig = kubeconfig_path();
@@ -47,31 +60,68 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ensure_crd(&backend, include_str!("../src/crds/convoy.crd.yaml")).await?;
     ensure_crd(&backend, include_str!("../src/crds/workflow_template.crd.yaml")).await?;
 
-    let resolver = ResourceBackend::Http(backend).using::<WorkflowTemplate>(namespace);
-    let spec = load_workflow_spec()?;
-    validate(&spec).map_err(|errors| format!("sample workflow failed validation: {errors:?}"))?;
-    let meta = InputMeta {
+    let backend = ResourceBackend::Http(backend);
+    let workflow_resolver = backend.clone().using::<WorkflowTemplate>(namespace);
+    let convoy_resolver = backend.using::<Convoy>(namespace);
+    let workflow_spec = load_workflow_spec()?;
+    validate(&workflow_spec).map_err(|errors| format!("sample workflow failed validation: {errors:?}"))?;
+    let workflow_meta = InputMeta {
         name: format!("demo-workflow-template-{}", std::process::id()),
         labels: [("app".to_string(), "flotilla".to_string())].into_iter().collect(),
         annotations: Default::default(),
     };
-    if let Err(err) = resolver.delete(&meta.name).await {
+    if let Err(err) = workflow_resolver.delete(&workflow_meta.name).await {
+        if !matches!(err, flotilla_resources::ResourceError::NotFound { .. }) {
+            return Err(err.into());
+        }
+    }
+    let convoy_meta = InputMeta {
+        name: format!("demo-convoy-{}", std::process::id()),
+        labels: [("app".to_string(), "flotilla".to_string())].into_iter().collect(),
+        annotations: Default::default(),
+    };
+    if let Err(err) = convoy_resolver.delete(&convoy_meta.name).await {
         if !matches!(err, flotilla_resources::ResourceError::NotFound { .. }) {
             return Err(err.into());
         }
     }
 
-    println!("creating resource");
-    let created = resolver.create(&meta, &spec).await?;
-    println!("created {} rv={}", created.metadata.name, created.metadata.resource_version);
+    println!("creating workflow template");
+    let created_workflow = workflow_resolver.create(&workflow_meta, &workflow_spec).await?;
+    println!("created workflow {} rv={}", created_workflow.metadata.name, created_workflow.metadata.resource_version);
 
-    let listed = resolver.list().await?;
-    println!("listed {} resources at rv={}", listed.items.len(), listed.resource_version);
+    println!("updating workflow template");
+    let updated_workflow = workflow_resolver
+        .update(&workflow_meta, &created_workflow.metadata.resource_version, &updated_workflow_spec())
+        .await?;
+    println!("updated workflow rv={}", updated_workflow.metadata.resource_version);
 
-    let mut watch = resolver.watch(WatchStart::FromVersion(listed.resource_version.clone())).await?;
-    println!("updating spec");
-    let updated = resolver.update(&meta, &created.metadata.resource_version, &updated_workflow_spec()).await?;
-    println!("updated rv={}", updated.metadata.resource_version);
+    println!("creating convoy");
+    let created_convoy = convoy_resolver.create(&convoy_meta, &convoy_spec(&workflow_meta.name)).await?;
+    println!("created convoy {} rv={}", created_convoy.metadata.name, created_convoy.metadata.resource_version);
+
+    let listed = convoy_resolver.list().await?;
+    println!("listed {} convoys at rv={}", listed.items.len(), listed.resource_version);
+
+    let mut watch = convoy_resolver.watch(WatchStart::FromVersion(listed.resource_version.clone())).await?;
+    println!("updating convoy status");
+    let updated_convoy = convoy_resolver
+        .update_status(
+            &created_convoy.metadata.name,
+            &created_convoy.metadata.resource_version,
+            &ConvoyStatus {
+                phase: ConvoyPhase::Active,
+                workflow_snapshot: None,
+                tasks: Default::default(),
+                message: None,
+                started_at: None,
+                finished_at: None,
+                observed_workflow_ref: None,
+                observed_workflows: None,
+            },
+        )
+        .await?;
+    println!("updated convoy rv={}", updated_convoy.metadata.resource_version);
 
     if let Some(event) = watch.next().await {
         match event? {
@@ -82,13 +132,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    println!("deleting resource");
-    resolver.delete(&created.metadata.name).await?;
+    println!("deleting convoy");
+    convoy_resolver.delete(&created_convoy.metadata.name).await?;
     if let Some(event) = watch.next().await {
         match event? {
             WatchEvent::Deleted(object) => println!("watch saw deleted resource rv={}", object.metadata.resource_version),
             WatchEvent::Added(_) | WatchEvent::Modified(_) => println!("watch saw non-deleted event"),
         }
     }
+
+    println!("deleting workflow template");
+    workflow_resolver.delete(&created_workflow.metadata.name).await?;
     Ok(())
 }

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -91,9 +91,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("created workflow {} rv={}", created_workflow.metadata.name, created_workflow.metadata.resource_version);
 
     println!("updating workflow template");
-    let updated_workflow = workflow_resolver
-        .update(&workflow_meta, &created_workflow.metadata.resource_version, &updated_workflow_spec())
-        .await?;
+    let updated_workflow =
+        workflow_resolver.update(&workflow_meta, &created_workflow.metadata.resource_version, &updated_workflow_spec()).await?;
     println!("updated workflow rv={}", updated_workflow.metadata.resource_version);
 
     println!("creating convoy");
@@ -106,20 +105,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut watch = convoy_resolver.watch(WatchStart::FromVersion(listed.resource_version.clone())).await?;
     println!("updating convoy status");
     let updated_convoy = convoy_resolver
-        .update_status(
-            &created_convoy.metadata.name,
-            &created_convoy.metadata.resource_version,
-            &ConvoyStatus {
-                phase: ConvoyPhase::Active,
-                workflow_snapshot: None,
-                tasks: Default::default(),
-                message: None,
-                started_at: None,
-                finished_at: None,
-                observed_workflow_ref: None,
-                observed_workflows: None,
-            },
-        )
+        .update_status(&created_convoy.metadata.name, &created_convoy.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Active,
+            workflow_snapshot: None,
+            tasks: Default::default(),
+            message: None,
+            started_at: None,
+            finished_at: None,
+            observed_workflow_ref: None,
+            observed_workflows: None,
+        })
         .await?;
     println!("updated convoy rv={}", updated_convoy.metadata.resource_version);
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -9,6 +9,10 @@ use crate::{
     workflow_template::ProcessDefinition,
 };
 
+mod reconcile;
+
+pub use reconcile::{reconcile, ConvoyEvent, ReconcileOutcome};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Convoy;
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -1,0 +1,316 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    resource::{ApiPaths, Resource},
+    status_patch::StatusPatch,
+    workflow_template::ProcessDefinition,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Convoy;
+
+impl Resource for Convoy {
+    type Spec = ConvoySpec;
+    type Status = ConvoyStatus;
+    type StatusPatch = ConvoyStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "convoys", kind: "Convoy" };
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvoySpec {
+    pub workflow_ref: String,
+    #[serde(default)]
+    pub inputs: BTreeMap<String, InputValue>,
+    #[serde(default)]
+    pub placement_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InputValue {
+    String(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ConvoyStatus {
+    pub phase: ConvoyPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_snapshot: Option<WorkflowSnapshot>,
+    #[serde(default)]
+    pub tasks: BTreeMap<String, TaskState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_workflow_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_workflows: Option<BTreeMap<String, String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowSnapshot {
+    pub tasks: Vec<SnapshotTask>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotTask {
+    pub name: String,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    pub processes: Vec<ProcessDefinition>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum ConvoyPhase {
+    #[default]
+    Pending,
+    Active,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskState {
+    pub phase: TaskPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<PlacementStatus>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TaskPhase {
+    Pending,
+    Ready,
+    Launching,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PlacementStatus {
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConvoyStatusPatch {
+    Bootstrap {
+        workflow_snapshot: WorkflowSnapshot,
+        observed_workflow_ref: String,
+        observed_workflows: BTreeMap<String, String>,
+        tasks: BTreeMap<String, TaskState>,
+        phase: ConvoyPhase,
+        started_at: Option<DateTime<Utc>>,
+    },
+    FailInit {
+        phase: ConvoyPhase,
+        message: String,
+        finished_at: DateTime<Utc>,
+    },
+    AdvanceTasksToReady {
+        ready: BTreeMap<String, DateTime<Utc>>,
+    },
+    FailConvoy {
+        cancelled_tasks: BTreeMap<String, DateTime<Utc>>,
+        finished_at: DateTime<Utc>,
+        message: Option<String>,
+    },
+    RollUpPhase {
+        phase: ConvoyPhase,
+        started_at: Option<DateTime<Utc>>,
+        finished_at: Option<DateTime<Utc>>,
+    },
+    TaskLaunching {
+        task: String,
+        started_at: DateTime<Utc>,
+        placement: PlacementStatus,
+    },
+    TaskRunning {
+        task: String,
+    },
+    MarkTaskCompleted {
+        task: String,
+        finished_at: DateTime<Utc>,
+        message: Option<String>,
+    },
+    MarkTaskFailed {
+        task: String,
+        finished_at: DateTime<Utc>,
+        message: String,
+    },
+    MarkTaskCancelled {
+        task: String,
+        finished_at: DateTime<Utc>,
+    },
+}
+
+impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
+    fn apply(&self, status: &mut ConvoyStatus) {
+        match self {
+            Self::Bootstrap {
+                workflow_snapshot,
+                observed_workflow_ref,
+                observed_workflows,
+                tasks,
+                phase,
+                started_at,
+            } => {
+                status.workflow_snapshot = Some(workflow_snapshot.clone());
+                status.observed_workflow_ref = Some(observed_workflow_ref.clone());
+                status.observed_workflows = Some(observed_workflows.clone());
+                status.tasks = tasks.clone();
+                status.phase = *phase;
+                status.started_at = *started_at;
+            }
+            Self::FailInit { phase, message, finished_at } => {
+                status.phase = *phase;
+                status.message = Some(message.clone());
+                status.finished_at = Some(*finished_at);
+            }
+            Self::AdvanceTasksToReady { ready } => {
+                for (task, ready_at) in ready {
+                    if let Some(state) = status.tasks.get_mut(task) {
+                        state.phase = TaskPhase::Ready;
+                        state.ready_at = Some(*ready_at);
+                    }
+                }
+            }
+            Self::FailConvoy { cancelled_tasks, finished_at, message } => {
+                status.phase = ConvoyPhase::Failed;
+                status.finished_at = Some(*finished_at);
+                status.message = message.clone();
+                for (task, cancelled_at) in cancelled_tasks {
+                    if let Some(state) = status.tasks.get_mut(task) {
+                        state.phase = TaskPhase::Cancelled;
+                        state.finished_at = Some(*cancelled_at);
+                    }
+                }
+            }
+            Self::RollUpPhase { phase, started_at, finished_at } => {
+                status.phase = *phase;
+                if let Some(started_at) = started_at {
+                    status.started_at = Some(*started_at);
+                }
+                if let Some(finished_at) = finished_at {
+                    status.finished_at = Some(*finished_at);
+                }
+            }
+            Self::TaskLaunching { task, started_at, placement } => {
+                if let Some(state) = status.tasks.get_mut(task) {
+                    state.phase = TaskPhase::Launching;
+                    state.started_at = Some(*started_at);
+                    state.placement = Some(placement.clone());
+                }
+            }
+            Self::TaskRunning { task } => {
+                if let Some(state) = status.tasks.get_mut(task) {
+                    state.phase = TaskPhase::Running;
+                }
+            }
+            Self::MarkTaskCompleted { task, finished_at, message } => {
+                if let Some(state) = status.tasks.get_mut(task) {
+                    state.phase = TaskPhase::Completed;
+                    state.finished_at = Some(*finished_at);
+                    state.message = message.clone();
+                }
+            }
+            Self::MarkTaskFailed { task, finished_at, message } => {
+                if let Some(state) = status.tasks.get_mut(task) {
+                    state.phase = TaskPhase::Failed;
+                    state.finished_at = Some(*finished_at);
+                    state.message = Some(message.clone());
+                }
+            }
+            Self::MarkTaskCancelled { task, finished_at } => {
+                if let Some(state) = status.tasks.get_mut(task) {
+                    state.phase = TaskPhase::Cancelled;
+                    state.finished_at = Some(*finished_at);
+                }
+            }
+        }
+    }
+}
+
+pub mod controller_patches {
+    use super::*;
+
+    pub fn bootstrap(
+        workflow_snapshot: WorkflowSnapshot,
+        observed_workflow_ref: String,
+        observed_workflows: BTreeMap<String, String>,
+        tasks: BTreeMap<String, TaskState>,
+        phase: ConvoyPhase,
+        started_at: Option<DateTime<Utc>>,
+    ) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::Bootstrap { workflow_snapshot, observed_workflow_ref, observed_workflows, tasks, phase, started_at }
+    }
+
+    pub fn fail_init(phase: ConvoyPhase, message: String, finished_at: DateTime<Utc>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::FailInit { phase, message, finished_at }
+    }
+
+    pub fn advance_tasks_to_ready(ready: BTreeMap<String, DateTime<Utc>>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::AdvanceTasksToReady { ready }
+    }
+
+    pub fn fail_convoy(
+        cancelled_tasks: BTreeMap<String, DateTime<Utc>>,
+        finished_at: DateTime<Utc>,
+        message: Option<String>,
+    ) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::FailConvoy { cancelled_tasks, finished_at, message }
+    }
+
+    pub fn roll_up_phase(
+        phase: ConvoyPhase,
+        started_at: Option<DateTime<Utc>>,
+        finished_at: Option<DateTime<Utc>>,
+    ) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::RollUpPhase { phase, started_at, finished_at }
+    }
+}
+
+pub mod provisioning_patches {
+    use super::*;
+
+    pub fn task_launching(task: String, started_at: DateTime<Utc>, placement: PlacementStatus) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::TaskLaunching { task, started_at, placement }
+    }
+
+    pub fn task_running(task: String) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::TaskRunning { task }
+    }
+}
+
+pub mod external_patches {
+    use super::*;
+
+    pub fn mark_task_completed(task: String, finished_at: DateTime<Utc>, message: Option<String>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::MarkTaskCompleted { task, finished_at, message }
+    }
+
+    pub fn mark_task_failed(task: String, finished_at: DateTime<Utc>, message: String) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::MarkTaskFailed { task, finished_at, message }
+    }
+
+    pub fn mark_task_cancelled(task: String, finished_at: DateTime<Utc>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::MarkTaskCancelled { task, finished_at }
+    }
+}

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -36,6 +36,8 @@ pub struct ConvoySpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InputValue {
+    // Keep inputs untagged so today's plain strings serialize naturally while leaving room
+    // for future structured input sources without changing the field shape.
     String(String),
 }
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -168,14 +168,7 @@ pub enum ConvoyStatusPatch {
 impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
     fn apply(&self, status: &mut ConvoyStatus) {
         match self {
-            Self::Bootstrap {
-                workflow_snapshot,
-                observed_workflow_ref,
-                observed_workflows,
-                tasks,
-                phase,
-                started_at,
-            } => {
+            Self::Bootstrap { workflow_snapshot, observed_workflow_ref, observed_workflows, tasks, phase, started_at } => {
                 status.workflow_snapshot = Some(workflow_snapshot.clone());
                 status.observed_workflow_ref = Some(observed_workflow_ref.clone());
                 status.observed_workflows = Some(observed_workflows.clone());
@@ -282,11 +275,7 @@ pub mod controller_patches {
         ConvoyStatusPatch::FailConvoy { cancelled_tasks, finished_at, message }
     }
 
-    pub fn roll_up_phase(
-        phase: ConvoyPhase,
-        started_at: Option<DateTime<Utc>>,
-        finished_at: Option<DateTime<Utc>>,
-    ) -> ConvoyStatusPatch {
+    pub fn roll_up_phase(phase: ConvoyPhase, started_at: Option<DateTime<Utc>>, finished_at: Option<DateTime<Utc>>) -> ConvoyStatusPatch {
         ConvoyStatusPatch::RollUpPhase { phase, started_at, finished_at }
     }
 }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -1,0 +1,190 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+
+use super::{
+    controller_patches, Convoy, ConvoyPhase, ConvoyStatusPatch, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot,
+};
+use crate::{
+    resource::ResourceObject,
+    workflow_template::{ValidationError, WorkflowTemplate, validate},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconcileOutcome {
+    pub patch: Option<ConvoyStatusPatch>,
+    pub events: Vec<ConvoyEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConvoyEvent {
+    PhaseChanged { from: ConvoyPhase, to: ConvoyPhase },
+    TaskPhaseChanged { task: String, from: TaskPhase, to: TaskPhase },
+    TemplateNotFound { name: String },
+    TemplateInvalid { name: String, errors: Vec<ValidationError> },
+    WorkflowRefChanged { from: String, to: String },
+    MissingInput { name: String },
+}
+
+pub fn reconcile(
+    convoy: &ResourceObject<Convoy>,
+    template: Option<&ResourceObject<WorkflowTemplate>>,
+    now: DateTime<Utc>,
+) -> ReconcileOutcome {
+    let status = convoy.status.clone().unwrap_or_default();
+
+    if let Some(observed) = status.observed_workflow_ref.as_ref() {
+        if observed != &convoy.spec.workflow_ref {
+            return ReconcileOutcome {
+                patch: Some(controller_patches::fail_init(
+                    ConvoyPhase::Failed,
+                    "workflow_ref changed after init; not supported".to_string(),
+                    now,
+                )),
+                events: vec![ConvoyEvent::WorkflowRefChanged { from: observed.clone(), to: convoy.spec.workflow_ref.clone() }],
+            };
+        }
+    }
+
+    if status.observed_workflow_ref.is_none() {
+        return bootstrap_outcome(convoy, template, now);
+    }
+
+    if let Some(patch) = fail_fast_patch(&status.tasks, now) {
+        return ReconcileOutcome { patch: Some(patch), events: Vec::new() };
+    }
+
+    if let Some(patch) = advance_ready_patch(&status, now) {
+        return ReconcileOutcome { patch: Some(patch), events: Vec::new() };
+    }
+
+    if let Some(patch) = roll_up_phase_patch(&status, now) {
+        return ReconcileOutcome { patch: Some(patch), events: Vec::new() };
+    }
+
+    ReconcileOutcome { patch: None, events: Vec::new() }
+}
+
+fn bootstrap_outcome(
+    convoy: &ResourceObject<Convoy>,
+    template: Option<&ResourceObject<WorkflowTemplate>>,
+    now: DateTime<Utc>,
+) -> ReconcileOutcome {
+    let Some(template) = template else {
+        return ReconcileOutcome {
+            patch: Some(controller_patches::fail_init(
+                ConvoyPhase::Failed,
+                format!("WorkflowTemplate '{}' not found", convoy.spec.workflow_ref),
+                now,
+            )),
+            events: vec![ConvoyEvent::TemplateNotFound { name: convoy.spec.workflow_ref.clone() }],
+        };
+    };
+
+    if let Err(errors) = validate(&template.spec) {
+        return ReconcileOutcome {
+            patch: Some(controller_patches::fail_init(
+                ConvoyPhase::Failed,
+                format!("WorkflowTemplate '{}' is invalid: {errors:?}", convoy.spec.workflow_ref),
+                now,
+            )),
+            events: vec![ConvoyEvent::TemplateInvalid { name: template.metadata.name.clone(), errors }],
+        };
+    }
+
+    for input in &template.spec.inputs {
+        if !convoy.spec.inputs.contains_key(&input.name) {
+            return ReconcileOutcome {
+                patch: Some(controller_patches::fail_init(
+                    ConvoyPhase::Failed,
+                    format!("missing input '{}'", input.name),
+                    now,
+                )),
+                events: vec![ConvoyEvent::MissingInput { name: input.name.clone() }],
+            };
+        }
+    }
+
+    let workflow_snapshot = WorkflowSnapshot {
+        tasks: template
+            .spec
+            .tasks
+            .iter()
+            .map(|task| SnapshotTask { name: task.name.clone(), depends_on: task.depends_on.clone(), processes: task.processes.clone() })
+            .collect(),
+    };
+    let tasks = template
+        .spec
+        .tasks
+        .iter()
+        .map(|task| {
+            (
+                task.name.clone(),
+                TaskState { phase: TaskPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None },
+            )
+        })
+        .collect();
+
+    ReconcileOutcome {
+        patch: Some(controller_patches::bootstrap(
+            workflow_snapshot,
+            convoy.spec.workflow_ref.clone(),
+            [(convoy.spec.workflow_ref.clone(), template.metadata.resource_version.clone())].into_iter().collect(),
+            tasks,
+            ConvoyPhase::Pending,
+            None,
+        )),
+        events: Vec::new(),
+    }
+}
+
+fn fail_fast_patch(tasks: &BTreeMap<String, TaskState>, now: DateTime<Utc>) -> Option<ConvoyStatusPatch> {
+    let any_failed = tasks.values().any(|task| task.phase == TaskPhase::Failed);
+    if !any_failed {
+        return None;
+    }
+
+    let cancelled_tasks = tasks
+        .iter()
+        .filter_map(|(name, task)| match task.phase {
+            TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled => None,
+            _ => Some((name.clone(), now)),
+        })
+        .collect();
+
+    Some(controller_patches::fail_convoy(cancelled_tasks, now, Some("task failure detected".to_string())))
+}
+
+fn advance_ready_patch(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ConvoyStatusPatch> {
+    let snapshot = status.workflow_snapshot.as_ref()?;
+    let ready = snapshot
+        .tasks
+        .iter()
+        .filter_map(|task| {
+            let state = status.tasks.get(&task.name)?;
+            if state.phase != TaskPhase::Pending {
+                return None;
+            }
+            let all_complete = task
+                .depends_on
+                .iter()
+                .all(|dependency| matches!(status.tasks.get(dependency), Some(dep_state) if dep_state.phase == TaskPhase::Completed));
+            all_complete.then(|| (task.name.clone(), now))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    (!ready.is_empty()).then(|| controller_patches::advance_tasks_to_ready(ready))
+}
+
+fn roll_up_phase_patch(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ConvoyStatusPatch> {
+    if !status.tasks.is_empty() && status.tasks.values().all(|task| task.phase == TaskPhase::Completed) {
+        return Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(now)));
+    }
+
+    let any_progressed = status.tasks.values().any(|task| task.phase != TaskPhase::Pending);
+    if any_progressed && status.phase == ConvoyPhase::Pending {
+        return Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(now), None));
+    }
+
+    None
+}

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -31,6 +31,10 @@ pub fn reconcile(
 ) -> ReconcileOutcome {
     let status = convoy.status.clone().unwrap_or_default();
 
+    if matches!(status.phase, ConvoyPhase::Completed | ConvoyPhase::Failed | ConvoyPhase::Cancelled) {
+        return ReconcileOutcome { patch: None, events: Vec::new() };
+    }
+
     if let Some(observed) = status.observed_workflow_ref.as_ref() {
         if observed != &convoy.spec.workflow_ref {
             return ReconcileOutcome {
@@ -48,16 +52,16 @@ pub fn reconcile(
         return bootstrap_outcome(convoy, template, now);
     }
 
-    if let Some(patch) = fail_fast_patch(&status.tasks, now) {
-        return ReconcileOutcome { patch: Some(patch), events: Vec::new() };
+    if let Some(outcome) = fail_fast_outcome(&status, now) {
+        return outcome;
     }
 
-    if let Some(patch) = advance_ready_patch(&status, now) {
-        return ReconcileOutcome { patch: Some(patch), events: Vec::new() };
+    if let Some(outcome) = advance_ready_outcome(&status, now) {
+        return outcome;
     }
 
-    if let Some(patch) = roll_up_phase_patch(&status, now) {
-        return ReconcileOutcome { patch: Some(patch), events: Vec::new() };
+    if let Some(outcome) = roll_up_phase_outcome(&status, now) {
+        return outcome;
     }
 
     ReconcileOutcome { patch: None, events: Vec::new() }
@@ -136,24 +140,38 @@ fn bootstrap_outcome(
     }
 }
 
-fn fail_fast_patch(tasks: &BTreeMap<String, TaskState>, now: DateTime<Utc>) -> Option<ConvoyStatusPatch> {
-    let any_failed = tasks.values().any(|task| task.phase == TaskPhase::Failed);
+fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ReconcileOutcome> {
+    let any_failed = status.tasks.values().any(|task| task.phase == TaskPhase::Failed);
     if !any_failed {
         return None;
     }
 
-    let cancelled_tasks = tasks
+    let cancelled_tasks = status
+        .tasks
         .iter()
         .filter_map(|(name, task)| match task.phase {
             TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled => None,
             _ => Some((name.clone(), now)),
         })
-        .collect();
+        .collect::<BTreeMap<_, _>>();
 
-    Some(controller_patches::fail_convoy(cancelled_tasks, now, Some("task failure detected".to_string())))
+    let mut events = Vec::new();
+    if status.phase != ConvoyPhase::Failed {
+        events.push(ConvoyEvent::PhaseChanged { from: status.phase, to: ConvoyPhase::Failed });
+    }
+    for task in cancelled_tasks.keys() {
+        if let Some(state) = status.tasks.get(task) {
+            events.push(ConvoyEvent::TaskPhaseChanged { task: task.clone(), from: state.phase, to: TaskPhase::Cancelled });
+        }
+    }
+
+    Some(ReconcileOutcome {
+        patch: Some(controller_patches::fail_convoy(cancelled_tasks, now, Some("task failure detected".to_string()))),
+        events,
+    })
 }
 
-fn advance_ready_patch(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ConvoyStatusPatch> {
+fn advance_ready_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ReconcileOutcome> {
     let snapshot = status.workflow_snapshot.as_ref()?;
     let ready = snapshot
         .tasks
@@ -171,17 +189,30 @@ fn advance_ready_patch(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Opti
         })
         .collect::<BTreeMap<_, _>>();
 
-    (!ready.is_empty()).then(|| controller_patches::advance_tasks_to_ready(ready))
+    if ready.is_empty() {
+        return None;
+    }
+
+    let events =
+        ready.keys().cloned().map(|task| ConvoyEvent::TaskPhaseChanged { task, from: TaskPhase::Pending, to: TaskPhase::Ready }).collect();
+
+    Some(ReconcileOutcome { patch: Some(controller_patches::advance_tasks_to_ready(ready)), events })
 }
 
-fn roll_up_phase_patch(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ConvoyStatusPatch> {
+fn roll_up_phase_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ReconcileOutcome> {
     if !status.tasks.is_empty() && status.tasks.values().all(|task| task.phase == TaskPhase::Completed) {
-        return Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(now)));
+        return Some(ReconcileOutcome {
+            patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(now))),
+            events: vec![ConvoyEvent::PhaseChanged { from: status.phase, to: ConvoyPhase::Completed }],
+        });
     }
 
     let any_progressed = status.tasks.values().any(|task| task.phase != TaskPhase::Pending);
     if any_progressed && status.phase == ConvoyPhase::Pending {
-        return Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(now), None));
+        return Some(ReconcileOutcome {
+            patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(now), None)),
+            events: vec![ConvoyEvent::PhaseChanged { from: ConvoyPhase::Pending, to: ConvoyPhase::Active }],
+        });
     }
 
     None

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -2,12 +2,10 @@ use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
 
-use super::{
-    controller_patches, Convoy, ConvoyPhase, ConvoyStatusPatch, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot,
-};
+use super::{controller_patches, Convoy, ConvoyPhase, ConvoyStatusPatch, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot};
 use crate::{
     resource::ResourceObject,
-    workflow_template::{ValidationError, WorkflowTemplate, validate},
+    workflow_template::{validate, ValidationError, WorkflowTemplate},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,11 +93,7 @@ fn bootstrap_outcome(
     for input in &template.spec.inputs {
         if !convoy.spec.inputs.contains_key(&input.name) {
             return ReconcileOutcome {
-                patch: Some(controller_patches::fail_init(
-                    ConvoyPhase::Failed,
-                    format!("missing input '{}'", input.name),
-                    now,
-                )),
+                patch: Some(controller_patches::fail_init(ConvoyPhase::Failed, format!("missing input '{}'", input.name), now)),
                 events: vec![ConvoyEvent::MissingInput { name: input.name.clone() }],
             };
         }
@@ -118,10 +112,14 @@ fn bootstrap_outcome(
         .tasks
         .iter()
         .map(|task| {
-            (
-                task.name.clone(),
-                TaskState { phase: TaskPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None },
-            )
+            (task.name.clone(), TaskState {
+                phase: TaskPhase::Pending,
+                ready_at: None,
+                started_at: None,
+                finished_at: None,
+                message: None,
+                placement: None,
+            })
         })
         .collect();
 

--- a/crates/flotilla-resources/src/crds/convoy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/convoy.crd.yaml
@@ -9,25 +9,108 @@ spec:
     plural: convoys
     singular: convoy
     kind: Convoy
+    shortNames: [cvy]
   versions:
     - name: v1
       served: true
       storage: true
       subresources:
         status: {}
+      additionalPrinterColumns:
+        - name: Workflow
+          type: string
+          jsonPath: .spec.workflow_ref
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
       schema:
         openAPIV3Schema:
           type: object
           properties:
             spec:
               type: object
+              required: [workflow_ref]
               properties:
-                template:
+                workflow_ref:
                   type: string
-              required:
-                - template
+                  minLength: 1
+                  x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "workflow_ref is immutable after creation"
+                inputs:
+                  type: object
+                  additionalProperties: true
+                  x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "inputs are immutable after creation"
+                placement_policy:
+                  type: string
+                  minLength: 1
             status:
               type: object
               properties:
                 phase:
                   type: string
+                  enum: [Pending, Active, Completed, Failed, Cancelled]
+                observed_workflow_ref:
+                  type: string
+                observed_workflows:
+                  type: object
+                  additionalProperties:
+                    type: string
+                workflow_snapshot:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    tasks:
+                      type: array
+                      items:
+                        type: object
+                        required: [name, processes]
+                        properties:
+                          name:
+                            type: string
+                            minLength: 1
+                          depends_on:
+                            type: array
+                            items:
+                              type: string
+                          processes:
+                            type: array
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                message:
+                  type: string
+                started_at:
+                  type: string
+                  format: date-time
+                finished_at:
+                  type: string
+                  format: date-time
+                tasks:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    required: [phase]
+                    properties:
+                      phase:
+                        type: string
+                        enum: [Pending, Ready, Launching, Running, Completed, Failed, Cancelled]
+                      ready_at:
+                        type: string
+                        format: date-time
+                      started_at:
+                        type: string
+                        format: date-time
+                      finished_at:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      placement:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -11,7 +11,7 @@ mod workflow_template;
 pub use backend::{ResourceBackend, TypedResolver};
 pub use convoy::{
     controller_patches, external_patches, provisioning_patches, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, ConvoyStatusPatch,
-    InputValue, PlacementStatus, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot,
+    ConvoyEvent, InputValue, PlacementStatus, ReconcileOutcome, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot, reconcile,
 };
 pub use error::ResourceError;
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -10,8 +10,8 @@ mod workflow_template;
 
 pub use backend::{ResourceBackend, TypedResolver};
 pub use convoy::{
-    controller_patches, external_patches, provisioning_patches, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, ConvoyStatusPatch,
-    ConvoyEvent, InputValue, PlacementStatus, ReconcileOutcome, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot, reconcile,
+    controller_patches, external_patches, provisioning_patches, reconcile, Convoy, ConvoyEvent, ConvoyPhase, ConvoySpec, ConvoyStatus,
+    ConvoyStatusPatch, InputValue, PlacementStatus, ReconcileOutcome, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot,
 };
 pub use error::ResourceError;
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod convoy;
 mod error;
 mod http;
 mod in_memory;
@@ -8,6 +9,10 @@ mod watch;
 mod workflow_template;
 
 pub use backend::{ResourceBackend, TypedResolver};
+pub use convoy::{
+    controller_patches, external_patches, provisioning_patches, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, ConvoyStatusPatch,
+    InputValue, PlacementStatus, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot,
+};
 pub use error::ResourceError;
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 mod http;
 mod in_memory;
 mod resource;
+mod status_patch;
 mod watch;
 mod workflow_template;
 
@@ -11,6 +12,7 @@ pub use error::ResourceError;
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use resource::{ApiPaths, InputMeta, ObjectMeta, Resource, ResourceObject};
+pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
 pub use workflow_template::{
     validate, InputDefinition, InterpolationField, InterpolationLocation, ProcessDefinition, ProcessSource, Selector, TaskDefinition,

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -3,6 +3,8 @@ use std::{collections::BTreeMap, fmt::Debug};
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+use crate::status_patch::StatusPatch;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ApiPaths {
     pub group: &'static str,
@@ -14,6 +16,7 @@ pub struct ApiPaths {
 pub trait Resource: Send + Sync + 'static {
     type Spec: Serialize + DeserializeOwned + Send + Sync + Debug + Clone;
     type Status: Serialize + DeserializeOwned + Send + Sync + Debug + Clone;
+    type StatusPatch: StatusPatch<Self::Status>;
 
     const API_PATHS: ApiPaths;
 }

--- a/crates/flotilla-resources/src/status_patch.rs
+++ b/crates/flotilla-resources/src/status_patch.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use crate::{
     error::ResourceError,
     resource::{Resource, ResourceObject},
@@ -27,11 +29,37 @@ where
     T: Resource,
     T::Status: Default,
 {
+    apply_status_patch_inner(
+        name,
+        patch,
+        || async {
+            let current = resolver.get(name).await?;
+            Ok((current.metadata.resource_version, current.status))
+        },
+        |resource_version, new_status| async move { resolver.update_status(name, &resource_version, &new_status).await },
+    )
+    .await
+}
+
+async fn apply_status_patch_inner<S, P, R, G, GFut, U, UFut>(
+    name: &str,
+    patch: &P,
+    mut get_current: G,
+    mut update: U,
+) -> Result<R, ResourceError>
+where
+    S: Clone + Default,
+    P: StatusPatch<S> + ?Sized,
+    G: FnMut() -> GFut,
+    GFut: Future<Output = Result<(String, Option<S>), ResourceError>>,
+    U: FnMut(String, S) -> UFut,
+    UFut: Future<Output = Result<R, ResourceError>>,
+{
     for _ in 0..MAX_RETRIES {
-        let current = resolver.get(name).await?;
-        let mut new_status = current.status.clone().unwrap_or_default();
+        let (resource_version, current_status) = get_current().await?;
+        let mut new_status = current_status.unwrap_or_default();
         patch.apply(&mut new_status);
-        match resolver.update_status(name, &current.metadata.resource_version, &new_status).await {
+        match update(resource_version, new_status).await {
             Ok(updated) => return Ok(updated),
             Err(ResourceError::Conflict { .. }) => continue,
             Err(other) => return Err(other),
@@ -39,4 +67,103 @@ where
     }
 
     Err(ResourceError::conflict(name, "status patch retry budget exhausted"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
+
+    use serde::{Deserialize, Serialize};
+
+    use super::StatusPatch;
+    use crate::error::ResourceError;
+
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+    struct CounterStatus {
+        value: u32,
+        note: Option<String>,
+    }
+
+    enum CounterPatch {
+        Increment,
+    }
+
+    impl StatusPatch<CounterStatus> for CounterPatch {
+        fn apply(&self, status: &mut CounterStatus) {
+            match self {
+                Self::Increment => status.value += 1,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_conflicts_and_reapplies_patch_to_latest_state() {
+        let reads = Arc::new(Mutex::new(VecDeque::from([
+            ("1".to_string(), Some(CounterStatus { value: 1, note: None })),
+            ("2".to_string(), Some(CounterStatus { value: 10, note: Some("fresh".to_string()) })),
+        ])));
+        let writes = Arc::new(Mutex::new(Vec::new()));
+
+        let result = super::apply_status_patch_inner::<CounterStatus, _, CounterStatus, _, _, _, _>(
+            "counter-a",
+            &CounterPatch::Increment,
+            {
+                let reads = Arc::clone(&reads);
+                move || {
+                    let reads = Arc::clone(&reads);
+                    async move { Ok(reads.lock().expect("reads lock").pop_front().expect("queued read")) }
+                }
+            },
+            {
+                let writes = Arc::clone(&writes);
+                move |resource_version: String, status: CounterStatus| {
+                    let writes = Arc::clone(&writes);
+                    async move {
+                        writes.lock().expect("writes lock").push((resource_version.clone(), status.clone()));
+                        if resource_version == "1" {
+                            Err(ResourceError::conflict("counter-a", "stale resourceVersion"))
+                        } else {
+                            Ok(status)
+                        }
+                    }
+                }
+            },
+        )
+        .await
+        .expect("second attempt should succeed");
+
+        assert_eq!(result, CounterStatus { value: 11, note: Some("fresh".to_string()) });
+        assert_eq!(
+            writes.lock().expect("writes lock").as_slice(),
+            &[
+                ("1".to_string(), CounterStatus { value: 2, note: None }),
+                ("2".to_string(), CounterStatus { value: 11, note: Some("fresh".to_string()) }),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_conflict_after_retry_budget_is_exhausted() {
+        let result = super::apply_status_patch_inner::<CounterStatus, _, CounterStatus, _, _, _, _>(
+            "counter-b",
+            &CounterPatch::Increment,
+            || async { Ok(("1".to_string(), Some(CounterStatus { value: 1, note: None }))) },
+            |_resource_version: String, _status: CounterStatus| async {
+                Err(ResourceError::conflict("counter-b", "stale resourceVersion"))
+            },
+        )
+        .await
+        .expect_err("conflicts should exhaust retry budget");
+
+        match result {
+            ResourceError::Conflict { name, message } => {
+                assert_eq!(name, "counter-b");
+                assert!(message.contains("retry budget exhausted"));
+            }
+            other => panic!("expected conflict, got {other}"),
+        }
+    }
 }

--- a/crates/flotilla-resources/src/status_patch.rs
+++ b/crates/flotilla-resources/src/status_patch.rs
@@ -1,0 +1,42 @@
+use crate::{
+    error::ResourceError,
+    resource::{Resource, ResourceObject},
+    TypedResolver,
+};
+
+const MAX_RETRIES: usize = 3;
+
+pub trait StatusPatch<S>: Send + Sync {
+    fn apply(&self, status: &mut S);
+}
+
+pub enum NoStatusPatch {}
+
+impl StatusPatch<()> for NoStatusPatch {
+    fn apply(&self, _: &mut ()) {
+        match *self {}
+    }
+}
+
+pub async fn apply_status_patch<T>(
+    resolver: &TypedResolver<T>,
+    name: &str,
+    patch: &T::StatusPatch,
+) -> Result<ResourceObject<T>, ResourceError>
+where
+    T: Resource,
+    T::Status: Default,
+{
+    for _ in 0..MAX_RETRIES {
+        let current = resolver.get(name).await?;
+        let mut new_status = current.status.clone().unwrap_or_default();
+        patch.apply(&mut new_status);
+        match resolver.update_status(name, &current.metadata.resource_version, &new_status).await {
+            Ok(updated) => return Ok(updated),
+            Err(ResourceError::Conflict { .. }) => continue,
+            Err(other) => return Err(other),
+        }
+    }
+
+    Err(ResourceError::conflict(name, "status patch retry budget exhausted"))
+}

--- a/crates/flotilla-resources/src/status_patch.rs
+++ b/crates/flotilla-resources/src/status_patch.rs
@@ -136,13 +136,10 @@ mod tests {
         .expect("second attempt should succeed");
 
         assert_eq!(result, CounterStatus { value: 11, note: Some("fresh".to_string()) });
-        assert_eq!(
-            writes.lock().expect("writes lock").as_slice(),
-            &[
-                ("1".to_string(), CounterStatus { value: 2, note: None }),
-                ("2".to_string(), CounterStatus { value: 11, note: Some("fresh".to_string()) }),
-            ]
-        );
+        assert_eq!(writes.lock().expect("writes lock").as_slice(), &[
+            ("1".to_string(), CounterStatus { value: 2, note: None }),
+            ("2".to_string(), CounterStatus { value: 11, note: Some("fresh".to_string()) }),
+        ]);
     }
 
     #[tokio::test]

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::resource::{ApiPaths, Resource};
+use crate::{
+    resource::{ApiPaths, Resource},
+    status_patch::NoStatusPatch,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WorkflowTemplate;
@@ -10,6 +13,7 @@ pub struct WorkflowTemplate;
 impl Resource for WorkflowTemplate {
     type Spec = WorkflowTemplateSpec;
     type Status = ();
+    type StatusPatch = NoStatusPatch;
 
     const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "workflowtemplates", kind: "WorkflowTemplate" };
 }

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -1,10 +1,12 @@
 #![allow(dead_code)]
 
 use flotilla_resources::{
-    ApiPaths, InputDefinition, InputMeta, ProcessDefinition, ProcessSource, Resource, Selector, StatusPatch, TaskDefinition,
-    WorkflowTemplateSpec,
+    ApiPaths, Convoy as RealConvoy, ConvoySpec as RealConvoySpec, ConvoyStatus as RealConvoyStatus, InputDefinition, InputMeta,
+    ObjectMeta, ProcessDefinition, ProcessSource, Resource, ResourceObject, Selector, StatusPatch, TaskDefinition, TaskPhase,
+    TaskState, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde::{Deserialize, Serialize};
+use chrono::{TimeZone, Utc};
 
 pub struct ConvoyResource;
 
@@ -115,4 +117,79 @@ pub fn updated_workflow_template_spec() -> WorkflowTemplateSpec {
 
 pub fn valid_workflow_template_yaml() -> &'static str {
     include_str!("../../examples/review-and-fix.yaml")
+}
+
+pub fn timestamp(seconds: i64) -> chrono::DateTime<Utc> {
+    Utc.timestamp_opt(seconds, 0).single().expect("valid timestamp")
+}
+
+pub fn object_meta(name: &str, namespace: &str, resource_version: &str) -> ObjectMeta {
+    ObjectMeta {
+        name: name.to_string(),
+        namespace: namespace.to_string(),
+        resource_version: resource_version.to_string(),
+        labels: Default::default(),
+        annotations: Default::default(),
+        creation_timestamp: timestamp(1),
+    }
+}
+
+pub fn valid_convoy_spec() -> RealConvoySpec {
+    RealConvoySpec {
+        workflow_ref: "review-and-fix".to_string(),
+        inputs: [
+            ("feature".to_string(), flotilla_resources::InputValue::String("Retry logic".to_string())),
+            ("branch".to_string(), flotilla_resources::InputValue::String("fix-retry-logic".to_string())),
+        ]
+        .into_iter()
+        .collect(),
+        placement_policy: Some("laptop-docker".to_string()),
+    }
+}
+
+pub fn pending_task_state() -> TaskState {
+    TaskState { phase: TaskPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None }
+}
+
+pub fn valid_workflow_template_object(name: &str) -> ResourceObject<WorkflowTemplate> {
+    ResourceObject {
+        metadata: object_meta(name, "flotilla", "42"),
+        spec: valid_workflow_template_spec(),
+        status: None,
+    }
+}
+
+pub fn convoy_object(name: &str, spec: RealConvoySpec, status: Option<RealConvoyStatus>) -> ResourceObject<RealConvoy> {
+    ResourceObject { metadata: object_meta(name, "flotilla", "7"), spec, status }
+}
+
+pub fn bootstrapped_convoy_status() -> RealConvoyStatus {
+    let snapshot = flotilla_resources::WorkflowSnapshot {
+        tasks: valid_workflow_template_spec()
+            .tasks
+            .into_iter()
+            .map(|task| flotilla_resources::SnapshotTask {
+                name: task.name,
+                depends_on: task.depends_on,
+                processes: task.processes,
+            })
+            .collect(),
+    };
+    let tasks = [
+        ("implement".to_string(), pending_task_state()),
+        ("review".to_string(), pending_task_state()),
+    ]
+    .into_iter()
+    .collect();
+
+    RealConvoyStatus {
+        phase: flotilla_resources::ConvoyPhase::Pending,
+        workflow_snapshot: Some(snapshot),
+        tasks,
+        message: None,
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: Some("review-and-fix".to_string()),
+        observed_workflows: Some([("review-and-fix".to_string(), "42".to_string())].into_iter().collect()),
+    }
 }

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
 use flotilla_resources::{
-    ApiPaths, InputDefinition, InputMeta, ProcessDefinition, ProcessSource, Resource, Selector, TaskDefinition, WorkflowTemplateSpec,
+    ApiPaths, InputDefinition, InputMeta, ProcessDefinition, ProcessSource, Resource, Selector, StatusPatch, TaskDefinition,
+    WorkflowTemplateSpec,
 };
 use serde::{Deserialize, Serialize};
 
@@ -17,9 +18,18 @@ pub struct ConvoyStatus {
     pub phase: String,
 }
 
+pub enum ConvoyStatusPatch {}
+
+impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
+    fn apply(&self, _: &mut ConvoyStatus) {
+        match *self {}
+    }
+}
+
 impl Resource for ConvoyResource {
     type Spec = ConvoySpec;
     type Status = ConvoyStatus;
+    type StatusPatch = ConvoyStatusPatch;
 
     const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "convoys", kind: "Convoy" };
 }

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 
+use chrono::{TimeZone, Utc};
 use flotilla_resources::{
-    ApiPaths, Convoy as RealConvoy, ConvoySpec as RealConvoySpec, ConvoyStatus as RealConvoyStatus, InputDefinition, InputMeta,
-    ObjectMeta, ProcessDefinition, ProcessSource, Resource, ResourceObject, Selector, StatusPatch, TaskDefinition, TaskPhase,
-    TaskState, WorkflowTemplate, WorkflowTemplateSpec,
+    ApiPaths, Convoy as RealConvoy, ConvoySpec as RealConvoySpec, ConvoyStatus as RealConvoyStatus, InputDefinition, InputMeta, ObjectMeta,
+    ProcessDefinition, ProcessSource, Resource, ResourceObject, Selector, StatusPatch, TaskDefinition, TaskPhase, TaskState,
+    WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde::{Deserialize, Serialize};
-use chrono::{TimeZone, Utc};
 
 pub struct ConvoyResource;
 
@@ -175,11 +175,7 @@ pub fn pending_task_state() -> TaskState {
 }
 
 pub fn valid_workflow_template_object(name: &str) -> ResourceObject<WorkflowTemplate> {
-    ResourceObject {
-        metadata: object_meta(name, "flotilla", "42"),
-        spec: valid_workflow_template_spec(),
-        status: None,
-    }
+    ResourceObject { metadata: object_meta(name, "flotilla", "42"), spec: valid_workflow_template_spec(), status: None }
 }
 
 pub fn convoy_object(name: &str, spec: RealConvoySpec, status: Option<RealConvoyStatus>) -> ResourceObject<RealConvoy> {
@@ -191,19 +187,10 @@ pub fn bootstrapped_convoy_status() -> RealConvoyStatus {
         tasks: valid_workflow_template_spec()
             .tasks
             .into_iter()
-            .map(|task| flotilla_resources::SnapshotTask {
-                name: task.name,
-                depends_on: task.depends_on,
-                processes: task.processes,
-            })
+            .map(|task| flotilla_resources::SnapshotTask { name: task.name, depends_on: task.depends_on, processes: task.processes })
             .collect(),
     };
-    let tasks = [
-        ("implement".to_string(), pending_task_state()),
-        ("review".to_string(), pending_task_state()),
-    ]
-    .into_iter()
-    .collect();
+    let tasks = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
 
     RealConvoyStatus {
         phase: flotilla_resources::ConvoyPhase::Pending,

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -52,6 +52,29 @@ pub fn status(phase: &str) -> ConvoyStatus {
     ConvoyStatus { phase: phase.to_string() }
 }
 
+pub fn convoy_meta(name: &str) -> InputMeta {
+    input_meta(name)
+}
+
+pub fn convoy_spec(workflow_ref: &str) -> RealConvoySpec {
+    let mut spec = valid_convoy_spec();
+    spec.workflow_ref = workflow_ref.to_string();
+    spec
+}
+
+pub fn convoy_status(phase: flotilla_resources::ConvoyPhase) -> RealConvoyStatus {
+    RealConvoyStatus {
+        phase,
+        workflow_snapshot: None,
+        tasks: Default::default(),
+        message: None,
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        observed_workflows: None,
+    }
+}
+
 pub fn workflow_template_meta(name: &str) -> InputMeta {
     InputMeta {
         name: name.to_string(),

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::{convoy_meta, timestamp, valid_convoy_spec, valid_workflow_template_object, workflow_template_meta};
 use flotilla_resources::{
-    apply_status_patch, external_patches, reconcile, Convoy, ConvoyPhase, InMemoryBackend, ResourceBackend, WorkflowTemplate,
+    apply_status_patch, external_patches, reconcile, Convoy, ConvoyPhase, InMemoryBackend, ResourceBackend, ResourceError, WorkflowTemplate,
 };
 
 async fn reconcile_once(
@@ -13,7 +13,11 @@ async fn reconcile_once(
 ) -> Option<flotilla_resources::ConvoyStatusPatch> {
     let convoy = convoys.get(name).await.expect("convoy get should succeed");
     let template = if convoy.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_none() {
-        Some(templates.get(&convoy.spec.workflow_ref).await.expect("template get should succeed"))
+        match templates.get(&convoy.spec.workflow_ref).await {
+            Ok(template) => Some(template),
+            Err(ResourceError::NotFound { .. }) => None,
+            Err(err) => panic!("template get should succeed: {err}"),
+        }
     } else {
         None
     };
@@ -70,4 +74,21 @@ async fn in_memory_controller_loop_drives_convoy_to_completion() {
     assert_eq!(final_status.phase, ConvoyPhase::Completed);
     assert_eq!(final_status.tasks["implement"].phase, flotilla_resources::TaskPhase::Completed);
     assert_eq!(final_status.tasks["review"].phase, flotilla_resources::TaskPhase::Completed);
+}
+
+#[tokio::test]
+async fn missing_template_transitions_convoy_to_failed() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
+    let convoys = backend.using::<Convoy>("flotilla");
+
+    convoys.create(&convoy_meta("convoy-missing-template"), &valid_convoy_spec()).await.expect("convoy create should succeed");
+
+    let patch = reconcile_once(&convoys, &templates, "convoy-missing-template", timestamp(10)).await.expect("fail-init patch");
+    assert!(matches!(patch, flotilla_resources::ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. }));
+
+    let convoy = convoys.get("convoy-missing-template").await.expect("convoy get should succeed");
+    let status = convoy.status.expect("convoy status");
+    assert_eq!(status.phase, ConvoyPhase::Failed);
+    assert!(status.message.as_deref().is_some_and(|message| message.contains("not found")));
 }

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -1,0 +1,83 @@
+mod common;
+
+use common::{convoy_meta, timestamp, valid_convoy_spec, valid_workflow_template_object, workflow_template_meta};
+use flotilla_resources::{
+    apply_status_patch, external_patches, reconcile, Convoy, ConvoyPhase, InMemoryBackend, ResourceBackend, WorkflowTemplate,
+};
+
+async fn reconcile_once(
+    convoys: &flotilla_resources::TypedResolver<Convoy>,
+    templates: &flotilla_resources::TypedResolver<WorkflowTemplate>,
+    name: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Option<flotilla_resources::ConvoyStatusPatch> {
+    let convoy = convoys.get(name).await.expect("convoy get should succeed");
+    let template = if convoy.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_none() {
+        Some(templates.get(&convoy.spec.workflow_ref).await.expect("template get should succeed"))
+    } else {
+        None
+    };
+
+    let outcome = reconcile(&convoy, template.as_ref(), now);
+    if let Some(patch) = outcome.patch.clone() {
+        apply_status_patch(convoys, name, &patch).await.expect("apply patch should succeed");
+        Some(patch)
+    } else {
+        None
+    }
+}
+
+#[tokio::test]
+async fn in_memory_controller_loop_drives_convoy_to_completion() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
+    let convoys = backend.using::<Convoy>("flotilla");
+
+    let template = valid_workflow_template_object("review-and-fix");
+    templates
+        .create(&workflow_template_meta(&template.metadata.name), &template.spec)
+        .await
+        .expect("template create should succeed");
+    convoys
+        .create(&convoy_meta("convoy-a"), &valid_convoy_spec())
+        .await
+        .expect("convoy create should succeed");
+
+    let bootstrap = reconcile_once(&convoys, &templates, "convoy-a", timestamp(10)).await.expect("bootstrap patch");
+    assert!(matches!(bootstrap, flotilla_resources::ConvoyStatusPatch::Bootstrap { .. }));
+
+    let ready_implement =
+        reconcile_once(&convoys, &templates, "convoy-a", timestamp(11)).await.expect("ready patch after bootstrap");
+    assert!(matches!(ready_implement, flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. }));
+
+    apply_status_patch(
+        &convoys,
+        "convoy-a",
+        &external_patches::mark_task_completed("implement".to_string(), timestamp(12), Some("implemented".to_string())),
+    )
+    .await
+    .expect("implement completion should succeed");
+
+    let ready_review = reconcile_once(&convoys, &templates, "convoy-a", timestamp(13)).await.expect("review should become ready");
+    assert!(matches!(ready_review, flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. }));
+
+    apply_status_patch(
+        &convoys,
+        "convoy-a",
+        &external_patches::mark_task_completed("review".to_string(), timestamp(14), Some("reviewed".to_string())),
+    )
+    .await
+    .expect("review completion should succeed");
+
+    let completed = reconcile_once(&convoys, &templates, "convoy-a", timestamp(15)).await.expect("completed roll-up patch");
+    assert!(matches!(
+        completed,
+        flotilla_resources::ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, .. }
+    ));
+
+    let final_convoy = convoys.get("convoy-a").await.expect("final convoy get should succeed");
+    let final_status = final_convoy.status.expect("convoy status");
+    assert_eq!(final_status.phase, ConvoyPhase::Completed);
+    assert_eq!(final_status.tasks["implement"].phase, flotilla_resources::TaskPhase::Completed);
+    assert_eq!(final_status.tasks["review"].phase, flotilla_resources::TaskPhase::Completed);
+}

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -34,20 +34,13 @@ async fn in_memory_controller_loop_drives_convoy_to_completion() {
     let convoys = backend.using::<Convoy>("flotilla");
 
     let template = valid_workflow_template_object("review-and-fix");
-    templates
-        .create(&workflow_template_meta(&template.metadata.name), &template.spec)
-        .await
-        .expect("template create should succeed");
-    convoys
-        .create(&convoy_meta("convoy-a"), &valid_convoy_spec())
-        .await
-        .expect("convoy create should succeed");
+    templates.create(&workflow_template_meta(&template.metadata.name), &template.spec).await.expect("template create should succeed");
+    convoys.create(&convoy_meta("convoy-a"), &valid_convoy_spec()).await.expect("convoy create should succeed");
 
     let bootstrap = reconcile_once(&convoys, &templates, "convoy-a", timestamp(10)).await.expect("bootstrap patch");
     assert!(matches!(bootstrap, flotilla_resources::ConvoyStatusPatch::Bootstrap { .. }));
 
-    let ready_implement =
-        reconcile_once(&convoys, &templates, "convoy-a", timestamp(11)).await.expect("ready patch after bootstrap");
+    let ready_implement = reconcile_once(&convoys, &templates, "convoy-a", timestamp(11)).await.expect("ready patch after bootstrap");
     assert!(matches!(ready_implement, flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. }));
 
     apply_status_patch(
@@ -70,10 +63,7 @@ async fn in_memory_controller_loop_drives_convoy_to_completion() {
     .expect("review completion should succeed");
 
     let completed = reconcile_once(&convoys, &templates, "convoy-a", timestamp(15)).await.expect("completed roll-up patch");
-    assert!(matches!(
-        completed,
-        flotilla_resources::ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, .. }
-    ));
+    assert!(matches!(completed, flotilla_resources::ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, .. }));
 
     let final_convoy = convoys.get("convoy-a").await.expect("final convoy get should succeed");
     let final_status = final_convoy.status.expect("convoy status");

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -1,0 +1,256 @@
+mod common;
+
+use common::{
+    bootstrapped_convoy_status, convoy_object, pending_task_state, timestamp, valid_convoy_spec, valid_workflow_template_object,
+};
+use flotilla_resources::{
+    controller_patches, reconcile, ConvoyEvent, ConvoyPhase, ConvoyStatusPatch, InputValue, TaskPhase, ValidationError,
+};
+
+#[test]
+fn bootstrap_from_valid_template_returns_bootstrap_patch() {
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
+    let template = valid_workflow_template_object("review-and-fix");
+
+    let outcome = reconcile(&convoy, Some(&template), timestamp(10));
+
+    let expected_tasks = [
+        ("implement".to_string(), pending_task_state()),
+        ("review".to_string(), pending_task_state()),
+    ]
+    .into_iter()
+    .collect();
+    let expected_patch = controller_patches::bootstrap(
+        common::bootstrapped_convoy_status().workflow_snapshot.expect("snapshot"),
+        "review-and-fix".to_string(),
+        [("review-and-fix".to_string(), "42".to_string())].into_iter().collect(),
+        expected_tasks,
+        ConvoyPhase::Pending,
+        None,
+    );
+
+    assert_eq!(outcome.patch, Some(expected_patch));
+    assert!(outcome.events.is_empty());
+}
+
+#[test]
+fn missing_template_fails_init() {
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
+
+    let outcome = reconcile(&convoy, None, timestamp(10));
+
+    assert!(matches!(
+        outcome.patch,
+        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
+    ));
+    assert!(matches!(
+        outcome.events.as_slice(),
+        [ConvoyEvent::TemplateNotFound { name }] if name == "review-and-fix"
+    ));
+}
+
+#[test]
+fn invalid_template_fails_init_with_validation_error_event() {
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
+    let mut template = valid_workflow_template_object("review-and-fix");
+    template.spec.tasks[1].depends_on = vec!["missing".to_string()];
+
+    let outcome = reconcile(&convoy, Some(&template), timestamp(10));
+
+    assert!(matches!(
+        outcome.patch,
+        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
+    ));
+    assert!(matches!(
+        outcome.events.as_slice(),
+        [ConvoyEvent::TemplateInvalid { name, errors }]
+            if name == "review-and-fix"
+                && matches!(errors.as_slice(), [ValidationError::UnknownDependency { task, missing }] if task == "review" && missing == "missing")
+    ));
+}
+
+#[test]
+fn missing_required_input_fails_init() {
+    let mut spec = valid_convoy_spec();
+    spec.inputs.remove("branch");
+    let convoy = convoy_object("convoy-a", spec, None);
+    let template = valid_workflow_template_object("review-and-fix");
+
+    let outcome = reconcile(&convoy, Some(&template), timestamp(10));
+
+    assert!(matches!(
+        outcome.patch,
+        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
+    ));
+    assert!(matches!(
+        outcome.events.as_slice(),
+        [ConvoyEvent::MissingInput { name }] if name == "branch"
+    ));
+}
+
+#[test]
+fn extra_input_is_allowed() {
+    let mut spec = valid_convoy_spec();
+    spec.inputs.insert("extra".to_string(), InputValue::String("ignored".to_string()));
+    let convoy = convoy_object("convoy-a", spec, None);
+    let template = valid_workflow_template_object("review-and-fix");
+
+    let outcome = reconcile(&convoy, Some(&template), timestamp(10));
+
+    assert!(matches!(outcome.patch, Some(ConvoyStatusPatch::Bootstrap { .. })));
+    assert!(outcome.events.is_empty());
+}
+
+#[test]
+fn fan_out_advances_all_newly_ready_tasks() {
+    let spec = valid_convoy_spec();
+    let mut status = bootstrapped_convoy_status();
+    status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
+        tasks: vec![
+            flotilla_resources::SnapshotTask { name: "a".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+            flotilla_resources::SnapshotTask { name: "b".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+            flotilla_resources::SnapshotTask { name: "c".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+        ],
+    });
+    status.tasks = [
+        ("a".to_string(), pending_task_state()),
+        ("b".to_string(), pending_task_state()),
+        ("c".to_string(), pending_task_state()),
+    ]
+    .into_iter()
+    .collect();
+
+    let convoy = convoy_object("convoy-a", spec, Some(status));
+    let outcome = reconcile(&convoy, None, timestamp(20));
+
+    assert_eq!(
+        outcome.patch,
+        Some(controller_patches::advance_tasks_to_ready(
+            [
+                ("a".to_string(), timestamp(20)),
+                ("b".to_string(), timestamp(20)),
+                ("c".to_string(), timestamp(20)),
+            ]
+            .into_iter()
+            .collect()
+        ))
+    );
+}
+
+#[test]
+fn fan_in_waits_until_all_dependencies_complete() {
+    let mut status = bootstrapped_convoy_status();
+    status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
+        tasks: vec![
+            flotilla_resources::SnapshotTask { name: "implement".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+            flotilla_resources::SnapshotTask { name: "verify".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+            flotilla_resources::SnapshotTask {
+                name: "review".to_string(),
+                depends_on: vec!["implement".to_string(), "verify".to_string()],
+                processes: Vec::new(),
+            },
+        ],
+    });
+    status.tasks.insert("verify".to_string(), pending_task_state());
+    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Completed;
+    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
+    status.tasks.get_mut("verify").expect("verify").phase = TaskPhase::Running;
+    status.tasks.get_mut("verify").expect("verify").started_at = Some(timestamp(9));
+    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Pending;
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status.clone()));
+
+    let first = reconcile(&convoy, None, timestamp(20));
+    assert_eq!(
+        first.patch,
+        Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(timestamp(20)), None))
+    );
+
+    status.tasks.get_mut("verify").expect("verify").phase = TaskPhase::Completed;
+    status.tasks.get_mut("verify").expect("verify").finished_at = Some(timestamp(10));
+    status.phase = ConvoyPhase::Active;
+
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+    let second = reconcile(&convoy, None, timestamp(21));
+
+    assert_eq!(
+        second.patch,
+        Some(controller_patches::advance_tasks_to_ready(
+            [("review".to_string(), timestamp(21))].into_iter().collect()
+        ))
+    );
+}
+
+#[test]
+fn failed_task_triggers_fail_fast() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Failed;
+    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Running;
+    status.tasks.get_mut("review").expect("review").started_at = Some(timestamp(11));
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(30));
+
+    assert_eq!(
+        outcome.patch,
+        Some(controller_patches::fail_convoy(
+            [("review".to_string(), timestamp(30))].into_iter().collect(),
+            timestamp(30),
+            Some("task failure detected".to_string())
+        ))
+    );
+}
+
+#[test]
+fn all_completed_rolls_up_to_completed() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    for task in status.tasks.values_mut() {
+        task.phase = TaskPhase::Completed;
+        task.finished_at = Some(timestamp(12));
+    }
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(40));
+
+    assert_eq!(
+        outcome.patch,
+        Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(timestamp(40))))
+    );
+}
+
+#[test]
+fn workflow_ref_change_after_init_fails_defensively() {
+    let mut spec = valid_convoy_spec();
+    spec.workflow_ref = "new-template".to_string();
+    let convoy = convoy_object("convoy-a", spec, Some(bootstrapped_convoy_status()));
+
+    let outcome = reconcile(&convoy, None, timestamp(50));
+
+    assert!(matches!(
+        outcome.patch,
+        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
+    ));
+    assert!(matches!(
+        outcome.events.as_slice(),
+        [ConvoyEvent::WorkflowRefChanged { from, to }] if from == "review-and-fix" && to == "new-template"
+    ));
+}
+
+#[test]
+fn snapshot_state_allows_advancement_without_template() {
+    let mut status = bootstrapped_convoy_status();
+    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Completed;
+    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(60));
+
+    assert_eq!(
+        outcome.patch,
+        Some(controller_patches::advance_tasks_to_ready(
+            [("review".to_string(), timestamp(60))].into_iter().collect()
+        ))
+    );
+}

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -1,8 +1,6 @@
 mod common;
 
-use common::{
-    bootstrapped_convoy_status, convoy_object, pending_task_state, timestamp, valid_convoy_spec, valid_workflow_template_object,
-};
+use common::{bootstrapped_convoy_status, convoy_object, pending_task_state, timestamp, valid_convoy_spec, valid_workflow_template_object};
 use flotilla_resources::{
     controller_patches, reconcile, ConvoyEvent, ConvoyPhase, ConvoyStatusPatch, InputValue, TaskPhase, ValidationError,
 };
@@ -14,12 +12,8 @@ fn bootstrap_from_valid_template_returns_bootstrap_patch() {
 
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
-    let expected_tasks = [
-        ("implement".to_string(), pending_task_state()),
-        ("review".to_string(), pending_task_state()),
-    ]
-    .into_iter()
-    .collect();
+    let expected_tasks =
+        [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
     let expected_patch = controller_patches::bootstrap(
         common::bootstrapped_convoy_status().workflow_snapshot.expect("snapshot"),
         "review-and-fix".to_string(),
@@ -39,10 +33,7 @@ fn missing_template_fails_init() {
 
     let outcome = reconcile(&convoy, None, timestamp(10));
 
-    assert!(matches!(
-        outcome.patch,
-        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
-    ));
+    assert!(matches!(outcome.patch, Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })));
     assert!(matches!(
         outcome.events.as_slice(),
         [ConvoyEvent::TemplateNotFound { name }] if name == "review-and-fix"
@@ -57,10 +48,7 @@ fn invalid_template_fails_init_with_validation_error_event() {
 
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
-    assert!(matches!(
-        outcome.patch,
-        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
-    ));
+    assert!(matches!(outcome.patch, Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })));
     assert!(matches!(
         outcome.events.as_slice(),
         [ConvoyEvent::TemplateInvalid { name, errors }]
@@ -78,10 +66,7 @@ fn missing_required_input_fails_init() {
 
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
-    assert!(matches!(
-        outcome.patch,
-        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
-    ));
+    assert!(matches!(outcome.patch, Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })));
     assert!(matches!(
         outcome.events.as_slice(),
         [ConvoyEvent::MissingInput { name }] if name == "branch"
@@ -112,13 +97,10 @@ fn fan_out_advances_all_newly_ready_tasks() {
             flotilla_resources::SnapshotTask { name: "c".to_string(), depends_on: Vec::new(), processes: Vec::new() },
         ],
     });
-    status.tasks = [
-        ("a".to_string(), pending_task_state()),
-        ("b".to_string(), pending_task_state()),
-        ("c".to_string(), pending_task_state()),
-    ]
-    .into_iter()
-    .collect();
+    status.tasks =
+        [("a".to_string(), pending_task_state()), ("b".to_string(), pending_task_state()), ("c".to_string(), pending_task_state())]
+            .into_iter()
+            .collect();
 
     let convoy = convoy_object("convoy-a", spec, Some(status));
     let outcome = reconcile(&convoy, None, timestamp(20));
@@ -126,13 +108,7 @@ fn fan_out_advances_all_newly_ready_tasks() {
     assert_eq!(
         outcome.patch,
         Some(controller_patches::advance_tasks_to_ready(
-            [
-                ("a".to_string(), timestamp(20)),
-                ("b".to_string(), timestamp(20)),
-                ("c".to_string(), timestamp(20)),
-            ]
-            .into_iter()
-            .collect()
+            [("a".to_string(), timestamp(20)), ("b".to_string(), timestamp(20)), ("c".to_string(), timestamp(20)),].into_iter().collect()
         ))
     );
 }
@@ -160,10 +136,7 @@ fn fan_in_waits_until_all_dependencies_complete() {
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status.clone()));
 
     let first = reconcile(&convoy, None, timestamp(20));
-    assert_eq!(
-        first.patch,
-        Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(timestamp(20)), None))
-    );
+    assert_eq!(first.patch, Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(timestamp(20)), None)));
 
     status.tasks.get_mut("verify").expect("verify").phase = TaskPhase::Completed;
     status.tasks.get_mut("verify").expect("verify").finished_at = Some(timestamp(10));
@@ -174,9 +147,7 @@ fn fan_in_waits_until_all_dependencies_complete() {
 
     assert_eq!(
         second.patch,
-        Some(controller_patches::advance_tasks_to_ready(
-            [("review".to_string(), timestamp(21))].into_iter().collect()
-        ))
+        Some(controller_patches::advance_tasks_to_ready([("review".to_string(), timestamp(21))].into_iter().collect()))
     );
 }
 
@@ -214,10 +185,7 @@ fn all_completed_rolls_up_to_completed() {
 
     let outcome = reconcile(&convoy, None, timestamp(40));
 
-    assert_eq!(
-        outcome.patch,
-        Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(timestamp(40))))
-    );
+    assert_eq!(outcome.patch, Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(timestamp(40)))));
 }
 
 #[test]
@@ -228,10 +196,7 @@ fn workflow_ref_change_after_init_fails_defensively() {
 
     let outcome = reconcile(&convoy, None, timestamp(50));
 
-    assert!(matches!(
-        outcome.patch,
-        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })
-    ));
+    assert!(matches!(outcome.patch, Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, .. })));
     assert!(matches!(
         outcome.events.as_slice(),
         [ConvoyEvent::WorkflowRefChanged { from, to }] if from == "review-and-fix" && to == "new-template"
@@ -249,8 +214,6 @@ fn snapshot_state_allows_advancement_without_template() {
 
     assert_eq!(
         outcome.patch,
-        Some(controller_patches::advance_tasks_to_ready(
-            [("review".to_string(), timestamp(60))].into_iter().collect()
-        ))
+        Some(controller_patches::advance_tasks_to_ready([("review".to_string(), timestamp(60))].into_iter().collect()))
     );
 }

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -189,6 +189,117 @@ fn all_completed_rolls_up_to_completed() {
 }
 
 #[test]
+fn terminal_completed_convoy_reconciles_to_noop() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Completed;
+    status.finished_at = Some(timestamp(40));
+    for task in status.tasks.values_mut() {
+        task.phase = TaskPhase::Completed;
+        task.finished_at = Some(timestamp(12));
+    }
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(41));
+
+    assert_eq!(outcome.patch, None);
+    assert!(outcome.events.is_empty());
+}
+
+#[test]
+fn terminal_failed_convoy_reconciles_to_noop() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Failed;
+    status.finished_at = Some(timestamp(30));
+    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Failed;
+    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Cancelled;
+    status.tasks.get_mut("review").expect("review").finished_at = Some(timestamp(30));
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(31));
+
+    assert_eq!(outcome.patch, None);
+    assert!(outcome.events.is_empty());
+}
+
+#[test]
+fn terminal_failed_init_convoy_reconciles_to_noop() {
+    let mut status = common::convoy_status(ConvoyPhase::Failed);
+    status.message = Some("missing input 'branch'".to_string());
+    status.finished_at = Some(timestamp(30));
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, Some(&valid_workflow_template_object("review-and-fix")), timestamp(31));
+
+    assert_eq!(outcome.patch, None);
+    assert!(outcome.events.is_empty());
+}
+
+#[test]
+fn advancing_ready_tasks_emits_task_phase_change_events() {
+    let spec = valid_convoy_spec();
+    let mut status = bootstrapped_convoy_status();
+    status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
+        tasks: vec![
+            flotilla_resources::SnapshotTask { name: "a".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+            flotilla_resources::SnapshotTask { name: "b".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+            flotilla_resources::SnapshotTask { name: "c".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+        ],
+    });
+    status.tasks =
+        [("a".to_string(), pending_task_state()), ("b".to_string(), pending_task_state()), ("c".to_string(), pending_task_state())]
+            .into_iter()
+            .collect();
+
+    let convoy = convoy_object("convoy-a", spec, Some(status));
+    let outcome = reconcile(&convoy, None, timestamp(20));
+
+    assert!(matches!(
+        outcome.events.as_slice(),
+        [
+            ConvoyEvent::TaskPhaseChanged { task: a, from: TaskPhase::Pending, to: TaskPhase::Ready },
+            ConvoyEvent::TaskPhaseChanged { task: b, from: TaskPhase::Pending, to: TaskPhase::Ready },
+            ConvoyEvent::TaskPhaseChanged { task: c, from: TaskPhase::Pending, to: TaskPhase::Ready },
+        ] if a == "a" && b == "b" && c == "c"
+    ));
+}
+
+#[test]
+fn fail_fast_emits_phase_and_task_phase_change_events() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Failed;
+    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Running;
+    status.tasks.get_mut("review").expect("review").started_at = Some(timestamp(11));
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(30));
+
+    assert!(matches!(
+        outcome.events.as_slice(),
+        [
+            ConvoyEvent::PhaseChanged { from: ConvoyPhase::Active, to: ConvoyPhase::Failed },
+            ConvoyEvent::TaskPhaseChanged { task, from: TaskPhase::Running, to: TaskPhase::Cancelled },
+        ] if task == "review"
+    ));
+}
+
+#[test]
+fn roll_up_to_active_emits_phase_change_event() {
+    let mut status = bootstrapped_convoy_status();
+    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Completed;
+    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
+    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Running;
+    status.tasks.get_mut("review").expect("review").started_at = Some(timestamp(9));
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(20));
+
+    assert!(matches!(outcome.events.as_slice(), [ConvoyEvent::PhaseChanged { from: ConvoyPhase::Pending, to: ConvoyPhase::Active }]));
+}
+
+#[test]
 fn workflow_ref_change_after_init_fails_defensively() {
     let mut spec = valid_convoy_spec();
     spec.workflow_ref = "new-template".to_string();

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -24,10 +24,7 @@ fn sample_snapshot() -> WorkflowSnapshot {
                             prompt: Some("Implement {{inputs.feature}}".to_string()),
                         },
                     },
-                    ProcessDefinition {
-                        role: "build".to_string(),
-                        source: ProcessSource::Tool { command: "cargo test".to_string() },
-                    },
+                    ProcessDefinition { role: "build".to_string(), source: ProcessSource::Tool { command: "cargo test".to_string() } },
                 ],
             },
             SnapshotTask {
@@ -84,17 +81,14 @@ fn advance_tasks_to_ready_updates_only_selected_tasks() {
         workflow_snapshot: Some(sample_snapshot()),
         tasks: BTreeMap::from([
             ("implement".to_string(), pending_task()),
-            (
-                "review".to_string(),
-                TaskState {
-                    phase: TaskPhase::Completed,
-                    ready_at: Some(ts(5)),
-                    started_at: Some(ts(6)),
-                    finished_at: Some(ts(7)),
-                    message: Some("done".to_string()),
-                    placement: None,
-                },
-            ),
+            ("review".to_string(), TaskState {
+                phase: TaskPhase::Completed,
+                ready_at: Some(ts(5)),
+                started_at: Some(ts(6)),
+                finished_at: Some(ts(7)),
+                message: Some("done".to_string()),
+                placement: None,
+            }),
         ]),
         message: Some("keep".to_string()),
         started_at: None,
@@ -118,28 +112,22 @@ fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         tasks: BTreeMap::from([
-            (
-                "implement".to_string(),
-                TaskState {
-                    phase: TaskPhase::Failed,
-                    ready_at: Some(ts(10)),
-                    started_at: Some(ts(11)),
-                    finished_at: Some(ts(12)),
-                    message: Some("boom".to_string()),
-                    placement: None,
-                },
-            ),
-            (
-                "review".to_string(),
-                TaskState {
-                    phase: TaskPhase::Running,
-                    ready_at: Some(ts(20)),
-                    started_at: Some(ts(21)),
-                    finished_at: None,
-                    message: None,
-                    placement: None,
-                },
-            ),
+            ("implement".to_string(), TaskState {
+                phase: TaskPhase::Failed,
+                ready_at: Some(ts(10)),
+                started_at: Some(ts(11)),
+                finished_at: Some(ts(12)),
+                message: Some("boom".to_string()),
+                placement: None,
+            }),
+            ("review".to_string(), TaskState {
+                phase: TaskPhase::Running,
+                ready_at: Some(ts(20)),
+                started_at: Some(ts(21)),
+                finished_at: None,
+                message: None,
+                placement: None,
+            }),
         ]),
         message: None,
         started_at: Some(ts(1)),
@@ -148,11 +136,7 @@ fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
     };
 
-    let patch = controller_patches::fail_convoy(
-        BTreeMap::from([("review".to_string(), ts(30))]),
-        ts(30),
-        Some("task failed".to_string()),
-    );
+    let patch = controller_patches::fail_convoy(BTreeMap::from([("review".to_string(), ts(30))]), ts(30), Some("task failed".to_string()));
     patch.apply(&mut status);
 
     assert_eq!(status.phase, ConvoyPhase::Failed);
@@ -198,17 +182,14 @@ fn external_completion_marks_task_complete_without_touching_convoy_phase() {
     let mut status = ConvoyStatus {
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
-        tasks: BTreeMap::from([(
-            "review".to_string(),
-            TaskState {
-                phase: TaskPhase::Running,
-                ready_at: Some(ts(10)),
-                started_at: Some(ts(11)),
-                finished_at: None,
-                message: None,
-                placement: None,
-            },
-        )]),
+        tasks: BTreeMap::from([("review".to_string(), TaskState {
+            phase: TaskPhase::Running,
+            ready_at: Some(ts(10)),
+            started_at: Some(ts(11)),
+            finished_at: None,
+            message: None,
+            placement: None,
+        })]),
         message: None,
         started_at: Some(ts(1)),
         finished_at: None,
@@ -216,11 +197,7 @@ fn external_completion_marks_task_complete_without_touching_convoy_phase() {
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
     };
 
-    let patch = ConvoyStatusPatch::MarkTaskCompleted {
-        task: "review".to_string(),
-        finished_at: ts(50),
-        message: Some("done".to_string()),
-    };
+    let patch = ConvoyStatusPatch::MarkTaskCompleted { task: "review".to_string(), finished_at: ts(50), message: Some("done".to_string()) };
     patch.apply(&mut status);
 
     assert_eq!(status.phase, ConvoyPhase::Active);

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -1,0 +1,230 @@
+use std::collections::BTreeMap;
+
+use chrono::{TimeZone, Utc};
+use flotilla_resources::{
+    controller_patches, ConvoyPhase, ConvoyStatus, ConvoyStatusPatch, ProcessDefinition, ProcessSource, Selector, SnapshotTask,
+    StatusPatch, TaskPhase, TaskState, WorkflowSnapshot,
+};
+
+fn ts(seconds: i64) -> chrono::DateTime<Utc> {
+    Utc.timestamp_opt(seconds, 0).single().expect("valid timestamp")
+}
+
+fn sample_snapshot() -> WorkflowSnapshot {
+    WorkflowSnapshot {
+        tasks: vec![
+            SnapshotTask {
+                name: "implement".to_string(),
+                depends_on: Vec::new(),
+                processes: vec![
+                    ProcessDefinition {
+                        role: "coder".to_string(),
+                        source: ProcessSource::Agent {
+                            selector: Selector { capability: "code".to_string() },
+                            prompt: Some("Implement {{inputs.feature}}".to_string()),
+                        },
+                    },
+                    ProcessDefinition {
+                        role: "build".to_string(),
+                        source: ProcessSource::Tool { command: "cargo test".to_string() },
+                    },
+                ],
+            },
+            SnapshotTask {
+                name: "review".to_string(),
+                depends_on: vec!["implement".to_string()],
+                processes: vec![ProcessDefinition {
+                    role: "reviewer".to_string(),
+                    source: ProcessSource::Agent {
+                        selector: Selector { capability: "code-review".to_string() },
+                        prompt: Some("Review {{inputs.feature}}".to_string()),
+                    },
+                }],
+            },
+        ],
+    }
+}
+
+fn pending_task() -> TaskState {
+    TaskState { phase: TaskPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None }
+}
+
+#[test]
+fn bootstrap_sets_snapshot_and_initial_task_map() {
+    let mut status = ConvoyStatus::default();
+    let mut tasks = BTreeMap::new();
+    tasks.insert("implement".to_string(), pending_task());
+    tasks.insert("review".to_string(), pending_task());
+
+    let patch = controller_patches::bootstrap(
+        sample_snapshot(),
+        "review-and-fix".to_string(),
+        [("review-and-fix".to_string(), "42".to_string())].into_iter().collect(),
+        tasks.clone(),
+        ConvoyPhase::Pending,
+        None,
+    );
+
+    patch.apply(&mut status);
+
+    assert_eq!(status.phase, ConvoyPhase::Pending);
+    assert_eq!(status.workflow_snapshot, Some(sample_snapshot()));
+    assert_eq!(status.observed_workflow_ref.as_deref(), Some("review-and-fix"));
+    assert_eq!(
+        status.observed_workflows.as_ref().expect("observed workflows"),
+        &BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])
+    );
+    assert_eq!(status.tasks, tasks);
+}
+
+#[test]
+fn advance_tasks_to_ready_updates_only_selected_tasks() {
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Pending,
+        workflow_snapshot: Some(sample_snapshot()),
+        tasks: BTreeMap::from([
+            ("implement".to_string(), pending_task()),
+            (
+                "review".to_string(),
+                TaskState {
+                    phase: TaskPhase::Completed,
+                    ready_at: Some(ts(5)),
+                    started_at: Some(ts(6)),
+                    finished_at: Some(ts(7)),
+                    message: Some("done".to_string()),
+                    placement: None,
+                },
+            ),
+        ]),
+        message: Some("keep".to_string()),
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: Some("review-and-fix".to_string()),
+        observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+    };
+
+    let patch = controller_patches::advance_tasks_to_ready(BTreeMap::from([("implement".to_string(), ts(10))]));
+    patch.apply(&mut status);
+
+    assert_eq!(status.tasks["implement"].phase, TaskPhase::Ready);
+    assert_eq!(status.tasks["implement"].ready_at, Some(ts(10)));
+    assert_eq!(status.tasks["review"].phase, TaskPhase::Completed);
+    assert_eq!(status.message.as_deref(), Some("keep"));
+}
+
+#[test]
+fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Active,
+        workflow_snapshot: Some(sample_snapshot()),
+        tasks: BTreeMap::from([
+            (
+                "implement".to_string(),
+                TaskState {
+                    phase: TaskPhase::Failed,
+                    ready_at: Some(ts(10)),
+                    started_at: Some(ts(11)),
+                    finished_at: Some(ts(12)),
+                    message: Some("boom".to_string()),
+                    placement: None,
+                },
+            ),
+            (
+                "review".to_string(),
+                TaskState {
+                    phase: TaskPhase::Running,
+                    ready_at: Some(ts(20)),
+                    started_at: Some(ts(21)),
+                    finished_at: None,
+                    message: None,
+                    placement: None,
+                },
+            ),
+        ]),
+        message: None,
+        started_at: Some(ts(1)),
+        finished_at: None,
+        observed_workflow_ref: Some("review-and-fix".to_string()),
+        observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+    };
+
+    let patch = controller_patches::fail_convoy(
+        BTreeMap::from([("review".to_string(), ts(30))]),
+        ts(30),
+        Some("task failed".to_string()),
+    );
+    patch.apply(&mut status);
+
+    assert_eq!(status.phase, ConvoyPhase::Failed);
+    assert_eq!(status.finished_at, Some(ts(30)));
+    assert_eq!(status.message.as_deref(), Some("task failed"));
+    assert_eq!(status.tasks["implement"].phase, TaskPhase::Failed);
+    assert_eq!(status.tasks["review"].phase, TaskPhase::Cancelled);
+    assert_eq!(status.tasks["review"].finished_at, Some(ts(30)));
+}
+
+#[test]
+fn roll_up_phase_only_touches_convoy_level_fields() {
+    let review = TaskState {
+        phase: TaskPhase::Completed,
+        ready_at: Some(ts(10)),
+        started_at: Some(ts(11)),
+        finished_at: Some(ts(12)),
+        message: Some("done".to_string()),
+        placement: None,
+    };
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Pending,
+        workflow_snapshot: Some(sample_snapshot()),
+        tasks: BTreeMap::from([("review".to_string(), review.clone())]),
+        message: Some("keep".to_string()),
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: Some("review-and-fix".to_string()),
+        observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+    };
+
+    let patch = controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(ts(40)));
+    patch.apply(&mut status);
+
+    assert_eq!(status.phase, ConvoyPhase::Completed);
+    assert_eq!(status.finished_at, Some(ts(40)));
+    assert_eq!(status.message.as_deref(), Some("keep"));
+    assert_eq!(status.tasks["review"], review);
+}
+
+#[test]
+fn external_completion_marks_task_complete_without_touching_convoy_phase() {
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Active,
+        workflow_snapshot: Some(sample_snapshot()),
+        tasks: BTreeMap::from([(
+            "review".to_string(),
+            TaskState {
+                phase: TaskPhase::Running,
+                ready_at: Some(ts(10)),
+                started_at: Some(ts(11)),
+                finished_at: None,
+                message: None,
+                placement: None,
+            },
+        )]),
+        message: None,
+        started_at: Some(ts(1)),
+        finished_at: None,
+        observed_workflow_ref: Some("review-and-fix".to_string()),
+        observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+    };
+
+    let patch = ConvoyStatusPatch::MarkTaskCompleted {
+        task: "review".to_string(),
+        finished_at: ts(50),
+        message: Some("done".to_string()),
+    };
+    patch.apply(&mut status);
+
+    assert_eq!(status.phase, ConvoyPhase::Active);
+    assert_eq!(status.tasks["review"].phase, TaskPhase::Completed);
+    assert_eq!(status.tasks["review"].finished_at, Some(ts(50)));
+    assert_eq!(status.tasks["review"].message.as_deref(), Some("done"));
+}

--- a/crates/flotilla-resources/tests/http_wire.rs
+++ b/crates/flotilla-resources/tests/http_wire.rs
@@ -119,10 +119,7 @@ async fn update_status_uses_status_subresource_path_and_body() {
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
-    let updated = resolver
-        .update_status("alpha", "7", &convoy_status(ConvoyPhase::Active))
-        .await
-        .expect("status update should succeed");
+    let updated = resolver.update_status("alpha", "7", &convoy_status(ConvoyPhase::Active)).await.expect("status update should succeed");
     assert_eq!(updated.metadata.resource_version, "8");
 
     let request = request_rx.await.expect("captured request");
@@ -189,7 +186,7 @@ async fn status_errors_map_to_resource_errors() {
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
-    let err = resolver.update(&convoy_meta("alpha"), "7", &convoy_spec("review")).await.err().expect("update should conflict");
+    let err = resolver.update(&convoy_meta("alpha"), "7", &convoy_spec("review")).await.expect_err("update should conflict");
     match err {
         ResourceError::Conflict { name, message } => {
             assert_eq!(name, "alpha");
@@ -206,7 +203,7 @@ async fn not_found_errors_preserve_requested_name() {
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
-    let err = resolver.get("alpha").await.err().expect("get should fail");
+    let err = resolver.get("alpha").await.expect_err("get should fail");
     match err {
         ResourceError::NotFound { name } => assert_eq!(name, "alpha"),
         other => panic!("expected not found, got {other}"),

--- a/crates/flotilla-resources/tests/http_wire.rs
+++ b/crates/flotilla-resources/tests/http_wire.rs
@@ -2,8 +2,8 @@ mod common;
 
 use std::{net::SocketAddr, time::Duration};
 
-use common::{input_meta, spec, status, ConvoyResource};
-use flotilla_resources::{HttpBackend, ResourceBackend, ResourceError, WatchEvent, WatchStart};
+use common::{convoy_meta, convoy_spec, convoy_status};
+use flotilla_resources::{Convoy, ConvoyPhase, HttpBackend, ResourceBackend, ResourceError, WatchEvent, WatchStart};
 use futures::StreamExt;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -73,20 +73,25 @@ async fn list_decodes_collection_resource_version() {
                 "annotations": { "note": "test" },
                 "creationTimestamp": "2026-04-13T12:00:00Z"
             },
-            "spec": { "template": "review" },
-            "status": { "phase": "Running" }
+            "spec": {
+                "workflow_ref": "review",
+                "inputs": {},
+                "placement_policy": "laptop-docker"
+            },
+            "status": { "phase": "Active" }
         }]
     })
     .to_string();
     let (base_url, _request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
-    let resolver = backend.using::<ConvoyResource>("flotilla");
+    let resolver = backend.using::<Convoy>("flotilla");
 
     let listed = resolver.list().await.expect("list should succeed");
     assert_eq!(listed.resource_version, "7");
     assert_eq!(listed.items.len(), 1);
     assert_eq!(listed.items[0].metadata.name, "alpha");
-    assert_eq!(listed.items[0].status.as_ref().expect("status").phase, "Running");
+    assert_eq!(listed.items[0].spec.workflow_ref, "review");
+    assert_eq!(listed.items[0].status.as_ref().expect("status").phase, ConvoyPhase::Active);
 }
 
 #[tokio::test]
@@ -102,32 +107,39 @@ async fn update_status_uses_status_subresource_path_and_body() {
             "annotations": { "note": "test" },
             "creationTimestamp": "2026-04-13T12:00:00Z"
         },
-        "spec": { "template": "review" },
-        "status": { "phase": "Running" }
+        "spec": {
+            "workflow_ref": "review",
+            "inputs": {},
+            "placement_policy": "laptop-docker"
+        },
+        "status": { "phase": "Active" }
     })
     .to_string();
     let (base_url, request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
-    let resolver = backend.using::<ConvoyResource>("flotilla");
+    let resolver = backend.using::<Convoy>("flotilla");
 
-    let updated = resolver.update_status("alpha", "7", &status("Running")).await.expect("status update should succeed");
+    let updated = resolver
+        .update_status("alpha", "7", &convoy_status(ConvoyPhase::Active))
+        .await
+        .expect("status update should succeed");
     assert_eq!(updated.metadata.resource_version, "8");
 
     let request = request_rx.await.expect("captured request");
     assert!(request.starts_with("PUT /apis/flotilla.work/v1/namespaces/flotilla/convoys/alpha/status HTTP/1.1"));
     assert!(request.contains("\"resourceVersion\":\"7\""));
-    assert!(request.contains("\"phase\":\"Running\""));
+    assert!(request.contains("\"phase\":\"Active\""));
 }
 
 #[tokio::test]
 async fn watch_decodes_kubernetes_watch_events() {
     let body = concat!(
-        "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"7\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"template\":\"review\"},\"status\":{\"phase\":\"Pending\"}}}\n",
-        "{\"type\":\"DELETED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"8\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"template\":\"review\"},\"status\":{\"phase\":\"Pending\"}}}\n"
+        "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"7\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"workflow_ref\":\"review\",\"inputs\":{},\"placement_policy\":\"laptop-docker\"},\"status\":{\"phase\":\"Pending\"}}}\n",
+        "{\"type\":\"DELETED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"8\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"workflow_ref\":\"review\",\"inputs\":{},\"placement_policy\":\"laptop-docker\"},\"status\":{\"phase\":\"Pending\"}}}\n"
     );
     let (base_url, request_rx) = spawn_one_shot_server(response("200 OK", body)).await;
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
-    let resolver = backend.using::<ConvoyResource>("flotilla");
+    let resolver = backend.using::<Convoy>("flotilla");
 
     let mut watch = resolver.watch(WatchStart::FromVersion("6".to_string())).await.expect("watch should succeed");
     let first = timeout(Duration::from_secs(1), watch.next())
@@ -156,10 +168,10 @@ async fn watch_decodes_kubernetes_watch_events() {
 #[tokio::test]
 async fn watch_decodes_crlf_terminated_events() {
     let body =
-        "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"7\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"template\":\"review\"},\"status\":{\"phase\":\"Pending\"}}}\r\n";
+        "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"7\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"workflow_ref\":\"review\",\"inputs\":{},\"placement_policy\":\"laptop-docker\"},\"status\":{\"phase\":\"Pending\"}}}\r\n";
     let (base_url, _request_rx) = spawn_one_shot_server(response("200 OK", body)).await;
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
-    let resolver = backend.using::<ConvoyResource>("flotilla");
+    let resolver = backend.using::<Convoy>("flotilla");
 
     let mut watch = resolver.watch(WatchStart::Now).await.expect("watch should succeed");
     let event =
@@ -175,9 +187,9 @@ async fn status_errors_map_to_resource_errors() {
     let body = serde_json::json!({ "message": "resource version conflict" }).to_string();
     let (base_url, _request_rx) = spawn_one_shot_server(response("409 Conflict", &body)).await;
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
-    let resolver = backend.using::<ConvoyResource>("flotilla");
+    let resolver = backend.using::<Convoy>("flotilla");
 
-    let err = resolver.update(&input_meta("alpha"), "7", &spec("review")).await.err().expect("update should conflict");
+    let err = resolver.update(&convoy_meta("alpha"), "7", &convoy_spec("review")).await.err().expect("update should conflict");
     match err {
         ResourceError::Conflict { name, message } => {
             assert_eq!(name, "alpha");
@@ -192,7 +204,7 @@ async fn not_found_errors_preserve_requested_name() {
     let body = serde_json::json!({ "message": "convoys.flotilla.work \"alpha\" not found" }).to_string();
     let (base_url, _request_rx) = spawn_one_shot_server(response("404 Not Found", &body)).await;
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
-    let resolver = backend.using::<ConvoyResource>("flotilla");
+    let resolver = backend.using::<Convoy>("flotilla");
 
     let err = resolver.get("alpha").await.err().expect("get should fail");
     match err {
@@ -205,7 +217,7 @@ async fn not_found_errors_preserve_requested_name() {
 async fn server_disconnect_ends_watch_stream_cleanly() {
     let (base_url, _request_rx) = spawn_one_shot_server(response("200 OK", "")).await;
     let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
-    let resolver = backend.using::<ConvoyResource>("flotilla");
+    let resolver = backend.using::<Convoy>("flotilla");
 
     let mut watch = resolver.watch(WatchStart::Now).await.expect("watch should succeed");
     let next = timeout(Duration::from_millis(200), watch.next()).await.expect("watch poll should finish");

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -36,7 +36,8 @@ async fn update_requires_current_resource_version() {
     let resolver = resolver("flotilla");
     let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
 
-    let conflict = resolver.update(&convoy_meta("alpha"), "0", &convoy_spec("template-b")).await.err().expect("stale version should conflict");
+    let conflict =
+        resolver.update(&convoy_meta("alpha"), "0", &convoy_spec("template-b")).await.expect_err("stale version should conflict");
     match conflict {
         flotilla_resources::ResourceError::Conflict { .. } => {}
         other => panic!("expected conflict, got {other}"),

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -2,28 +2,28 @@ mod common;
 
 use std::time::Duration;
 
-use common::{input_meta, spec, status, ConvoyResource};
-use flotilla_resources::{InMemoryBackend, ResourceBackend, WatchEvent, WatchStart};
+use common::{convoy_meta, convoy_spec, convoy_status};
+use flotilla_resources::{Convoy, ConvoyPhase, InMemoryBackend, ResourceBackend, WatchEvent, WatchStart};
 use futures::StreamExt;
 use tokio::time::timeout;
 
-fn resolver(namespace: &str) -> flotilla_resources::TypedResolver<ConvoyResource> {
-    ResourceBackend::InMemory(InMemoryBackend::default()).using::<ConvoyResource>(namespace)
+fn resolver(namespace: &str) -> flotilla_resources::TypedResolver<Convoy> {
+    ResourceBackend::InMemory(InMemoryBackend::default()).using::<Convoy>(namespace)
 }
 
 #[tokio::test]
 async fn create_get_list_roundtrip() {
     let resolver = resolver("flotilla");
-    let created = resolver.create(&input_meta("alpha"), &spec("template-a")).await.expect("create should succeed");
+    let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
     assert_eq!(created.metadata.name, "alpha");
     assert_eq!(created.metadata.namespace, "flotilla");
     assert!(!created.metadata.resource_version.is_empty());
-    assert_eq!(created.spec.template, "template-a");
+    assert_eq!(created.spec.workflow_ref, "template-a");
     assert!(created.status.is_none());
 
     let fetched = resolver.get("alpha").await.expect("get should succeed");
     assert_eq!(fetched.metadata.resource_version, created.metadata.resource_version);
-    assert_eq!(fetched.spec.template, "template-a");
+    assert_eq!(fetched.spec.workflow_ref, "template-a");
 
     let listed = resolver.list().await.expect("list should succeed");
     assert_eq!(listed.resource_version, created.metadata.resource_version);
@@ -34,41 +34,41 @@ async fn create_get_list_roundtrip() {
 #[tokio::test]
 async fn update_requires_current_resource_version() {
     let resolver = resolver("flotilla");
-    let created = resolver.create(&input_meta("alpha"), &spec("template-a")).await.expect("create should succeed");
+    let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
 
-    let conflict = resolver.update(&input_meta("alpha"), "0", &spec("template-b")).await.err().expect("stale version should conflict");
+    let conflict = resolver.update(&convoy_meta("alpha"), "0", &convoy_spec("template-b")).await.err().expect("stale version should conflict");
     match conflict {
         flotilla_resources::ResourceError::Conflict { .. } => {}
         other => panic!("expected conflict, got {other}"),
     }
 
     let updated = resolver
-        .update(&input_meta("alpha"), &created.metadata.resource_version, &spec("template-b"))
+        .update(&convoy_meta("alpha"), &created.metadata.resource_version, &convoy_spec("template-b"))
         .await
         .expect("update should succeed");
     assert_eq!(updated.metadata.resource_version, "2");
-    assert_eq!(updated.spec.template, "template-b");
+    assert_eq!(updated.spec.workflow_ref, "template-b");
     assert_eq!(updated.metadata.labels.get("app").expect("label"), "flotilla");
 }
 
 #[tokio::test]
 async fn update_status_does_not_require_or_change_input_meta() {
     let resolver = resolver("flotilla");
-    let created = resolver.create(&input_meta("alpha"), &spec("template-a")).await.expect("create should succeed");
+    let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
     let updated = resolver
-        .update_status("alpha", &created.metadata.resource_version, &status("Running"))
+        .update_status("alpha", &created.metadata.resource_version, &convoy_status(ConvoyPhase::Active))
         .await
         .expect("status update should succeed");
 
     assert_eq!(updated.metadata.resource_version, "2");
     assert_eq!(updated.metadata.labels.get("app").expect("label"), "flotilla");
-    assert_eq!(updated.status.expect("status").phase, "Running");
+    assert_eq!(updated.status.expect("status").phase, ConvoyPhase::Active);
 }
 
 #[tokio::test]
 async fn delete_emits_deleted_event() {
     let resolver = resolver("flotilla");
-    let created = resolver.create(&input_meta("alpha"), &spec("template-a")).await.expect("create should succeed");
+    let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
     let mut watch = resolver.watch(WatchStart::FromVersion(created.metadata.resource_version.clone())).await.expect("watch should succeed");
 
     resolver.delete("alpha").await.expect("delete should succeed");
@@ -90,12 +90,12 @@ async fn delete_emits_deleted_event() {
 #[tokio::test]
 async fn watch_from_version_replays_gaplessly_after_list() {
     let resolver = resolver("flotilla");
-    resolver.create(&input_meta("alpha"), &spec("template-a")).await.expect("create should succeed");
+    resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
     let listed = resolver.list().await.expect("list should succeed");
     let mut watch = resolver.watch(WatchStart::FromVersion(listed.resource_version.clone())).await.expect("watch should succeed");
 
     resolver
-        .update_status("alpha", &listed.items[0].metadata.resource_version, &status("Running"))
+        .update_status("alpha", &listed.items[0].metadata.resource_version, &convoy_status(ConvoyPhase::Active))
         .await
         .expect("status update should succeed");
     let modified = timeout(Duration::from_secs(1), watch.next())
@@ -104,7 +104,7 @@ async fn watch_from_version_replays_gaplessly_after_list() {
         .expect("stream should yield item")
         .expect("event should decode");
     match modified {
-        WatchEvent::Modified(object) => assert_eq!(object.status.expect("status").phase, "Running"),
+        WatchEvent::Modified(object) => assert_eq!(object.status.expect("status").phase, ConvoyPhase::Active),
         _ => panic!("expected modified event"),
     }
 
@@ -126,20 +126,23 @@ async fn watch_from_version_replays_gaplessly_after_list() {
 #[tokio::test]
 async fn watch_now_only_sees_future_events() {
     let resolver = resolver("flotilla");
-    resolver.create(&input_meta("alpha"), &spec("template-a")).await.expect("create should succeed");
+    resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
 
     let mut watch = resolver.watch(WatchStart::Now).await.expect("watch should succeed");
     assert!(timeout(Duration::from_millis(100), watch.next()).await.is_err(), "watch-now should not replay existing state");
 
     let current = resolver.get("alpha").await.expect("get should succeed");
-    resolver.update_status("alpha", &current.metadata.resource_version, &status("Running")).await.expect("status update should succeed");
+    resolver
+        .update_status("alpha", &current.metadata.resource_version, &convoy_status(ConvoyPhase::Active))
+        .await
+        .expect("status update should succeed");
     let event = timeout(Duration::from_secs(1), watch.next())
         .await
         .expect("watch should produce future event")
         .expect("stream should yield item")
         .expect("event should decode");
     match event {
-        WatchEvent::Modified(object) => assert_eq!(object.status.expect("status").phase, "Running"),
+        WatchEvent::Modified(object) => assert_eq!(object.status.expect("status").phase, ConvoyPhase::Active),
         _ => panic!("expected modified event"),
     }
 }
@@ -147,16 +150,16 @@ async fn watch_now_only_sees_future_events() {
 #[tokio::test]
 async fn namespaces_are_isolated() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    let alpha = backend.using::<ConvoyResource>("alpha");
-    let beta = backend.using::<ConvoyResource>("beta");
+    let alpha = backend.using::<Convoy>("alpha");
+    let beta = backend.using::<Convoy>("beta");
 
-    alpha.create(&input_meta("shared"), &spec("template-a")).await.expect("alpha create should succeed");
-    beta.create(&input_meta("shared"), &spec("template-b")).await.expect("beta create should succeed");
+    alpha.create(&convoy_meta("shared"), &convoy_spec("template-a")).await.expect("alpha create should succeed");
+    beta.create(&convoy_meta("shared"), &convoy_spec("template-b")).await.expect("beta create should succeed");
 
     let alpha_item = alpha.get("shared").await.expect("alpha get should succeed");
     let beta_item = beta.get("shared").await.expect("beta get should succeed");
     assert_eq!(alpha_item.metadata.namespace, "alpha");
     assert_eq!(beta_item.metadata.namespace, "beta");
-    assert_eq!(alpha_item.spec.template, "template-a");
-    assert_eq!(beta_item.spec.template, "template-b");
+    assert_eq!(alpha_item.spec.workflow_ref, "template-a");
+    assert_eq!(beta_item.spec.workflow_ref, "template-b");
 }

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -1,39 +1,10 @@
 use std::{env, path::PathBuf};
 
 use flotilla_resources::{
-    ensure_crd, ensure_namespace, validate, ApiPaths, HttpBackend, InputMeta, Resource, ResourceBackend, StatusPatch, WatchEvent,
-    WatchStart, WorkflowTemplate, WorkflowTemplateSpec,
+    apply_status_patch, ensure_crd, ensure_namespace, external_patches, reconcile, validate, Convoy, ConvoyPhase, ConvoySpec,
+    HttpBackend, InputMeta, InputValue, ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
 };
-use futures::StreamExt;
-use serde::{Deserialize, Serialize};
-
-struct ConvoyResource;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ConvoySpec {
-    template: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct ConvoyStatus {
-    phase: String,
-}
-
-enum ConvoyStatusPatch {}
-
-impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
-    fn apply(&self, _: &mut ConvoyStatus) {
-        match *self {}
-    }
-}
-
-impl Resource for ConvoyResource {
-    type Spec = ConvoySpec;
-    type Status = ConvoyStatus;
-    type StatusPatch = ConvoyStatusPatch;
-
-    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "convoys", kind: "Convoy" };
-}
+use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 struct WorkflowTemplateDocument {
@@ -54,50 +25,43 @@ fn workflow_template_spec() -> WorkflowTemplateSpec {
     document.spec
 }
 
-#[tokio::test]
-#[ignore = "requires minikube or another Kubernetes cluster"]
-async fn k8s_crud_and_watch_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
-    if env::var("FLOTILLA_RUN_K8S_TESTS").ok().as_deref() != Some("1") {
-        return Ok(());
+fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
+    ConvoySpec {
+        workflow_ref: workflow_ref.to_string(),
+        inputs: [
+            ("feature".to_string(), InputValue::String("Retry logic".to_string())),
+            ("branch".to_string(), InputValue::String("fix-retry".to_string())),
+        ]
+        .into_iter()
+        .collect(),
+        placement_policy: Some("laptop-docker".to_string()),
     }
+}
 
-    let backend = HttpBackend::from_kubeconfig(kubeconfig_path())?;
-    let namespace = "flotilla";
-    ensure_namespace(&backend, namespace).await?;
-    ensure_crd(&backend, include_str!("../src/crds/convoy.crd.yaml")).await?;
-
-    let resolver = ResourceBackend::Http(backend).using::<ConvoyResource>(namespace);
-    let meta = InputMeta { name: format!("convoy-{}", std::process::id()), labels: Default::default(), annotations: Default::default() };
-
-    let created = resolver.create(&meta, &ConvoySpec { template: "review".to_string() }).await?;
-    let listed = resolver.list().await?;
-    let mut watch = resolver.watch(WatchStart::FromVersion(listed.resource_version.clone())).await?;
-
-    let updated = resolver
-        .update_status(&created.metadata.name, &created.metadata.resource_version, &ConvoyStatus { phase: "Running".to_string() })
-        .await?;
-
-    match watch.next().await.expect("watch event")? {
-        WatchEvent::Modified(object) => {
-            assert_eq!(object.metadata.name, created.metadata.name);
-            assert_eq!(object.status.expect("status").phase, "Running");
-        }
-        _ => panic!("expected modified event"),
+async fn reconcile_once(
+    convoys: &flotilla_resources::TypedResolver<Convoy>,
+    templates: &flotilla_resources::TypedResolver<WorkflowTemplate>,
+    name: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<flotilla_resources::ConvoyStatusPatch>, ResourceError> {
+    let convoy = convoys.get(name).await?;
+    let template = if convoy.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_none() {
+        Some(templates.get(&convoy.spec.workflow_ref).await?)
+    } else {
+        None
+    };
+    let outcome = reconcile(&convoy, template.as_ref(), now);
+    if let Some(patch) = outcome.patch.clone() {
+        apply_status_patch(convoys, name, &patch).await?;
+        Ok(Some(patch))
+    } else {
+        Ok(None)
     }
-
-    resolver.delete(&created.metadata.name).await?;
-    match watch.next().await.expect("watch event")? {
-        WatchEvent::Deleted(object) => assert_eq!(object.metadata.name, created.metadata.name),
-        _ => panic!("expected deleted event"),
-    }
-
-    assert_eq!(updated.status.expect("status").phase, "Running");
-    Ok(())
 }
 
 #[tokio::test]
 #[ignore = "requires minikube or another Kubernetes cluster"]
-async fn workflow_template_crud_and_watch_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
+async fn convoy_controller_roundtrip_and_cel_validation() -> Result<(), Box<dyn std::error::Error>> {
     if env::var("FLOTILLA_RUN_K8S_TESTS").ok().as_deref() != Some("1") {
         return Ok(());
     }
@@ -106,39 +70,73 @@ async fn workflow_template_crud_and_watch_roundtrip() -> Result<(), Box<dyn std:
     let namespace = "flotilla";
     ensure_namespace(&backend, namespace).await?;
     ensure_crd(&backend, include_str!("../src/crds/workflow_template.crd.yaml")).await?;
+    ensure_crd(&backend, include_str!("../src/crds/convoy.crd.yaml")).await?;
 
-    let resolver = ResourceBackend::Http(backend).using::<WorkflowTemplate>(namespace);
-    let meta = InputMeta {
+    let backend = ResourceBackend::Http(backend);
+    let templates = backend.clone().using::<WorkflowTemplate>(namespace);
+    let convoys = backend.using::<Convoy>(namespace);
+
+    let workflow_meta = InputMeta {
         name: format!("workflow-template-{}", std::process::id()),
         labels: Default::default(),
         annotations: Default::default(),
     };
+    let workflow_spec = workflow_template_spec();
+    validate(&workflow_spec).map_err(|errors| format!("fixture workflow failed validation: {errors:?}"))?;
+    let _workflow = templates.create(&workflow_meta, &workflow_spec).await?;
 
-    let spec = workflow_template_spec();
-    validate(&spec).map_err(|errors| format!("fixture workflow failed validation: {errors:?}"))?;
-    let created = resolver.create(&meta, &spec).await?;
-    let listed = resolver.list().await?;
-    let mut watch = resolver.watch(WatchStart::FromVersion(listed.resource_version.clone())).await?;
+    let convoy_meta = InputMeta {
+        name: format!("convoy-{}", std::process::id()),
+        labels: Default::default(),
+        annotations: Default::default(),
+    };
+    let created = convoys.create(&convoy_meta, &convoy_spec(&workflow_meta.name)).await?;
 
-    let mut updated_spec = workflow_template_spec();
-    if let flotilla_resources::ProcessSource::Tool { command } = &mut updated_spec.tasks[0].processes[1].source {
-        *command = "cargo check --all-targets".to_string();
-    }
-    let updated = resolver.update(&meta, &created.metadata.resource_version, &updated_spec).await?;
+    let mut changed_workflow = convoy_spec(&workflow_meta.name);
+    changed_workflow.workflow_ref = format!("{}-other", workflow_meta.name);
+    let workflow_err = convoys
+        .update(&convoy_meta, &created.metadata.resource_version, &changed_workflow)
+        .await
+        .expect_err("workflow_ref update should be rejected");
+    assert!(matches!(workflow_err, ResourceError::Invalid { .. }));
 
-    match watch.next().await.expect("watch event")? {
-        WatchEvent::Modified(object) => {
-            assert_eq!(object.metadata.name, created.metadata.name);
-            assert_eq!(object.metadata.resource_version, updated.metadata.resource_version);
-        }
-        _ => panic!("expected modified event"),
-    }
+    let mut changed_inputs = convoy_spec(&workflow_meta.name);
+    changed_inputs.inputs.insert("feature".to_string(), InputValue::String("Changed".to_string()));
+    let current = convoys.get(&created.metadata.name).await?;
+    let inputs_err = convoys
+        .update(&convoy_meta, &current.metadata.resource_version, &changed_inputs)
+        .await
+        .expect_err("inputs update should be rejected");
+    assert!(matches!(inputs_err, ResourceError::Invalid { .. }));
 
-    resolver.delete(&created.metadata.name).await?;
-    match watch.next().await.expect("watch event")? {
-        WatchEvent::Deleted(object) => assert_eq!(object.metadata.name, created.metadata.name),
-        _ => panic!("expected deleted event"),
-    }
+    reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;
+    reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;
 
+    apply_status_patch(
+        &convoys,
+        &created.metadata.name,
+        &external_patches::mark_task_completed("implement".to_string(), chrono::Utc::now(), Some("implemented".to_string())),
+    )
+    .await?;
+    let ready_review = reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;
+    assert!(matches!(
+        ready_review,
+        Some(flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. })
+    ));
+
+    apply_status_patch(
+        &convoys,
+        &created.metadata.name,
+        &external_patches::mark_task_completed("review".to_string(), chrono::Utc::now(), Some("reviewed".to_string())),
+    )
+    .await?;
+    let completed = reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;
+    assert!(matches!(
+        completed,
+        Some(flotilla_resources::ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, .. })
+    ));
+
+    let final_convoy = convoys.get(&created.metadata.name).await?;
+    assert_eq!(final_convoy.status.expect("status").phase, ConvoyPhase::Completed);
     Ok(())
 }

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -1,8 +1,8 @@
 use std::{env, path::PathBuf};
 
 use flotilla_resources::{
-    apply_status_patch, ensure_crd, ensure_namespace, external_patches, reconcile, validate, Convoy, ConvoyPhase, ConvoySpec,
-    HttpBackend, InputMeta, InputValue, ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
+    apply_status_patch, ensure_crd, ensure_namespace, external_patches, reconcile, validate, Convoy, ConvoyPhase, ConvoySpec, HttpBackend,
+    InputMeta, InputValue, ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde::Deserialize;
 
@@ -85,11 +85,8 @@ async fn convoy_controller_roundtrip_and_cel_validation() -> Result<(), Box<dyn 
     validate(&workflow_spec).map_err(|errors| format!("fixture workflow failed validation: {errors:?}"))?;
     let _workflow = templates.create(&workflow_meta, &workflow_spec).await?;
 
-    let convoy_meta = InputMeta {
-        name: format!("convoy-{}", std::process::id()),
-        labels: Default::default(),
-        annotations: Default::default(),
-    };
+    let convoy_meta =
+        InputMeta { name: format!("convoy-{}", std::process::id()), labels: Default::default(), annotations: Default::default() };
     let created = convoys.create(&convoy_meta, &convoy_spec(&workflow_meta.name)).await?;
 
     let mut changed_workflow = convoy_spec(&workflow_meta.name);
@@ -119,10 +116,7 @@ async fn convoy_controller_roundtrip_and_cel_validation() -> Result<(), Box<dyn 
     )
     .await?;
     let ready_review = reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;
-    assert!(matches!(
-        ready_review,
-        Some(flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. })
-    ));
+    assert!(matches!(ready_review, Some(flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. })));
 
     apply_status_patch(
         &convoys,
@@ -131,10 +125,7 @@ async fn convoy_controller_roundtrip_and_cel_validation() -> Result<(), Box<dyn 
     )
     .await?;
     let completed = reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;
-    assert!(matches!(
-        completed,
-        Some(flotilla_resources::ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, .. })
-    ));
+    assert!(matches!(completed, Some(flotilla_resources::ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, .. })));
 
     let final_convoy = convoys.get(&created.metadata.name).await?;
     assert_eq!(final_convoy.status.expect("status").phase, ConvoyPhase::Completed);

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -1,8 +1,8 @@
 use std::{env, path::PathBuf};
 
 use flotilla_resources::{
-    ensure_crd, ensure_namespace, validate, ApiPaths, HttpBackend, InputMeta, Resource, ResourceBackend, WatchEvent, WatchStart,
-    WorkflowTemplate, WorkflowTemplateSpec,
+    ensure_crd, ensure_namespace, validate, ApiPaths, HttpBackend, InputMeta, Resource, ResourceBackend, StatusPatch, WatchEvent,
+    WatchStart, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -19,9 +19,18 @@ struct ConvoyStatus {
     phase: String,
 }
 
+enum ConvoyStatusPatch {}
+
+impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
+    fn apply(&self, _: &mut ConvoyStatus) {
+        match *self {}
+    }
+}
+
 impl Resource for ConvoyResource {
     type Spec = ConvoySpec;
     type Status = ConvoyStatus;
+    type StatusPatch = ConvoyStatusPatch;
 
     const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "convoys", kind: "Convoy" };
 }

--- a/crates/flotilla-resources/tests/status_patch.rs
+++ b/crates/flotilla-resources/tests/status_patch.rs
@@ -54,9 +54,8 @@ async fn apply_status_patch_updates_existing_status() {
         .await
         .expect("seed status should succeed");
 
-    let updated = flotilla_resources::apply_status_patch(&resolver, "alpha", &CounterPatch::Increment)
-        .await
-        .expect("status patch should succeed");
+    let updated =
+        flotilla_resources::apply_status_patch(&resolver, "alpha", &CounterPatch::Increment).await.expect("status patch should succeed");
 
     assert_eq!(updated.status.expect("status"), CounterStatus { value: 2, note: None });
     assert_eq!(updated.metadata.resource_version, "3");

--- a/crates/flotilla-resources/tests/status_patch.rs
+++ b/crates/flotilla-resources/tests/status_patch.rs
@@ -62,3 +62,17 @@ async fn apply_status_patch_updates_existing_status() {
     assert_eq!(updated.metadata.resource_version, "3");
     assert_eq!(current.metadata.resource_version, "2");
 }
+
+#[tokio::test]
+async fn apply_status_patch_initializes_missing_status_from_default() {
+    let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<CounterResource>("flotilla");
+    let created = resolver.create(&counter_meta("beta"), &counter_spec("beta")).await.expect("create should succeed");
+
+    let updated = flotilla_resources::apply_status_patch(&resolver, "beta", &CounterPatch::SetNote("ready"))
+        .await
+        .expect("status patch should succeed");
+
+    assert_eq!(created.status, None);
+    assert_eq!(updated.status.expect("status"), CounterStatus { value: 0, note: Some("ready".to_string()) });
+    assert_eq!(updated.metadata.resource_version, "2");
+}

--- a/crates/flotilla-resources/tests/status_patch.rs
+++ b/crates/flotilla-resources/tests/status_patch.rs
@@ -1,0 +1,64 @@
+use flotilla_resources::{ApiPaths, InMemoryBackend, InputMeta, Resource, ResourceBackend, StatusPatch};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy)]
+struct CounterResource;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct CounterSpec {
+    name: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct CounterStatus {
+    value: u32,
+    note: Option<String>,
+}
+
+enum CounterPatch {
+    Increment,
+    SetNote(&'static str),
+}
+
+impl Resource for CounterResource {
+    type Spec = CounterSpec;
+    type Status = CounterStatus;
+    type StatusPatch = CounterPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "counters", kind: "Counter" };
+}
+
+impl StatusPatch<CounterStatus> for CounterPatch {
+    fn apply(&self, status: &mut CounterStatus) {
+        match self {
+            Self::Increment => status.value += 1,
+            Self::SetNote(note) => status.note = Some((*note).to_string()),
+        }
+    }
+}
+
+fn counter_meta(name: &str) -> InputMeta {
+    InputMeta { name: name.to_string(), labels: Default::default(), annotations: Default::default() }
+}
+
+fn counter_spec(name: &str) -> CounterSpec {
+    CounterSpec { name: name.to_string() }
+}
+
+#[tokio::test]
+async fn apply_status_patch_updates_existing_status() {
+    let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<CounterResource>("flotilla");
+    let created = resolver.create(&counter_meta("alpha"), &counter_spec("alpha")).await.expect("create should succeed");
+    let current = resolver
+        .update_status("alpha", &created.metadata.resource_version, &CounterStatus { value: 1, note: None })
+        .await
+        .expect("seed status should succeed");
+
+    let updated = flotilla_resources::apply_status_patch(&resolver, "alpha", &CounterPatch::Increment)
+        .await
+        .expect("status patch should succeed");
+
+    assert_eq!(updated.status.expect("status"), CounterStatus { value: 2, note: None });
+    assert_eq!(updated.metadata.resource_version, "3");
+    assert_eq!(current.metadata.resource_version, "2");
+}

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -116,19 +116,21 @@ fn issue_page(range: std::ops::RangeInclusive<usize>, has_more: bool) -> IssueRe
     IssueResultPage { items: range.map(issue_row).collect(), total: None, has_more }
 }
 
+fn daemon_test_config_store(config_dir: PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&config_dir).expect("create daemon config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(config_dir))
+}
+
 async fn app_with_issue_query_service(service: Arc<dyn IssueQueryService>) -> (tempfile::TempDir, PathBuf, Arc<InProcessDaemon>, App) {
     let temp = tempdir().expect("tempdir");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo dir");
 
     let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_issue_query_service(service));
-    let daemon = InProcessDaemon::new(
-        vec![repo.clone()],
-        Arc::new(ConfigStore::with_base(temp.path().join("daemon-config"))),
-        discovery,
-        HostName::local(),
-    )
-    .await;
+    let daemon =
+        InProcessDaemon::new(vec![repo.clone()], daemon_test_config_store(temp.path().join("daemon-config")), discovery, HostName::local())
+            .await;
     daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh repo");
 
     let daemon_handle: Arc<dyn DaemonHandle> = daemon.clone();

--- a/crates/flotilla-tui/tests/support/high_fidelity.rs
+++ b/crates/flotilla-tui/tests/support/high_fidelity.rs
@@ -37,6 +37,12 @@ use tempfile::TempDir;
 const WIDTH: u16 = 120;
 const HEIGHT: u16 = 30;
 
+fn daemon_test_config_store(config_dir: PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&config_dir).expect("create daemon config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(config_dir))
+}
+
 pub struct HighFidelityHarness {
     _tempdir: TempDir,
     _leader: Arc<InProcessDaemon>,
@@ -96,14 +102,14 @@ impl HighFidelityHarness {
 
         let leader = InProcessDaemon::new(
             vec![leader_repo.clone()],
-            Arc::new(ConfigStore::with_base(tempdir.path().join("leader-config"))),
+            daemon_test_config_store(tempdir.path().join("leader-config")),
             leader_runtime,
             HostName::new("leader"),
         )
         .await;
         let follower = InProcessDaemon::new(
             vec![follower_repo.clone()],
-            Arc::new(ConfigStore::with_base(tempdir.path().join("follower-config"))),
+            daemon_test_config_store(tempdir.path().join("follower-config")),
             follower_runtime,
             HostName::new("follower"),
         )

--- a/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
@@ -243,7 +243,19 @@ Things deliberately pushed out of earlier stages. Each stage's spec should resta
 
 ### From Stage 3 (Convoy resource + controller)
 
-*(To be filled in when Stage 3 is designed.)*
+See `docs/superpowers/specs/2026-04-14-convoy-resource-design.md` for the spec.
+
+- **`PlacementPolicy` resource** — named, default, auto-discovered (today's `docker@host` style). Eventually delegates to or is implemented by a `PersistentAgent`. Stage 3's Convoy references one by opaque string in `spec.placement_policy`; Stage 4 reifies.
+- **`PersistentAgent` resource** — one resource type with k8s-style labels/selectors. Quartermaster, Yeoman, TestCoach, SecurityReviewer, etc. are conventionally-labeled instances. Agent runtime shape deliberately open: managed CLI (input-send), external CLI (shell-out), headless JSON/ACP, or internal LLM loop. All presentable — CLI by attaching terminals, others via interaction-log views.
+- **Presentation-scope decoupling** — `PresentationManager` at full-flotilla / repo / convoy scopes, no longer coupled to a single workspace.
+- **Interactive launch UX** — CLI/TUI flow: fetch template → infer inputs from context (current branch, selected issues) → present for approval → create convoy.
+- **Typed `InputValue` variants** — `Issue`, `IssueList`, `Branch`, `ChangeRequest`. Requires matching `InputDefinition.kind` in `WorkflowTemplate` (Stage 2 revision). Enables UI-driven workflow discovery ("user has issues selected → find workflows that accept issue[]") and semantic downstream use (correlation, PR metadata).
+- **Label-based workflow discovery** — alternative or complement to typed inputs; `flotilla.work/accepts: issue` label on `WorkflowTemplate`.
+- **Workflow composition (`includes`)** — sub-workflows; transitive snapshotting into `observed_workflows` (the map shape in Stage 3 is already forward-compatible). Opens snapshot-at-root vs snapshot-per-include choice.
+- **Template versioning / rev references** — `spec.workflow_ref_revision` for convoys that want a specific template version. Stage 3 just snapshots whatever was current at init.
+- **Convoy re-run** — copy a convoy, reset status, re-snapshot against newer template. Not a common case, but useful enough to capture.
+- **Convoy cancellation** — user-initiated cancel producing `ConvoyPhase::Cancelled`. The phase is reserved in Stage 3 but never produced.
+- **Admission webhook / fast-feedback validation** — complements the client-side Convoy validator once shared-cluster authoring demands it.
 
 ### From Stage 4 (Task provisioning / policy)
 

--- a/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
+++ b/docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md
@@ -256,6 +256,11 @@ See `docs/superpowers/specs/2026-04-14-convoy-resource-design.md` for the spec.
 - **Convoy re-run** — copy a convoy, reset status, re-snapshot against newer template. Not a common case, but useful enough to capture.
 - **Convoy cancellation** — user-initiated cancel producing `ConvoyPhase::Cancelled`. The phase is reserved in Stage 3 but never produced.
 - **Admission webhook / fast-feedback validation** — complements the client-side Convoy validator once shared-cluster authoring demands it.
+- **Controller deployment and leader election.** Stage 3 runs the controller as a single example binary. Intended trajectory:
+  - (a) Every controller uses a k8s `Lease` resource for leader election — exactly one replica active.
+  - (b) The regular `flotilla` binary embeds controllers, activated by default, claiming leases unless explicitly disabled. Single-process installs get controllers for free.
+  - (c) Cluster-native deployments schedule N flotilla daemon pods into the cluster, all competing for the same leases — standard k8s HA.
+  - (d) Open problem: leader election for flotilla-cp *itself* when embedded across multiple daemons. Leases depend on the API server, which is what needs electing — a separate (consensus / external coordinator / static leader) mechanism, not a convoy-controller concern.
 
 ### From Stage 4 (Task provisioning / policy)
 

--- a/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
+++ b/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
@@ -10,6 +10,76 @@ Stage 3 ships the resource, a reconciliation controller that advances tasks thro
 
 Lives in the existing `crates/flotilla-resources` crate alongside `WorkflowTemplate`. New `convoy` module. Replaces the existing stub CRD at `src/crds/convoy.crd.yaml`.
 
+Stage 3 also makes a small revision to the Stage 1 resource-client surface — see "Resource-client revision: typed status patches" below.
+
+## Resource-client revision: typed status patches
+
+To let multiple actors (convoy controller, future provisioning controller, external CLI/TUI) mutate disjoint parts of a convoy's status without overwriting each other, full-status replacement (`update_status`) is insufficient. Stage 3 adds a typed patch primitive to the Stage 1 API:
+
+```rust
+pub trait Resource: Send + Sync + 'static {
+    type Spec: ...;
+    type Status: ...;
+    type StatusPatch: StatusPatch<Self::Status>;
+    const API_PATHS: ApiPaths;
+}
+
+pub trait StatusPatch<S>: Send + Sync {
+    /// Apply the patch directly to an in-memory status value.
+    /// Used by the in-memory backend and by a future in-process
+    /// flotilla-cp that keeps state in Rust structures, not JSON.
+    fn apply(&self, status: &mut S);
+
+    /// Serialise to a JSON merge-patch (RFC 7396) body.
+    /// Used by the HTTP backend against real k8s.
+    fn to_merge_patch(&self) -> serde_json::Value;
+}
+
+// New resolver method:
+impl<T: Resource> TypedResolver<T> {
+    async fn patch_status(
+        &self,
+        name: &str,
+        resource_version: &str,
+        patch: &T::StatusPatch,
+    ) -> Result<ResourceObject<T>, ResourceError>;
+}
+```
+
+### Dispatch
+
+- **HTTP backend**: `PATCH /apis/.../<kind>/<name>/status` with `Content-Type: application/merge-patch+json`, body from `patch.to_merge_patch()`, and `resourceVersion` as an optimistic-concurrency precondition (`?resourceVersion=...` query — k8s honors this for PATCH).
+- **In-memory backend**: look up the stored status under the resource lock, check `resource_version`, call `patch.apply(&mut status)`, bump the stored version.
+- **Full `update_status` stays.** It's still the right tool for create-time and bootstrap paths where "the whole status is new" is the shape.
+
+### Resources with no status
+
+`WorkflowTemplate` has `type Status = ()`. Its `StatusPatch` is uninhabited:
+
+```rust
+pub enum NoStatusPatch {}
+
+impl StatusPatch<()> for NoStatusPatch {
+    fn apply(&self, _: &mut ()) { match *self {} }
+    fn to_merge_patch(&self) -> Value { match *self {} }
+}
+
+impl Resource for WorkflowTemplate {
+    // ... as today
+    type StatusPatch = NoStatusPatch;
+}
+```
+
+`patch_status` exists on the resolver for every `T`, but no caller can construct a `NoStatusPatch` — the method is compile-time unreachable for status-less resources. Stronger than a runtime "not supported" error.
+
+### Why this over `serde_json::Value` patches
+
+A call-site-constructed `Value` lets any caller write any status field. An associated enum makes the legitimate mutations a declared vocabulary: unknown mutations are compile errors. Ownership partitioning can be further enforced by gating variant construction behind owner-scoped constructor modules with private variant fields. The in-memory backend avoids implementing JSON merge-patch semantics (subtle: null-as-remove, array replacement, nested merging).
+
+### Parity test
+
+Every `StatusPatch` variant gets a round-trip test: apply the patch via `apply(&mut status)`, serialise a clone of the starting status to JSON, apply `to_merge_patch()` via a JSON merge-patch library (`json-patch` crate, RFC 7396), assert the resulting states match. Keeps the two serialisers provably in sync.
+
 ## Scope
 
 ### In scope
@@ -80,8 +150,20 @@ pub enum InputValue {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConvoyStatus {
     pub phase: ConvoyPhase,
+
+    /// Frozen at init from the referenced WorkflowTemplate. Holds the complete
+    /// executable task definitions so Stage 4 can launch deterministically
+    /// without re-reading the live template.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_snapshot: Option<WorkflowSnapshot>,
+
+    /// Per-task runtime state, keyed by task name. Definitions live in
+    /// `workflow_snapshot.tasks`. `spec.inputs` is enforced immutable at
+    /// the API layer (CRD CEL validations), so no snapshot of inputs is
+    /// required — consumers can safely read `spec.inputs`.
     #[serde(default)]
     pub tasks: BTreeMap<String, TaskState>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -92,6 +174,21 @@ pub struct ConvoyStatus {
     pub observed_workflow_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_workflows: Option<BTreeMap<String, String>>, // ref → resourceVersion
+}
+
+/// Snapshot of the referenced WorkflowTemplate's executable content at init.
+/// Mirrors the subset of `WorkflowTemplateSpec` Stage 4 needs to launch tasks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowSnapshot {
+    pub tasks: Vec<SnapshotTask>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotTask {
+    pub name: String,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    pub processes: Vec<ProcessDefinition>, // re-exported from workflow_template
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -110,10 +207,14 @@ impl Default for ConvoyPhase {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskState {
     pub phase: TaskPhase,
-    #[serde(default)]
-    pub depends_on: Vec<String>,                      // snapshot, populated at init
+    /// Pending → Ready. Written by the convoy controller.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ready_at: Option<DateTime<Utc>>,
+    /// Ready → Launching (actual provisioning start). Written by Stage 4.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub started_at: Option<DateTime<Utc>>,
+    /// Any terminal transition (Completed/Failed/Cancelled).
+    /// Written by whoever drives the terminal transition.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finished_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -161,22 +262,40 @@ status:
   observed_workflow_ref: review-and-fix
   observed_workflows:
     review-and-fix: "42"
+  workflow_snapshot:
+    tasks:
+      - name: implement
+        depends_on: []
+        processes:
+          - role: coder
+            selector: { capability: code }
+            prompt: |
+              Implement {{inputs.feature}} on branch {{inputs.branch}}.
+          - role: build
+            command: "cargo watch -x check"
+      - name: review
+        depends_on: [implement]
+        processes:
+          - role: reviewer
+            selector: { capability: code-review }
+            prompt: "Review branch {{inputs.branch}}."
   started_at: "2026-04-14T10:00:00Z"
   tasks:
     implement:
       phase: Running
-      depends_on: []
+      ready_at: "2026-04-14T10:00:00Z"
       started_at: "2026-04-14T10:00:05Z"
     review:
       phase: Pending
-      depends_on: [implement]
 ```
 
 ### Notes on shape
 
 - **`observed_workflow_ref` + `observed_workflows`** are populated only after the controller successfully resolves the template and bootstraps task state. Callers watching "is this convoy actually tied to the template?" check status, not spec.
 - **`observed_workflows` is a map**, not a single version field, so the future `includes` case (a workflow that pulls in other workflows) extends naturally — each snapshotted template gets an entry.
-- **`TaskState.depends_on` is a snapshot** taken from the template at init. Reconcile reads this for DAG advancement; it never re-fetches the live template. Template edits after convoy start do not propagate.
+- **`workflow_snapshot` holds the complete task definitions** (names, deps, processes, selectors, prompts, commands) taken from the template at init. This is what Stage 4 reads when launching a task. The live template is never re-fetched after bootstrap. A snapshot is required because k8s doesn't permit retrieving past `resourceVersion`s of an object — `observed_workflows` records the version seen but is not a retrieval key.
+- **Inputs are immutable at the API layer.** `spec.workflow_ref` and `spec.inputs` are locked by CRD CEL validations (`x-kubernetes-validations: self == oldSelf`) — the k8s API server rejects updates that change them. Consumers can safely read `spec.inputs` without fear of mid-flight change; no snapshot is needed.
+- **Timestamps are single-writer.** `ready_at` is written by the convoy controller when a task transitions Pending→Ready. `started_at` is written by Stage 4 at Ready→Launching. `finished_at` is written by whoever drives the terminal transition (external actor, Stage 4 on launch failure, or the convoy controller during fail-fast cancellation).
 - **`TaskState.placement`** is reserved for Stage 4. Stage 3 leaves it unset.
 - **`ConvoyPhase::Cancelled`** is reserved for future user-initiated cancel; Stage 3 never produces it directly.
 - **`InputValue` is untagged**, so today's YAML reads as plain scalars. When typed variants (`Issue`, `IssueList`, `Branch`) land, richer shapes slot in without a schema break.
@@ -222,10 +341,18 @@ spec:
               type: object
               required: [workflow_ref]
               properties:
-                workflow_ref: { type: string, minLength: 1 }
+                workflow_ref:
+                  type: string
+                  minLength: 1
+                  x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "workflow_ref is immutable after creation"
                 inputs:
                   type: object
                   additionalProperties: true
+                  x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "inputs are immutable after creation"
                 placement_policy: { type: string, minLength: 1 }
             status:
               type: object
@@ -237,6 +364,25 @@ spec:
                 observed_workflows:
                   type: object
                   additionalProperties: { type: string }
+                workflow_snapshot:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    tasks:
+                      type: array
+                      items:
+                        type: object
+                        required: [name, processes]
+                        properties:
+                          name: { type: string, minLength: 1 }
+                          depends_on:
+                            type: array
+                            items: { type: string }
+                          processes:
+                            type: array
+                            items:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
                 message: { type: string }
                 started_at: { type: string, format: date-time }
                 finished_at: { type: string, format: date-time }
@@ -244,14 +390,12 @@ spec:
                   type: object
                   additionalProperties:
                     type: object
-                    required: [phase, depends_on]
+                    required: [phase]
                     properties:
                       phase:
                         type: string
                         enum: [Pending, Ready, Launching, Running, Completed, Failed, Cancelled]
-                      depends_on:
-                        type: array
-                        items: { type: string }
+                      ready_at: { type: string, format: date-time }
                       started_at: { type: string, format: date-time }
                       finished_at: { type: string, format: date-time }
                       message: { type: string }
@@ -263,10 +407,58 @@ spec:
 - `subresources.status: {}` enables the `/status` subresource so status patches don't contend with spec edits.
 - `inputs.additionalProperties: true` keeps the schema open for future typed `InputValue` variants. Rust holds the real shape.
 - `placement` uses `x-kubernetes-preserve-unknown-fields: true` so Stage 4 can populate arbitrary metadata without a CRD bump.
+- **CEL validations** (`x-kubernetes-validations`) enforce immutability of `workflow_ref` and `inputs` at the API server. Requires k8s 1.25+ (stable in 1.30+); minikube defaults are fine. A cluster without CEL support would need an admission webhook for equivalent enforcement — deferred.
 
 ## Reconciliation
 
-### Pure function
+### ConvoyStatusPatch enum
+
+All status mutations pass through a single typed vocabulary:
+
+```rust
+pub enum ConvoyStatusPatch {
+    /// First successful reconcile: snapshot the template, initialize task map.
+    Bootstrap {
+        workflow_snapshot: WorkflowSnapshot,
+        observed_workflow_ref: String,
+        observed_workflows: BTreeMap<String, String>,
+        tasks: BTreeMap<String, TaskState>,  // all Pending
+        phase: ConvoyPhase,                  // typically Pending or Active
+        started_at: Option<DateTime<Utc>>,
+    },
+
+    /// Bootstrap-time fatal error (template not found, template invalid,
+    /// missing input). Convoy terminal.
+    FailInit { phase: ConvoyPhase /* = Failed */, message: String, finished_at: DateTime<Utc> },
+
+    /// Convoy-controller transitions: advance 0+ tasks Pending→Ready.
+    AdvanceTasksToReady { ready: BTreeMap<String, DateTime<Utc>> },
+
+    /// Fail-fast: a task is Failed; cancel 0+ non-terminal siblings, roll up
+    /// convoy to Failed.
+    FailConvoy {
+        cancelled_tasks: BTreeMap<String, DateTime<Utc>>,
+        finished_at: DateTime<Utc>,
+        message: Option<String>,
+    },
+
+    /// Phase roll-up: set convoy phase + optionally started_at/finished_at.
+    RollUpPhase { phase: ConvoyPhase, started_at: Option<DateTime<Utc>>, finished_at: Option<DateTime<Utc>> },
+
+    /// Stage 4 (defined in shape; no Stage 3 code produces them):
+    TaskLaunching { task: String, started_at: DateTime<Utc>, placement: PlacementStatus },
+    TaskRunning   { task: String },
+
+    /// External-actor terminal transitions:
+    MarkTaskCompleted { task: String, finished_at: DateTime<Utc>, message: Option<String> },
+    MarkTaskFailed    { task: String, finished_at: DateTime<Utc>, message: String },
+    MarkTaskCancelled { task: String, finished_at: DateTime<Utc> },
+}
+```
+
+`impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch` implements both `apply(&mut status)` and `to_merge_patch()`. Ownership partitioning is enforced by owner-scoped constructor modules (details in implementation); Stage 3 code only constructs `Bootstrap`, `FailInit`, `AdvanceTasksToReady`, `FailConvoy`, `RollUpPhase`.
+
+### Pure reconcile function
 
 ```rust
 pub fn reconcile(
@@ -276,49 +468,57 @@ pub fn reconcile(
 ) -> ReconcileOutcome;
 
 pub struct ReconcileOutcome {
-    pub patch: Option<ConvoyStatus>,     // None = no change
-    pub events: Vec<ConvoyEvent>,        // observability
+    pub patch: Option<ConvoyStatusPatch>, // None = no change
+    pub events: Vec<ConvoyEvent>,         // observability only
 }
 
 pub enum ConvoyEvent {
-    PhaseChanged { from: ConvoyPhase, to: ConvoyPhase },
-    TaskPhaseChanged { task: String, from: TaskPhase, to: TaskPhase },
-    TemplateNotFound { name: String },
+    PhaseChanged       { from: ConvoyPhase, to: ConvoyPhase },
+    TaskPhaseChanged   { task: String, from: TaskPhase, to: TaskPhase },
+    TemplateNotFound   { name: String },
+    TemplateInvalid    { name: String, errors: Vec<workflow_template::ValidationError> },
     WorkflowRefChanged { from: String, to: String },
-    MissingInput { name: String },
+    MissingInput       { name: String },
 }
 ```
 
-`ConvoyEvent` is purely for observability — the watch loop logs them via `tracing`. They are not persisted in the resource. A future addition may emit k8s `Event` resources from the same enum, but that's out of scope for Stage 3.
+`ConvoyEvent` is observability only — the watch loop logs via `tracing`; events are not persisted in the resource. Future addition may emit k8s `Event` resources.
 
-Pure, no I/O. The watch loop reads the convoy (and template on first resolve only), calls `reconcile`, applies the patch via `update_status`. Tests drive it directly.
+Pure, no I/O. The watch loop reads the convoy (and the live template on first resolve only), calls `reconcile`, applies the returned patch via `patch_status`. Tests drive it directly.
 
 ### Reconcile steps (single pass)
 
-1. **Template resolution and snapshot.**
-   - If `status.observed_workflow_ref` is unset → this is init. Look up the template.
-     - Not found → `phase = Failed`, message `"WorkflowTemplate '<ref>' not found"`, emit `TemplateNotFound`, return.
-     - Found → initialize `status.tasks` with every template task at `TaskPhase::Pending`, snapshot each task's `depends_on`. Set `status.observed_workflow_ref = spec.workflow_ref`. Set `status.observed_workflows = {ref: resourceVersion}`.
-   - If `status.observed_workflow_ref` is set and `spec.workflow_ref` differs → `phase = Failed`, message `"workflow_ref changed after convoy start; not supported"`, emit `WorkflowRefChanged`, return. (Re-running with a new template is a future concern.)
-   - Otherwise, snapshot exists; do not refetch the template.
+Reconcile is a pure decision function: given the current convoy (and template on init), produce zero or one `ConvoyStatusPatch`. The watch loop applies whatever patch is returned.
 
-2. **Input validation (init only).**
-   - Happens on the same reconcile as step 1 bootstrap — the template is in hand.
-   - Every declared template input must appear in `spec.inputs`. Missing → `phase = Failed`, message `"missing input '<name>'"`, emit `MissingInput`.
-   - Extra inputs (in spec but not declared) → informational event only, not a failure.
-   - After init, the controller does not re-validate inputs. The template has been snapshotted and will not be re-fetched; the declared input set is fixed. User edits to `spec.inputs` after init are visible to Stage 4's task launcher but not re-checked by the convoy controller.
+1. **`workflow_ref` change guard (post-init).**
+   - If `status.observed_workflow_ref` is set and `spec.workflow_ref` differs — the CRD's CEL validation should have prevented this, but handle defensively — emit `WorkflowRefChanged`, produce `FailInit { phase: Failed, message: "workflow_ref changed after init; not supported" }`.
 
-3. **Fail-fast.**
-   - If any task is `TaskPhase::Failed`: set convoy `phase = Failed` and convoy `finished_at = now`. For every non-terminal sibling (not `Completed`/`Failed`/`Cancelled`), transition to `Cancelled` and set the task's `finished_at = now`. The failed task itself retains its `finished_at` as written by whoever marked it Failed. Return.
+2. **Bootstrap (`status.observed_workflow_ref` unset).**
+   - Look up the template by `spec.workflow_ref`.
+     - **Not found** → emit `TemplateNotFound`, produce `FailInit { phase: Failed, message: "WorkflowTemplate '<ref>' not found" }`.
+     - **Found but fails `workflow_template::validate()`** → emit `TemplateInvalid { errors }`, produce `FailInit { phase: Failed, message: "WorkflowTemplate '<ref>' is invalid: <summary>" }`. This is the Stage-2-mandated consumer revalidation.
+     - **Found and valid** → continue.
+   - **Input completeness check**: every declared template input has a value in `spec.inputs`. Missing → emit `MissingInput { name }`, produce `FailInit { phase: Failed, message: "missing input '<name>'" }`. Extra inputs (in spec but not declared) → informational event only.
+   - **Produce `Bootstrap`**: snapshot the full task definitions into `workflow_snapshot`, initialize `tasks` with every template task at `TaskPhase::Pending` (no `ready_at`), record `observed_workflow_ref` and `observed_workflows`, set convoy `phase = Pending` (or `Active` directly if step 4 would transition any task this pass — compute inside the same outcome).
 
-4. **DAG advancement.**
-   - For each `Pending` task whose every `depends_on` entry maps to a task in `Completed`: transition to `Ready`, set task `started_at = now`.
-   - No other transitions produced by the convoy controller. `Ready → Launching → Running → Completed` is driven by Stage 4 (provisioning) and external actors (explicit completion).
+3. **Post-init: compute tasks that should transition Pending → Ready.**
+   - For each `Pending` task whose every `depends_on` entry maps to a task in `Completed`: include in an `AdvanceTasksToReady` patch with `ready_at = now`.
+
+4. **Fail-fast.**
+   - If any task is `TaskPhase::Failed`: compute set of non-terminal siblings (not `Completed`/`Failed`/`Cancelled`). Produce `FailConvoy { cancelled_tasks: <siblings → now>, finished_at: now, message }`. The failed task itself retains its `finished_at` from whoever marked it Failed.
 
 5. **Phase roll-up.**
-   - All tasks `Completed` → `phase = Completed`, `finished_at = now`.
-   - Any task past `Pending` but no terminal convoy state → `phase = Active`, `started_at = now` if unset.
-   - Otherwise → `phase = Pending`.
+   - All tasks `Completed` → produce `RollUpPhase { phase: Completed, finished_at: Some(now), started_at: None }`.
+   - Any task past `Pending` but no terminal convoy state, and current `phase` is still `Pending` → produce `RollUpPhase { phase: Active, started_at: Some(now), finished_at: None }`.
+   - Otherwise no phase roll-up.
+
+**Patch aggregation.** At most one `ConvoyStatusPatch` is returned per reconcile. In the common case (e.g. a task just completed, unblocking two dependents, and that was the last work so convoy rolls to Completed), the patch is a composite — typically `AdvanceTasksToReady` combined with `RollUpPhase`. Rather than chain multiple patches, the variants themselves contain enough information to express a single-pass transition, and the watch loop gets one atomic status update per reconcile.
+
+In practice this is implemented as: produce the structurally most "outer" variant (e.g. `FailConvoy` dominates `RollUpPhase`), and let the next reconcile run handle anything that requires observing the previous patch's effect. K8s-style controllers converge via multiple passes; we don't need one-shot atomicity.
+
+### Post-init behavior and user edits
+
+Because CRD CEL validations lock `spec.workflow_ref` and `spec.inputs` post-creation, the controller never needs to re-validate them on each reconcile. Any reconcile after Bootstrap simply reads `status.workflow_snapshot` and `status.tasks` for DAG work.
 
 ### Watch loop (example binary)
 
@@ -350,35 +550,62 @@ async fn run(backend: &ResourceBackend, namespace: &str) -> Result<()> {
 
 ### Conflict handling
 
-`update_status` returns `ResourceError::Conflict` if `resourceVersion` is stale. The controller re-fetches the convoy and retries up to a bounded number of times (3). If still conflicting, drop — the next watch event or resync tick will re-reconcile.
+`patch_status` returns `ResourceError::Conflict` if `resourceVersion` is stale. The controller re-fetches the convoy and retries up to a bounded number of times (3). If still conflicting, drop — the next watch event or resync tick will re-reconcile.
 
-### Ownership contract
+### Ownership contract — enforced by the patch vocabulary
 
-Single-writer per field; transitions on `tasks[*].phase` are partitioned across owners.
+Ownership is expressed in the `ConvoyStatusPatch` enum, not in prose. Each writer constructs only the variants that correspond to its owned transitions. Variant construction is gated by owner-scoped constructor modules (private variant fields; public constructor functions in the owning module), so misuse is a compile error rather than a convention.
 
-| Who | What they write |
-|-----|-----------------|
-| Convoy controller (Stage 3) | `status.phase`, `status.observed_workflow_ref`, `status.observed_workflows`, `status.message`, `status.started_at`, `status.finished_at`, `status.tasks[*].phase` (`Pending↔Ready`, fail-fast cancels, template-init), `status.tasks[*].depends_on` (at init), `tasks[*].started_at`/`finished_at` at those transitions |
-| Provisioning controller (Stage 4, future) | `status.tasks[*].placement`, `status.tasks[*].phase` for `Ready→Launching→Running`, `tasks[*].started_at` at Launching |
-| External actors (CLI, TUI, agent-side CLI) | `status.tasks[*].phase` for terminal transitions (`Completed`, `Failed`, `Cancelled`), `tasks[*].finished_at` at those |
+| Writer | Variants it constructs |
+|--------|-----------------------|
+| Convoy controller (Stage 3) | `Bootstrap`, `FailInit`, `AdvanceTasksToReady`, `FailConvoy`, `RollUpPhase` |
+| Provisioning controller (Stage 4) | `TaskLaunching`, `TaskRunning` |
+| External actors (CLI, TUI, agent-side CLI) | `MarkTaskCompleted`, `MarkTaskFailed`, `MarkTaskCancelled` |
 
-Task completion is signalled by a direct `PATCH` against the `/status` subresource of the convoy. K8s supports multiple writers on `/status` (Deployment + HPA pattern); our disjoint-transition partition keeps ownership clear.
+Each variant's `apply(&mut ConvoyStatus)` touches a disjoint subset of fields — the partition is visible in code, not just documented. Two concurrent writers constructing different variants produce non-overlapping mutations and compose cleanly under merge-patch. Concurrent writers constructing variants that touch the same field (e.g. two external actors both marking a task Completed) collide on `resourceVersion` and retry.
 
 ## Tests
 
 ### Table tests (pure `reconcile`)
 
-- Fresh convoy, template found → bootstrap status: all tasks Pending with `depends_on` snapshot; `observed_workflow_ref` and `observed_workflows` set.
-- Template not found → `phase = Failed` with clear message.
-- Missing input → `phase = Failed`.
-- Extra input (not declared) → informational event only; no failure.
-- All deps satisfied on a Pending task → transition to Ready with `started_at`.
-- Fan-out: three tasks with no deps → all three go Ready in one reconcile.
-- Fan-in: A→C, B→C, A=Completed, B=Running → C stays Pending. B completes → C goes Ready.
-- One task Failed → all non-terminal siblings → Cancelled, convoy `phase = Failed`.
-- All tasks Completed → `phase = Completed`, `finished_at` set.
-- `spec.workflow_ref` changed after init → `phase = Failed`.
-- Template refetch does not happen after init (verify by passing `None` for template on second call after snapshot; reconcile proceeds from status alone).
+- Fresh convoy, template found + valid → returns `Bootstrap` with full `workflow_snapshot`, all tasks Pending, `observed_workflow_ref` and `observed_workflows` set.
+- Template not found → returns `FailInit` with clear message; event `TemplateNotFound`.
+- **Template invalid** (fails `workflow_template::validate()`) → returns `FailInit`; event `TemplateInvalid` carrying the validation errors.
+- Missing input → returns `FailInit`; event `MissingInput`.
+- Extra input (not declared) → informational event only; no failure patch.
+- All deps satisfied on a Pending task → returns `AdvanceTasksToReady` with `ready_at = now`.
+- Fan-out: three tasks with no deps → a single `AdvanceTasksToReady` carries all three.
+- Fan-in: A→C, B→C, A=Completed, B=Running → C stays Pending. B completes → next reconcile returns `AdvanceTasksToReady` for C.
+- One task Failed → returns `FailConvoy` with all non-terminal siblings in `cancelled_tasks`.
+- All tasks Completed → returns `RollUpPhase { phase: Completed, finished_at: Some(now) }`.
+- `spec.workflow_ref` changed after init (defensive, post-CEL) → returns `FailInit` with the "workflow_ref changed" message.
+- Template refetch does not happen after init (verify by passing `None` for template on second call after snapshot; reconcile returns a DAG-advancement patch from status alone).
+
+### StatusPatch apply/merge-patch parity
+
+For every `ConvoyStatusPatch` variant:
+
+1. Construct a representative starting `ConvoyStatus`.
+2. Apply the patch via `apply(&mut status_a)`.
+3. Serialise a clone of the starting status to JSON, apply `patch.to_merge_patch()` using the `json-patch` crate's RFC 7396 merge-patch implementation, deserialise back into `ConvoyStatus`.
+4. Assert `status_a == status_b`.
+
+Keeps the in-memory and HTTP serialisers provably in sync.
+
+### In-memory backend end-to-end
+
+- Create `WorkflowTemplate` + `Convoy` in the in-memory backend.
+- Run the controller loop against simulated `MarkTaskCompleted` patches that drive tasks through completion.
+- Assert the observed sequence of convoy phases and task phases matches expectation.
+
+### HTTP backend integration (minikube, gated)
+
+- Apply both CRDs. Confirm CEL validations reject edits to `spec.workflow_ref` and `spec.inputs` (one negative test per field).
+- Create a WorkflowTemplate with a two-task DAG (`implement` → `review`).
+- Create a Convoy referencing it.
+- Run the example controller binary in a background task.
+- Patch `tasks.implement.phase = Completed` via `patch_status(MarkTaskCompleted)`; assert `review` moves to Ready.
+- Patch `tasks.review.phase = Completed`; assert convoy `phase = Completed`.
 
 ### In-memory backend end-to-end
 
@@ -407,14 +634,29 @@ Task completion is signalled by a direct `PATCH` against the `/status` subresour
 
 ## Deliverables
 
-1. `Convoy` Rust type and `Resource` impl.
-2. `ConvoySpec`, `ConvoyStatus`, `ConvoyPhase`, `TaskState`, `TaskPhase`, `InputValue`, `PlacementStatus`, `ReconcileOutcome`, `ConvoyEvent` types.
-3. Pure `reconcile(convoy, template, now) -> ReconcileOutcome` function.
-4. Convoy CRD YAML (replaces the stub).
-5. Table tests for reconcile.
-6. In-memory backend end-to-end test.
-7. HTTP backend integration test against minikube.
-8. `examples/convoy_controller.rs` — runnable controller binary.
+### Stage 1 revision (as part of Stage 3 work)
+
+1. `Resource::StatusPatch` associated type and `StatusPatch` trait (`apply` + `to_merge_patch`).
+2. `TypedResolver::patch_status(name, rv, patch)` method.
+3. HTTP backend: `PATCH` against `/status` subresource with merge-patch content-type and resourceVersion precondition.
+4. In-memory backend: implement `patch_status` via `StatusPatch::apply` under the store lock.
+5. `NoStatusPatch` uninhabited enum; `WorkflowTemplate` adopts it (trivial existing-crate revision).
+6. Parity tests for `WorkflowTemplate::StatusPatch` (trivially pass since uninhabited) and for the Convoy variants (detailed above).
+
+### Stage 3 proper
+
+7. `Convoy` Rust type and `Resource` impl.
+8. `ConvoySpec`, `ConvoyStatus`, `ConvoyPhase`, `TaskState`, `TaskPhase`, `InputValue`, `PlacementStatus`, `WorkflowSnapshot`, `SnapshotTask` types.
+9. `ConvoyStatusPatch` enum and its `StatusPatch<ConvoyStatus>` impl.
+10. Owner-scoped constructor modules (`controller_patches`, `provisioning_patches`, `external_patches`) gating variant construction by visibility.
+11. Pure `reconcile(convoy, template, now) -> ReconcileOutcome` function.
+12. `ReconcileOutcome`, `ConvoyEvent` types.
+13. Convoy CRD YAML with CEL immutability validations (replaces the stub).
+14. Table tests for reconcile.
+15. StatusPatch apply/merge-patch parity tests.
+16. In-memory backend end-to-end test.
+17. HTTP backend integration test against minikube, including CEL-rejection checks.
+18. `examples/convoy_controller.rs` — runnable controller binary.
 
 No provisioning, no policy resolution, no presentation, no CLI surface beyond what the example needs.
 
@@ -424,19 +666,29 @@ No provisioning, no policy resolution, no presentation, no CLI surface beyond wh
 
 One Convoy resource carrying a map of task states, versus a separate `ConvoyTask` resource per task. Per the design doc, sub-status is simpler for v1: no resource-per-task proliferation, no cross-resource watches. Promotion to independent resources is a well-understood migration (reachable later if we need per-task independent watches).
 
-### Template snapshot at init; no template watching
+### Full template snapshot at init; no template watching
 
-Cascading template edits into running convoys produces too many failure modes — task renames, dep reshapes, removed tasks all break observed state. Snapshotting the DAG into `status.tasks` at init makes Stage 3 reconciliation depend only on the convoy's own status after bootstrap. Template edits affect only new convoys. Re-running a convoy with a newer template version is a future primitive (copy convoy, reset status, re-snapshot).
+The snapshot includes the complete executable content (task names, deps, processes, selectors, prompts, commands) — not just the DAG structure. Stage 4 reads `status.workflow_snapshot` to launch tasks; the live template is never re-fetched.
+
+This is *required*, not merely defensive: k8s does not permit retrieving a past `resourceVersion` of an object. `observed_workflows: {ref: version}` records what was seen, but is not a retrieval key — the controller can't go back and read "template foo at version 42" later. The snapshot is the only durable record of what was authorised to run.
+
+Cascading template edits into running convoys would produce too many failure modes even if retrievability weren't a problem (task renames, dep reshapes, removed tasks all break observed state). Snapshotting once at init removes the concern.
+
+Re-running a convoy with a newer template version is a future primitive (copy convoy, reset status, re-snapshot). If flotilla-cp gains versioned history and immutable-by-convention templates, the snapshot may become redundant for that deployment — still required against raw k8s.
 
 ### `observed_workflows` as a map
 
 Single-entry today (root → resourceVersion). When workflow composition (`includes`) lands, every snapshotted template — root plus includes — gets an entry. Naming the field as a map now avoids a schema change later.
 
-### Direct status patch for task completion
+### Typed status patches (`StatusPatch` associated type)
 
-K8s supports multiple writers on `/status` (Deployment + HPA touch the same Deployment's status). Partitioning transitions across writers — convoy controller for DAG advancement, external actors for terminal completions — gives clean ownership without an RPC-style back-channel through spec.
+Multi-writer safety on `/status` needs either full-status replacement with optimistic concurrency retry, or partial patches. Full replacement forces every writer to round-trip the entire status to mutate one field — noisy, and susceptible to "I replaced the whole thing but forgot to preserve the field you just wrote" bugs. Partial patches, expressed as typed `ConvoyStatusPatch` variants, scope each mutation to exactly its owned fields.
 
-The alternative of a spec-side command queue (`spec.task_actions: [{task, action: Complete}]`) was rejected: controllers normally don't mutate their own spec, "mark complete" is an event not desired state, and there's no real gain over direct status patches.
+The associated type (`Resource::StatusPatch`) makes the legitimate mutations a declared vocabulary per resource. Owner-scoped constructor modules gate variant construction so "only the convoy controller can advance tasks to Ready" becomes a compile-time property, not a comment.
+
+The in-memory backend's `StatusPatch::apply(&mut status)` avoids re-implementing JSON merge-patch semantics (null-as-remove, nested merge, array replacement); the HTTP backend's `to_merge_patch()` handles wire serialisation. The two are kept in sync by an exhaustive parity test per variant.
+
+The alternative of a spec-side command queue (`spec.task_actions: [{task, action: Complete}]`) was rejected: controllers normally don't mutate their own spec, "mark complete" is an event not desired state, and there's no real gain over typed status patches.
 
 ### List-then-watch on the controller
 
@@ -458,6 +710,10 @@ A single policy reference on the convoy, rather than per-task placement override
 
 User-initiated convoy cancel is a real future feature but adds a control-plane verb (patch spec flag? delete convoy and let finalizer GC?) that deserves its own design round. Stage 3 reserves the phase so consumers can pattern-match today without later breaking them.
 
+### Spec immutability via CRD CEL validations, not a snapshot
+
+Earlier drafts proposed `input_snapshot` to freeze `spec.inputs` against user edits. The correct mechanism is CRD `x-kubernetes-validations` with transition rules (`self == oldSelf`), which make the API server reject mutating requests — the field is actually immutable, not "effectively immutable via a snapshot." Applies to `spec.workflow_ref` and `spec.inputs`. The `workflow_snapshot` remains because the *template*'s content isn't frozen by any validation rule (templates are meant to be edited) — only the convoy's reference to it is.
+
 ## Deferred Items (captured in `docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md`)
 
 To add under "From Stage 3":
@@ -472,4 +728,5 @@ To add under "From Stage 3":
 - **Template versioning** — `spec.workflow_ref_revision` for convoys that want a specific template version.
 - **Convoy re-run** — copy a convoy, reset status, re-snapshot against newer template.
 - **Convoy cancellation** — user-initiated cancel producing `ConvoyPhase::Cancelled`.
-- **Admission webhook / fast-feedback validation** — complements the client-side Convoy validator once shared-cluster workflows demand it.
+- **Admission webhook / fast-feedback validation** — complements the client-side Convoy validator once shared-cluster workflows demand it; also a fallback for clusters without CEL support (k8s < 1.25).
+- **Immutable-by-convention templates** — if flotilla-cp introduces versioned-history semantics (retrievable by `resourceVersion`) plus admission enforcement against in-place template edits, `workflow_snapshot` becomes redundant for that deployment and convoys could just reference `(ref, version)`.

--- a/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
+++ b/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
@@ -744,3 +744,8 @@ To add under "From Stage 3":
 - **Convoy cancellation** — user-initiated cancel producing `ConvoyPhase::Cancelled`.
 - **Admission webhook / fast-feedback validation** — complements the client-side Convoy validator once shared-cluster workflows demand it; also a fallback for clusters without CEL support (k8s < 1.25).
 - **Immutable-by-convention templates** — if flotilla-cp introduces versioned-history semantics (retrievable by `resourceVersion`) plus admission enforcement against in-place template edits, `workflow_snapshot` becomes redundant for that deployment and convoys could just reference `(ref, version)`.
+- **Controller deployment and leader election.** Stage 3 runs the controller as a standalone example binary — a single process. The intended trajectory, deliberately deferred:
+  - (a) Every controller uses a k8s `Lease` resource for leader election. Exactly one replica is active; others stand by.
+  - (b) The regular `flotilla` binary carries controllers embedded, activated by default, trying to claim the lease unless explicitly disabled. Single-process flotilla installs get controllers for free.
+  - (c) "Cluster-native" mode schedules N flotilla daemon pods into the cluster, all competing for the same leases — standard k8s HA pattern.
+  - (d) Open problem: when flotilla-cp itself is embedded across multiple daemons, the Lease mechanism can't elect the leader flotilla-cp — leases depend on the API server whose implementation is what needs electing. Solved separately (consensus, external coordinator, static leader, etc.); not a convoy-controller concern.

--- a/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
+++ b/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
@@ -12,9 +12,9 @@ Lives in the existing `crates/flotilla-resources` crate alongside `WorkflowTempl
 
 Stage 3 also makes a small revision to the Stage 1 resource-client surface — see "Resource-client revision: typed status patches" below.
 
-## Resource-client revision: typed status patches
+## Resource-client revision: typed status mutations via `StatusPatch`
 
-To let multiple actors (convoy controller, future provisioning controller, external CLI/TUI) mutate disjoint parts of a convoy's status without overwriting each other, full-status replacement (`update_status`) is insufficient. Stage 3 adds a typed patch primitive to the Stage 1 API:
+Multi-writer safety on `/status` needs documented optimistic-concurrency guarantees. Partial-patch transport on top of k8s is subtle: `application/merge-patch+json` has no documented precondition mechanism, `application/json-patch+json` needs an explicit `test` op, and Server-Side Apply brings its own managed-fields model. For Stage 3 we keep the transport simple — full-status replacement via `update_status`, which **is** documented to reject stale `resourceVersion` with 409 Conflict — and add a small layer above it that keeps mutations typed:
 
 ```rust
 pub trait Resource: Send + Sync + 'static {
@@ -25,32 +25,45 @@ pub trait Resource: Send + Sync + 'static {
 }
 
 pub trait StatusPatch<S>: Send + Sync {
-    /// Apply the patch directly to an in-memory status value.
-    /// Used by the in-memory backend and by a future in-process
-    /// flotilla-cp that keeps state in Rust structures, not JSON.
+    /// Apply the patch directly to a status value.
+    /// Used by every backend; the HTTP backend then calls update_status
+    /// with the resulting full status.
     fn apply(&self, status: &mut S);
-
-    /// Serialise to a JSON merge-patch (RFC 7396) body.
-    /// Used by the HTTP backend against real k8s.
-    fn to_merge_patch(&self) -> serde_json::Value;
-}
-
-// New resolver method:
-impl<T: Resource> TypedResolver<T> {
-    async fn patch_status(
-        &self,
-        name: &str,
-        resource_version: &str,
-        patch: &T::StatusPatch,
-    ) -> Result<ResourceObject<T>, ResourceError>;
 }
 ```
 
-### Dispatch
+No new resolver method. Writers use the existing `update_status(name, rv, new_status)`, plus this read-modify-write helper that every controller loop needs anyway:
 
-- **HTTP backend**: `PATCH /apis/.../<kind>/<name>/status` with `Content-Type: application/merge-patch+json`, body from `patch.to_merge_patch()`, and `resourceVersion` as an optimistic-concurrency precondition (`?resourceVersion=...` query — k8s honors this for PATCH).
-- **In-memory backend**: look up the stored status under the resource lock, check `resource_version`, call `patch.apply(&mut status)`, bump the stored version.
-- **Full `update_status` stays.** It's still the right tool for create-time and bootstrap paths where "the whole status is new" is the shape.
+```rust
+pub async fn apply_status_patch<T: Resource>(
+    resolver: &TypedResolver<T>,
+    name: &str,
+    patch: &T::StatusPatch,
+) -> Result<ResourceObject<T>, ResourceError> {
+    for _ in 0..MAX_RETRIES {
+        let current = resolver.get(name).await?;
+        let mut new_status = current.status.clone().unwrap_or_default();
+        patch.apply(&mut new_status);
+        match resolver
+            .update_status(name, &current.metadata.resource_version, &new_status)
+            .await
+        {
+            Ok(updated) => return Ok(updated),
+            Err(ResourceError::Conflict { .. }) => continue,   // re-read, re-apply
+            Err(other) => return Err(other),
+        }
+    }
+    Err(ResourceError::Conflict { /* retry budget exhausted */ })
+}
+```
+
+### Why this shape
+
+- **Documented concurrency guarantees.** PUT with `resourceVersion` is k8s's explicit lost-update protection mechanism (API Concepts §"HTTP PUT to replace existing resource"). 409-on-stale-rv is part of the contract.
+- **Typed vocabulary still runs the show.** `StatusPatch` variants name legitimate mutations; owner-scoped constructor modules gate who can build which variant; `apply(&mut status)` is the single authoritative mutator. The transport just carries the resulting full status.
+- **Concurrent disjoint writers still compose correctly.** Two writers constructing different variants both read state, apply their patch, try to update; one wins, the other gets 409, re-reads, re-applies, writes. Because each variant's `apply` touches disjoint fields, the re-applied patch on the newer state is still semantically correct.
+- **Concurrent same-field writers collide loudly.** Two external actors each marking a task Completed: one wins, the other retries on updated state (which now shows the task Completed) and either no-ops or reconciles its view.
+- **One backend contract, no new transport primitives.** `update_status` and `get` already exist. The in-memory backend works out of the box; the HTTP backend doesn't need to learn any new verbs. Stage 1 revision is limited to adding the associated type + trait; no HTTP or in-memory changes.
 
 ### Resources with no status
 
@@ -61,7 +74,6 @@ pub enum NoStatusPatch {}
 
 impl StatusPatch<()> for NoStatusPatch {
     fn apply(&self, _: &mut ()) { match *self {} }
-    fn to_merge_patch(&self) -> Value { match *self {} }
 }
 
 impl Resource for WorkflowTemplate {
@@ -70,15 +82,15 @@ impl Resource for WorkflowTemplate {
 }
 ```
 
-`patch_status` exists on the resolver for every `T`, but no caller can construct a `NoStatusPatch` — the method is compile-time unreachable for status-less resources. Stronger than a runtime "not supported" error.
+Since `NoStatusPatch` has no variants, no caller can construct one, and `apply_status_patch::<WorkflowTemplate>` is compile-time unreachable. Stronger than a runtime "not supported" error.
 
 ### Why this over `serde_json::Value` patches
 
-A call-site-constructed `Value` lets any caller write any status field. An associated enum makes the legitimate mutations a declared vocabulary: unknown mutations are compile errors. Ownership partitioning can be further enforced by gating variant construction behind owner-scoped constructor modules with private variant fields. The in-memory backend avoids implementing JSON merge-patch semantics (subtle: null-as-remove, array replacement, nested merging).
+A call-site `Value` lets any caller write any status field. An associated enum makes the legitimate mutations a declared vocabulary: unknown mutations are compile errors. Ownership partitioning is enforced by owner-scoped constructor modules with private variant fields.
 
-### Parity test
+### Cost we accept
 
-Every `StatusPatch` variant gets a round-trip test: apply the patch via `apply(&mut status)`, serialise a clone of the starting status to JSON, apply `to_merge_patch()` via a JSON merge-patch library (`json-patch` crate, RFC 7396), assert the resulting states match. Keeps the two serialisers provably in sync.
+Full status replacement per write — every writer serialises and sends the whole `ConvoyStatus` back. At Stage 3 scale (low-write-rate controllers and small status bodies, a few KB), the wire overhead is immaterial. When/if it becomes a problem (Stage 7+ with AttachableSet migration and many external writers), we can upgrade to `application/json-patch+json` with an explicit `test` op on `/metadata/resourceVersion` — the typed `StatusPatch` vocabulary is already in place to back that transport. Server-Side Apply (`application/apply-patch+yaml` with managed-fields) is a further future option for much-larger-scale coordination.
 
 ## Scope
 
@@ -456,7 +468,7 @@ pub enum ConvoyStatusPatch {
 }
 ```
 
-`impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch` implements both `apply(&mut status)` and `to_merge_patch()`. Ownership partitioning is enforced by owner-scoped constructor modules (details in implementation); Stage 3 code only constructs `Bootstrap`, `FailInit`, `AdvanceTasksToReady`, `FailConvoy`, `RollUpPhase`.
+`impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch` implements `apply(&mut status)`. Writers then call `apply_status_patch(resolver, name, &patch)`, which reads the current object, applies the patch to a clone, and writes via `update_status` with `resourceVersion` as precondition (retrying on 409). Ownership partitioning is enforced by owner-scoped constructor modules (details in implementation); Stage 3 code only constructs `Bootstrap`, `FailInit`, `AdvanceTasksToReady`, `FailConvoy`, `RollUpPhase`.
 
 ### Pure reconcile function
 
@@ -484,7 +496,7 @@ pub enum ConvoyEvent {
 
 `ConvoyEvent` is observability only — the watch loop logs via `tracing`; events are not persisted in the resource. Future addition may emit k8s `Event` resources.
 
-Pure, no I/O. The watch loop reads the convoy (and the live template on first resolve only), calls `reconcile`, applies the returned patch via `patch_status`. Tests drive it directly.
+Pure, no I/O. The watch loop reads the convoy (and the live template on first resolve only), calls `reconcile`, applies the returned patch via `apply_status_patch`. Tests drive it directly.
 
 ### Reconcile steps (single pass)
 
@@ -512,9 +524,22 @@ Reconcile is a pure decision function: given the current convoy (and template on
    - Any task past `Pending` but no terminal convoy state, and current `phase` is still `Pending` → produce `RollUpPhase { phase: Active, started_at: Some(now), finished_at: None }`.
    - Otherwise no phase roll-up.
 
-**Patch aggregation.** At most one `ConvoyStatusPatch` is returned per reconcile. In the common case (e.g. a task just completed, unblocking two dependents, and that was the last work so convoy rolls to Completed), the patch is a composite — typically `AdvanceTasksToReady` combined with `RollUpPhase`. Rather than chain multiple patches, the variants themselves contain enough information to express a single-pass transition, and the watch loop gets one atomic status update per reconcile.
+**One patch per reconcile — priority-driven, multi-pass convergence.**
 
-In practice this is implemented as: produce the structurally most "outer" variant (e.g. `FailConvoy` dominates `RollUpPhase`), and let the next reconcile run handle anything that requires observing the previous patch's effect. K8s-style controllers converge via multiple passes; we don't need one-shot atomicity.
+Each reconcile returns at most one `ConvoyStatusPatch`. When multiple transitions are eligible in a single pass, pick the one highest in this priority order:
+
+1. `FailConvoy` — fail-fast dominates everything else.
+2. `FailInit` — init-time failures are terminal and take precedence over advancement.
+3. `Bootstrap` — init before any advancement.
+4. `AdvanceTasksToReady` — DAG advancement before phase roll-up.
+5. `RollUpPhase` — lowest priority; only when no structural change is pending.
+
+Each successful patch write bumps the convoy's `resourceVersion`, which produces a watch event that triggers the next reconcile; the controller converges in multiple passes. Two common cases:
+
+- *Last task completes, convoy should now roll to Completed.* Reconcile sees all tasks terminal, emits `RollUpPhase { phase: Completed, finished_at }`. One patch.
+- *Root tasks become Ready immediately after bootstrap.* Two reconciles: first emits `Bootstrap`, second (triggered by the bootstrap status write) emits `AdvanceTasksToReady`.
+
+This is standard k8s controller-loop behavior. No composite variants; no claims of single-atomic-multi-transition updates.
 
 ### Post-init behavior and user edits
 
@@ -550,7 +575,7 @@ async fn run(backend: &ResourceBackend, namespace: &str) -> Result<()> {
 
 ### Conflict handling
 
-`patch_status` returns `ResourceError::Conflict` if `resourceVersion` is stale. The controller re-fetches the convoy and retries up to a bounded number of times (3). If still conflicting, drop — the next watch event or resync tick will re-reconcile.
+`update_status` returns `ResourceError::Conflict` if `resourceVersion` is stale. `apply_status_patch` re-reads the object, re-applies the patch to the new state, and retries (bounded at 3 attempts). If the retry budget is exhausted, the helper returns `Conflict` — the next watch event or resync tick will produce a fresh reconcile.
 
 ### Ownership contract — enforced by the patch vocabulary
 
@@ -562,7 +587,7 @@ Ownership is expressed in the `ConvoyStatusPatch` enum, not in prose. Each write
 | Provisioning controller (Stage 4) | `TaskLaunching`, `TaskRunning` |
 | External actors (CLI, TUI, agent-side CLI) | `MarkTaskCompleted`, `MarkTaskFailed`, `MarkTaskCancelled` |
 
-Each variant's `apply(&mut ConvoyStatus)` touches a disjoint subset of fields — the partition is visible in code, not just documented. Two concurrent writers constructing different variants produce non-overlapping mutations and compose cleanly under merge-patch. Concurrent writers constructing variants that touch the same field (e.g. two external actors both marking a task Completed) collide on `resourceVersion` and retry.
+Each variant's `apply(&mut ConvoyStatus)` touches a disjoint subset of fields — the partition is visible in code, not just documented. Two concurrent writers constructing different variants collide on `resourceVersion` in `update_status`; the loser retries by re-reading the updated base and re-applying its patch. Because the two variants touch disjoint fields, the re-applied patch on the newer state is still semantically correct and the writers compose. Concurrent writers constructing variants that touch the same field (e.g. two external actors both marking a task Completed) also collide on `resourceVersion`; the retry sees the task already in the terminal state and the second write is either a no-op or converges to the same value.
 
 ## Tests
 
@@ -581,21 +606,19 @@ Each variant's `apply(&mut ConvoyStatus)` touches a disjoint subset of fields �
 - `spec.workflow_ref` changed after init (defensive, post-CEL) → returns `FailInit` with the "workflow_ref changed" message.
 - Template refetch does not happen after init (verify by passing `None` for template on second call after snapshot; reconcile returns a DAG-advancement patch from status alone).
 
-### StatusPatch apply/merge-patch parity
+### `StatusPatch::apply` unit tests
 
-For every `ConvoyStatusPatch` variant:
+For every `ConvoyStatusPatch` variant: construct a representative starting `ConvoyStatus`, apply the patch, assert the resulting fields match expectation. No cross-serialiser parity test needed — since there is only one serialiser path (`apply` → full status → `update_status`), there is no second implementation to disagree with.
 
-1. Construct a representative starting `ConvoyStatus`.
-2. Apply the patch via `apply(&mut status_a)`.
-3. Serialise a clone of the starting status to JSON, apply `patch.to_merge_patch()` using the `json-patch` crate's RFC 7396 merge-patch implementation, deserialise back into `ConvoyStatus`.
-4. Assert `status_a == status_b`.
+### `apply_status_patch` retry behavior
 
-Keeps the in-memory and HTTP serialisers provably in sync.
+- Simulated conflict: resolver returns `Conflict` on first write; helper re-reads and retries; second attempt succeeds. Assert the final state reflects the patch applied to the updated base.
+- Retry budget exhausted: resolver returns `Conflict` repeatedly; helper returns `ResourceError::Conflict` after `MAX_RETRIES`. Assert the caller sees the error (and can back off / wait for the next watch tick).
 
 ### In-memory backend end-to-end
 
 - Create `WorkflowTemplate` + `Convoy` in the in-memory backend.
-- Run the controller loop against simulated `MarkTaskCompleted` patches that drive tasks through completion.
+- Run the controller loop against simulated `MarkTaskCompleted` patches (applied via `apply_status_patch`) that drive tasks through completion.
 - Assert the observed sequence of convoy phases and task phases matches expectation.
 
 ### HTTP backend integration (minikube, gated)
@@ -604,23 +627,8 @@ Keeps the in-memory and HTTP serialisers provably in sync.
 - Create a WorkflowTemplate with a two-task DAG (`implement` → `review`).
 - Create a Convoy referencing it.
 - Run the example controller binary in a background task.
-- Patch `tasks.implement.phase = Completed` via `patch_status(MarkTaskCompleted)`; assert `review` moves to Ready.
-- Patch `tasks.review.phase = Completed`; assert convoy `phase = Completed`.
-
-### In-memory backend end-to-end
-
-- Create `WorkflowTemplate` + `Convoy` in the in-memory backend.
-- Run the controller loop against simulated status patches that advance tasks through Ready → Running → Completed.
-- Assert sequence of convoy phase transitions and task-phase transitions.
-
-### HTTP backend integration (minikube, gated)
-
-- Apply both CRDs.
-- Create a WorkflowTemplate with a two-task DAG (`implement` → `review`).
-- Create a Convoy referencing it.
-- Run the example controller binary in a background task.
-- Patch `tasks.implement.phase = Completed` via `/status`; assert `review` moves to Ready.
-- Patch `tasks.review.phase = Completed`; assert convoy `phase = Completed`.
+- Drive `tasks.implement.phase = Completed` via `apply_status_patch(MarkTaskCompleted)`; assert `review` moves to Ready.
+- Drive `tasks.review.phase = Completed`; assert convoy `phase = Completed`.
 
 ## Example Binary
 
@@ -636,27 +644,27 @@ Keeps the in-memory and HTTP serialisers provably in sync.
 
 ### Stage 1 revision (as part of Stage 3 work)
 
-1. `Resource::StatusPatch` associated type and `StatusPatch` trait (`apply` + `to_merge_patch`).
-2. `TypedResolver::patch_status(name, rv, patch)` method.
-3. HTTP backend: `PATCH` against `/status` subresource with merge-patch content-type and resourceVersion precondition.
-4. In-memory backend: implement `patch_status` via `StatusPatch::apply` under the store lock.
-5. `NoStatusPatch` uninhabited enum; `WorkflowTemplate` adopts it (trivial existing-crate revision).
-6. Parity tests for `WorkflowTemplate::StatusPatch` (trivially pass since uninhabited) and for the Convoy variants (detailed above).
+1. `Resource::StatusPatch` associated type and `StatusPatch` trait (`apply(&mut Status)` only — no transport method).
+2. `NoStatusPatch` uninhabited enum; `WorkflowTemplate` adopts it (trivial existing-crate revision).
+3. `apply_status_patch::<T>(resolver, name, patch)` helper function implementing read-modify-write + conflict retry on top of the existing `get` + `update_status`.
+
+No HTTP or in-memory backend changes are required — the transport primitives stay as-is.
 
 ### Stage 3 proper
 
-7. `Convoy` Rust type and `Resource` impl.
-8. `ConvoySpec`, `ConvoyStatus`, `ConvoyPhase`, `TaskState`, `TaskPhase`, `InputValue`, `PlacementStatus`, `WorkflowSnapshot`, `SnapshotTask` types.
-9. `ConvoyStatusPatch` enum and its `StatusPatch<ConvoyStatus>` impl.
-10. Owner-scoped constructor modules (`controller_patches`, `provisioning_patches`, `external_patches`) gating variant construction by visibility.
-11. Pure `reconcile(convoy, template, now) -> ReconcileOutcome` function.
-12. `ReconcileOutcome`, `ConvoyEvent` types.
-13. Convoy CRD YAML with CEL immutability validations (replaces the stub).
-14. Table tests for reconcile.
-15. StatusPatch apply/merge-patch parity tests.
-16. In-memory backend end-to-end test.
-17. HTTP backend integration test against minikube, including CEL-rejection checks.
-18. `examples/convoy_controller.rs` — runnable controller binary.
+4. `Convoy` Rust type and `Resource` impl.
+5. `ConvoySpec`, `ConvoyStatus`, `ConvoyPhase`, `TaskState`, `TaskPhase`, `InputValue`, `PlacementStatus`, `WorkflowSnapshot`, `SnapshotTask` types.
+6. `ConvoyStatusPatch` enum and its `StatusPatch<ConvoyStatus>` impl.
+7. Owner-scoped constructor modules (`controller_patches`, `provisioning_patches`, `external_patches`) gating variant construction by visibility.
+8. Pure `reconcile(convoy, template, now) -> ReconcileOutcome` function.
+9. `ReconcileOutcome`, `ConvoyEvent` types.
+10. Convoy CRD YAML with CEL immutability validations (replaces the stub).
+11. Table tests for reconcile.
+12. `StatusPatch::apply` unit tests per variant.
+13. `apply_status_patch` retry-behavior tests.
+14. In-memory backend end-to-end test.
+15. HTTP backend integration test against minikube, including CEL-rejection checks.
+16. `examples/convoy_controller.rs` — runnable controller binary.
 
 No provisioning, no policy resolution, no presentation, no CLI surface beyond what the example needs.
 
@@ -680,15 +688,15 @@ Re-running a convoy with a newer template version is a future primitive (copy co
 
 Single-entry today (root → resourceVersion). When workflow composition (`includes`) lands, every snapshotted template — root plus includes — gets an entry. Naming the field as a map now avoids a schema change later.
 
-### Typed status patches (`StatusPatch` associated type)
+### Typed status mutations (`StatusPatch` associated type), full-status transport
 
-Multi-writer safety on `/status` needs either full-status replacement with optimistic concurrency retry, or partial patches. Full replacement forces every writer to round-trip the entire status to mutate one field — noisy, and susceptible to "I replaced the whole thing but forgot to preserve the field you just wrote" bugs. Partial patches, expressed as typed `ConvoyStatusPatch` variants, scope each mutation to exactly its owned fields.
+Multi-writer safety on `/status` needs optimistic-concurrency guarantees. K8s documents precondition behavior for PUT-with-resourceVersion (409 on stale); for PATCH, the merge-patch content type has no documented precondition, json-patch requires an explicit `test` op, and Server-Side Apply has its own managed-fields model. For Stage 3 we keep the transport simple and stay on documented ground — every writer does a full `update_status` with the current resourceVersion as precondition. The "I forgot to preserve the field you just wrote" risk is avoided by structure rather than by wire protocol: writers read the current status, call `StatusPatch::apply(&mut cloned_status)` to mutate only their owned fields, then `update_status` with the result. Two concurrent disjoint writers re-read each other's writes on conflict-retry and compose correctly.
 
-The associated type (`Resource::StatusPatch`) makes the legitimate mutations a declared vocabulary per resource. Owner-scoped constructor modules gate variant construction so "only the convoy controller can advance tasks to Ready" becomes a compile-time property, not a comment.
+`Resource::StatusPatch` makes legitimate mutations a declared vocabulary; owner-scoped constructor modules gate variant construction so "only the convoy controller can advance tasks to Ready" is a compile-time property, not a comment.
 
-The in-memory backend's `StatusPatch::apply(&mut status)` avoids re-implementing JSON merge-patch semantics (null-as-remove, nested merge, array replacement); the HTTP backend's `to_merge_patch()` handles wire serialisation. The two are kept in sync by an exhaustive parity test per variant.
+Trade-off accepted: every status write serialises the full status body. At Stage 3 scale this is fine. When it isn't, we can upgrade to json-patch with `test` op (the `StatusPatch` vocabulary survives the transport change), or Server-Side Apply for much larger scale.
 
-The alternative of a spec-side command queue (`spec.task_actions: [{task, action: Complete}]`) was rejected: controllers normally don't mutate their own spec, "mark complete" is an event not desired state, and there's no real gain over typed status patches.
+The alternative of a spec-side command queue (`spec.task_actions: [{task, action: Complete}]`) was rejected: controllers normally don't mutate their own spec, "mark complete" is an event not desired state, and there's no real gain over typed status patches applied via `update_status`.
 
 ### List-then-watch on the controller
 

--- a/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
+++ b/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
@@ -35,11 +35,15 @@ pub trait StatusPatch<S>: Send + Sync {
 No new resolver method. Writers use the existing `update_status(name, rv, new_status)`, plus this read-modify-write helper that every controller loop needs anyway:
 
 ```rust
-pub async fn apply_status_patch<T: Resource>(
+pub async fn apply_status_patch<T>(
     resolver: &TypedResolver<T>,
     name: &str,
     patch: &T::StatusPatch,
-) -> Result<ResourceObject<T>, ResourceError> {
+) -> Result<ResourceObject<T>, ResourceError>
+where
+    T: Resource,
+    T::Status: Default,
+{
     for _ in 0..MAX_RETRIES {
         let current = resolver.get(name).await?;
         let mut new_status = current.status.clone().unwrap_or_default();
@@ -56,6 +60,8 @@ pub async fn apply_status_patch<T: Resource>(
     Err(ResourceError::Conflict { /* retry budget exhausted */ })
 }
 ```
+
+The `T::Status: Default` bound is placed on the helper only, not on the `Resource` trait. This keeps the trait unchanged and leaves the door open for resources that can't or don't want to implement `Default` (they can still use `update_status` directly). `ConvoyStatus` derives `Default` (see the type definition below); `WorkflowTemplate::Status = ()` trivially has `Default` but also cannot be patched (`NoStatusPatch` is uninhabited).
 
 ### Why this shape
 

--- a/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
+++ b/docs/superpowers/specs/2026-04-14-convoy-resource-design.md
@@ -1,0 +1,475 @@
+# Convoy Resource and Controller — Design
+
+## Context
+
+Convoy is Stage 3 of the convoy implementation (see `docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md`). A Convoy is a named workflow instance: it references a `WorkflowTemplate`, carries inputs, and tracks per-task state as the DAG advances.
+
+Stage 3 ships the resource, a reconciliation controller that advances tasks through the DAG, and a runnable example binary against minikube. It deliberately stops at the "task becomes Ready" boundary — actual provisioning (Stage 4) is the first consumer of that state. Presentation, TUI, CLI, and the `PersistentAgent` / policy work all live in later stages.
+
+## Crate
+
+Lives in the existing `crates/flotilla-resources` crate alongside `WorkflowTemplate`. New `convoy` module. Replaces the existing stub CRD at `src/crds/convoy.crd.yaml`.
+
+## Scope
+
+### In scope
+
+- Rust `Convoy` type implementing `Resource`, with `ConvoySpec` / `ConvoyStatus` and the task state machine.
+- Hand-written CRD YAML replacing the stub; namespaced, status subresource enabled, printer columns for `kubectl get cvy`.
+- Pure `reconcile(convoy, spec, status, template, now) -> ReconcileOutcome` function.
+- Example controller binary (`examples/convoy_controller.rs`) using list-then-watch + periodic resync.
+- Table tests for `reconcile`, in-memory backend end-to-end test, HTTP backend integration test against minikube.
+- Template snapshotting on first successful reconcile — the DAG is frozen into `convoy.status` at init.
+
+### Out of scope (for this stage)
+
+- Task provisioning, placement-policy resolution, container/environment creation.
+- `PlacementPolicy` resource (Stage 4 or a sibling concern).
+- `PersistentAgent` resource (future — houses Quartermaster, Yeoman, custom SDLC agents).
+- Presentation / workspace integration (Stage 5).
+- TUI / CLI surface (Stage 6+).
+- Interactive launch UX (fetch template → auto-fill from context → approve).
+- AttachableSet migration (Stage 7).
+- Workflow composition (`includes`) and typed inputs — still deferred from Stage 2.
+
+## Blue-sky Model (for orientation)
+
+Stage 3's seams are designed around the following future split, captured here so the shape doesn't paint us in:
+
+- **`WorkflowTemplate`** — shared, portable. *What to run, in what order.* Identical across deployment contexts.
+- **`Convoy`** — workflow instance. *Which template, what inputs, which policy.*
+- **`PlacementPolicy`** (future) — *where and how.* Named, with a default, possibly auto-discovered (today's `docker@host` style). Eventually delegates to or is implemented by a `PersistentAgent` (Quartermaster).
+- **`PersistentAgent`** (future) — a single resource type with k8s-style labels/selectors. Conventional instances (Quartermaster, Yeoman, TestCoach, SecurityReviewer, …) are just labeled realizations. Agent runtime shape deliberately not committed: managed CLI (input-send), external CLI (shell-out), headless JSON/ACP, or internal LLM loop. All of them are presentable.
+- **`PresentationManager`** (future) — scope-decoupled: full-flotilla / repo / convoy views.
+
+Everything after `Convoy` is deferred. Stage 3's convoy carries an opaque `placement_policy: Option<String>` reference so Stage 4 can take over without a schema break.
+
+## Resource Definition
+
+### Rust
+
+```rust
+pub struct Convoy;
+impl Resource for Convoy {
+    type Spec = ConvoySpec;
+    type Status = ConvoyStatus;
+    const API_PATHS: ApiPaths = ApiPaths {
+        group: "flotilla.work",
+        version: "v1",
+        plural: "convoys",
+        kind: "Convoy",
+    };
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConvoySpec {
+    pub workflow_ref: String,                         // WorkflowTemplate name in same namespace
+    #[serde(default)]
+    pub inputs: BTreeMap<String, InputValue>,
+    #[serde(default)]
+    pub placement_policy: Option<String>,             // opaque; Stage 4 resolves
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InputValue {
+    String(String),
+    // Future: Issue(IssueRef), IssueList(Vec<IssueRef>), Branch(BranchRef), ...
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ConvoyStatus {
+    pub phase: ConvoyPhase,
+    #[serde(default)]
+    pub tasks: BTreeMap<String, TaskState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_workflow_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_workflows: Option<BTreeMap<String, String>>, // ref → resourceVersion
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ConvoyPhase {
+    Pending,
+    Active,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl Default for ConvoyPhase {
+    fn default() -> Self { ConvoyPhase::Pending }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskState {
+    pub phase: TaskPhase,
+    #[serde(default)]
+    pub depends_on: Vec<String>,                      // snapshot, populated at init
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<PlacementStatus>,           // Stage 4 populates
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TaskPhase {
+    Pending,
+    Ready,
+    Launching,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// Placement metadata written by Stage 4's provisioning controller.
+/// Shape is deferred; Stage 3 only reserves the field.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlacementStatus {
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, serde_json::Value>,
+}
+```
+
+### YAML
+
+```yaml
+apiVersion: flotilla.work/v1
+kind: Convoy
+metadata:
+  name: fix-bug-123
+  namespace: flotilla
+spec:
+  workflow_ref: review-and-fix
+  inputs:
+    feature: "Retry logic for the poller"
+    branch: "fix-bug-123"
+  placement_policy: laptop-docker
+status:
+  phase: Active
+  observed_workflow_ref: review-and-fix
+  observed_workflows:
+    review-and-fix: "42"
+  started_at: "2026-04-14T10:00:00Z"
+  tasks:
+    implement:
+      phase: Running
+      depends_on: []
+      started_at: "2026-04-14T10:00:05Z"
+    review:
+      phase: Pending
+      depends_on: [implement]
+```
+
+### Notes on shape
+
+- **`observed_workflow_ref` + `observed_workflows`** are populated only after the controller successfully resolves the template and bootstraps task state. Callers watching "is this convoy actually tied to the template?" check status, not spec.
+- **`observed_workflows` is a map**, not a single version field, so the future `includes` case (a workflow that pulls in other workflows) extends naturally — each snapshotted template gets an entry.
+- **`TaskState.depends_on` is a snapshot** taken from the template at init. Reconcile reads this for DAG advancement; it never re-fetches the live template. Template edits after convoy start do not propagate.
+- **`TaskState.placement`** is reserved for Stage 4. Stage 3 leaves it unset.
+- **`ConvoyPhase::Cancelled`** is reserved for future user-initiated cancel; Stage 3 never produces it directly.
+- **`InputValue` is untagged**, so today's YAML reads as plain scalars. When typed variants (`Issue`, `IssueList`, `Branch`) land, richer shapes slot in without a schema break.
+
+## CRD YAML
+
+Replaces `crates/flotilla-resources/src/crds/convoy.crd.yaml`. Namespaced, group `flotilla.work`, v1, status subresource enabled.
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: convoys.flotilla.work
+spec:
+  group: flotilla.work
+  scope: Namespaced
+  names:
+    plural: convoys
+    singular: convoy
+    kind: Convoy
+    shortNames: [cvy]
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Workflow
+          type: string
+          jsonPath: .spec.workflow_ref
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [workflow_ref]
+              properties:
+                workflow_ref: { type: string, minLength: 1 }
+                inputs:
+                  type: object
+                  additionalProperties: true
+                placement_policy: { type: string, minLength: 1 }
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Active, Completed, Failed, Cancelled]
+                observed_workflow_ref: { type: string }
+                observed_workflows:
+                  type: object
+                  additionalProperties: { type: string }
+                message: { type: string }
+                started_at: { type: string, format: date-time }
+                finished_at: { type: string, format: date-time }
+                tasks:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    required: [phase, depends_on]
+                    properties:
+                      phase:
+                        type: string
+                        enum: [Pending, Ready, Launching, Running, Completed, Failed, Cancelled]
+                      depends_on:
+                        type: array
+                        items: { type: string }
+                      started_at: { type: string, format: date-time }
+                      finished_at: { type: string, format: date-time }
+                      message: { type: string }
+                      placement:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+```
+
+- `subresources.status: {}` enables the `/status` subresource so status patches don't contend with spec edits.
+- `inputs.additionalProperties: true` keeps the schema open for future typed `InputValue` variants. Rust holds the real shape.
+- `placement` uses `x-kubernetes-preserve-unknown-fields: true` so Stage 4 can populate arbitrary metadata without a CRD bump.
+
+## Reconciliation
+
+### Pure function
+
+```rust
+pub fn reconcile(
+    convoy: &ResourceObject<Convoy>,
+    template: Option<&ResourceObject<WorkflowTemplate>>,
+    now: DateTime<Utc>,
+) -> ReconcileOutcome;
+
+pub struct ReconcileOutcome {
+    pub patch: Option<ConvoyStatus>,     // None = no change
+    pub events: Vec<ConvoyEvent>,        // observability
+}
+
+pub enum ConvoyEvent {
+    PhaseChanged { from: ConvoyPhase, to: ConvoyPhase },
+    TaskPhaseChanged { task: String, from: TaskPhase, to: TaskPhase },
+    TemplateNotFound { name: String },
+    WorkflowRefChanged { from: String, to: String },
+    MissingInput { name: String },
+}
+```
+
+`ConvoyEvent` is purely for observability — the watch loop logs them via `tracing`. They are not persisted in the resource. A future addition may emit k8s `Event` resources from the same enum, but that's out of scope for Stage 3.
+
+Pure, no I/O. The watch loop reads the convoy (and template on first resolve only), calls `reconcile`, applies the patch via `update_status`. Tests drive it directly.
+
+### Reconcile steps (single pass)
+
+1. **Template resolution and snapshot.**
+   - If `status.observed_workflow_ref` is unset → this is init. Look up the template.
+     - Not found → `phase = Failed`, message `"WorkflowTemplate '<ref>' not found"`, emit `TemplateNotFound`, return.
+     - Found → initialize `status.tasks` with every template task at `TaskPhase::Pending`, snapshot each task's `depends_on`. Set `status.observed_workflow_ref = spec.workflow_ref`. Set `status.observed_workflows = {ref: resourceVersion}`.
+   - If `status.observed_workflow_ref` is set and `spec.workflow_ref` differs → `phase = Failed`, message `"workflow_ref changed after convoy start; not supported"`, emit `WorkflowRefChanged`, return. (Re-running with a new template is a future concern.)
+   - Otherwise, snapshot exists; do not refetch the template.
+
+2. **Input validation (init only).**
+   - Happens on the same reconcile as step 1 bootstrap — the template is in hand.
+   - Every declared template input must appear in `spec.inputs`. Missing → `phase = Failed`, message `"missing input '<name>'"`, emit `MissingInput`.
+   - Extra inputs (in spec but not declared) → informational event only, not a failure.
+   - After init, the controller does not re-validate inputs. The template has been snapshotted and will not be re-fetched; the declared input set is fixed. User edits to `spec.inputs` after init are visible to Stage 4's task launcher but not re-checked by the convoy controller.
+
+3. **Fail-fast.**
+   - If any task is `TaskPhase::Failed`: set convoy `phase = Failed` and convoy `finished_at = now`. For every non-terminal sibling (not `Completed`/`Failed`/`Cancelled`), transition to `Cancelled` and set the task's `finished_at = now`. The failed task itself retains its `finished_at` as written by whoever marked it Failed. Return.
+
+4. **DAG advancement.**
+   - For each `Pending` task whose every `depends_on` entry maps to a task in `Completed`: transition to `Ready`, set task `started_at = now`.
+   - No other transitions produced by the convoy controller. `Ready → Launching → Running → Completed` is driven by Stage 4 (provisioning) and external actors (explicit completion).
+
+5. **Phase roll-up.**
+   - All tasks `Completed` → `phase = Completed`, `finished_at = now`.
+   - Any task past `Pending` but no terminal convoy state → `phase = Active`, `started_at = now` if unset.
+   - Otherwise → `phase = Pending`.
+
+### Watch loop (example binary)
+
+```rust
+async fn run(backend: &ResourceBackend, namespace: &str) -> Result<()> {
+    let convoys = backend.using::<Convoy>(namespace);
+    let templates = backend.using::<WorkflowTemplate>(namespace);
+
+    // Catch-up: list then watch from the collection resourceVersion.
+    let list = convoys.list().await?;
+    for convoy in &list.items {
+        reconcile_and_apply(&convoys, &templates, convoy).await?;
+    }
+    let mut events = convoys.watch(WatchStart::FromVersion(list.resource_version)).await?;
+
+    let mut resync = tokio::time::interval(Duration::from_secs(60));
+    loop {
+        tokio::select! {
+            Some(event) = events.next() => { reconcile_from_event(&convoys, &templates, event?).await?; }
+            _ = resync.tick() => { resync_all(&convoys, &templates).await?; }
+        }
+    }
+}
+```
+
+- **List-then-watch** (`WatchStart::FromVersion(collection_rv)`) ensures no gap if the controller starts after convoys already exist. `WatchStart::Now` would miss pre-existing convoys — wrong for a controller.
+- **Templates are not watched.** Once snapshotted, they are read only at convoy init. Template edits do not affect running convoys. This removes a whole class of "what if the template changes under me?" failure modes.
+- **Periodic resync** (~60s) guards against missed events / cache drift. Standard k8s controller pattern.
+
+### Conflict handling
+
+`update_status` returns `ResourceError::Conflict` if `resourceVersion` is stale. The controller re-fetches the convoy and retries up to a bounded number of times (3). If still conflicting, drop — the next watch event or resync tick will re-reconcile.
+
+### Ownership contract
+
+Single-writer per field; transitions on `tasks[*].phase` are partitioned across owners.
+
+| Who | What they write |
+|-----|-----------------|
+| Convoy controller (Stage 3) | `status.phase`, `status.observed_workflow_ref`, `status.observed_workflows`, `status.message`, `status.started_at`, `status.finished_at`, `status.tasks[*].phase` (`Pending↔Ready`, fail-fast cancels, template-init), `status.tasks[*].depends_on` (at init), `tasks[*].started_at`/`finished_at` at those transitions |
+| Provisioning controller (Stage 4, future) | `status.tasks[*].placement`, `status.tasks[*].phase` for `Ready→Launching→Running`, `tasks[*].started_at` at Launching |
+| External actors (CLI, TUI, agent-side CLI) | `status.tasks[*].phase` for terminal transitions (`Completed`, `Failed`, `Cancelled`), `tasks[*].finished_at` at those |
+
+Task completion is signalled by a direct `PATCH` against the `/status` subresource of the convoy. K8s supports multiple writers on `/status` (Deployment + HPA pattern); our disjoint-transition partition keeps ownership clear.
+
+## Tests
+
+### Table tests (pure `reconcile`)
+
+- Fresh convoy, template found → bootstrap status: all tasks Pending with `depends_on` snapshot; `observed_workflow_ref` and `observed_workflows` set.
+- Template not found → `phase = Failed` with clear message.
+- Missing input → `phase = Failed`.
+- Extra input (not declared) → informational event only; no failure.
+- All deps satisfied on a Pending task → transition to Ready with `started_at`.
+- Fan-out: three tasks with no deps → all three go Ready in one reconcile.
+- Fan-in: A→C, B→C, A=Completed, B=Running → C stays Pending. B completes → C goes Ready.
+- One task Failed → all non-terminal siblings → Cancelled, convoy `phase = Failed`.
+- All tasks Completed → `phase = Completed`, `finished_at` set.
+- `spec.workflow_ref` changed after init → `phase = Failed`.
+- Template refetch does not happen after init (verify by passing `None` for template on second call after snapshot; reconcile proceeds from status alone).
+
+### In-memory backend end-to-end
+
+- Create `WorkflowTemplate` + `Convoy` in the in-memory backend.
+- Run the controller loop against simulated status patches that advance tasks through Ready → Running → Completed.
+- Assert sequence of convoy phase transitions and task-phase transitions.
+
+### HTTP backend integration (minikube, gated)
+
+- Apply both CRDs.
+- Create a WorkflowTemplate with a two-task DAG (`implement` → `review`).
+- Create a Convoy referencing it.
+- Run the example controller binary in a background task.
+- Patch `tasks.implement.phase = Completed` via `/status`; assert `review` moves to Ready.
+- Patch `tasks.review.phase = Completed`; assert convoy `phase = Completed`.
+
+## Example Binary
+
+`crates/flotilla-resources/examples/convoy_controller.rs`:
+
+- Accepts `--namespace` flag, defaults to `flotilla`.
+- Bootstraps CRDs via `ensure_crd`.
+- List-then-watch loop as above.
+- Structured logging with `tracing` matching the codebase style.
+- Runs against minikube by default via `HttpBackend::from_kubeconfig`.
+
+## Deliverables
+
+1. `Convoy` Rust type and `Resource` impl.
+2. `ConvoySpec`, `ConvoyStatus`, `ConvoyPhase`, `TaskState`, `TaskPhase`, `InputValue`, `PlacementStatus`, `ReconcileOutcome`, `ConvoyEvent` types.
+3. Pure `reconcile(convoy, template, now) -> ReconcileOutcome` function.
+4. Convoy CRD YAML (replaces the stub).
+5. Table tests for reconcile.
+6. In-memory backend end-to-end test.
+7. HTTP backend integration test against minikube.
+8. `examples/convoy_controller.rs` — runnable controller binary.
+
+No provisioning, no policy resolution, no presentation, no CLI surface beyond what the example needs.
+
+## Design Decisions
+
+### Tasks as convoy sub-status, not independent resources
+
+One Convoy resource carrying a map of task states, versus a separate `ConvoyTask` resource per task. Per the design doc, sub-status is simpler for v1: no resource-per-task proliferation, no cross-resource watches. Promotion to independent resources is a well-understood migration (reachable later if we need per-task independent watches).
+
+### Template snapshot at init; no template watching
+
+Cascading template edits into running convoys produces too many failure modes — task renames, dep reshapes, removed tasks all break observed state. Snapshotting the DAG into `status.tasks` at init makes Stage 3 reconciliation depend only on the convoy's own status after bootstrap. Template edits affect only new convoys. Re-running a convoy with a newer template version is a future primitive (copy convoy, reset status, re-snapshot).
+
+### `observed_workflows` as a map
+
+Single-entry today (root → resourceVersion). When workflow composition (`includes`) lands, every snapshotted template — root plus includes — gets an entry. Naming the field as a map now avoids a schema change later.
+
+### Direct status patch for task completion
+
+K8s supports multiple writers on `/status` (Deployment + HPA touch the same Deployment's status). Partitioning transitions across writers — convoy controller for DAG advancement, external actors for terminal completions — gives clean ownership without an RPC-style back-channel through spec.
+
+The alternative of a spec-side command queue (`spec.task_actions: [{task, action: Complete}]`) was rejected: controllers normally don't mutate their own spec, "mark complete" is an event not desired state, and there's no real gain over direct status patches.
+
+### List-then-watch on the controller
+
+`WatchStart::Now` would miss convoys that exist before the controller starts. The Stage 1 API was designed exactly for the list-then-watch pattern (collection resourceVersion → `WatchStart::FromVersion`) — use it for any controller that cares about pre-existing state.
+
+### Placement as an opaque field
+
+`TaskState.placement` is present in the schema so Stage 4 has a place to write, but its shape is not modelled in Stage 3 (`BTreeMap<String, serde_json::Value>` + `x-kubernetes-preserve-unknown-fields`). This lets Stage 4 iterate the placement model without CRD bumps. Stage 3 never writes to it.
+
+### `placement_policy` on spec, not per-task
+
+A single policy reference on the convoy, rather than per-task placement overrides inline in the convoy spec. Rationale:
+
+- The policy (future `PlacementPolicy` resource) is the thing that decides per-task details, possibly delegating to a Quartermaster agent.
+- Inline per-task overrides would duplicate what a policy controls, and make every consumer re-implement resolution logic.
+- Launch-time override is expressed by writing a different policy into `spec.placement_policy` — it *is* the override. No separate override channel is needed.
+
+### `ConvoyPhase::Cancelled` reserved, not produced in Stage 3
+
+User-initiated convoy cancel is a real future feature but adds a control-plane verb (patch spec flag? delete convoy and let finalizer GC?) that deserves its own design round. Stage 3 reserves the phase so consumers can pattern-match today without later breaking them.
+
+## Deferred Items (captured in `docs/superpowers/specs/2026-04-13-convoy-brainstorm-prompts.md`)
+
+To add under "From Stage 3":
+
+- **`PlacementPolicy` resource** — named, default, auto-discovered; delegates to or is implemented by a `PersistentAgent`. Stage 3 references by opaque string; Stage 4 reifies.
+- **`PersistentAgent` resource** — one resource type with k8s-style labels/selectors. Quartermaster, Yeoman, TestCoach, etc. are conventionally-labeled instances. Agent runtime shape deliberately open (managed CLI, external CLI, headless JSON/ACP, internal LLM loop).
+- **Presentation scope decoupling** — `PresentationManager` at full-flotilla / repo / convoy scopes.
+- **Interactive launch UX** — CLI/TUI flow: fetch template → infer inputs from context (current branch, selected issues) → present for approval → create convoy.
+- **Typed `InputValue` variants** — `Issue`, `IssueList`, `Branch`, `ChangeRequest`, etc. Requires matching `InputDefinition.kind` in WorkflowTemplate (Stage 2 revision).
+- **Label-based workflow discovery** — e.g. `flotilla.work/accepts: issue` on WorkflowTemplate, for UI surfacing based on user selection context. May be subsumed by typed inputs.
+- **Workflow composition (`includes`)** — sub-workflows, transitive snapshotting into `observed_workflows`.
+- **Template versioning** — `spec.workflow_ref_revision` for convoys that want a specific template version.
+- **Convoy re-run** — copy a convoy, reset status, re-snapshot against newer template.
+- **Convoy cancellation** — user-initiated cancel producing `ConvoyPhase::Cancelled`.
+- **Admission webhook / fast-feedback validation** — complements the client-side Convoy validator once shared-cluster workflows demand it.


### PR DESCRIPTION
## Summary
- add typed `StatusPatch` support to `flotilla-resources` and implement the Stage 3 `Convoy` resource, reconcile logic, CRD, controller example, and end-to-end tests
- extend the resource test surface with convoy reconcile/status-patch coverage plus Kubernetes integration coverage updates
- seed deterministic `machine_id` values in daemon-backed test harnesses so the sandbox-safe workspace test command no longer depends on ambient host identity

## Why
- Stage 3 needs a concrete convoy resource/controller implementation on top of the Stage 1 resource client surface
- the workspace test failure was not sandbox-specific; several daemon harnesses were constructing local configs without `machine_id`, which broke on hosts without ambient identity

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `/bin/zsh -lc 'mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo clippy --workspace --all-targets --locked -- -D warnings'`
- `/bin/zsh -lc 'mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests'`
