### PR TITLE
feat(tui): convoy task completion via command palette

### DIFF
--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -131,6 +131,8 @@ pub struct KeysConfig {
     #[serde(default)]
     pub convoys: HashMap<String, String>,
     #[serde(default)]
+    pub convoy_tasks: HashMap<String, String>,
+    #[serde(default)]
     pub action_menu: HashMap<String, String>,
     #[serde(default)]
     pub delete_confirm: HashMap<String, String>,

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -405,11 +405,17 @@ impl App {
     }
 
     /// Open the command palette pre-filled with `convoy <id> task <task> complete `.
-    /// No-op when no convoy or task is selected.
+    /// No-op when no convoy or task is selected. Convoy ids and task names are
+    /// arbitrary strings (no validation), so they are routed through the
+    /// palette's quoting helper to round-trip whitespace and special characters.
     pub(super) fn open_complete_convoy_task_palette(&mut self) {
         let Some(convoy_id) = self.convoys_ui.selected.as_ref() else { return };
         let Some(task) = self.convoys_ui.selected_task.as_ref() else { return };
-        let prefill = format!("convoy {} task {} complete ", convoy_id.name(), task);
+        let prefill = format!(
+            "convoy {} task {} complete ",
+            crate::palette::quote_palette_token(convoy_id.name()),
+            crate::palette::quote_palette_token(task),
+        );
         let widget = crate::widgets::command_palette::CommandPaletteWidget::with_prefill(prefill, None);
         self.screen.modal_stack.push(Box::new(widget));
     }

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -14,13 +14,18 @@ impl App {
     /// Resolve a key event using the app-level config/convoys/normal distinction.
     ///
     /// Called when the base layer widget (Normal mode_id) is on top, so that
-    /// config mode gets Overview bindings, convoys mode gets Convoys bindings,
-    /// and normal mode gets Normal bindings.
+    /// config mode gets Overview bindings, convoys mode gets Convoys bindings
+    /// (or ConvoyTasks when the user has drilled into the task tree), and
+    /// normal mode gets Normal bindings.
     fn resolve_action(&self, key: KeyEvent) -> Option<Action> {
         let mode = if self.ui.is_config {
             KeyBindingMode::Composed(vec![BindingModeId::TabPage, BindingModeId::Overview])
         } else if self.ui.is_convoys {
-            KeyBindingMode::Composed(vec![BindingModeId::TabPage, BindingModeId::Convoys])
+            let inner = match self.convoys_focus() {
+                super::ConvoysFocus::List => BindingModeId::Convoys,
+                super::ConvoysFocus::Tasks => BindingModeId::ConvoyTasks,
+            };
+            KeyBindingMode::Composed(vec![BindingModeId::TabPage, inner])
         } else {
             KeyBindingMode::Composed(vec![BindingModeId::TabPage, BindingModeId::Normal])
         };
@@ -34,14 +39,29 @@ impl App {
     /// convoy selection navigation.
     pub(super) fn dispatch_action(&mut self, action: Action) {
         match action {
-            Action::SelectNext if self.ui.is_convoys => self.convoys_tab_select_delta(1),
-            Action::SelectPrev if self.ui.is_convoys => self.convoys_tab_select_delta(-1),
-            // Focus detail / expand tree — deferred; no-op for now.
-            // This guard also prevents zero-repo panics and stops Enter from
-            // acting on the hidden repo page while the Convoys tab is visible.
-            Action::Confirm if self.ui.is_convoys => {}
-            // Collapse tree / back — deferred; no-op for now.
-            Action::Dismiss if self.ui.is_convoys => {}
+            Action::SelectNext if self.ui.is_convoys => match self.convoys_focus() {
+                super::ConvoysFocus::List => self.convoys_tab_select_delta(1),
+                super::ConvoysFocus::Tasks => self.convoy_tasks_select_delta("flotilla", 1),
+            },
+            Action::SelectPrev if self.ui.is_convoys => match self.convoys_focus() {
+                super::ConvoysFocus::List => self.convoys_tab_select_delta(-1),
+                super::ConvoysFocus::Tasks => self.convoy_tasks_select_delta("flotilla", -1),
+            },
+            // On the Convoys list, Confirm (enter / l / right) drills into the task tree.
+            // In the task tree, Confirm is currently a no-op (task-attach lands in PR 3).
+            Action::Confirm if self.ui.is_convoys => {
+                if matches!(self.convoys_focus(), super::ConvoysFocus::List) {
+                    self.enter_convoy_tasks_focus("flotilla");
+                }
+            }
+            // In the task tree, Dismiss (esc / left) returns to the convoy list.
+            // On the convoy list, Dismiss is a no-op (don't act on the hidden repo page).
+            Action::Dismiss if self.ui.is_convoys => {
+                if matches!(self.convoys_focus(), super::ConvoysFocus::Tasks) {
+                    self.exit_convoy_tasks_focus();
+                }
+            }
+            Action::CompleteConvoyTask if self.ui.is_convoys => self.open_complete_convoy_task_palette(),
             Action::Confirm if !self.ui.is_config => self.action_enter(),
             Action::OpenActionMenu if !self.ui.is_config => self.open_action_menu(),
             Action::OpenFilePicker if !self.ui.is_config => self.open_file_picker_from_active_repo_parent(),
@@ -382,6 +402,16 @@ impl App {
             };
             self.proto_commands.push_with_context(cmd, Some(pending_ctx));
         }
+    }
+
+    /// Open the command palette pre-filled with `convoy <id> task <task> complete `.
+    /// No-op when no convoy or task is selected.
+    pub(super) fn open_complete_convoy_task_palette(&mut self) {
+        let Some(convoy_id) = self.convoys_ui.selected.as_ref() else { return };
+        let Some(task) = self.convoys_ui.selected_task.as_ref() else { return };
+        let prefill = format!("convoy {} task {} complete ", convoy_id.name(), task);
+        let widget = crate::widgets::command_palette::CommandPaletteWidget::with_prefill(prefill, None);
+        self.screen.modal_stack.push(Box::new(widget));
     }
 
     pub(super) fn open_action_menu(&mut self) {

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -1498,12 +1498,15 @@ impl App {
     }
 
     /// If `selected_task` no longer matches a task in the selected convoy,
-    /// reset it (`None`). Doesn't auto-pick a default — that's `enter_tasks_focus`'s job.
+    /// reset it (`None`) and snap focus back to the convoy list. Otherwise the
+    /// task pane would render with bold borders but no selected row — visual
+    /// limbo until the user pressed `j`/`k`.
     fn clamp_selected_task(&mut self, namespace: &str) {
         let Some(task) = self.convoys_ui.selected_task.clone() else { return };
         let still_valid = self.selected_convoy_summary(namespace).is_some_and(|c| c.tasks.iter().any(|t| t.name == task));
         if !still_valid {
             self.convoys_ui.selected_task = None;
+            self.convoys_ui.focus = ConvoysFocus::List;
         }
     }
 

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -270,13 +270,25 @@ pub struct NamespaceModel {
     pub last_seq: u64,
 }
 
-/// UI state for the Convoys tab (selection, filter).
-///
-/// Minimal stub for Task 25; full selection wiring lands in Task 26,
-/// filter input in Task 27.
+/// Which pane has focus on the Convoys tab — the convoy list (left) or the
+/// task tree (right). `j/k` semantics depend on this: in `List` they move
+/// between convoys; in `Tasks` they move between tasks of the selected convoy.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConvoysFocus {
+    #[default]
+    List,
+    Tasks,
+}
+
+/// UI state for the Convoys tab.
 #[derive(Default)]
 pub struct ConvoysUiState {
     pub selected: Option<flotilla_protocol::namespace::ConvoyId>,
+    /// Name of the selected task within `selected`. Cleared when the convoy
+    /// selection changes; clamped against the convoy's task list on every
+    /// snapshot/delta apply.
+    pub selected_task: Option<String>,
+    pub focus: ConvoysFocus,
     pub filter: String,
 }
 
@@ -855,6 +867,7 @@ impl App {
             is_config: &mut self.ui.is_config,
             is_convoys,
             active_repo_is_remote_only,
+            namespaces: &self.namespaces,
             app_actions: Vec::new(),
         }
     }
@@ -1439,25 +1452,97 @@ impl App {
         &self.convoys_ui.filter
     }
 
+    /// Returns the selected task name within the selected convoy, if any.
+    pub fn selected_convoy_task(&self) -> Option<&str> {
+        self.convoys_ui.selected_task.as_deref()
+    }
+
+    /// Returns the current focus pane for the Convoys tab.
+    pub fn convoys_focus(&self) -> ConvoysFocus {
+        self.convoys_ui.focus
+    }
+
     /// Validate the current convoy selection and default-select when needed.
     ///
     /// Called after every namespace snapshot or delta:
     /// - Clears selection when there are no convoys.
     /// - Replaces a dangling selection (removed convoy) with the first available convoy.
     /// - Sets the first convoy as the default when no selection is set yet.
+    /// - Resets task focus state when the selected convoy changes.
+    /// - Clamps `selected_task` against the selected convoy's current task list.
     fn refresh_convoy_selection(&mut self, namespace: &str) {
+        let prior_selected = self.convoys_ui.selected.clone();
         let Some(model) = self.namespaces.get(namespace) else {
             self.convoys_ui.selected = None;
+            self.reset_convoy_task_state();
             return;
         };
         if model.convoys.is_empty() {
             self.convoys_ui.selected = None;
+            self.reset_convoy_task_state();
             return;
         }
         let still_valid = self.convoys_ui.selected.as_ref().is_some_and(|id| model.convoys.contains_key(id));
         if !still_valid {
             self.convoys_ui.selected = Some(model.convoys.keys().next().cloned().expect("non-empty checked above"));
         }
+        if self.convoys_ui.selected != prior_selected {
+            self.reset_convoy_task_state();
+        }
+        self.clamp_selected_task(namespace);
+    }
+
+    fn reset_convoy_task_state(&mut self) {
+        self.convoys_ui.selected_task = None;
+        self.convoys_ui.focus = ConvoysFocus::List;
+    }
+
+    /// If `selected_task` no longer matches a task in the selected convoy,
+    /// reset it (`None`). Doesn't auto-pick a default — that's `enter_tasks_focus`'s job.
+    fn clamp_selected_task(&mut self, namespace: &str) {
+        let Some(task) = self.convoys_ui.selected_task.clone() else { return };
+        let still_valid = self.selected_convoy_summary(namespace).is_some_and(|c| c.tasks.iter().any(|t| t.name == task));
+        if !still_valid {
+            self.convoys_ui.selected_task = None;
+        }
+    }
+
+    fn selected_convoy_summary<'a>(&'a self, namespace: &str) -> Option<&'a flotilla_protocol::namespace::ConvoySummary> {
+        let id = self.convoys_ui.selected.as_ref()?;
+        self.namespaces.get(namespace)?.convoys.get(id)
+    }
+
+    /// Switch focus to the task tree, defaulting to the first task if none selected.
+    /// No-op when no convoy is selected or the convoy has no tasks.
+    pub fn enter_convoy_tasks_focus(&mut self, namespace: &str) {
+        let Some(convoy) = self.selected_convoy_summary(namespace) else { return };
+        if convoy.tasks.is_empty() {
+            return;
+        }
+        if self.convoys_ui.selected_task.is_none() {
+            self.convoys_ui.selected_task = Some(convoy.tasks[0].name.clone());
+        }
+        self.convoys_ui.focus = ConvoysFocus::Tasks;
+    }
+
+    /// Return focus to the convoy list. Keeps `selected_task` so re-entering Tasks
+    /// resumes at the same row.
+    pub fn exit_convoy_tasks_focus(&mut self) {
+        self.convoys_ui.focus = ConvoysFocus::List;
+    }
+
+    /// Move task selection within the selected convoy by `delta` (positive = down).
+    /// Clamps at both ends. No-op when no tasks are visible.
+    pub fn convoy_tasks_select_delta(&mut self, namespace: &str, delta: isize) {
+        let Some(convoy) = self.selected_convoy_summary(namespace) else { return };
+        if convoy.tasks.is_empty() {
+            self.convoys_ui.selected_task = None;
+            return;
+        }
+        let names: Vec<String> = convoy.tasks.iter().map(|t| t.name.clone()).collect();
+        let current_idx = self.convoys_ui.selected_task.as_ref().and_then(|n| names.iter().position(|m| m == n)).unwrap_or(0);
+        let new_idx = (current_idx as isize + delta).clamp(0, (names.len() - 1) as isize) as usize;
+        self.convoys_ui.selected_task = Some(names[new_idx].clone());
     }
 
     /// Move the convoy selection by `delta` positions (positive = down, negative = up).
@@ -1468,14 +1553,19 @@ impl App {
         // Single-namespace MVP: all convoys live in "flotilla". Multi-namespace
         // support will need a namespace scoping concept on ConvoysUiState —
         // see issue #589 (arbitrary tabs).
+        let prior_selected = self.convoys_ui.selected.clone();
         let ids: Vec<flotilla_protocol::namespace::ConvoyId> = self.visible_convoys("flotilla").map(|c| c.id.clone()).collect();
         if ids.is_empty() {
             self.convoys_ui.selected = None;
+            self.reset_convoy_task_state();
             return;
         }
         let current_idx = self.convoys_ui.selected.as_ref().and_then(|id| ids.iter().position(|candidate| candidate == id)).unwrap_or(0);
         let new_idx = (current_idx as isize + delta).clamp(0, (ids.len() - 1) as isize) as usize;
         self.convoys_ui.selected = Some(ids[new_idx].clone());
+        if self.convoys_ui.selected != prior_selected {
+            self.reset_convoy_task_state();
+        }
     }
 
     /// Set the filter string for the Convoys tab.
@@ -1496,11 +1586,16 @@ impl App {
     /// When the filter changes, check whether the current selection is still
     /// visible. If not, default to the first visible convoy (or `None`).
     fn refresh_convoy_selection_for_filter(&mut self, namespace: &str) {
+        let prior_selected = self.convoys_ui.selected.clone();
         let visible_ids: Vec<_> = self.visible_convoys(namespace).map(|c| c.id.clone()).collect();
         let current_visible = self.convoys_ui.selected.as_ref().is_some_and(|id| visible_ids.contains(id));
         if !current_visible {
             self.convoys_ui.selected = visible_ids.into_iter().next();
         }
+        if self.convoys_ui.selected != prior_selected {
+            self.reset_convoy_task_state();
+        }
+        self.clamp_selected_task(namespace);
     }
 
     pub(super) fn open_file_picker_from_active_repo_parent(&mut self) {

--- a/crates/flotilla-tui/src/app/test_support.rs
+++ b/crates/flotilla-tui/src/app/test_support.rs
@@ -211,6 +211,7 @@ pub(crate) struct TestWidgetHarness {
     pub my_node_id: Option<NodeId>,
     pub is_config: bool,
     pub active_repo_is_remote_only: bool,
+    pub namespaces: crate::app::NamespaceMap,
 }
 
 impl TestWidgetHarness {
@@ -227,6 +228,7 @@ impl TestWidgetHarness {
             my_node_id: None,
             is_config: false,
             active_repo_is_remote_only: false,
+            namespaces: Default::default(),
         }
     }
 
@@ -245,6 +247,7 @@ impl TestWidgetHarness {
             is_config: &mut self.is_config,
             is_convoys: false,
             active_repo_is_remote_only: self.active_repo_is_remote_only,
+            namespaces: &self.namespaces,
             app_actions: Vec::new(),
         }
     }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1395,6 +1395,8 @@ fn screen_renders_convoys_page_on_convoys_tab() {
     let mut terminal = Terminal::new(backend).expect("terminal");
 
     let convoys_selected = app.convoys_ui.selected.clone();
+    let convoys_selected_task = app.convoys_ui.selected_task.clone();
+    let convoys_focus = app.convoys_ui.focus;
     let convoy_filter = app.convoys_ui.filter.clone();
     terminal
         .draw(|f| {
@@ -1409,6 +1411,8 @@ fn screen_renders_convoys_page_on_convoys_tab() {
                 in_flight: &app.in_flight,
                 namespaces: &app.namespaces,
                 convoys_selected,
+                convoys_selected_task: convoys_selected_task.as_deref(),
+                convoys_focus,
                 convoy_filter: &convoy_filter,
                 convoys,
             };
@@ -1798,4 +1802,245 @@ fn move_tab_is_ignored_on_convoys_tab() {
 
     assert_eq!(app.model.repo_order, order_before, "{{ / }} must not reorder repos while on the Convoys tab");
     assert_eq!(app.model.active_repo, active_before, "active_repo must be unchanged after {{ / }} on Convoys tab");
+}
+
+// -- Convoy task selection state --
+
+fn convoy_with_tasks(name: &str, tasks: &[&str]) -> flotilla_protocol::namespace::ConvoySummary {
+    let mut c = test_convoy("flotilla", name, flotilla_protocol::namespace::ConvoyPhase::Active, false);
+    c.tasks = tasks
+        .iter()
+        .map(|t| flotilla_protocol::namespace::TaskSummary {
+            name: (*t).into(),
+            depends_on: vec![],
+            phase: flotilla_protocol::namespace::TaskPhase::Pending,
+            processes: vec![],
+            host: None,
+            checkout: None,
+            workspace_ref: None,
+            ready_at: None,
+            started_at: None,
+            finished_at: None,
+            message: None,
+        })
+        .collect();
+    c
+}
+
+fn snapshot_with(convoys: Vec<flotilla_protocol::namespace::ConvoySummary>) -> flotilla_protocol::namespace::NamespaceSnapshot {
+    flotilla_protocol::namespace::NamespaceSnapshot { seq: 1, namespace: "flotilla".into(), convoys }
+}
+
+#[test]
+fn enter_tasks_focus_default_selects_first_task() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.ui.is_convoys = true;
+
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
+    assert_eq!(app.selected_convoy_task(), None);
+
+    app.enter_convoy_tasks_focus("flotilla");
+
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.selected_convoy_task(), Some("t1"));
+}
+
+#[test]
+fn enter_tasks_focus_noop_on_empty_tasks() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &[])]))));
+    app.ui.is_convoys = true;
+
+    app.enter_convoy_tasks_focus("flotilla");
+
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List, "focus should stay on List when convoy has no tasks");
+    assert_eq!(app.selected_convoy_task(), None);
+}
+
+#[test]
+fn convoy_tasks_select_delta_clamps_within_tasks() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2", "t3"])]))));
+    app.ui.is_convoys = true;
+    app.enter_convoy_tasks_focus("flotilla");
+
+    app.convoy_tasks_select_delta("flotilla", 1);
+    assert_eq!(app.selected_convoy_task(), Some("t2"));
+    app.convoy_tasks_select_delta("flotilla", 5);
+    assert_eq!(app.selected_convoy_task(), Some("t3"), "clamps at last task");
+    app.convoy_tasks_select_delta("flotilla", -10);
+    assert_eq!(app.selected_convoy_task(), Some("t1"), "clamps at first task");
+}
+
+#[test]
+fn switching_convoys_resets_task_state_and_focus() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![
+        convoy_with_tasks("alpha", &["a1"]),
+        convoy_with_tasks("beta", &["b1"]),
+    ]))));
+    app.ui.is_convoys = true;
+    app.enter_convoy_tasks_focus("flotilla");
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+
+    app.convoys_tab_select_delta(1);
+
+    assert_eq!(app.selected_convoy_id().map(|id| id.name()), Some("beta"));
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List, "switching convoy snaps focus back to List");
+    assert_eq!(app.selected_convoy_task(), None, "switching convoy clears task selection");
+}
+
+#[test]
+fn delta_removing_selected_task_clamps_to_none() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.ui.is_convoys = true;
+    app.enter_convoy_tasks_focus("flotilla");
+    app.convoy_tasks_select_delta("flotilla", 1);
+    assert_eq!(app.selected_convoy_task(), Some("t2"));
+
+    // Remove t2 via delta.
+    let mut shrunk = convoy_with_tasks("alpha", &["t1"]);
+    shrunk.id = flotilla_protocol::namespace::ConvoyId::new("flotilla", "alpha");
+    app.handle_daemon_event(DaemonEvent::NamespaceDelta(Box::new(flotilla_protocol::namespace::NamespaceDelta {
+        seq: 2,
+        namespace: "flotilla".into(),
+        changed: vec![shrunk],
+        removed: vec![],
+    })));
+
+    assert_eq!(app.selected_convoy_task(), None, "selected_task is reset when it disappears from the convoy");
+}
+
+#[test]
+fn exit_tasks_focus_keeps_selected_task() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.ui.is_convoys = true;
+    app.enter_convoy_tasks_focus("flotilla");
+    app.convoy_tasks_select_delta("flotilla", 1);
+
+    app.exit_convoy_tasks_focus();
+
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
+    assert_eq!(app.selected_convoy_task(), Some("t2"), "selected_task survives exit so re-entering picks up the same row");
+}
+
+#[test]
+fn l_drills_in_then_esc_returns_to_list_focus() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.ui.is_convoys = true;
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
+
+    app.handle_key(key(KeyCode::Char('l')));
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.selected_convoy_task(), Some("t1"));
+
+    app.handle_key(key(KeyCode::Esc));
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
+}
+
+#[test]
+fn enter_also_drills_into_tasks_focus() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1"])]))));
+    app.ui.is_convoys = true;
+
+    app.handle_key(key(KeyCode::Enter));
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+}
+
+#[test]
+fn right_and_left_arrows_navigate_focus() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1"])]))));
+    app.ui.is_convoys = true;
+
+    app.handle_key(key(KeyCode::Right));
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+
+    app.handle_key(key(KeyCode::Left));
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
+}
+
+#[test]
+fn arrow_keys_route_task_navigation_when_tasks_focused() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2", "t3"])]))));
+    app.ui.is_convoys = true;
+    app.handle_key(key(KeyCode::Right));
+
+    app.handle_key(key(KeyCode::Down));
+    assert_eq!(app.selected_convoy_task(), Some("t2"));
+    app.handle_key(key(KeyCode::Up));
+    assert_eq!(app.selected_convoy_task(), Some("t1"));
+}
+
+#[test]
+fn jk_routes_to_task_navigation_when_tasks_focused() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2", "t3"])]))));
+    app.ui.is_convoys = true;
+
+    app.handle_key(key(KeyCode::Char('l')));
+    assert_eq!(app.selected_convoy_task(), Some("t1"));
+
+    app.handle_key(key(KeyCode::Char('j')));
+    assert_eq!(app.selected_convoy_task(), Some("t2"));
+
+    app.handle_key(key(KeyCode::Char('j')));
+    assert_eq!(app.selected_convoy_task(), Some("t3"));
+
+    app.handle_key(key(KeyCode::Char('k')));
+    assert_eq!(app.selected_convoy_task(), Some("t2"));
+}
+
+#[test]
+fn x_in_tasks_focus_opens_palette_with_complete_prefill() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("fix-bug-123", &[
+        "implement",
+        "review",
+    ])]))));
+    app.ui.is_convoys = true;
+    app.handle_key(key(KeyCode::Char('l')));
+    app.handle_key(key(KeyCode::Char('j')));
+    assert_eq!(app.selected_convoy_task(), Some("review"));
+
+    app.handle_key(key(KeyCode::Char('x')));
+
+    assert!(app.screen.has_modal(), "pressing 'x' on a task should open the command palette modal");
+    let palette = app
+        .screen
+        .modal_stack
+        .last()
+        .expect("modal pushed")
+        .as_any()
+        .downcast_ref::<crate::widgets::command_palette::CommandPaletteWidget>()
+        .expect("top modal is CommandPaletteWidget");
+    assert_eq!(palette.input_value(), "convoy fix-bug-123 task review complete ");
+}
+
+#[test]
+fn x_then_enter_dispatches_convoy_task_complete() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("fix-bug-123", &[
+        "implement",
+    ])]))));
+    app.ui.is_convoys = true;
+    app.handle_key(key(KeyCode::Char('l')));
+    app.handle_key(key(KeyCode::Char('x')));
+    app.handle_key(key(KeyCode::Enter));
+
+    let cmd = app.proto_commands.take_next().expect("expected a command after Enter on palette");
+    match &cmd.0.action {
+        flotilla_protocol::CommandAction::ConvoyTaskComplete { convoy, task, message } => {
+            assert_eq!(convoy, "fix-bug-123");
+            assert_eq!(task, "implement");
+            assert_eq!(*message, None);
+        }
+        other => panic!("expected ConvoyTaskComplete, got {other:?}"),
+    }
 }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1892,13 +1892,14 @@ fn switching_convoys_resets_task_state_and_focus() {
 }
 
 #[test]
-fn delta_removing_selected_task_clamps_to_none() {
+fn delta_removing_selected_task_clamps_to_none_and_drops_focus() {
     let mut app = stub_app();
     app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
     app.enter_convoy_tasks_focus("flotilla");
     app.convoy_tasks_select_delta("flotilla", 1);
     assert_eq!(app.selected_convoy_task(), Some("t2"));
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
 
     // Remove t2 via delta.
     let mut shrunk = convoy_with_tasks("alpha", &["t1"]);
@@ -1911,6 +1912,11 @@ fn delta_removing_selected_task_clamps_to_none() {
     })));
 
     assert_eq!(app.selected_convoy_task(), None, "selected_task is reset when it disappears from the convoy");
+    assert_eq!(
+        app.convoys_focus(),
+        crate::app::ConvoysFocus::List,
+        "focus snaps back to List so the task pane isn't focused with no row selected"
+    );
 }
 
 #[test]
@@ -2021,6 +2027,28 @@ fn x_in_tasks_focus_opens_palette_with_complete_prefill() {
         .downcast_ref::<crate::widgets::command_palette::CommandPaletteWidget>()
         .expect("top modal is CommandPaletteWidget");
     assert_eq!(palette.input_value(), "convoy fix-bug-123 task review complete ");
+}
+
+#[test]
+fn x_prefill_quotes_task_names_with_whitespace() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_tasks("fix-bug-123", &[
+        "fix my bug",
+    ])]))));
+    app.ui.is_convoys = true;
+    app.handle_key(key(KeyCode::Char('l')));
+    assert_eq!(app.selected_convoy_task(), Some("fix my bug"));
+
+    app.handle_key(key(KeyCode::Char('x')));
+    let palette = app
+        .screen
+        .modal_stack
+        .last()
+        .expect("modal pushed")
+        .as_any()
+        .downcast_ref::<crate::widgets::command_palette::CommandPaletteWidget>()
+        .expect("top modal is CommandPaletteWidget");
+    assert_eq!(palette.input_value(), "convoy fix-bug-123 task \"fix my bug\" complete ");
 }
 
 #[test]

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -27,6 +27,10 @@ pub enum BindingModeId {
     /// confirm dialog.
     TabPage,
     Convoys,
+    /// Inner focus on the Convoys tab — the task tree on the right pane.
+    /// Composed with `TabPage`. `j/k` navigate tasks; `esc` returns to the
+    /// convoy list; `x` opens the palette pre-filled to complete the task.
+    ConvoyTasks,
     Help,
     ActionMenu,
     DeleteConfirm,
@@ -138,13 +142,22 @@ pub static BINDINGS: &[Binding] = &[
     b(BindingModeId::Normal, "u", Action::ToggleArchived),
     b(BindingModeId::Normal, "d", Action::Dispatch(Intent::RemoveCheckout)),
     b(BindingModeId::Normal, "p", Action::Dispatch(Intent::OpenChangeRequest)),
-    // ── Convoys ──
-    h(BindingModeId::Convoys, "j", Action::SelectNext, "Down"),
-    h(BindingModeId::Convoys, "k", Action::SelectPrev, "Up"),
-    // l/enter (Focus) are omitted: the nested focus navigation isn't shipped in PR 1.
-    // Add them back when the behaviour is implemented.
+    // ── Convoys (outer focus: convoy list) ──
+    // j/k/up/down come from Shared (SelectNext/SelectPrev). enter comes from Shared (Confirm).
+    // l and right are vim-style and arrow-style synonyms for "drill into the task tree" — the
+    // app dispatches Confirm on the Convoys list to enter task focus.
+    h(BindingModeId::Convoys, "l", Action::Confirm, "Tasks"),
+    b(BindingModeId::Convoys, "right", Action::Confirm),
     // [, ], q come from TabPage (composed). Keep r here: refresh semantics are tab-specific.
     h(BindingModeId::Convoys, "r", Action::Refresh, "Refresh"),
+    // ── ConvoyTasks (inner focus: task tree) ──
+    // j/k/up/down come from Shared. esc comes from Shared (Dismiss). left mirrors esc as the
+    // arrow-style synonym for "back to the convoy list" — the app dispatches Dismiss in Tasks
+    // focus to return to the list.
+    b(BindingModeId::ConvoyTasks, "left", Action::Dismiss),
+    hk(BindingModeId::ConvoyTasks, "esc", "ESC", Action::Dismiss, "List"),
+    h(BindingModeId::ConvoyTasks, "x", Action::CompleteConvoyTask, "Complete"),
+    h(BindingModeId::ConvoyTasks, "r", Action::Refresh, "Refresh"),
     // ── Overview (replaces old Config) ──
     h(BindingModeId::Overview, "j", Action::SelectNext, "Down"),
     h(BindingModeId::Overview, "k", Action::SelectPrev, "Up"),

--- a/crates/flotilla-tui/src/keymap.rs
+++ b/crates/flotilla-tui/src/keymap.rs
@@ -43,6 +43,8 @@ pub enum Action {
     OpenCommandPalette,
     OpenContextualPalette,
     FillSelected,
+    /// Open the command palette pre-filled to complete the selected convoy task.
+    CompleteConvoyTask,
     Dispatch(Intent),
 }
 
@@ -109,6 +111,7 @@ impl Action {
             "open_command_palette" => Action::OpenCommandPalette,
             "open_contextual_palette" => Action::OpenContextualPalette,
             "fill_selected" => Action::FillSelected,
+            "complete_convoy_task" => Action::CompleteConvoyTask,
             // Intent-wrapping actions
             "switch_to_workspace" => Action::Dispatch(Intent::SwitchToWorkspace),
             "create_workspace" => Action::Dispatch(Intent::CreateWorkspace),
@@ -157,6 +160,7 @@ impl Action {
             Action::OpenCommandPalette => "open_command_palette",
             Action::OpenContextualPalette => "open_contextual_palette",
             Action::FillSelected => "fill_selected",
+            Action::CompleteConvoyTask => "complete_convoy_task",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "switch_to_workspace",
                 Intent::CreateWorkspace => "create_workspace",
@@ -202,6 +206,7 @@ impl Action {
             Action::OpenCommandPalette => "Open command palette",
             Action::OpenContextualPalette => "Open contextual palette (pre-filled)",
             Action::FillSelected => "Fill selected item",
+            Action::CompleteConvoyTask => "Complete convoy task",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "Switch to workspace",
                 Intent::CreateWorkspace => "Create workspace",
@@ -272,6 +277,7 @@ impl Keymap {
             (&config.help, BindingModeId::Help),
             (&config.config, BindingModeId::Overview),
             (&config.convoys, BindingModeId::Convoys),
+            (&config.convoy_tasks, BindingModeId::ConvoyTasks),
             (&config.action_menu, BindingModeId::ActionMenu),
             (&config.delete_confirm, BindingModeId::DeleteConfirm),
             (&config.close_confirm, BindingModeId::CloseConfirm),

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -1150,7 +1150,7 @@ mod tests {
         // Round-trip property: quote(s) tokenizes back to a single token equal to s.
         // Empty strings are not a valid resource name and are not exercised here —
         // the tokenizer drops empty-quoted tokens, which is fine for that case.
-        for s in ["fix-bug-123", "implement", "fix my bug", "name with \"quote\"", "back\\slash"] {
+        for s in ["fix-bug-123", "implement", "fix my bug", "name with \"quote\"", "it's", "back\\slash"] {
             let quoted = quote_palette_token(s);
             let tokens = tokenize_palette_input(&quoted).expect("tokenize");
             assert_eq!(tokens.len(), 1, "quoted {quoted:?} should tokenize to one token");

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -286,6 +286,13 @@ pub fn palette_completions(
     // a free-form positional and would otherwise return nothing. Past the task
     // subject we fall through to the clap walker for verbs (`complete` etc.).
     if noun_name == "convoy" && tokens.len() >= 3 && tokens[2] == "task" {
+        // tokens[1] is the raw whitespace-split token: convoy ids that contain
+        // whitespace (and would have been double-quoted by `quote_palette_token`)
+        // won't look up correctly here, since `palette_completions` uses
+        // `split_whitespace` rather than `tokenize_palette_input`. Acceptable at
+        // MVP scale — convoy ids are slug-style. Enter-dispatch goes through
+        // `parse_palette_input` (which uses the quote-aware tokenizer), so the
+        // command itself dispatches correctly even when completions don't fire.
         let convoy_id = tokens[1];
         if tokens.len() == 3 && trailing_space {
             return convoy_task_completions(convoy_id, "", namespaces);

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -111,6 +111,27 @@ pub struct Token {
 ///
 /// Returns tokens with their byte offsets in the original input, enabling
 /// prefix slicing for Tab completion.
+/// Quote a palette token if it contains whitespace, quotes, or backslashes.
+/// Inverse of the tokenizer: round-trips arbitrary identifier strings (including
+/// those with spaces) through the palette grammar without breaking subsequent
+/// parses or completions.
+pub fn quote_palette_token(s: &str) -> String {
+    let needs_quoting = s.is_empty() || s.chars().any(|c| c.is_whitespace() || c == '"' || c == '\'' || c == '\\');
+    if !needs_quoting {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        if c == '"' || c == '\\' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
+}
+
 pub fn tokenize_palette_input(input: &str) -> Result<Vec<Token>, String> {
     let mut tokens = Vec::new();
     let mut current = String::new();
@@ -262,19 +283,15 @@ pub fn palette_completions(
 
     // `convoy <id> task <Tab>` and `convoy <id> task <partial>`: complete with
     // task names from the named convoy. The clap tree treats the task subject as
-    // a free-form positional and would otherwise return nothing.
+    // a free-form positional and would otherwise return nothing. Past the task
+    // subject we fall through to the clap walker for verbs (`complete` etc.).
     if noun_name == "convoy" && tokens.len() >= 3 && tokens[2] == "task" {
         let convoy_id = tokens[1];
-        let partial = if tokens.len() == 3 && trailing_space {
-            ""
-        } else if tokens.len() == 4 && !trailing_space {
-            tokens[3]
-        } else {
-            // We're past the task subject — fall through to the clap walker for verbs.
-            ""
-        };
-        if tokens.len() == 3 || (tokens.len() == 4 && !trailing_space) {
-            return convoy_task_completions(convoy_id, partial, namespaces);
+        if tokens.len() == 3 && trailing_space {
+            return convoy_task_completions(convoy_id, "", namespaces);
+        }
+        if tokens.len() == 4 && !trailing_space {
+            return convoy_task_completions(convoy_id, tokens[3], namespaces);
         }
     }
 
@@ -1109,5 +1126,35 @@ mod tests {
         let completions = palette_completions("convoy fix-bug-123 task implement ", &model, &namespaces, true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"complete"), "expected 'complete' verb in {values:?}");
+    }
+
+    #[test]
+    fn quote_palette_token_passes_simple_identifiers_through() {
+        assert_eq!(quote_palette_token("fix-bug-123"), "fix-bug-123");
+        assert_eq!(quote_palette_token("implement"), "implement");
+    }
+
+    #[test]
+    fn quote_palette_token_quotes_whitespace() {
+        assert_eq!(quote_palette_token("fix my bug"), "\"fix my bug\"");
+    }
+
+    #[test]
+    fn quote_palette_token_escapes_embedded_quotes_and_backslashes() {
+        assert_eq!(quote_palette_token("a\"b"), "\"a\\\"b\"");
+        assert_eq!(quote_palette_token("a\\b"), "\"a\\\\b\"");
+    }
+
+    #[test]
+    fn quote_palette_token_round_trips_through_tokenizer() {
+        // Round-trip property: quote(s) tokenizes back to a single token equal to s.
+        // Empty strings are not a valid resource name and are not exercised here —
+        // the tokenizer drops empty-quoted tokens, which is fine for that case.
+        for s in ["fix-bug-123", "implement", "fix my bug", "name with \"quote\"", "back\\slash"] {
+            let quoted = quote_palette_token(s);
+            let tokens = tokenize_palette_input(&quoted).expect("tokenize");
+            assert_eq!(tokens.len(), 1, "quoted {quoted:?} should tokenize to one token");
+            assert_eq!(tokens[0].value, s, "round-trip for {s:?} via {quoted:?}");
+        }
     }
 }

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -211,7 +211,12 @@ const REPO_SCOPED_NOUNS: &[&str] = &["checkout", "cr", "issue", "agent", "worksp
 /// - Noun + space: subject completions from model
 /// - Noun + subject + space: verb completions from clap tree
 /// - Palette-local command + space: argument completions
-pub fn palette_completions(input: &str, model: &TuiModel, has_repo_context: bool) -> Vec<PaletteCompletion> {
+pub fn palette_completions(
+    input: &str,
+    model: &TuiModel,
+    namespaces: &crate::app::NamespaceMap,
+    has_repo_context: bool,
+) -> Vec<PaletteCompletion> {
     let trailing_space = input.ends_with(' ');
     let tokens: Vec<&str> = input.split_whitespace().collect();
 
@@ -242,17 +247,35 @@ pub fn palette_completions(input: &str, model: &TuiModel, has_repo_context: bool
     // tokens[0] = noun, tokens[1..] = rest
     if tokens.len() == 1 && trailing_space {
         // Noun typed with trailing space: show subjects from model.
-        return subject_completions(&noun_name, "", model);
+        return subject_completions(&noun_name, "", model, namespaces);
     }
 
     if tokens.len() == 2 && !trailing_space {
         // Partial subject: filter subjects.
-        return subject_completions(&noun_name, tokens[1], model);
+        return subject_completions(&noun_name, tokens[1], model, namespaces);
     }
 
     if tokens.len() == 2 && trailing_space {
         // Noun + subject + space: show verbs from clap tree.
         return verb_completions(&noun_name, "");
+    }
+
+    // `convoy <id> task <Tab>` and `convoy <id> task <partial>`: complete with
+    // task names from the named convoy. The clap tree treats the task subject as
+    // a free-form positional and would otherwise return nothing.
+    if noun_name == "convoy" && tokens.len() >= 3 && tokens[2] == "task" {
+        let convoy_id = tokens[1];
+        let partial = if tokens.len() == 3 && trailing_space {
+            ""
+        } else if tokens.len() == 4 && !trailing_space {
+            tokens[3]
+        } else {
+            // We're past the task subject — fall through to the clap walker for verbs.
+            ""
+        };
+        if tokens.len() == 3 || (tokens.len() == 4 && !trailing_space) {
+            return convoy_task_completions(convoy_id, partial, namespaces);
+        }
     }
 
     if tokens.len() >= 3 {
@@ -267,6 +290,20 @@ pub fn palette_completions(input: &str, model: &TuiModel, has_repo_context: bool
     }
 
     vec![]
+}
+
+/// Task-name completions for `convoy <id> task <Tab>` / partial.
+fn convoy_task_completions(convoy_id: &str, partial: &str, namespaces: &crate::app::NamespaceMap) -> Vec<PaletteCompletion> {
+    // Single-namespace MVP: search the "flotilla" namespace.
+    let lower = partial.to_lowercase();
+    let Some(model) = namespaces.get("flotilla") else { return vec![] };
+    let Some(convoy) = model.convoys.values().find(|c| c.id.name() == convoy_id) else { return vec![] };
+    convoy
+        .tasks
+        .iter()
+        .filter(|t| lower.is_empty() || t.name.to_lowercase().starts_with(&lower))
+        .map(|t| PaletteCompletion { value: t.name.clone(), description: format!("{:?}", t.phase), key_hint: None })
+        .collect()
 }
 
 /// Completions at the root level: noun names, aliases, and palette-local entries.
@@ -345,9 +382,16 @@ fn resolve_noun_name(token: &str) -> Option<String> {
 }
 
 /// Subject completions for a given noun, drawn from model data.
-fn subject_completions(noun: &str, partial: &str, model: &TuiModel) -> Vec<PaletteCompletion> {
+fn subject_completions(noun: &str, partial: &str, model: &TuiModel, namespaces: &crate::app::NamespaceMap) -> Vec<PaletteCompletion> {
     let lower = partial.to_lowercase();
     let items: Vec<(String, String)> = match noun {
+        "convoy" => {
+            // Single-namespace MVP: list convoys in "flotilla".
+            namespaces
+                .get("flotilla")
+                .map(|m| m.convoys.values().map(|c| (c.id.name().to_string(), format!("{:?}", c.phase))).collect::<Vec<(String, String)>>())
+                .unwrap_or_default()
+        }
         "checkout" => {
             if let Some(repo) = model.active_opt() {
                 repo.providers.checkouts.values().map(|c| (c.branch.clone(), String::new())).collect()
@@ -727,6 +771,44 @@ mod tests {
 
     use crate::app::test_builders::repo_info;
 
+    fn namespaces_with_convoy(name: &str, tasks: &[&str]) -> crate::app::NamespaceMap {
+        use flotilla_protocol::namespace::{ConvoyId, ConvoyPhase, ConvoySummary, TaskPhase, TaskSummary};
+        let convoy = ConvoySummary {
+            id: ConvoyId::new("flotilla", name),
+            namespace: "flotilla".into(),
+            name: name.into(),
+            workflow_ref: "wf".into(),
+            phase: ConvoyPhase::Active,
+            message: None,
+            repo_hint: None,
+            tasks: tasks
+                .iter()
+                .map(|t| TaskSummary {
+                    name: (*t).into(),
+                    depends_on: vec![],
+                    phase: TaskPhase::Pending,
+                    processes: vec![],
+                    host: None,
+                    checkout: None,
+                    workspace_ref: None,
+                    ready_at: None,
+                    started_at: None,
+                    finished_at: None,
+                    message: None,
+                })
+                .collect(),
+            started_at: None,
+            finished_at: None,
+            observed_workflow_ref: None,
+            initializing: false,
+        };
+        let mut model = crate::app::NamespaceModel::default();
+        model.convoys.insert(convoy.id.clone(), convoy);
+        let mut map = crate::app::NamespaceMap::default();
+        map.insert("flotilla".into(), model);
+        map
+    }
+
     fn empty_model() -> TuiModel {
         TuiModel::from_repo_info(vec![repo_info("/tmp/test-repo", "test-repo", RepoLabels::default())])
     }
@@ -795,7 +877,7 @@ mod tests {
     #[test]
     fn empty_input_shows_nouns_and_local_commands() {
         let model = empty_model();
-        let completions = palette_completions("", &model, true);
+        let completions = palette_completions("", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"cr"), "expected 'cr' in {values:?}");
         assert!(values.contains(&"checkout"), "expected 'checkout' in {values:?}");
@@ -807,7 +889,7 @@ mod tests {
     #[test]
     fn overview_tab_excludes_repo_scoped_nouns() {
         let model = empty_model();
-        let completions = palette_completions("", &model, false);
+        let completions = palette_completions("", &model, &Default::default(), false);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"host"), "expected 'host' in {values:?}");
         assert!(values.contains(&"layout"), "expected 'layout' in {values:?}");
@@ -821,7 +903,7 @@ mod tests {
     #[test]
     fn partial_noun_filters() {
         let model = empty_model();
-        let completions = palette_completions("cr", &model, true);
+        let completions = palette_completions("cr", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"cr"), "expected 'cr' in {values:?}");
         assert!(!values.contains(&"checkout"), "checkout should be filtered out by 'cr' prefix");
@@ -830,7 +912,7 @@ mod tests {
     #[test]
     fn noun_typed_shows_subjects_from_model() {
         let model = model_with_crs();
-        let completions = palette_completions("cr ", &model, true);
+        let completions = palette_completions("cr ", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"42"), "expected '42' in {values:?}");
         assert!(values.contains(&"99"), "expected '99' in {values:?}");
@@ -839,7 +921,7 @@ mod tests {
     #[test]
     fn noun_subject_shows_verbs() {
         let model = empty_model();
-        let completions = palette_completions("cr 42 ", &model, true);
+        let completions = palette_completions("cr 42 ", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"open"), "expected 'open' in {values:?}");
         assert!(values.contains(&"close"), "expected 'close' in {values:?}");
@@ -848,7 +930,7 @@ mod tests {
     #[test]
     fn layout_shows_values() {
         let model = empty_model();
-        let completions = palette_completions("layout ", &model, true);
+        let completions = palette_completions("layout ", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"zoom"), "expected 'zoom' in {values:?}");
         assert!(values.contains(&"auto"), "expected 'auto' in {values:?}");
@@ -859,7 +941,7 @@ mod tests {
     #[test]
     fn host_typed_shows_host_names() {
         let model = model_with_hosts();
-        let completions = palette_completions("host ", &model, true);
+        let completions = palette_completions("host ", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"feta"), "expected 'feta' in {values:?}");
         assert!(values.contains(&"brie"), "expected 'brie' in {values:?}");
@@ -868,7 +950,7 @@ mod tests {
     #[test]
     fn environment_typed_shows_host_and_nested_environment_ids() {
         let model = model_with_rich_hosts();
-        let completions = palette_completions("environment ", &model, true);
+        let completions = palette_completions("environment ", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"host:feta-env"), "expected host environment id in {values:?}");
         assert!(values.contains(&"host:brie-env"), "expected host environment id in {values:?}");
@@ -878,7 +960,7 @@ mod tests {
     #[test]
     fn pr_alias_appears_in_root_completions() {
         let model = empty_model();
-        let completions = palette_completions("pr", &model, true);
+        let completions = palette_completions("pr", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"pr"), "expected 'pr' alias in {values:?}");
     }
@@ -886,7 +968,7 @@ mod tests {
     #[test]
     fn repo_noun_visible_at_root() {
         let model = empty_model();
-        let completions = palette_completions("", &model, true);
+        let completions = palette_completions("", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"repo"), "expected 'repo' in {values:?}");
     }
@@ -894,7 +976,7 @@ mod tests {
     #[test]
     fn layout_partial_arg_filters() {
         let model = empty_model();
-        let completions = palette_completions("layout z", &model, true);
+        let completions = palette_completions("layout z", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert_eq!(values, vec!["zoom"]);
     }
@@ -941,7 +1023,7 @@ mod tests {
     #[test]
     fn target_shows_bare_hosts() {
         let model = model_with_hosts();
-        let completions = palette_completions("target ", &model, true);
+        let completions = palette_completions("target ", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"@feta"), "expected '@feta' in {values:?}");
         assert!(values.contains(&"@brie"), "expected '@brie' in {values:?}");
@@ -950,7 +1032,7 @@ mod tests {
     #[test]
     fn target_shows_environment_providers_and_existing_envs() {
         let model = model_with_rich_hosts();
-        let completions = palette_completions("target ", &model, true);
+        let completions = palette_completions("target ", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
 
         // Bare hosts always present.
@@ -970,7 +1052,7 @@ mod tests {
     #[test]
     fn target_partial_filters() {
         let model = model_with_rich_hosts();
-        let completions = palette_completions("target @f", &model, true);
+        let completions = palette_completions("target @f", &model, &Default::default(), true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"@feta"), "expected '@feta' in {values:?}");
         assert!(!values.contains(&"@brie"), "@brie should be filtered by '@f' prefix");
@@ -979,7 +1061,53 @@ mod tests {
     #[test]
     fn target_no_completions_without_hosts() {
         let model = empty_model();
-        let completions = palette_completions("target ", &model, true);
+        let completions = palette_completions("target ", &model, &Default::default(), true);
         assert!(completions.is_empty(), "expected no completions with no hosts");
+    }
+
+    #[test]
+    fn convoy_subjects_listed_after_noun_space() {
+        let model = empty_model();
+        let namespaces = namespaces_with_convoy("fix-bug-123", &["implement", "review"]);
+        let completions = palette_completions("convoy ", &model, &namespaces, true);
+        let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
+        assert!(values.contains(&"fix-bug-123"), "expected convoy id in completions: {values:?}");
+    }
+
+    #[test]
+    fn convoy_subjects_filter_by_partial() {
+        let model = empty_model();
+        let namespaces = namespaces_with_convoy("fix-bug-123", &[]);
+        let completions = palette_completions("convoy fix", &model, &namespaces, true);
+        let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
+        assert_eq!(values, vec!["fix-bug-123"]);
+    }
+
+    #[test]
+    fn convoy_task_names_listed_after_task_keyword() {
+        let model = empty_model();
+        let namespaces = namespaces_with_convoy("fix-bug-123", &["implement", "review"]);
+        let completions = palette_completions("convoy fix-bug-123 task ", &model, &namespaces, true);
+        let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
+        assert!(values.contains(&"implement"), "expected 'implement' in {values:?}");
+        assert!(values.contains(&"review"), "expected 'review' in {values:?}");
+    }
+
+    #[test]
+    fn convoy_task_names_filter_by_partial() {
+        let model = empty_model();
+        let namespaces = namespaces_with_convoy("fix-bug-123", &["implement", "review"]);
+        let completions = palette_completions("convoy fix-bug-123 task imp", &model, &namespaces, true);
+        let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
+        assert_eq!(values, vec!["implement"]);
+    }
+
+    #[test]
+    fn convoy_task_complete_verb_completes_after_task_subject() {
+        let model = empty_model();
+        let namespaces = namespaces_with_convoy("fix-bug-123", &["implement"]);
+        let completions = palette_completions("convoy fix-bug-123 task implement ", &model, &namespaces, true);
+        let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
+        assert!(values.contains(&"complete"), "expected 'complete' verb in {values:?}");
     }
 }

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -148,6 +148,8 @@ fn render_frame(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Resul
     terminal.draw(|f| {
         let area = f.area();
         let convoys_selected = app.convoys_ui.selected.clone();
+        let convoys_selected_task = app.convoys_ui.selected_task.as_deref();
+        let convoys_focus = app.convoys_ui.focus;
         let convoy_filter = app.convoys_ui.filter.as_str();
         // Single-namespace MVP: all convoys live in "flotilla". Multi-namespace
         // support will need a namespace scoping concept on ConvoysUiState —
@@ -164,6 +166,8 @@ fn render_frame(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Resul
             in_flight: &app.in_flight,
             namespaces: &app.namespaces,
             convoys_selected,
+            convoys_selected_task,
+            convoys_focus,
             convoy_filter,
             convoys,
         };

--- a/crates/flotilla-tui/src/widgets/command_palette.rs
+++ b/crates/flotilla-tui/src/widgets/command_palette.rs
@@ -74,13 +74,18 @@ impl CommandPaletteWidget {
         Self { input: Input::from(text.as_ref()), entries: palette::all_entries(), selected: 0, scroll_top: 0, source_item: item }
     }
 
+    /// Current input text (for tests / introspection).
+    pub fn input_value(&self) -> &str {
+        self.input.value()
+    }
+
     fn filtered(&self) -> Vec<&'static PaletteEntry> {
         palette::filter_entries(self.entries, self.input.value())
     }
 
     /// Compute position-aware completions using model context.
-    fn completions(&self, model: &TuiModel, has_repo_context: bool) -> Vec<PaletteCompletion> {
-        palette::palette_completions(self.input.value(), model, has_repo_context)
+    fn completions(&self, model: &TuiModel, namespaces: &crate::app::NamespaceMap, has_repo_context: bool) -> Vec<PaletteCompletion> {
+        palette::palette_completions(self.input.value(), model, namespaces, has_repo_context)
     }
 
     /// Fill the selected completion value into the input, appending to the
@@ -450,7 +455,7 @@ impl InteractiveWidget for CommandPaletteWidget {
         let has_repo_context = !*ctx.is_config;
         match action {
             Action::SelectNext => {
-                let count = self.completions(ctx.model, has_repo_context).len();
+                let count = self.completions(ctx.model, ctx.namespaces, has_repo_context).len();
                 if count > 0 {
                     self.selected = (self.selected + 1) % count;
                     self.adjust_scroll();
@@ -458,7 +463,7 @@ impl InteractiveWidget for CommandPaletteWidget {
                 Outcome::Consumed
             }
             Action::SelectPrev => {
-                let count = self.completions(ctx.model, has_repo_context).len();
+                let count = self.completions(ctx.model, ctx.namespaces, has_repo_context).len();
                 if count > 0 {
                     self.selected = if self.selected == 0 { count - 1 } else { self.selected - 1 };
                     self.adjust_scroll();
@@ -468,7 +473,7 @@ impl InteractiveWidget for CommandPaletteWidget {
             Action::Confirm => self.confirm(ctx),
             Action::Dismiss => Outcome::Finished,
             Action::FillSelected => {
-                let completions = self.completions(ctx.model, has_repo_context);
+                let completions = self.completions(ctx.model, ctx.namespaces, has_repo_context);
                 if let Some(completion) = completions.get(self.selected) {
                     self.fill_completion(completion);
                 }
@@ -482,7 +487,7 @@ impl InteractiveWidget for CommandPaletteWidget {
         let has_repo_context = !*ctx.is_config;
         // Right arrow: fill selected completion into input (Tab goes through handle_action)
         if matches!(key.code, KeyCode::Right) {
-            let completions = self.completions(ctx.model, has_repo_context);
+            let completions = self.completions(ctx.model, ctx.namespaces, has_repo_context);
             if let Some(completion) = completions.get(self.selected) {
                 self.fill_completion(completion);
             }
@@ -512,7 +517,7 @@ impl InteractiveWidget for CommandPaletteWidget {
     fn render(&mut self, frame: &mut Frame, _area: Rect, ctx: &mut RenderContext) {
         let theme = ctx.theme;
         let has_repo_context = !ctx.ui.is_config;
-        let completions = self.completions(ctx.model, has_repo_context);
+        let completions = self.completions(ctx.model, ctx.namespaces, has_repo_context);
         let overlay = crate::ui_helpers::bottom_anchored_overlay(frame.area(), 1, MAX_PALETTE_ROWS as u16);
         let area = overlay.body;
 
@@ -618,7 +623,7 @@ mod tests {
     fn select_next_wraps_around() {
         let mut widget = CommandPaletteWidget::new();
         let mut harness = TestWidgetHarness::new();
-        let total = widget.completions(&harness.model, true).len();
+        let total = widget.completions(&harness.model, &harness.namespaces, true).len();
 
         // Advance to end
         for _ in 0..total - 1 {
@@ -637,7 +642,7 @@ mod tests {
     fn select_prev_wraps_around() {
         let mut widget = CommandPaletteWidget::new();
         let mut harness = TestWidgetHarness::new();
-        let total = widget.completions(&harness.model, true).len();
+        let total = widget.completions(&harness.model, &harness.namespaces, true).len();
 
         // Prev from 0 wraps to end
         let mut ctx = harness.ctx();
@@ -651,7 +656,7 @@ mod tests {
         let mut harness = TestWidgetHarness::new();
 
         // Get the first completion value to verify fill works
-        let first_value = widget.completions(&harness.model, true)[0].value.clone();
+        let first_value = widget.completions(&harness.model, &harness.namespaces, true)[0].value.clone();
 
         let mut ctx = harness.ctx();
         let outcome = widget.handle_action(Action::FillSelected, &mut ctx);

--- a/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
@@ -3,6 +3,7 @@
 use flotilla_protocol::namespace::ConvoySummary;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
     Frame,
@@ -13,11 +14,15 @@ use super::glyphs::{convoy_glyph, task_glyph};
 
 pub struct ConvoyDetail<'a> {
     pub convoy: &'a ConvoySummary,
+    pub selected_task: Option<&'a str>,
+    pub focused: bool,
 }
 
 impl<'a> ConvoyDetail<'a> {
     pub fn render(&self, f: &mut Frame, area: Rect) {
         let chunks = Layout::default().direction(Direction::Vertical).constraints([Constraint::Length(3), Constraint::Min(0)]).split(area);
+
+        let border_style = if self.focused { Style::default().add_modifier(Modifier::BOLD) } else { Style::default() };
 
         // Header
         let glyph = convoy_glyph(self.convoy.phase);
@@ -26,11 +31,11 @@ impl<'a> ConvoyDetail<'a> {
             Span::raw(format!(" {} ", self.convoy.name)),
             Span::raw(format!("[{}]", self.convoy.workflow_ref)),
         ]))
-        .block(Block::default().borders(Borders::ALL));
+        .block(Block::default().borders(Borders::ALL).border_style(border_style));
         f.render_widget(header, chunks[0]);
 
         // Body: task tree OR initializing placeholder
-        let body_block = Block::default().borders(Borders::ALL).title(" Tasks ");
+        let body_block = Block::default().borders(Borders::ALL).border_style(border_style).title(" Tasks ");
         let body_area = chunks[1];
         if self.convoy.initializing {
             let p = Paragraph::new("initializing…").block(body_block);
@@ -50,10 +55,17 @@ impl<'a> ConvoyDetail<'a> {
             })
             .collect();
 
-        // TODO(task-attach): lift tree expansion state into ConvoysUiState once
-        // tree interaction (expand/collapse) lands with the task-attach PR.
+        // TreeState is built from `selected_task` on every render. Selection lives
+        // in `ConvoysUiState` (the source of truth); expansion isn't needed because
+        // tasks render as flat leaves today. Lift TreeState if we get nested tasks.
         let mut state = TreeState::default();
-        let tree = Tree::new(&items).expect("unique task names").block(body_block);
+        if let Some(name) = self.selected_task {
+            state.select(vec![name.to_string()]);
+        }
+        let tree = Tree::new(&items)
+            .expect("unique task names")
+            .block(body_block)
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
         f.render_stateful_widget(tree, body_area, &mut state);
     }
 }
@@ -115,10 +127,26 @@ mod tests {
         let convoy = multi_task_convoy();
         terminal
             .draw(|f| {
-                ConvoyDetail { convoy: &convoy }.render(f, f.area());
+                ConvoyDetail { convoy: &convoy, selected_task: None, focused: false }.render(f, f.area());
             })
             .unwrap();
         insta::assert_snapshot!(terminal.backend());
+    }
+
+    #[test]
+    fn convoy_detail_with_selected_task_renders() {
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        let convoy = multi_task_convoy();
+        terminal
+            .draw(|f| {
+                ConvoyDetail { convoy: &convoy, selected_task: Some("review"), focused: true }.render(f, f.area());
+            })
+            .unwrap();
+        let rendered: String = terminal.backend().buffer().content().iter().map(|c| c.symbol()).collect();
+        // Both task names should appear; selection is style-only so the buffer
+        // content check is for parity with the unselected snapshot.
+        assert!(rendered.contains("implement"), "expected 'implement' task in render: {rendered}");
+        assert!(rendered.contains("review"), "expected 'review' task in render: {rendered}");
     }
 
     #[test]
@@ -129,7 +157,7 @@ mod tests {
         convoy.tasks.clear();
         terminal
             .draw(|f| {
-                ConvoyDetail { convoy: &convoy }.render(f, f.area());
+                ConvoyDetail { convoy: &convoy, selected_task: None, focused: false }.render(f, f.area());
             })
             .unwrap();
         insta::assert_snapshot!(terminal.backend());

--- a/crates/flotilla-tui/src/widgets/convoys_page/list.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/list.rs
@@ -14,6 +14,7 @@ use super::glyphs::convoy_glyph;
 pub struct ConvoyList<'a> {
     pub convoys: &'a [&'a ConvoySummary],
     pub selected: Option<&'a ConvoyId>,
+    pub focused: bool,
 }
 
 impl<'a> ConvoyList<'a> {
@@ -35,7 +36,8 @@ impl<'a> ConvoyList<'a> {
                 ]))
             })
             .collect();
-        let block = Block::default().borders(Borders::ALL).title(" Convoys ");
+        let border_style = if self.focused { Style::default().add_modifier(Modifier::BOLD) } else { Style::default() };
+        let block = Block::default().borders(Borders::ALL).border_style(border_style).title(" Convoys ");
         f.render_widget(List::new(items).block(block), area);
     }
 }
@@ -73,7 +75,7 @@ mod tests {
         let convoys: Vec<&ConvoySummary> = vec![&a, &b, &c];
         terminal
             .draw(|f| {
-                ConvoyList { convoys: &convoys, selected: Some(&a.id) }.render(f, f.area());
+                ConvoyList { convoys: &convoys, selected: Some(&a.id), focused: true }.render(f, f.area());
             })
             .unwrap();
         insta::assert_snapshot!(terminal.backend());

--- a/crates/flotilla-tui/src/widgets/convoys_page/mod.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/mod.rs
@@ -20,6 +20,8 @@ use ratatui::{
 pub struct ConvoysPage<'a> {
     pub convoys: Vec<&'a ConvoySummary>,
     pub selected: Option<&'a ConvoyId>,
+    pub selected_task: Option<&'a str>,
+    pub focus: crate::app::ConvoysFocus,
     pub filter: &'a str,
 }
 
@@ -36,10 +38,11 @@ impl<'a> ConvoysPage<'a> {
             .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
             .split(area);
 
-        ConvoyList { convoys: self.convoys.as_slice(), selected: self.selected }.render(f, chunks[0]);
+        let list_focused = matches!(self.focus, crate::app::ConvoysFocus::List);
+        ConvoyList { convoys: self.convoys.as_slice(), selected: self.selected, focused: list_focused }.render(f, chunks[0]);
         if let Some(id) = self.selected {
             if let Some(convoy) = self.convoys.iter().find(|c| &c.id == id) {
-                ConvoyDetail { convoy }.render(f, chunks[1]);
+                ConvoyDetail { convoy, selected_task: self.selected_task, focused: !list_focused }.render(f, chunks[1]);
             }
         }
     }

--- a/crates/flotilla-tui/src/widgets/mod.rs
+++ b/crates/flotilla-tui/src/widgets/mod.rs
@@ -112,6 +112,8 @@ pub struct WidgetContext<'a> {
     /// Whether the Convoys tab is currently active.
     pub is_convoys: bool,
     pub active_repo_is_remote_only: bool,
+    /// Per-namespace convoy model — used by the command palette for convoy/task completions.
+    pub namespaces: &'a crate::app::NamespaceMap,
     pub app_actions: Vec<AppAction>,
 }
 
@@ -129,6 +131,10 @@ pub struct RenderContext<'a> {
     pub namespaces: &'a crate::app::NamespaceMap,
     /// Currently selected convoy id for the Convoys tab.
     pub convoys_selected: Option<flotilla_protocol::namespace::ConvoyId>,
+    /// Currently selected task name within the selected convoy, if any.
+    pub convoys_selected_task: Option<&'a str>,
+    /// Which pane (list / tasks) currently has focus on the Convoys tab.
+    pub convoys_focus: crate::app::ConvoysFocus,
     /// Active filter string for the Convoys tab.
     pub convoy_filter: &'a str,
     /// Pre-filtered convoy list for the Convoys tab.

--- a/crates/flotilla-tui/src/widgets/overview_page.rs
+++ b/crates/flotilla-tui/src/widgets/overview_page.rs
@@ -145,6 +145,8 @@ mod tests {
                     in_flight: &in_flight,
                     namespaces: &empty_namespaces,
                     convoys_selected: None,
+                    convoys_selected_task: None,
+                    convoys_focus: crate::app::ConvoysFocus::List,
                     convoy_filter: "",
                     convoys: vec![],
                 };

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -325,7 +325,14 @@ impl InteractiveWidget for Screen {
         let active_identity = self.active_repo_identity(&ctx.model.repo_order, ctx.model.active_repo, is_config, is_convoys).cloned();
         if is_convoys {
             let selected = ctx.convoys_selected.as_ref();
-            ConvoysPage { convoys: ctx.convoys.clone(), selected, filter: ctx.convoy_filter }.render(frame, chunks[1]);
+            ConvoysPage {
+                convoys: ctx.convoys.clone(),
+                selected,
+                selected_task: ctx.convoys_selected_task,
+                focus: ctx.convoys_focus,
+                filter: ctx.convoy_filter,
+            }
+            .render(frame, chunks[1]);
         } else if let Some(ref identity) = active_identity {
             if let Some(page) = self.repo_pages.get_mut(identity) {
                 page.render(frame, chunks[1], ctx);

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -15,7 +15,10 @@ use flotilla_core::{
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::HostName;
-use flotilla_resources::{Convoy, ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend};
+use flotilla_resources::{
+    apply_status_patch, controller_patches, Convoy, ConvoyPhase, ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend, SnapshotTask,
+    TaskPhase, TaskState, WorkflowSnapshot,
+};
 use flotilla_tui::{app::App, theme::Theme};
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -110,4 +113,127 @@ async fn tui_shows_convoys_from_daemon() {
     let convoy_list = app.convoys("flotilla");
     assert_eq!(convoy_list.len(), 1, "expected exactly one convoy; got {convoy_list:?}");
     assert_eq!(convoy_list[0].name, "my-convoy", "convoy name mismatch");
+}
+
+#[tokio::test]
+async fn x_then_enter_completes_task_via_palette() {
+    use std::collections::BTreeMap;
+
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+
+    let mut daemon_rx = daemon.subscribe();
+
+    let options = RuntimeOptions {
+        namespace: "flotilla".to_string(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_secs(300),
+        start_controllers: true,
+    };
+    let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
+
+    let daemon_handle: Arc<dyn DaemonHandle> = Arc::clone(&daemon) as Arc<dyn DaemonHandle>;
+    let repos = daemon_handle.list_repos().await.expect("list repos");
+    let tui_config = Arc::new(ConfigStore::with_base(tmp.path().join("tui-config")));
+    let mut app = App::new(Arc::clone(&daemon_handle), repos, tui_config, Theme::classic());
+
+    for event in daemon_handle.replay_since(&HashMap::new()).await.expect("replay_since") {
+        app.handle_daemon_event(event);
+    }
+
+    // Create a convoy and bootstrap its status so it has a task ready for completion.
+    let convoys = backend.using::<Convoy>("flotilla");
+    convoys.create(&convoy_meta("fix-bug-123"), &convoy_spec("review-and-fix")).await.expect("create convoy");
+
+    let mut tasks = BTreeMap::new();
+    tasks.insert("implement".to_string(), TaskState {
+        phase: TaskPhase::Pending,
+        ready_at: None,
+        started_at: None,
+        finished_at: None,
+        message: None,
+        placement: None,
+    });
+    let snapshot = WorkflowSnapshot { tasks: vec![SnapshotTask { name: "implement".into(), depends_on: vec![], processes: vec![] }] };
+    apply_status_patch(
+        &convoys,
+        "fix-bug-123",
+        &controller_patches::bootstrap(snapshot, "review-and-fix".into(), BTreeMap::new(), tasks, ConvoyPhase::Active, None),
+    )
+    .await
+    .expect("bootstrap convoy");
+
+    // Drain events until the convoy's task appears in the App.
+    let drain = |app: &mut App, daemon_rx: &mut tokio::sync::broadcast::Receiver<flotilla_protocol::DaemonEvent>| loop {
+        match daemon_rx.try_recv() {
+            Ok(event) => app.handle_daemon_event(event),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(n)) => panic!("lagged by {n}"),
+            Err(tokio::sync::broadcast::error::TryRecvError::Closed) => panic!("closed"),
+        }
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        drain(&mut app, &mut daemon_rx);
+        if app.convoys("flotilla").iter().any(|c| !c.tasks.is_empty()) {
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for convoy task to appear in app: {:?}", app.convoys("flotilla"));
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Switch the TUI into the Convoys tab and drive the keybinding flow.
+    app.ui.is_config = false;
+    app.ui.is_convoys = true;
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty())
+    }
+    fn enter() -> KeyEvent {
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::empty())
+    }
+
+    app.handle_key(key('l')); // drill into task focus
+    app.handle_key(key('x')); // open palette pre-filled
+    app.handle_key(enter()); // confirm — dispatch ConvoyTaskComplete
+
+    // Dispatch the queued command through the daemon.
+    let mut took_one = false;
+    while let Some((cmd, pending_ctx)) = app.proto_commands.take_next() {
+        flotilla_tui::app::executor::dispatch(cmd, &mut app, pending_ctx).await;
+        took_one = true;
+    }
+    assert!(took_one, "expected at least one command to be dispatched after Enter");
+
+    // Wait for TaskPhase::Completed to land back in the app via NamespaceDelta.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        drain(&mut app, &mut daemon_rx);
+        if let Some(c) = app.convoys("flotilla").first() {
+            if let Some(t) = c.tasks.iter().find(|t| t.name == "implement") {
+                if t.phase == flotilla_protocol::namespace::TaskPhase::Completed {
+                    break;
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out: task did not transition to Completed in app: {:?}", app.convoys("flotilla"));
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
 }

--- a/crates/flotilla-tui/tests/support/high_fidelity.rs
+++ b/crates/flotilla-tui/tests/support/high_fidelity.rs
@@ -354,6 +354,8 @@ impl HighFidelityHarness {
         let mut terminal = Terminal::new(backend).expect("create test terminal");
         let theme = self.app.theme.clone();
         let convoys_selected = self.app.convoys_ui.selected.clone();
+        let convoys_selected_task = self.app.convoys_ui.selected_task.clone();
+        let convoys_focus = self.app.convoys_ui.focus;
         let convoy_filter_str = self.app.convoys_ui.filter.clone();
         terminal
             .draw(|frame| {
@@ -368,6 +370,8 @@ impl HighFidelityHarness {
                     in_flight: &self.app.in_flight,
                     namespaces: &self.app.namespaces,
                     convoys_selected,
+                    convoys_selected_task: convoys_selected_task.as_deref(),
+                    convoys_focus,
                     convoy_filter: &convoy_filter_str,
                     convoys,
                 };

--- a/crates/flotilla-tui/tests/support/mod.rs
+++ b/crates/flotilla-tui/tests/support/mod.rs
@@ -187,6 +187,8 @@ impl TestHarness {
                     in_flight: &self.in_flight,
                     namespaces: &empty_namespaces,
                     convoys_selected: None,
+                    convoys_selected_task: None,
+                    convoys_focus: flotilla_tui::app::ConvoysFocus::List,
                     convoy_filter: "",
                     convoys: vec![],
                 };


### PR DESCRIPTION
## Summary

Stage 6 PR 2: wire `x` on the Convoys tab to complete the selected task by opening the command palette pre-filled with the existing `convoy <id> task <name> complete` noun-verb command. The palette is the action surface — no bespoke confirm widget.

- Convoys tab gains nested focus. `j/k/up/down` move within the focused pane; `enter/l/right` drill from the convoy list into the task tree; `esc/left` returns. Bindings match the rest of the app (vim + arrow keys both work).
- `x` in the task tree opens the palette pre-filled with `convoy <id> task <task> complete `; pressing Enter dispatches the existing `ConvoyTaskComplete` command.
- Palette gains native `convoy` subject completions (active convoys from the namespace state) and task-name completions after `convoy <id> task <Tab>`. Typing the command directly works on any tab.
- Border style indicates focused pane; selected task highlighted in the tree.
- Plumbs `selected_task`, `focus`, and `namespaces` through `RenderContext` / `WidgetContext` so the convoys page widgets and the palette completion path can read them.

## Test plan
- [x] 884 unit tests pass (`cargo test -p flotilla-tui --lib --locked`)
- [x] 2 E2E tests pass (`cargo test -p flotilla-tui --test convoy_view_e2e --locked`) — the new test drives a real `InProcessDaemon` end-to-end: bootstraps a convoy with a task, types `l → x → Enter`, and asserts `TaskPhase::Completed` propagates back to the TUI's namespace state via `NamespaceDelta`
- [x] Workspace tests pass (`cargo test --workspace --locked`)
- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`

Branched off `main` after PR #590 merged. Stage 6 PR 3 (task attach) depends on the per-task Presentation addendum (`docs/superpowers/specs/2026-04-22-per-task-presentation-design.md`) and is not blocked by this PR.