### PR TITLE
feat(cli): convoy create + workflow-template apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,6 +1221,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "flotilla-protocol",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/flotilla-commands/Cargo.toml
+++ b/crates/flotilla-commands/Cargo.toml
@@ -7,3 +7,6 @@ license.workspace = true
 [dependencies]
 flotilla-protocol = { path = "../flotilla-protocol" }
 clap = { version = "4", features = ["derive", "string"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -20,6 +20,29 @@ pub struct ConvoyNoun {
 pub enum ConvoyVerb {
     /// Manage convoy tasks
     Task(ConvoyTaskNoun),
+    /// Create a convoy from a workflow template
+    Create {
+        /// Workflow template to instantiate
+        #[arg(long)]
+        template: String,
+        /// Input value (repeatable): --input key=value
+        #[arg(long = "input", value_parser = parse_input_kv)]
+        inputs: Vec<(String, String)>,
+        /// Repository URL the workflow operates on
+        #[arg(long = "repo")]
+        repository_url: Option<String>,
+        /// Git ref (branch/tag/commit) within the repository
+        #[arg(long = "ref")]
+        r#ref: Option<String>,
+    },
+}
+
+fn parse_input_kv(raw: &str) -> Result<(String, String), String> {
+    let (key, value) = raw.split_once('=').ok_or_else(|| format!("input must be key=value: {raw}"))?;
+    if key.is_empty() {
+        return Err(format!("input key cannot be empty: {raw}"));
+    }
+    Ok((key.to_string(), value.to_string()))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
@@ -56,6 +79,16 @@ impl ConvoyNoun {
                     host: HostResolution::Local,
                 }),
             },
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref } => Ok(Resolved::NeedsContext {
+                command: Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::ConvoyCreate { name: self.subject, workflow_ref: template, inputs, repository_url, r#ref },
+                },
+                repo: RepoContext::None,
+                host: HostResolution::Local,
+            }),
         }
     }
 }
@@ -73,6 +106,18 @@ impl std::fmt::Display for ConvoyNoun {
                             write!(f, " --message {message}")?;
                         }
                     }
+                }
+            }
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref } => {
+                write!(f, " create --template {template}")?;
+                for (k, v) in inputs {
+                    write!(f, " --input {k}={v}")?;
+                }
+                if let Some(url) = repository_url {
+                    write!(f, " --repo {url}")?;
+                }
+                if let Some(reference) = r#ref {
+                    write!(f, " --ref {reference}")?;
                 }
             }
         }
@@ -133,5 +178,80 @@ mod tests {
     #[test]
     fn round_trip_complete() {
         assert_round_trip::<ConvoyNoun>(&["convoy", "convoy-a", "task", "implement", "complete"]);
+    }
+
+    #[test]
+    fn convoy_create_resolves() {
+        let resolved = parse(&[
+            "convoy",
+            "my-convoy",
+            "create",
+            "--template",
+            "scratch",
+            "--input",
+            "topic=demo",
+            "--input",
+            "branch=foo",
+            "--repo",
+            "https://github.com/flotilla-org/flotilla.git",
+            "--ref",
+            "main",
+        ])
+        .resolve()
+        .expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "my-convoy".into(),
+                    workflow_ref: "scratch".into(),
+                    inputs: vec![("topic".into(), "demo".into()), ("branch".into(), "foo".into())],
+                    repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
+                    r#ref: Some("main".into()),
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn convoy_create_minimal_resolves() {
+        let resolved = parse(&["convoy", "scratch-1", "create", "--template", "scratch"]).resolve().expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "scratch-1".into(),
+                    workflow_ref: "scratch".into(),
+                    inputs: vec![],
+                    repository_url: None,
+                    r#ref: None,
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn round_trip_create() {
+        assert_round_trip::<ConvoyNoun>(&[
+            "convoy",
+            "my-convoy",
+            "create",
+            "--template",
+            "scratch",
+            "--input",
+            "topic=demo",
+            "--repo",
+            "https://example.com/repo.git",
+            "--ref",
+            "main",
+        ]);
     }
 }

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use flotilla_protocol::{Command, CommandAction};
 
 use crate::{
+    quote::quote_value,
     resolved::{HostResolution, RepoContext},
     Resolved,
 };
@@ -109,15 +110,15 @@ impl std::fmt::Display for ConvoyNoun {
                 }
             }
             ConvoyVerb::Create { template, inputs, repository_url, r#ref } => {
-                write!(f, " create --template {template}")?;
+                write!(f, " create --template {}", quote_value(template))?;
                 for (k, v) in inputs {
-                    write!(f, " --input {k}={v}")?;
+                    write!(f, " --input {}", quote_value(&format!("{k}={v}")))?;
                 }
                 if let Some(url) = repository_url {
-                    write!(f, " --repo {url}")?;
+                    write!(f, " --repo {}", quote_value(url))?;
                 }
                 if let Some(reference) = r#ref {
-                    write!(f, " --ref {reference}")?;
+                    write!(f, " --ref {}", quote_value(reference))?;
                 }
             }
         }
@@ -253,5 +254,23 @@ mod tests {
             "--ref",
             "main",
         ]);
+    }
+
+    #[test]
+    fn create_display_quotes_values_with_whitespace() {
+        let parsed = parse(&[
+            "convoy",
+            "my-convoy",
+            "create",
+            "--template",
+            "scratch",
+            "--input",
+            "topic=my work",
+            "--repo",
+            "https://example.com/path with space.git",
+        ]);
+        let displayed = parsed.to_string();
+        assert!(displayed.contains("--input \"topic=my work\""), "expected quoted input in {displayed:?}");
+        assert!(displayed.contains("--repo \"https://example.com/path with space.git\""), "expected quoted repo in {displayed:?}");
     }
 }

--- a/crates/flotilla-commands/src/commands/mod.rs
+++ b/crates/flotilla-commands/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub mod environment;
 pub mod host;
 pub mod issue;
 pub mod repo;
+pub mod workflow_template;
 pub mod workspace;

--- a/crates/flotilla-commands/src/commands/workflow_template.rs
+++ b/crates/flotilla-commands/src/commands/workflow_template.rs
@@ -4,6 +4,7 @@ use clap::{Parser, Subcommand};
 use flotilla_protocol::{Command, CommandAction};
 
 use crate::{
+    quote::quote_value,
     resolved::{HostResolution, RepoContext},
     Resolved,
 };
@@ -50,9 +51,9 @@ impl WorkflowTemplateNoun {
 
 impl std::fmt::Display for WorkflowTemplateNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "workflow-template {}", self.subject)?;
+        write!(f, "workflow-template {}", quote_value(&self.subject))?;
         match &self.verb {
-            WorkflowTemplateVerb::Apply { file } => write!(f, " apply --file {}", file.display())?,
+            WorkflowTemplateVerb::Apply { file } => write!(f, " apply --file {}", quote_value(&file.display().to_string()))?,
         }
         Ok(())
     }
@@ -66,6 +67,7 @@ mod tests {
     use super::WorkflowTemplateNoun;
     use crate::{
         resolved::{HostResolution, RepoContext},
+        test_utils::assert_round_trip,
         Resolved,
     };
 
@@ -98,5 +100,17 @@ mod tests {
             .resolve()
             .expect_err("should fail");
         assert!(err.contains("read"));
+    }
+
+    #[test]
+    fn round_trip_apply() {
+        assert_round_trip::<WorkflowTemplateNoun>(&["workflow-template", "scratch", "apply", "--file", "/tmp/x.yaml"]);
+    }
+
+    #[test]
+    fn apply_display_quotes_path_with_whitespace() {
+        let parsed = parse(&["workflow-template", "scratch", "apply", "--file", "/tmp/my dir/template.yaml"]);
+        let displayed = parsed.to_string();
+        assert!(displayed.contains("--file \"/tmp/my dir/template.yaml\""), "expected quoted file path in {displayed:?}");
     }
 }

--- a/crates/flotilla-commands/src/commands/workflow_template.rs
+++ b/crates/flotilla-commands/src/commands/workflow_template.rs
@@ -1,0 +1,102 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use flotilla_protocol::{Command, CommandAction};
+
+use crate::{
+    resolved::{HostResolution, RepoContext},
+    Resolved,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
+#[command(about = "Manage workflow templates")]
+pub struct WorkflowTemplateNoun {
+    /// Workflow template name (used as metadata.name on the resource)
+    pub subject: String,
+
+    #[command(subcommand)]
+    pub verb: WorkflowTemplateVerb,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
+pub enum WorkflowTemplateVerb {
+    /// Apply a workflow template spec from a YAML file
+    Apply {
+        /// Path to a YAML file containing the WorkflowTemplate spec body
+        #[arg(long = "file", short = 'f')]
+        file: PathBuf,
+    },
+}
+
+impl WorkflowTemplateNoun {
+    pub fn resolve(self) -> Result<Resolved, String> {
+        match self.verb {
+            WorkflowTemplateVerb::Apply { file } => {
+                let spec_yaml = std::fs::read_to_string(&file).map_err(|e| format!("read {}: {e}", file.display()))?;
+                Ok(Resolved::NeedsContext {
+                    command: Command {
+                        node_id: None,
+                        provisioning_target: None,
+                        context_repo: None,
+                        action: CommandAction::WorkflowTemplateApply { name: self.subject, spec_yaml },
+                    },
+                    repo: RepoContext::None,
+                    host: HostResolution::Local,
+                })
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for WorkflowTemplateNoun {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "workflow-template {}", self.subject)?;
+        match &self.verb {
+            WorkflowTemplateVerb::Apply { file } => write!(f, " apply --file {}", file.display())?,
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use flotilla_protocol::{Command, CommandAction};
+
+    use super::WorkflowTemplateNoun;
+    use crate::{
+        resolved::{HostResolution, RepoContext},
+        Resolved,
+    };
+
+    fn parse(args: &[&str]) -> WorkflowTemplateNoun {
+        WorkflowTemplateNoun::try_parse_from(args).expect("should parse")
+    }
+
+    #[test]
+    fn apply_reads_file_into_spec_yaml() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(tmp.path(), "tasks: []\n").expect("write");
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let resolved = parse(&["workflow-template", "scratch", "apply", "--file", &path]).resolve().expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::WorkflowTemplateApply { name: "scratch".into(), spec_yaml: "tasks: []\n".into() },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn missing_file_returns_error() {
+        let err = parse(&["workflow-template", "scratch", "apply", "--file", "/nonexistent/path/template.yaml"])
+            .resolve()
+            .expect_err("should fail");
+        assert!(err.contains("read"));
+    }
+}

--- a/crates/flotilla-commands/src/lib.rs
+++ b/crates/flotilla-commands/src/lib.rs
@@ -2,10 +2,12 @@ pub mod commands;
 pub mod complete;
 pub mod noun;
 pub mod parse;
+mod quote;
 pub mod resolved;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
 pub use noun::NounCommand;
 pub use parse::{parse_host_command, parse_noun_command};
+pub use quote::quote_value;
 pub use resolved::{HostResolution, Refinable, RepoContext, Resolved};

--- a/crates/flotilla-commands/src/noun.rs
+++ b/crates/flotilla-commands/src/noun.rs
@@ -5,7 +5,7 @@ use clap::Subcommand;
 use crate::{
     commands::{
         agent::AgentNoun, checkout::CheckoutNoun, convoy::ConvoyNoun, cr::CrNoun, environment::EnvironmentNoun, issue::IssueNoun,
-        repo::RepoNoun, workspace::WorkspaceNoun,
+        repo::RepoNoun, workflow_template::WorkflowTemplateNoun, workspace::WorkspaceNoun,
     },
     Resolved,
 };
@@ -22,6 +22,7 @@ pub enum NounCommand {
     Issue(IssueNoun),
     Agent(AgentNoun),
     Workspace(WorkspaceNoun),
+    WorkflowTemplate(WorkflowTemplateNoun),
     // Host is NOT included — host doesn't nest inside host
 }
 
@@ -36,6 +37,7 @@ impl NounCommand {
             NounCommand::Issue(noun) => noun.resolve(),
             NounCommand::Agent(noun) => noun.resolve(),
             NounCommand::Workspace(noun) => noun.resolve(),
+            NounCommand::WorkflowTemplate(noun) => noun.resolve(),
         }
     }
 }
@@ -51,6 +53,7 @@ impl fmt::Display for NounCommand {
             NounCommand::Issue(noun) => write!(f, "{noun}"),
             NounCommand::Agent(noun) => write!(f, "{noun}"),
             NounCommand::Workspace(noun) => write!(f, "{noun}"),
+            NounCommand::WorkflowTemplate(noun) => write!(f, "{noun}"),
         }
     }
 }

--- a/crates/flotilla-commands/src/quote.rs
+++ b/crates/flotilla-commands/src/quote.rs
@@ -1,0 +1,49 @@
+/// Quote a value if it contains whitespace, quotes, or backslashes.
+///
+/// Used by the `Display` impls of noun-verb commands so values containing spaces
+/// (e.g. `--input topic="my work"`) survive a Display → re-parse round-trip.
+pub fn quote_value(s: &str) -> String {
+    let needs_quoting = s.is_empty() || s.chars().any(|c| c.is_whitespace() || c == '"' || c == '\'' || c == '\\');
+    if !needs_quoting {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        if c == '"' || c == '\\' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quote_value;
+
+    #[test]
+    fn plain_identifiers_pass_through() {
+        assert_eq!(quote_value("scratch"), "scratch");
+        assert_eq!(quote_value("topic=demo"), "topic=demo");
+        assert_eq!(quote_value("https://example.com/repo.git"), "https://example.com/repo.git");
+    }
+
+    #[test]
+    fn whitespace_triggers_quoting() {
+        assert_eq!(quote_value("hello world"), "\"hello world\"");
+        assert_eq!(quote_value("topic=my work"), "\"topic=my work\"");
+    }
+
+    #[test]
+    fn embedded_quotes_and_backslashes_are_escaped() {
+        assert_eq!(quote_value("with\"quote"), "\"with\\\"quote\"");
+        assert_eq!(quote_value("back\\slash"), "\"back\\\\slash\"");
+    }
+
+    #[test]
+    fn empty_string_is_quoted() {
+        assert_eq!(quote_value(""), "\"\"");
+    }
+}

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -309,6 +309,8 @@ pub async fn build_plan(
 
         // Daemon-level commands should not reach build_plan.
         CommandAction::ConvoyTaskComplete { .. }
+        | CommandAction::ConvoyCreate { .. }
+        | CommandAction::WorkflowTemplateApply { .. }
         | CommandAction::TrackRepoPath { .. }
         | CommandAction::UntrackRepo { .. }
         | CommandAction::Refresh { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,7 +22,7 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Convoy as ResourceConvoy,
-    ResourceBackend,
+    ConvoyRepositorySpec, ConvoySpec, InputMeta, InputValue, ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -198,6 +198,15 @@ async fn register_static_ssh_direct_environments(
 
 fn fallback_repo_identity(path: &Path) -> flotilla_protocol::RepoIdentity {
     flotilla_protocol::RepoIdentity { authority: "local".into(), path: path.to_string_lossy().into_owned() }
+}
+
+fn parse_and_validate_workflow_template_yaml(yaml: &str) -> Result<WorkflowTemplateSpec, String> {
+    let spec: WorkflowTemplateSpec = serde_yml::from_str(yaml).map_err(|err| format!("invalid workflow template YAML: {err}"))?;
+    flotilla_resources::validate(&spec).map_err(|errors| {
+        let joined = errors.iter().map(|e| format!("{e:?}")).collect::<Vec<_>>().join("; ");
+        format!("workflow template validation failed: {joined}")
+    })?;
+    Ok(spec)
 }
 
 fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {
@@ -1991,6 +2000,75 @@ impl InProcessDaemon {
                     }
                 },
                 Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+            };
+            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity,
+                repo: None,
+                result,
+            });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ConvoyCreate { name, workflow_ref, inputs, repository_url, r#ref } = &command.action {
+            let empty_identity = flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() };
+            let _ = self.event_tx.send(DaemonEvent::CommandStarted {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity.clone(),
+                repo: None,
+                description: command.description().to_string(),
+            });
+            let namespace = self.provisioning_namespace().await;
+            let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
+            let spec = ConvoySpec {
+                workflow_ref: workflow_ref.clone(),
+                inputs: inputs.iter().map(|(k, v)| (k.clone(), InputValue::String(v.clone()))).collect(),
+                placement_policy: None,
+                repository: repository_url.clone().map(|url| ConvoyRepositorySpec { url }),
+                r#ref: r#ref.clone(),
+            };
+            let meta = InputMeta::builder().name(name.clone()).build();
+            let result = match convoys.create(&meta, &spec).await {
+                Ok(_) => flotilla_protocol::CommandValue::ConvoyCreated { name: name.clone() },
+                Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+            };
+            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity,
+                repo: None,
+                result,
+            });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::WorkflowTemplateApply { name, spec_yaml } = &command.action {
+            let empty_identity = flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() };
+            let _ = self.event_tx.send(DaemonEvent::CommandStarted {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity.clone(),
+                repo: None,
+                description: command.description().to_string(),
+            });
+            let namespace = self.provisioning_namespace().await;
+            let templates = self.resource_backend.clone().using::<WorkflowTemplate>(&namespace);
+            let result = match parse_and_validate_workflow_template_yaml(spec_yaml) {
+                Ok(spec) => {
+                    let meta = InputMeta::builder().name(name.clone()).build();
+                    let outcome = match templates.get(name).await {
+                        Ok(existing) => templates.update(&meta, &existing.metadata.resource_version, &spec).await.map(|_| ()),
+                        Err(ResourceError::NotFound { .. }) => templates.create(&meta, &spec).await.map(|_| ()),
+                        Err(err) => Err(err),
+                    };
+                    match outcome {
+                        Ok(()) => flotilla_protocol::CommandValue::WorkflowTemplateApplied { name: name.clone() },
+                        Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+                    }
+                }
+                Err(err) => flotilla_protocol::CommandValue::Error { message: err },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {
                 command_id: id,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -200,10 +200,14 @@ fn fallback_repo_identity(path: &Path) -> flotilla_protocol::RepoIdentity {
     flotilla_protocol::RepoIdentity { authority: "local".into(), path: path.to_string_lossy().into_owned() }
 }
 
+fn empty_repo_identity() -> flotilla_protocol::RepoIdentity {
+    flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() }
+}
+
 fn parse_and_validate_workflow_template_yaml(yaml: &str) -> Result<WorkflowTemplateSpec, String> {
     let spec: WorkflowTemplateSpec = serde_yml::from_str(yaml).map_err(|err| format!("invalid workflow template YAML: {err}"))?;
     flotilla_resources::validate(&spec).map_err(|errors| {
-        let joined = errors.iter().map(|e| format!("{e:?}")).collect::<Vec<_>>().join("; ");
+        let joined = errors.iter().map(|e| format!("{e}")).collect::<Vec<_>>().join("; ");
         format!("workflow template validation failed: {joined}")
     })?;
     Ok(spec)
@@ -1908,7 +1912,7 @@ impl InProcessDaemon {
         if command.action.is_query() {
             // Query commands should be dispatched through `execute_query`,
             // not through `execute`. Return an error to surface misrouting.
-            let empty_identity = flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() };
+            let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
                 command_id: id,
                 node_id: self.node_id.clone(),
@@ -1970,7 +1974,7 @@ impl InProcessDaemon {
         }
 
         if let flotilla_protocol::CommandAction::ConvoyTaskComplete { convoy, task, message } = &command.action {
-            let empty_identity = flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() };
+            let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
                 command_id: id,
                 node_id: self.node_id.clone(),
@@ -2012,7 +2016,7 @@ impl InProcessDaemon {
         }
 
         if let flotilla_protocol::CommandAction::ConvoyCreate { name, workflow_ref, inputs, repository_url, r#ref } = &command.action {
-            let empty_identity = flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() };
+            let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
                 command_id: id,
                 node_id: self.node_id.clone(),
@@ -2045,7 +2049,7 @@ impl InProcessDaemon {
         }
 
         if let flotilla_protocol::CommandAction::WorkflowTemplateApply { name, spec_yaml } = &command.action {
-            let empty_identity = flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() };
+            let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
                 command_id: id,
                 node_id: self.node_id.clone(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -29,8 +29,9 @@ use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec
 use flotilla_resources::{
     canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, repo_key, Clone, CloneSpec, Convoy,
     ConvoyReconciler, DockerCheckoutStrategy, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec, Host,
-    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta,
-    PlacementPolicy, PlacementPolicySpec, Presentation, ResourceBackend, ResourceError, ResourceObject, TaskWorkspace, WorkflowTemplate,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
+    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError,
+    ResourceObject, TaskDefinition, TaskWorkspace, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -250,6 +251,36 @@ async fn register_startup_resources(
     ensure_host_direct_environment_exists(&backend, namespace, profile).await?;
     discover_local_clones(daemon, &backend, namespace, profile).await?;
     ensure_default_policies(&backend, namespace, profile).await?;
+    ensure_default_workflow_templates(&backend, namespace).await?;
+    Ok(())
+}
+
+fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
+    vec![(
+        "scratch",
+        WorkflowTemplateSpec::builder()
+            .inputs(vec![InputDefinition { name: "topic".to_string(), description: Some("Short label for this convoy".into()) }])
+            .tasks(vec![TaskDefinition::builder()
+                .name("work".to_string())
+                .processes(vec![ProcessDefinition::builder()
+                    .role("shell".to_string())
+                    .source(ProcessSource::Tool {
+                        command: r#"bash -c 'echo "Convoy {{workflow.name}} ({{inputs.topic}})"; exec bash'"#.to_string(),
+                    })
+                    .build()])
+                .build()])
+            .build(),
+    )]
+}
+
+async fn ensure_default_workflow_templates(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
+    let templates = backend.clone().using::<WorkflowTemplate>(namespace);
+    for (name, spec) in default_workflow_templates() {
+        if templates.get(name).await.is_ok() {
+            continue;
+        }
+        templates.create(&empty_meta(name), &spec).await.map(|_| ()).map_err(|err| format!("seed workflow template {name}: {err}"))?;
+    }
     Ok(())
 }
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -276,8 +276,10 @@ fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
 async fn ensure_default_workflow_templates(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
     let templates = backend.clone().using::<WorkflowTemplate>(namespace);
     for (name, spec) in default_workflow_templates() {
-        if templates.get(name).await.is_ok() {
-            continue;
+        match templates.get(name).await {
+            Ok(_) => continue,
+            Err(ResourceError::NotFound { .. }) => {}
+            Err(err) => return Err(format!("check workflow template {name}: {err}")),
         }
         templates.create(&empty_meta(name), &spec).await.map(|_| ()).map_err(|err| format!("seed workflow template {name}: {err}"))?;
     }
@@ -286,8 +288,10 @@ async fn ensure_default_workflow_templates(backend: &ResourceBackend, namespace:
 
 async fn ensure_host_exists(backend: &ResourceBackend, namespace: &str, host_name: &str) -> Result<(), String> {
     let hosts = backend.clone().using::<Host>(namespace);
-    if hosts.get(host_name).await.is_ok() {
-        return Ok(());
+    match hosts.get(host_name).await {
+        Ok(_) => return Ok(()),
+        Err(ResourceError::NotFound { .. }) => {}
+        Err(err) => return Err(format!("check host {host_name}: {err}")),
     }
     hosts.create(&empty_meta(host_name), &HostSpec {}).await.map(|_| ()).map_err(|err| err.to_string())
 }
@@ -299,8 +303,10 @@ async fn ensure_host_direct_environment_exists(
 ) -> Result<(), String> {
     let name = profile.host_direct_environment_name();
     let environments = backend.clone().using::<Environment>(namespace);
-    if environments.get(&name).await.is_ok() {
-        return Ok(());
+    match environments.get(&name).await {
+        Ok(_) => return Ok(()),
+        Err(ResourceError::NotFound { .. }) => {}
+        Err(err) => return Err(format!("check environment {name}: {err}")),
     }
 
     environments

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -1,0 +1,164 @@
+//! Integration tests for the `ConvoyCreate` + `WorkflowTemplateApply` daemon actions
+//! and the seeded `scratch` WorkflowTemplate registered at startup.
+
+use std::{sync::Arc, time::Duration};
+
+use flotilla_core::{
+    config::ConfigStore, daemon::DaemonHandle, in_process::InProcessDaemon, providers::discovery::test_support::fake_discovery,
+};
+use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
+use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName};
+use flotilla_resources::{Convoy, InMemoryBackend, ResourceBackend, WorkflowTemplate};
+
+fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&dir).expect("create config dir");
+    std::fs::write(dir.join("daemon.toml"), "machine_id = \"test-convoy-create-cli\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(dir))
+}
+
+async fn start_daemon() -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigStore>, DaemonRuntime, tempfile::TempDir) {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    let options = RuntimeOptions {
+        namespace: "flotilla".to_string(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_secs(300),
+        start_controllers: false,
+        ..RuntimeOptions::default()
+    };
+    let runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
+    (daemon, backend, config, runtime, tmp)
+}
+
+async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let event = tokio::time::timeout(remaining, rx.recv()).await.expect("timed out").expect("recv");
+        if let DaemonEvent::CommandFinished { command_id: id, result, .. } = event {
+            if id == command_id {
+                return result;
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn scratch_workflow_template_is_seeded_at_startup() {
+    let (_daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let templates = backend.using::<WorkflowTemplate>("flotilla");
+    let scratch = templates.get("scratch").await.expect("scratch template should be seeded");
+    assert_eq!(scratch.metadata.name, "scratch");
+    assert_eq!(scratch.spec.tasks.len(), 1);
+    assert_eq!(scratch.spec.tasks[0].name, "work");
+}
+
+#[tokio::test]
+async fn convoy_create_command_creates_convoy_resource() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+
+    let mut rx = daemon.subscribe();
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "my-scratch".into(),
+                workflow_ref: "scratch".into(),
+                inputs: vec![("topic".into(), "first-convoy".into())],
+                repository_url: None,
+                r#ref: None,
+            },
+        })
+        .await
+        .expect("execute");
+
+    let result = await_command_result(&mut rx, id).await;
+    assert_eq!(result, CommandValue::ConvoyCreated { name: "my-scratch".into() });
+
+    let convoys = backend.using::<Convoy>("flotilla");
+    let convoy = convoys.get("my-scratch").await.expect("convoy should exist");
+    assert_eq!(convoy.spec.workflow_ref, "scratch");
+    assert_eq!(convoy.spec.inputs.len(), 1);
+    assert!(convoy.spec.repository.is_none());
+}
+
+#[tokio::test]
+async fn workflow_template_apply_creates_then_updates() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let templates = backend.using::<WorkflowTemplate>("flotilla");
+
+    let mut rx = daemon.subscribe();
+
+    // First apply: creates a new template.
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::WorkflowTemplateApply {
+                name: "custom".into(),
+                spec_yaml: "tasks:\n  - name: only\n    processes:\n      - role: shell\n        command: 'echo first'\n".into(),
+            },
+        })
+        .await
+        .expect("execute create");
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::WorkflowTemplateApplied { name: "custom".into() });
+    let v1 = templates.get("custom").await.expect("template should exist");
+    let v1_command = match &v1.spec.tasks[0].processes[0].source {
+        flotilla_resources::ProcessSource::Tool { command } => command.clone(),
+        _ => panic!("expected tool process"),
+    };
+    assert_eq!(v1_command, "echo first");
+
+    // Second apply with the same name: updates the existing template.
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::WorkflowTemplateApply {
+                name: "custom".into(),
+                spec_yaml: "tasks:\n  - name: only\n    processes:\n      - role: shell\n        command: 'echo updated'\n".into(),
+            },
+        })
+        .await
+        .expect("execute update");
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::WorkflowTemplateApplied { name: "custom".into() });
+    let v2 = templates.get("custom").await.expect("template should still exist");
+    let v2_command = match &v2.spec.tasks[0].processes[0].source {
+        flotilla_resources::ProcessSource::Tool { command } => command.clone(),
+        _ => panic!("expected tool process"),
+    };
+    assert_eq!(v2_command, "echo updated");
+}
+
+#[tokio::test]
+async fn workflow_template_apply_rejects_invalid_yaml() {
+    let (daemon, _backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::WorkflowTemplateApply {
+                name: "broken".into(),
+                spec_yaml: "this is not: {valid yaml structure for: a workflow".into(),
+            },
+        })
+        .await
+        .expect("execute");
+    let result = await_command_result(&mut rx, id).await;
+    assert!(matches!(result, CommandValue::Error { .. }), "expected Error, got {result:?}");
+}

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -149,6 +149,20 @@ pub enum CommandAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
     },
+    ConvoyCreate {
+        name: String,
+        workflow_ref: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        inputs: Vec<(String, String)>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repository_url: Option<String>,
+        #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+        r#ref: Option<String>,
+    },
+    WorkflowTemplateApply {
+        name: String,
+        spec_yaml: String,
+    },
     TeleportSession {
         session_id: String,
         branch: Option<String>,
@@ -234,6 +248,8 @@ impl Command {
             CommandAction::ArchiveSession { .. } => "Archiving session...",
             CommandAction::GenerateBranchName { .. } => "Generating branch name...",
             CommandAction::ConvoyTaskComplete { .. } => "Completing convoy task...",
+            CommandAction::ConvoyCreate { .. } => "Creating convoy...",
+            CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
             CommandAction::TeleportSession { .. } => "Teleporting session...",
             CommandAction::TrackRepoPath { .. } => "Tracking repository...",
             CommandAction::UntrackRepo { .. } => "Untracking repository...",
@@ -317,6 +333,12 @@ pub enum CommandValue {
     IssuePage(IssueResultPage),
     IssuesByIds {
         items: Vec<(String, crate::provider_data::Issue)>,
+    },
+    ConvoyCreated {
+        name: String,
+    },
+    WorkflowTemplateApplied {
+        name: String,
     },
 }
 
@@ -485,6 +507,24 @@ mod tests {
                     task: "implement".into(),
                     message: Some("done".into()),
                 },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "my-convoy".into(),
+                    workflow_ref: "scratch".into(),
+                    inputs: vec![("topic".into(), "convoy-create-cli".into())],
+                    repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
+                    r#ref: Some("main".into()),
+                },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::WorkflowTemplateApply { name: "scratch".into(), spec_yaml: "tasks: []\n".into() },
             },
             Command {
                 node_id: Some(NodeId::new("feta")),
@@ -708,6 +748,8 @@ mod tests {
             },
             CommandValue::IssuePage(crate::issue_query::IssueResultPage { items: vec![], total: Some(10), has_more: true }),
             CommandValue::IssuesByIds { items: vec![] },
+            CommandValue::ConvoyCreated { name: "my-convoy".into() },
+            CommandValue::WorkflowTemplateApplied { name: "scratch".into() },
         ];
 
         for result in cases {

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -84,6 +84,41 @@ pub enum InterpolationField {
     Command,
 }
 
+impl std::fmt::Display for InterpolationField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InterpolationField::Prompt => f.write_str("prompt"),
+            InterpolationField::Command => f.write_str("command"),
+        }
+    }
+}
+
+impl std::fmt::Display for InterpolationLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "task `{}` role `{}` {}", self.task, self.role, self.field)
+    }
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationError::DuplicateTaskName { name } => write!(f, "duplicate task name `{name}`"),
+            ValidationError::DuplicateRoleInTask { task, role } => write!(f, "duplicate role `{role}` in task `{task}`"),
+            ValidationError::ReservedLabelKey { task, role, key } => {
+                write!(f, "reserved label key `{key}` on task `{task}` role `{role}`")
+            }
+            ValidationError::UnknownDependency { task, missing } => write!(f, "task `{task}` depends on unknown task `{missing}`"),
+            ValidationError::DependencyCycle { cycle } => write!(f, "dependency cycle: {}", cycle.join(" -> ")),
+            ValidationError::DuplicateInputName { name } => write!(f, "duplicate input name `{name}`"),
+            ValidationError::MalformedInterpolation { location, text } => {
+                write!(f, "malformed interpolation `{{{{{text}}}}}` at {location}")
+            }
+            ValidationError::UnknownInputReference { location, name } => write!(f, "unknown input `{name}` at {location}"),
+            ValidationError::UnknownWorkflowField { location, name } => write!(f, "unknown workflow field `{name}` at {location}"),
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum VisitState {
     Visiting,

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -140,6 +140,14 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
             tracing::warn!("unexpected environment lifecycle result reached UI handler");
         }
         CommandValue::IssuePage(_) | CommandValue::IssuesByIds { .. } => {}
+        CommandValue::ConvoyCreated { name } => {
+            info!(%name, "convoy created");
+            app.model.status_message = Some(format!("Convoy created: {name}"));
+        }
+        CommandValue::WorkflowTemplateApplied { name } => {
+            info!(%name, "workflow template applied");
+            app.model.status_message = Some(format!("Workflow template applied: {name}"));
+        }
     }
 }
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -303,6 +303,8 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::EnvironmentSpecRead { .. } => "environment spec read".to_string(),
         CommandValue::IssuePage(page) => format!("issue page: {} items, has_more={}", page.items.len(), page.has_more),
         CommandValue::IssuesByIds { items } => format!("issues by ids: {} items", items.len()),
+        CommandValue::ConvoyCreated { name } => format!("convoy created: {name}"),
+        CommandValue::WorkflowTemplateApplied { name } => format!("workflow template applied: {name}"),
     }
 }
 

--- a/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_open.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_open.snap
@@ -24,11 +24,11 @@ expression: output
                                                                         │                                              │
                                                                         │                                              │
 /                            <ENT> RUN  <ESC> CLOSE  <TAB> FILL                                   ◫ auto   @local
-  repo         Manage repositories
-  environment  Manage environments
-  env          Manage environments
-  checkout     Manage checkouts
-  convoy       Manage convoys
-  cr           Code review
-  pr           Code review
-  issue        Issues
+  repo               Manage repositories
+  environment        Manage environments
+  env                Manage environments
+  checkout           Manage checkouts
+  convoy             Manage convoys
+  cr                 Code review
+  pr                 Code review
+  issue              Issues

--- a/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_selection.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_selection.snap
@@ -24,11 +24,11 @@ expression: output
                                                                         │                                              │
                                                                         │                                              │
 /                            <ENT> RUN  <ESC> CLOSE  <TAB> FILL                                   ◫ auto   @local
-  repo         Manage repositories
-  environment  Manage environments
-  env          Manage environments
-  checkout     Manage checkouts
-  convoy       Manage convoys
-  cr           Code review
-  pr           Code review
-  issue        Issues
+  repo               Manage repositories
+  environment        Manage environments
+  env                Manage environments
+  checkout           Manage checkouts
+  convoy             Manage convoys
+  cr                 Code review
+  pr                 Code review
+  issue              Issues


### PR DESCRIPTION
## Summary

First user-facing way to launch a convoy.

- `flotilla convoy <name> create --template <ref> [--input k=v]... [--repo URL] [--ref BRANCH]`
- `flotilla workflow-template <name> apply --file <path.yaml>` (create-or-update semantics)
- `scratch` WorkflowTemplate seeded at daemon startup: 1 task, 1 tool process that opens a shell labelled with the convoy name + the `topic` input. Demonstrates the full loop without needing the user to first build a template.

## Why

Until now, convoys could only be created programmatically — tests construct them via the resource backend directly. The TUI's convoys page literally renders "Create one via 'flotilla convoy create ...' (coming soon)". This PR makes that real for the limited tool-only path.

## Wire layout

- **Protocol** (`flotilla-protocol`): new `CommandAction::ConvoyCreate` and `CommandAction::WorkflowTemplateApply`, matching `CommandValue::{ConvoyCreated, WorkflowTemplateApplied}`; existing roundtrip tests extended.
- **CLI parsing** (`flotilla-commands`): `ConvoyVerb::Create` parses `--input k=v` via custom value parser; new `WorkflowTemplateNoun` reads the YAML file at resolve time.
- **Daemon** (`InProcessDaemon::execute`): both actions handled inline against `ResourceBackend`. `WorkflowTemplateApply` parses YAML (`serde_yml`), runs `workflow_template::validate`, then does `get → update` or falls back to `create`. `ConvoyCreate` builds `ConvoySpec` from the protocol fields.
- **Runtime**: `register_startup_resources` now seeds `default_workflow_templates()` idempotently.

## Snapshot deltas

Only column-width shifts in `command_palette_open` / `command_palette_selection` — the new `workflow-template` noun widens the longest-name column. The visible list itself is unchanged in content.

## Not in this cut

- `--wait` to stream convoy phase transitions
- Multi-template seeding (one is enough for first cut)
- Agent processes (still gated at Stage 4b in the reconciler)
- cwd auto-detection of repo (intentionally explicit until Project resource exists)

## Test plan

- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — including 4 new integration tests in `crates/flotilla-daemon/tests/convoy_create_cli.rs`:
  - seeded `scratch` template appears after daemon startup
  - `ConvoyCreate` action creates a Convoy resource
  - `WorkflowTemplateApply` creates, then updates a custom template
  - invalid YAML produces a `CommandValue::Error`
- [ ] Smoke test the CLI against a real daemon