### PR TITLE
docs: transition roadmap, ADRs, glossary, and Plane-A freeze

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@ A system for improving multi-agent developer workflows. Consists of a daemon mes
 
 We are in a **no backwards compatibility** phase. Protocol types, snapshot formats, config file formats, and wire formats can all change freely without migration logic or deprecation paths.
 
+### Plane-A freeze (transition in progress)
+
+Flotilla is mid-transition from a fleet *observer* (providers → correlation → WorkItems → snapshots → TUI) to a *control plane* (k8s-isomorphic resources → reconcilers → convoys). See `docs/roadmap.md`, `CONTEXT.md`, and `docs/adr/0001-0003`; the umbrella is flotilla-org/flotilla#604.
+
+**Plane A is bugfix-only.** Do not add net-new features to: correlation / union-find, `WorkItem`, the `ProviderData → WorkItem → Snapshot` core pipeline, or the peer-merge subsystem (`flotilla-daemon/src/peer`). These are slated for deletion (the observer reshape moves providers to *observed resources* + an on-demand Aggregator; multi-host moves to resource-store federation). Bugfixes and tests are fine; new capability belongs on the control-plane side. If a change feels like it grows Plane A, stop and check the roadmap.
+
+The TUI is *factored, not frozen* — keep it maintained, but extract the surface-agnostic view-model rather than duplicating presentation logic per surface.
+
 ## Quick Reference
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ We are in a **no backwards compatibility** phase. Protocol types, snapshot forma
 
 ### Plane-A freeze (transition in progress)
 
-Flotilla is mid-transition from a fleet *observer* (providers → correlation → WorkItems → snapshots → TUI) to a *control plane* (k8s-isomorphic resources → reconcilers → convoys). See `docs/roadmap.md`, `CONTEXT.md`, and `docs/adr/0001-0003`; the umbrella is flotilla-org/flotilla#604.
+Flotilla is mid-transition from a fleet *observer* (providers → correlation → WorkItems → snapshots → TUI) to a *control plane* (k8s-isomorphic resources → reconcilers → convoys). See `docs/roadmap.md`, `CONTEXT.md`, and the ADRs in `docs/adr/`; the umbrella is flotilla-org/flotilla#604.
 
 **Plane A is bugfix-only.** Do not add net-new features to: correlation / union-find, `WorkItem`, the `ProviderData → WorkItem → Snapshot` core pipeline, or the peer-merge subsystem (`flotilla-daemon/src/peer`). These are slated for deletion (the observer reshape moves providers to *observed resources* + an on-demand Aggregator; multi-host moves to resource-store federation). Bugfixes and tests are fine; new capability belongs on the control-plane side. If a change feels like it grows Plane A, stop and check the roadmap.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -147,8 +147,8 @@ _Avoid_: Bot, assistant.
 These are sibling products in separate repositories, reached over
 HTTP-over-UDS (and, for cleat, a C ABI for native embedding):
 
-- **cleat** — terminal/PTY/VT engine. (`~/dev/cleat`)
+- **cleat** — terminal/PTY/VT engine.
 - **porthole** — window-system helper for composing external side-by-side
-  surfaces. (`~/dev/porthole`)
+  surfaces.
 - **uishell** — native UI shell (RAD-derived) that composes Panels/Views and
-  embeds cleat; the intended premier interface to Flotilla. (`~/dev/ui-scratch`)
+  embeds cleat; the intended premier interface to Flotilla.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,154 @@
+# Flotilla
+
+Flotilla manages a fleet of development resources — agents, checkouts, PRs, issues,
+terminals, environments — across many repositories and many hosts. It is both an
+**observer** (it reports what exists across the fleet) and an **orchestrator** (it
+causes desired work to come into being via a control plane).
+
+Flotilla is one member of a product family that communicates over HTTP-over-UDS
+(with cross-host federation). See _External Collaborators_ below.
+
+## Language
+
+**Fleet**:
+The whole set of development resources Flotilla coordinates across hosts. The
+boats are the dev resources; the islands are the repositories/projects.
+
+**Island**:
+The guiding metaphor for a repository/project as a stewarded place where work
+happens. Realised concretely as the **Project** resource.
+_Avoid_: using "Island" as a code/identifier name — it is the metaphor, not the type.
+
+**Project**:
+The resource that structurally groups work (convoys) belonging to one
+repository/codebase. The concrete form of the **Island** metaphor.
+_Avoid_: Repo (a Project may span more than the bare git remote), Workspace.
+
+**Convoy**:
+A named instance of a workflow — the primary unit of *launched* work. A DAG of
+**Tasks** that cooperate to accomplish something. Replaces the older "attachable
+set" / "new branch" framing.
+_Avoid_: Job, pipeline, attachable set.
+
+**Task**:
+A placement unit within a **Convoy** — a single (host, checkout, environment)
+placement that hosts one or more **Processes**. Completed explicitly, not by
+process exit.
+_Avoid_: Step (a Task is a placement, not a workflow stage), pod.
+
+**Process**:
+A running program within a **Task**, resolved to a placement by selectors
+(e.g. `capability: code`) rather than by template variable substitution.
+_Avoid_: Pane, terminal (those are presentation concerns).
+
+**Control Plane**:
+The desired-state engine: typed resources, reconcilers/controllers, and a
+backing store. Causes work to exist by reconciling observed state toward
+declared resources.
+_Avoid_: Tiller (Helm 2 collision), scheduler, orchestrator-as-a-noun.
+
+**Fleet Observer**:
+The descriptive half of Flotilla: it gathers facts from external tools and
+reports what already exists across the fleet. Distinct from the **Control
+Plane**, which causes things to exist.
+_Avoid_: Monitor, dashboard (those are presentation surfaces over the observer).
+
+**Provider**:
+An adapter that gathers facts from one external tool (git, GitHub, a coding
+agent, a multiplexer) and/or surfaces actions on it. Belongs to the **Fleet
+Observer**.
+_Avoid_: Plugin, integration (reserve "integration" for the user-facing list).
+
+**Correlation**:
+The act of piecing observed fragments from many **Providers** into one logical
+unit of work. Exists only because Flotilla did not create the work; for
+Flotilla-launched (**Convoy**) work, linkage is known by construction (owner
+references / labels), not inferred. Demoted from a baked-in core service
+(union-find) to an on-demand **Aggregator** utility used only for purely-observed
+state.
+_Avoid_: Grouping, merging, dedup.
+
+**Lifecycle Authority**:
+Per-resource property stating how far Flotilla's control extends over a resource:
+**Observed** (report only), **Adopted** (act on it for requested purposes, do not
+own its lifecycle — e.g. the user's hand-managed local clone), or **Managed**
+(Flotilla provisioned it and may destroy it). Adoption is promotion along this
+axis, never a kind change.
+_Avoid_: Owned/unowned (too coarse), internal/external.
+
+**Federation**:
+The model by which independent local daemons (Flotilla, cleat, porthole, the
+uishell control surface) reach each other's HTTP-over-UDS endpoints across a
+group of machines, over a pluggable transport (ssh today; wireguard/https
+possible). Includes arbitrary listener forwarding. Multi-host coordination is
+"watch a remote resource store over a forwarded socket," not snapshot-merge.
+_Avoid_: Peering (the legacy merge implementation being retired), clustering,
+mesh-as-a-noun.
+
+**Tender**:
+The slim, standalone, per-host daemon that realises **Federation**: it owns host
+inventory, identity, the pluggable transport, and arbitrary UDS-listener
+forwarding, exposed via its own HTTP-over-UDS control API. Carries no Flotilla
+domain semantics; the whole product family uses it. Named for a tender boat —
+it ferries and services connections between ship and shore.
+_Avoid_: Bridge, peer, gateway, proxy, router, tug.
+
+**Aggregator**:
+A view-time component that pieces observed resources together (across hosts or
+providers) on demand, for a particular reason — an event, a view. Where any
+**Correlation** lives now that it is no longer a core always-on service.
+_Avoid_: Merger, the correlation engine (that is the retired baked-in form).
+
+**Provisioning**:
+Bringing an execution context into being — a checkout, an **Environment**
+(container/host-direct), the sockets and forwarding a **Task** needs to run.
+Interacts closely with **Federation**.
+_Avoid_: Setup, bootstrap.
+
+**Environment**:
+A provisioned execution context (e.g. a Docker container or a host-direct
+context) in which a **Task**'s **Processes** run.
+_Avoid_: Sandbox (reserve for the future restricted-execution feature), VM.
+
+**Presentation**:
+How running work is surfaced to a person — which panes/surfaces show which
+**Processes**, across multiplexers and external windows. Dual to placement.
+_Avoid_: Layout, UI, workspace template (the latter is one mechanism).
+
+**Surface**:
+A presentation client of Flotilla — the ratatui **TUI**, a future web UI, or
+**uishell** — that consumes the resource store + **Aggregator** + a shared
+**View Model** over HTTP-over-UDS and renders it in its own idiom. Surfaces own
+rendering; they do not own truth.
+_Avoid_: Frontend, client (too generic), view (that is the View Model).
+
+**View Model**:
+A surface-agnostic description of what to show and what can be done — sections,
+columns, rows bound to resources, and the **Intents** (actions) available on
+them — with no rendering or styling baked in. Each **Surface** renders it
+natively. Partly latent in the TUI today (`SectionTable`/`ColumnDef`).
+_Avoid_: Widget, layout, table (those are renderings of a View Model).
+
+**Intent**:
+A surface-agnostic action available on a resource/row (e.g. open PR, check out,
+attach), with its own availability rules, resolving to a control-plane command.
+The reusable action model shared by all **Surfaces**.
+_Avoid_: Command (the resolved wire form), keybinding, button.
+
+**Meta-agent**:
+A persistent agent that operates the fleet rather than writing code — allocation
+(Quartermaster), accounting (Purser), stewardship (Governor), presentation
+(Yeoman), discipline/continuation (Bosun). A future layer above observer +
+control plane.
+_Avoid_: Bot, assistant.
+
+## External Collaborators
+
+These are sibling products in separate repositories, reached over
+HTTP-over-UDS (and, for cleat, a C ABI for native embedding):
+
+- **cleat** — terminal/PTY/VT engine. (`~/dev/cleat`)
+- **porthole** — window-system helper for composing external side-by-side
+  surfaces. (`~/dev/porthole`)
+- **uishell** — native UI shell (RAD-derived) that composes Panels/Views and
+  embeds cleat; the intended premier interface to Flotilla. (`~/dev/ui-scratch`)

--- a/docs/adr/0001-k8s-isomorphic-resource-model.md
+++ b/docs/adr/0001-k8s-isomorphic-resource-model.md
@@ -1,0 +1,48 @@
+# k8s-isomorphic resource model; k8s is a backend, not the API contract
+
+The control plane's typed resources are deliberately **isomorphic to Kubernetes
+objects** — every resource has a lossless k8s-object representation (`apiVersion`,
+`kind`, k8s-style `metadata` including `resourceVersion`, `ownerReferences`,
+`finalizers`, `deletionTimestamp`, `spec`, `status`) and k8s-style semantics
+(optimistic concurrency, list + watch-from-version, status subresource).
+
+We split this into two capabilities that were being conflated:
+
+- **B — always maintain a k8s representation of every resource: yes, now.** The
+  canonical k8s-object projection is a property of the resource *model*, not of
+  any one backend. (Today the envelope mapping lives privately in the HTTP
+  backend as `WireResource<T>`; the decision is to lift it into the model so
+  in-memory, sqlite, and k8s backends all share one envelope.) This is low-regret
+  because the typed model is already k8s-isomorphic in everything but field
+  casing, and it makes a non-k8s backing store (sqlite/libsql) a near-mechanical
+  port of the in-memory backend's version/watch semantics.
+
+- **A — present a k8s-compatible API edge (external clients kubectl/REST against
+  us): deferred.** This is a larger commitment (honouring the k8s *server*
+  contract: selectors, apply, watch bookmarks, possibly admission). With B always
+  true it stays a cheap optional adapter, built only when a real consumer needs
+  it (e.g. federating to a real cluster, or being faked as one).
+
+**Source of truth:** typed Rust structs are the spine; the k8s object is a
+guaranteed projection derived from them — not the reverse. This keeps type safety
+end-to-end and avoids resources degrading into opaque JSON blobs.
+
+## Why
+
+k8s semantics (resourceVersion / optimistic concurrency / watch) are the valuable,
+hard-won, already-proven part, and they are exactly what makes alternative backing
+stores tractable. k8s *wire ceremony and server contract* are the parts that lock
+us in — so we keep the former always-on and treat the latter as an optional edge.
+A bonus: k8s resources are heavily represented in model training data, which suits
+the goal of small, coherent pieces agents already understand.
+
+## Consequences
+
+- Every resource we ever define must remain expressible as a k8s object
+  (group/version/kind + structural-ish spec/status). We have already adopted this
+  shape, so the marginal cost is ~zero.
+- k8s is one backend among several (in-memory for tests, sqlite/libsql for
+  embedded durability, real k8s REST for cluster-backed). The public
+  `TypedResolver` API stays backend-agnostic.
+- "Federate to k8s / fake being k8s" survives as future adapter work, not a
+  present constraint.

--- a/docs/adr/0001-k8s-isomorphic-resource-model.md
+++ b/docs/adr/0001-k8s-isomorphic-resource-model.md
@@ -9,7 +9,9 @@ objects** — every resource has a lossless k8s-object representation (`apiVersi
 `finalizers`, `deletionTimestamp`, `spec`, `status`) and k8s-style semantics
 (optimistic concurrency, list + watch-from-version, status subresource).
 
-We split this into two capabilities that were being conflated:
+We split this into two capabilities that were being conflated (these **A**/**B**
+labels are local to this ADR and unrelated to *Plane A* / *Plane B* in
+`docs/roadmap.md`):
 
 - **B — always maintain a k8s representation of every resource: yes, now.** The
   canonical k8s-object projection is a property of the resource *model*, not of

--- a/docs/adr/0001-k8s-isomorphic-resource-model.md
+++ b/docs/adr/0001-k8s-isomorphic-resource-model.md
@@ -1,5 +1,8 @@
 # k8s-isomorphic resource model; k8s is a backend, not the API contract
 
+**Status:** Accepted
+**Date:** 2026-06-21
+
 The control plane's typed resources are deliberately **isomorphic to Kubernetes
 objects** — every resource has a lossless k8s-object representation (`apiVersion`,
 `kind`, k8s-style `metadata` including `resourceVersion`, `ownerReferences`,

--- a/docs/adr/0002-multi-host-is-resource-store-federation.md
+++ b/docs/adr/0002-multi-host-is-resource-store-federation.md
@@ -1,18 +1,21 @@
 # Multi-host is resource-store federation, not peer-merge
 
+**Status:** Accepted
+**Date:** 2026-06-21
+
 Multi-host coordination is delivered by **federating the resource store**, not by
 a bespoke peer snapshot/query-state merge protocol.
 
-- A slim, standalone, **per-host federation bridge** owns host inventory, identity,
-  pluggable transport (ssh control-masters now; wireguard/https later), and
-  **arbitrary UDS-listener forwarding**, exposed via its own HTTP-over-UDS control
-  API. It carries no flotilla domain semantics. The whole product family (cleat,
-  porthole, uishell, flotilla) uses it, so remoting is ambient: a service dials a
-  local socket and the bridge forwards it.
+- A slim, standalone, **per-host Tender** (the federation daemon) owns host
+  inventory, identity, pluggable transport (ssh control-masters now; wireguard/https
+  later), and **arbitrary UDS-listener forwarding**, exposed via its own
+  HTTP-over-UDS control API. It carries no flotilla domain semantics. The whole
+  product family (cleat, porthole, uishell, flotilla) uses it, so remoting is
+  ambient: a service dials a local socket and the Tender forwards it.
 - "See host B's work" becomes **"watch host B's resource store over a forwarded
   UDS"** — there is no peer-merge protocol.
-- The control plane sits *above* the bridge: it models `Host` and forward-rules as
-  resources and **actuates** the bridge through its control API (a federation
+- The control plane sits *above* the Tender: it models `Host` and forward-rules as
+  resources and **actuates** the Tender through its control API (a federation
   actuator, same pattern as the docker/checkout actuators). Federation depends on
   nothing flotilla-specific; the control plane depends on federation.
 - Any **merging/aggregation** across hosts is a **view/aggregator** concern,
@@ -22,12 +25,13 @@ a bespoke peer snapshot/query-state merge protocol.
 
 ## Why
 
-The current peering (~4,300 LOC in `flotilla-daemon`: `peer/manager.rs`,
-`peer/merge.rs`, the peer wire protocol, ssh/channel transports) entangles a
-generic transport with flotilla's own snapshot-merge semantics. Splitting out a
-generic bridge and treating multi-host as store-federation lets most of the
-peer-merge layer be deleted, leaves a much smaller flotilla on top of a shared
-substrate, and gives the rest of the product family the same remoting model.
+The current peering (~5,400 LOC in `flotilla-daemon/src/peer`: `manager.rs`,
+`merge.rs`, the peer wire protocol, ssh/channel transports, and their tests)
+entangles a generic transport with flotilla's own snapshot-merge semantics.
+Splitting out a generic Tender and treating multi-host as store-federation lets
+most of the peer-merge layer be deleted, leaves a much smaller flotilla on top of
+a shared substrate, and gives the rest of the product family the same remoting
+model.
 
 ## The event log is the replication primitive
 
@@ -53,6 +57,6 @@ The **Tender** carries the log between hosts; it does not interpret or merge it.
 - The bespoke peer snapshot/query-state merge subsystem is slated for removal once
   resource-store federation is in place. This is the deletion the decision pays
   for.
-- The bridge becomes a new always-on per-host process (small, single-purpose).
+- The Tender becomes a new always-on per-host process (small, single-purpose).
 - A federation actuator/controller is added to the control plane to drive the
-  bridge from `Host`/forward-rule resources.
+  Tender from `Host`/forward-rule resources.

--- a/docs/adr/0002-multi-host-is-resource-store-federation.md
+++ b/docs/adr/0002-multi-host-is-resource-store-federation.md
@@ -1,0 +1,58 @@
+# Multi-host is resource-store federation, not peer-merge
+
+Multi-host coordination is delivered by **federating the resource store**, not by
+a bespoke peer snapshot/query-state merge protocol.
+
+- A slim, standalone, **per-host federation bridge** owns host inventory, identity,
+  pluggable transport (ssh control-masters now; wireguard/https later), and
+  **arbitrary UDS-listener forwarding**, exposed via its own HTTP-over-UDS control
+  API. It carries no flotilla domain semantics. The whole product family (cleat,
+  porthole, uishell, flotilla) uses it, so remoting is ambient: a service dials a
+  local socket and the bridge forwards it.
+- "See host B's work" becomes **"watch host B's resource store over a forwarded
+  UDS"** — there is no peer-merge protocol.
+- The control plane sits *above* the bridge: it models `Host` and forward-rules as
+  resources and **actuates** the bridge through its control API (a federation
+  actuator, same pattern as the docker/checkout actuators). Federation depends on
+  nothing flotilla-specific; the control plane depends on federation.
+- Any **merging/aggregation** across hosts is a **view/aggregator** concern,
+  performed on demand where needed — not a core always-on service.
+- Large installations are expected to use **real Kubernetes** as the backing
+  store, where "one resource controller" is a whole cluster (later).
+
+## Why
+
+The current peering (~4,300 LOC in `flotilla-daemon`: `peer/manager.rs`,
+`peer/merge.rs`, the peer wire protocol, ssh/channel transports) entangles a
+generic transport with flotilla's own snapshot-merge semantics. Splitting out a
+generic bridge and treating multi-host as store-federation lets most of the
+peer-merge layer be deleted, leaves a much smaller flotilla on top of a shared
+substrate, and gives the rest of the product family the same remoting model.
+
+## The event log is the replication primitive
+
+The resource store's watch stream (ADR 0001's `resourceVersion` +
+watch-from-version semantics) *is* a kafka-like log. This reframes "federation" as
+**remote access to that log**, and makes replication fall out for free:
+
+- A **materialized replica** of another host/cluster is just "tail its resource
+  log from a version and apply" — the same operation a local watcher already does.
+- **Aggregators** (the demoted form of correlation, ADR 0003) are **pure
+  functions over one or more logs** — ephemeral, rebuildable, multiple view
+  configs (per-host, per-agent), no merged state persisted.
+- This is the concrete realization of the long-standing "kafka-like log" multi-host
+  direction (issue #256): each source writes its own scoped log; replication is
+  outsourceable to a real log substrate later; the double-merge bug class is
+  eliminated by construction because you never feed merged state back into a
+  source log.
+
+The **Tender** carries the log between hosts; it does not interpret or merge it.
+
+## Consequences
+
+- The bespoke peer snapshot/query-state merge subsystem is slated for removal once
+  resource-store federation is in place. This is the deletion the decision pays
+  for.
+- The bridge becomes a new always-on per-host process (small, single-purpose).
+- A federation actuator/controller is added to the control plane to drive the
+  bridge from `Host`/forward-rule resources.

--- a/docs/adr/0003-observed-adopted-managed-resources.md
+++ b/docs/adr/0003-observed-adopted-managed-resources.md
@@ -1,5 +1,8 @@
 # Observed, adopted, and managed resources share one store; lifecycle authority is per-resource
 
+**Status:** Accepted
+**Date:** 2026-06-21
+
 Observed reality and desired state live in **one resource store and the same
 kinds** (ADR 0001's model), distinguished not by a binary observed/desired flag
 but by a **lifecycle-authority** property on each resource:

--- a/docs/adr/0003-observed-adopted-managed-resources.md
+++ b/docs/adr/0003-observed-adopted-managed-resources.md
@@ -1,0 +1,43 @@
+# Observed, adopted, and managed resources share one store; lifecycle authority is per-resource
+
+Observed reality and desired state live in **one resource store and the same
+kinds** (ADR 0001's model), distinguished not by a binary observed/desired flag
+but by a **lifecycle-authority** property on each resource:
+
+- **Observed** — Flotilla only reports the resource exists. It reconciles nothing.
+- **Adopted** — Flotilla acts on the resource for specific, requested purposes
+  (open a PR from it, attach a Convoy to it) but does **not** own its lifecycle.
+  The canonical case: a user's hand-managed local clone in their favoured `~/dev`
+  directory, kept "forever," from which they submit PRs (e.g. open-source
+  contributions). Reconcilers must never move, recreate, or garbage-collect it.
+- **Managed** — Flotilla provisioned the resource and may destroy/GC it (e.g. a
+  Convoy's throwaway worktree + container).
+
+Adoption is a **promotion along the authority axis**, never a kind change.
+
+## Why
+
+- **Correlation only existed because Flotilla didn't create the work.** Union-find
+  over `CorrelationKey` is *inference*. For Flotilla-launched (Convoy) work,
+  linkage is known by construction via owner references / labels — no inference.
+  Union-find is therefore **demoted** from a core always-on service to an on-demand
+  **Aggregator** utility used only for purely-observed state (and possibly agentic
+  later). It is demoted, not deleted.
+- **Providers stop emitting fragments-for-correlation** and instead **contribute
+  observed resources** into the shared store.
+- One store + one set of kinds + a lifecycle-authority axis is what makes the
+  Plane-A/Plane-B unification (observe + orchestrate) real, and gives users a
+  smooth on-ramp: start with existing work (observed), let Flotilla act on it
+  (adopted), opt into Flotilla-managed workflows (managed) — without any object
+  ever changing type.
+
+## Consequences
+
+- Every reconciler must check lifecycle authority and **refuse to
+  create/destroy** observed/adopted resources — it may only perform explicitly
+  requested operations on them.
+- The legacy `ProviderData → correlation → WorkItem → Snapshot` core pipeline is
+  dismantled; the TUI work-item table becomes an **Aggregator view over the
+  resource store**, not a consumer of core-correlated snapshots.
+- A user's local clone is a first-class, permanently-adopted resource — never a
+  second-class "external" thing bolted on.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,80 @@
+# Flotilla Transition Roadmap
+
+This is the plan for getting Flotilla out of its current two-plane straddle and
+onto a single coherent track. It is the "where we're going and in what order"
+companion to the glossary ([`/CONTEXT.md`](../CONTEXT.md)) and the decisions in
+[`docs/adr/`](adr/).
+
+## The situation
+
+Two complete data planes live inside one daemon and barely touch:
+
+- **Plane A — the fleet observer** (`flotilla-core` + `flotilla-tui` +
+  `flotilla-daemon`, ~93k LOC, the bulk of recent commits): providers →
+  correlation (union-find) → WorkItems → snapshots → TUI. *Descriptive.*
+- **Plane B — the control plane** (`flotilla-resources` + `flotilla-controllers`
+  + `flotilla-commands`, ~8.6k LOC, newest work): k8s-isomorphic resources →
+  reconcilers → projection → convoy view. *Prescriptive.*
+
+The destination (Q1): **Plane B subsumes Plane A's prescriptive role**, with a
+long transition. Observed reality and desired state share one resource store
+(ADR 0003); correlation demotes to an on-demand Aggregator; convoys become the
+unit of launched work.
+
+## Decisions already recorded
+
+- **ADR 0001** — k8s-isomorphic resource model; k8s is a backend, not the API
+  contract. Always keep a k8s representation (B); defer a k8s-compatible API edge
+  (A). Typed structs are the spine.
+- **ADR 0002** — multi-host is resource-store federation, not peer-merge. A slim
+  per-host **Tender** owns transport + forwarding; the bespoke peer-merge layer is
+  retired.
+- **ADR 0003** — observed / adopted / managed resources share one store and one
+  set of kinds; lifecycle authority is a per-resource property. The user's
+  hand-managed local clone is permanently *adopted*, never reconciled away.
+
+## Two freezes (the most important near-term discipline)
+
+1. **Plane A is bugfix-only.** No net-new features on correlation, WorkItem, the
+   old `ProviderData → WorkItem → Snapshot` pipeline, or peer-merge. The
+   151-vs-22 commit imbalance *is* the straddle; stopping it is the highest-value
+   move.
+2. **The TUI is *factored*, not frozen.** Both the TUI and uishell stay relevant
+   (Q6). ~70% of `flotilla-tui` is legitimate ratatui rendering; ~30% is a
+   surface-agnostic domain/view-model layer (intent/action engine, declarative
+   tables, the data→view-model pipeline) that should be extracted and shared.
+   Stop *duplicating* that layer per surface; do keep the TUI itself maintained.
+
+## Sequencing
+
+The rule that resolves bottom-up-vs-top-down: **freeze the doomed plane
+immediately, but extract generic pieces only after Flotilla has proven the
+boundary by consuming them.** Keep extractions as workspace crates in this repo
+until boundary-proven, *then* promote to separate repos (as cleat/porthole are).
+
+| Phase | Work | Why here |
+|------|------|----------|
+| **0** | **Freeze Plane A** (bugfix-only). | Stops the bleed; costs nothing to start. |
+| **1** | **Non-k8s backing store** (sqlite/libsql) + **lift the k8s projection into the resource model** (ADR 0001-B). | Precondition for dogfooding convoys without a live cluster. Low conceptual risk — semantics are proven. Makes the sqlite store a near-mechanical port of the in-memory backend. |
+| **2** | **Convoy as the real end-to-end launch path** (create → provision → present → TUI), dogfooded. | Proves the resource/reconciler/provisioning boundaries *in the real consumer* before any extraction. |
+| **3** | **Reshape the observer**: providers contribute *observed resources*; add lifecycle-authority; build the **Aggregator** view; delete the old `ProviderData→WorkItem→Snapshot` pipeline. | Plane A is now gone, not just frozen. Correlation/union-find demotes to an on-demand Aggregator utility. |
+| **4** | **Extract the Tender** (generic federation); delete peer-merge. | Boundary now informed by real store-federation needs. Not rushed — porthole is the likeliest first external consumer, and the family can wait a little. |
+| **5** | **Extract the minimal control-plane core** (generic resource-client + controller runtime) as a standalone crate/repo, leaving Flotilla-specific kinds behind. | Boundary-proven by phases 1–3. Yields a small, coherent piece "that could have been in the training data." |
+| **6** | **Provisioning extraction** (if still warranted) + **TUI↔uishell sharing**: extract the surface-agnostic domain/view-model layer; TUI/web/uishell become thin **Surfaces** over it. | Depends on a stable resource/aggregator API beneath. |
+
+## Cross-cutting
+
+- **Tests ride along with the refactors** (Q7). Verbose, ad-hoc tests for old
+  shapes get deleted wholesale as those shapes move; new shapes get **contract
+  tests** per the CLAUDE.md testing philosophy. The only standalone test work
+  worth pulling forward is fixing a *harness gap* that is forcing verbosity.
+- **Headless core, thin surfaces.** Flotilla's end state is a headless daemon
+  exposing the resource store + Aggregator + a shared View Model + the command
+  model over HTTP-over-UDS. The TUI, a future web UI, and uishell are all
+  Surfaces. (This extends the existing "clients own presentation" decision.)
+
+## The unbuilt layer above all this
+
+Meta-agents (Quartermaster, Bosun, Purser, Governor, Yeoman) sit above observer +
+control plane and are explicitly *later*. The Aggregator's "possibly agentic"
+piecing-together is the first place they touch this roadmap.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,7 +39,7 @@ unit of launched work.
    old `ProviderData → WorkItem → Snapshot` pipeline, or peer-merge. The
    151-vs-22 commit imbalance *is* the straddle; stopping it is the highest-value
    move.
-2. **The TUI is *factored*, not frozen.** Both the TUI and uishell stay relevant
+2. **The TUI is *factored*, not frozen.** Both the TUI and uishell stay relevant:
    ~70% of `flotilla-tui` is legitimate ratatui rendering; ~30% is a
    surface-agnostic domain/view-model layer (intent/action engine, declarative
    tables, the data→view-model pipeline) that should be extracted and shared.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,7 +16,7 @@ Two complete data planes live inside one daemon and barely touch:
   + `flotilla-commands`, ~8.6k LOC, newest work): k8s-isomorphic resources →
   reconcilers → projection → convoy view. *Prescriptive.*
 
-The destination (Q1): **Plane B subsumes Plane A's prescriptive role**, with a
+The destination: **Plane B subsumes Plane A's prescriptive role**, with a
 long transition. Observed reality and desired state share one resource store
 (ADR 0003); correlation demotes to an on-demand Aggregator; convoys become the
 unit of launched work.
@@ -40,7 +40,7 @@ unit of launched work.
    151-vs-22 commit imbalance *is* the straddle; stopping it is the highest-value
    move.
 2. **The TUI is *factored*, not frozen.** Both the TUI and uishell stay relevant
-   (Q6). ~70% of `flotilla-tui` is legitimate ratatui rendering; ~30% is a
+   ~70% of `flotilla-tui` is legitimate ratatui rendering; ~30% is a
    surface-agnostic domain/view-model layer (intent/action engine, declarative
    tables, the data→view-model pipeline) that should be extracted and shared.
    Stop *duplicating* that layer per surface; do keep the TUI itself maintained.
@@ -64,7 +64,7 @@ until boundary-proven, *then* promote to separate repos (as cleat/porthole are).
 
 ## Cross-cutting
 
-- **Tests ride along with the refactors** (Q7). Verbose, ad-hoc tests for old
+- **Tests ride along with the refactors.** Verbose, ad-hoc tests for old
   shapes get deleted wholesale as those shapes move; new shapes get **contract
   tests** per the CLAUDE.md testing philosophy. The only standalone test work
   worth pulling forward is fixing a *harness gap* that is forcing verbosity.


### PR DESCRIPTION
Captures the fleet-observer → control-plane transition worked out in a design session. Docs only — no code changes.

## What's here
- **`CONTEXT.md`** — glossary for the system and the product family (cleat / porthole / uishell).
- **`docs/adr/0001`** — k8s-isomorphic resource model; k8s is *a backend*, not the API contract (always keep a k8s representation; defer a k8s API edge).
- **`docs/adr/0002`** — multi-host is resource-store federation via the **Tender**, not peer-merge; the resource watch stream *is* the replication log.
- **`docs/adr/0003`** — observed / adopted / managed resources share one store; lifecycle authority is per-resource (the hand-managed local clone is permanently *adopted*).
- **`docs/roadmap.md`** — phases 0–6 and the two freezes; the sequencing rule (freeze the doomed plane now, extract generics only after the boundary is proven).
- **`CLAUDE.md`** — the **Plane-A freeze** note (the one enforceable artifact of the freeze: visible to every agent session).

## Tracking
Umbrella: #604. Critical path to a k8s-free dogfoodable convoy: #606 → #611 → #612 → #613; #607 unblocks the observer reshape in parallel.

Refs #604.