### PR TITLE
refactor(daemon): thread provisioning namespace into convoy completion

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -495,7 +495,16 @@ pub struct InProcessDaemon {
     /// `NamespaceDelta` events arrive on the broadcast channel.  Consulted by
     /// `replay_since` so reconnecting clients can receive missed namespace state.
     namespace_state: Arc<RwLock<HashMap<String, flotilla_protocol::namespace::NamespaceSnapshot>>>,
+    /// Provisioning namespace used by daemon-side resource operations (e.g.
+    /// looking up the Convoy whose task is being marked complete). Set by the
+    /// daemon runtime at startup; defaults to [`DEFAULT_PROVISIONING_NAMESPACE`].
+    provisioning_namespace: RwLock<String>,
 }
+
+/// Default provisioning namespace used until [`InProcessDaemon::set_provisioning_namespace`]
+/// is called. Matches `RuntimeOptions::namespace`'s default so tests that construct
+/// the daemon directly hit the same namespace the runtime uses.
+pub const DEFAULT_PROVISIONING_NAMESPACE: &str = "flotilla";
 
 impl InProcessDaemon {
     /// Create a new in-process daemon tracking the given repo paths.
@@ -618,6 +627,7 @@ impl InProcessDaemon {
             daemon_socket_path: RwLock::new(None),
             resource_backend,
             namespace_state: Arc::new(RwLock::new(HashMap::new())),
+            provisioning_namespace: RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
         });
 
         // Spawn self-driving poll loop with a Weak reference.
@@ -774,6 +784,17 @@ impl InProcessDaemon {
 
     pub async fn daemon_socket_path(&self) -> Option<PathBuf> {
         self.daemon_socket_path.read().await.clone()
+    }
+
+    /// Override the provisioning namespace used for daemon-side resource lookups
+    /// (e.g. `ConvoyTaskComplete`). Called by the daemon runtime at startup with
+    /// `RuntimeOptions::namespace`.
+    pub async fn set_provisioning_namespace(&self, namespace: String) {
+        *self.provisioning_namespace.write().await = namespace;
+    }
+
+    pub async fn provisioning_namespace(&self) -> String {
+        self.provisioning_namespace.read().await.clone()
     }
 
     pub fn resource_backend(&self) -> ResourceBackend {
@@ -1984,7 +2005,8 @@ impl InProcessDaemon {
                 repo: None,
                 description: command.description().to_string(),
             });
-            let convoys = self.resource_backend.clone().using::<ResourceConvoy>("flotilla");
+            let namespace = self.provisioning_namespace().await;
+            let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
             let result = match convoys.get(convoy).await {
                 Ok(current) => match current.status.as_ref() {
                     None => flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} has no status") },

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -678,6 +678,90 @@ async fn convoy_completion_command_updates_convoy_task_status() {
 }
 
 #[tokio::test]
+async fn convoy_completion_command_targets_configured_provisioning_namespace() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    daemon.set_provisioning_namespace("custom-ns".to_string()).await;
+
+    let convoys = daemon.resource_backend().using::<Convoy>("custom-ns");
+    let created = convoys
+        .create(&empty_input_meta("convoy-a"), &ConvoySpec {
+            workflow_ref: "review-and-fix".to_string(),
+            inputs: BTreeMap::new(),
+            placement_policy: Some("laptop-docker".to_string()),
+            repository: None,
+            r#ref: None,
+        })
+        .await
+        .expect("convoy create should succeed");
+    convoys
+        .update_status("convoy-a", &created.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Active,
+            workflow_snapshot: None,
+            tasks: [("implement".to_string(), TaskState {
+                phase: TaskPhase::Running,
+                ready_at: None,
+                started_at: None,
+                finished_at: None,
+                message: None,
+                placement: None,
+            })]
+            .into_iter()
+            .collect(),
+            message: None,
+            started_at: None,
+            finished_at: None,
+            observed_workflow_ref: Some("review-and-fix".to_string()),
+            observed_workflows: None,
+        })
+        .await
+        .expect("convoy status update should succeed");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyTaskComplete {
+                convoy: "convoy-a".to_string(),
+                task: "implement".to_string(),
+                message: Some("done".to_string()),
+            },
+        })
+        .await
+        .expect("execute should return a command id");
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected event error: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for command result");
+
+    assert_eq!(result, CommandValue::Ok);
+    let convoy = convoys.get("convoy-a").await.expect("convoy get should succeed");
+    let status = convoy.status.expect("convoy status should exist");
+    assert_eq!(status.tasks["implement"].phase, TaskPhase::Completed);
+
+    // The default namespace must NOT contain the convoy — completion should target
+    // only the configured provisioning namespace, not the legacy hardcoded one.
+    let default_convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    let missing = default_convoys.get("convoy-a").await;
+    assert!(missing.is_err(), "convoy should not exist in the default namespace: got {missing:?}");
+}
+
+#[tokio::test]
 async fn normalize_local_provider_hosts_uses_mount_metadata_for_provisioned_checkouts() {
     struct TestProvisionedEnvironment {
         id: EnvironmentId,

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -37,7 +37,6 @@ use tracing::{error, warn};
 
 use crate::ConvoyProjection;
 
-const NAMESPACE: &str = "flotilla";
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 
@@ -52,7 +51,7 @@ pub struct RuntimeOptions {
 impl Default for RuntimeOptions {
     fn default() -> Self {
         Self {
-            namespace: NAMESPACE.to_string(),
+            namespace: flotilla_core::in_process::DEFAULT_PROVISIONING_NAMESPACE.to_string(),
             heartbeat_interval: Duration::from_secs(30),
             controller_resync_interval: Duration::from_secs(60),
             start_controllers: true,
@@ -82,6 +81,7 @@ impl DaemonRuntime {
         if let Some(path) = daemon_socket_path.as_ref() {
             daemon.set_daemon_socket_path(path.clone()).await;
         }
+        daemon.set_provisioning_namespace(options.namespace.clone()).await;
 
         let local_registry = probe_local_provider_registry(&daemon, &config).await?;
         let profile = build_local_profile(&daemon, &local_registry)?;
@@ -872,6 +872,7 @@ mod tests {
     use flotilla_core::{
         config::ConfigStore,
         daemon::DaemonHandle,
+        in_process::DEFAULT_PROVISIONING_NAMESPACE as NAMESPACE,
         providers::discovery::{test_support::git_process_discovery, EnvironmentAssertion, EnvironmentBag},
     };
     use flotilla_protocol::{Command, CommandAction};


### PR DESCRIPTION
## Summary
- Replace the hardcoded `"flotilla"` namespace in `InProcessDaemon`'s `ConvoyTaskComplete` handler with a configurable per-daemon namespace, set from `RuntimeOptions::namespace` at daemon-runtime startup.
- Make `flotilla_core::in_process::DEFAULT_PROVISIONING_NAMESPACE` the single source of truth for the default; `RuntimeOptions::default()` now pulls from it instead of duplicating the literal.

## Why
From PR #582 review: convoy completion was the one provisioning path that ignored `RuntimeOptions::namespace`. Not user-visible today because Stage 4a runs in the default namespace, but it left a configuration hole that would bite as soon as a non-default namespace is used.

## Test plan
- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] New test `convoy_completion_command_targets_configured_provisioning_namespace` verifies completion targets the configured namespace and does not fall back to `"flotilla"`.

Closes #584.