### PR TITLE
refactor(resources): extract shared delete_matching helper (#587)

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
+++ b/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, marker::PhantomData};
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
-    controller::{Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
+    controller::{delete_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
     descriptive_repo_slug, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
     DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec,
     FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, OwnerReference, PlacementPolicy,
@@ -568,17 +568,6 @@ fn build_session_labels(
     labels.insert(TASK_ORDINAL_LABEL.to_string(), format!("{task_index:03}"));
     labels.insert(PROCESS_ORDINAL_LABEL.to_string(), format!("{process_index:03}"));
     labels
-}
-
-async fn delete_matching<T: Resource>(resolver: &TypedResolver<T>, selector: &BTreeMap<String, String>) -> Result<(), ResourceError> {
-    let listed = resolver.list_matching_labels(selector).await?;
-    for object in listed.items {
-        match resolver.delete(&object.metadata.name).await {
-            Ok(()) | Err(ResourceError::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    Ok(())
 }
 
 impl PlacementStrategy {

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -459,3 +459,17 @@ impl<R: Reconciler> ControllerLoop<R> {
         }
     }
 }
+
+/// List every resource matching `selector` and delete it, swallowing `NotFound` from
+/// races with concurrent deletes. Used by cascading-teardown reconcilers (TaskWorkspace,
+/// Convoy) to garbage-collect their owned children before the finalizer is removed.
+pub async fn delete_matching<T: Resource>(resolver: &TypedResolver<T>, selector: &BTreeMap<String, String>) -> Result<(), ResourceError> {
+    let listed = resolver.list_matching_labels(selector).await?;
+    for object in listed.items {
+        match resolver.delete(&object.metadata.name).await {
+            Ok(()) | Err(ResourceError::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -8,7 +8,9 @@ use super::{
 };
 use crate::{
     canonicalize_repo_url,
-    controller::{Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler, SecondaryWatch},
+    controller::{
+        delete_matching, Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler, SecondaryWatch,
+    },
     labels::{CONVOY_LABEL, TASK_LABEL},
     presentation::{Presentation, PresentationSpec},
     resource::ResourceObject,
@@ -632,15 +634,4 @@ fn insert_optional_field(fields: &mut BTreeMap<String, serde_json::Value>, key: 
 /// together by name.
 fn per_task_resource_name(convoy_name: &str, task: &str) -> String {
     format!("{convoy_name}-{task}")
-}
-
-async fn delete_matching<T: Resource>(resolver: &TypedResolver<T>, selector: &BTreeMap<String, String>) -> Result<(), ResourceError> {
-    let listed = resolver.list_matching_labels(selector).await?;
-    for object in listed.items {
-        match resolver.delete(&object.metadata.name).await {
-            Ok(()) | Err(ResourceError::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    Ok(())
 }


### PR DESCRIPTION
## Summary

Closes #587. Promotes the duplicated label-selector-based bulk-delete helper to a single shared `flotilla_resources::controller::delete_matching` so cascading-teardown semantics stay aligned across reconcilers.

## What changed

- **Added** `pub async fn delete_matching` in `crates/flotilla-resources/src/controller/mod.rs` with a doc comment explaining its role.
- **Removed** the byte-identical private fn from `crates/flotilla-resources/src/convoy/reconcile.rs` and updated callers to import from the shared location.
- **Removed** the byte-identical private fn from `crates/flotilla-controllers/src/reconcilers/task_workspace.rs` and updated callers similarly.

## Notes

Pure refactor; no behavior change. The two functions were verified byte-for-byte identical (modulo whitespace) before extraction.

## Test plan

- [x] `cargo +nightly-2026-03-12 fmt --check`
- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings` — local artifact dir contended; CI will validate
- [ ] `cargo test --workspace --locked` — CI will validate