### PR TITLE
refactor(daemon): replay_since reads namespace state from projection directly

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -41,6 +41,7 @@ use crate::{
     },
     host_registry::HostCounts,
     model::{provider_names_from_registry, repo_name, RepoModel},
+    namespace_projection::NamespaceProjectionState,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
         discovery::{discover_providers, run_host_detectors, DiscoveryResult, DiscoveryRuntime, EnvironmentAssertion, EnvironmentBag},
@@ -490,11 +491,11 @@ pub struct InProcessDaemon {
     /// Used to inject FLOTILLA_DAEMON_SOCKET into managed terminal sessions.
     daemon_socket_path: RwLock<Option<PathBuf>>,
     resource_backend: ResourceBackend,
-    /// Retained namespace snapshots, keyed by namespace name.
-    /// Updated by a background subscriber whenever `NamespaceSnapshot` or
-    /// `NamespaceDelta` events arrive on the broadcast channel.  Consulted by
-    /// `replay_since` so reconnecting clients can receive missed namespace state.
-    namespace_state: Arc<RwLock<HashMap<String, flotilla_protocol::namespace::NamespaceSnapshot>>>,
+    /// Shared with `ConvoyProjection` (in flotilla-daemon): the projection is the
+    /// sole writer, the daemon reads here for `replay_since`.  Replaces an earlier
+    /// broadcast-driven mirror that had correctness seams under lag and
+    /// delta-before-snapshot races.  Set by the daemon runtime at startup.
+    namespace_projection_state: RwLock<NamespaceProjectionState>,
     /// Provisioning namespace used by daemon-side resource operations (e.g.
     /// looking up the Convoy whose task is being marked complete). Set by the
     /// daemon runtime at startup; defaults to [`DEFAULT_PROVISIONING_NAMESPACE`].
@@ -626,7 +627,7 @@ impl InProcessDaemon {
             agent_state_store,
             daemon_socket_path: RwLock::new(None),
             resource_backend,
-            namespace_state: Arc::new(RwLock::new(HashMap::new())),
+            namespace_projection_state: RwLock::new(NamespaceProjectionState::new()),
             provisioning_namespace: RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
         });
 
@@ -641,54 +642,6 @@ impl InProcessDaemon {
                 match weak.upgrade() {
                     Some(d) => d.poll_snapshots().await,
                     None => break,
-                }
-            }
-        });
-
-        // Subscribe to the broadcast channel and mirror namespace events into
-        // `namespace_state` for replay.  The subscriber holds a strong Arc to
-        // `namespace_state` but exits cleanly when the daemon drops its broadcast
-        // sender (Err(Closed) breaks the loop).
-        let namespace_state = Arc::clone(&daemon.namespace_state);
-        let mut namespace_rx = daemon.event_tx.subscribe();
-        tokio::spawn(async move {
-            loop {
-                match namespace_rx.recv().await {
-                    Ok(DaemonEvent::NamespaceSnapshot(snap)) => {
-                        let mut state = namespace_state.write().await;
-                        state.insert(snap.namespace.clone(), *snap);
-                    }
-                    Ok(DaemonEvent::NamespaceDelta(delta)) => {
-                        let mut state = namespace_state.write().await;
-                        let Some(entry) = state.get_mut(&delta.namespace) else {
-                            // Delta arrived before any snapshot for this namespace — this can
-                            // happen under lag or ordering anomalies.  Synthesising a seq-0
-                            // baseline risks client regression (a reconnecting client at seq N>0
-                            // would regress).  Skip and wait for the next full snapshot.
-                            warn!(ns = %delta.namespace, "received NamespaceDelta for unknown namespace; skipping — awaiting snapshot");
-                            continue;
-                        };
-                        // Apply delta: remove deleted convoys, upsert changed ones.
-                        entry.convoys.retain(|c| !delta.removed.contains(&c.id));
-                        for changed in &delta.changed {
-                            if let Some(existing) = entry.convoys.iter_mut().find(|c| c.id == changed.id) {
-                                *existing = changed.clone();
-                            } else {
-                                entry.convoys.push(changed.clone());
-                            }
-                        }
-                        entry.seq = delta.seq;
-                    }
-                    Ok(_) => {}
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        // We dropped messages — we don't know which namespaces were affected,
-                        // so clear all namespace state.  Reconnecting clients will get nothing
-                        // from replay_since until the next snapshot arrives; that is preferable
-                        // to serving known-stale data.
-                        warn!(lagged = n, "namespace_state subscriber lagged; clearing all namespace state");
-                        namespace_state.write().await.clear();
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
                 }
             }
         });
@@ -795,6 +748,17 @@ impl InProcessDaemon {
 
     pub async fn provisioning_namespace(&self) -> String {
         self.provisioning_namespace.read().await.clone()
+    }
+
+    /// Install the shared namespace state that `ConvoyProjection` (in flotilla-daemon)
+    /// will write into.  `replay_since` reads from the same state.  Called by the daemon
+    /// runtime at startup before the projection is spawned.
+    pub async fn set_namespace_projection_state(&self, state: NamespaceProjectionState) {
+        *self.namespace_projection_state.write().await = state;
+    }
+
+    pub async fn namespace_projection_state(&self) -> NamespaceProjectionState {
+        self.namespace_projection_state.read().await.clone()
     }
 
     pub fn resource_backend(&self) -> ResourceBackend {
@@ -2465,13 +2429,14 @@ impl DaemonHandle for InProcessDaemon {
             }
         }
 
-        // Emit namespace events for each retained namespace snapshot.
-        let namespace_state = self.namespace_state.read().await;
-        for (namespace, snap) in namespace_state.iter() {
-            let stream_key = StreamKey::Namespace { name: namespace.clone() };
+        // Emit namespace events by reading directly from the projection's authoritative
+        // state.  No mirror, no lag — see [`NamespaceProjectionState`] for the rationale.
+        let projection_state = self.namespace_projection_state.read().await.clone();
+        for snap in projection_state.all_snapshots().await {
+            let stream_key = StreamKey::Namespace { name: snap.namespace.clone() };
             let up_to_date = last_seen.get(&stream_key).is_some_and(|&seq| seq == snap.seq);
             if !up_to_date {
-                events.push(DaemonEvent::NamespaceSnapshot(Box::new(snap.clone())));
+                events.push(DaemonEvent::NamespaceSnapshot(Box::new(snap)));
             }
         }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2434,6 +2434,9 @@ impl DaemonHandle for InProcessDaemon {
         let projection_state = self.namespace_projection_state.read().await.clone();
         for snap in projection_state.all_snapshots().await {
             let stream_key = StreamKey::Namespace { name: snap.namespace.clone() };
+            // `==`, not `>=`: if a client's `last_seen` is ahead of the daemon's current
+            // seq (e.g. after a daemon restart that resets in-memory seq to 0), we still
+            // want to resend a full snapshot rather than treat the client as up-to-date.
             let up_to_date = last_seen.get(&stream_key).is_some_and(|&seq| seq == snap.seq);
             if !up_to_date {
                 events.push(DaemonEvent::NamespaceSnapshot(Box::new(snap)));

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1014,3 +1014,120 @@ async fn replay_since_skips_namespace_when_last_seen_matches_seq() {
     let has_flotilla_snapshot = events.iter().any(|e| matches!(e, DaemonEvent::NamespaceSnapshot(snap) if snap.namespace == "flotilla"));
     assert!(!has_flotilla_snapshot, "client up-to-date at seq=7 should not receive a redundant namespace snapshot");
 }
+
+/// With two namespaces at different seqs and the client up-to-date on only one,
+/// `replay_since` resends only the stale namespace's snapshot.
+#[tokio::test]
+async fn replay_since_emits_only_stale_namespace_when_one_is_current() {
+    use flotilla_protocol::{
+        namespace::{ConvoyId, ConvoyPhase, ConvoySummary},
+        DaemonEvent, StreamKey,
+    };
+
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+
+    let summary = |namespace: &str, name: &str| ConvoySummary {
+        id: ConvoyId::new(namespace, name),
+        namespace: namespace.into(),
+        name: name.into(),
+        workflow_ref: "wf".into(),
+        phase: ConvoyPhase::Active,
+        message: None,
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: false,
+    };
+
+    let projection_state = daemon.namespace_projection_state().await;
+    {
+        let mut namespaces = projection_state.write().await;
+        let ns_a = namespaces.entry("alpha".into()).or_default();
+        let s_a = summary("alpha", "convoy-a");
+        ns_a.convoys.insert(s_a.id.clone(), s_a);
+        ns_a.seq = 3;
+
+        let ns_b = namespaces.entry("beta".into()).or_default();
+        let s_b = summary("beta", "convoy-b");
+        ns_b.convoys.insert(s_b.id.clone(), s_b);
+        ns_b.seq = 5;
+    }
+
+    let mut last_seen = HashMap::new();
+    last_seen.insert(StreamKey::Namespace { name: "alpha".into() }, 3); // up-to-date
+    last_seen.insert(StreamKey::Namespace { name: "beta".into() }, 2); // stale
+
+    let events = daemon.replay_since(&last_seen).await.expect("replay_since should succeed");
+    let namespace_snapshots: Vec<&str> = events
+        .iter()
+        .filter_map(|e| match e {
+            DaemonEvent::NamespaceSnapshot(snap) => Some(snap.namespace.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(namespace_snapshots, vec!["beta"], "only the stale namespace should be resent");
+}
+
+/// If `last_seen` is ahead of the daemon's current namespace seq — e.g. after
+/// a daemon restart that resets in-memory seq to 0 — the client still receives
+/// a full snapshot (`==`, not `>=`).  Regression guard for the conservative
+/// behaviour documented in `replay_since`.
+#[tokio::test]
+async fn replay_since_resends_snapshot_when_client_seq_is_ahead() {
+    use flotilla_protocol::{
+        namespace::{ConvoyId, ConvoyPhase, ConvoySummary},
+        DaemonEvent, StreamKey,
+    };
+
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+
+    let projection_state = daemon.namespace_projection_state().await;
+    let summary = ConvoySummary {
+        id: ConvoyId::new("flotilla", "convoy-1"),
+        namespace: "flotilla".into(),
+        name: "convoy-1".into(),
+        workflow_ref: "wf".into(),
+        phase: ConvoyPhase::Active,
+        message: None,
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: false,
+    };
+    {
+        let mut namespaces = projection_state.write().await;
+        let view = namespaces.entry("flotilla".into()).or_default();
+        view.convoys.insert(summary.id.clone(), summary.clone());
+        view.seq = 2;
+    }
+
+    // Client's last_seen is ahead of the daemon's seq — simulates daemon restart.
+    let mut last_seen = HashMap::new();
+    last_seen.insert(StreamKey::Namespace { name: "flotilla".into() }, 99);
+
+    let events = daemon.replay_since(&last_seen).await.expect("replay_since should succeed");
+    let snap = events
+        .iter()
+        .find_map(|e| match e {
+            DaemonEvent::NamespaceSnapshot(snap) if snap.namespace == "flotilla" => Some(snap.clone()),
+            _ => None,
+        })
+        .expect("client ahead of daemon must still receive a snapshot");
+    assert_eq!(snap.seq, 2, "snapshot reflects the daemon's current seq, not the client's stale claim");
+}

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -913,14 +913,16 @@ async fn normalize_local_provider_hosts_keeps_environment_qualified_checkout_whe
     assert_eq!(checkout.correlation_keys, vec![CorrelationKey::CheckoutPath(checkout_path.clone())]);
 }
 
-// --- namespace_state correctness under lag / delta-before-snapshot ---
+// --- replay_since reads directly from the projection's authoritative state ---
 
-/// A NamespaceDelta that arrives before any snapshot for that namespace must be
-/// silently skipped.  `replay_since` must not return a synthetic seq-0 snapshot.
+/// `replay_since` returns a `NamespaceSnapshot` synthesised from the shared
+/// `NamespaceProjectionState`.  The projection (in flotilla-daemon) is the
+/// sole writer; the daemon reads here.  No broadcast mirror, no lag-clearing,
+/// no delta-before-snapshot race.
 #[tokio::test]
-async fn namespace_delta_before_snapshot_is_skipped() {
+async fn replay_since_reads_namespace_snapshots_from_projection_state() {
     use flotilla_protocol::{
-        namespace::{ConvoyId, ConvoyPhase, ConvoySummary, NamespaceDelta},
+        namespace::{ConvoyId, ConvoyPhase, ConvoySummary},
         DaemonEvent,
     };
 
@@ -932,93 +934,83 @@ async fn namespace_delta_before_snapshot_is_skipped() {
     let daemon =
         InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
 
-    // Broadcast a NamespaceDelta with no prior snapshot — simulates the broken
-    // path (lag/race).  The background subscriber should discard it.
-    let delta = DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
-        seq: 5,
+    let projection_state = daemon.namespace_projection_state().await;
+    let summary = ConvoySummary {
+        id: ConvoyId::new("flotilla", "convoy-1"),
         namespace: "flotilla".into(),
-        changed: vec![ConvoySummary {
-            id: ConvoyId::new("flotilla", "orphan-convoy"),
-            namespace: "flotilla".into(),
-            name: "orphan-convoy".into(),
-            workflow_ref: "wf".into(),
-            phase: ConvoyPhase::Active,
-            message: None,
-            repo_hint: None,
-            tasks: vec![],
-            started_at: None,
-            finished_at: None,
-            observed_workflow_ref: None,
-            initializing: false,
-        }],
-        removed: vec![],
-    }));
-    daemon.event_tx.send(delta).expect("broadcast delta should succeed");
-
-    // Give the background subscriber time to process the event.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-    // replay_since should not surface a synthetic seq-0 snapshot for "flotilla".
-    let events = daemon.replay_since(&HashMap::new()).await.expect("replay_since should succeed");
-    let has_flotilla_snapshot = events.iter().any(|e| match e {
-        DaemonEvent::NamespaceSnapshot(snap) => snap.namespace == "flotilla",
-        _ => false,
-    });
-    assert!(!has_flotilla_snapshot, "delta-before-snapshot must not produce a synthetic seq-0 entry in replay_since");
-}
-
-/// On broadcast lag the entire namespace_state cache is cleared.  After clearing,
-/// `replay_since` must not return any namespace snapshots until the next real snapshot
-/// arrives and repopulates the cache.
-#[tokio::test]
-async fn namespace_state_cleared_on_broadcast_lag() {
-    use flotilla_protocol::{
-        namespace::{ConvoyId, ConvoyPhase, ConvoySummary, NamespaceSnapshot},
-        DaemonEvent,
+        name: "convoy-1".into(),
+        workflow_ref: "wf".into(),
+        phase: ConvoyPhase::Active,
+        message: None,
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: false,
     };
-
-    let temp = tempfile::tempdir().expect("create tempdir");
-    let config_base = temp.path().join("config");
-    std::fs::create_dir_all(&config_base).expect("create config dir");
-    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-
-    let daemon =
-        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
-
-    // Inject a snapshot directly into namespace_state, bypassing the projection.
-    // This simulates a namespace that was previously populated.
     {
-        let mut state = daemon.namespace_state.write().await;
-        state.insert("flotilla".into(), NamespaceSnapshot {
-            seq: 10,
-            namespace: "flotilla".into(),
-            convoys: vec![ConvoySummary {
-                id: ConvoyId::new("flotilla", "existing-convoy"),
-                namespace: "flotilla".into(),
-                name: "existing-convoy".into(),
-                workflow_ref: "wf".into(),
-                phase: ConvoyPhase::Active,
-                message: None,
-                repo_hint: None,
-                tasks: vec![],
-                started_at: None,
-                finished_at: None,
-                observed_workflow_ref: None,
-                initializing: false,
-            }],
-        });
+        let mut namespaces = projection_state.write().await;
+        let view = namespaces.entry("flotilla".into()).or_default();
+        view.convoys.insert(summary.id.clone(), summary.clone());
+        view.seq = 7;
     }
 
-    // Confirm it shows up in replay_since before lag.
-    let events_before = daemon.replay_since(&HashMap::new()).await.expect("replay_since before lag");
-    let snap_before = events_before.iter().any(|e| matches!(e, DaemonEvent::NamespaceSnapshot(s) if s.namespace == "flotilla"));
-    assert!(snap_before, "namespace snapshot should appear in replay_since before lag");
+    let events = daemon.replay_since(&HashMap::new()).await.expect("replay_since should succeed");
+    let snap = events
+        .iter()
+        .find_map(|e| match e {
+            DaemonEvent::NamespaceSnapshot(snap) if snap.namespace == "flotilla" => Some(snap.clone()),
+            _ => None,
+        })
+        .expect("expected NamespaceSnapshot in replay output");
+    assert_eq!(snap.seq, 7);
+    assert_eq!(snap.convoys.len(), 1);
+    assert_eq!(snap.convoys[0].name, "convoy-1");
+}
 
-    // Simulate lag by directly clearing namespace_state (as the subscriber now does on Lagged).
-    daemon.namespace_state.write().await.clear();
+/// When a client's `last_seen` is up-to-date with the namespace's current `seq`,
+/// `replay_since` must not emit a redundant snapshot for that namespace.
+#[tokio::test]
+async fn replay_since_skips_namespace_when_last_seen_matches_seq() {
+    use flotilla_protocol::{
+        namespace::{ConvoyId, ConvoyPhase, ConvoySummary},
+        DaemonEvent, StreamKey,
+    };
 
-    // After clearing, replay_since must return no namespace snapshots for "flotilla".
-    let events_after = daemon.replay_since(&HashMap::new()).await.expect("replay_since after lag");
-    let snap_after = events_after.iter().any(|e| matches!(e, DaemonEvent::NamespaceSnapshot(s) if s.namespace == "flotilla"));
-    assert!(!snap_after, "namespace snapshot must not appear in replay_since after namespace_state was cleared");
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+
+    let projection_state = daemon.namespace_projection_state().await;
+    let summary = ConvoySummary {
+        id: ConvoyId::new("flotilla", "convoy-1"),
+        namespace: "flotilla".into(),
+        name: "convoy-1".into(),
+        workflow_ref: "wf".into(),
+        phase: ConvoyPhase::Active,
+        message: None,
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: false,
+    };
+    {
+        let mut namespaces = projection_state.write().await;
+        let view = namespaces.entry("flotilla".into()).or_default();
+        view.convoys.insert(summary.id.clone(), summary.clone());
+        view.seq = 7;
+    }
+
+    let mut last_seen = HashMap::new();
+    last_seen.insert(StreamKey::Namespace { name: "flotilla".into() }, 7);
+    let events = daemon.replay_since(&last_seen).await.expect("replay_since should succeed");
+    let has_flotilla_snapshot = events.iter().any(|e| matches!(e, DaemonEvent::NamespaceSnapshot(snap) if snap.namespace == "flotilla"));
+    assert!(!has_flotilla_snapshot, "client up-to-date at seq=7 should not receive a redundant namespace snapshot");
 }

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod host_summary;
 pub mod in_process;
 pub mod merge;
 pub mod model;
+pub mod namespace_projection;
 pub mod path_context;
 pub mod path_policy;
 pub mod provider_data;

--- a/crates/flotilla-core/src/namespace_projection.rs
+++ b/crates/flotilla-core/src/namespace_projection.rs
@@ -28,7 +28,7 @@ impl NamespaceView {
 
 /// Shared namespace state owned by the projection and read by the daemon for
 /// `replay_since`.  Cloning is cheap — it shares the same inner `Arc<RwLock>`.
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct NamespaceProjectionState {
     inner: Arc<RwLock<HashMap<String, NamespaceView>>>,
 }

--- a/crates/flotilla-core/src/namespace_projection.rs
+++ b/crates/flotilla-core/src/namespace_projection.rs
@@ -18,7 +18,6 @@ use tokio::sync::{RwLock, RwLockWriteGuard};
 pub struct NamespaceView {
     pub convoys: HashMap<ConvoyId, ConvoySummary>,
     pub seq: u64,
-    pub emitted_initial_snapshot: bool,
 }
 
 impl NamespaceView {

--- a/crates/flotilla-core/src/namespace_projection.rs
+++ b/crates/flotilla-core/src/namespace_projection.rs
@@ -1,0 +1,50 @@
+//! Shared in-memory namespace state.
+//!
+//! `ConvoyProjection` (in `flotilla-daemon`) owns the authoritative view of each
+//! namespace's convoys and is the single writer.  `InProcessDaemon::replay_since`
+//! reads from the same state to construct namespace snapshots for reconnecting
+//! clients.  A previous design mirrored projection events into a daemon-local
+//! cache via the broadcast channel — that approach had correctness seams (broadcast
+//! lag, delta-before-snapshot races).  Reading directly from the projection's state
+//! removes both seams.
+
+use std::{collections::HashMap, sync::Arc};
+
+use flotilla_protocol::namespace::{ConvoyId, ConvoySummary, NamespaceSnapshot};
+use tokio::sync::{RwLock, RwLockWriteGuard};
+
+/// In-memory view of one namespace's convoys, owned by the projection.
+#[derive(Default, Debug, Clone)]
+pub struct NamespaceView {
+    pub convoys: HashMap<ConvoyId, ConvoySummary>,
+    pub seq: u64,
+    pub emitted_initial_snapshot: bool,
+}
+
+impl NamespaceView {
+    pub fn to_snapshot(&self, namespace: &str) -> NamespaceSnapshot {
+        NamespaceSnapshot { seq: self.seq, namespace: namespace.to_owned(), convoys: self.convoys.values().cloned().collect() }
+    }
+}
+
+/// Shared namespace state owned by the projection and read by the daemon for
+/// `replay_since`.  Cloning is cheap — it shares the same inner `Arc<RwLock>`.
+#[derive(Default, Clone)]
+pub struct NamespaceProjectionState {
+    inner: Arc<RwLock<HashMap<String, NamespaceView>>>,
+}
+
+impl NamespaceProjectionState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn write(&self) -> RwLockWriteGuard<'_, HashMap<String, NamespaceView>> {
+        self.inner.write().await
+    }
+
+    pub async fn all_snapshots(&self) -> Vec<NamespaceSnapshot> {
+        let inner = self.inner.read().await;
+        inner.iter().map(|(name, view)| view.to_snapshot(name)).collect()
+    }
+}

--- a/crates/flotilla-daemon/src/convoy_projection.rs
+++ b/crates/flotilla-daemon/src/convoy_projection.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use flotilla_core::namespace_projection::{NamespaceProjectionState, NamespaceView};
 use flotilla_protocol::{
     namespace::{
         ConvoyId, ConvoyPhase as WireConvoyPhase, ConvoySummary, NamespaceDelta, NamespaceSnapshot, ProcessSummary,
@@ -20,27 +21,20 @@ use flotilla_resources::{
 use futures::StreamExt;
 use tokio::sync::broadcast;
 
-/// In-memory view of one namespace's convoys, owned by the projection.
-#[derive(Default)]
-struct NamespaceView {
-    convoys: HashMap<ConvoyId, ConvoySummary>,
-    seq: u64,
-    emitted_initial_snapshot: bool,
-}
-
 /// Key: `(namespace, convoy_name, task_name)`.
 type PresentationKey = (String, String, String);
 
 pub struct ConvoyProjection {
-    namespaces: HashMap<String, NamespaceView>,
+    /// Authoritative namespace state, shared with `InProcessDaemon::replay_since`.
+    state: NamespaceProjectionState,
     presentation_workspaces: HashMap<PresentationKey, String>,
     /// Emitter for events going to connected clients.
     event_tx: broadcast::Sender<DaemonEvent>,
 }
 
 impl ConvoyProjection {
-    pub fn new(event_tx: broadcast::Sender<DaemonEvent>) -> Self {
-        Self { namespaces: HashMap::new(), presentation_workspaces: HashMap::new(), event_tx }
+    pub fn new(state: NamespaceProjectionState, event_tx: broadcast::Sender<DaemonEvent>) -> Self {
+        Self { state, presentation_workspaces: HashMap::new(), event_tx }
     }
 
     /// Drive the projection event loop. Lists both resources to get initial state, then
@@ -160,16 +154,14 @@ impl ConvoyProjection {
         // 2. Re-emit a delta for the affected convoy with refreshed workspace_ref values.
         let id = ConvoyId::new(&namespace, &convoy_name);
 
-        // Collect workspace refs before taking a mutable borrow on the namespace view,
-        // to avoid the conflict between &self (workspace_ref_for) and &mut self (view).
-        let Some(existing) = self.namespaces.get(&namespace).and_then(|v| v.convoys.get(&id)).cloned() else {
+        let mut namespaces = self.state.write().await;
+        let Some(stored) = namespaces.get(&namespace).and_then(|v| v.convoys.get(&id)).cloned() else {
             return;
         };
         let refreshed_refs: Vec<Option<String>> =
-            existing.tasks.iter().map(|t| self.workspace_ref_for(&namespace, &convoy_name, &t.name)).collect();
+            stored.tasks.iter().map(|t| self.workspace_ref_for(&namespace, &convoy_name, &t.name)).collect();
 
-        // Now take the mutable borrow and apply the refreshed refs.
-        let view = self.namespaces.get_mut(&namespace).expect("namespace present; just read above");
+        let view = namespaces.get_mut(&namespace).expect("namespace present; just read above");
         let Some(stored) = view.convoys.get_mut(&id) else { return };
         for (task, ws_ref) in stored.tasks.iter_mut().zip(refreshed_refs.iter()) {
             task.workspace_ref = ws_ref.clone();
@@ -177,6 +169,7 @@ impl ConvoyProjection {
         let refreshed = stored.clone();
         view.seq = view.seq.saturating_add(1);
         let seq = view.seq;
+        drop(namespaces);
 
         let _ = self.event_tx.send(DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
             seq,
@@ -207,24 +200,28 @@ impl ConvoyProjection {
                 let summary = self.summarize(&convoy);
                 let namespace = summary.namespace.clone();
                 let id = summary.id.clone();
-                let view = self.namespaces.entry(namespace.clone()).or_default();
-                view.convoys.insert(id, summary.clone());
-                view.seq = view.seq.saturating_add(1);
 
-                let daemon_event = if !view.emitted_initial_snapshot {
-                    view.emitted_initial_snapshot = true;
-                    DaemonEvent::NamespaceSnapshot(Box::new(NamespaceSnapshot {
-                        seq: view.seq,
-                        namespace: namespace.clone(),
-                        convoys: view.convoys.values().cloned().collect(),
-                    }))
-                } else {
-                    DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
-                        seq: view.seq,
-                        namespace,
-                        changed: vec![summary],
-                        removed: Vec::new(),
-                    }))
+                let daemon_event = {
+                    let mut namespaces = self.state.write().await;
+                    let view = namespaces.entry(namespace.clone()).or_insert_with(NamespaceView::default);
+                    view.convoys.insert(id, summary.clone());
+                    view.seq = view.seq.saturating_add(1);
+
+                    if !view.emitted_initial_snapshot {
+                        view.emitted_initial_snapshot = true;
+                        DaemonEvent::NamespaceSnapshot(Box::new(NamespaceSnapshot {
+                            seq: view.seq,
+                            namespace: namespace.clone(),
+                            convoys: view.convoys.values().cloned().collect(),
+                        }))
+                    } else {
+                        DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
+                            seq: view.seq,
+                            namespace,
+                            changed: vec![summary],
+                            removed: Vec::new(),
+                        }))
+                    }
                 };
                 let _ = self.event_tx.send(daemon_event);
             }
@@ -232,18 +229,22 @@ impl ConvoyProjection {
                 let namespace = convoy.metadata.namespace.clone();
                 let name = convoy.metadata.name.clone();
                 let id = ConvoyId::new(&namespace, &name);
-                if let Some(view) = self.namespaces.get_mut(&namespace) {
-                    if view.convoys.remove(&id).is_some() {
-                        view.seq = view.seq.saturating_add(1);
-                        let daemon_event = DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
-                            seq: view.seq,
-                            namespace,
-                            changed: Vec::new(),
-                            removed: vec![id],
-                        }));
-                        let _ = self.event_tx.send(daemon_event);
+
+                let daemon_event = {
+                    let mut namespaces = self.state.write().await;
+                    let Some(view) = namespaces.get_mut(&namespace) else { return };
+                    if view.convoys.remove(&id).is_none() {
+                        return;
                     }
-                }
+                    view.seq = view.seq.saturating_add(1);
+                    DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
+                        seq: view.seq,
+                        namespace,
+                        changed: Vec::new(),
+                        removed: vec![id],
+                    }))
+                };
+                let _ = self.event_tx.send(daemon_event);
             }
         }
     }
@@ -439,7 +440,7 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let summary = ConvoyProjection::new(broadcast::channel(16).0).summarize(&convoy);
+        let summary = ConvoyProjection::new(NamespaceProjectionState::new(), broadcast::channel(16).0).summarize(&convoy);
         assert_eq!(summary.namespace, "flotilla");
         assert_eq!(summary.name, "fix-bug-123");
         assert_eq!(summary.workflow_ref, "review-and-fix");
@@ -461,7 +462,7 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let summary = ConvoyProjection::new(broadcast::channel(16).0).summarize(&convoy);
+        let summary = ConvoyProjection::new(NamespaceProjectionState::new(), broadcast::channel(16).0).summarize(&convoy);
         assert!(summary.initializing);
         assert!(summary.tasks.is_empty());
     }
@@ -469,7 +470,7 @@ mod tests {
     #[test]
     fn summarize_with_index_populates_workspace_ref() {
         let (tx, _rx) = broadcast::channel(16);
-        let mut projection = ConvoyProjection::new(tx);
+        let mut projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
         projection.apply_presentation(&presentation_obj("fix-bug-123", "implement", Some("ws-1")));
 
         let convoy = convoy_for_test("flotilla", "fix-bug-123", "wf", ResConvoyPhase::Active, &[("implement", ResTaskPhase::Running)]);
@@ -483,7 +484,7 @@ mod tests {
         use flotilla_resources::REPO_LABEL;
 
         let (tx, _rx) = broadcast::channel(16);
-        let projection = ConvoyProjection::new(tx);
+        let projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
 
         let mut convoy = convoy_for_test("flotilla", "x", "wf", ResConvoyPhase::Pending, &[]);
         convoy.metadata.labels.insert(REPO_LABEL.into(), "flotilla-org/flotilla".into());
@@ -495,7 +496,7 @@ mod tests {
     #[test]
     fn presentation_index_resolves_workspace_ref_per_task() {
         let (tx, _rx) = broadcast::channel(16);
-        let mut projection = ConvoyProjection::new(tx);
+        let mut projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
         projection.apply_presentation(&presentation_obj("fix-bug-123", "implement", Some("ws-1")));
         projection.apply_presentation(&presentation_obj("fix-bug-123", "review", Some("ws-2")));
 
@@ -506,7 +507,7 @@ mod tests {
     #[test]
     fn presentation_without_task_label_is_ignored() {
         let (tx, _rx) = broadcast::channel(16);
-        let mut projection = ConvoyProjection::new(tx);
+        let mut projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
         let mut p = presentation_obj("fix-bug-123", "implement", Some("ws-1"));
         p.metadata.labels.remove(TASK_LABEL);
         projection.apply_presentation(&p);
@@ -528,7 +529,7 @@ mod tests {
     #[tokio::test]
     async fn presentation_update_refreshes_workspace_ref_on_affected_convoy() {
         let (tx, mut rx) = broadcast::channel(16);
-        let mut projection = ConvoyProjection::new(tx);
+        let mut projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
 
         let convoy = convoy_for_test("flotilla", "fix-bug-123", "wf", ResConvoyPhase::Active, &[("implement", ResTaskPhase::Running)]);
         projection.apply_convoy_event(WatchEvent::Added(convoy.clone())).await;
@@ -552,7 +553,7 @@ mod tests {
     #[tokio::test]
     async fn applying_convoy_added_emits_initial_snapshot_then_delta() {
         let (tx, mut rx) = broadcast::channel(16);
-        let mut projection = ConvoyProjection::new(tx);
+        let mut projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
 
         let convoy = convoy_for_test("flotilla", "x", "wf", ResConvoyPhase::Pending, &[]);
         projection.apply_convoy_event(WatchEvent::Added(convoy.clone())).await;
@@ -592,7 +593,7 @@ mod tests {
     #[tokio::test]
     async fn applying_convoy_deleted_emits_removal_delta() {
         let (tx, mut rx) = broadcast::channel(16);
-        let mut projection = ConvoyProjection::new(tx);
+        let mut projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
         let convoy = convoy_for_test("flotilla", "x", "wf", ResConvoyPhase::Pending, &[]);
         projection.apply_convoy_event(WatchEvent::Added(convoy.clone())).await;
         let _ = drain(&mut rx); // consume snapshot
@@ -616,7 +617,7 @@ mod tests {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
 
         let (tx, mut rx) = broadcast::channel(16);
-        let projection = ConvoyProjection::new(tx);
+        let projection = ConvoyProjection::new(NamespaceProjectionState::new(), tx);
 
         let convoys = backend.clone().using::<Convoy>("flotilla");
         let presentations = backend.clone().using::<Presentation>("flotilla");

--- a/crates/flotilla-daemon/src/convoy_projection.rs
+++ b/crates/flotilla-daemon/src/convoy_projection.rs
@@ -4,7 +4,7 @@
 //
 // Spec: docs/superpowers/specs/2026-04-21-tui-convoy-view-design.md §Architecture.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use flotilla_core::namespace_projection::NamespaceProjectionState;
 use flotilla_protocol::{
@@ -28,16 +28,16 @@ pub struct ConvoyProjection {
     /// Authoritative namespace state, shared with `InProcessDaemon::replay_since`.
     state: NamespaceProjectionState,
     presentation_workspaces: HashMap<PresentationKey, String>,
-    /// Per-namespace flag: has the projection emitted its initial `NamespaceSnapshot`?
+    /// Namespaces that have already received their initial `NamespaceSnapshot`.
     /// Private to the projection — replay reads do not need it.
-    emitted_initial_snapshot: HashMap<String, bool>,
+    emitted_initial_snapshot: HashSet<String>,
     /// Emitter for events going to connected clients.
     event_tx: broadcast::Sender<DaemonEvent>,
 }
 
 impl ConvoyProjection {
     pub fn new(state: NamespaceProjectionState, event_tx: broadcast::Sender<DaemonEvent>) -> Self {
-        Self { state, presentation_workspaces: HashMap::new(), emitted_initial_snapshot: HashMap::new(), event_tx }
+        Self { state, presentation_workspaces: HashMap::new(), emitted_initial_snapshot: HashSet::new(), event_tx }
     }
 
     /// Drive the projection event loop. Lists both resources to get initial state, then
@@ -204,7 +204,7 @@ impl ConvoyProjection {
                 let namespace = summary.namespace.clone();
                 let id = summary.id.clone();
 
-                let already_emitted = self.emitted_initial_snapshot.get(&namespace).copied().unwrap_or(false);
+                let already_emitted = self.emitted_initial_snapshot.contains(&namespace);
                 let daemon_event = {
                     let mut namespaces = self.state.write().await;
                     let view = namespaces.entry(namespace.clone()).or_default();
@@ -226,7 +226,7 @@ impl ConvoyProjection {
                         }))
                     }
                 };
-                self.emitted_initial_snapshot.insert(namespace, true);
+                self.emitted_initial_snapshot.insert(namespace);
                 let _ = self.event_tx.send(daemon_event);
             }
             WatchEvent::Deleted(convoy) => {

--- a/crates/flotilla-daemon/src/convoy_projection.rs
+++ b/crates/flotilla-daemon/src/convoy_projection.rs
@@ -204,14 +204,14 @@ impl ConvoyProjection {
                 let namespace = summary.namespace.clone();
                 let id = summary.id.clone();
 
-                let already_emitted_snapshot = *self.emitted_initial_snapshot.entry(namespace.clone()).or_default();
+                let already_emitted = self.emitted_initial_snapshot.get(&namespace).copied().unwrap_or(false);
                 let daemon_event = {
                     let mut namespaces = self.state.write().await;
                     let view = namespaces.entry(namespace.clone()).or_default();
                     view.convoys.insert(id, summary.clone());
                     view.seq = view.seq.saturating_add(1);
 
-                    if already_emitted_snapshot {
+                    if already_emitted {
                         DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
                             seq: view.seq,
                             namespace: namespace.clone(),

--- a/crates/flotilla-daemon/src/convoy_projection.rs
+++ b/crates/flotilla-daemon/src/convoy_projection.rs
@@ -165,7 +165,7 @@ impl ConvoyProjection {
             stored.tasks.iter().map(|t| self.workspace_ref_for(&namespace, &convoy_name, &t.name)).collect();
 
         let view = namespaces.get_mut(&namespace).expect("namespace present; just read above");
-        let Some(stored) = view.convoys.get_mut(&id) else { return };
+        let stored = view.convoys.get_mut(&id).expect("convoy present; write lock held continuously from the cloned read above");
         for (task, ws_ref) in stored.tasks.iter_mut().zip(refreshed_refs.iter()) {
             task.workspace_ref = ws_ref.clone();
         }

--- a/crates/flotilla-daemon/src/convoy_projection.rs
+++ b/crates/flotilla-daemon/src/convoy_projection.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use flotilla_core::namespace_projection::{NamespaceProjectionState, NamespaceView};
+use flotilla_core::namespace_projection::NamespaceProjectionState;
 use flotilla_protocol::{
     namespace::{
         ConvoyId, ConvoyPhase as WireConvoyPhase, ConvoySummary, NamespaceDelta, NamespaceSnapshot, ProcessSummary,
@@ -28,13 +28,16 @@ pub struct ConvoyProjection {
     /// Authoritative namespace state, shared with `InProcessDaemon::replay_since`.
     state: NamespaceProjectionState,
     presentation_workspaces: HashMap<PresentationKey, String>,
+    /// Per-namespace flag: has the projection emitted its initial `NamespaceSnapshot`?
+    /// Private to the projection — replay reads do not need it.
+    emitted_initial_snapshot: HashMap<String, bool>,
     /// Emitter for events going to connected clients.
     event_tx: broadcast::Sender<DaemonEvent>,
 }
 
 impl ConvoyProjection {
     pub fn new(state: NamespaceProjectionState, event_tx: broadcast::Sender<DaemonEvent>) -> Self {
-        Self { state, presentation_workspaces: HashMap::new(), event_tx }
+        Self { state, presentation_workspaces: HashMap::new(), emitted_initial_snapshot: HashMap::new(), event_tx }
     }
 
     /// Drive the projection event loop. Lists both resources to get initial state, then
@@ -201,28 +204,29 @@ impl ConvoyProjection {
                 let namespace = summary.namespace.clone();
                 let id = summary.id.clone();
 
+                let already_emitted_snapshot = *self.emitted_initial_snapshot.entry(namespace.clone()).or_default();
                 let daemon_event = {
                     let mut namespaces = self.state.write().await;
-                    let view = namespaces.entry(namespace.clone()).or_insert_with(NamespaceView::default);
+                    let view = namespaces.entry(namespace.clone()).or_default();
                     view.convoys.insert(id, summary.clone());
                     view.seq = view.seq.saturating_add(1);
 
-                    if !view.emitted_initial_snapshot {
-                        view.emitted_initial_snapshot = true;
+                    if already_emitted_snapshot {
+                        DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
+                            seq: view.seq,
+                            namespace: namespace.clone(),
+                            changed: vec![summary],
+                            removed: Vec::new(),
+                        }))
+                    } else {
                         DaemonEvent::NamespaceSnapshot(Box::new(NamespaceSnapshot {
                             seq: view.seq,
                             namespace: namespace.clone(),
                             convoys: view.convoys.values().cloned().collect(),
                         }))
-                    } else {
-                        DaemonEvent::NamespaceDelta(Box::new(NamespaceDelta {
-                            seq: view.seq,
-                            namespace,
-                            changed: vec![summary],
-                            removed: Vec::new(),
-                        }))
                     }
                 };
+                self.emitted_initial_snapshot.insert(namespace, true);
                 let _ = self.event_tx.send(daemon_event);
             }
             WatchEvent::Deleted(convoy) => {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -15,6 +15,7 @@ use flotilla_controllers::reconcilers::{
 use flotilla_core::{
     config::ConfigStore,
     in_process::InProcessDaemon,
+    namespace_projection::NamespaceProjectionState,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
         discovery::{EnvironmentAssertion, EnvironmentBag},
@@ -82,6 +83,8 @@ impl DaemonRuntime {
             daemon.set_daemon_socket_path(path.clone()).await;
         }
         daemon.set_provisioning_namespace(options.namespace.clone()).await;
+        let namespace_projection_state = NamespaceProjectionState::new();
+        daemon.set_namespace_projection_state(namespace_projection_state.clone()).await;
 
         let local_registry = probe_local_provider_registry(&daemon, &config).await?;
         let profile = build_local_profile(&daemon, &local_registry)?;
@@ -611,8 +614,10 @@ fn spawn_controller_loops(
         tokio::spawn({
             let namespace_string = namespace_string.clone();
             let event_tx = state.daemon.event_sender();
+            let daemon = Arc::clone(&state.daemon);
             async move {
-                ConvoyProjection::new(event_tx)
+                let namespace_projection_state = daemon.namespace_projection_state().await;
+                ConvoyProjection::new(namespace_projection_state, event_tx)
                     .run(backend.clone().using::<Convoy>(&namespace_string), backend.using::<Presentation>(&namespace_string))
                     .await;
             }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -105,7 +105,7 @@ impl DaemonRuntime {
                 local_repo_root,
                 profile.host_direct_environment_name(),
             ));
-            tasks.extend(spawn_controller_loops(state, &options.namespace, options.controller_resync_interval));
+            tasks.extend(spawn_controller_loops(state, &options.namespace, options.controller_resync_interval, namespace_projection_state));
         }
 
         Ok(Self { tasks })
@@ -439,6 +439,7 @@ fn spawn_controller_loops(
     state: Arc<ControllerRuntimeState>,
     namespace: &str,
     controller_resync_interval: Duration,
+    namespace_projection_state: NamespaceProjectionState,
 ) -> Vec<JoinHandle<()>> {
     let backend = state.daemon.resource_backend();
     let namespace_string = namespace.to_string();
@@ -614,9 +615,7 @@ fn spawn_controller_loops(
         tokio::spawn({
             let namespace_string = namespace_string.clone();
             let event_tx = state.daemon.event_sender();
-            let daemon = Arc::clone(&state.daemon);
             async move {
-                let namespace_projection_state = daemon.namespace_projection_state().await;
                 ConvoyProjection::new(namespace_projection_state, event_tx)
                     .run(backend.clone().using::<Convoy>(&namespace_string), backend.using::<Presentation>(&namespace_string))
                     .await;
@@ -1089,7 +1088,10 @@ mod tests {
             Some(ExecutionEnvironmentPath::new(&repo)),
             profile.host_direct_environment_name(),
         ));
-        let controller_handles = spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(25));
+        let namespace_projection_state = NamespaceProjectionState::new();
+        daemon.set_namespace_projection_state(namespace_projection_state.clone()).await;
+        let controller_handles =
+            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(25), namespace_projection_state);
 
         backend
             .clone()


### PR DESCRIPTION
## Summary

Previously, `InProcessDaemon` maintained a `namespace_state` mirror populated by a background subscriber on the broadcast channel, and `replay_since` consulted that cache. The mirror had two correctness seams:

- On broadcast lag we cleared the entire cache (no namespace state in replay until the next snapshot arrives).
- A delta arriving before any snapshot for a namespace had to be discarded to avoid synthesising a seq-0 baseline that would regress reconnecting clients.

This PR makes `ConvoyProjection` the sole owner of authoritative namespace state. A small new type — `NamespaceProjectionState` in `flotilla-core` — wraps an `Arc<RwLock<HashMap<String, NamespaceView>>>`, is cloned cheaply, and is shared between the projection (single writer) and `InProcessDaemon::replay_since` (reader). The broadcast-driven mirror, its subscriber task, and both workarounds disappear with it.

Wiring follows the existing `set_daemon_socket_path` / `set_provisioning_namespace` precedent: the daemon runtime constructs the shared state in `start_with_options` and installs it on the daemon before the projection is spawned.

Closes #591.

## Changes

- `flotilla-core/src/namespace_projection.rs` (new) — `NamespaceView` and `NamespaceProjectionState`.
- `InProcessDaemon`:
  - Drop `namespace_state: Arc<RwLock<HashMap<…, NamespaceSnapshot>>>` and the spawned broadcast subscriber.
  - Add `set_namespace_projection_state` / `namespace_projection_state` accessors.
  - `replay_since` reads directly from the projection state.
- `ConvoyProjection`:
  - Take `NamespaceProjectionState` at construction, read/write through it.
  - `apply_convoy_event` and `apply_presentation_event` lock the shared state instead of a private `HashMap`.
- `DaemonRuntime::start_with_options` creates the shared state once and installs it on the daemon before spawning the projection.

## Test plan

- [x] Replace `namespace_delta_before_snapshot_is_skipped` and `namespace_state_cleared_on_broadcast_lag` (which probed the mirror's failure modes) with two tests against the new direct-read path:
  - `replay_since_reads_namespace_snapshots_from_projection_state` — writes go into the shared state, `replay_since` synthesises a `NamespaceSnapshot` with the expected `seq` and convoys.
  - `replay_since_skips_namespace_when_last_seen_matches_seq` — client at the current `seq` does not receive a redundant snapshot.
- [x] `cargo test --workspace --locked`
- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`