### PR TITLE
[codex] Implement embeddable control plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1097,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1356,7 @@ dependencies = [
  "futures",
  "reqwest",
  "rstest",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yml",
@@ -1637,6 +1662,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1653,6 +1687,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2185,6 +2228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2770,6 +2824,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -3391,6 +3451,20 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-ident",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4513,6 +4587,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -38,6 +38,9 @@ pub enum ConvoyVerb {
         /// Project this convoy belongs to (metadata grouping)
         #[arg(long = "project")]
         project_ref: Option<String>,
+        /// PlacementPolicy resource to use for task provisioning
+        #[arg(long = "placement-policy")]
+        placement_policy: Option<String>,
     },
 }
 
@@ -83,7 +86,7 @@ impl ConvoyNoun {
                     host: HostResolution::Local,
                 }),
             },
-            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref } => Ok(Resolved::NeedsContext {
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy } => Ok(Resolved::NeedsContext {
                 command: Command {
                     node_id: None,
                     provisioning_target: None,
@@ -95,6 +98,7 @@ impl ConvoyNoun {
                         repository_url,
                         r#ref,
                         project_ref,
+                        placement_policy,
                     },
                 },
                 repo: RepoContext::None,
@@ -119,7 +123,7 @@ impl std::fmt::Display for ConvoyNoun {
                     }
                 }
             }
-            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref } => {
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy } => {
                 write!(f, " create --template {}", quote_value(template))?;
                 for (k, v) in inputs {
                     write!(f, " --input {}", quote_value(&format!("{k}={v}")))?;
@@ -132,6 +136,9 @@ impl std::fmt::Display for ConvoyNoun {
                 }
                 if let Some(project) = project_ref {
                     write!(f, " --project {}", quote_value(project))?;
+                }
+                if let Some(placement_policy) = placement_policy {
+                    write!(f, " --placement-policy {}", quote_value(placement_policy))?;
                 }
             }
         }
@@ -225,6 +232,7 @@ mod tests {
                     repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
                     r#ref: Some("main".into()),
                     project_ref: None,
+                    placement_policy: None,
                 },
             },
             repo: RepoContext::None,
@@ -247,6 +255,32 @@ mod tests {
                     repository_url: None,
                     r#ref: None,
                     project_ref: None,
+                    placement_policy: None,
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn convoy_create_with_placement_policy_resolves() {
+        let resolved = parse(&["convoy", "scratch-1", "create", "--template", "scratch", "--placement-policy", "host-direct-local"])
+            .resolve()
+            .expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "scratch-1".into(),
+                    workflow_ref: "scratch".into(),
+                    inputs: vec![],
+                    repository_url: None,
+                    r#ref: None,
+                    project_ref: None,
+                    placement_policy: Some("host-direct-local".into()),
                 },
             },
             repo: RepoContext::None,
@@ -268,6 +302,8 @@ mod tests {
             "https://example.com/repo.git",
             "--ref",
             "main",
+            "--placement-policy",
+            "host-direct-local",
         ]);
     }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,8 +22,8 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Convoy as ResourceConvoy,
-    ConvoyRepositorySpec, ConvoySpec, InputMeta, InputValue, Project, ProjectRepositorySpec, ProjectSpec, ResourceBackend, ResourceError,
-    WorkflowTemplate, WorkflowTemplateSpec,
+    ConvoyRepositorySpec, ConvoySpec, InputMeta, InputValue, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, ResourceBackend,
+    ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -216,6 +216,16 @@ fn parse_and_validate_workflow_template_yaml(yaml: &str) -> Result<WorkflowTempl
 
 fn parse_project_yaml(yaml: &str) -> Result<ProjectSpec, String> {
     serde_yml::from_str(yaml).map_err(|err| format!("invalid project YAML: {err}"))
+}
+
+async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str) -> Option<String> {
+    let mut policies = backend.clone().using::<PlacementPolicy>(namespace).list().await.ok()?.items;
+    policies.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
+    policies
+        .iter()
+        .find(|policy| policy.metadata.name.starts_with("host-direct-"))
+        .or_else(|| policies.first())
+        .map(|policy| policy.metadata.name.clone())
 }
 
 fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {
@@ -2020,8 +2030,15 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ConvoyCreate { name, workflow_ref, inputs, repository_url, r#ref, project_ref } =
-            &command.action
+        if let flotilla_protocol::CommandAction::ConvoyCreate {
+            name,
+            workflow_ref,
+            inputs,
+            repository_url,
+            r#ref,
+            project_ref,
+            placement_policy,
+        } = &command.action
         {
             let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
@@ -2033,10 +2050,14 @@ impl InProcessDaemon {
             });
             let namespace = self.provisioning_namespace().await;
             let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
+            let placement_policy = match placement_policy {
+                Some(policy) => Some(policy.clone()),
+                None => default_convoy_placement_policy(&self.resource_backend, &namespace).await,
+            };
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),
                 inputs: inputs.iter().map(|(k, v)| (k.clone(), InputValue::String(v.clone()))).collect(),
-                placement_policy: None,
+                placement_policy,
                 repository: repository_url.clone().map(|url| ConvoyRepositorySpec { url }),
                 r#ref: r#ref.clone(),
                 project_ref: project_ref.clone(),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -219,13 +219,23 @@ fn parse_project_yaml(yaml: &str) -> Result<ProjectSpec, String> {
 }
 
 async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str) -> Option<String> {
-    let mut policies = backend.clone().using::<PlacementPolicy>(namespace).list().await.ok()?.items;
+    let mut policies = match backend.clone().using::<PlacementPolicy>(namespace).list().await {
+        Ok(list) => list.items,
+        Err(err) => {
+            warn!(%namespace, error = %err, "failed to list placement policies; convoy will remain Pending until one is registered");
+            return None;
+        }
+    };
     policies.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
-    policies
+    let policy = policies
         .iter()
         .find(|policy| policy.metadata.name.starts_with("host-direct-"))
         .or_else(|| policies.first())
-        .map(|policy| policy.metadata.name.clone())
+        .map(|policy| policy.metadata.name.clone());
+    if policy.is_none() {
+        warn!(%namespace, "no placement policy found; convoy will remain Pending until one is registered");
+    }
+    policy
 }
 
 fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -827,21 +827,21 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
 
         if local_exists {
             self.runner
-                .run("git", &["-C", clone_path, "worktree", "add", target_path, branch], Path::new("/"), &ChannelLabel::Noop)
+                .run("git", &["-C", clone_path, "worktree", "add", "--detach", target_path, branch], Path::new("/"), &ChannelLabel::Noop)
                 .await?;
         } else if remote_exists {
             let _ = self.runner.run("git", &["-C", clone_path, "fetch", "origin", branch], Path::new("/"), &ChannelLabel::Noop).await;
             self.runner
                 .run(
                     "git",
-                    &["-C", clone_path, "worktree", "add", "-b", branch, target_path, &format!("origin/{branch}")],
+                    &["-C", clone_path, "worktree", "add", "--detach", target_path, &format!("origin/{branch}")],
                     Path::new("/"),
                     &ChannelLabel::Noop,
                 )
                 .await?;
         } else {
             self.runner
-                .run("git", &["-C", clone_path, "worktree", "add", target_path, branch], Path::new("/"), &ChannelLabel::Noop)
+                .run("git", &["-C", clone_path, "worktree", "add", "--detach", target_path, branch], Path::new("/"), &ChannelLabel::Noop)
                 .await?;
         }
 
@@ -966,8 +966,8 @@ mod tests {
     };
     use flotilla_protocol::{Command, CommandAction};
     use flotilla_resources::{
-        ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, PlacementPolicy, ProcessDefinition, ProcessSource, TaskDefinition, TaskPhase,
-        TypedResolver, WorkflowTemplate, WorkflowTemplateSpec,
+        ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, PlacementPolicy, ProcessDefinition, ProcessSource, SqliteBackend, TaskDefinition,
+        TaskPhase, TypedResolver, WorkflowTemplate, WorkflowTemplateSpec,
     };
     use tempfile::TempDir;
 
@@ -1000,13 +1000,13 @@ mod tests {
         }
     }
 
-    async fn in_memory_daemon(tracked_repos: Vec<PathBuf>, config: Arc<ConfigStore>) -> Arc<InProcessDaemon> {
+    async fn daemon_with_backend(tracked_repos: Vec<PathBuf>, config: Arc<ConfigStore>, backend: ResourceBackend) -> Arc<InProcessDaemon> {
         let daemon = InProcessDaemon::new_with_resource_backend(
             tracked_repos,
             config,
             git_process_discovery(false),
             flotilla_protocol::HostName::new("test-host"),
-            ResourceBackend::InMemory(Default::default()),
+            backend,
         )
         .await;
         daemon
@@ -1017,6 +1017,137 @@ mod tests {
             )
             .expect("local environment bag should be replaceable in tests");
         daemon
+    }
+
+    async fn in_memory_daemon(tracked_repos: Vec<PathBuf>, config: Arc<ConfigStore>) -> Arc<InProcessDaemon> {
+        daemon_with_backend(tracked_repos, config, ResourceBackend::InMemory(Default::default())).await
+    }
+
+    async fn sqlite_daemon(tracked_repos: Vec<PathBuf>, config: Arc<ConfigStore>) -> Arc<InProcessDaemon> {
+        std::fs::create_dir_all(config.state_dir()).expect("state dir");
+        let backend = ResourceBackend::Sqlite(SqliteBackend::open(config.state_dir().join("resources.sqlite")).expect("sqlite backend"));
+        daemon_with_backend(tracked_repos, config, backend).await
+    }
+
+    async fn run_stage4a_flow_reaches_running_and_completes_convoy(
+        daemon: Arc<InProcessDaemon>,
+        config: Arc<ConfigStore>,
+        repo_default_dir: PathBuf,
+        repo: PathBuf,
+    ) {
+        std::fs::create_dir_all(&repo_default_dir).expect("repo default dir");
+        let host_id = daemon.local_host_id().expect("local host id").to_string();
+        let profile =
+            LocalProvisioningProfile { repo_default_dir: repo_default_dir.display().to_string(), ..manual_profile(&host_id, false) };
+        let backend = daemon.resource_backend();
+
+        register_startup_resources(&daemon, NAMESPACE, &profile).await.expect("startup registration should succeed");
+        apply_host_heartbeat(&daemon, NAMESPACE, &profile).await.expect("host heartbeat should succeed");
+
+        let state = Arc::new(ControllerRuntimeState::new(
+            Arc::clone(&daemon),
+            Arc::clone(&config),
+            passthrough_registry(),
+            None,
+            profile.host_id.clone(),
+            Some(ExecutionEnvironmentPath::new(&repo)),
+            profile.host_direct_environment_name(),
+        ));
+        let namespace_projection_state = NamespaceProjectionState::new();
+        daemon.set_namespace_projection_state(namespace_projection_state.clone()).await;
+        let controller_handles = spawn_controller_loops(
+            Arc::clone(&state),
+            NAMESPACE,
+            Duration::from_millis(25),
+            ControllerSupervision::default(),
+            namespace_projection_state,
+        );
+
+        backend
+            .clone()
+            .using::<WorkflowTemplate>(NAMESPACE)
+            .create(
+                &empty_meta("wf-a"),
+                &WorkflowTemplateSpec::builder()
+                    .inputs(Vec::new())
+                    .tasks(vec![TaskDefinition::builder()
+                        .name("implement".to_string())
+                        .processes(vec![ProcessDefinition::builder()
+                            .role("coder".to_string())
+                            .source(ProcessSource::Tool { command: "bash -lc 'echo stage4a'".to_string() })
+                            .build()])
+                        .build()])
+                    .build(),
+            )
+            .await
+            .expect("workflow template create should succeed");
+        backend
+            .clone()
+            .using::<Convoy>(NAMESPACE)
+            .create(&empty_meta("convoy-a"), &ConvoySpec {
+                workflow_ref: "wf-a".to_string(),
+                inputs: BTreeMap::new(),
+                placement_policy: Some(format!("host-direct-{host_id}")),
+                repository: Some(ConvoyRepositorySpec { url: "https://github.com/flotilla-org/flotilla.git".to_string() }),
+                r#ref: Some("main".to_string()),
+                project_ref: None,
+            })
+            .await
+            .expect("convoy create should succeed");
+
+        let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+        let run_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if matches!(
+                convoys.get("convoy-a").await.ok().and_then(|convoy| convoy.status).as_ref(),
+                Some(status)
+                    if status.phase == ConvoyPhase::Active
+                        && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Running)
+            ) {
+                break;
+            }
+            if tokio::time::Instant::now() >= run_deadline {
+                let convoy = convoys.get("convoy-a").await.expect("convoy should exist");
+                let workspace = backend.clone().using::<TaskWorkspace>(NAMESPACE).list().await.expect("workspace list should succeed");
+                panic!("convoy did not reach running state: convoy={convoy:?} task_workspaces={workspace:?}");
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let host = backend.clone().using::<Host>(NAMESPACE).get(&host_id).await.expect("host should exist after startup");
+        assert!(host.status.is_some(), "startup heartbeat should publish host status");
+
+        daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyTaskComplete {
+                    convoy: "convoy-a".to_string(),
+                    task: "implement".to_string(),
+                    message: Some("done".to_string()),
+                },
+            })
+            .await
+            .expect("convoy completion command should succeed");
+
+        wait_until(|| {
+            let convoys = convoys.clone();
+            async move {
+                matches!(
+                    convoys.get("convoy-a").await.ok().and_then(|convoy| convoy.status).as_ref(),
+                    Some(status)
+                        if status.phase == ConvoyPhase::Completed
+                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Completed)
+                )
+            }
+        })
+        .await;
+
+        for handle in controller_handles {
+            handle.abort();
+            let _ = handle.await;
+        }
     }
 
     async fn wait_for_host_status(hosts: &TypedResolver<Host>, name: &str) -> HostStatus {
@@ -1147,126 +1278,25 @@ mod tests {
     async fn in_memory_stage4a_flow_reaches_running_and_completes_convoy() {
         let temp = TempDir::new().expect("tempdir");
         let repo_default_dir = temp.path().join("flotilla-repos");
-        std::fs::create_dir_all(&repo_default_dir).expect("repo default dir");
         let git_repo =
             TestGitRepo::init(temp.path().join("repo")).with_initial_commit().with_origin("git@github.com:flotilla-org/flotilla.git");
         let repo = git_repo.path().to_path_buf();
-        let commit = git_repo.head();
-
         let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
         config.save_repo(&ExecutionEnvironmentPath::new(&repo));
         let daemon = in_memory_daemon(vec![repo.clone()], Arc::clone(&config)).await;
-        let host_id = daemon.local_host_id().expect("local host id").to_string();
-        let profile =
-            LocalProvisioningProfile { repo_default_dir: repo_default_dir.display().to_string(), ..manual_profile(&host_id, false) };
-        let backend = daemon.resource_backend();
+        run_stage4a_flow_reaches_running_and_completes_convoy(daemon, config, repo_default_dir, repo).await;
+    }
 
-        register_startup_resources(&daemon, NAMESPACE, &profile).await.expect("startup registration should succeed");
-        apply_host_heartbeat(&daemon, NAMESPACE, &profile).await.expect("host heartbeat should succeed");
-
-        let state = Arc::new(ControllerRuntimeState::new(
-            Arc::clone(&daemon),
-            Arc::clone(&config),
-            passthrough_registry(),
-            None,
-            profile.host_id.clone(),
-            Some(ExecutionEnvironmentPath::new(&repo)),
-            profile.host_direct_environment_name(),
-        ));
-        let namespace_projection_state = NamespaceProjectionState::new();
-        daemon.set_namespace_projection_state(namespace_projection_state.clone()).await;
-        let controller_handles = spawn_controller_loops(
-            Arc::clone(&state),
-            NAMESPACE,
-            Duration::from_millis(25),
-            ControllerSupervision::default(),
-            namespace_projection_state,
-        );
-
-        backend
-            .clone()
-            .using::<WorkflowTemplate>(NAMESPACE)
-            .create(
-                &empty_meta("wf-a"),
-                &WorkflowTemplateSpec::builder()
-                    .inputs(Vec::new())
-                    .tasks(vec![TaskDefinition::builder()
-                        .name("implement".to_string())
-                        .processes(vec![ProcessDefinition::builder()
-                            .role("coder".to_string())
-                            .source(ProcessSource::Tool { command: "bash -lc 'echo stage4a'".to_string() })
-                            .build()])
-                        .build()])
-                    .build(),
-            )
-            .await
-            .expect("workflow template create should succeed");
-        backend
-            .clone()
-            .using::<Convoy>(NAMESPACE)
-            .create(&empty_meta("convoy-a"), &ConvoySpec {
-                workflow_ref: "wf-a".to_string(),
-                inputs: BTreeMap::new(),
-                placement_policy: Some(format!("host-direct-{host_id}")),
-                repository: Some(ConvoyRepositorySpec { url: "https://github.com/flotilla-org/flotilla.git".to_string() }),
-                r#ref: Some(commit),
-                project_ref: None,
-            })
-            .await
-            .expect("convoy create should succeed");
-
-        let convoys = backend.clone().using::<Convoy>(NAMESPACE);
-        let run_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if matches!(
-                convoys.get("convoy-a").await.ok().and_then(|convoy| convoy.status).as_ref(),
-                Some(status)
-                    if status.phase == ConvoyPhase::Active
-                        && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Running)
-            ) {
-                break;
-            }
-            if tokio::time::Instant::now() >= run_deadline {
-                let convoy = convoys.get("convoy-a").await.expect("convoy should exist");
-                let workspace = backend.clone().using::<TaskWorkspace>(NAMESPACE).list().await.expect("workspace list should succeed");
-                panic!("convoy did not reach running state: convoy={convoy:?} task_workspaces={workspace:?}");
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-
-        let host = backend.clone().using::<Host>(NAMESPACE).get(&host_id).await.expect("host should exist after startup");
-        assert!(host.status.is_some(), "startup heartbeat should publish host status");
-
-        daemon
-            .execute(Command {
-                node_id: None,
-                provisioning_target: None,
-                context_repo: None,
-                action: CommandAction::ConvoyTaskComplete {
-                    convoy: "convoy-a".to_string(),
-                    task: "implement".to_string(),
-                    message: Some("done".to_string()),
-                },
-            })
-            .await
-            .expect("convoy completion command should succeed");
-
-        wait_until(|| {
-            let convoys = convoys.clone();
-            async move {
-                matches!(
-                    convoys.get("convoy-a").await.ok().and_then(|convoy| convoy.status).as_ref(),
-                    Some(status)
-                        if status.phase == ConvoyPhase::Completed
-                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Completed)
-                )
-            }
-        })
-        .await;
-
-        for handle in controller_handles {
-            handle.abort();
-            let _ = handle.await;
-        }
+    #[tokio::test]
+    async fn sqlite_stage4a_flow_reaches_running_and_completes_convoy() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo_default_dir = temp.path().join("flotilla-repos");
+        let git_repo =
+            TestGitRepo::init(temp.path().join("repo")).with_initial_commit().with_origin("git@github.com:flotilla-org/flotilla.git");
+        let repo = git_repo.path().to_path_buf();
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        config.save_repo(&ExecutionEnvironmentPath::new(&repo));
+        let daemon = sqlite_daemon(vec![repo.clone()], Arc::clone(&config)).await;
+        run_stage4a_flow_reaches_running_and_completes_convoy(daemon, config, repo_default_dir, repo).await;
     }
 }

--- a/crates/flotilla-daemon/src/runtime/test_git_repo.rs
+++ b/crates/flotilla-daemon/src/runtime/test_git_repo.rs
@@ -38,13 +38,6 @@ impl TestGitRepo {
         self
     }
 
-    pub fn head(&self) -> String {
-        let path_str = self.path.to_string_lossy().to_string();
-        let output = Command::new("git").args(["-C", &path_str, "rev-parse", "HEAD"]).output().expect("git rev-parse should run");
-        assert!(output.status.success(), "git rev-parse failed");
-        String::from_utf8(output.stdout).expect("git rev-parse stdout utf-8").trim().to_string()
-    }
-
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -22,6 +22,7 @@ use flotilla_core::{
     agents::SharedAgentStateStore, config::ConfigStore, in_process::InProcessDaemon, providers::discovery::DiscoveryRuntime,
 };
 use flotilla_protocol::{ConfigLabel, ConnectionRole, EnvironmentId, HostName, Message, NodeId, PROTOCOL_VERSION};
+use flotilla_resources::{ResourceBackend, SqliteBackend};
 use flotilla_transport::message::{unix_message_session, MessageSession};
 use tokio::{
     net::UnixListener,
@@ -96,6 +97,14 @@ fn build_peer_manager(daemon: &Arc<InProcessDaemon>, config: &ConfigStore) -> Re
     info!(host = %host_name, %peer_count, "initialized PeerManager");
 
     Ok(Arc::new(Mutex::new(peer_manager)))
+}
+
+fn build_embedded_resource_backend(config: &ConfigStore) -> Result<ResourceBackend, String> {
+    let path = config.state_dir().as_path().join("resources.sqlite");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| format!("create embedded resource store directory {}: {err}", parent.display()))?;
+    }
+    SqliteBackend::open(&path).map(ResourceBackend::Sqlite).map_err(|err| format!("open embedded resource store {}: {err}", path.display()))
 }
 
 pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &ConfigStore) -> Result<tokio::task::JoinHandle<()>, String> {
@@ -178,7 +187,10 @@ impl DaemonServer {
     ) -> Result<Self, String> {
         let daemon_config = config.load_daemon_config()?;
         let host_name = daemon_config.host_name.map(HostName::new).unwrap_or_else(HostName::local);
-        let daemon = InProcessDaemon::new(repo_paths, Arc::clone(&config), discovery, host_name.clone()).await;
+        let resource_backend = build_embedded_resource_backend(&config)?;
+        let daemon =
+            InProcessDaemon::new_with_resource_backend(repo_paths, Arc::clone(&config), discovery, host_name.clone(), resource_backend)
+                .await;
         let peer_manager = build_peer_manager(&daemon, &config)?;
         sync_peer_query_state(&peer_manager, &daemon).await;
         let (shutdown_tx, shutdown_rx) = watch::channel(false);

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -25,6 +25,7 @@ use flotilla_protocol::{
     Request, Response, ResponseResult, RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey,
     VectorClock, PROTOCOL_VERSION,
 };
+use flotilla_resources::{Convoy, ConvoySpec, InputMeta, ResourceBackend};
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
 use tokio::{
@@ -262,6 +263,42 @@ async fn dispatch_add_list_remove_repo_round_trip() {
     })
     .await;
     assert!(matches!(ok_response(remove, 12), Response::RemoveRepo));
+}
+
+#[tokio::test]
+async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(tmp.path().join("config"));
+    let socket_path = tmp.path().join("flotilla.sock");
+
+    let server = DaemonServer::new(Vec::new(), Arc::clone(&config), fake_discovery(false), socket_path.clone(), StdDuration::from_secs(30))
+        .await
+        .expect("server should start");
+    let backend = server.daemon().resource_backend();
+    assert!(matches!(backend, ResourceBackend::Sqlite(_)));
+    assert!(config.state_dir().as_path().join("resources.sqlite").exists());
+
+    backend
+        .using::<Convoy>("flotilla")
+        .create(&InputMeta::builder().name("persisted".to_string()).build(), &ConvoySpec {
+            workflow_ref: "scratch".to_string(),
+            inputs: Default::default(),
+            placement_policy: None,
+            repository: None,
+            r#ref: None,
+            project_ref: None,
+        })
+        .await
+        .expect("convoy create should succeed");
+    drop(server);
+
+    let restarted = DaemonServer::new(Vec::new(), config, fake_discovery(false), socket_path, StdDuration::from_secs(30))
+        .await
+        .expect("server should restart");
+    let fetched =
+        restarted.daemon().resource_backend().using::<Convoy>("flotilla").get("persisted").await.expect("convoy should survive restart");
+
+    assert_eq!(fetched.spec.workflow_ref, "scratch");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -8,7 +8,7 @@ use flotilla_core::{
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName};
-use flotilla_resources::{Convoy, InMemoryBackend, ResourceBackend, WorkflowTemplate};
+use flotilla_resources::{Convoy, ConvoyPhase, InMemoryBackend, ResourceBackend, SqliteBackend, WorkflowTemplate};
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&dir).expect("create config dir");
@@ -33,6 +33,31 @@ async fn start_daemon() -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigSto
         heartbeat_interval: Duration::from_secs(300),
         controller_resync_interval: Duration::from_secs(300),
         start_controllers: false,
+        ..RuntimeOptions::default()
+    };
+    let runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
+    (daemon, backend, config, runtime, tmp)
+}
+
+async fn start_sqlite_daemon(
+    start_controllers: bool,
+) -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigStore>, DaemonRuntime, tempfile::TempDir) {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(config.state_dir().as_path().join("resources.sqlite")).expect("sqlite open"));
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    let options = RuntimeOptions {
+        namespace: "flotilla".to_string(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_millis(25),
+        start_controllers,
         ..RuntimeOptions::default()
     };
     let runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
@@ -79,6 +104,7 @@ async fn convoy_create_command_creates_convoy_resource() {
                 repository_url: None,
                 r#ref: None,
                 project_ref: None,
+                placement_policy: None,
             },
         })
         .await
@@ -92,6 +118,10 @@ async fn convoy_create_command_creates_convoy_resource() {
     assert_eq!(convoy.spec.workflow_ref, "scratch");
     assert_eq!(convoy.spec.inputs.len(), 1);
     assert!(convoy.spec.repository.is_none());
+    assert!(
+        convoy.spec.placement_policy.as_deref().is_some_and(|policy| policy.starts_with("host-direct-")),
+        "convoy create should default to the seeded host-direct placement policy: {convoy:?}"
+    );
 }
 
 #[tokio::test]
@@ -162,4 +192,62 @@ async fn workflow_template_apply_rejects_invalid_yaml() {
         .expect("execute");
     let result = await_command_result(&mut rx, id).await;
     assert!(matches!(result, CommandValue::Error { .. }), "expected Error, got {result:?}");
+}
+
+#[tokio::test]
+async fn sqlite_backed_runtime_reconciles_convoy_create_into_namespace_view() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_sqlite_daemon(true).await;
+    let mut rx = daemon.subscribe();
+
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "sqlite-scratch".into(),
+                workflow_ref: "scratch".into(),
+                inputs: vec![("topic".into(), "embedded".into())],
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: None,
+            },
+        })
+        .await
+        .expect("execute");
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ConvoyCreated { name: "sqlite-scratch".into() });
+
+    let convoys = backend.using::<Convoy>("flotilla");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let convoy = convoys.get("sqlite-scratch").await.expect("convoy should exist");
+        if matches!(
+            convoy.status.as_ref(),
+            Some(status) if status.phase == ConvoyPhase::Active && status.observed_workflow_ref.as_deref() == Some("scratch")
+        ) {
+            break;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "timed out waiting for sqlite-backed convoy reconcile: {convoy:?}");
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let event = tokio::time::timeout(remaining, rx.recv()).await.expect("timed out waiting for namespace event").expect("recv");
+        match event {
+            DaemonEvent::NamespaceSnapshot(snapshot) if snapshot.namespace == "flotilla" => {
+                if snapshot.convoys.iter().any(|convoy| convoy.name == "sqlite-scratch" && !convoy.initializing) {
+                    break;
+                }
+            }
+            DaemonEvent::NamespaceDelta(delta) if delta.namespace == "flotilla" => {
+                if delta.changed.iter().any(|convoy| convoy.name == "sqlite-scratch" && !convoy.initializing) {
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
 }

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -237,15 +237,17 @@ async fn sqlite_backed_runtime_reconciles_convoy_create_into_namespace_view() {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         let event = tokio::time::timeout(remaining, rx.recv()).await.expect("timed out waiting for namespace event").expect("recv");
         match event {
-            DaemonEvent::NamespaceSnapshot(snapshot) if snapshot.namespace == "flotilla" => {
-                if snapshot.convoys.iter().any(|convoy| convoy.name == "sqlite-scratch" && !convoy.initializing) {
-                    break;
-                }
+            DaemonEvent::NamespaceSnapshot(snapshot)
+                if snapshot.namespace == "flotilla"
+                    && snapshot.convoys.iter().any(|convoy| convoy.name == "sqlite-scratch" && !convoy.initializing) =>
+            {
+                break;
             }
-            DaemonEvent::NamespaceDelta(delta) if delta.namespace == "flotilla" => {
-                if delta.changed.iter().any(|convoy| convoy.name == "sqlite-scratch" && !convoy.initializing) {
-                    break;
-                }
+            DaemonEvent::NamespaceDelta(delta)
+                if delta.namespace == "flotilla"
+                    && delta.changed.iter().any(|convoy| convoy.name == "sqlite-scratch" && !convoy.initializing) =>
+            {
+                break;
             }
             _ => {}
         }

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -170,6 +170,7 @@ async fn convoy_create_carries_project_ref() {
                 repository_url: None,
                 r#ref: None,
                 project_ref: Some("my-project".into()),
+                placement_policy: None,
             },
         })
         .await

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -160,6 +160,8 @@ pub enum CommandAction {
         r#ref: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         project_ref: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        placement_policy: Option<String>,
     },
     WorkflowTemplateApply {
         name: String,
@@ -544,6 +546,7 @@ mod tests {
                     repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
                     r#ref: Some("main".into()),
                     project_ref: Some("my-project".into()),
+                    placement_policy: Some("host-direct-local".into()),
                 },
             },
             Command {

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -21,6 +21,7 @@ base64 = "0.22"
 bytes = "1"
 tracing = "0.1"
 sha2 = "0.10"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 flotilla-controllers = { path = "../flotilla-controllers" }

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -5,6 +5,7 @@ use crate::{
     http::HttpBackend,
     in_memory::InMemoryBackend,
     resource::{InputMeta, Resource, ResourceObject},
+    sqlite::SqliteBackend,
     watch::{ResourceList, WatchStart, WatchStream},
 };
 
@@ -13,6 +14,7 @@ macro_rules! dispatch_backend {
         match &$self.backend {
             ResourceBackend::InMemory(backend) => backend.$method::<T>(&$self.namespace $(, $args)*).await,
             ResourceBackend::Http(backend) => backend.$method::<T>(&$self.namespace $(, $args)*).await,
+            ResourceBackend::Sqlite(backend) => backend.$method::<T>(&$self.namespace $(, $args)*).await,
         }
     };
 }
@@ -21,6 +23,7 @@ macro_rules! dispatch_backend {
 pub enum ResourceBackend {
     InMemory(InMemoryBackend),
     Http(HttpBackend),
+    Sqlite(SqliteBackend),
 }
 
 impl ResourceBackend {

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -5,14 +5,16 @@ use std::{borrow::Cow, collections::BTreeMap, pin::Pin};
 
 pub use bootstrap::{ensure_crd, ensure_namespace};
 use bytes::Bytes;
-use chrono::{DateTime, Utc};
 use futures::{stream, Stream, StreamExt};
 use reqwest::{Client, StatusCode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::{
     error::ResourceError,
-    resource::{ApiPaths, InputMeta, ObjectMeta, Resource, ResourceObject},
+    resource::{
+        ApiPaths, InputMeta, K8sInputResourceObject, K8sResourceList, K8sResourceObject, K8sStatusResourceObject, K8sWatchEvent, Resource,
+        ResourceObject,
+    },
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
 };
 
@@ -71,15 +73,15 @@ impl HttpBackend {
     pub(crate) async fn get_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceObject<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, Some(name), false);
         let response = self.http.get(url).send().await.map_err(|err| ResourceError::other(format!("GET resource: {err}")))?;
-        let wire: WireResource<T> = Self::decode_response(response, Some(name)).await?;
-        wire.into_public()
+        let object: K8sResourceObject<T> = Self::decode_response(response, Some(name)).await?;
+        ResourceObject::from_k8s_object(object)
     }
 
     pub(crate) async fn list_typed<T: Resource>(&self, namespace: &str) -> Result<ResourceList<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
         let response = self.http.get(url).send().await.map_err(|err| ResourceError::other(format!("LIST resources: {err}")))?;
-        let wire: WireList<T> = Self::decode_response(response, None).await?;
-        wire.into_public()
+        let list: K8sResourceList<T> = Self::decode_response(response, None).await?;
+        list.into_resource_list()
     }
 
     pub(crate) async fn list_typed_matching_labels<T: Resource>(
@@ -100,8 +102,8 @@ impl HttpBackend {
             .send()
             .await
             .map_err(|err| ResourceError::other(format!("LIST resources: {err}")))?;
-        let wire: WireList<T> = Self::decode_response(response, None).await?;
-        wire.into_public()
+        let list: K8sResourceList<T> = Self::decode_response(response, None).await?;
+        list.into_resource_list()
     }
 
     pub(crate) async fn create_typed<T: Resource>(
@@ -111,11 +113,11 @@ impl HttpBackend {
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
-        let body = OutgoingResource::<T>::for_spec(meta, None, spec)?;
+        let body = K8sInputResourceObject::<T>::for_spec(meta, None, spec);
         let response =
             self.http.post(url).json(&body).send().await.map_err(|err| ResourceError::other(format!("CREATE resource: {err}")))?;
-        let wire: WireResource<T> = Self::decode_response(response, Some(&meta.name)).await?;
-        wire.into_public()
+        let object: K8sResourceObject<T> = Self::decode_response(response, Some(&meta.name)).await?;
+        ResourceObject::from_k8s_object(object)
     }
 
     pub(crate) async fn update_typed<T: Resource>(
@@ -126,11 +128,11 @@ impl HttpBackend {
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, Some(&meta.name), false);
-        let body = OutgoingResource::<T>::for_spec(meta, Some(resource_version), spec)?;
+        let body = K8sInputResourceObject::<T>::for_spec(meta, Some(resource_version), spec);
         let response =
             self.http.put(url).json(&body).send().await.map_err(|err| ResourceError::other(format!("UPDATE resource: {err}")))?;
-        let wire: WireResource<T> = Self::decode_response(response, Some(&meta.name)).await?;
-        wire.into_public()
+        let object: K8sResourceObject<T> = Self::decode_response(response, Some(&meta.name)).await?;
+        ResourceObject::from_k8s_object(object)
     }
 
     pub(crate) async fn update_status_typed<T: Resource>(
@@ -141,10 +143,10 @@ impl HttpBackend {
         status: &T::Status,
     ) -> Result<ResourceObject<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, Some(name), true);
-        let body = OutgoingStatusResource::<T>::new(name, resource_version, status)?;
+        let body = K8sStatusResourceObject::<T>::new(name, resource_version, status);
         let response = self.http.put(url).json(&body).send().await.map_err(|err| ResourceError::other(format!("UPDATE status: {err}")))?;
-        let wire: WireResource<T> = Self::decode_response(response, Some(name)).await?;
-        wire.into_public()
+        let object: K8sResourceObject<T> = Self::decode_response(response, Some(name)).await?;
+        ResourceObject::from_k8s_object(object)
     }
 
     pub(crate) async fn delete_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<(), ResourceError> {
@@ -258,195 +260,7 @@ fn map_status_error(status: StatusCode, bytes: &[u8], resource_name: Option<&str
 }
 
 fn parse_watch_line<T: Resource>(line: &[u8]) -> Result<WatchEvent<T>, ResourceError> {
-    let wire =
-        serde_json::from_slice::<WireWatchEvent<T>>(line).map_err(|err| ResourceError::decode(format!("decode watch event: {err}")))?;
-    wire.into_public()
-}
-
-fn api_version(paths: ApiPaths) -> String {
-    if paths.group.is_empty() {
-        paths.version.to_string()
-    } else {
-        format!("{}/{}", paths.group, paths.version)
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(bound(deserialize = "T::Spec: DeserializeOwned, T::Status: DeserializeOwned"))]
-struct WireResource<T: Resource> {
-    #[serde(rename = "apiVersion")]
-    api_version: String,
-    kind: String,
-    metadata: WireObjectMeta,
-    spec: T::Spec,
-    #[serde(default)]
-    status: Option<T::Status>,
-}
-
-impl<T: Resource> WireResource<T> {
-    fn into_public(self) -> Result<ResourceObject<T>, ResourceError> {
-        let expected_api_version = api_version(T::API_PATHS);
-        if self.api_version != expected_api_version {
-            return Err(ResourceError::decode(format!(
-                "unexpected apiVersion '{}', expected '{}'",
-                self.api_version, expected_api_version
-            )));
-        }
-        if self.kind != T::API_PATHS.kind {
-            return Err(ResourceError::decode(format!("unexpected kind '{}', expected '{}'", self.kind, T::API_PATHS.kind)));
-        }
-        Ok(ResourceObject { metadata: self.metadata.into_public()?, spec: self.spec, status: self.status })
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(bound(deserialize = "T::Spec: DeserializeOwned, T::Status: DeserializeOwned"))]
-struct WireList<T: Resource> {
-    metadata: WireListMeta,
-    items: Vec<WireResource<T>>,
-}
-
-impl<T: Resource> WireList<T> {
-    fn into_public(self) -> Result<ResourceList<T>, ResourceError> {
-        Ok(ResourceList {
-            items: self.items.into_iter().map(WireResource::into_public).collect::<Result<_, _>>()?,
-            resource_version: self.metadata.resource_version,
-        })
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct WireListMeta {
-    #[serde(rename = "resourceVersion")]
-    resource_version: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct WireObjectMeta {
-    name: String,
-    namespace: String,
-    #[serde(rename = "resourceVersion")]
-    resource_version: Option<String>,
-    #[serde(default)]
-    labels: std::collections::BTreeMap<String, String>,
-    #[serde(default)]
-    annotations: std::collections::BTreeMap<String, String>,
-    #[serde(default, rename = "ownerReferences")]
-    owner_references: Vec<crate::resource::OwnerReference>,
-    #[serde(default)]
-    finalizers: Vec<String>,
-    #[serde(rename = "deletionTimestamp")]
-    deletion_timestamp: Option<DateTime<Utc>>,
-    #[serde(rename = "creationTimestamp")]
-    creation_timestamp: Option<DateTime<Utc>>,
-}
-
-impl WireObjectMeta {
-    fn into_public(self) -> Result<ObjectMeta, ResourceError> {
-        Ok(ObjectMeta {
-            name: self.name,
-            namespace: self.namespace,
-            resource_version: self.resource_version.ok_or_else(|| ResourceError::decode("missing metadata.resourceVersion"))?,
-            labels: self.labels,
-            annotations: self.annotations,
-            owner_references: self.owner_references,
-            finalizers: self.finalizers,
-            deletion_timestamp: self.deletion_timestamp,
-            creation_timestamp: self.creation_timestamp.ok_or_else(|| ResourceError::decode("missing metadata.creationTimestamp"))?,
-        })
-    }
-}
-
-#[derive(Debug, Serialize)]
-struct OutgoingMetadata<'a> {
-    name: &'a str,
-    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
-    labels: &'a std::collections::BTreeMap<String, String>,
-    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
-    annotations: &'a std::collections::BTreeMap<String, String>,
-    #[serde(default, rename = "ownerReferences", skip_serializing_if = "Vec::is_empty")]
-    owner_references: &'a Vec<crate::resource::OwnerReference>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    finalizers: &'a Vec<String>,
-    #[serde(rename = "deletionTimestamp", skip_serializing_if = "Option::is_none")]
-    deletion_timestamp: &'a Option<DateTime<Utc>>,
-    #[serde(rename = "resourceVersion", skip_serializing_if = "Option::is_none")]
-    resource_version: Option<&'a str>,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(bound(serialize = "T::Spec: Serialize"))]
-struct OutgoingResource<'a, T: Resource> {
-    #[serde(rename = "apiVersion")]
-    api_version: String,
-    kind: &'static str,
-    metadata: OutgoingMetadata<'a>,
-    spec: &'a T::Spec,
-}
-
-impl<'a, T: Resource> OutgoingResource<'a, T> {
-    fn for_spec(meta: &'a InputMeta, resource_version: Option<&'a str>, spec: &'a T::Spec) -> Result<Self, ResourceError> {
-        Ok(Self {
-            api_version: api_version(T::API_PATHS),
-            kind: T::API_PATHS.kind,
-            metadata: OutgoingMetadata {
-                name: &meta.name,
-                labels: &meta.labels,
-                annotations: &meta.annotations,
-                owner_references: &meta.owner_references,
-                finalizers: &meta.finalizers,
-                deletion_timestamp: &meta.deletion_timestamp,
-                resource_version,
-            },
-            spec,
-        })
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[serde(bound(serialize = "T::Status: Serialize"))]
-struct OutgoingStatusResource<'a, T: Resource> {
-    #[serde(rename = "apiVersion")]
-    api_version: String,
-    kind: &'static str,
-    metadata: OutgoingStatusMetadata<'a>,
-    status: &'a T::Status,
-}
-
-#[derive(Debug, Serialize)]
-struct OutgoingStatusMetadata<'a> {
-    name: &'a str,
-    #[serde(rename = "resourceVersion")]
-    resource_version: &'a str,
-}
-
-impl<'a, T: Resource> OutgoingStatusResource<'a, T> {
-    fn new(name: &'a str, resource_version: &'a str, status: &'a T::Status) -> Result<Self, ResourceError> {
-        Ok(Self {
-            api_version: api_version(T::API_PATHS),
-            kind: T::API_PATHS.kind,
-            metadata: OutgoingStatusMetadata { name, resource_version },
-            status,
-        })
-    }
-}
-
-#[derive(Deserialize)]
-#[serde(bound(deserialize = "T::Spec: DeserializeOwned, T::Status: DeserializeOwned"))]
-struct WireWatchEvent<T: Resource> {
-    #[serde(rename = "type")]
-    event_type: String,
-    object: WireResource<T>,
-}
-
-impl<T: Resource> WireWatchEvent<T> {
-    fn into_public(self) -> Result<WatchEvent<T>, ResourceError> {
-        let object = self.object.into_public()?;
-        match self.event_type.as_str() {
-            "ADDED" => Ok(WatchEvent::Added(object)),
-            "MODIFIED" => Ok(WatchEvent::Modified(object)),
-            "DELETED" => Ok(WatchEvent::Deleted(object)),
-            other => Err(ResourceError::decode(format!("unknown watch event type '{other}'"))),
-        }
-    }
+    let event =
+        serde_json::from_slice::<K8sWatchEvent<T>>(line).map_err(|err| ResourceError::decode(format!("decode watch event: {err}")))?;
+    event.into_watch_event()
 }

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -10,7 +10,7 @@ use tokio::sync::{mpsc, Mutex};
 
 use crate::{
     error::ResourceError,
-    resource::{InputMeta, ObjectMeta, Resource, ResourceObject},
+    resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
 };
 
@@ -102,11 +102,13 @@ impl InMemoryBackend {
     }
 
     fn decode_object<T: Resource>(value: Value) -> Result<ResourceObject<T>, ResourceError> {
-        serde_json::from_value(value).map_err(|err| ResourceError::decode(format!("decode stored object: {err}")))
+        let object: K8sResourceObject<T> =
+            serde_json::from_value(value).map_err(|err| ResourceError::decode(format!("decode stored object: {err}")))?;
+        ResourceObject::from_k8s_object(object)
     }
 
     fn encode_object<T: Resource>(object: &ResourceObject<T>) -> Result<Value, ResourceError> {
-        serde_json::to_value(object).map_err(|err| ResourceError::decode(format!("encode object: {err}")))
+        serde_json::to_value(object.to_k8s_object()).map_err(|err| ResourceError::decode(format!("encode object: {err}")))
     }
 
     fn decode_event<T: Resource>(event: StoredEvent) -> Result<WatchEvent<T>, ResourceError> {

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -14,6 +14,7 @@ mod presentation;
 mod project;
 mod provisioning_identity;
 mod resource;
+mod sqlite;
 mod status_patch;
 mod task_workspace;
 mod terminal_session;
@@ -48,7 +49,11 @@ pub use placement_policy::{
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
 pub use project::{Project, ProjectRepositorySpec, ProjectSpec};
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
-pub use resource::{ApiPaths, InputMeta, ObjectMeta, OwnerReference, Resource, ResourceObject};
+pub use resource::{
+    api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,
+    OwnerReference, Resource, ResourceObject,
+};
+pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};
 pub use task_workspace::{TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TaskWorkspaceStatusPatch};
 pub use terminal_session::{

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -3,7 +3,11 @@ use std::{collections::BTreeMap, fmt::Debug};
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::status_patch::StatusPatch;
+use crate::{
+    error::ResourceError,
+    status_patch::StatusPatch,
+    watch::{ResourceList, WatchEvent},
+};
 
 macro_rules! define_resource {
     ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty) => {
@@ -108,6 +112,226 @@ pub struct ResourceObject<T: Resource> {
     pub spec: T::Spec,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<T::Status>,
+}
+
+impl<T: Resource> ResourceObject<T> {
+    pub fn to_k8s_object(&self) -> K8sResourceObject<T> {
+        K8sResourceObject {
+            api_version: api_version(T::API_PATHS),
+            kind: T::API_PATHS.kind.to_string(),
+            metadata: K8sObjectMeta::from(&self.metadata),
+            spec: self.spec.clone(),
+            status: self.status.clone(),
+        }
+    }
+
+    pub fn from_k8s_object(value: K8sResourceObject<T>) -> Result<Self, ResourceError> {
+        let expected_api_version = api_version(T::API_PATHS);
+        if value.api_version != expected_api_version {
+            return Err(ResourceError::decode(format!(
+                "unexpected apiVersion '{}', expected '{}'",
+                value.api_version, expected_api_version
+            )));
+        }
+        if value.kind != T::API_PATHS.kind {
+            return Err(ResourceError::decode(format!("unexpected kind '{}', expected '{}'", value.kind, T::API_PATHS.kind)));
+        }
+        Ok(Self { metadata: value.metadata.into(), spec: value.spec, status: value.status })
+    }
+}
+
+pub fn api_version(paths: ApiPaths) -> String {
+    if paths.group.is_empty() {
+        paths.version.to_string()
+    } else {
+        format!("{}/{}", paths.group, paths.version)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct K8sObjectMeta {
+    pub name: String,
+    pub namespace: String,
+    #[serde(rename = "resourceVersion")]
+    pub resource_version: String,
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
+    #[serde(default)]
+    pub annotations: BTreeMap<String, String>,
+    #[serde(default, rename = "ownerReferences", skip_serializing_if = "Vec::is_empty")]
+    pub owner_references: Vec<OwnerReference>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub finalizers: Vec<String>,
+    #[serde(default, rename = "deletionTimestamp", skip_serializing_if = "Option::is_none")]
+    pub deletion_timestamp: Option<DateTime<Utc>>,
+    #[serde(rename = "creationTimestamp")]
+    pub creation_timestamp: DateTime<Utc>,
+}
+
+impl From<&ObjectMeta> for K8sObjectMeta {
+    fn from(value: &ObjectMeta) -> Self {
+        Self {
+            name: value.name.clone(),
+            namespace: value.namespace.clone(),
+            resource_version: value.resource_version.clone(),
+            labels: value.labels.clone(),
+            annotations: value.annotations.clone(),
+            owner_references: value.owner_references.clone(),
+            finalizers: value.finalizers.clone(),
+            deletion_timestamp: value.deletion_timestamp,
+            creation_timestamp: value.creation_timestamp,
+        }
+    }
+}
+
+impl From<K8sObjectMeta> for ObjectMeta {
+    fn from(value: K8sObjectMeta) -> Self {
+        Self {
+            name: value.name,
+            namespace: value.namespace,
+            resource_version: value.resource_version,
+            labels: value.labels,
+            annotations: value.annotations,
+            owner_references: value.owner_references,
+            finalizers: value.finalizers,
+            deletion_timestamp: value.deletion_timestamp,
+            creation_timestamp: value.creation_timestamp,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "T::Spec: Serialize, T::Status: Serialize",
+    deserialize = "T::Spec: DeserializeOwned, T::Status: DeserializeOwned"
+))]
+pub struct K8sResourceObject<T: Resource> {
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: K8sObjectMeta,
+    pub spec: T::Spec,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<T::Status>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct K8sListMeta {
+    #[serde(rename = "resourceVersion")]
+    pub resource_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "T::Spec: Serialize, T::Status: Serialize",
+    deserialize = "T::Spec: DeserializeOwned, T::Status: DeserializeOwned"
+))]
+pub struct K8sResourceList<T: Resource> {
+    pub metadata: K8sListMeta,
+    pub items: Vec<K8sResourceObject<T>>,
+}
+
+impl<T: Resource> K8sResourceList<T> {
+    pub fn into_resource_list(self) -> Result<ResourceList<T>, ResourceError> {
+        Ok(ResourceList {
+            items: self.items.into_iter().map(ResourceObject::from_k8s_object).collect::<Result<_, _>>()?,
+            resource_version: self.metadata.resource_version,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct K8sInputMetadata<'a> {
+    pub(crate) name: &'a str,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) labels: &'a BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) annotations: &'a BTreeMap<String, String>,
+    #[serde(default, rename = "ownerReferences", skip_serializing_if = "Vec::is_empty")]
+    pub(crate) owner_references: &'a Vec<OwnerReference>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) finalizers: &'a Vec<String>,
+    #[serde(rename = "deletionTimestamp", skip_serializing_if = "Option::is_none")]
+    pub(crate) deletion_timestamp: &'a Option<DateTime<Utc>>,
+    #[serde(rename = "resourceVersion", skip_serializing_if = "Option::is_none")]
+    pub(crate) resource_version: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(bound(serialize = "T::Spec: Serialize"))]
+pub(crate) struct K8sInputResourceObject<'a, T: Resource> {
+    #[serde(rename = "apiVersion")]
+    pub(crate) api_version: String,
+    pub(crate) kind: &'static str,
+    pub(crate) metadata: K8sInputMetadata<'a>,
+    pub(crate) spec: &'a T::Spec,
+}
+
+impl<'a, T: Resource> K8sInputResourceObject<'a, T> {
+    pub(crate) fn for_spec(meta: &'a InputMeta, resource_version: Option<&'a str>, spec: &'a T::Spec) -> Self {
+        Self {
+            api_version: api_version(T::API_PATHS),
+            kind: T::API_PATHS.kind,
+            metadata: K8sInputMetadata {
+                name: &meta.name,
+                labels: &meta.labels,
+                annotations: &meta.annotations,
+                owner_references: &meta.owner_references,
+                finalizers: &meta.finalizers,
+                deletion_timestamp: &meta.deletion_timestamp,
+                resource_version,
+            },
+            spec,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct K8sStatusMetadata<'a> {
+    pub(crate) name: &'a str,
+    #[serde(rename = "resourceVersion")]
+    pub(crate) resource_version: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(bound(serialize = "T::Status: Serialize"))]
+pub(crate) struct K8sStatusResourceObject<'a, T: Resource> {
+    #[serde(rename = "apiVersion")]
+    pub(crate) api_version: String,
+    pub(crate) kind: &'static str,
+    pub(crate) metadata: K8sStatusMetadata<'a>,
+    pub(crate) status: &'a T::Status,
+}
+
+impl<'a, T: Resource> K8sStatusResourceObject<'a, T> {
+    pub(crate) fn new(name: &'a str, resource_version: &'a str, status: &'a T::Status) -> Self {
+        Self {
+            api_version: api_version(T::API_PATHS),
+            kind: T::API_PATHS.kind,
+            metadata: K8sStatusMetadata { name, resource_version },
+            status,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(bound(deserialize = "T::Spec: DeserializeOwned, T::Status: DeserializeOwned"))]
+pub struct K8sWatchEvent<T: Resource> {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub object: K8sResourceObject<T>,
+}
+
+impl<T: Resource> K8sWatchEvent<T> {
+    pub fn into_watch_event(self) -> Result<WatchEvent<T>, ResourceError> {
+        let object = ResourceObject::from_k8s_object(self.object)?;
+        match self.event_type.as_str() {
+            "ADDED" => Ok(WatchEvent::Added(object)),
+            "MODIFIED" => Ok(WatchEvent::Modified(object)),
+            "DELETED" => Ok(WatchEvent::Deleted(object)),
+            other => Err(ResourceError::decode(format!("unknown watch event type '{other}'"))),
+        }
+    }
 }
 
 impl From<&ObjectMeta> for InputMeta {

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -1,0 +1,537 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::Path,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use chrono::Utc;
+use futures::{stream, StreamExt};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::{
+    error::ResourceError,
+    resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
+    watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
+};
+
+type StoreKey = (String, String, String, String);
+type WatchSender = mpsc::UnboundedSender<StoredEvent>;
+type WatchersByStore = HashMap<StoreKey, Vec<WatchSender>>;
+
+#[derive(Debug, Clone)]
+pub struct SqliteBackend {
+    connection: Arc<Mutex<Connection>>,
+    watchers: Arc<Mutex<WatchersByStore>>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredEvent {
+    kind: StoredEventKind,
+    object: Value,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StoredEventKind {
+    Added,
+    Modified,
+    Deleted,
+}
+
+impl StoredEventKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Added => "ADDED",
+            Self::Modified => "MODIFIED",
+            Self::Deleted => "DELETED",
+        }
+    }
+
+    fn from_str(value: &str) -> Result<Self, ResourceError> {
+        match value {
+            "ADDED" => Ok(Self::Added),
+            "MODIFIED" => Ok(Self::Modified),
+            "DELETED" => Ok(Self::Deleted),
+            other => Err(ResourceError::decode(format!("unknown stored event type '{other}'"))),
+        }
+    }
+}
+
+impl SqliteBackend {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, ResourceError> {
+        let connection = Connection::open(path).map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
+        Self::from_connection(connection)
+    }
+
+    pub fn open_in_memory() -> Result<Self, ResourceError> {
+        let connection = Connection::open_in_memory().map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
+        Self::from_connection(connection)
+    }
+
+    fn from_connection(connection: Connection) -> Result<Self, ResourceError> {
+        connection
+            .execute_batch(
+                r#"
+                PRAGMA foreign_keys = ON;
+
+                CREATE TABLE IF NOT EXISTS resource_sequences (
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    next_version INTEGER NOT NULL,
+                    PRIMARY KEY (group_name, version, kind, namespace)
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_objects (
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    resource_version INTEGER NOT NULL,
+                    body_json TEXT NOT NULL,
+                    PRIMARY KEY (group_name, version, kind, namespace, name)
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_events (
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    event_version INTEGER NOT NULL,
+                    event_type TEXT NOT NULL,
+                    body_json TEXT NOT NULL,
+                    PRIMARY KEY (group_name, version, kind, namespace, event_version)
+                );
+                "#,
+            )
+            .map_err(|err| ResourceError::other(format!("initialize sqlite resource store: {err}")))?;
+        Ok(Self { connection: Arc::new(Mutex::new(connection)), watchers: Arc::new(Mutex::new(HashMap::new())) })
+    }
+
+    fn store_key<T: Resource>(namespace: &str) -> StoreKey {
+        (T::API_PATHS.group.to_string(), T::API_PATHS.version.to_string(), T::API_PATHS.kind.to_string(), namespace.to_string())
+    }
+
+    fn lock_connection(&self) -> Result<MutexGuard<'_, Connection>, ResourceError> {
+        self.connection.lock().map_err(|_| ResourceError::other("sqlite resource store lock poisoned"))
+    }
+
+    fn lock_watchers(&self) -> Result<MutexGuard<'_, WatchersByStore>, ResourceError> {
+        self.watchers.lock().map_err(|_| ResourceError::other("sqlite resource watch lock poisoned"))
+    }
+
+    fn clone_through_serde<T>(value: &T) -> Result<T, ResourceError>
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        serde_json::from_value(serde_json::to_value(value).map_err(|err| ResourceError::decode(format!("serialize value: {err}")))?)
+            .map_err(|err| ResourceError::decode(format!("deserialize value: {err}")))
+    }
+
+    fn decode_object<T: Resource>(value: Value) -> Result<ResourceObject<T>, ResourceError> {
+        let object: K8sResourceObject<T> =
+            serde_json::from_value(value).map_err(|err| ResourceError::decode(format!("decode stored object: {err}")))?;
+        ResourceObject::from_k8s_object(object)
+    }
+
+    fn encode_object<T: Resource>(object: &ResourceObject<T>) -> Result<Value, ResourceError> {
+        serde_json::to_value(object.to_k8s_object()).map_err(|err| ResourceError::decode(format!("encode object: {err}")))
+    }
+
+    fn decode_event<T: Resource>(event: StoredEvent) -> Result<WatchEvent<T>, ResourceError> {
+        let object = Self::decode_object::<T>(event.object)?;
+        Ok(match event.kind {
+            StoredEventKind::Added => WatchEvent::Added(object),
+            StoredEventKind::Modified => WatchEvent::Modified(object),
+            StoredEventKind::Deleted => WatchEvent::Deleted(object),
+        })
+    }
+
+    fn map_sqlite(err: rusqlite::Error, action: &str) -> ResourceError {
+        ResourceError::other(format!("{action}: {err}"))
+    }
+
+    fn current_version(conn: &Connection, key: &StoreKey) -> Result<u64, ResourceError> {
+        let version = conn
+            .query_row(
+                "SELECT next_version FROM resource_sequences WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4",
+                params![key.0, key.1, key.2, key.3],
+                |row| row.get::<_, u64>(0),
+            )
+            .optional()
+            .map_err(|err| Self::map_sqlite(err, "read sqlite resource sequence"))?;
+        Ok(version.unwrap_or(1).saturating_sub(1))
+    }
+
+    fn allocate_version(tx: &rusqlite::Transaction<'_>, key: &StoreKey) -> Result<u64, ResourceError> {
+        let next = tx
+            .query_row(
+                "SELECT next_version FROM resource_sequences WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4",
+                params![key.0, key.1, key.2, key.3],
+                |row| row.get::<_, u64>(0),
+            )
+            .optional()
+            .map_err(|err| Self::map_sqlite(err, "read sqlite resource sequence"))?
+            .unwrap_or(1);
+        tx.execute(
+            r#"
+            INSERT INTO resource_sequences (group_name, version, kind, namespace, next_version)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(group_name, version, kind, namespace)
+            DO UPDATE SET next_version = excluded.next_version
+            "#,
+            params![key.0, key.1, key.2, key.3, next + 1],
+        )
+        .map_err(|err| Self::map_sqlite(err, "write sqlite resource sequence"))?;
+        Ok(next)
+    }
+
+    fn insert_event(
+        tx: &rusqlite::Transaction<'_>,
+        key: &StoreKey,
+        event_version: u64,
+        kind: StoredEventKind,
+        body_json: &str,
+    ) -> Result<(), ResourceError> {
+        tx.execute(
+            r#"
+            INSERT INTO resource_events (group_name, version, kind, namespace, event_version, event_type, body_json)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "#,
+            params![key.0, key.1, key.2, key.3, event_version, kind.as_str(), body_json],
+        )
+        .map_err(|err| Self::map_sqlite(err, "insert sqlite resource event"))?;
+        Ok(())
+    }
+
+    fn notify_watchers(&self, key: &StoreKey, event: StoredEvent) {
+        if let Ok(mut watchers) = self.lock_watchers() {
+            if let Some(entries) = watchers.get_mut(key) {
+                entries.retain(|watcher| watcher.send(event.clone()).is_ok());
+            }
+        }
+    }
+
+    pub(crate) async fn get_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceObject<T>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let conn = self.lock_connection()?;
+        let body: String = conn
+            .query_row(
+                r#"
+                SELECT body_json FROM resource_objects
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                "#,
+                params![key.0, key.1, key.2, key.3, name],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|err| Self::map_sqlite(err, "read sqlite resource object"))?
+            .ok_or_else(|| ResourceError::not_found(name))?;
+        let value = serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
+        Self::decode_object::<T>(value)
+    }
+
+    pub(crate) async fn list_typed<T: Resource>(&self, namespace: &str) -> Result<ResourceList<T>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let conn = self.lock_connection()?;
+        let mut statement = conn
+            .prepare(
+                r#"
+                SELECT body_json FROM resource_objects
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4
+                ORDER BY name
+                "#,
+            )
+            .map_err(|err| Self::map_sqlite(err, "prepare sqlite resource list"))?;
+        let rows = statement
+            .query_map(params![key.0, key.1, key.2, key.3], |row| row.get::<_, String>(0))
+            .map_err(|err| Self::map_sqlite(err, "query sqlite resource list"))?;
+        let mut items = Vec::new();
+        for row in rows {
+            let body = row.map_err(|err| Self::map_sqlite(err, "read sqlite resource list row"))?;
+            let value = serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
+            items.push(Self::decode_object::<T>(value)?);
+        }
+        Ok(ResourceList { items, resource_version: Self::current_version(&conn, &key)?.to_string() })
+    }
+
+    pub(crate) async fn list_typed_matching_labels<T: Resource>(
+        &self,
+        namespace: &str,
+        required: &BTreeMap<String, String>,
+    ) -> Result<ResourceList<T>, ResourceError> {
+        if required.is_empty() {
+            return self.list_typed::<T>(namespace).await;
+        }
+
+        let listed = self.list_typed::<T>(namespace).await?;
+        let items = listed
+            .items
+            .into_iter()
+            .filter(|object| required.iter().all(|(key, expected)| object.metadata.labels.get(key) == Some(expected)))
+            .collect();
+        Ok(ResourceList { items, resource_version: listed.resource_version })
+    }
+
+    pub(crate) async fn create_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        spec: &T::Spec,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let mut conn = self.lock_connection()?;
+        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource create"))?;
+        let exists = tx
+            .query_row(
+                r#"
+                SELECT 1 FROM resource_objects
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                "#,
+                params![key.0, key.1, key.2, key.3, meta.name],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(|err| Self::map_sqlite(err, "check sqlite resource create conflict"))?
+            .is_some();
+        if exists {
+            return Err(ResourceError::conflict(&meta.name, "resource already exists"));
+        }
+
+        let version = Self::allocate_version(&tx, &key)?;
+        let object = ResourceObject::<T> {
+            metadata: ObjectMeta {
+                name: meta.name.clone(),
+                namespace: namespace.to_string(),
+                resource_version: version.to_string(),
+                labels: meta.labels.clone(),
+                annotations: meta.annotations.clone(),
+                owner_references: meta.owner_references.clone(),
+                finalizers: meta.finalizers.clone(),
+                deletion_timestamp: meta.deletion_timestamp,
+                creation_timestamp: Utc::now(),
+            },
+            spec: Self::clone_through_serde(spec)?,
+            status: None,
+        };
+        let encoded = Self::encode_object(&object)?;
+        let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+        tx.execute(
+            r#"
+            INSERT INTO resource_objects (group_name, version, kind, namespace, name, resource_version, body_json)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "#,
+            params![key.0, key.1, key.2, key.3, meta.name, version, body_json],
+        )
+        .map_err(|err| Self::map_sqlite(err, "insert sqlite resource object"))?;
+        Self::insert_event(&tx, &key, version, StoredEventKind::Added, &body_json)?;
+        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource create"))?;
+        self.notify_watchers(&key, StoredEvent { kind: StoredEventKind::Added, object: encoded });
+        Ok(object)
+    }
+
+    pub(crate) async fn update_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        resource_version: &str,
+        spec: &T::Spec,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let mut conn = self.lock_connection()?;
+        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource update"))?;
+        let existing = Self::select_existing::<T>(&tx, &key, &meta.name)?;
+        let mut object = existing.ok_or_else(|| ResourceError::not_found(&meta.name))?;
+        if object.metadata.resource_version != resource_version {
+            return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
+        }
+
+        let version = Self::allocate_version(&tx, &key)?;
+        object.metadata.resource_version = version.to_string();
+        object.metadata.labels = meta.labels.clone();
+        object.metadata.annotations = meta.annotations.clone();
+        object.metadata.owner_references = meta.owner_references.clone();
+        object.metadata.finalizers = meta.finalizers.clone();
+        object.metadata.deletion_timestamp = meta.deletion_timestamp;
+        object.spec = Self::clone_through_serde(spec)?;
+
+        let encoded = Self::encode_object(&object)?;
+        let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+        let event_kind = if object.metadata.deletion_timestamp.is_some() && object.metadata.finalizers.is_empty() {
+            tx.execute(
+                r#"
+                DELETE FROM resource_objects
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                "#,
+                params![key.0, key.1, key.2, key.3, meta.name],
+            )
+            .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
+            StoredEventKind::Deleted
+        } else {
+            Self::upsert_object(&tx, &key, &meta.name, version, &body_json)?;
+            StoredEventKind::Modified
+        };
+        Self::insert_event(&tx, &key, version, event_kind, &body_json)?;
+        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource update"))?;
+        self.notify_watchers(&key, StoredEvent { kind: event_kind, object: encoded });
+        Ok(object)
+    }
+
+    pub(crate) async fn update_status_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        name: &str,
+        resource_version: &str,
+        status: &T::Status,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let mut conn = self.lock_connection()?;
+        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource status update"))?;
+        let existing = Self::select_existing::<T>(&tx, &key, name)?;
+        let mut object = existing.ok_or_else(|| ResourceError::not_found(name))?;
+        if object.metadata.resource_version != resource_version {
+            return Err(ResourceError::conflict(name, "stale resourceVersion"));
+        }
+
+        let version = Self::allocate_version(&tx, &key)?;
+        object.metadata.resource_version = version.to_string();
+        object.status = Some(Self::clone_through_serde(status)?);
+
+        let encoded = Self::encode_object(&object)?;
+        let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+        Self::upsert_object(&tx, &key, name, version, &body_json)?;
+        Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json)?;
+        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource status update"))?;
+        self.notify_watchers(&key, StoredEvent { kind: StoredEventKind::Modified, object: encoded });
+        Ok(object)
+    }
+
+    pub(crate) async fn delete_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<(), ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let mut conn = self.lock_connection()?;
+        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource delete"))?;
+        let existing = Self::select_existing::<T>(&tx, &key, name)?;
+        let mut object = existing.ok_or_else(|| ResourceError::not_found(name))?;
+        let version = Self::allocate_version(&tx, &key)?;
+        object.metadata.resource_version = version.to_string();
+
+        let (event_kind, encoded) = if !object.metadata.finalizers.is_empty() && object.metadata.deletion_timestamp.is_none() {
+            object.metadata.deletion_timestamp = Some(Utc::now());
+            let encoded = Self::encode_object(&object)?;
+            let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+            Self::upsert_object(&tx, &key, name, version, &body_json)?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json)?;
+            (StoredEventKind::Modified, encoded)
+        } else {
+            let encoded = Self::encode_object(&object)?;
+            let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+            tx.execute(
+                r#"
+                DELETE FROM resource_objects
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                "#,
+                params![key.0, key.1, key.2, key.3, name],
+            )
+            .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json)?;
+            (StoredEventKind::Deleted, encoded)
+        };
+        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource delete"))?;
+        self.notify_watchers(&key, StoredEvent { kind: event_kind, object: encoded });
+        Ok(())
+    }
+
+    pub(crate) async fn watch_typed<T: Resource>(&self, namespace: &str, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let replay_from = match &start {
+            WatchStart::Now => None,
+            WatchStart::FromVersion(version) => {
+                Some(version.parse::<u64>().map_err(|err| ResourceError::invalid(format!("invalid resourceVersion '{version}': {err}")))?)
+            }
+        };
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let replay = {
+            let conn = self.lock_connection()?;
+            self.lock_watchers()?.entry(key.clone()).or_default().push(sender);
+            match replay_from {
+                Some(version) => Self::replay_events(&conn, &key, version)?,
+                None => Vec::new(),
+            }
+        };
+
+        let replay_stream = stream::iter(replay.into_iter().map(Self::decode_event::<T>));
+        let live_stream = stream::unfold(receiver, |mut receiver| async {
+            receiver.recv().await.map(|event| (Self::decode_event::<T>(event), receiver))
+        });
+        Ok(Box::pin(replay_stream.chain(live_stream)))
+    }
+
+    fn select_existing<T: Resource>(
+        tx: &rusqlite::Transaction<'_>,
+        key: &StoreKey,
+        name: &str,
+    ) -> Result<Option<ResourceObject<T>>, ResourceError> {
+        let body = tx
+            .query_row(
+                r#"
+                SELECT body_json FROM resource_objects
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                "#,
+                params![key.0, key.1, key.2, key.3, name],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(|err| Self::map_sqlite(err, "read sqlite resource object"))?;
+        body.map(|body| {
+            let value = serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
+            Self::decode_object::<T>(value)
+        })
+        .transpose()
+    }
+
+    fn upsert_object(
+        tx: &rusqlite::Transaction<'_>,
+        key: &StoreKey,
+        name: &str,
+        resource_version: u64,
+        body_json: &str,
+    ) -> Result<(), ResourceError> {
+        tx.execute(
+            r#"
+            INSERT INTO resource_objects (group_name, version, kind, namespace, name, resource_version, body_json)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            ON CONFLICT(group_name, version, kind, namespace, name)
+            DO UPDATE SET resource_version = excluded.resource_version, body_json = excluded.body_json
+            "#,
+            params![key.0, key.1, key.2, key.3, name, resource_version, body_json],
+        )
+        .map_err(|err| Self::map_sqlite(err, "upsert sqlite resource object"))?;
+        Ok(())
+    }
+
+    fn replay_events(conn: &Connection, key: &StoreKey, replay_from: u64) -> Result<Vec<StoredEvent>, ResourceError> {
+        let mut statement = conn
+            .prepare(
+                r#"
+                SELECT event_type, body_json FROM resource_events
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND event_version > ?5
+                ORDER BY event_version
+                "#,
+            )
+            .map_err(|err| Self::map_sqlite(err, "prepare sqlite resource event replay"))?;
+        let rows = statement
+            .query_map(params![key.0, key.1, key.2, key.3, replay_from], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+            .map_err(|err| Self::map_sqlite(err, "query sqlite resource event replay"))?;
+        let mut events = Vec::new();
+        for row in rows {
+            let (event_type, body_json) = row.map_err(|err| Self::map_sqlite(err, "read sqlite resource event replay row"))?;
+            let object =
+                serde_json::from_str(&body_json).map_err(|err| ResourceError::decode(format!("decode stored event JSON: {err}")))?;
+            events.push(StoredEvent { kind: StoredEventKind::from_str(&event_type)?, object });
+        }
+        Ok(events)
+    }
+}

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -22,6 +22,9 @@ type WatchersByStore = HashMap<StoreKey, Vec<WatchSender>>;
 
 #[derive(Debug, Clone)]
 pub struct SqliteBackend {
+    // rusqlite is synchronous. The embedded daemon currently serializes SQLite
+    // access behind one mutex; move this behind spawn_blocking or tokio-rusqlite
+    // if controller contention shows up in practice.
     connection: Arc<Mutex<Connection>>,
     watchers: Arc<Mutex<WatchersByStore>>,
 }
@@ -73,8 +76,6 @@ impl SqliteBackend {
         connection
             .execute_batch(
                 r#"
-                PRAGMA foreign_keys = ON;
-
                 CREATE TABLE IF NOT EXISTS resource_sequences (
                     group_name TEXT NOT NULL,
                     version TEXT NOT NULL,
@@ -95,6 +96,8 @@ impl SqliteBackend {
                     PRIMARY KEY (group_name, version, kind, namespace, name)
                 );
 
+                -- TODO: add event-log pruning once watch retention requirements
+                -- are clearer for long-running embedded daemons.
                 CREATE TABLE IF NOT EXISTS resource_events (
                     group_name TEXT NOT NULL,
                     version TEXT NOT NULL,

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use flotilla_resources::{
-    Convoy, InMemoryBackend, InputMeta, OwnerReference, Resource, ResourceBackend, ResourceError, ResourceObject, WatchEvent, WatchStart,
-    WorkflowTemplate,
+    Convoy, InMemoryBackend, InputMeta, OwnerReference, Resource, ResourceBackend, ResourceError, ResourceObject, TypedResolver,
+    WatchEvent, WatchStart, WorkflowTemplate,
 };
 use futures::StreamExt;
 use tokio::time::timeout;
@@ -88,12 +88,16 @@ impl ResourceContractFixture for WorkflowTemplateFixture {
     }
 }
 
-pub fn resolver<F: ResourceContractFixture>(namespace: &str) -> flotilla_resources::TypedResolver<F::Resource> {
-    ResourceBackend::InMemory(InMemoryBackend::default()).using::<F::Resource>(namespace)
+pub fn in_memory_backend() -> ResourceBackend {
+    ResourceBackend::InMemory(InMemoryBackend::default())
 }
 
-pub async fn assert_create_get_list_roundtrip<F: ResourceContractFixture>() {
-    let resolver = resolver::<F>("flotilla");
+pub fn resolver<F: ResourceContractFixture>(backend: ResourceBackend, namespace: &str) -> TypedResolver<F::Resource> {
+    backend.using::<F::Resource>(namespace)
+}
+
+pub async fn assert_create_get_list_roundtrip_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
     let created = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
 
     assert_eq!(created.metadata.name, "alpha", "{} create should preserve name", F::label());
@@ -110,8 +114,12 @@ pub async fn assert_create_get_list_roundtrip<F: ResourceContractFixture>() {
     assert_eq!(listed.items[0].metadata.name, "alpha");
 }
 
-pub async fn assert_stale_resource_version_conflicts<F: ResourceContractFixture>() {
-    let resolver = resolver::<F>("flotilla");
+pub async fn assert_create_get_list_roundtrip<F: ResourceContractFixture>() {
+    assert_create_get_list_roundtrip_with_backend::<F>(in_memory_backend()).await;
+}
+
+pub async fn assert_stale_resource_version_conflicts_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
     let created = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
 
     let conflict = resolver.update(&F::meta("alpha"), "0", &F::updated_spec()).await.err().expect("stale version should conflict");
@@ -123,8 +131,12 @@ pub async fn assert_stale_resource_version_conflicts<F: ResourceContractFixture>
     F::assert_updated(&updated);
 }
 
-pub async fn assert_delete_emits_event<F: ResourceContractFixture>() {
-    let resolver = resolver::<F>("flotilla");
+pub async fn assert_stale_resource_version_conflicts<F: ResourceContractFixture>() {
+    assert_stale_resource_version_conflicts_with_backend::<F>(in_memory_backend()).await;
+}
+
+pub async fn assert_delete_emits_event_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
     let created = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
     let mut watch = resolver.watch(WatchStart::FromVersion(created.metadata.resource_version.clone())).await.expect("watch should succeed");
 
@@ -144,8 +156,12 @@ pub async fn assert_delete_emits_event<F: ResourceContractFixture>() {
     }
 }
 
-pub async fn assert_watch_from_version_replays<F: ResourceContractFixture>() {
-    let resolver = resolver::<F>("flotilla");
+pub async fn assert_delete_emits_event<F: ResourceContractFixture>() {
+    assert_delete_emits_event_with_backend::<F>(in_memory_backend()).await;
+}
+
+pub async fn assert_watch_from_version_replays_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
     resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
 
     let listed = resolver.list().await.expect("list should succeed");
@@ -178,8 +194,12 @@ pub async fn assert_watch_from_version_replays<F: ResourceContractFixture>() {
     }
 }
 
-pub async fn assert_watch_now_semantics<F: ResourceContractFixture>() {
-    let resolver = resolver::<F>("flotilla");
+pub async fn assert_watch_from_version_replays<F: ResourceContractFixture>() {
+    assert_watch_from_version_replays_with_backend::<F>(in_memory_backend()).await;
+}
+
+pub async fn assert_watch_now_semantics_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
     resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
 
     let mut watch = resolver.watch(WatchStart::Now).await.expect("watch should succeed");
@@ -199,8 +219,11 @@ pub async fn assert_watch_now_semantics<F: ResourceContractFixture>() {
     }
 }
 
-pub async fn assert_namespace_isolation<F: ResourceContractFixture>() {
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+pub async fn assert_watch_now_semantics<F: ResourceContractFixture>() {
+    assert_watch_now_semantics_with_backend::<F>(in_memory_backend()).await;
+}
+
+pub async fn assert_namespace_isolation_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
     let alpha = backend.using::<F::Resource>("alpha");
     let beta = backend.using::<F::Resource>("beta");
 
@@ -215,8 +238,12 @@ pub async fn assert_namespace_isolation<F: ResourceContractFixture>() {
     assert_ne!(beta_item.metadata.resource_version, "");
 }
 
-pub async fn assert_metadata_roundtrip<F: ResourceContractFixture>() {
-    let resolver = resolver::<F>("flotilla");
+pub async fn assert_namespace_isolation<F: ResourceContractFixture>() {
+    assert_namespace_isolation_with_backend::<F>(in_memory_backend()).await;
+}
+
+pub async fn assert_metadata_roundtrip_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
     let mut meta = F::meta("alpha");
     meta.labels.insert("flotilla.work/convoy".to_string(), "convoy-a".to_string());
     meta.annotations.insert("note".to_string(), "preserve-me".to_string());
@@ -236,4 +263,8 @@ pub async fn assert_metadata_roundtrip<F: ResourceContractFixture>() {
     assert_eq!(fetched.metadata.annotations, meta.annotations);
     assert_eq!(created.metadata.owner_references, meta.owner_references);
     assert_eq!(fetched.metadata.owner_references, meta.owner_references);
+}
+
+pub async fn assert_metadata_roundtrip<F: ResourceContractFixture>() {
+    assert_metadata_roundtrip_with_backend::<F>(in_memory_backend()).await;
 }

--- a/crates/flotilla-resources/tests/resource_projection.rs
+++ b/crates/flotilla-resources/tests/resource_projection.rs
@@ -1,0 +1,78 @@
+mod common;
+
+use common::{convoy_object, convoy_spec, convoy_status, timestamp};
+use flotilla_resources::{Convoy, ConvoyPhase, K8sResourceObject, ResourceError, ResourceObject};
+
+#[test]
+fn resource_object_projects_to_k8s_object_shape() {
+    let object = convoy_object("alpha", convoy_spec("review"), Some(convoy_status(ConvoyPhase::Active)));
+
+    let projected = object.to_k8s_object();
+    let json = serde_json::to_value(&projected).expect("projection should serialize");
+
+    assert_eq!(json["apiVersion"], "flotilla.work/v1");
+    assert_eq!(json["kind"], "Convoy");
+    assert_eq!(json["metadata"]["name"], "alpha");
+    assert_eq!(json["metadata"]["namespace"], "flotilla");
+    assert_eq!(json["metadata"]["resourceVersion"], "7");
+    assert_eq!(json["metadata"]["creationTimestamp"], "1970-01-01T00:00:01Z");
+    assert_eq!(json["spec"]["workflow_ref"], "review");
+    assert_eq!(json["status"]["phase"], "Active");
+}
+
+#[test]
+fn k8s_object_projection_roundtrips_to_typed_resource_object() {
+    let object = convoy_object("alpha", convoy_spec("review"), Some(convoy_status(ConvoyPhase::Active)));
+
+    let roundtripped = ResourceObject::<Convoy>::from_k8s_object(object.to_k8s_object()).expect("projection should roundtrip");
+
+    assert_eq!(roundtripped.metadata.name, "alpha");
+    assert_eq!(roundtripped.metadata.namespace, "flotilla");
+    assert_eq!(roundtripped.metadata.resource_version, "7");
+    assert_eq!(roundtripped.metadata.creation_timestamp, timestamp(1));
+    assert_eq!(roundtripped.spec.workflow_ref, "review");
+    assert_eq!(roundtripped.status.expect("status").phase, ConvoyPhase::Active);
+}
+
+#[test]
+fn k8s_object_projection_rejects_wrong_resource_identity() {
+    let object = convoy_object("alpha", convoy_spec("review"), None);
+    let mut projected = object.to_k8s_object();
+    projected.kind = "WorkflowTemplate".to_string();
+
+    let err = ResourceObject::<Convoy>::from_k8s_object(projected).expect_err("wrong kind should fail");
+
+    match err {
+        ResourceError::Other { message } => assert!(message.contains("unexpected kind")),
+        other => panic!("expected decode error, got {other}"),
+    }
+}
+
+#[test]
+fn k8s_object_projection_deserializes_kubernetes_casing() {
+    let json = serde_json::json!({
+        "apiVersion": "flotilla.work/v1",
+        "kind": "Convoy",
+        "metadata": {
+            "name": "alpha",
+            "namespace": "flotilla",
+            "resourceVersion": "9",
+            "labels": { "app": "flotilla" },
+            "annotations": { "note": "test" },
+            "creationTimestamp": "2026-04-13T12:00:00Z"
+        },
+        "spec": {
+            "workflow_ref": "review",
+            "inputs": {},
+            "placement_policy": "laptop-docker"
+        },
+        "status": { "phase": "Pending" }
+    });
+
+    let projected: K8sResourceObject<Convoy> = serde_json::from_value(json).expect("k8s object should deserialize");
+    let object = ResourceObject::<Convoy>::from_k8s_object(projected).expect("k8s object should map to typed object");
+
+    assert_eq!(object.metadata.resource_version, "9");
+    assert_eq!(object.spec.workflow_ref, "review");
+    assert_eq!(object.status.expect("status").phase, ConvoyPhase::Pending);
+}

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -1,0 +1,123 @@
+mod common;
+
+use common::{
+    contract::{
+        assert_create_get_list_roundtrip_with_backend, assert_delete_emits_event_with_backend, assert_metadata_roundtrip_with_backend,
+        assert_namespace_isolation_with_backend, assert_stale_resource_version_conflicts_with_backend,
+        assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend, ConvoyFixture,
+    },
+    convoy_meta, convoy_spec,
+};
+use flotilla_resources::{Convoy, ResourceBackend, SqliteBackend, WatchEvent, WatchStart};
+use futures::StreamExt;
+use rstest::rstest;
+use tempfile::tempdir;
+use tokio::time::{timeout, Duration};
+
+fn backend() -> ResourceBackend {
+    ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend should open"))
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn create_get_list_roundtrip(#[case] _fixture: ConvoyFixture) {
+    assert_create_get_list_roundtrip_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn update_requires_current_resource_version(#[case] _fixture: ConvoyFixture) {
+    assert_stale_resource_version_conflicts_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn delete_emits_deleted_event(#[case] _fixture: ConvoyFixture) {
+    assert_delete_emits_event_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn watch_from_version_replays_gaplessly_after_list(#[case] _fixture: ConvoyFixture) {
+    assert_watch_from_version_replays_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn watch_now_only_sees_future_events(#[case] _fixture: ConvoyFixture) {
+    assert_watch_now_semantics_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn namespaces_are_isolated(#[case] _fixture: ConvoyFixture) {
+    assert_namespace_isolation_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn owner_references_roundtrip_through_sqlite_backend(#[case] _fixture: ConvoyFixture) {
+    assert_metadata_roundtrip_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[tokio::test]
+async fn objects_and_resource_versions_survive_restart() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should open"));
+    let resolver = backend.using::<Convoy>("flotilla");
+    let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
+    assert_eq!(created.metadata.resource_version, "1");
+    drop(resolver);
+    drop(backend);
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should reopen"));
+    let resolver = backend.using::<Convoy>("flotilla");
+    let fetched = resolver.get("alpha").await.expect("object should survive restart");
+    assert_eq!(fetched.metadata.resource_version, "1");
+    assert_eq!(fetched.spec.workflow_ref, "template-a");
+
+    let updated = resolver
+        .update(&convoy_meta("alpha"), &fetched.metadata.resource_version, &convoy_spec("template-b"))
+        .await
+        .expect("update should succeed after restart");
+    assert_eq!(updated.metadata.resource_version, "2");
+}
+
+#[tokio::test]
+async fn watch_from_version_replays_events_persisted_before_restart() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should open"));
+    let resolver = backend.using::<Convoy>("flotilla");
+    let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
+    let updated = resolver
+        .update(&convoy_meta("alpha"), &created.metadata.resource_version, &convoy_spec("template-b"))
+        .await
+        .expect("update should succeed");
+    drop(resolver);
+    drop(backend);
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should reopen"));
+    let resolver = backend.using::<Convoy>("flotilla");
+    let mut watch = resolver.watch(WatchStart::FromVersion(created.metadata.resource_version)).await.expect("watch should succeed");
+
+    let event = timeout(Duration::from_secs(1), watch.next())
+        .await
+        .expect("watch should replay persisted event")
+        .expect("stream should yield item")
+        .expect("event should decode");
+    match event {
+        WatchEvent::Modified(object) => assert_eq!(object.metadata.resource_version, updated.metadata.resource_version),
+        other => panic!("expected modified event, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements the embeddable control-plane work for issues #606, #611, #612, and #613.

- Lifts the Kubernetes-style resource projection into the shared resource model and reuses it from HTTP and in-memory storage.
- Adds a sqlite-backed `ResourceBackend` with durable objects, resource versions, and persisted watch replay.
- Embeds the sqlite-backed resource store into the daemon at `state/resources.sqlite` with restart coverage.
- Wires convoy creation into the seeded local placement policy, adds explicit `--placement-policy`, and covers sqlite-backed create/provision/run/complete dogfood flow.
- Uses detached git worktrees for controller-created task checkouts so repeated convoys can target refs like `main` without branch ownership conflicts.

## Notes

- `rusqlite` uses the `bundled` feature so the embedded resource store works without requiring a host `libsqlite3` development package. This improves portability at the cost of slower cold builds and a slightly larger binary.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo test -p flotilla-resources --locked`
- `cargo test -p flotilla-commands -p flotilla-protocol --locked`
- `cargo test -p flotilla-daemon --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Additional review-cycle validation:

- `cargo +nightly-2026-03-12 fmt --check && cargo clippy --test convoy_create_cli -p flotilla-daemon --locked -- -D warnings && cargo test -p flotilla-daemon --test convoy_create_cli --locked`
- `cargo +nightly-2026-03-12 fmt --check && cargo clippy -p flotilla-core -p flotilla-resources -p flotilla-daemon --all-targets --locked -- -D warnings && cargo test -p flotilla-resources -p flotilla-daemon --locked`

## Dogfood

Ran the real `flotillad` and `flotilla` binaries against an isolated `FLOTILLA_ROOT`/`HOME` using the sqlite-backed daemon store. A repo-backed scratch convoy reached `Active|Running`, then `convoy dogfood-repo task work complete --message done` reached `Completed|Completed|done`.

Headless attach was not exercised because the standalone daemon run had no presentation manager configured; the control-plane lifecycle itself is covered by tests and binary dogfood.

Resolves #606
Resolves #611
Resolves #612
Resolves #613