### PR TITLE
feat(resources,cli): add Project resource + project_ref on ConvoySpec

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -35,6 +35,9 @@ pub enum ConvoyVerb {
         /// Git ref (branch/tag/commit) within the repository
         #[arg(long = "ref")]
         r#ref: Option<String>,
+        /// Project this convoy belongs to (metadata grouping)
+        #[arg(long = "project")]
+        project_ref: Option<String>,
     },
 }
 
@@ -80,12 +83,19 @@ impl ConvoyNoun {
                     host: HostResolution::Local,
                 }),
             },
-            ConvoyVerb::Create { template, inputs, repository_url, r#ref } => Ok(Resolved::NeedsContext {
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref } => Ok(Resolved::NeedsContext {
                 command: Command {
                     node_id: None,
                     provisioning_target: None,
                     context_repo: None,
-                    action: CommandAction::ConvoyCreate { name: self.subject, workflow_ref: template, inputs, repository_url, r#ref },
+                    action: CommandAction::ConvoyCreate {
+                        name: self.subject,
+                        workflow_ref: template,
+                        inputs,
+                        repository_url,
+                        r#ref,
+                        project_ref,
+                    },
                 },
                 repo: RepoContext::None,
                 host: HostResolution::Local,
@@ -109,7 +119,7 @@ impl std::fmt::Display for ConvoyNoun {
                     }
                 }
             }
-            ConvoyVerb::Create { template, inputs, repository_url, r#ref } => {
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref } => {
                 write!(f, " create --template {}", quote_value(template))?;
                 for (k, v) in inputs {
                     write!(f, " --input {}", quote_value(&format!("{k}={v}")))?;
@@ -119,6 +129,9 @@ impl std::fmt::Display for ConvoyNoun {
                 }
                 if let Some(reference) = r#ref {
                     write!(f, " --ref {}", quote_value(reference))?;
+                }
+                if let Some(project) = project_ref {
+                    write!(f, " --project {}", quote_value(project))?;
                 }
             }
         }
@@ -211,6 +224,7 @@ mod tests {
                     inputs: vec![("topic".into(), "demo".into()), ("branch".into(), "foo".into())],
                     repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
                     r#ref: Some("main".into()),
+                    project_ref: None,
                 },
             },
             repo: RepoContext::None,
@@ -232,6 +246,7 @@ mod tests {
                     inputs: vec![],
                     repository_url: None,
                     r#ref: None,
+                    project_ref: None,
                 },
             },
             repo: RepoContext::None,

--- a/crates/flotilla-commands/src/commands/mod.rs
+++ b/crates/flotilla-commands/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod cr;
 pub mod environment;
 pub mod host;
 pub mod issue;
+pub mod project;
 pub mod repo;
 pub mod workflow_template;
 pub mod workspace;

--- a/crates/flotilla-commands/src/commands/project.rs
+++ b/crates/flotilla-commands/src/commands/project.rs
@@ -1,0 +1,214 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use flotilla_protocol::{Command, CommandAction};
+
+use crate::{
+    quote::quote_value,
+    resolved::{HostResolution, RepoContext},
+    Resolved,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
+#[command(about = "Manage projects")]
+pub struct ProjectNoun {
+    /// Project name (used as metadata.name on the resource)
+    pub subject: String,
+
+    #[command(subcommand)]
+    pub verb: ProjectVerb,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
+pub enum ProjectVerb {
+    /// Create a project (single-repo convenience form; use `apply` for multi-repo)
+    Create {
+        /// Human-readable name displayed in UIs
+        #[arg(long = "display-name")]
+        display_name: Option<String>,
+        /// Repository URL (creates a single-entry `repositories` list)
+        #[arg(long = "repo")]
+        repository_url: Option<String>,
+        /// Subpath within the repository (monorepo slice)
+        #[arg(long = "subpath")]
+        subpath: Option<String>,
+        /// Default branch for the repository
+        #[arg(long = "ref")]
+        r#ref: Option<String>,
+    },
+    /// Apply a project spec from a YAML file (full multi-repo form)
+    Apply {
+        /// Path to a YAML file containing the ProjectSpec body
+        #[arg(long = "file", short = 'f')]
+        file: PathBuf,
+    },
+}
+
+impl ProjectNoun {
+    pub fn resolve(self) -> Result<Resolved, String> {
+        match self.verb {
+            ProjectVerb::Create { display_name, repository_url, subpath, r#ref } => Ok(Resolved::NeedsContext {
+                command: Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::ProjectCreate { name: self.subject, display_name, repository_url, subpath, r#ref },
+                },
+                repo: RepoContext::None,
+                host: HostResolution::Local,
+            }),
+            ProjectVerb::Apply { file } => {
+                let spec_yaml = std::fs::read_to_string(&file).map_err(|e| format!("read {}: {e}", file.display()))?;
+                Ok(Resolved::NeedsContext {
+                    command: Command {
+                        node_id: None,
+                        provisioning_target: None,
+                        context_repo: None,
+                        action: CommandAction::ProjectApply { name: self.subject, spec_yaml },
+                    },
+                    repo: RepoContext::None,
+                    host: HostResolution::Local,
+                })
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ProjectNoun {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "project {}", quote_value(&self.subject))?;
+        match &self.verb {
+            ProjectVerb::Create { display_name, repository_url, subpath, r#ref } => {
+                write!(f, " create")?;
+                if let Some(name) = display_name {
+                    write!(f, " --display-name {}", quote_value(name))?;
+                }
+                if let Some(url) = repository_url {
+                    write!(f, " --repo {}", quote_value(url))?;
+                }
+                if let Some(sub) = subpath {
+                    write!(f, " --subpath {}", quote_value(sub))?;
+                }
+                if let Some(reference) = r#ref {
+                    write!(f, " --ref {}", quote_value(reference))?;
+                }
+            }
+            ProjectVerb::Apply { file } => write!(f, " apply --file {}", quote_value(&file.display().to_string()))?,
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use flotilla_protocol::{Command, CommandAction};
+
+    use super::ProjectNoun;
+    use crate::{
+        resolved::{HostResolution, RepoContext},
+        test_utils::assert_round_trip,
+        Resolved,
+    };
+
+    fn parse(args: &[&str]) -> ProjectNoun {
+        ProjectNoun::try_parse_from(args).expect("should parse")
+    }
+
+    #[test]
+    fn project_create_resolves() {
+        let resolved = parse(&[
+            "project",
+            "my-project",
+            "create",
+            "--display-name",
+            "My Project",
+            "--repo",
+            "https://github.com/org/repo.git",
+            "--subpath",
+            "apps/frontend",
+            "--ref",
+            "main",
+        ])
+        .resolve()
+        .expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ProjectCreate {
+                    name: "my-project".into(),
+                    display_name: Some("My Project".into()),
+                    repository_url: Some("https://github.com/org/repo.git".into()),
+                    subpath: Some("apps/frontend".into()),
+                    r#ref: Some("main".into()),
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn project_create_minimal_resolves() {
+        let resolved = parse(&["project", "empty", "create"]).resolve().expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ProjectCreate {
+                    name: "empty".into(),
+                    display_name: None,
+                    repository_url: None,
+                    subpath: None,
+                    r#ref: None,
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn project_apply_reads_file() {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        std::fs::write(tmp.path(), "repositories: []\n").expect("write");
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let resolved = parse(&["project", "scratch", "apply", "--file", &path]).resolve().expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ProjectApply { name: "scratch".into(), spec_yaml: "repositories: []\n".into() },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn round_trip_create() {
+        assert_round_trip::<ProjectNoun>(&[
+            "project",
+            "p",
+            "create",
+            "--display-name",
+            "MyProj",
+            "--repo",
+            "https://example.com/repo.git",
+            "--subpath",
+            "apps/x",
+            "--ref",
+            "main",
+        ]);
+    }
+
+    #[test]
+    fn round_trip_apply() {
+        assert_round_trip::<ProjectNoun>(&["project", "p", "apply", "--file", "/tmp/p.yaml"]);
+    }
+}

--- a/crates/flotilla-commands/src/commands/project.rs
+++ b/crates/flotilla-commands/src/commands/project.rs
@@ -29,11 +29,11 @@ pub enum ProjectVerb {
         /// Repository URL (creates a single-entry `repositories` list)
         #[arg(long = "repo")]
         repository_url: Option<String>,
-        /// Subpath within the repository (monorepo slice)
-        #[arg(long = "subpath")]
+        /// Subpath within the repository (monorepo slice). Requires `--repo`.
+        #[arg(long = "subpath", requires = "repository_url")]
         subpath: Option<String>,
-        /// Default branch for the repository
-        #[arg(long = "ref")]
+        /// Default branch for the repository. Requires `--repo`.
+        #[arg(long = "ref", requires = "repository_url")]
         r#ref: Option<String>,
     },
     /// Apply a project spec from a YAML file (full multi-repo form)
@@ -210,5 +210,17 @@ mod tests {
     #[test]
     fn round_trip_apply() {
         assert_round_trip::<ProjectNoun>(&["project", "p", "apply", "--file", "/tmp/p.yaml"]);
+    }
+
+    #[test]
+    fn subpath_without_repo_is_rejected() {
+        let err = ProjectNoun::try_parse_from(["project", "p", "create", "--subpath", "apps/x"]).expect_err("should fail");
+        assert!(err.to_string().contains("--subpath"), "error should mention --subpath: {err}");
+    }
+
+    #[test]
+    fn ref_without_repo_is_rejected() {
+        let err = ProjectNoun::try_parse_from(["project", "p", "create", "--ref", "main"]).expect_err("should fail");
+        assert!(err.to_string().contains("--ref"), "error should mention --ref: {err}");
     }
 }

--- a/crates/flotilla-commands/src/commands/project.rs
+++ b/crates/flotilla-commands/src/commands/project.rs
@@ -209,6 +209,8 @@ mod tests {
 
     #[test]
     fn round_trip_apply() {
+        // `assert_round_trip` only exercises the parse → Display → reparse cycle on the
+        // clap struct, not the file-reading path in `resolve()` — the path doesn't need to exist.
         assert_round_trip::<ProjectNoun>(&["project", "p", "apply", "--file", "/tmp/p.yaml"]);
     }
 

--- a/crates/flotilla-commands/src/noun.rs
+++ b/crates/flotilla-commands/src/noun.rs
@@ -5,7 +5,7 @@ use clap::Subcommand;
 use crate::{
     commands::{
         agent::AgentNoun, checkout::CheckoutNoun, convoy::ConvoyNoun, cr::CrNoun, environment::EnvironmentNoun, issue::IssueNoun,
-        repo::RepoNoun, workflow_template::WorkflowTemplateNoun, workspace::WorkspaceNoun,
+        project::ProjectNoun, repo::RepoNoun, workflow_template::WorkflowTemplateNoun, workspace::WorkspaceNoun,
     },
     Resolved,
 };
@@ -23,6 +23,7 @@ pub enum NounCommand {
     Agent(AgentNoun),
     Workspace(WorkspaceNoun),
     WorkflowTemplate(WorkflowTemplateNoun),
+    Project(ProjectNoun),
     // Host is NOT included — host doesn't nest inside host
 }
 
@@ -38,6 +39,7 @@ impl NounCommand {
             NounCommand::Agent(noun) => noun.resolve(),
             NounCommand::Workspace(noun) => noun.resolve(),
             NounCommand::WorkflowTemplate(noun) => noun.resolve(),
+            NounCommand::Project(noun) => noun.resolve(),
         }
     }
 }
@@ -54,6 +56,7 @@ impl fmt::Display for NounCommand {
             NounCommand::Agent(noun) => write!(f, "{noun}"),
             NounCommand::Workspace(noun) => write!(f, "{noun}"),
             NounCommand::WorkflowTemplate(noun) => write!(f, "{noun}"),
+            NounCommand::Project(noun) => write!(f, "{noun}"),
         }
     }
 }

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -64,6 +64,7 @@ pub async fn create_convoy_with_single_task(
             placement_policy: None,
             repository: Some(ConvoyRepositorySpec { url: repo_url.to_string() }),
             r#ref: Some(git_ref.to_string()),
+            project_ref: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
+++ b/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
@@ -430,6 +430,7 @@ async fn create_convoy_with_labeled_processes(
             placement_policy: None,
             repository: Some(ConvoyRepositorySpec { url: repo_url.to_string() }),
             r#ref: Some(git_ref.to_string()),
+            project_ref: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -311,6 +311,8 @@ pub async fn build_plan(
         CommandAction::ConvoyTaskComplete { .. }
         | CommandAction::ConvoyCreate { .. }
         | CommandAction::WorkflowTemplateApply { .. }
+        | CommandAction::ProjectCreate { .. }
+        | CommandAction::ProjectApply { .. }
         | CommandAction::TrackRepoPath { .. }
         | CommandAction::UntrackRepo { .. }
         | CommandAction::Refresh { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,7 +22,8 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Convoy as ResourceConvoy,
-    ConvoyRepositorySpec, ConvoySpec, InputMeta, InputValue, ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
+    ConvoyRepositorySpec, ConvoySpec, InputMeta, InputValue, Project, ProjectRepositorySpec, ProjectSpec, ResourceBackend, ResourceError,
+    WorkflowTemplate, WorkflowTemplateSpec,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -211,6 +212,10 @@ fn parse_and_validate_workflow_template_yaml(yaml: &str) -> Result<WorkflowTempl
         format!("workflow template validation failed: {joined}")
     })?;
     Ok(spec)
+}
+
+fn parse_project_yaml(yaml: &str) -> Result<ProjectSpec, String> {
+    serde_yml::from_str(yaml).map_err(|err| format!("invalid project YAML: {err}"))
 }
 
 fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {
@@ -2015,7 +2020,9 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ConvoyCreate { name, workflow_ref, inputs, repository_url, r#ref } = &command.action {
+        if let flotilla_protocol::CommandAction::ConvoyCreate { name, workflow_ref, inputs, repository_url, r#ref, project_ref } =
+            &command.action
+        {
             let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
                 command_id: id,
@@ -2032,6 +2039,7 @@ impl InProcessDaemon {
                 placement_policy: None,
                 repository: repository_url.clone().map(|url| ConvoyRepositorySpec { url }),
                 r#ref: r#ref.clone(),
+                project_ref: project_ref.clone(),
             };
             let meta = InputMeta::builder().name(name.clone()).build();
             let result = match convoys.create(&meta, &spec).await {
@@ -2069,6 +2077,73 @@ impl InProcessDaemon {
                     };
                     match outcome {
                         Ok(()) => flotilla_protocol::CommandValue::WorkflowTemplateApplied { name: name.clone() },
+                        Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+                    }
+                }
+                Err(err) => flotilla_protocol::CommandValue::Error { message: err },
+            };
+            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity,
+                repo: None,
+                result,
+            });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ProjectCreate { name, display_name, repository_url, subpath, r#ref } = &command.action {
+            let empty_identity = empty_repo_identity();
+            let _ = self.event_tx.send(DaemonEvent::CommandStarted {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity.clone(),
+                repo: None,
+                description: command.description().to_string(),
+            });
+            let namespace = self.provisioning_namespace().await;
+            let projects = self.resource_backend.clone().using::<Project>(&namespace);
+            let repositories = match repository_url {
+                Some(url) => vec![ProjectRepositorySpec { repo: url.clone(), subpath: subpath.clone(), default_branch: r#ref.clone() }],
+                None => vec![],
+            };
+            let spec = ProjectSpec { display_name: display_name.clone(), repositories };
+            let meta = InputMeta::builder().name(name.clone()).build();
+            let result = match projects.create(&meta, &spec).await {
+                Ok(_) => flotilla_protocol::CommandValue::ProjectCreated { name: name.clone() },
+                Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+            };
+            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity,
+                repo: None,
+                result,
+            });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ProjectApply { name, spec_yaml } = &command.action {
+            let empty_identity = empty_repo_identity();
+            let _ = self.event_tx.send(DaemonEvent::CommandStarted {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity.clone(),
+                repo: None,
+                description: command.description().to_string(),
+            });
+            let namespace = self.provisioning_namespace().await;
+            let projects = self.resource_backend.clone().using::<Project>(&namespace);
+            let result = match parse_project_yaml(spec_yaml) {
+                Ok(spec) => {
+                    let meta = InputMeta::builder().name(name.clone()).build();
+                    let outcome = match projects.get(name).await {
+                        Ok(existing) => projects.update(&meta, &existing.metadata.resource_version, &spec).await.map(|_| ()),
+                        Err(ResourceError::NotFound { .. }) => projects.create(&meta, &spec).await.map(|_| ()),
+                        Err(err) => Err(err),
+                    };
+                    match outcome {
+                        Ok(()) => flotilla_protocol::CommandValue::ProjectApplied { name: name.clone() },
                         Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
                     }
                 }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -617,6 +617,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
             placement_policy: Some("laptop-docker".to_string()),
             repository: None,
             r#ref: None,
+            project_ref: None,
         })
         .await
         .expect("convoy create should succeed");
@@ -696,6 +697,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
             placement_policy: Some("laptop-docker".to_string()),
             repository: None,
             r#ref: None,
+            project_ref: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-daemon/src/convoy_projection.rs
+++ b/crates/flotilla-daemon/src/convoy_projection.rs
@@ -410,6 +410,7 @@ mod tests {
                 placement_policy: None,
                 repository: None,
                 r#ref: None,
+                project_ref: None,
             },
             status: Some(ConvoyStatus { phase, workflow_snapshot, tasks: task_states, ..Default::default() }),
         }
@@ -425,6 +426,7 @@ mod tests {
                 placement_policy: None,
                 repository: None,
                 r#ref: None,
+                project_ref: None,
             },
             status: Some(ConvoyStatus {
                 phase: ResConvoyPhase::Active,
@@ -458,7 +460,14 @@ mod tests {
     fn summarize_convoy_marks_initializing_when_snapshot_absent() {
         let convoy = ResourceObject {
             metadata: meta("flotilla", "new-one"),
-            spec: ConvoySpec { workflow_ref: "wf".into(), inputs: BTreeMap::new(), placement_policy: None, repository: None, r#ref: None },
+            spec: ConvoySpec {
+                workflow_ref: "wf".into(),
+                inputs: BTreeMap::new(),
+                placement_policy: None,
+                repository: None,
+                r#ref: None,
+                project_ref: None,
+            },
             status: Some(ConvoyStatus {
                 phase: ResConvoyPhase::Pending,
                 workflow_snapshot: None,

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1210,6 +1210,7 @@ mod tests {
                 placement_policy: Some(format!("host-direct-{host_id}")),
                 repository: Some(ConvoyRepositorySpec { url: "https://github.com/flotilla-org/flotilla.git".to_string() }),
                 r#ref: Some(commit),
+                project_ref: None,
             })
             .await
             .expect("convoy create should succeed");

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -78,6 +78,7 @@ async fn convoy_create_command_creates_convoy_resource() {
                 inputs: vec![("topic".into(), "first-convoy".into())],
                 repository_url: None,
                 r#ref: None,
+                project_ref: None,
             },
         })
         .await

--- a/crates/flotilla-daemon/tests/convoy_projection.rs
+++ b/crates/flotilla-daemon/tests/convoy_projection.rs
@@ -30,7 +30,14 @@ fn convoy_meta(name: &str) -> InputMeta {
 }
 
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
-    ConvoySpec { workflow_ref: workflow_ref.to_string(), inputs: BTreeMap::new(), placement_policy: None, repository: None, r#ref: None }
+    ConvoySpec {
+        workflow_ref: workflow_ref.to_string(),
+        inputs: BTreeMap::new(),
+        placement_policy: None,
+        repository: None,
+        r#ref: None,
+        project_ref: None,
+    }
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -1,0 +1,205 @@
+//! Integration tests for the `ProjectCreate` + `ProjectApply` daemon actions
+//! and the `project_ref` field on `ConvoyCreate`.
+
+use std::{sync::Arc, time::Duration};
+
+use flotilla_core::{
+    config::ConfigStore, daemon::DaemonHandle, in_process::InProcessDaemon, providers::discovery::test_support::fake_discovery,
+};
+use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
+use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName};
+use flotilla_resources::{Convoy, InMemoryBackend, Project, ResourceBackend};
+
+fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&dir).expect("create config dir");
+    std::fs::write(dir.join("daemon.toml"), "machine_id = \"test-project-cli\"\n").expect("write daemon config");
+    Arc::new(ConfigStore::with_base(dir))
+}
+
+async fn start_daemon() -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigStore>, DaemonRuntime, tempfile::TempDir) {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    let options = RuntimeOptions {
+        namespace: "flotilla".to_string(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_secs(300),
+        start_controllers: false,
+        ..RuntimeOptions::default()
+    };
+    let runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
+    (daemon, backend, config, runtime, tmp)
+}
+
+async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let event = tokio::time::timeout(remaining, rx.recv()).await.expect("timed out").expect("recv");
+        if let DaemonEvent::CommandFinished { command_id: id, result, .. } = event {
+            if id == command_id {
+                return result;
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn project_create_command_creates_project_resource() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ProjectCreate {
+                name: "my-project".into(),
+                display_name: Some("My Project".into()),
+                repository_url: Some("https://github.com/org/repo.git".into()),
+                subpath: Some("apps/frontend".into()),
+                r#ref: Some("main".into()),
+            },
+        })
+        .await
+        .expect("execute");
+
+    let result = await_command_result(&mut rx, id).await;
+    assert_eq!(result, CommandValue::ProjectCreated { name: "my-project".into() });
+
+    let projects = backend.using::<Project>("flotilla");
+    let project = projects.get("my-project").await.expect("project should exist");
+    assert_eq!(project.spec.display_name.as_deref(), Some("My Project"));
+    assert_eq!(project.spec.repositories.len(), 1);
+    assert_eq!(project.spec.repositories[0].repo, "https://github.com/org/repo.git");
+    assert_eq!(project.spec.repositories[0].subpath.as_deref(), Some("apps/frontend"));
+    assert_eq!(project.spec.repositories[0].default_branch.as_deref(), Some("main"));
+}
+
+#[tokio::test]
+async fn project_apply_supports_multi_repo() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+
+    let yaml = r#"
+display_name: "Cross-Project Demo"
+repositories:
+  - repo: https://github.com/org/repo-a.git
+    default_branch: main
+  - repo: https://github.com/org/repo-b.git
+    subpath: services/api
+    default_branch: develop
+"#;
+
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ProjectApply { name: "cross".into(), spec_yaml: yaml.into() },
+        })
+        .await
+        .expect("execute");
+
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ProjectApplied { name: "cross".into() });
+
+    let projects = backend.using::<Project>("flotilla");
+    let project = projects.get("cross").await.expect("project should exist");
+    assert_eq!(project.spec.repositories.len(), 2);
+    assert_eq!(project.spec.repositories[0].repo, "https://github.com/org/repo-a.git");
+    assert_eq!(project.spec.repositories[1].subpath.as_deref(), Some("services/api"));
+}
+
+#[tokio::test]
+async fn project_apply_updates_existing() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+
+    // First apply.
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ProjectApply { name: "iter".into(), spec_yaml: "display_name: V1\nrepositories: []\n".into() },
+        })
+        .await
+        .expect("first apply");
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ProjectApplied { name: "iter".into() });
+
+    // Second apply same name, different content.
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ProjectApply { name: "iter".into(), spec_yaml: "display_name: V2\nrepositories: []\n".into() },
+        })
+        .await
+        .expect("second apply");
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ProjectApplied { name: "iter".into() });
+
+    let projects = backend.using::<Project>("flotilla");
+    let project = projects.get("iter").await.expect("project should exist");
+    assert_eq!(project.spec.display_name.as_deref(), Some("V2"));
+}
+
+#[tokio::test]
+async fn convoy_create_carries_project_ref() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "linked".into(),
+                workflow_ref: "scratch".into(),
+                inputs: vec![],
+                repository_url: None,
+                r#ref: None,
+                project_ref: Some("my-project".into()),
+            },
+        })
+        .await
+        .expect("execute");
+
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ConvoyCreated { name: "linked".into() });
+
+    let convoys = backend.using::<Convoy>("flotilla");
+    let convoy = convoys.get("linked").await.expect("convoy should exist");
+    assert_eq!(convoy.spec.project_ref.as_deref(), Some("my-project"));
+}
+
+#[tokio::test]
+async fn project_apply_rejects_invalid_yaml() {
+    let (daemon, _backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ProjectApply {
+                name: "broken".into(),
+                spec_yaml: "this is: not {valid yaml structure for: a project".into(),
+            },
+        })
+        .await
+        .expect("execute");
+
+    let result = await_command_result(&mut rx, id).await;
+    assert!(matches!(result, CommandValue::Error { .. }), "expected Error, got {result:?}");
+}

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -203,3 +203,26 @@ async fn project_apply_rejects_invalid_yaml() {
     let result = await_command_result(&mut rx, id).await;
     assert!(matches!(result, CommandValue::Error { .. }), "expected Error, got {result:?}");
 }
+
+#[tokio::test]
+async fn project_apply_rejects_wrong_shape_yaml() {
+    // Valid YAML, but a `repositories` entry is missing the required `repo` field.
+    let (daemon, _backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ProjectApply {
+                name: "shapeless".into(),
+                spec_yaml: "repositories:\n  - subpath: apps/x\n    default_branch: main\n".into(),
+            },
+        })
+        .await
+        .expect("execute");
+
+    let result = await_command_result(&mut rx, id).await;
+    assert!(matches!(result, CommandValue::Error { .. }), "expected Error, got {result:?}");
+}

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -158,8 +158,25 @@ pub enum CommandAction {
         repository_url: Option<String>,
         #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
         r#ref: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project_ref: Option<String>,
     },
     WorkflowTemplateApply {
+        name: String,
+        spec_yaml: String,
+    },
+    ProjectCreate {
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display_name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repository_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        subpath: Option<String>,
+        #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+        r#ref: Option<String>,
+    },
+    ProjectApply {
         name: String,
         spec_yaml: String,
     },
@@ -250,6 +267,8 @@ impl Command {
             CommandAction::ConvoyTaskComplete { .. } => "Completing convoy task...",
             CommandAction::ConvoyCreate { .. } => "Creating convoy...",
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
+            CommandAction::ProjectCreate { .. } => "Creating project...",
+            CommandAction::ProjectApply { .. } => "Applying project...",
             CommandAction::TeleportSession { .. } => "Teleporting session...",
             CommandAction::TrackRepoPath { .. } => "Tracking repository...",
             CommandAction::UntrackRepo { .. } => "Untracking repository...",
@@ -338,6 +357,12 @@ pub enum CommandValue {
         name: String,
     },
     WorkflowTemplateApplied {
+        name: String,
+    },
+    ProjectCreated {
+        name: String,
+    },
+    ProjectApplied {
         name: String,
     },
 }
@@ -518,6 +543,7 @@ mod tests {
                     inputs: vec![("topic".into(), "convoy-create-cli".into())],
                     repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
                     r#ref: Some("main".into()),
+                    project_ref: Some("my-project".into()),
                 },
             },
             Command {
@@ -525,6 +551,24 @@ mod tests {
                 provisioning_target: None,
                 context_repo: None,
                 action: CommandAction::WorkflowTemplateApply { name: "scratch".into(), spec_yaml: "tasks: []\n".into() },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ProjectCreate {
+                    name: "my-project".into(),
+                    display_name: Some("My Project".into()),
+                    repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
+                    subpath: Some("apps/frontend".into()),
+                    r#ref: Some("main".into()),
+                },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ProjectApply { name: "my-project".into(), spec_yaml: "repositories: []\n".into() },
             },
             Command {
                 node_id: Some(NodeId::new("feta")),
@@ -750,6 +794,8 @@ mod tests {
             CommandValue::IssuesByIds { items: vec![] },
             CommandValue::ConvoyCreated { name: "my-convoy".into() },
             CommandValue::WorkflowTemplateApplied { name: "scratch".into() },
+            CommandValue::ProjectCreated { name: "my-project".into() },
+            CommandValue::ProjectApplied { name: "my-project".into() },
         ];
 
         for result in cases {

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -176,6 +176,7 @@ pub enum ResponseResult {
 }
 
 /// Top-level message envelope for the JSON protocol.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum Message {

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -50,6 +50,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         placement_policy: Some("laptop-docker".to_string()),
         repository: None,
         r#ref: None,
+        project_ref: None,
     }
 }
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -22,6 +22,10 @@ pub struct ConvoySpec {
     pub repository: Option<ConvoyRepositorySpec>,
     #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
     pub r#ref: Option<String>,
+    /// Grouping reference to a [`Project`](crate::Project) resource. Metadata only in v1 —
+    /// the reconciler does not consult it. Future: substitute repository/ref from project.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -11,6 +11,7 @@ mod in_memory;
 mod labels;
 mod placement_policy;
 mod presentation;
+mod project;
 mod provisioning_identity;
 mod resource;
 mod status_patch;
@@ -45,6 +46,7 @@ pub use placement_policy::{
     PlacementPolicy, PlacementPolicySpec,
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
+pub use project::{Project, ProjectRepositorySpec, ProjectSpec};
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use resource::{ApiPaths, InputMeta, ObjectMeta, OwnerReference, Resource, ResourceObject};
 pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};

--- a/crates/flotilla-resources/src/project.rs
+++ b/crates/flotilla-resources/src/project.rs
@@ -18,6 +18,7 @@ pub struct ProjectRepositorySpec {
     pub repo: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subpath: Option<String>,
+    /// Surfaced as `--ref` on the `flotilla project create` CLI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_branch: Option<String>,
 }

--- a/crates/flotilla-resources/src/project.rs
+++ b/crates/flotilla-resources/src/project.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{resource::define_resource, status_patch::NoStatusPatch};
+
+define_resource!(Project, "projects", ProjectSpec, (), NoStatusPatch);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, bon::Builder)]
+pub struct ProjectSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[builder(default)]
+    #[serde(default)]
+    pub repositories: Vec<ProjectRepositorySpec>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct ProjectRepositorySpec {
+    pub repo: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subpath: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_branch: Option<String>,
+}

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -202,6 +202,7 @@ pub fn valid_convoy_spec() -> RealConvoySpec {
         placement_policy: Some("laptop-docker".to_string()),
         repository: None,
         r#ref: None,
+        project_ref: None,
     }
 }
 

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -37,6 +37,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         placement_policy: Some("laptop-docker".to_string()),
         repository: None,
         r#ref: None,
+        project_ref: None,
     }
 }
 

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -148,6 +148,14 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
             info!(%name, "workflow template applied");
             app.model.status_message = Some(format!("Workflow template applied: {name}"));
         }
+        CommandValue::ProjectCreated { name } => {
+            info!(%name, "project created");
+            app.model.status_message = Some(format!("Project created: {name}"));
+        }
+        CommandValue::ProjectApplied { name } => {
+            info!(%name, "project applied");
+            app.model.status_message = Some(format!("Project applied: {name}"));
+        }
     }
 }
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -305,6 +305,8 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::IssuesByIds { items } => format!("issues by ids: {} items", items.len()),
         CommandValue::ConvoyCreated { name } => format!("convoy created: {name}"),
         CommandValue::WorkflowTemplateApplied { name } => format!("workflow template applied: {name}"),
+        CommandValue::ProjectCreated { name } => format!("project created: {name}"),
+        CommandValue::ProjectApplied { name } => format!("project applied: {name}"),
     }
 }
 

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -39,7 +39,14 @@ fn convoy_meta(name: &str) -> InputMeta {
 }
 
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
-    ConvoySpec { workflow_ref: workflow_ref.to_string(), inputs: BTreeMap::new(), placement_policy: None, repository: None, r#ref: None }
+    ConvoySpec {
+        workflow_ref: workflow_ref.to_string(),
+        inputs: BTreeMap::new(),
+        placement_policy: None,
+        repository: None,
+        r#ref: None,
+        project_ref: None,
+    }
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,8 @@ enum SubCommand {
     Host(flotilla_commands::commands::host::HostNounPartial),
     /// Manage workflow templates
     WorkflowTemplate(flotilla_commands::commands::workflow_template::WorkflowTemplateNoun),
+    /// Manage projects
+    Project(flotilla_commands::commands::project::ProjectNoun),
 
     /// Generate completions (hidden, called by shell scripts)
     #[command(hide = true)]
@@ -188,6 +190,7 @@ async fn main() -> Result<()> {
             dispatch(partial.refine().and_then(|n| n.resolve()).map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await
         }
         Some(SubCommand::WorkflowTemplate(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
+        Some(SubCommand::Project(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
 
         Some(SubCommand::Complete { line, cursor_pos }) => {
             run_complete(&line, cursor_pos);
@@ -896,6 +899,13 @@ mod tests {
         let cli = Cli::try_parse_from(["flotilla", "workflow-template", "scratch", "apply", "--file", "/tmp/x.yaml"])
             .expect("workflow-template cli should parse");
         assert!(matches!(cli.command, Some(SubCommand::WorkflowTemplate(_))));
+    }
+
+    #[test]
+    fn cli_parses_project_noun() {
+        let cli = Cli::try_parse_from(["flotilla", "project", "my-project", "create", "--repo", "https://example.com/repo.git"])
+            .expect("project cli should parse");
+        assert!(matches!(cli.command, Some(SubCommand::Project(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

New \`Project\` resource for grouping convoys around shared identity — one or more repositories with optional monorepo subpath and default branch. Sits alongside the existing TrackedRepo concept (collapsing them is deferred until Yeoman/Governor surface a clearer driver).

\`ConvoySpec\` gains a \`project_ref: Option<String>\` field. **Metadata only in v1** — the reconciler doesn't consult it. Future work: substitute the project's repository/ref when the convoy doesn't supply one.

## Resource shape

\`\`\`rust
pub struct ProjectSpec {
    pub display_name: Option<String>,
    pub repositories: Vec<ProjectRepositorySpec>,
}

pub struct ProjectRepositorySpec {
    pub repo: String,                  // URL
    pub subpath: Option<String>,       // monorepo slice
    pub default_branch: Option<String>,
}
\`\`\`

\`Vec<repo, subpath>\` from the start, per the design discussion — supports cross-project (multiple repos as one logical unit) and monorepo-slice (one repo split into multiple projects).

## CLI

- \`flotilla project <name> create [--display-name "…"] [--repo URL [--subpath …] [--ref …]]\` — single-repo convenience.
- \`flotilla project <name> apply --file <yaml>\` — full multi-repo form.
- \`flotilla convoy <name> create … --project <project>\` — tags the convoy with a project grouping.

## Wire layout

- **Protocol**: new \`CommandAction::ProjectCreate\` / \`ProjectApply\` + matching \`CommandValue\` shapes; \`ConvoyCreate\` gains \`project_ref\`. Roundtrip cases extended.
- **Daemon**: \`InProcessDaemon\` handles both actions inline against \`ResourceBackend\`. \`ProjectApply\` parses YAML (\`serde_yml\`) and does \`get → update\` or \`create\`.
- **CLI**: new \`ProjectNoun\` in \`flotilla-commands\`; wired into \`NounCommand\` AND \`SubCommand\` in \`src/main.rs\` (avoiding #602's omission).

## \`Message\` enum allow

\`#[allow(clippy::large_enum_variant)]\` on \`Message\` — same allow already on \`Response\`. Adding two more action variants to \`CommandAction\` pushed the Request variant past clippy's threshold; boxing every variant clutters the wire shape for no real benefit.

## Test plan

- [x] \`cargo +nightly-2026-03-12 fmt --check\`
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\`
- [x] \`cargo test --workspace --locked\` — including 5 new integration tests in \`crates/flotilla-daemon/tests/project_cli.rs\`:
  - \`project_create_command_creates_project_resource\` — single-repo create
  - \`project_apply_supports_multi_repo\` — YAML with two entries (one with subpath)
  - \`project_apply_updates_existing\` — apply-as-update semantics
  - \`convoy_create_carries_project_ref\` — \`--project\` flows through to ConvoySpec
  - \`project_apply_rejects_invalid_yaml\` — clear error path
- [x] Top-level CLI regression test \`cli_parses_project_noun\` in \`src/main.rs\` (mirrors #602's fix)
- [ ] Smoke against a real daemon

## Not in this cut

- Reconciler doesn't read \`project_ref\` yet
- No TUI surface
- No auto-creation of Projects from existing TrackedRepos
- No multi-repo-aware convoy expansion