### PR TITLE
docs: observer-reshape design (ADRs 0004-0006) for #607

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,26 @@ A running program within a **Task**, resolved to a placement by selectors
 (e.g. `capability: code`) rather than by template variable substitution.
 _Avoid_: Pane, terminal (those are presentation concerns).
 
+**CloudAgent**:
+A coding agent whose harness loop runs remotely / under management (Claude Code,
+Codex, Cursor as a managed session), as opposed to an agent running locally in a
+terminal. A **resource** with a lifecycle, typically **service-provided**
+(claude.ai, cursor) and reached via the service's API rather than the **Tender**.
+_Avoid_: Agent (ambiguous — reserve for the abstract notion), bot, session.
+
+**Reference Data**:
+Service-scoped external records that Flotilla links to but does not own the
+lifecycle of — **ChangeRequest** (PR), **Issue**. Not resources: they live in a
+cache layer, fetched per external-service+repo (not per host), and the
+**Aggregator** links them to resources for views.
+_Avoid_: Resource (they are not), entity.
+
+**External Result**:
+An artifact a **Convoy** produces in an external service — a PR, a CMS article, a
+YouTube video. Producing one is an action with an external result that Flotilla
+*references*, not a resource it models.
+_Avoid_: Output resource, artifact resource.
+
 **Control Plane**:
 The desired-state engine: typed resources, reconcilers/controllers, and a
 backing store. Causes work to exist by reconciling observed state toward
@@ -96,8 +116,17 @@ _Avoid_: Bridge, peer, gateway, proxy, router, tug.
 **Aggregator**:
 A view-time component that pieces observed resources together (across hosts or
 providers) on demand, for a particular reason — an event, a view. Where any
-**Correlation** lives now that it is no longer a core always-on service.
+**Correlation** lives now that it is no longer a core always-on service. Treats
+observed views as rebuildable, not as a continuous log.
 _Avoid_: Merger, the correlation engine (that is the retired baked-in form).
+
+**Generation**:
+A lifespan of the ephemeral observed-resource store. A daemon restart discards
+observed state and starts a new generation (repopulated by a full provider
+refresh). Watch-from-version is valid only within a generation; a consumer or
+federated replica that sees the generation change must re-list. The durable
+**Managed** log has no generations — its version is continuous across restarts.
+_Avoid_: Epoch, session, restart-id.
 
 **Provisioning**:
 Bringing an execution context into being — a checkout, an **Environment**
@@ -106,8 +135,11 @@ Interacts closely with **Federation**.
 _Avoid_: Setup, bootstrap.
 
 **Environment**:
-A provisioned execution context (e.g. a Docker container or a host-direct
-context) in which a **Task**'s **Processes** run.
+A provisioned execution context in which a **Task**'s **Processes** run —
+host-direct, a nested container/sandbox (docker, sandbox-exec, firecracker), or
+service-provided (runpod, modal, aws). Most resources live *in* an Environment.
+A **Host** is/has a direct environment and may contain nested ones; the precise
+host/environment relationship is still being pinned down.
 _Avoid_: Sandbox (reserve for the future restricted-execution feature), VM.
 
 **Presentation**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,6 +46,8 @@ A coding agent whose harness loop runs remotely / under management (Claude Code,
 Codex, Cursor as a managed session), as opposed to an agent running locally in a
 terminal. A **resource** with a lifecycle, typically **service-provided**
 (claude.ai, cursor) and reached via the service's API rather than the **Tender**.
+Used interchangeably with **ManagedAgent**; CloudAgent is the canonical name and
+the precise distinction (if any) is not yet pinned.
 _Avoid_: Agent (ambiguous — reserve for the abstract notion), bot, session.
 
 **Reference Data**:

--- a/docs/adr/0004-observed-resources-ephemeral-and-generational.md
+++ b/docs/adr/0004-observed-resources-ephemeral-and-generational.md
@@ -1,0 +1,53 @@
+# Observed resources are ephemeral and generational; lifecycle authority selects the backing store
+
+Observed facts (open PRs, assigned issues, local checkouts, running agents) are
+contributed into the **same resource store and watch/aggregator interface** as
+managed resources — but **lifecycle authority (ADR 0003) selects the backing
+store**:
+
+- **Observed / Adopted → ephemeral, in-memory backing.** Not persisted. The
+  source of truth is the external system; the resource is a published projection
+  of it.
+- **Managed → durable backing** (sqlite, per PR #618). It carries desired state,
+  so it must survive restarts with a continuous `resourceVersion` log.
+
+Both are reached through the same `TypedResolver` / list / watch API — a surface
+consumer (the dashboard, an aggregator, a remote replica) does not care which
+backing a kind uses.
+
+## Generations
+
+The ephemeral observed store is **generational**. A daemon restart discards
+observed state and begins a **new generation**, repopulated by a full provider
+refresh. Therefore:
+
+- `watch(FromVersion(v))` is valid only *within* a generation.
+- The watch/snapshot stream for ephemeral kinds carries a **generation marker**.
+  A consumer (including a federated replica tailing the log over the Tender) that
+  sees the generation change must discard its view and re-list from the new
+  generation — it must not expect version continuity across a restart.
+- The durable managed log has no such reset: its `resourceVersion` is continuous
+  across restarts.
+
+## Why
+
+- Observed facts are high-churn, derived, and have **no desired state to
+  reconcile**. Modelling them as durable, optimistically-versioned objects would
+  tax every poll and treat facts as if they were intentions.
+- Correlation fell down precisely because, lacking a real state store, it assumed
+  all relationships could be re-inferred from whatever currently exists. Making
+  observed items explicit resources fixes the source-of-truth problem; making them
+  ephemeral keeps them honest about *where* that truth lives.
+- One interface (uniform watch/aggregator/federation) means the dashboard reads
+  one place (S1) and remote observed work federates for free (S2, ADR 0002),
+  without paying durability costs for ephemeral data.
+
+## Consequences
+
+- Lifecycle authority and durability are **deliberately coupled**, not orthogonal.
+- The watch/snapshot protocol needs a generation marker on ephemeral streams.
+- Aggregators must treat observed views as rebuildable, not as a continuous log.
+- **Deferred (S5/S6):** when "adopt" and user-driven "grouping" land, the durable
+  *intent* ("I adopted/grouped these") is a small separate **Managed** resource
+  that references the observed ones — not a change to the observed resource's
+  ephemeral backing. Today, Adopted is treated like Observed (ephemeral).

--- a/docs/adr/0004-observed-resources-ephemeral-and-generational.md
+++ b/docs/adr/0004-observed-resources-ephemeral-and-generational.md
@@ -1,5 +1,8 @@
 # Observed resources are ephemeral and generational; lifecycle authority selects the backing store
 
+**Status:** Accepted
+**Date:** 2026-06-25
+
 Observed facts (open PRs, assigned issues, local checkouts, running agents) are
 contributed into the **same resource store and watch/aggregator interface** as
 managed resources — but **lifecycle authority (ADR 0003) selects the backing
@@ -7,7 +10,8 @@ store**:
 
 - **Observed / Adopted → ephemeral, in-memory backing.** Not persisted. The
   source of truth is the external system; the resource is a published projection
-  of it.
+  of it. (Adopted is treated as Observed for now — the durable adoption *intent*
+  is deferred; see _Consequences_.)
 - **Managed → durable backing** (sqlite, per PR #618). It carries desired state,
   so it must survive restarts with a continuous `resourceVersion` log.
 

--- a/docs/adr/0005-dashboard-is-a-composition-of-panels.md
+++ b/docs/adr/0005-dashboard-is-a-composition-of-panels.md
@@ -1,0 +1,41 @@
+# The main view is a surface-agnostic composition of panels
+
+The main view is modelled as a **View Model**, not a fixed repo-centric table:
+
+- **A tab is a composition of panels.**
+- **A panel is a filtered view over one resource kind/query at a scope** —
+  `(kind or query, scope, columns, available intents)`. Scope may be a **Project**
+  (island) or **fleet**-wide. Examples for a Project dashboard: *Convoys (active
+  work)*, *Open PRs*, *Assigned issues*, *Local checkouts*, *Running agents*.
+- **A row is a resource.** A **Convoy** row drills into its **Task** DAG (the
+  detail/tree the existing convoy view already renders).
+- The View Model is **surface-agnostic**: the ratatui TUI renders panels as its
+  split-table, **uishell** as its Panel/View, a web UI as cards/tables.
+
+This subsumes both the old repo-page (its per-`SectionKind` split becomes panels,
+no longer correlation-derived) and the separate Convoys tab (now just a default
+panel/composition).
+
+**Configurability:** the *shape* is composable now (a tab genuinely is a set of
+panels), but near-term we ship **fixed default compositions** (a per-Project
+dashboard, a fleet overview, the convoys view). User/agent (Yeoman) composition is
+deferred — and supported by the shape without re-cutting data. A tab is not 1:1
+with a repo (issue #518).
+
+## Why
+
+- It is the only model where "one place for what's relevant" (S1) survives
+  alongside convoys, observed resources, and cross-host scope (S2) — and where
+  observed and managed resources render through one mechanism.
+- Getting the *shape* right is substrate work (it's what #614 produces and every
+  Surface consumes); leaving *who composes panels* as an app-layer capability lets
+  it grow toward #518 / uishell / Yeoman without a data re-cut.
+
+## Consequences
+
+- #614 produces a panel View Model from the **Aggregator**; the TUI split-table
+  becomes one renderer of it.
+- The separate `TabId::Convoys` tab folds into being a default composition.
+- The current per-`SectionKind` column definitions are reworked as panel View
+  Models (style-agnostic columns + intents), feeding the Phase-6 shared view-model
+  extraction.

--- a/docs/adr/0005-dashboard-is-a-composition-of-panels.md
+++ b/docs/adr/0005-dashboard-is-a-composition-of-panels.md
@@ -1,5 +1,8 @@
 # The main view is a surface-agnostic composition of panels
 
+**Status:** Accepted
+**Date:** 2026-06-25
+
 The main view is modelled as a **View Model**, not a fixed repo-centric table:
 
 - **A tab is a composition of panels.**

--- a/docs/adr/0006-resources-vs-reference-data.md
+++ b/docs/adr/0006-resources-vs-reference-data.md
@@ -1,5 +1,8 @@
 # Observed things split: resources vs reference data
 
+**Status:** Accepted
+**Date:** 2026-06-25
+
 Not everything Flotilla observes is a resource. The distinguishing cut is
 **lifecycle ownership**, *not* where the thing physically lives:
 

--- a/docs/adr/0006-resources-vs-reference-data.md
+++ b/docs/adr/0006-resources-vs-reference-data.md
@@ -1,0 +1,67 @@
+# Observed things split: resources vs reference data
+
+Not everything Flotilla observes is a resource. The distinguishing cut is
+**lifecycle ownership**, *not* where the thing physically lives:
+
+- **Resources** — things with a Flotilla-owned/managed lifecycle or placement,
+  whether they live locally or are provided by an external service:
+  `Checkout`/`Clone`, `CloudAgent`, `TerminalSession`, `Environment`, `Host`
+  (plus managed `Convoy`/`Task`). Observed instances are ephemeral per ADR 0004.
+  - `CloudAgent`/`ManagedAgent` (never bare "Agent") is typically
+    **service-provided** (claude.ai, cursor), reached via the service's API.
+  - `Environment` may be host-local (host-direct, docker, sandbox-exec,
+    firecracker) **or** service-provided (runpod, modal, aws).
+
+- **Reference data** — service-scoped external records with no Flotilla-owned
+  lifecycle, link-only, often numerous: `ChangeRequest` (PR), `Issue`. They are
+  **bits of data linked to things**, scoped to an external service + repo. They
+  live in a **reference/cache layer** (building on the existing issue cache and
+  the stateless query service from #565/#568), fetched **per service+repo** with
+  incremental sync (etag/since) and pagination. The **Aggregator links** them to
+  resources for views.
+
+- **External results** — a convoy's "main result" is frequently an artifact in an
+  external service: a PR, a CMS article, a YouTube video. Producing one is an
+  **action with an external result** that Flotilla *references*, not a resource it
+  models.
+
+## Reachability is a separate axis
+
+Where a thing lives / how it is reached is **orthogonal** to whether it is a
+resource:
+
+- A resource may be reached **over the Tender** (host/environment-local) or via an
+  **external service API** (service-provided `CloudAgent`, service-provided
+  `Environment`).
+- Reference data is always reached via an external service API.
+
+So "needs the Tender" tracks *location*, not the resource/reference distinction.
+
+## Open: the host / environment / location model
+
+Most resources live **in an Environment**. A `Host` is/has a direct environment
+and may contain nested environments; a service-provided environment may itself be
+an ephemeral `Host`. This relationship is **not yet pinned down** and is tracked
+as a separate design (see backlog), out of scope for the observer reshape.
+
+## Why
+
+- The cut that matters is lifecycle ownership vs link-only external record — not
+  physical location. This avoids cramming lifecycle-less external records into the
+  store and keeps the Aggregator's job as **linking** (what `AssociationKey`
+  already did), cleanly separated from retired union-find *merging*.
+- The dashboard (S1) still reads one *aggregated* view over two sources (resource
+  store + reference cache).
+
+## Consequences
+
+- `ChangeRequestTracker` / `IssueProvider` become reference-data fetchers/cache,
+  not resource contributors.
+- #616 splits into: (i) migrate observed *resource* providers (checkouts, cloud
+  agents, sessions) off `ProviderData`; (ii) wire the reference-data layer +
+  Aggregator linking for PRs/issues; then delete the old
+  `ProviderData → WorkItem → Snapshot` pipeline.
+- #614's tracer (`Checkout`) is unaffected and remains the right first slice; an
+  observed `Checkout` references the `Environment` it lives in (the host's native
+  environment for the local-checkout tracer).
+- A convoy's external result is a future "link/output reference" concept.


### PR DESCRIPTION
Resolves the #607 design (observed-resource contribution + lifecycle authority + what becomes of the main views). Docs only.

## Decisions
- **ADR 0004** — observed resources flow through the store interface but are **ephemeral + generational**; lifecycle authority selects the backing store (Observed/Adopted → ephemeral, Managed → durable). A daemon restart starts a new generation.
- **ADR 0005** — the main view is a **surface-agnostic composition of panels** (tab = composition; panel = filtered resource view at a scope; row = resource; convoy-row drills to its Task DAG). Fixed defaults now, composable later (#518).
- **ADR 0006** — observed things split into **resources** (lifecycle-owned: Checkout, CloudAgent, TerminalSession, Environment, Host — some service-provided) vs **reference data** (link-only external records: ChangeRequest, Issue). A convoy's **external result** (PR, CMS article, video) is referenced, not modeled. Reachability (Tender vs external API) is orthogonal to this cut.

## CONTEXT
Adds Generation, CloudAgent, Reference Data, External Result; refines Environment (container; host/env relationship flagged open) and Aggregator.

## Follow-ups (filed separately)
- Reference-data layer + Aggregator linking; dashboard panel view-model.
- Parked Brainstorms: agentic/dynamic convoy launch; host/environment/location model.

Refs #604, #607.