### PR TITLE
fix(cli): wire workflow-template into top-level SubCommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,8 @@ enum SubCommand {
     Workspace(flotilla_commands::commands::workspace::WorkspaceNoun),
     /// Manage and route to hosts
     Host(flotilla_commands::commands::host::HostNounPartial),
+    /// Manage workflow templates
+    WorkflowTemplate(flotilla_commands::commands::workflow_template::WorkflowTemplateNoun),
 
     /// Generate completions (hidden, called by shell scripts)
     #[command(hide = true)]
@@ -185,6 +187,7 @@ async fn main() -> Result<()> {
             use flotilla_commands::Refinable;
             dispatch(partial.refine().and_then(|n| n.resolve()).map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await
         }
+        Some(SubCommand::WorkflowTemplate(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
 
         Some(SubCommand::Complete { line, cursor_pos }) => {
             run_complete(&line, cursor_pos);
@@ -886,6 +889,20 @@ mod tests {
     fn cli_parses_workspace_noun() {
         let cli = Cli::try_parse_from(["flotilla", "workspace", "feat-ws", "select"]).expect("workspace cli should parse");
         assert!(matches!(cli.command, Some(SubCommand::Workspace(_))));
+    }
+
+    #[test]
+    fn cli_parses_workflow_template_noun() {
+        let cli = Cli::try_parse_from(["flotilla", "workflow-template", "scratch", "apply", "--file", "/tmp/x.yaml"])
+            .expect("workflow-template cli should parse");
+        assert!(matches!(cli.command, Some(SubCommand::WorkflowTemplate(_))));
+    }
+
+    #[test]
+    fn cli_parses_convoy_create() {
+        let cli = Cli::try_parse_from(["flotilla", "convoy", "my-convoy", "create", "--template", "scratch", "--input", "topic=hi"])
+            .expect("convoy create cli should parse");
+        assert!(matches!(cli.command, Some(SubCommand::Convoy(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

#599 added \`WorkflowTemplateNoun\` to \`flotilla_commands::NounCommand\` and the daemon-side handler, but missed adding it to \`SubCommand\` in \`src/main.rs\`. As a result \`flotilla workflow-template ...\` didn't appear in \`flotilla --help\` and couldn't be invoked from the CLI.

Caught while smoke-testing the binary against a real daemon — found that the CLI surface advertised \`convoy\` but not \`workflow-template\`. Adding the missing variant + dispatch arm.

## Test plan

- [x] \`cargo +nightly-2026-03-12 fmt --check\`
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo test --workspace --locked\` — including two new regression tests:
  - \`cli_parses_workflow_template_noun\` — \`flotilla workflow-template scratch apply --file /tmp/x.yaml\` parses
  - \`cli_parses_convoy_create\` — \`flotilla convoy my-convoy create --template scratch --input topic=hi\` parses
- [x] **Manual smoke** against a release-build daemon:
  - \`flotilla workflow-template <name> apply --file <yaml>\` creates and updates
  - Validation errors render through the new \`ValidationError::Display\` impls cleanly
  - Seeded \`scratch\` template is auto-applied at daemon startup and overwritable via \`apply\`
  - \`flotilla convoy <name> create --template scratch --input topic=hello\` creates a convoy; re-creating the same name yields a clear conflict error; whitespace inputs survive the shell layer