### PR TITLE
feat(tui): convoy task attach via 'a' keybinding

### DIFF
--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -421,19 +421,12 @@ impl App {
         self.screen.modal_stack.push(Box::new(widget));
     }
 
-    /// Resolve the selected convoy task's `workspace_ref` and dispatch
-    /// `SelectWorkspace { ws_ref }`. When the task has no workspace yet
-    /// (its Presentation has not produced an `observed_workspace_ref`),
-    /// surface a transient status line instead of erroring.
+    /// Dispatch `SelectWorkspace` for the selected task's workspace, or show a transient status when none exists yet.
     pub(super) fn attach_selected_convoy_task(&mut self) {
-        let Some(convoy_id) = self.convoys_ui.selected.clone() else { return };
         let Some(task) = self.convoys_ui.selected_task.clone() else { return };
-        // Single-namespace MVP: all convoys live in "flotilla" (see app::mod for
-        // the matching note in convoys_tab_select_delta).
+        // Single-namespace MVP: all convoys live in "flotilla" (see convoys_tab_select_delta).
         let workspace_ref = self
-            .namespaces
-            .get("flotilla")
-            .and_then(|ns| ns.convoys.get(&convoy_id))
+            .selected_convoy_summary("flotilla")
             .and_then(|convoy| convoy.tasks.iter().find(|t| t.name == task))
             .and_then(|t| t.workspace_ref.clone());
         match workspace_ref {

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -62,6 +62,7 @@ impl App {
                 }
             }
             Action::CompleteConvoyTask if self.ui.is_convoys => self.open_complete_convoy_task_palette(),
+            Action::AttachConvoyTask if self.ui.is_convoys => self.attach_selected_convoy_task(),
             Action::Confirm if !self.ui.is_config => self.action_enter(),
             Action::OpenActionMenu if !self.ui.is_config => self.open_action_menu(),
             Action::OpenFilePicker if !self.ui.is_config => self.open_file_picker_from_active_repo_parent(),
@@ -418,6 +419,30 @@ impl App {
         );
         let widget = crate::widgets::command_palette::CommandPaletteWidget::with_prefill(prefill, None);
         self.screen.modal_stack.push(Box::new(widget));
+    }
+
+    /// Resolve the selected convoy task's `workspace_ref` and dispatch
+    /// `SelectWorkspace { ws_ref }`. When the task has no workspace yet
+    /// (its Presentation has not produced an `observed_workspace_ref`),
+    /// surface a transient status line instead of erroring.
+    pub(super) fn attach_selected_convoy_task(&mut self) {
+        let Some(convoy_id) = self.convoys_ui.selected.clone() else { return };
+        let Some(task) = self.convoys_ui.selected_task.clone() else { return };
+        // Single-namespace MVP: all convoys live in "flotilla" (see app::mod for
+        // the matching note in convoys_tab_select_delta).
+        let workspace_ref = self
+            .namespaces
+            .get("flotilla")
+            .and_then(|ns| ns.convoys.get(&convoy_id))
+            .and_then(|convoy| convoy.tasks.iter().find(|t| t.name == task))
+            .and_then(|t| t.workspace_ref.clone());
+        match workspace_ref {
+            Some(ws_ref) => {
+                let cmd = self.repo_command(flotilla_protocol::CommandAction::SelectWorkspace { ws_ref });
+                self.proto_commands.push(cmd);
+            }
+            None => self.set_status_message(Some(format!("no workspace yet for task '{task}'"))),
+        }
     }
 
     pub(super) fn open_action_menu(&mut self) {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2072,3 +2072,98 @@ fn x_then_enter_dispatches_convoy_task_complete() {
         other => panic!("expected ConvoyTaskComplete, got {other:?}"),
     }
 }
+
+// -- Convoy task attach (`a`) --
+
+fn convoy_with_task_workspace_refs(name: &str, tasks: &[(&str, Option<&str>)]) -> flotilla_protocol::namespace::ConvoySummary {
+    let mut c = test_convoy("flotilla", name, flotilla_protocol::namespace::ConvoyPhase::Active, false);
+    c.tasks = tasks
+        .iter()
+        .map(|(t, ws)| flotilla_protocol::namespace::TaskSummary {
+            name: (*t).into(),
+            depends_on: vec![],
+            phase: flotilla_protocol::namespace::TaskPhase::Running,
+            processes: vec![],
+            host: None,
+            checkout: None,
+            workspace_ref: ws.map(str::to_string),
+            ready_at: None,
+            started_at: None,
+            finished_at: None,
+            message: None,
+        })
+        .collect();
+    c
+}
+
+#[test]
+fn a_on_task_with_workspace_ref_dispatches_select_workspace() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_task_workspace_refs("alpha", &[(
+        "implement",
+        Some("ws://task-a-implement"),
+    )])]))));
+    app.ui.is_convoys = true;
+    app.handle_key(key(KeyCode::Char('l')));
+    assert_eq!(app.selected_convoy_task(), Some("implement"));
+
+    app.handle_key(key(KeyCode::Char('a')));
+
+    let cmd = app.proto_commands.take_next().expect("expected a SelectWorkspace command");
+    match &cmd.0.action {
+        flotilla_protocol::CommandAction::SelectWorkspace { ws_ref } => {
+            assert_eq!(ws_ref, "ws://task-a-implement");
+        }
+        other => panic!("expected SelectWorkspace, got {other:?}"),
+    }
+    assert!(app.model.status_message.is_none(), "no status message when workspace_ref is present");
+}
+
+#[test]
+fn a_on_task_without_workspace_ref_sets_status_message() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_task_workspace_refs("alpha", &[(
+        "implement",
+        None,
+    )])]))));
+    app.ui.is_convoys = true;
+    app.handle_key(key(KeyCode::Char('l')));
+    assert_eq!(app.selected_convoy_task(), Some("implement"));
+
+    app.handle_key(key(KeyCode::Char('a')));
+
+    assert!(app.proto_commands.take_next().is_none(), "no command dispatched when workspace_ref is None");
+    let msg = app.model.status_message.as_deref().expect("expected a transient status message");
+    assert!(msg.contains("implement"), "status message should reference the task name, got: {msg}");
+    assert!(msg.contains("no workspace yet"), "status message should explain no workspace yet, got: {msg}");
+}
+
+#[test]
+fn a_on_two_task_convoy_dispatches_correct_ws_ref_per_selection() {
+    let mut app = stub_app();
+    app.handle_daemon_event(DaemonEvent::NamespaceSnapshot(Box::new(snapshot_with(vec![convoy_with_task_workspace_refs("alpha", &[
+        ("implement", Some("ws://impl")),
+        ("review", Some("ws://rev")),
+    ])]))));
+    app.ui.is_convoys = true;
+    app.handle_key(key(KeyCode::Char('l')));
+    assert_eq!(app.selected_convoy_task(), Some("implement"));
+
+    // First task selected -> dispatches implement's ws_ref.
+    app.handle_key(key(KeyCode::Char('a')));
+    let first = app.proto_commands.take_next().expect("first dispatch");
+    match &first.0.action {
+        flotilla_protocol::CommandAction::SelectWorkspace { ws_ref } => assert_eq!(ws_ref, "ws://impl"),
+        other => panic!("expected SelectWorkspace, got {other:?}"),
+    }
+
+    // Move to second task -> dispatches review's ws_ref.
+    app.handle_key(key(KeyCode::Char('j')));
+    assert_eq!(app.selected_convoy_task(), Some("review"));
+    app.handle_key(key(KeyCode::Char('a')));
+    let second = app.proto_commands.take_next().expect("second dispatch");
+    match &second.0.action {
+        flotilla_protocol::CommandAction::SelectWorkspace { ws_ref } => assert_eq!(ws_ref, "ws://rev"),
+        other => panic!("expected SelectWorkspace, got {other:?}"),
+    }
+}

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -157,6 +157,7 @@ pub static BINDINGS: &[Binding] = &[
     b(BindingModeId::ConvoyTasks, "left", Action::Dismiss),
     hk(BindingModeId::ConvoyTasks, "esc", "ESC", Action::Dismiss, "List"),
     h(BindingModeId::ConvoyTasks, "x", Action::CompleteConvoyTask, "Complete"),
+    h(BindingModeId::ConvoyTasks, "a", Action::AttachConvoyTask, "Attach"),
     h(BindingModeId::ConvoyTasks, "r", Action::Refresh, "Refresh"),
     // ── Overview (replaces old Config) ──
     h(BindingModeId::Overview, "j", Action::SelectNext, "Down"),

--- a/crates/flotilla-tui/src/keymap.rs
+++ b/crates/flotilla-tui/src/keymap.rs
@@ -45,6 +45,8 @@ pub enum Action {
     FillSelected,
     /// Open the command palette pre-filled to complete the selected convoy task.
     CompleteConvoyTask,
+    /// Attach the active workspace manager to the selected convoy task's workspace.
+    AttachConvoyTask,
     Dispatch(Intent),
 }
 
@@ -112,6 +114,7 @@ impl Action {
             "open_contextual_palette" => Action::OpenContextualPalette,
             "fill_selected" => Action::FillSelected,
             "complete_convoy_task" => Action::CompleteConvoyTask,
+            "attach_convoy_task" => Action::AttachConvoyTask,
             // Intent-wrapping actions
             "switch_to_workspace" => Action::Dispatch(Intent::SwitchToWorkspace),
             "create_workspace" => Action::Dispatch(Intent::CreateWorkspace),
@@ -161,6 +164,7 @@ impl Action {
             Action::OpenContextualPalette => "open_contextual_palette",
             Action::FillSelected => "fill_selected",
             Action::CompleteConvoyTask => "complete_convoy_task",
+            Action::AttachConvoyTask => "attach_convoy_task",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "switch_to_workspace",
                 Intent::CreateWorkspace => "create_workspace",
@@ -207,6 +211,7 @@ impl Action {
             Action::OpenContextualPalette => "Open contextual palette (pre-filled)",
             Action::FillSelected => "Fill selected item",
             Action::CompleteConvoyTask => "Complete convoy task",
+            Action::AttachConvoyTask => "Attach to task workspace",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "Switch to workspace",
                 Intent::CreateWorkspace => "Create workspace",


### PR DESCRIPTION
## Summary

Stage 6 PR 3 — task attach. From the [convoy view design spec](docs/superpowers/specs/2026-04-21-tui-convoy-view-design.md#pr-3--task-attach):

> \`a\` keybinding on a task reads \`TaskSummary.workspace_ref\`. When \`Some(ws_ref)\` it dispatches \`CommandAction::SelectWorkspace { ws_ref }\`. When \`None\` it shows a transient status line ("no workspace yet") rather than erroring.

## What changed

- `flotilla-tui/src/keymap.rs`: new `Action::AttachConvoyTask` variant with snake_case config key and label.
- `flotilla-tui/src/binding_table.rs`: `a` → `AttachConvoyTask` in the `ConvoyTasks` binding mode.
- `flotilla-tui/src/app/key_handlers.rs`: `attach_selected_convoy_task` looks up the selected convoy + task's `workspace_ref` from `self.namespaces`. Some → `SelectWorkspace { ws_ref }` dispatched via `repo_command`. None → transient status message.
- `flotilla-tui/src/app/tests.rs`: three new tests cover the spec's three contract cases (present ws_ref dispatches; absent sets status; two-task convoy dispatches correct ws_ref per selection).

## Dependencies

Builds on #593 (per-task Presentation addendum). With that landed, the daemon-side `ConvoyProjection` populates per-task `workspace_ref` values, which this PR consumes.

## Notes

No new protocol commands or attach machinery — this PR is pure UI wiring on top of the existing `SelectWorkspace` action and the per-task `workspace_ref` field that the projection now populates.

## Test plan

- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test -p flotilla-tui --locked --tests` (892 + 3 new attach tests pass)
- [ ] Full workspace `cargo test --workspace --locked` — local artifact dir contended; CI will validate