### PR TITLE
feat(daemon): bounded restart supervision for provisioning controllers

### DIFF
--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -5,3 +5,4 @@ pub mod cli;
 pub mod peer;
 pub mod runtime;
 pub mod server;
+pub mod supervisor;

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -34,9 +34,12 @@ use flotilla_resources::{
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
-use tracing::{error, warn};
+use tracing::warn;
 
-use crate::ConvoyProjection;
+use crate::{
+    supervisor::{supervise, ControllerSupervision},
+    ConvoyProjection,
+};
 
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
@@ -46,6 +49,7 @@ pub struct RuntimeOptions {
     pub namespace: String,
     pub heartbeat_interval: Duration,
     pub controller_resync_interval: Duration,
+    pub controller_supervision: ControllerSupervision,
     pub start_controllers: bool,
 }
 
@@ -55,6 +59,7 @@ impl Default for RuntimeOptions {
             namespace: flotilla_core::in_process::DEFAULT_PROVISIONING_NAMESPACE.to_string(),
             heartbeat_interval: Duration::from_secs(30),
             controller_resync_interval: Duration::from_secs(60),
+            controller_supervision: ControllerSupervision::default(),
             start_controllers: true,
         }
     }
@@ -105,7 +110,13 @@ impl DaemonRuntime {
                 local_repo_root,
                 profile.host_direct_environment_name(),
             ));
-            tasks.extend(spawn_controller_loops(state, &options.namespace, options.controller_resync_interval, namespace_projection_state));
+            tasks.extend(spawn_controller_loops(
+                state,
+                &options.namespace,
+                options.controller_resync_interval,
+                options.controller_supervision.clone(),
+                namespace_projection_state,
+            ));
         }
 
         Ok(Self { tasks })
@@ -439,6 +450,7 @@ fn spawn_controller_loops(
     state: Arc<ControllerRuntimeState>,
     namespace: &str,
     controller_resync_interval: Duration,
+    supervision: ControllerSupervision,
     namespace_projection_state: NamespaceProjectionState,
 ) -> Vec<JoinHandle<()>> {
     let backend = state.daemon.resource_backend();
@@ -448,168 +460,204 @@ fn spawn_controller_loops(
             let backend = backend.clone();
             let namespace_string = namespace_string.clone();
             let state = Arc::clone(&state);
+            let supervision = supervision.clone();
             async move {
-                if let Err(err) = (ControllerLoop {
-                    primary: backend.clone().using::<Environment>(&namespace_string),
-                    secondaries: vec![],
-                    reconciler: EnvironmentReconciler::new(Arc::new(DockerControllerRuntime { state: Arc::clone(&state) })),
-                    resync_interval: controller_resync_interval,
-                    backend: backend.clone(),
-                })
-                .run()
-                .await
-                {
-                    error!(controller = "environment", %err, "controller loop exited");
-                }
-            }
-        }),
-        tokio::spawn({
-            let backend = backend.clone();
-            let namespace_string = namespace_string.clone();
-            let state = Arc::clone(&state);
-            async move {
-                if let Err(err) = (ControllerLoop {
-                    primary: backend.clone().using::<Clone>(&namespace_string),
-                    secondaries: vec![],
-                    reconciler: CloneReconciler::new(Arc::new(CloneControllerRuntime {
-                        runner: state.daemon.local_command_runner().expect("local runner should exist"),
-                    })),
-                    resync_interval: controller_resync_interval,
-                    backend: backend.clone(),
-                })
-                .run()
-                .await
-                {
-                    error!(controller = "clone", %err, "controller loop exited");
-                }
-            }
-        }),
-        tokio::spawn({
-            let backend = backend.clone();
-            let namespace_string = namespace_string.clone();
-            let state = Arc::clone(&state);
-            async move {
-                if let Err(err) = (ControllerLoop {
-                    primary: backend.clone().using::<flotilla_resources::Checkout>(&namespace_string),
-                    secondaries: vec![],
-                    reconciler: CheckoutReconciler::new(
-                        Arc::new(CheckoutControllerRuntime {
-                            runner: state.daemon.local_command_runner().expect("local runner should exist"),
-                        }),
-                        backend.clone(),
-                        &namespace_string,
-                    ),
-                    resync_interval: controller_resync_interval,
-                    backend: backend.clone(),
-                })
-                .run()
-                .await
-                {
-                    error!(controller = "checkout", %err, "controller loop exited");
-                }
-            }
-        }),
-        tokio::spawn({
-            let backend = backend.clone();
-            let namespace_string = namespace_string.clone();
-            let state = Arc::clone(&state);
-            async move {
-                if let Err(err) = (ControllerLoop {
-                    primary: backend.clone().using::<flotilla_resources::TerminalSession>(&namespace_string),
-                    secondaries: vec![],
-                    reconciler: TerminalSessionReconciler::new(
-                        Arc::new(TerminalControllerRuntime { state: Arc::clone(&state) }),
-                        backend.clone(),
-                        &namespace_string,
-                    ),
-                    resync_interval: controller_resync_interval,
-                    backend: backend.clone(),
-                })
-                .run()
-                .await
-                {
-                    error!(controller = "terminal_session", %err, "controller loop exited");
-                }
-            }
-        }),
-        tokio::spawn({
-            let backend = backend.clone();
-            let namespace_string = namespace_string.clone();
-            async move {
-                if let Err(err) = (ControllerLoop {
-                    primary: backend.clone().using::<TaskWorkspace>(&namespace_string),
-                    secondaries: TaskWorkspaceReconciler::secondary_watches(),
-                    reconciler: TaskWorkspaceReconciler::new(backend.clone(), &namespace_string),
-                    resync_interval: controller_resync_interval,
-                    backend: backend.clone(),
-                })
-                .run()
-                .await
-                {
-                    error!(controller = "task_workspace", %err, "controller loop exited");
-                }
-            }
-        }),
-        tokio::spawn({
-            let backend = backend.clone();
-            let namespace_string = namespace_string.clone();
-            let state = Arc::clone(&state);
-            async move {
-                let policies = Arc::new(PresentationPolicyRegistry::with_defaults());
-                let runtime = Arc::new(ProviderPresentationRuntime::new(Arc::clone(&state.local_registry), Arc::clone(&policies)));
-                let mut hop_chain = HopChainContext::new(
-                    state.local_host_ref.clone(),
-                    state.daemon.host_name().clone(),
-                    state.config.base_path().clone(),
-                    {
-                        let state = Arc::clone(&state);
-                        move |env_ref| {
-                            if env_ref == state.host_direct_environment_name {
-                                return Ok(Arc::clone(&state.local_registry));
-                            }
-                            state
-                                .daemon
-                                .environment_registry_for_environment(&EnvironmentId::new(env_ref.to_string()))
-                                .ok_or_else(|| format!("provider registry unavailable for environment {env_ref}"))
+                supervise("environment", supervision, move || {
+                    let backend = backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    let state = Arc::clone(&state);
+                    async move {
+                        ControllerLoop {
+                            primary: backend.clone().using::<Environment>(&namespace_string),
+                            secondaries: vec![],
+                            reconciler: EnvironmentReconciler::new(Arc::new(DockerControllerRuntime { state })),
+                            resync_interval: controller_resync_interval,
+                            backend,
                         }
-                    },
-                );
-                if let Some(repo_root) = state.local_repo_root.clone() {
-                    hop_chain = hop_chain.with_repo_root(repo_root);
-                }
-
-                if let Err(err) = (ControllerLoop {
-                    primary: backend.clone().using::<Presentation>(&namespace_string),
-                    secondaries: PresentationReconciler::<ProviderPresentationRuntime>::secondary_watches(),
-                    reconciler: PresentationReconciler::new(runtime, backend.clone(), &namespace_string, hop_chain, policies),
-                    resync_interval: controller_resync_interval,
-                    backend: backend.clone(),
+                        .run()
+                        .await
+                    }
                 })
-                .run()
-                .await
-                {
-                    error!(controller = "presentation", %err, "controller loop exited");
-                }
+                .await;
             }
         }),
         tokio::spawn({
+            let backend = backend.clone();
             let namespace_string = namespace_string.clone();
-            let backend_for_reconciler = backend.clone();
+            let state = Arc::clone(&state);
+            let supervision = supervision.clone();
             async move {
-                if let Err(err) = (ControllerLoop {
-                    primary: backend_for_reconciler.clone().using::<Convoy>(&namespace_string),
-                    secondaries: ConvoyReconciler::secondary_watches(),
-                    reconciler: ConvoyReconciler::new(backend_for_reconciler.clone().using::<WorkflowTemplate>(&namespace_string))
-                        .with_task_workspaces(backend_for_reconciler.clone().using::<TaskWorkspace>(&namespace_string))
-                        .with_presentations(backend_for_reconciler.clone().using::<Presentation>(&namespace_string)),
-                    resync_interval: controller_resync_interval,
-                    backend: backend_for_reconciler,
+                supervise("clone", supervision, move || {
+                    let backend = backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    let runner = state.daemon.local_command_runner().expect("local runner should exist");
+                    async move {
+                        ControllerLoop {
+                            primary: backend.clone().using::<Clone>(&namespace_string),
+                            secondaries: vec![],
+                            reconciler: CloneReconciler::new(Arc::new(CloneControllerRuntime { runner })),
+                            resync_interval: controller_resync_interval,
+                            backend,
+                        }
+                        .run()
+                        .await
+                    }
                 })
-                .run()
-                .await
-                {
-                    error!(controller = "convoy", %err, "controller loop exited");
-                }
+                .await;
+            }
+        }),
+        tokio::spawn({
+            let backend = backend.clone();
+            let namespace_string = namespace_string.clone();
+            let state = Arc::clone(&state);
+            let supervision = supervision.clone();
+            async move {
+                supervise("checkout", supervision, move || {
+                    let backend = backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    let runner = state.daemon.local_command_runner().expect("local runner should exist");
+                    async move {
+                        ControllerLoop {
+                            primary: backend.clone().using::<flotilla_resources::Checkout>(&namespace_string),
+                            secondaries: vec![],
+                            reconciler: CheckoutReconciler::new(
+                                Arc::new(CheckoutControllerRuntime { runner }),
+                                backend.clone(),
+                                &namespace_string,
+                            ),
+                            resync_interval: controller_resync_interval,
+                            backend,
+                        }
+                        .run()
+                        .await
+                    }
+                })
+                .await;
+            }
+        }),
+        tokio::spawn({
+            let backend = backend.clone();
+            let namespace_string = namespace_string.clone();
+            let state = Arc::clone(&state);
+            let supervision = supervision.clone();
+            async move {
+                supervise("terminal_session", supervision, move || {
+                    let backend = backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    let state = Arc::clone(&state);
+                    async move {
+                        ControllerLoop {
+                            primary: backend.clone().using::<flotilla_resources::TerminalSession>(&namespace_string),
+                            secondaries: vec![],
+                            reconciler: TerminalSessionReconciler::new(
+                                Arc::new(TerminalControllerRuntime { state }),
+                                backend.clone(),
+                                &namespace_string,
+                            ),
+                            resync_interval: controller_resync_interval,
+                            backend,
+                        }
+                        .run()
+                        .await
+                    }
+                })
+                .await;
+            }
+        }),
+        tokio::spawn({
+            let backend = backend.clone();
+            let namespace_string = namespace_string.clone();
+            let supervision = supervision.clone();
+            async move {
+                supervise("task_workspace", supervision, move || {
+                    let backend = backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    async move {
+                        ControllerLoop {
+                            primary: backend.clone().using::<TaskWorkspace>(&namespace_string),
+                            secondaries: TaskWorkspaceReconciler::secondary_watches(),
+                            reconciler: TaskWorkspaceReconciler::new(backend.clone(), &namespace_string),
+                            resync_interval: controller_resync_interval,
+                            backend,
+                        }
+                        .run()
+                        .await
+                    }
+                })
+                .await;
+            }
+        }),
+        tokio::spawn({
+            let backend = backend.clone();
+            let namespace_string = namespace_string.clone();
+            let state = Arc::clone(&state);
+            let supervision = supervision.clone();
+            async move {
+                supervise("presentation", supervision, move || {
+                    let backend = backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    let state = Arc::clone(&state);
+                    async move {
+                        let policies = Arc::new(PresentationPolicyRegistry::with_defaults());
+                        let runtime = Arc::new(ProviderPresentationRuntime::new(Arc::clone(&state.local_registry), Arc::clone(&policies)));
+                        let mut hop_chain = HopChainContext::new(
+                            state.local_host_ref.clone(),
+                            state.daemon.host_name().clone(),
+                            state.config.base_path().clone(),
+                            {
+                                let state = Arc::clone(&state);
+                                move |env_ref| {
+                                    if env_ref == state.host_direct_environment_name {
+                                        return Ok(Arc::clone(&state.local_registry));
+                                    }
+                                    state
+                                        .daemon
+                                        .environment_registry_for_environment(&EnvironmentId::new(env_ref.to_string()))
+                                        .ok_or_else(|| format!("provider registry unavailable for environment {env_ref}"))
+                                }
+                            },
+                        );
+                        if let Some(repo_root) = state.local_repo_root.clone() {
+                            hop_chain = hop_chain.with_repo_root(repo_root);
+                        }
+
+                        ControllerLoop {
+                            primary: backend.clone().using::<Presentation>(&namespace_string),
+                            secondaries: PresentationReconciler::<ProviderPresentationRuntime>::secondary_watches(),
+                            reconciler: PresentationReconciler::new(runtime, backend.clone(), &namespace_string, hop_chain, policies),
+                            resync_interval: controller_resync_interval,
+                            backend,
+                        }
+                        .run()
+                        .await
+                    }
+                })
+                .await;
+            }
+        }),
+        tokio::spawn({
+            let backend = backend.clone();
+            let namespace_string = namespace_string.clone();
+            let supervision = supervision.clone();
+            async move {
+                supervise("convoy", supervision, move || {
+                    let backend = backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    async move {
+                        ControllerLoop {
+                            primary: backend.clone().using::<Convoy>(&namespace_string),
+                            secondaries: ConvoyReconciler::secondary_watches(),
+                            reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(&namespace_string))
+                                .with_task_workspaces(backend.clone().using::<TaskWorkspace>(&namespace_string))
+                                .with_presentations(backend.clone().using::<Presentation>(&namespace_string)),
+                            resync_interval: controller_resync_interval,
+                            backend,
+                        }
+                        .run()
+                        .await
+                    }
+                })
+                .await;
             }
         }),
         tokio::spawn({
@@ -1090,8 +1138,13 @@ mod tests {
         ));
         let namespace_projection_state = NamespaceProjectionState::new();
         daemon.set_namespace_projection_state(namespace_projection_state.clone()).await;
-        let controller_handles =
-            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(25), namespace_projection_state);
+        let controller_handles = spawn_controller_loops(
+            Arc::clone(&state),
+            NAMESPACE,
+            Duration::from_millis(25),
+            ControllerSupervision::default(),
+            namespace_projection_state,
+        );
 
         backend
             .clone()

--- a/crates/flotilla-daemon/src/supervisor.rs
+++ b/crates/flotilla-daemon/src/supervisor.rs
@@ -1,0 +1,195 @@
+//! Bounded restart supervision for daemon controller tasks.
+//!
+//! Each provisioning controller runs a `ControllerLoop::run()` future that can return
+//! `Err` from reconcile-path work (`fetch_dependencies`, `apply_actuation`, status
+//! patches). The internal watch loop already restarts watch streams on disconnect,
+//! but a reconcile-path error bubbles out and ends the loop. Without supervision
+//! the daemon's `tokio::spawn` task ends silently and provisioning stays disabled
+//! until daemon restart.
+//!
+//! `supervise` re-invokes the controller after backoff, resetting the budget after
+//! a run survives long enough to suggest the controller has stabilised. When the
+//! budget is exhausted the supervisor logs and gives up — better to fail loudly
+//! than to spin forever on a permanent error.
+
+use std::{future::Future, time::Duration};
+
+use flotilla_resources::ResourceError;
+use tracing::{error, warn};
+
+/// Bounded restart + exponential backoff config for [`supervise`].
+#[derive(Debug, Clone)]
+pub struct ControllerSupervision {
+    /// Maximum number of consecutive failed runs before the supervisor gives up.
+    pub max_consecutive_failures: usize,
+    /// Backoff applied after the first failure; doubles each consecutive failure.
+    pub initial_backoff: Duration,
+    /// Cap on the doubled backoff.
+    pub max_backoff: Duration,
+    /// If a run survives at least this long before erroring, the consecutive-failure
+    /// counter resets — a controller that runs for a minute and then trips on a
+    /// new error is treated as fresh, not as accumulating toward exhaustion.
+    pub success_reset_after: Duration,
+}
+
+impl Default for ControllerSupervision {
+    fn default() -> Self {
+        Self {
+            max_consecutive_failures: 10,
+            initial_backoff: Duration::from_millis(100),
+            max_backoff: Duration::from_secs(30),
+            success_reset_after: Duration::from_secs(60),
+        }
+    }
+}
+
+/// Run `make_run` repeatedly with bounded restart + exponential backoff.
+///
+/// Returns when the controller returns `Ok(())` (clean shutdown — all watch
+/// streams closed) or when the consecutive-failure budget is exhausted.
+pub async fn supervise<F, Fut>(name: &'static str, config: ControllerSupervision, mut make_run: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<(), ResourceError>>,
+{
+    let mut consecutive_failures: usize = 0;
+    let mut backoff = config.initial_backoff;
+    loop {
+        let started_at = tokio::time::Instant::now();
+        match make_run().await {
+            Ok(()) => return,
+            Err(err) => {
+                if started_at.elapsed() >= config.success_reset_after {
+                    consecutive_failures = 0;
+                    backoff = config.initial_backoff;
+                }
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if consecutive_failures > config.max_consecutive_failures {
+                    error!(
+                        controller = name,
+                        %err,
+                        attempts = consecutive_failures,
+                        "controller exhausted restart budget; provisioning disabled until daemon restart",
+                    );
+                    return;
+                }
+                warn!(
+                    controller = name,
+                    %err,
+                    attempt = consecutive_failures,
+                    backoff_ms = backoff.as_millis() as u64,
+                    "controller errored; restarting after backoff",
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = backoff.saturating_mul(2).min(config.max_backoff);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use super::*;
+
+    fn fast_config(max_consecutive_failures: usize) -> ControllerSupervision {
+        ControllerSupervision {
+            max_consecutive_failures,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(4),
+            success_reset_after: Duration::from_secs(60),
+        }
+    }
+
+    #[tokio::test]
+    async fn supervise_returns_on_clean_ok() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        supervise("test", fast_config(3), {
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            }
+        })
+        .await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn supervise_restarts_until_run_succeeds() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        supervise("test", fast_config(5), {
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    let n = attempts.fetch_add(1, Ordering::SeqCst);
+                    if n < 2 {
+                        Err(ResourceError::other("flap"))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        })
+        .await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn supervise_gives_up_after_max_consecutive_failures() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        supervise("test", fast_config(2), {
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err::<(), _>(ResourceError::other("permanent"))
+                }
+            }
+        })
+        .await;
+        // Budget of 2 means: 1st failure (count=1) → retry; 2nd (count=2) → retry;
+        // 3rd (count=3 > 2) → give up. So make_run runs 3 times.
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn supervise_resets_budget_after_long_run() {
+        // Budget tolerates 2 consecutive failures (gives up at the 3rd). The scenario:
+        // 2 quick fails (cf=1,2), then a long-running fail that exceeds
+        // `success_reset_after` so cf resets to 0 → next quick fail re-enters at cf=1, and
+        // exhaustion happens on the cumulative 5th call. Without the reset, the supervisor
+        // would have given up after call 3.
+        let config = ControllerSupervision {
+            max_consecutive_failures: 2,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(1),
+            success_reset_after: Duration::from_millis(20),
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        supervise("test", config, {
+            let attempts = Arc::clone(&attempts);
+            move || {
+                let attempts = Arc::clone(&attempts);
+                async move {
+                    let n = attempts.fetch_add(1, Ordering::SeqCst);
+                    if n == 2 {
+                        tokio::time::sleep(Duration::from_millis(30)).await;
+                    }
+                    Err::<(), _>(ResourceError::other("flap"))
+                }
+            }
+        })
+        .await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 5);
+    }
+}

--- a/crates/flotilla-daemon/src/supervisor.rs
+++ b/crates/flotilla-daemon/src/supervisor.rs
@@ -1,16 +1,5 @@
-//! Bounded restart supervision for daemon controller tasks.
-//!
-//! Each provisioning controller runs a `ControllerLoop::run()` future that can return
-//! `Err` from reconcile-path work (`fetch_dependencies`, `apply_actuation`, status
-//! patches). The internal watch loop already restarts watch streams on disconnect,
-//! but a reconcile-path error bubbles out and ends the loop. Without supervision
-//! the daemon's `tokio::spawn` task ends silently and provisioning stays disabled
-//! until daemon restart.
-//!
-//! `supervise` re-invokes the controller after backoff, resetting the budget after
-//! a run survives long enough to suggest the controller has stabilised. When the
-//! budget is exhausted the supervisor logs and gives up — better to fail loudly
-//! than to spin forever on a permanent error.
+//! Bounded restart supervision: reconcile-path errors from `ControllerLoop::run()` bubble
+//! out and kill the spawned task; this re-invokes the loop with exponential backoff and a capped budget.
 
 use std::{future::Future, time::Duration};
 
@@ -64,7 +53,7 @@ where
                     backoff = config.initial_backoff;
                 }
                 consecutive_failures = consecutive_failures.saturating_add(1);
-                if consecutive_failures > config.max_consecutive_failures {
+                if consecutive_failures >= config.max_consecutive_failures {
                     error!(
                         controller = name,
                         %err,
@@ -157,18 +146,16 @@ mod tests {
             }
         })
         .await;
-        // Budget of 2 means: 1st failure (count=1) → retry; 2nd (count=2) → retry;
-        // 3rd (count=3 > 2) → give up. So make_run runs 3 times.
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        // Budget of 2 means: 1st failure (cf=1, 1>=2 false) retries; 2nd (cf=2, 2>=2) gives up.
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]
     async fn supervise_resets_budget_after_long_run() {
-        // Budget tolerates 2 consecutive failures (gives up at the 3rd). The scenario:
-        // 2 quick fails (cf=1,2), then a long-running fail that exceeds
-        // `success_reset_after` so cf resets to 0 → next quick fail re-enters at cf=1, and
-        // exhaustion happens on the cumulative 5th call. Without the reset, the supervisor
-        // would have given up after call 3.
+        // Budget of 2 gives up on the 2nd consecutive failure. Scenario: 1 quick fail (cf=1),
+        // 1 long fail that exceeds `success_reset_after` so cf resets to 0 then increments to 1,
+        // then 1 quick fail (cf=2 → give up). Total 3 calls. Without the reset the supervisor
+        // would have given up after call 2.
         let config = ControllerSupervision {
             max_consecutive_failures: 2,
             initial_backoff: Duration::from_millis(1),
@@ -182,7 +169,7 @@ mod tests {
                 let attempts = Arc::clone(&attempts);
                 async move {
                     let n = attempts.fetch_add(1, Ordering::SeqCst);
-                    if n == 2 {
+                    if n == 1 {
                         tokio::time::sleep(Duration::from_millis(30)).await;
                     }
                     Err::<(), _>(ResourceError::other("flap"))
@@ -190,6 +177,6 @@ mod tests {
             }
         })
         .await;
-        assert_eq!(attempts.load(Ordering::SeqCst), 5);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 }

--- a/crates/flotilla-daemon/tests/convoy_projection.rs
+++ b/crates/flotilla-daemon/tests/convoy_projection.rs
@@ -57,6 +57,7 @@ async fn convoy_projection_emits_namespace_events() {
         heartbeat_interval: Duration::from_secs(300),
         controller_resync_interval: Duration::from_secs(300),
         start_controllers: true,
+        ..RuntimeOptions::default()
     };
     let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
 
@@ -114,6 +115,7 @@ async fn replay_since_returns_namespace_events_after_seq() {
         heartbeat_interval: Duration::from_secs(300),
         controller_resync_interval: Duration::from_secs(300),
         start_controllers: true,
+        ..RuntimeOptions::default()
     };
     let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
 

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -65,6 +65,7 @@ async fn tui_shows_convoys_from_daemon() {
         heartbeat_interval: Duration::from_secs(300),
         controller_resync_interval: Duration::from_secs(300),
         start_controllers: true,
+        ..RuntimeOptions::default()
     };
     let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
 
@@ -141,6 +142,7 @@ async fn x_then_enter_completes_task_via_palette() {
         heartbeat_interval: Duration::from_secs(300),
         controller_resync_interval: Duration::from_secs(300),
         start_controllers: true,
+        ..RuntimeOptions::default()
     };
     let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
 


### PR DESCRIPTION
## Summary

- Wrap each `ControllerLoop` spawn in a new `supervise()` helper with bounded restart + exponential backoff
- Add `ControllerSupervision` config exposed via `RuntimeOptions::controller_supervision` (defaults: 10 consecutive failures, 100ms → 30s backoff, 60s reset window)
- Log at `error` level when the restart budget is exhausted

## Why

PR #582 made `ControllerLoop`'s internal watch loop survive watch-stream disconnects, but reconcile-path errors (`fetch_dependencies`, `apply_actuation`, status patches) still bubble out of `run()` and end the daemon's `tokio::spawn` task. Result: a single transient backend failure silently disabled provisioning until daemon restart.

The supervisor wraps each of the 7 controller spawn sites (Environment, Clone, Checkout, TerminalSession, TaskWorkspace, Presentation, Convoy). The 8th spawn (`ConvoyProjection`) has a different return type and is out of scope.

A run that survives `success_reset_after` resets the consecutive-failure counter — a controller that runs cleanly for a minute and then trips on a new error gets the full retry budget again, instead of accumulating toward exhaustion across the controller's lifetime.

## Test plan

- [x] 4 new unit tests covering supervise contract: clean-Ok, retry-until-success, budget exhaustion, reset-after-long-run
- [x] Existing `in_memory_stage4a_flow_reaches_running_and_completes_convoy` still passes (verifies wiring doesn't break the happy path)
- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`

Closes #583.