### PR TITLE
[codex] Observed-resource substrate for #626

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use flotilla_resources::{
     controller::{ReconcileOutcome, Reconciler},
-    Checkout, CheckoutPhase, CheckoutStatusPatch, Clone, ClonePhase, ResourceBackend, ResourceError, ResourceObject, TypedResolver,
+    Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatusPatch, Clone, ClonePhase, ResourceBackend, ResourceError, ResourceObject,
+    TypedResolver,
 };
 
 #[async_trait]
@@ -43,32 +44,30 @@ where
             return Ok(CheckoutDeps::None);
         }
 
-        if let Some(worktree) = &obj.spec.worktree {
-            let clone = match self.clones.get(&worktree.clone_ref).await {
-                Ok(clone) => clone,
-                Err(ResourceError::NotFound { .. }) => return Ok(CheckoutDeps::Waiting),
-                Err(err) => return Err(err),
-            };
-            if clone.status.as_ref().map(|status| status.phase) != Some(ClonePhase::Ready) {
-                return Ok(CheckoutDeps::Waiting);
+        match &obj.spec {
+            CheckoutSpec::Worktree(spec) => {
+                let clone = match self.clones.get(&spec.clone_ref).await {
+                    Ok(clone) => clone,
+                    Err(ResourceError::NotFound { .. }) => return Ok(CheckoutDeps::Waiting),
+                    Err(err) => return Err(err),
+                };
+                if clone.status.as_ref().map(|status| status.phase) != Some(ClonePhase::Ready) {
+                    return Ok(CheckoutDeps::Waiting);
+                }
+                if clone.spec.env_ref != spec.env_ref {
+                    return Ok(CheckoutDeps::Failed("worktree clone env_ref mismatch".to_string()));
+                }
+                Ok(match self.runtime.create_worktree(&clone.spec.path, &spec.r#ref, &spec.target_path).await {
+                    Ok(commit) => CheckoutDeps::Ready { commit },
+                    Err(err) => CheckoutDeps::Failed(err),
+                })
             }
-            if clone.spec.env_ref != obj.spec.env_ref {
-                return Ok(CheckoutDeps::Failed("worktree clone env_ref mismatch".to_string()));
-            }
-            return Ok(match self.runtime.create_worktree(&clone.spec.path, &obj.spec.r#ref, &obj.spec.target_path).await {
+            CheckoutSpec::FreshClone(spec) => Ok(match self.runtime.create_fresh_clone(&spec.url, &spec.r#ref, &spec.target_path).await {
                 Ok(commit) => CheckoutDeps::Ready { commit },
                 Err(err) => CheckoutDeps::Failed(err),
-            });
+            }),
+            CheckoutSpec::Observed(_) => Ok(CheckoutDeps::None),
         }
-
-        if let Some(fresh_clone) = &obj.spec.fresh_clone {
-            return Ok(match self.runtime.create_fresh_clone(&fresh_clone.url, &obj.spec.r#ref, &obj.spec.target_path).await {
-                Ok(commit) => CheckoutDeps::Ready { commit },
-                Err(err) => CheckoutDeps::Failed(err),
-            });
-        }
-
-        Ok(CheckoutDeps::Failed("checkout spec missing strategy".to_string()))
     }
 
     fn reconcile(
@@ -80,7 +79,7 @@ where
         let patch = if obj.status.as_ref().map(|status| status.phase).unwrap_or(CheckoutPhase::Pending) == CheckoutPhase::Pending {
             match deps {
                 CheckoutDeps::Ready { commit } => {
-                    Some(CheckoutStatusPatch::MarkReady { path: obj.spec.target_path.clone(), commit: commit.clone() })
+                    obj.spec.target_path().map(|path| CheckoutStatusPatch::MarkReady { path: path.to_string(), commit: commit.clone() })
                 }
                 CheckoutDeps::Failed(message) => Some(CheckoutStatusPatch::MarkFailed { message: message.clone() }),
                 CheckoutDeps::Waiting | CheckoutDeps::None => None,
@@ -93,7 +92,10 @@ where
     }
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
-        self.runtime.remove_checkout(&obj.spec.target_path).await.map_err(ResourceError::other)
+        let Some(target_path) = obj.spec.target_path() else {
+            return Ok(());
+        };
+        self.runtime.remove_checkout(target_path).await.map_err(ResourceError::other)
     }
 
     fn finalizer_name(&self) -> Option<&'static str> {

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -66,6 +66,8 @@ where
                 Ok(commit) => CheckoutDeps::Ready { commit },
                 Err(err) => CheckoutDeps::Failed(err),
             }),
+            // Observed checkouts are facts from the observed-resource backend.
+            // The managed checkout reconciler must not actuate or patch them.
             CheckoutSpec::Observed(_) => Ok(CheckoutDeps::None),
         }
     }

--- a/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
+++ b/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
@@ -294,12 +294,15 @@ impl Reconciler for TaskWorkspaceReconciler {
                     return Ok(TaskWorkspaceDeps::failed(message));
                 }
                 if existing.status.as_ref().map(|status| status.phase) == Some(CheckoutPhase::Ready) {
-                    checkout_ready_path = existing
+                    let Some(path) = existing
                         .status
                         .as_ref()
                         .and_then(|status| status.path.clone())
                         .or_else(|| existing.spec.target_path().map(str::to_string))
-                        .expect("managed checkout should have a target path");
+                    else {
+                        return Ok(TaskWorkspaceDeps::failed(format!("checkout {checkout_name} is ready but has no target path")));
+                    };
+                    checkout_ready_path = path;
                 } else {
                     return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
                 }

--- a/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
+++ b/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
@@ -294,33 +294,36 @@ impl Reconciler for TaskWorkspaceReconciler {
                     return Ok(TaskWorkspaceDeps::failed(message));
                 }
                 if existing.status.as_ref().map(|status| status.phase) == Some(CheckoutPhase::Ready) {
-                    checkout_ready_path =
-                        existing.status.as_ref().and_then(|status| status.path.clone()).unwrap_or(existing.spec.target_path);
+                    checkout_ready_path = existing
+                        .status
+                        .as_ref()
+                        .and_then(|status| status.path.clone())
+                        .or_else(|| existing.spec.target_path().map(str::to_string))
+                        .expect("managed checkout should have a target path");
                 } else {
                     return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
                 }
             }
             Err(ResourceError::NotFound { .. }) => {
                 let spec = match &strategy {
-                    PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => CheckoutSpec {
-                        env_ref: clone_env_ref.clone(),
-                        r#ref: git_ref,
-                        target_path: checkout_target_path.clone(),
-                        worktree: Some(CheckoutWorktreeSpec {
+                    PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
+                        CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                            env_ref: clone_env_ref.clone(),
+                            r#ref: git_ref,
+                            target_path: checkout_target_path.clone(),
                             clone_ref: clone_name.clone().expect("shared-clone strategy requires clone name"),
-                        }),
-                        fresh_clone: None,
-                    },
-                    PlacementStrategy::DockerFreshCloneInContainer { .. } => CheckoutSpec {
+                        })
+                    }
+                    PlacementStrategy::DockerFreshCloneInContainer { .. } => CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
                         env_ref: precreated_environment_ref.clone().expect("fresh-clone strategy should precreate environment"),
                         r#ref: git_ref,
                         target_path: checkout_target_path.clone(),
-                        worktree: None,
-                        fresh_clone: Some(FreshCloneCheckoutSpec { url: repo_url.clone() }),
-                    },
+                        url: repo_url.clone(),
+                    }),
                 };
+                let env_ref = spec.env_ref().expect("managed checkout should have an env_ref").to_string();
                 actuations.push(Actuation::CreateCheckout {
-                    meta: owned_child_meta(&checkout_name, obj, BTreeMap::from([(ENV_LABEL.to_string(), spec.env_ref.clone())])),
+                    meta: owned_child_meta(&checkout_name, obj, BTreeMap::from([(ENV_LABEL.to_string(), env_ref)])),
                     spec,
                 });
                 return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -133,7 +133,12 @@ async fn terminal_actuator_uses_literal_command_and_cwd() {
 
 #[tokio::test]
 async fn checkout_actuator_exposes_fresh_clone_transport_url() {
-    let spec = FreshCloneCheckoutSpec { url: "git@github.com:flotilla-org/flotilla.git".to_string() };
+    let spec = FreshCloneCheckoutSpec {
+        env_ref: "env-a".to_string(),
+        r#ref: "main".to_string(),
+        target_path: "/workspace".to_string(),
+        url: "git@github.com:flotilla-org/flotilla.git".to_string(),
+    };
     let command = flotilla_controllers::actuators::fresh_clone_transport_url(&spec);
 
     assert_eq!(command, "git@github.com:flotilla-org/flotilla.git");

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -246,16 +246,13 @@ pub async fn create_ready_checkout(
     fixture: ReadyCheckoutFixture,
 ) -> flotilla_resources::ResourceObject<Checkout> {
     let checkouts = backend.clone().using::<Checkout>(namespace);
-    let created = checkouts
-        .create(&meta(&fixture.name), &CheckoutSpec {
-            env_ref: fixture.env_ref.clone(),
-            r#ref: fixture.git_ref,
-            target_path: fixture.path.clone(),
-            worktree: fixture.worktree,
-            fresh_clone: fixture.fresh_clone,
-        })
-        .await
-        .expect("checkout create should succeed");
+    let spec = match (fixture.worktree, fixture.fresh_clone) {
+        (Some(worktree), None) => CheckoutSpec::Worktree(worktree),
+        (None, Some(fresh_clone)) => CheckoutSpec::FreshClone(fresh_clone),
+        (None, None) => panic!("ready checkout fixture must provide a checkout strategy"),
+        (Some(_), Some(_)) => panic!("ready checkout fixture must provide exactly one checkout strategy"),
+    };
+    let created = checkouts.create(&meta(&fixture.name), &spec).await.expect("checkout create should succeed");
     checkouts
         .update_status(&fixture.name, &created.metadata.resource_version, &CheckoutStatus {
             phase: CheckoutPhase::Ready,

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -303,13 +303,15 @@ async fn checkout_controller_marks_worktree_checkout_ready() {
     .await;
     let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
     checkouts
-        .create(&controller_meta().name("checkout-a").call(), &flotilla_resources::CheckoutSpec {
-            env_ref: "host-direct-01HXYZ".to_string(),
-            r#ref: "feat/convoy-resource".to_string(),
-            target_path: "/Users/alice/dev/flotilla.feat-123".to_string(),
-            worktree: Some(CheckoutWorktreeSpec { clone_ref: "clone-a".to_string() }),
-            fresh_clone: None,
-        })
+        .create(
+            &controller_meta().name("checkout-a").call(),
+            &flotilla_resources::CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                env_ref: "host-direct-01HXYZ".to_string(),
+                r#ref: "feat/convoy-resource".to_string(),
+                target_path: "/Users/alice/dev/flotilla.feat-123".to_string(),
+                clone_ref: "clone-a".to_string(),
+            }),
+        )
         .await
         .expect("checkout create should succeed");
 
@@ -534,13 +536,12 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
                 .name("checkout-workspace-delete")
                 .labels([(TASK_WORKSPACE_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
                 .call(),
-            &CheckoutSpec {
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
                 env_ref: "host-direct-01HXYZ".to_string(),
                 r#ref: "feat/task-provisioning".to_string(),
                 target_path: "/Users/alice/dev/flotilla-repos/workspace-delete".to_string(),
-                worktree: Some(CheckoutWorktreeSpec { clone_ref: "clone-a".to_string() }),
-                fresh_clone: None,
-            },
+                clone_ref: "clone-a".to_string(),
+            }),
         )
         .await
         .expect("checkout create should succeed");

--- a/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
+++ b/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
@@ -64,7 +64,7 @@ async fn reuses_existing_clone_by_deterministic_name() {
         matches!(
             actuation,
             Actuation::CreateCheckout { spec, .. }
-                if spec.worktree.as_ref().map(|worktree| worktree.clone_ref.as_str()) == Some(clone_name.as_str())
+                if matches!(spec, CheckoutSpec::Worktree(worktree) if worktree.clone_ref == clone_name)
         )
     }));
 }
@@ -106,7 +106,12 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
             .env_ref(host_direct_env_name())
             .git_ref(GIT_REF.to_string())
             .path("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-c".to_string())
-            .maybe_worktree(Some(CheckoutWorktreeSpec { clone_ref: "clone-placeholder".to_string() }))
+            .maybe_worktree(Some(worktree_checkout_spec(
+                &host_direct_env_name(),
+                GIT_REF,
+                "/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-c",
+                "clone-placeholder",
+            )))
             .build(),
     )
     .await;
@@ -216,7 +221,12 @@ async fn child_failure_propagates_to_workspace_failure() {
             .env_ref(host_direct_env_name())
             .git_ref(GIT_REF.to_string())
             .path("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-f".to_string())
-            .maybe_worktree(Some(CheckoutWorktreeSpec { clone_ref: "clone-placeholder".to_string() }))
+            .maybe_worktree(Some(worktree_checkout_spec(
+                &host_direct_env_name(),
+                GIT_REF,
+                "/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-f",
+                "clone-placeholder",
+            )))
             .build(),
     )
     .await;
@@ -306,7 +316,12 @@ async fn terminal_session_actuation_includes_system_and_user_labels() {
             .env_ref(host_direct_env_name())
             .git_ref(GIT_REF.to_string())
             .path("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-labels".to_string())
-            .maybe_worktree(Some(CheckoutWorktreeSpec { clone_ref: "clone-placeholder".to_string() }))
+            .maybe_worktree(Some(worktree_checkout_spec(
+                &host_direct_env_name(),
+                GIT_REF,
+                "/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-labels",
+                "clone-placeholder",
+            )))
             .build(),
     )
     .await;
@@ -378,16 +393,16 @@ async fn assert_terminal_cwd_for_strategy(
         NAMESPACE,
         ReadyCheckoutFixture::builder()
             .name(format!("checkout-{workspace_name}"))
-            .env_ref(checkout_env_ref)
+            .env_ref(checkout_env_ref.clone())
             .git_ref(GIT_REF.to_string())
             .path(checkout_path.to_string())
             .maybe_worktree(if checkout_path == "/workspace" && workspace_name == "workspace-docker-fresh" {
                 None
             } else {
-                Some(CheckoutWorktreeSpec { clone_ref: "clone-placeholder".to_string() })
+                Some(worktree_checkout_spec(&checkout_env_ref, GIT_REF, checkout_path, "clone-placeholder"))
             })
             .maybe_fresh_clone(if checkout_path == "/workspace" && workspace_name == "workspace-docker-fresh" {
-                Some(flotilla_resources::FreshCloneCheckoutSpec { url: REPO_URL.to_string() })
+                Some(fresh_clone_checkout_spec(&checkout_env_ref, GIT_REF, checkout_path, REPO_URL))
             } else {
                 None
             })
@@ -413,6 +428,24 @@ async fn assert_terminal_cwd_for_strategy(
 
 fn host_direct_env_name() -> String {
     format!("host-direct-{HOST_REF}")
+}
+
+fn worktree_checkout_spec(env_ref: &str, git_ref: &str, target_path: &str, clone_ref: &str) -> CheckoutWorktreeSpec {
+    CheckoutWorktreeSpec {
+        env_ref: env_ref.to_string(),
+        r#ref: git_ref.to_string(),
+        target_path: target_path.to_string(),
+        clone_ref: clone_ref.to_string(),
+    }
+}
+
+fn fresh_clone_checkout_spec(env_ref: &str, git_ref: &str, target_path: &str, url: &str) -> flotilla_resources::FreshCloneCheckoutSpec {
+    flotilla_resources::FreshCloneCheckoutSpec {
+        env_ref: env_ref.to_string(),
+        r#ref: git_ref.to_string(),
+        target_path: target_path.to_string(),
+        url: url.to_string(),
+    }
 }
 
 async fn create_convoy_with_labeled_processes(
@@ -536,13 +569,15 @@ async fn create_labeled_checkout(backend: &ResourceBackend, namespace: &str, nam
     backend
         .clone()
         .using::<Checkout>(namespace)
-        .create(&labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())]), &CheckoutSpec {
-            env_ref: host_direct_env_name(),
-            r#ref: GIT_REF.to_string(),
-            target_path: format!("/Users/alice/dev/flotilla-repos/{workspace_name}"),
-            worktree: Some(CheckoutWorktreeSpec { clone_ref: "clone-placeholder".to_string() }),
-            fresh_clone: None,
-        })
+        .create(
+            &labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())]),
+            &CheckoutSpec::Worktree(worktree_checkout_spec(
+                &host_direct_env_name(),
+                GIT_REF,
+                &format!("/Users/alice/dev/flotilla-repos/{workspace_name}"),
+                "clone-placeholder",
+            )),
+        )
         .await
         .expect("checkout create should succeed");
 }

--- a/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
+++ b/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
@@ -12,12 +12,12 @@ use flotilla_controllers::reconcilers::TaskWorkspaceReconciler;
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{Actuation, Reconciler},
-    Checkout, CheckoutSpec, CheckoutWorktreeSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, DockerCheckoutStrategy,
-    DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, PlacementPolicySpec, ProcessDefinition,
-    ProcessSource, ResourceBackend, ResourceError, SnapshotTask, TaskWorkspace, TerminalSession, TerminalSessionPhase, TerminalSessionSpec,
-    TerminalSessionStatus, WorkflowSnapshot, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL,
-    TASK_WORKSPACE_LABEL,
+    Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
+    DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, ObservedCheckoutSpec,
+    PlacementPolicySpec, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError, SnapshotTask, TaskWorkspace, TerminalSession,
+    TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, WorkflowSnapshot, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL,
+    TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
 };
 use rstest::rstest;
 
@@ -253,6 +253,31 @@ async fn child_failure_propagates_to_workspace_failure() {
     assert!(matches!(
         outcome.patch,
         Some(flotilla_resources::TaskWorkspaceStatusPatch::MarkFailed { ref message }) if message == "boom"
+    ));
+}
+
+#[tokio::test]
+async fn observed_checkout_at_managed_name_marks_workspace_failed() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-observed", "implement", REPO_URL, GIT_REF).await;
+    create_host_direct_policy(&backend, NAMESPACE, "policy-observed", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+
+    let canonical_repo = canonicalize_repo_url(REPO_URL).expect("repo canonicalization");
+    let clone_name = format!("clone-{}", clone_key(&canonical_repo, &host_direct_env_name()));
+    create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/Users/alice/dev/flotilla-repos/clone").await;
+    create_ready_observed_checkout_without_status_path(&backend, NAMESPACE, "checkout-workspace-observed").await;
+    let workspace =
+        create_workspace(&backend, NAMESPACE, "workspace-observed", "convoy-observed", "implement", "policy-observed", REPO_URL).await;
+
+    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::TaskWorkspaceStatusPatch::MarkFailed { ref message })
+            if message == "checkout checkout-workspace-observed is ready but has no target path"
     ));
 }
 
@@ -580,6 +605,31 @@ async fn create_labeled_checkout(backend: &ResourceBackend, namespace: &str, nam
         )
         .await
         .expect("checkout create should succeed");
+}
+
+async fn create_ready_observed_checkout_without_status_path(backend: &ResourceBackend, namespace: &str, name: &str) {
+    let checkouts = backend.clone().using::<Checkout>(namespace);
+    let checkout = checkouts
+        .create(
+            &meta(name),
+            &CheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: GIT_REF.to_string(),
+                path: "/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-observed".to_string(),
+                repo_ref: "repo-flotilla".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("checkout create should succeed");
+    checkouts
+        .update_status(name, &checkout.metadata.resource_version, &CheckoutStatus {
+            phase: CheckoutPhase::Ready,
+            path: None,
+            commit: Some("abc123".to_string()),
+            message: None,
+        })
+        .await
+        .expect("checkout status update should succeed");
 }
 
 async fn create_labeled_terminal(backend: &ResourceBackend, namespace: &str, name: &str, workspace_name: &str) {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,8 +22,8 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Convoy as ResourceConvoy,
-    ConvoyRepositorySpec, ConvoySpec, InputMeta, InputValue, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, ResourceBackend,
-    ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
+    ConvoyRepositorySpec, ConvoySpec, InMemoryBackend, InputMeta, InputValue, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec,
+    ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -529,6 +529,7 @@ pub struct InProcessDaemon {
     /// Used to inject FLOTILLA_DAEMON_SOCKET into managed terminal sessions.
     daemon_socket_path: RwLock<Option<PathBuf>>,
     resource_backend: ResourceBackend,
+    observed_resource_backend: ResourceBackend,
     /// Shared with `ConvoyProjection` (in flotilla-daemon): the projection is the
     /// sole writer, the daemon reads here for `replay_since`.  Replaces an earlier
     /// broadcast-driven mirror that had correctness seams under lag and
@@ -665,6 +666,7 @@ impl InProcessDaemon {
             agent_state_store,
             daemon_socket_path: RwLock::new(None),
             resource_backend,
+            observed_resource_backend: ResourceBackend::InMemory(InMemoryBackend::observed()),
             namespace_projection_state: RwLock::new(NamespaceProjectionState::new()),
             provisioning_namespace: RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
         });
@@ -801,6 +803,10 @@ impl InProcessDaemon {
 
     pub fn resource_backend(&self) -> ResourceBackend {
         self.resource_backend.clone()
+    }
+
+    pub fn observed_resource_backend(&self) -> ResourceBackend {
+        self.observed_resource_backend.clone()
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -25,7 +25,10 @@ use flotilla_protocol::{
     Request, Response, ResponseResult, RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey,
     VectorClock, PROTOCOL_VERSION,
 };
-use flotilla_resources::{Convoy, ConvoySpec, InputMeta, ResourceBackend};
+use flotilla_resources::{
+    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, ResourceBackend, ResourceError,
+};
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
 use tokio::{
@@ -299,6 +302,42 @@ async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
         restarted.daemon().resource_backend().using::<Convoy>("flotilla").get("persisted").await.expect("convoy should survive restart");
 
     assert_eq!(fetched.spec.workflow_ref, "scratch");
+}
+
+#[tokio::test]
+async fn daemon_server_observed_resource_backend_is_ephemeral_per_restart() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(tmp.path().join("config"));
+    let socket_path = tmp.path().join("flotilla.sock");
+
+    let server = DaemonServer::new(Vec::new(), Arc::clone(&config), fake_discovery(false), socket_path.clone(), StdDuration::from_secs(30))
+        .await
+        .expect("server should start");
+    let observed = server.daemon().observed_resource_backend();
+    let checkouts = observed.using::<ResourceCheckout>("flotilla");
+    checkouts
+        .create(
+            &InputMeta::builder().name("local-main".to_string()).build(),
+            &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+                r#ref: "main".to_string(),
+                path: "/Users/alice/dev/flotilla".to_string(),
+                repo_ref: "project-flotilla".to_string(),
+                is_main: true,
+            }),
+        )
+        .await
+        .expect("observed checkout create should succeed");
+    let first_generation = checkouts.list().await.expect("observed list should succeed").generation.expect("generation");
+    drop(server);
+
+    let restarted = DaemonServer::new(Vec::new(), config, fake_discovery(false), socket_path, StdDuration::from_secs(30))
+        .await
+        .expect("server should restart");
+    let restarted_checkouts = restarted.daemon().observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let restarted_list = restarted_checkouts.list().await.expect("observed list after restart should succeed");
+
+    assert_ne!(restarted_list.generation.expect("generation"), first_generation);
+    assert!(matches!(restarted_checkouts.get("local-main").await, Err(ResourceError::NotFound { .. })));
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -22,6 +22,7 @@ bytes = "1"
 tracing = "0.1"
 sha2 = "0.10"
 rusqlite = { version = "0.32", features = ["bundled"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 flotilla-controllers = { path = "../flotilla-controllers" }

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -5,25 +5,56 @@ use crate::{resource::define_resource, status_patch::StatusPatch};
 define_resource!(Checkout, "checkouts", CheckoutSpec, CheckoutStatus, CheckoutStatusPatch);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CheckoutSpec {
-    pub env_ref: String,
-    #[serde(rename = "ref")]
-    pub r#ref: String,
-    pub target_path: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub worktree: Option<CheckoutWorktreeSpec>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub fresh_clone: Option<FreshCloneCheckoutSpec>,
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CheckoutSpec {
+    Worktree(CheckoutWorktreeSpec),
+    FreshClone(FreshCloneCheckoutSpec),
+    Observed(ObservedCheckoutSpec),
+}
+
+impl CheckoutSpec {
+    pub fn env_ref(&self) -> Option<&str> {
+        match self {
+            Self::Worktree(spec) => Some(&spec.env_ref),
+            Self::FreshClone(spec) => Some(&spec.env_ref),
+            Self::Observed(_) => None,
+        }
+    }
+
+    pub fn target_path(&self) -> Option<&str> {
+        match self {
+            Self::Worktree(spec) => Some(&spec.target_path),
+            Self::FreshClone(spec) => Some(&spec.target_path),
+            Self::Observed(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CheckoutWorktreeSpec {
+    pub env_ref: String,
+    #[serde(rename = "ref")]
+    pub r#ref: String,
+    pub target_path: String,
     pub clone_ref: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FreshCloneCheckoutSpec {
+    pub env_ref: String,
+    #[serde(rename = "ref")]
+    pub r#ref: String,
+    pub target_path: String,
     pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObservedCheckoutSpec {
+    #[serde(rename = "ref")]
+    pub r#ref: String,
+    pub path: String,
+    pub repo_ref: String,
+    pub is_main: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     clone::CloneSpec,
     environment::EnvironmentSpec,
     error::ResourceError,
+    labels::LifecycleAuthority,
     presentation::PresentationSpec,
     resource::{InputMeta, Resource, ResourceObject},
     task_workspace::TaskWorkspaceSpec,
@@ -273,7 +274,8 @@ impl<R: Reconciler> ControllerLoop<R> {
         }
     }
 
-    async fn create_if_missing<T: Resource>(resolver: &TypedResolver<T>, meta: InputMeta, spec: T::Spec) -> Result<(), ResourceError> {
+    async fn create_if_missing<T: Resource>(resolver: &TypedResolver<T>, mut meta: InputMeta, spec: T::Spec) -> Result<(), ResourceError> {
+        meta.set_lifecycle_authority(LifecycleAuthority::Managed);
         match resolver.create(&meta, &spec).await {
             Ok(_) | Err(ResourceError::Conflict { .. }) => Ok(()),
             Err(err) => Err(err),

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -158,8 +158,12 @@ impl HttpBackend {
     pub(crate) async fn watch_typed<T: Resource>(&self, namespace: &str, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
         let mut query = vec![("watch", Cow::Borrowed("true"))];
-        if let WatchStart::FromVersion(version) = &start {
-            query.push(("resourceVersion", Cow::Owned(version.clone())));
+        match &start {
+            WatchStart::Now => {}
+            WatchStart::FromVersion(version) => query.push(("resourceVersion", Cow::Owned(version.clone()))),
+            WatchStart::FromVersionInGeneration { .. } => {
+                return Err(ResourceError::invalid("http resource watches do not use generations"));
+            }
         }
         let response =
             self.http.get(url).query(&query).send().await.map_err(|err| ResourceError::other(format!("WATCH resources: {err}")))?;
@@ -175,48 +179,51 @@ impl HttpBackend {
             done: false,
             _marker: std::marker::PhantomData,
         };
-        Ok(Box::pin(stream::unfold(state, |mut state| async move {
-            if state.done {
-                return None;
-            }
-            loop {
-                if let Some(position) = state.buffer.iter().position(|byte| *byte == b'\n') {
-                    let line = state.buffer.drain(..=position).collect::<Vec<_>>();
-                    let mut line = &line[..line.len().saturating_sub(1)];
-                    if line.last() == Some(&b'\r') {
-                        line = &line[..line.len().saturating_sub(1)];
-                    }
-                    if line.iter().all(|byte| byte.is_ascii_whitespace()) {
-                        continue;
-                    }
-                    let item = parse_watch_line::<T>(line);
-                    if item.is_err() {
-                        state.done = true;
-                    }
-                    return Some((item, state));
+        Ok(WatchStream::new(
+            None,
+            Box::pin(stream::unfold(state, |mut state| async move {
+                if state.done {
+                    return None;
                 }
-
-                match state.stream.next().await {
-                    Some(Ok(chunk)) => state.buffer.extend_from_slice(&chunk),
-                    Some(Err(err)) => {
-                        state.done = true;
-                        return Some((Err(ResourceError::other(format!("watch stream error: {err}"))), state));
-                    }
-                    None if state.buffer.is_empty() => return None,
-                    None => {
-                        let line = std::mem::take(&mut state.buffer);
-                        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
-                            return None;
+                loop {
+                    if let Some(position) = state.buffer.iter().position(|byte| *byte == b'\n') {
+                        let line = state.buffer.drain(..=position).collect::<Vec<_>>();
+                        let mut line = &line[..line.len().saturating_sub(1)];
+                        if line.last() == Some(&b'\r') {
+                            line = &line[..line.len().saturating_sub(1)];
                         }
-                        let item = parse_watch_line::<T>(&line);
+                        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+                            continue;
+                        }
+                        let item = parse_watch_line::<T>(line);
                         if item.is_err() {
                             state.done = true;
                         }
                         return Some((item, state));
                     }
+
+                    match state.stream.next().await {
+                        Some(Ok(chunk)) => state.buffer.extend_from_slice(&chunk),
+                        Some(Err(err)) => {
+                            state.done = true;
+                            return Some((Err(ResourceError::other(format!("watch stream error: {err}"))), state));
+                        }
+                        None if state.buffer.is_empty() => return None,
+                        None => {
+                            let line = std::mem::take(&mut state.buffer);
+                            if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+                                return None;
+                            }
+                            let item = parse_watch_line::<T>(&line);
+                            if item.is_err() {
+                                state.done = true;
+                            }
+                            return Some((item, state));
+                        }
+                    }
                 }
-            }
-        })))
+            })),
+        ))
     }
 }
 

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -19,6 +19,7 @@ type StoreKey = (String, String, String, String);
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryBackend {
     stores: Arc<Mutex<HashMap<StoreKey, ResourceStore>>>,
+    generation: Option<String>,
 }
 
 #[derive(Debug)]
@@ -68,6 +69,10 @@ impl Default for ResourceStore {
 }
 
 impl InMemoryBackend {
+    pub fn observed() -> Self {
+        Self { stores: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()) }
+    }
+
     fn store_key<T: Resource>(namespace: &str) -> StoreKey {
         (T::API_PATHS.group.to_string(), T::API_PATHS.version.to_string(), T::API_PATHS.plural.to_string(), namespace.to_string())
     }
@@ -135,7 +140,7 @@ impl InMemoryBackend {
                 items.push(Self::decode_object::<T>(value)?);
             }
             items.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
-            Ok(ResourceList { items, resource_version: store.current_version().to_string() })
+            Ok(ResourceList { items, resource_version: store.current_version().to_string(), generation: self.generation.clone() })
         })
         .await
     }
@@ -159,7 +164,7 @@ impl InMemoryBackend {
                 }
             }
             items.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
-            Ok(ResourceList { items, resource_version: store.current_version().to_string() })
+            Ok(ResourceList { items, resource_version: store.current_version().to_string(), generation: self.generation.clone() })
         })
         .await
     }
@@ -285,14 +290,37 @@ impl InMemoryBackend {
     }
 
     pub(crate) async fn watch_typed<T: Resource>(&self, namespace: &str, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {
+        let generation = self.generation.clone();
         let (replay, receiver) = {
             let mut stores = self.stores.lock().await;
             let store = stores.entry(Self::store_key::<T>(namespace)).or_default();
             let replay_from = match &start {
                 WatchStart::Now => None,
-                WatchStart::FromVersion(version) => Some(
-                    version.parse::<u64>().map_err(|err| ResourceError::invalid(format!("invalid resourceVersion '{version}': {err}")))?,
-                ),
+                WatchStart::FromVersion(version) => {
+                    if generation.is_some() {
+                        return Err(ResourceError::invalid("generational in-memory watches require a generation"));
+                    }
+                    Some(
+                        version
+                            .parse::<u64>()
+                            .map_err(|err| ResourceError::invalid(format!("invalid resourceVersion '{version}': {err}")))?,
+                    )
+                }
+                WatchStart::FromVersionInGeneration { generation: requested_generation, resource_version } => {
+                    let Some(current_generation) = &generation else {
+                        return Err(ResourceError::invalid("in-memory resource watches are not generational"));
+                    };
+                    if requested_generation != current_generation {
+                        return Err(ResourceError::invalid(format!(
+                            "resourceVersion belongs to generation '{requested_generation}', current generation is '{current_generation}'"
+                        )));
+                    }
+                    Some(
+                        resource_version
+                            .parse::<u64>()
+                            .map_err(|err| ResourceError::invalid(format!("invalid resourceVersion '{resource_version}': {err}")))?,
+                    )
+                }
             };
             let replay = match replay_from {
                 Some(version) => store.event_log.iter().filter(|event| event.version > version).cloned().collect(),
@@ -307,6 +335,6 @@ impl InMemoryBackend {
         let live_stream = stream::unfold(receiver, |mut receiver| async {
             receiver.recv().await.map(|event| (Self::decode_event::<T>(event), receiver))
         });
-        Ok(Box::pin(replay_stream.chain(live_stream)))
+        Ok(WatchStream::new(generation, Box::pin(replay_stream.chain(live_stream))))
     }
 }

--- a/crates/flotilla-resources/src/labels.rs
+++ b/crates/flotilla-resources/src/labels.rs
@@ -1,3 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::ResourceError;
+
+pub const AUTHORITY_LABEL: &str = "flotilla.work/authority";
 pub const CONVOY_LABEL: &str = "flotilla.work/convoy";
 pub const TASK_LABEL: &str = "flotilla.work/task";
 pub const TASK_WORKSPACE_LABEL: &str = "flotilla.work/task_workspace";
@@ -6,3 +11,32 @@ pub const TASK_ORDINAL_LABEL: &str = "flotilla.work/task_ordinal";
 pub const PROCESS_ORDINAL_LABEL: &str = "flotilla.work/process_ordinal";
 pub const REPO_LABEL: &str = "flotilla.work/repo";
 pub const RESERVED_PREFIX: &str = "flotilla.work/";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LifecycleAuthority {
+    #[serde(rename = "observed")]
+    Observed,
+    #[serde(rename = "adopted")]
+    Adopted,
+    #[serde(rename = "managed")]
+    Managed,
+}
+
+impl LifecycleAuthority {
+    pub fn as_label_value(self) -> &'static str {
+        match self {
+            Self::Observed => "observed",
+            Self::Adopted => "adopted",
+            Self::Managed => "managed",
+        }
+    }
+
+    pub fn from_label_value(value: &str) -> Result<Self, ResourceError> {
+        match value {
+            "observed" => Ok(Self::Observed),
+            "adopted" => Ok(Self::Adopted),
+            "managed" => Ok(Self::Managed),
+            other => Err(ResourceError::invalid(format!("invalid lifecycle authority '{other}'"))),
+        }
+    }
+}

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -24,6 +24,7 @@ mod workflow_template;
 pub use backend::{ResourceBackend, TypedResolver};
 pub use checkout::{
     Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, CheckoutWorktreeSpec, FreshCloneCheckoutSpec,
+    ObservedCheckoutSpec,
 };
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
@@ -40,7 +41,8 @@ pub use host::{Host, HostSpec, HostStatus, HostStatusPatch};
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use labels::{
-    CONVOY_LABEL, PROCESS_ORDINAL_LABEL, REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, TASK_LABEL,
+    TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
 };
 pub use placement_policy::{
     DockerCheckoutStrategy, DockerPerTaskPlacementPolicySpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -5,6 +5,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     error::ResourceError,
+    labels::{LifecycleAuthority, AUTHORITY_LABEL},
     status_patch::StatusPatch,
     watch::{ResourceList, WatchEvent},
 };
@@ -72,6 +73,19 @@ pub struct InputMeta {
 }
 
 impl InputMeta {
+    pub fn lifecycle_authority(&self) -> Result<Option<LifecycleAuthority>, ResourceError> {
+        self.labels.get(AUTHORITY_LABEL).map(|value| LifecycleAuthority::from_label_value(value)).transpose()
+    }
+
+    pub fn set_lifecycle_authority(&mut self, authority: LifecycleAuthority) {
+        self.labels.insert(AUTHORITY_LABEL.to_string(), authority.as_label_value().to_string());
+    }
+
+    pub fn with_lifecycle_authority(mut self, authority: LifecycleAuthority) -> Self {
+        self.set_lifecycle_authority(authority);
+        self
+    }
+
     pub fn with_added_finalizer(mut self, finalizer: impl Into<String>) -> Self {
         let finalizer = finalizer.into();
         if self.finalizers.iter().all(|existing| existing != &finalizer) {
@@ -100,6 +114,16 @@ pub struct ObjectMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deletion_timestamp: Option<DateTime<Utc>>,
     pub creation_timestamp: DateTime<Utc>,
+}
+
+impl ObjectMeta {
+    pub fn lifecycle_authority(&self) -> Result<Option<LifecycleAuthority>, ResourceError> {
+        self.labels.get(AUTHORITY_LABEL).map(|value| LifecycleAuthority::from_label_value(value)).transpose()
+    }
+
+    pub fn set_lifecycle_authority(&mut self, authority: LifecycleAuthority) {
+        self.labels.insert(AUTHORITY_LABEL.to_string(), authority.as_label_value().to_string());
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -236,6 +260,7 @@ impl<T: Resource> K8sResourceList<T> {
         Ok(ResourceList {
             items: self.items.into_iter().map(ResourceObject::from_k8s_object).collect::<Result<_, _>>()?,
             resource_version: self.metadata.resource_version,
+            generation: None,
         })
     }
 }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -258,7 +258,7 @@ impl SqliteBackend {
             let value = serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
             items.push(Self::decode_object::<T>(value)?);
         }
-        Ok(ResourceList { items, resource_version: Self::current_version(&conn, &key)?.to_string() })
+        Ok(ResourceList { items, resource_version: Self::current_version(&conn, &key)?.to_string(), generation: None })
     }
 
     pub(crate) async fn list_typed_matching_labels<T: Resource>(
@@ -276,7 +276,7 @@ impl SqliteBackend {
             .into_iter()
             .filter(|object| required.iter().all(|(key, expected)| object.metadata.labels.get(key) == Some(expected)))
             .collect();
-        Ok(ResourceList { items, resource_version: listed.resource_version })
+        Ok(ResourceList { items, resource_version: listed.resource_version, generation: None })
     }
 
     pub(crate) async fn create_typed<T: Resource>(
@@ -454,6 +454,9 @@ impl SqliteBackend {
             WatchStart::FromVersion(version) => {
                 Some(version.parse::<u64>().map_err(|err| ResourceError::invalid(format!("invalid resourceVersion '{version}': {err}")))?)
             }
+            WatchStart::FromVersionInGeneration { .. } => {
+                return Err(ResourceError::invalid("sqlite resource watches do not use generations"));
+            }
         };
         let (sender, receiver) = mpsc::unbounded_channel();
         let replay = {
@@ -469,7 +472,7 @@ impl SqliteBackend {
         let live_stream = stream::unfold(receiver, |mut receiver| async {
             receiver.recv().await.map(|event| (Self::decode_event::<T>(event), receiver))
         });
-        Ok(Box::pin(replay_stream.chain(live_stream)))
+        Ok(WatchStream::new(None, Box::pin(replay_stream.chain(live_stream))))
     }
 
     fn select_existing<T: Resource>(

--- a/crates/flotilla-resources/src/watch.rs
+++ b/crates/flotilla-resources/src/watch.rs
@@ -1,4 +1,10 @@
-use futures::stream::BoxStream;
+use std::{
+    fmt,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{stream::BoxStream, Stream};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
@@ -6,7 +12,34 @@ use crate::{
     resource::{Resource, ResourceObject},
 };
 
-pub type WatchStream<T> = BoxStream<'static, Result<WatchEvent<T>, ResourceError>>;
+pub struct WatchStream<T: Resource> {
+    generation: Option<String>,
+    inner: BoxStream<'static, Result<WatchEvent<T>, ResourceError>>,
+}
+
+impl<T: Resource> WatchStream<T> {
+    pub fn new(generation: Option<String>, inner: BoxStream<'static, Result<WatchEvent<T>, ResourceError>>) -> Self {
+        Self { generation, inner }
+    }
+
+    pub fn generation(&self) -> Option<&str> {
+        self.generation.as_deref()
+    }
+}
+
+impl<T: Resource> fmt::Debug for WatchStream<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WatchStream").field("generation", &self.generation).finish_non_exhaustive()
+    }
+}
+
+impl<T: Resource> Stream for WatchStream<T> {
+    type Item = Result<WatchEvent<T>, ResourceError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum WatchStart {
@@ -14,6 +47,8 @@ pub enum WatchStart {
     Now,
     /// Resume from a specific version, delivering all events since that point.
     FromVersion(String),
+    /// Resume from a specific version within an ephemeral store generation.
+    FromVersionInGeneration { generation: String, resource_version: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +70,8 @@ pub enum WatchEvent<T: Resource> {
 pub struct ResourceList<T: Resource> {
     pub items: Vec<ResourceObject<T>>,
     pub resource_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -11,8 +11,8 @@ use std::{
 use common::{resource_meta, TestLoopHarness};
 use flotilla_resources::{
     controller::{Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler},
-    ApiPaths, InMemoryBackend, InputMeta, NoStatusPatch, Presentation, PresentationSpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, TaskWorkspace, TaskWorkspaceSpec,
+    ApiPaths, InMemoryBackend, InputMeta, LifecycleAuthority, NoStatusPatch, Presentation, PresentationSpec, Resource, ResourceBackend,
+    ResourceError, ResourceObject, TaskWorkspace, TaskWorkspaceSpec,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{sync::mpsc, time::timeout};
@@ -571,6 +571,9 @@ async fn controller_loop_applies_create_presentation_actuation() {
     })
     .await
     .expect("create presentation actuation should create the resource");
+
+    let created = presentations.get("alpha-presentation").await.expect("created presentation should be readable");
+    assert_eq!(created.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Managed));
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -114,3 +114,57 @@ async fn list_matching_labels_returns_only_exact_matches() {
     assert_eq!(listed.items.len(), 1);
     assert_eq!(listed.items[0].metadata.name, "alpha");
 }
+
+#[tokio::test]
+async fn observed_backend_surfaces_generation_on_list_and_watch() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::observed());
+    let resolver = backend.using::<Convoy>("flotilla");
+    resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create should succeed");
+
+    let listed = resolver.list().await.expect("list should succeed");
+    let generation = listed.generation.clone().expect("observed list should expose generation");
+    let watch = resolver
+        .watch(flotilla_resources::WatchStart::FromVersionInGeneration {
+            generation: generation.clone(),
+            resource_version: listed.resource_version.clone(),
+        })
+        .await
+        .expect("watch should start within listed generation");
+
+    assert_eq!(watch.generation(), Some(generation.as_str()));
+}
+
+#[tokio::test]
+async fn observed_backend_rejects_watch_resume_from_previous_generation() {
+    let first_backend = ResourceBackend::InMemory(InMemoryBackend::observed());
+    let first = first_backend.using::<Convoy>("flotilla");
+    let first_list = first.list().await.expect("first list should succeed");
+    let stale_generation = first_list.generation.expect("observed list should expose generation");
+
+    let restarted_backend = ResourceBackend::InMemory(InMemoryBackend::observed());
+    let restarted = restarted_backend.using::<Convoy>("flotilla");
+    let restarted_generation =
+        restarted.list().await.expect("restarted list should succeed").generation.expect("observed list should expose generation");
+    assert_ne!(restarted_generation, stale_generation, "restart should mint a new observed generation");
+
+    let err = restarted
+        .watch(flotilla_resources::WatchStart::FromVersionInGeneration { generation: stale_generation, resource_version: "0".to_string() })
+        .await
+        .expect_err("watch resume from a previous generation should fail");
+
+    assert!(matches!(err, flotilla_resources::ResourceError::Invalid { .. }));
+}
+
+#[tokio::test]
+async fn observed_backend_rejects_bare_watch_resume_without_generation() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::observed());
+    let resolver = backend.using::<Convoy>("flotilla");
+    let listed = resolver.list().await.expect("list should succeed");
+
+    let err = resolver
+        .watch(flotilla_resources::WatchStart::FromVersion(listed.resource_version))
+        .await
+        .expect_err("observed watch resume should require generation");
+
+    assert!(matches!(err, flotilla_resources::ResourceError::Invalid { .. }));
+}

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -105,19 +105,21 @@ async fn environment_and_checkout_specs_serialize_through_in_memory_backend() {
             env: [("FOO".to_string(), "bar".to_string())].into_iter().collect(),
         }),
     };
-    let checkout_spec = CheckoutSpec {
+    let checkout_spec = CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
         env_ref: "env-a".to_string(),
         r#ref: "feat/convoy-resource".to_string(),
         target_path: "/workspace".to_string(),
-        worktree: None,
-        fresh_clone: Some(FreshCloneCheckoutSpec { url: "git@github.com:flotilla-org/flotilla.git".to_string() }),
-    };
+        url: "git@github.com:flotilla-org/flotilla.git".to_string(),
+    });
 
     let env = environments.create(&docker_environment_meta("env-a"), &env_spec).await.expect("env create should succeed");
     let checkout = checkouts.create(&docker_environment_meta("checkout-a"), &checkout_spec).await.expect("checkout create should succeed");
 
     assert_eq!(env.spec.docker.expect("docker spec").mounts[0].target_path, "/workspace");
-    assert_eq!(checkout.spec.fresh_clone.expect("fresh clone").url, "git@github.com:flotilla-org/flotilla.git");
+    match checkout.spec {
+        CheckoutSpec::FreshClone(spec) => assert_eq!(spec.url, "git@github.com:flotilla-org/flotilla.git"),
+        other => panic!("expected fresh clone checkout, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/resource_projection.rs
+++ b/crates/flotilla-resources/tests/resource_projection.rs
@@ -1,7 +1,10 @@
 mod common;
 
 use common::{convoy_object, convoy_spec, convoy_status, timestamp};
-use flotilla_resources::{Convoy, ConvoyPhase, K8sResourceObject, ResourceError, ResourceObject};
+use flotilla_resources::{
+    Checkout, CheckoutSpec, CheckoutWorktreeSpec, Convoy, ConvoyPhase, InputMeta, K8sResourceObject, LifecycleAuthority,
+    ObservedCheckoutSpec, ResourceError, ResourceObject, AUTHORITY_LABEL,
+};
 
 #[test]
 fn resource_object_projects_to_k8s_object_shape() {
@@ -75,4 +78,76 @@ fn k8s_object_projection_deserializes_kubernetes_casing() {
     assert_eq!(object.metadata.resource_version, "9");
     assert_eq!(object.spec.workflow_ref, "review");
     assert_eq!(object.status.expect("status").phase, ConvoyPhase::Pending);
+}
+
+#[test]
+fn lifecycle_authority_is_stored_as_reserved_label_on_input_metadata() {
+    let mut meta = InputMeta::builder().name("alpha".to_string()).build();
+
+    meta.set_lifecycle_authority(LifecycleAuthority::Observed);
+
+    assert_eq!(meta.labels.get(AUTHORITY_LABEL).map(String::as_str), Some("observed"));
+    assert_eq!(meta.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
+}
+
+#[test]
+fn lifecycle_authority_roundtrips_through_k8s_projection_labels() {
+    let mut object = convoy_object("alpha", convoy_spec("review"), None);
+    object.metadata.set_lifecycle_authority(LifecycleAuthority::Managed);
+
+    let roundtripped = ResourceObject::<Convoy>::from_k8s_object(object.to_k8s_object()).expect("projection should roundtrip");
+
+    assert_eq!(roundtripped.metadata.labels.get(AUTHORITY_LABEL).map(String::as_str), Some("managed"));
+    assert_eq!(roundtripped.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Managed));
+}
+
+#[test]
+fn checkout_spec_worktree_variant_roundtrips_through_k8s_projection() {
+    let object = ResourceObject::<Checkout> {
+        metadata: common::object_meta("checkout-a", "flotilla", "3"),
+        spec: CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+            env_ref: "env-a".to_string(),
+            r#ref: "feature-a".to_string(),
+            target_path: "/worktrees/feature-a".to_string(),
+            clone_ref: "clone-a".to_string(),
+        }),
+        status: None,
+    };
+
+    let json = serde_json::to_value(object.to_k8s_object()).expect("checkout projection should serialize");
+    assert_eq!(json["spec"]["kind"], "worktree");
+    assert_eq!(json["spec"]["env_ref"], "env-a");
+    assert_eq!(json["spec"]["target_path"], "/worktrees/feature-a");
+    assert_eq!(json["spec"]["clone_ref"], "clone-a");
+
+    let roundtripped = ResourceObject::<Checkout>::from_k8s_object(serde_json::from_value(json).expect("deserialize checkout"))
+        .expect("checkout projection should roundtrip");
+    assert_eq!(roundtripped.spec, object.spec);
+}
+
+#[test]
+fn checkout_spec_observed_variant_carries_only_observed_facts() {
+    let object = ResourceObject::<Checkout> {
+        metadata: common::object_meta("checkout-a", "flotilla", "3"),
+        spec: CheckoutSpec::Observed(ObservedCheckoutSpec {
+            r#ref: "main".to_string(),
+            path: "/Users/dev/flotilla".to_string(),
+            repo_ref: "project-flotilla".to_string(),
+            is_main: true,
+        }),
+        status: None,
+    };
+
+    let json = serde_json::to_value(object.to_k8s_object()).expect("checkout projection should serialize");
+    assert_eq!(json["spec"]["kind"], "observed");
+    assert_eq!(json["spec"]["ref"], "main");
+    assert_eq!(json["spec"]["path"], "/Users/dev/flotilla");
+    assert_eq!(json["spec"]["repo_ref"], "project-flotilla");
+    assert_eq!(json["spec"]["is_main"], true);
+    assert!(json["spec"].get("env_ref").is_none(), "observed checkout should not carry env_ref");
+    assert!(json["spec"].get("target_path").is_none(), "observed checkout should not carry target_path");
+
+    let roundtripped = ResourceObject::<Checkout>::from_k8s_object(serde_json::from_value(json).expect("deserialize checkout"))
+        .expect("checkout projection should roundtrip");
+    assert_eq!(roundtripped.spec, object.spec);
 }


### PR DESCRIPTION
## Summary

- Add `LifecycleAuthority` as the reserved `flotilla.work/authority` label with metadata helpers, and stamp controller-created resources as `managed`.
- Add an observed in-memory resource backend with per-process generation IDs surfaced on list/watch, generation-checked watch resume, and daemon restart coverage.
- Reshape `CheckoutSpec` into `Worktree`, `FreshClone`, and `Observed` variants; observed checkouts carry facts only, while managed variants require environment and target path data.

Closes #626.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `cargo test --workspace --locked`