### PR TITLE
feat(resources): per-task Presentations from convoy reconciler

### DIFF
--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -495,21 +495,24 @@ fn cleanup_actuations(
 
     let mut actuations = Vec::new();
 
-    if predicted_status.phase == ConvoyPhase::Active && presentations.is_empty() {
-        actuations.push(create_presentation_actuation(convoy));
-    }
-
-    if matches!(predicted_status.phase, ConvoyPhase::Completed | ConvoyPhase::Failed | ConvoyPhase::Cancelled) && !presentations.is_empty()
-    {
-        actuations.extend(presentations.keys().cloned().map(|name| Actuation::DeletePresentation { name }));
-    }
-
     for (task, state) in &predicted_status.tasks {
-        if matches!(state.phase, TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled) {
-            let name = task_workspace_name(&convoy.metadata.name, task);
-            if task_workspaces.contains_key(&name) {
-                actuations.push(Actuation::DeleteTaskWorkspace { name });
+        let presentation = presentation_name(&convoy.metadata.name, task);
+        let workspace = task_workspace_name(&convoy.metadata.name, task);
+        match state.phase {
+            TaskPhase::Ready | TaskPhase::Launching | TaskPhase::Running => {
+                if !presentations.contains_key(&presentation) {
+                    actuations.push(create_presentation_actuation(convoy, task));
+                }
             }
+            TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled => {
+                if presentations.contains_key(&presentation) {
+                    actuations.push(Actuation::DeletePresentation { name: presentation });
+                }
+                if task_workspaces.contains_key(&workspace) {
+                    actuations.push(Actuation::DeleteTaskWorkspace { name: workspace });
+                }
+            }
+            TaskPhase::Pending => {}
         }
     }
 
@@ -553,11 +556,11 @@ fn create_task_workspace_outcome(convoy: &ResourceObject<Convoy>, task: &str, no
     })
 }
 
-fn create_presentation_actuation(convoy: &ResourceObject<Convoy>) -> Actuation {
+fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, task: &str) -> Actuation {
     Actuation::CreatePresentation {
         meta: InputMeta::builder()
-            .name(presentation_name(&convoy.metadata.name))
-            .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.metadata.name.clone())]))
+            .name(presentation_name(&convoy.metadata.name, task))
+            .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.metadata.name.clone()), (TASK_LABEL.to_string(), task.to_string())]))
             .owner_references(vec![OwnerReference {
                 api_version: format!("{}/{}", Convoy::API_PATHS.group, Convoy::API_PATHS.version),
                 kind: Convoy::API_PATHS.kind.to_string(),
@@ -570,8 +573,11 @@ fn create_presentation_actuation(convoy: &ResourceObject<Convoy>) -> Actuation {
             // Stage 4a always uses the built-in default policy. Threading a policy ref through
             // ConvoySpec remains follow-up work once convoys can choose among multiple layouts.
             presentation_policy_ref: "default".to_string(),
-            name: convoy.metadata.name.clone(),
-            process_selector: BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.metadata.name.clone())]),
+            name: task.to_string(),
+            process_selector: BTreeMap::from([
+                (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
+                (TASK_LABEL.to_string(), task.to_string()),
+            ]),
         },
     }
 }
@@ -625,8 +631,8 @@ fn task_workspace_name(convoy_name: &str, task: &str) -> String {
     format!("{convoy_name}-{task}")
 }
 
-fn presentation_name(convoy_name: &str) -> String {
-    format!("{convoy_name}-presentation")
+fn presentation_name(convoy_name: &str, task: &str) -> String {
+    format!("{convoy_name}-{task}")
 }
 
 async fn delete_matching<T: Resource>(resolver: &TypedResolver<T>, selector: &BTreeMap<String, String>) -> Result<(), ResourceError> {

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -408,7 +408,7 @@ fn task_workspace_outcome(
         let Some(state) = status.tasks.get(&task.name) else {
             continue;
         };
-        let workspace = task_workspaces.get(&task_workspace_name(&convoy.metadata.name, &task.name));
+        let workspace = task_workspaces.get(&per_task_resource_name(&convoy.metadata.name, &task.name));
         match state.phase {
             TaskPhase::Ready => {
                 if let Some(workspace) = workspace {
@@ -496,20 +496,19 @@ fn cleanup_actuations(
     let mut actuations = Vec::new();
 
     for (task, state) in &predicted_status.tasks {
-        let presentation = presentation_name(&convoy.metadata.name, task);
-        let workspace = task_workspace_name(&convoy.metadata.name, task);
+        let resource_name = per_task_resource_name(&convoy.metadata.name, task);
         match state.phase {
             TaskPhase::Ready | TaskPhase::Launching | TaskPhase::Running => {
-                if !presentations.contains_key(&presentation) {
+                if !presentations.contains_key(&resource_name) {
                     actuations.push(create_presentation_actuation(convoy, task));
                 }
             }
             TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled => {
-                if presentations.contains_key(&presentation) {
-                    actuations.push(Actuation::DeletePresentation { name: presentation });
+                if presentations.contains_key(&resource_name) {
+                    actuations.push(Actuation::DeletePresentation { name: resource_name.clone() });
                 }
-                if task_workspaces.contains_key(&workspace) {
-                    actuations.push(Actuation::DeleteTaskWorkspace { name: workspace });
+                if task_workspaces.contains_key(&resource_name) {
+                    actuations.push(Actuation::DeleteTaskWorkspace { name: resource_name });
                 }
             }
             TaskPhase::Pending => {}
@@ -537,7 +536,7 @@ fn create_task_workspace_outcome(convoy: &ResourceObject<Convoy>, task: &str, no
         patch: None,
         actuations: vec![Actuation::CreateTaskWorkspace {
             meta: crate::InputMeta::builder()
-                .name(task_workspace_name(&convoy.metadata.name, task))
+                .name(per_task_resource_name(&convoy.metadata.name, task))
                 .labels(BTreeMap::from([
                     (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
                     (TASK_LABEL.to_string(), task.to_string()),
@@ -559,7 +558,7 @@ fn create_task_workspace_outcome(convoy: &ResourceObject<Convoy>, task: &str, no
 fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, task: &str) -> Actuation {
     Actuation::CreatePresentation {
         meta: InputMeta::builder()
-            .name(presentation_name(&convoy.metadata.name, task))
+            .name(per_task_resource_name(&convoy.metadata.name, task))
             .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.metadata.name.clone()), (TASK_LABEL.to_string(), task.to_string())]))
             .owner_references(vec![OwnerReference {
                 api_version: format!("{}/{}", Convoy::API_PATHS.group, Convoy::API_PATHS.version),
@@ -627,11 +626,11 @@ fn insert_optional_field(fields: &mut BTreeMap<String, serde_json::Value>, key: 
     }
 }
 
-fn task_workspace_name(convoy_name: &str, task: &str) -> String {
-    format!("{convoy_name}-{task}")
-}
-
-fn presentation_name(convoy_name: &str, task: &str) -> String {
+/// Per-task convoy resources (`TaskWorkspace`, `Presentation`) share the name
+/// shape `<convoy>-<task>`. Resource kinds have separate namespaces, so the
+/// shared shape causes no collision and keeps both resources discoverable
+/// together by name.
+fn per_task_resource_name(convoy_name: &str, task: &str) -> String {
     format!("{convoy_name}-{task}")
 }
 

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -286,14 +286,23 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
     presentations
         .create(
             &InputMeta::builder()
-                .name("convoy-delete-presentation".to_string())
-                .labels([(CONVOY_LABEL.to_string(), "convoy-delete".to_string())].into_iter().collect())
+                .name("convoy-delete-implement".to_string())
+                .labels(
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "implement".to_string())]
+                        .into_iter()
+                        .collect(),
+                )
                 .build(),
             &PresentationSpec {
                 convoy_ref: "convoy-delete".to_string(),
                 presentation_policy_ref: "default".to_string(),
-                name: "convoy-delete".to_string(),
-                process_selector: [(CONVOY_LABEL.to_string(), "convoy-delete".to_string())].into_iter().collect(),
+                name: "implement".to_string(),
+                process_selector: [
+                    (CONVOY_LABEL.to_string(), "convoy-delete".to_string()),
+                    (TASK_LABEL.to_string(), "implement".to_string()),
+                ]
+                .into_iter()
+                .collect(),
             },
         )
         .await
@@ -330,7 +339,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
         loop {
             if matches!(convoys.get("convoy-delete").await, Err(ResourceError::NotFound { .. }))
                 && matches!(workspaces.get("convoy-delete-implement").await, Err(ResourceError::NotFound { .. }))
-                && matches!(presentations.get("convoy-delete-presentation").await, Err(ResourceError::NotFound { .. }))
+                && matches!(presentations.get("convoy-delete-implement").await, Err(ResourceError::NotFound { .. }))
             {
                 break;
             }
@@ -339,6 +348,65 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
     })
     .await
     .expect("convoy finalizer should delete presentation and task workspaces");
+
+    loop_task.abort();
+}
+
+#[tokio::test]
+async fn controller_loop_creates_one_presentation_per_active_task() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let presentations = backend.clone().using::<Presentation>("flotilla");
+    let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
+
+    let created =
+        convoys.create(&convoy_meta("convoy-multi"), &task_provisioning_convoy_spec()).await.expect("convoy create should succeed");
+    let mut status = bootstrapped_tool_only_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.started_at = Some(timestamp(18));
+    status.tasks.get_mut("implement").expect("implement task").phase = flotilla_resources::TaskPhase::Running;
+    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.tasks.get_mut("review").expect("review task").phase = flotilla_resources::TaskPhase::Ready;
+    status.tasks.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
+    convoys.update_status("convoy-multi", &created.metadata.resource_version, &status).await.expect("convoy status update should succeed");
+
+    let loop_task = tokio::spawn(
+        ControllerLoop {
+            primary: convoys.clone(),
+            secondaries: ConvoyReconciler::secondary_watches(),
+            reconciler: ConvoyReconciler::new(templates.clone())
+                .with_task_workspaces(workspaces.clone())
+                .with_presentations(presentations.clone()),
+            resync_interval: Duration::from_millis(50),
+            backend: backend.clone(),
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if let (Ok(implement), Ok(review)) =
+                (presentations.get("convoy-multi-implement").await, presentations.get("convoy-multi-review").await)
+            {
+                break (implement, review);
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .map(|(implement, review)| {
+        assert_eq!(implement.spec.name, "implement");
+        assert_eq!(implement.spec.process_selector.get(CONVOY_LABEL).map(String::as_str), Some("convoy-multi"));
+        assert_eq!(implement.spec.process_selector.get(TASK_LABEL).map(String::as_str), Some("implement"));
+        assert_eq!(implement.metadata.labels.get(TASK_LABEL).map(String::as_str), Some("implement"));
+
+        assert_eq!(review.spec.name, "review");
+        assert_eq!(review.spec.process_selector.get(CONVOY_LABEL).map(String::as_str), Some("convoy-multi"));
+        assert_eq!(review.spec.process_selector.get(TASK_LABEL).map(String::as_str), Some("review"));
+        assert_eq!(review.metadata.labels.get(TASK_LABEL).map(String::as_str), Some("review"));
+    })
+    .expect("controller loop should create one presentation per active task");
 
     loop_task.abort();
 }

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -774,14 +774,13 @@ async fn terminal_completed_convoy_without_observed_presentation_does_not_emit_s
 }
 
 #[tokio::test]
-async fn multi_task_convoy_creates_one_presentation_per_active_task() {
+async fn multi_task_convoy_creates_presentations_only_for_active_tasks() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
     status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
     status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
-    status.tasks.get_mut("review").expect("review task").phase = TaskPhase::Ready;
-    status.tasks.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
+    // `review` intentionally stays in Pending — covers the `TaskPhase::Pending => {}` arm.
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
@@ -794,15 +793,64 @@ async fn multi_task_convoy_creates_one_presentation_per_active_task() {
             _ => None,
         })
         .collect();
-    assert_eq!(creates.len(), 2);
-    assert!(creates.contains(&("convoy-a-implement".to_string(), "implement".to_string())));
-    assert!(creates.contains(&("convoy-a-review".to_string(), "review".to_string())));
-
-    let pending_task_has_no_create = !outcome
+    assert_eq!(creates, vec![("convoy-a-implement".to_string(), "implement".to_string())]);
+    assert!(!outcome
         .actuations
         .iter()
-        .any(|actuation| matches!(actuation, Actuation::CreatePresentation { meta, .. } if meta.name == "convoy-a-pending-task"));
-    assert!(pending_task_has_no_create);
+        .any(|actuation| matches!(actuation, Actuation::CreatePresentation { meta, .. } if meta.name == "convoy-a-review")));
+}
+
+#[tokio::test]
+async fn ready_and_running_tasks_both_create_presentations_when_missing() {
+    let mut status = bootstrapped_tool_only_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.started_at = Some(timestamp(18));
+    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
+    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.tasks.get_mut("review").expect("review task").phase = TaskPhase::Ready;
+    status.tasks.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
+    let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+
+    let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
+
+    let mut create_names: Vec<_> = outcome
+        .actuations
+        .iter()
+        .filter_map(|actuation| match actuation {
+            Actuation::CreatePresentation { meta, .. } => Some(meta.name.clone()),
+            _ => None,
+        })
+        .collect();
+    create_names.sort();
+    assert_eq!(create_names, vec!["convoy-a-implement".to_string(), "convoy-a-review".to_string()]);
+}
+
+#[tokio::test]
+async fn launching_task_creates_presentation_when_missing() {
+    let mut status = bootstrapped_tool_only_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.started_at = Some(timestamp(18));
+    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Launching;
+    status.tasks.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
+    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+
+    let outcome = reconcile_once_with_resources(
+        &convoy,
+        None,
+        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        Vec::new(),
+        timestamp(20),
+    )
+    .await;
+
+    assert!(outcome.actuations.iter().any(|actuation| matches!(
+        actuation,
+        Actuation::CreatePresentation { meta, spec }
+            if meta.name == "convoy-a-implement"
+                && spec.name == "implement"
+                && spec.process_selector.get(TASK_LABEL).map(String::as_str) == Some("implement")
+    )));
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -12,7 +12,7 @@ use flotilla_resources::{
     controller::{Actuation, Reconciler},
     controller_patches, reconcile, repo_key, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, InMemoryBackend,
     InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ResourceBackend, TaskPhase, TaskWorkspace, TaskWorkspacePhase,
-    TaskWorkspaceSpec, TaskWorkspaceStatus, ValidationError, WorkflowTemplate, CONVOY_LABEL,
+    TaskWorkspaceSpec, TaskWorkspaceStatus, ValidationError, WorkflowTemplate, CONVOY_LABEL, TASK_LABEL,
 };
 
 async fn reconcile_once_with_resources(
@@ -55,7 +55,10 @@ async fn reconcile_once_with_resources(
 
     for presentation in presentations {
         let created = presentations_resolver
-            .create(&presentation_meta(&presentation.metadata.name, &presentation.spec.convoy_ref), &presentation.spec)
+            .create(
+                &presentation_meta(&presentation.metadata.name, &presentation.spec.convoy_ref, &presentation.spec.name),
+                &presentation.spec,
+            )
             .await
             .expect("presentation create should succeed");
         if let Some(status) = presentation.status.as_ref() {
@@ -124,10 +127,10 @@ fn task_workspace_object(
     }
 }
 
-fn presentation_meta(name: &str, convoy_name: &str) -> InputMeta {
+fn presentation_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
     InputMeta::builder()
         .name(name.to_string())
-        .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy_name.to_string())]))
+        .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy_name.to_string()), (TASK_LABEL.to_string(), task.to_string())]))
         .owner_references(vec![OwnerReference {
             api_version: "flotilla.work/v1".to_string(),
             kind: "Convoy".to_string(),
@@ -137,14 +140,17 @@ fn presentation_meta(name: &str, convoy_name: &str) -> InputMeta {
         .build()
 }
 
-fn presentation_object(convoy_name: &str) -> flotilla_resources::ResourceObject<Presentation> {
+fn presentation_object(convoy_name: &str, task: &str) -> flotilla_resources::ResourceObject<Presentation> {
     flotilla_resources::ResourceObject {
-        metadata: common::object_meta(&format!("{convoy_name}-presentation"), "flotilla", "23"),
+        metadata: common::object_meta(&format!("{convoy_name}-{task}"), "flotilla", "23"),
         spec: PresentationSpec {
             convoy_ref: convoy_name.to_string(),
             presentation_policy_ref: "default".to_string(),
-            name: convoy_name.to_string(),
-            process_selector: BTreeMap::from([(CONVOY_LABEL.to_string(), convoy_name.to_string())]),
+            name: task.to_string(),
+            process_selector: BTreeMap::from([
+                (CONVOY_LABEL.to_string(), convoy_name.to_string()),
+                (TASK_LABEL.to_string(), task.to_string()),
+            ]),
         },
         status: None,
     }
@@ -626,15 +632,19 @@ async fn active_convoy_creates_presentation_when_missing() {
         matches!(
             actuation,
             Actuation::CreatePresentation { meta, spec }
-                if meta.name == "convoy-a-presentation"
+                if meta.name == "convoy-a-implement"
                     && meta.labels.get(CONVOY_LABEL).map(String::as_str) == Some("convoy-a")
+                    && meta.labels.get(TASK_LABEL).map(String::as_str) == Some("implement")
                     && meta.owner_references.len() == 1
                     && meta.owner_references[0].kind == "Convoy"
                     && meta.owner_references[0].name == "convoy-a"
                     && spec.convoy_ref == "convoy-a"
                     && spec.presentation_policy_ref == "default"
-                    && spec.name == "convoy-a"
-                    && spec.process_selector == BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string())])
+                    && spec.name == "implement"
+                    && spec.process_selector == BTreeMap::from([
+                        (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+                        (TASK_LABEL.to_string(), "implement".to_string()),
+                    ])
         )
     }));
 }
@@ -648,7 +658,8 @@ async fn active_convoy_does_not_recreate_existing_presentation() {
     status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
-    let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), vec![presentation_object("convoy-a")], timestamp(20)).await;
+    let outcome =
+        reconcile_once_with_resources(&convoy, None, Vec::new(), vec![presentation_object("convoy-a", "implement")], timestamp(20)).await;
 
     assert!(!outcome.actuations.iter().any(|actuation| matches!(actuation, Actuation::CreatePresentation { .. })));
 }
@@ -671,7 +682,7 @@ async fn completed_convoy_emits_presentation_and_workspace_deletes() {
             task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None),
             task_workspace_object("convoy-a", "review", TaskWorkspacePhase::Ready, None),
         ],
-        vec![presentation_object("convoy-a")],
+        vec![presentation_object("convoy-a", "implement"), presentation_object("convoy-a", "review")],
         timestamp(20),
     )
     .await;
@@ -684,7 +695,11 @@ async fn completed_convoy_emits_presentation_and_workspace_deletes() {
     assert!(outcome
         .actuations
         .iter()
-        .any(|actuation| matches!(actuation, Actuation::DeletePresentation { name } if name == "convoy-a-presentation")));
+        .any(|actuation| matches!(actuation, Actuation::DeletePresentation { name } if name == "convoy-a-implement")));
+    assert!(outcome
+        .actuations
+        .iter()
+        .any(|actuation| matches!(actuation, Actuation::DeletePresentation { name } if name == "convoy-a-review")));
     assert!(outcome
         .actuations
         .iter()
@@ -710,7 +725,7 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
         &convoy,
         None,
         vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
-        vec![presentation_object("convoy-a")],
+        vec![presentation_object("convoy-a", "implement"), presentation_object("convoy-a", "review")],
         timestamp(21),
     )
     .await;
@@ -719,7 +734,11 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
     assert!(outcome
         .actuations
         .iter()
-        .any(|actuation| matches!(actuation, Actuation::DeletePresentation { name } if name == "convoy-a-presentation")));
+        .any(|actuation| matches!(actuation, Actuation::DeletePresentation { name } if name == "convoy-a-implement")));
+    assert!(outcome
+        .actuations
+        .iter()
+        .any(|actuation| matches!(actuation, Actuation::DeletePresentation { name } if name == "convoy-a-review")));
     assert!(outcome
         .actuations
         .iter()
@@ -747,12 +766,72 @@ async fn terminal_completed_convoy_without_observed_presentation_does_not_emit_s
     .await;
 
     assert_eq!(outcome.patch, None);
-    assert!(!outcome
-        .actuations
-        .iter()
-        .any(|actuation| matches!(actuation, Actuation::DeletePresentation { name } if name == "convoy-a-presentation")));
+    assert!(!outcome.actuations.iter().any(|actuation| matches!(actuation, Actuation::DeletePresentation { .. })));
     assert!(outcome
         .actuations
         .iter()
         .any(|actuation| matches!(actuation, Actuation::DeleteTaskWorkspace { name } if name == "convoy-a-implement")));
+}
+
+#[tokio::test]
+async fn multi_task_convoy_creates_one_presentation_per_active_task() {
+    let mut status = bootstrapped_tool_only_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.started_at = Some(timestamp(18));
+    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
+    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.tasks.get_mut("review").expect("review task").phase = TaskPhase::Ready;
+    status.tasks.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
+    let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+
+    let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
+
+    let creates: Vec<_> = outcome
+        .actuations
+        .iter()
+        .filter_map(|actuation| match actuation {
+            Actuation::CreatePresentation { meta, spec } => Some((meta.name.clone(), spec.name.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(creates.len(), 2);
+    assert!(creates.contains(&("convoy-a-implement".to_string(), "implement".to_string())));
+    assert!(creates.contains(&("convoy-a-review".to_string(), "review".to_string())));
+
+    let pending_task_has_no_create = !outcome
+        .actuations
+        .iter()
+        .any(|actuation| matches!(actuation, Actuation::CreatePresentation { meta, .. } if meta.name == "convoy-a-pending-task"));
+    assert!(pending_task_has_no_create);
+}
+
+#[tokio::test]
+async fn one_task_completed_deletes_only_that_presentation() {
+    let mut status = bootstrapped_tool_only_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.started_at = Some(timestamp(18));
+    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Completed;
+    status.tasks.get_mut("implement").expect("implement task").finished_at = Some(timestamp(19));
+    status.tasks.get_mut("review").expect("review task").phase = TaskPhase::Running;
+    status.tasks.get_mut("review").expect("review task").started_at = Some(timestamp(18));
+    let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+
+    let outcome = reconcile_once_with_resources(
+        &convoy,
+        None,
+        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        vec![presentation_object("convoy-a", "implement"), presentation_object("convoy-a", "review")],
+        timestamp(20),
+    )
+    .await;
+
+    let deletes: Vec<_> = outcome
+        .actuations
+        .iter()
+        .filter_map(|actuation| match actuation {
+            Actuation::DeletePresentation { name } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(deletes, vec!["convoy-a-implement".to_string()]);
 }


### PR DESCRIPTION
## Summary

Implements the stage-5 addendum [`2026-04-22-per-task-presentation-design.md`](docs/superpowers/specs/2026-04-22-per-task-presentation-design.md). The convoy reconciler now creates **one Presentation per task** keyed on `{flotilla.work/convoy, flotilla.work/task}` instead of one per convoy keyed on `flotilla.work/convoy`. Per-task Presentations are created when their task enters `Ready` (or any non-terminal post-Ready phase) and deleted when their task reaches a terminal phase.

This is a prerequisite for [Stage 6 PR 3 — task attach](docs/superpowers/specs/2026-04-21-tui-convoy-view-design.md#pr-3--task-attach), where the TUI's `a` keybinding reads per-task `workspace_ref` from `TaskSummary` to dispatch `SelectWorkspace { ws_ref }`. With this PR landed, the daemon-side `ConvoyProjection` will populate distinct `workspace_ref` values per task instead of always `None`, and PR 3 can ship.

## What changed

- `crates/flotilla-resources/src/convoy/reconcile.rs`:
  - `presentation_name(convoy, task)` returns `<convoy>-<task>`.
  - `create_presentation_actuation` takes a task name and stamps both labels + a two-label `process_selector`.
  - `cleanup_actuations` switched from convoy-phase triggers (`Active+empty → create`, `terminal → delete all`) to per-task phase triggers (`{Ready,Launching,Running} → create if missing`, `{Completed,Failed,Cancelled} → delete if present`).
- Unit tests in `tests/convoy_reconcile.rs` updated for the new contract; added `multi_task_convoy_creates_one_presentation_per_active_task` and `one_task_completed_deletes_only_that_presentation`.
- E2E test in `tests/convoy_in_memory.rs`: `controller_loop_creates_one_presentation_per_active_task` drives the controller loop with a two-task convoy and asserts two distinct Presentations are created with correct names, labels, and per-task `process_selector`.

## Notes

Owner reference still points at the `Convoy`, so the existing `flotilla.work/convoy-teardown` finalizer (which lists Presentations by `CONVOY_LABEL`) continues to clean up all per-task Presentations on convoy delete without modification.

The daemon-side `ConvoyProjection`'s `workspace_ref_for(namespace, convoy, task)` already keyed its lookup by `{convoy, task}` (presumably anticipating this addendum), and its existing tests already use the new label shape — no daemon changes were needed.

## Test plan

- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `cargo dylint --all -- --all-targets` (no new warnings; only pre-existing tui/daemon path warnings)