### PR TITLE
[codex] Support adopted checkout convoys

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -57,6 +57,10 @@ fn parse_input_kv(raw: &str) -> Result<(String, String), String> {
     Ok((key.to_string(), value.to_string()))
 }
 
+fn resolve_adopted_checkout(path: PathBuf) -> Result<Box<PathBuf>, String> {
+    std::fs::canonicalize(&path).map(Box::new).map_err(|err| format!("adopted checkout path {} cannot be resolved: {err}", path.display()))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 pub struct ConvoyTaskNoun {
     /// Task name
@@ -105,7 +109,7 @@ impl ConvoyNoun {
                             r#ref,
                             project_ref,
                             placement_policy,
-                            adopted_checkout: adopted_checkout.map(Box::new),
+                            adopted_checkout: adopted_checkout.map(resolve_adopted_checkout).transpose()?,
                         },
                     },
                     repo: RepoContext::None,
@@ -159,8 +163,6 @@ impl std::fmt::Display for ConvoyNoun {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use clap::Parser;
     use flotilla_protocol::{Command, CommandAction};
 
@@ -306,8 +308,9 @@ mod tests {
 
     #[test]
     fn convoy_create_with_adopted_checkout_resolves() {
+        let cwd = std::env::current_dir().expect("current dir");
         let resolved =
-            parse(&["convoy", "scratch-1", "create", "--template", "scratch", "--adopt-checkout", "/tmp/repo"]).resolve().expect("resolve");
+            parse(&["convoy", "scratch-1", "create", "--template", "scratch", "--adopt-checkout", "."]).resolve().expect("resolve");
         assert_eq!(resolved, Resolved::NeedsContext {
             command: Command {
                 node_id: None,
@@ -321,12 +324,20 @@ mod tests {
                     r#ref: None,
                     project_ref: None,
                     placement_policy: None,
-                    adopted_checkout: Some(Box::new(PathBuf::from("/tmp/repo"))),
+                    adopted_checkout: Some(Box::new(cwd)),
                 },
             },
             repo: RepoContext::None,
             host: HostResolution::Local,
         });
+    }
+
+    #[test]
+    fn convoy_create_with_missing_adopted_checkout_fails_resolution() {
+        let err = parse(&["convoy", "scratch-1", "create", "--template", "scratch", "--adopt-checkout", "/tmp/flotilla-missing-checkout"])
+            .resolve()
+            .expect_err("missing checkout should fail before daemon handoff");
+        assert!(err.contains("adopted checkout path /tmp/flotilla-missing-checkout cannot be resolved"), "{err}");
     }
 
     #[test]

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 use flotilla_protocol::{Command, CommandAction};
 
@@ -41,6 +43,9 @@ pub enum ConvoyVerb {
         /// PlacementPolicy resource to use for task provisioning
         #[arg(long = "placement-policy")]
         placement_policy: Option<String>,
+        /// Existing local checkout/worktree to adopt as the convoy vessel
+        #[arg(long = "adopt-checkout")]
+        adopted_checkout: Option<PathBuf>,
     },
 }
 
@@ -86,24 +91,27 @@ impl ConvoyNoun {
                     host: HostResolution::Local,
                 }),
             },
-            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy } => Ok(Resolved::NeedsContext {
-                command: Command {
-                    node_id: None,
-                    provisioning_target: None,
-                    context_repo: None,
-                    action: CommandAction::ConvoyCreate {
-                        name: self.subject,
-                        workflow_ref: template,
-                        inputs,
-                        repository_url,
-                        r#ref,
-                        project_ref,
-                        placement_policy,
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy, adopted_checkout } => {
+                Ok(Resolved::NeedsContext {
+                    command: Command {
+                        node_id: None,
+                        provisioning_target: None,
+                        context_repo: None,
+                        action: CommandAction::ConvoyCreate {
+                            name: self.subject,
+                            workflow_ref: template,
+                            inputs,
+                            repository_url,
+                            r#ref,
+                            project_ref,
+                            placement_policy,
+                            adopted_checkout: adopted_checkout.map(Box::new),
+                        },
                     },
-                },
-                repo: RepoContext::None,
-                host: HostResolution::Local,
-            }),
+                    repo: RepoContext::None,
+                    host: HostResolution::Local,
+                })
+            }
         }
     }
 }
@@ -123,7 +131,7 @@ impl std::fmt::Display for ConvoyNoun {
                     }
                 }
             }
-            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy } => {
+            ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy, adopted_checkout } => {
                 write!(f, " create --template {}", quote_value(template))?;
                 for (k, v) in inputs {
                     write!(f, " --input {}", quote_value(&format!("{k}={v}")))?;
@@ -140,6 +148,9 @@ impl std::fmt::Display for ConvoyNoun {
                 if let Some(placement_policy) = placement_policy {
                     write!(f, " --placement-policy {}", quote_value(placement_policy))?;
                 }
+                if let Some(adopted_checkout) = adopted_checkout {
+                    write!(f, " --adopt-checkout {}", quote_value(&adopted_checkout.display().to_string()))?;
+                }
             }
         }
         Ok(())
@@ -148,6 +159,8 @@ impl std::fmt::Display for ConvoyNoun {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use clap::Parser;
     use flotilla_protocol::{Command, CommandAction};
 
@@ -233,6 +246,7 @@ mod tests {
                     r#ref: Some("main".into()),
                     project_ref: None,
                     placement_policy: None,
+                    adopted_checkout: None,
                 },
             },
             repo: RepoContext::None,
@@ -256,6 +270,7 @@ mod tests {
                     r#ref: None,
                     project_ref: None,
                     placement_policy: None,
+                    adopted_checkout: None,
                 },
             },
             repo: RepoContext::None,
@@ -281,6 +296,32 @@ mod tests {
                     r#ref: None,
                     project_ref: None,
                     placement_policy: Some("host-direct-local".into()),
+                    adopted_checkout: None,
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn convoy_create_with_adopted_checkout_resolves() {
+        let resolved =
+            parse(&["convoy", "scratch-1", "create", "--template", "scratch", "--adopt-checkout", "/tmp/repo"]).resolve().expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "scratch-1".into(),
+                    workflow_ref: "scratch".into(),
+                    inputs: vec![],
+                    repository_url: None,
+                    r#ref: None,
+                    project_ref: None,
+                    placement_policy: None,
+                    adopted_checkout: Some(Box::new(PathBuf::from("/tmp/repo"))),
                 },
             },
             repo: RepoContext::None,
@@ -304,6 +345,8 @@ mod tests {
             "main",
             "--placement-policy",
             "host-direct-local",
+            "--adopt-checkout",
+            "/tmp/repo",
         ]);
     }
 

--- a/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
+++ b/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
@@ -3,13 +3,14 @@ use std::{collections::BTreeMap, marker::PhantomData};
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
-    controller::{delete_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
+    controller::{Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
     descriptive_repo_slug, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
     DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec,
-    FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, OwnerReference, PlacementPolicy,
-    PlacementPolicySpec, ProcessDefinition, ProcessSource, Resource, ResourceBackend, ResourceError, ResourceObject, TaskWorkspace,
-    TaskWorkspacePhase, TaskWorkspaceStatusPatch, TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, CONVOY_LABEL,
-    PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority,
+    OwnerReference, PlacementPolicy, PlacementPolicySpec, ProcessDefinition, ProcessSource, Resource, ResourceBackend, ResourceError,
+    ResourceObject, TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceStatusPatch, TerminalSession, TerminalSessionPhase,
+    TerminalSessionSpec, TypedResolver, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL,
+    TASK_WORKSPACE_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -159,11 +160,12 @@ impl Reconciler for TaskWorkspaceReconciler {
         };
         let repo_key = repo_key(&canonical_repo);
         let repo_slug = descriptive_repo_slug(&canonical_repo);
+        let adopted_checkout_ref = obj.spec.adopted_checkout_ref.clone();
 
         let clone_env_ref = host_direct_environment_name(strategy.host_ref());
         let mut actuations = Vec::new();
 
-        let clone_name = if strategy.needs_shared_clone() {
+        let clone_name = if adopted_checkout_ref.is_none() && strategy.needs_shared_clone() {
             let clone_env = match self.environments.get(&clone_env_ref).await {
                 Ok(environment) => environment,
                 Err(ResourceError::NotFound { .. }) => {
@@ -263,7 +265,7 @@ impl Reconciler for TaskWorkspaceReconciler {
             _ => None,
         };
 
-        let checkout_name = checkout_name(&obj.metadata.name);
+        let checkout_name = adopted_checkout_ref.clone().unwrap_or_else(|| checkout_name(&obj.metadata.name));
         let checkout_target_path = match &strategy {
             PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
                 let clone_env = match self.environments.get(&clone_env_ref).await {
@@ -285,6 +287,9 @@ impl Reconciler for TaskWorkspaceReconciler {
         let checkout_ready_path;
         match self.checkouts.get(&checkout_name).await {
             Ok(existing) => {
+                if adopted_checkout_ref.is_some() && existing.metadata.lifecycle_authority()? != Some(LifecycleAuthority::Adopted) {
+                    return Ok(TaskWorkspaceDeps::failed(format!("checkout {checkout_name} is not adopted")));
+                }
                 if existing.status.as_ref().map(|status| status.phase) == Some(CheckoutPhase::Failed) {
                     let message = existing
                         .status
@@ -308,6 +313,9 @@ impl Reconciler for TaskWorkspaceReconciler {
                 }
             }
             Err(ResourceError::NotFound { .. }) => {
+                if adopted_checkout_ref.is_some() {
+                    return Ok(TaskWorkspaceDeps::failed(format!("adopted checkout {checkout_name} not found")));
+                }
                 let spec = match &strategy {
                     PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
                         CheckoutSpec::Worktree(CheckoutWorktreeSpec {
@@ -474,9 +482,9 @@ impl Reconciler for TaskWorkspaceReconciler {
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
         let selector = BTreeMap::from([(TASK_WORKSPACE_LABEL.to_string(), obj.metadata.name.clone())]);
 
-        delete_matching(&self.terminal_sessions, &selector).await?;
-        delete_matching(&self.checkouts, &selector).await?;
-        delete_matching(&self.environments, &selector).await?;
+        delete_lifecycle_owned_matching(&self.terminal_sessions, &selector).await?;
+        delete_lifecycle_owned_matching(&self.checkouts, &selector).await?;
+        delete_lifecycle_owned_matching(&self.environments, &selector).await?;
 
         Ok(())
     }
@@ -484,6 +492,23 @@ impl Reconciler for TaskWorkspaceReconciler {
     fn finalizer_name(&self) -> Option<&'static str> {
         Some("flotilla.work/task-workspace-teardown")
     }
+}
+
+async fn delete_lifecycle_owned_matching<T: Resource>(
+    resolver: &TypedResolver<T>,
+    selector: &BTreeMap<String, String>,
+) -> Result<(), ResourceError> {
+    let listed = resolver.list_matching_labels(selector).await?;
+    for object in listed.items {
+        if matches!(object.metadata.lifecycle_authority()?, Some(LifecycleAuthority::Observed | LifecycleAuthority::Adopted)) {
+            continue;
+        }
+        match resolver.delete(&object.metadata.name).await {
+            Ok(()) | Err(ResourceError::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
 }
 
 fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, String> {

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -65,6 +65,7 @@ pub async fn create_convoy_with_single_task(
             repository: Some(ConvoyRepositorySpec { url: repo_url.to_string() }),
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
+            adopted_checkout_ref: None,
         })
         .await
         .expect("convoy create should succeed");
@@ -102,6 +103,7 @@ pub async fn create_workspace(
             convoy_ref: convoy_ref.to_string(),
             task: task.to_string(),
             placement_policy_ref: placement_policy_ref.to_string(),
+            adopted_checkout_ref: None,
         })
         .await
         .expect("workspace create should succeed")

--- a/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
+++ b/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use common::{
     create_convoy_with_single_task, create_docker_worktree_policy, create_host_direct_policy, create_policy, create_ready_checkout,
     create_ready_clone, create_ready_docker_environment, create_ready_host_direct_environment, create_stopped_terminal, create_workspace,
-    labeled_meta, meta, DockerWorktreePolicyFixture, ReadyCheckoutFixture, StoppedTerminalFixture,
+    labeled_meta, meta, task_workspace_meta, DockerWorktreePolicyFixture, ReadyCheckoutFixture, StoppedTerminalFixture,
 };
 use flotilla_controllers::reconcilers::TaskWorkspaceReconciler;
 use flotilla_resources::{
@@ -14,10 +14,10 @@ use flotilla_resources::{
     controller::{Actuation, Reconciler},
     Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
     DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec,
-    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, ObservedCheckoutSpec,
-    PlacementPolicySpec, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError, SnapshotTask, TaskWorkspace, TerminalSession,
-    TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, WorkflowSnapshot, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL,
-    TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, LifecycleAuthority,
+    ObservedCheckoutSpec, PlacementPolicySpec, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError, SnapshotTask,
+    TaskWorkspace, TaskWorkspaceSpec, TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, WorkflowSnapshot,
+    CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
 };
 use rstest::rstest;
 
@@ -257,6 +257,44 @@ async fn child_failure_propagates_to_workspace_failure() {
 }
 
 #[tokio::test]
+async fn adopted_checkout_ref_reuses_checkout_without_creating_clone_or_checkout() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-adopted", "implement", REPO_URL, GIT_REF).await;
+    create_host_direct_policy(&backend, NAMESPACE, "policy-adopted", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    create_ready_adopted_checkout(&backend, NAMESPACE, "adopted-checkout-convoy-adopted", "/Users/alice/dev/flotilla-existing").await;
+    let workspace = backend
+        .clone()
+        .using::<TaskWorkspace>(NAMESPACE)
+        .create(&task_workspace_meta("workspace-adopted", REPO_URL), &TaskWorkspaceSpec {
+            convoy_ref: "convoy-adopted".to_string(),
+            task: "implement".to_string(),
+            placement_policy_ref: "policy-adopted".to_string(),
+            adopted_checkout_ref: Some("adopted-checkout-convoy-adopted".to_string()),
+        })
+        .await
+        .expect("workspace create should succeed");
+
+    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
+
+    assert!(outcome
+        .actuations
+        .iter()
+        .all(|actuation| { !matches!(actuation, Actuation::CreateClone { .. } | Actuation::CreateCheckout { .. }) }));
+    assert!(outcome.actuations.iter().any(|actuation| {
+        matches!(
+            actuation,
+            Actuation::CreateTerminalSession { spec, .. }
+                if spec.env_ref == host_direct_env_name()
+                    && spec.pool == "cleat"
+                    && spec.cwd == "/Users/alice/dev/flotilla-existing"
+        )
+    }));
+}
+
+#[tokio::test]
 async fn observed_checkout_at_managed_name_marks_workspace_failed() {
     let backend = ResourceBackend::InMemory(Default::default());
     create_convoy_with_single_task(&backend, NAMESPACE, "convoy-observed", "implement", REPO_URL, GIT_REF).await;
@@ -303,6 +341,26 @@ async fn run_finalizer_deletes_all_labeled_children() {
     ));
     assert!(matches!(
         backend.clone().using::<TerminalSession>(NAMESPACE).get("terminal-workspace-finalize-coder").await,
+        Err(ResourceError::NotFound { .. })
+    ));
+}
+
+#[tokio::test]
+async fn run_finalizer_preserves_adopted_checkout() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let workspace = create_workspace(&backend, NAMESPACE, "workspace-adopted", "convoy-a", "implement", "policy-a", REPO_URL).await;
+
+    create_labeled_adopted_checkout(&backend, NAMESPACE, "checkout-workspace-adopted", "workspace-adopted").await;
+    create_labeled_terminal(&backend, NAMESPACE, "terminal-workspace-adopted-coder", "workspace-adopted").await;
+
+    let reconciler = TaskWorkspaceReconciler::new(backend.clone(), NAMESPACE);
+    reconciler.run_finalizer(&workspace).await.expect("finalizer should succeed");
+
+    let checkout =
+        backend.clone().using::<Checkout>(NAMESPACE).get("checkout-workspace-adopted").await.expect("adopted checkout should be preserved");
+    assert_eq!(checkout.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Adopted));
+    assert!(matches!(
+        backend.clone().using::<TerminalSession>(NAMESPACE).get("terminal-workspace-adopted-coder").await,
         Err(ResourceError::NotFound { .. })
     ));
 }
@@ -489,6 +547,7 @@ async fn create_convoy_with_labeled_processes(
             repository: Some(ConvoyRepositorySpec { url: repo_url.to_string() }),
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
+            adopted_checkout_ref: None,
         })
         .await
         .expect("convoy create should succeed");
@@ -605,6 +664,49 @@ async fn create_labeled_checkout(backend: &ResourceBackend, namespace: &str, nam
         )
         .await
         .expect("checkout create should succeed");
+}
+
+async fn create_labeled_adopted_checkout(backend: &ResourceBackend, namespace: &str, name: &str, workspace_name: &str) {
+    backend
+        .clone()
+        .using::<Checkout>(namespace)
+        .create(
+            &labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())])
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &CheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: GIT_REF.to_string(),
+                path: format!("/Users/alice/dev/flotilla-repos/{workspace_name}"),
+                repo_ref: "repo-flotilla".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("adopted checkout create should succeed");
+}
+
+async fn create_ready_adopted_checkout(backend: &ResourceBackend, namespace: &str, name: &str, path: &str) {
+    let checkouts = backend.clone().using::<Checkout>(namespace);
+    let created = checkouts
+        .create(
+            &meta(name).with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &CheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: GIT_REF.to_string(),
+                path: path.to_string(),
+                repo_ref: "repo-flotilla".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("adopted checkout create should succeed");
+    checkouts
+        .update_status(name, &created.metadata.resource_version, &CheckoutStatus {
+            phase: CheckoutPhase::Ready,
+            path: Some(path.to_string()),
+            commit: Some("abc123".to_string()),
+            message: None,
+        })
+        .await
+        .expect("checkout status update should succeed");
 }
 
 async fn create_ready_observed_checkout_without_status_path(backend: &ResourceBackend, namespace: &str, name: &str) {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -281,7 +281,10 @@ async fn create_adopted_checkout_resource(
             if existing.metadata.lifecycle_authority().map_err(|err| err.to_string())? != Some(LifecycleAuthority::Adopted) {
                 return Err(format!("checkout {checkout_ref} already exists but is not adopted"));
             }
-            checkouts.update(&meta, &existing.metadata.resource_version, &spec).await.map_err(|err| err.to_string())?
+            if existing.spec != spec {
+                return Err(format!("checkout {checkout_ref} already exists with different adopted checkout details"));
+            }
+            existing
         }
         Err(err) => return Err(err.to_string()),
     };
@@ -2147,6 +2150,31 @@ impl InProcessDaemon {
             });
             let namespace = self.provisioning_namespace().await;
             let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
+            match convoys.get(name).await {
+                Ok(_) => {
+                    let result = flotilla_protocol::CommandValue::Error { message: format!("convoy {name} already exists") };
+                    let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                        command_id: id,
+                        node_id: self.node_id.clone(),
+                        repo_identity: empty_identity,
+                        repo: None,
+                        result,
+                    });
+                    return Ok(id);
+                }
+                Err(ResourceError::NotFound { .. }) => {}
+                Err(err) => {
+                    let result = flotilla_protocol::CommandValue::Error { message: err.to_string() };
+                    let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                        command_id: id,
+                        node_id: self.node_id.clone(),
+                        repo_identity: empty_identity,
+                        repo: None,
+                        result,
+                    });
+                    return Ok(id);
+                }
+            }
             let placement_policy = match placement_policy {
                 Some(policy) => Some(policy.clone()),
                 None => default_convoy_placement_policy(&self.resource_backend, &namespace).await,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4,7 +4,7 @@
 //! and broadcasts events — all within the same process.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -21,9 +21,11 @@ use flotilla_protocol::{
     SystemInfo, ToolInventory, TopologyResponse, TopologyRoute,
 };
 use flotilla_resources::{
-    apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Convoy as ResourceConvoy,
-    ConvoyRepositorySpec, ConvoySpec, InMemoryBackend, InputMeta, InputValue, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec,
-    ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec,
+    apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Checkout as ResourceCheckout,
+    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus,
+    Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, InMemoryBackend, InputMeta, InputValue, LifecycleAuthority,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, ResourceBackend,
+    ResourceError, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -216,6 +218,84 @@ fn parse_and_validate_workflow_template_yaml(yaml: &str) -> Result<WorkflowTempl
 
 fn parse_project_yaml(yaml: &str) -> Result<ProjectSpec, String> {
     serde_yml::from_str(yaml).map_err(|err| format!("invalid project YAML: {err}"))
+}
+
+fn adopted_checkout_name(convoy_name: &str) -> String {
+    format!("adopted-checkout-{convoy_name}")
+}
+
+async fn git_stdout(runner: &dyn CommandRunner, checkout_path: &Path, args: &[&str], description: &str) -> Result<String, String> {
+    runner
+        .run("git", args, checkout_path, &ChannelLabel::Noop)
+        .await
+        .map(|stdout| stdout.trim().to_string())
+        .map_err(|err| format!("{description} for {}: {err}", checkout_path.display()))
+}
+
+async fn infer_adopted_checkout_ref(runner: &dyn CommandRunner, checkout_path: &Path) -> Result<String, String> {
+    let branch = git_stdout(runner, checkout_path, &["rev-parse", "--abbrev-ref", "HEAD"], "failed to read checkout ref").await?;
+    if branch != "HEAD" {
+        return Ok(branch);
+    }
+    git_stdout(runner, checkout_path, &["rev-parse", "HEAD"], "failed to read checkout commit").await
+}
+
+async fn create_adopted_checkout_resource(
+    backend: &ResourceBackend,
+    namespace: &str,
+    convoy_name: &str,
+    checkout_path: &Path,
+    repository_url: Option<&String>,
+    git_ref: Option<&String>,
+    runner: &dyn CommandRunner,
+) -> Result<(String, String, String), String> {
+    let path = std::fs::canonicalize(checkout_path)
+        .map_err(|err| format!("adopted checkout path {} cannot be resolved: {err}", checkout_path.display()))?;
+    let path_str = path.to_string_lossy().to_string();
+    let repo_url = match repository_url {
+        Some(url) => url.clone(),
+        None => git_stdout(runner, &path, &["config", "--get", "remote.origin.url"], "failed to read origin URL").await?,
+    };
+    let git_ref = match git_ref {
+        Some(git_ref) => git_ref.clone(),
+        None => infer_adopted_checkout_ref(runner, &path).await?,
+    };
+    let checkout_ref = adopted_checkout_name(convoy_name);
+    let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
+    let meta = InputMeta::builder()
+        .name(checkout_ref.clone())
+        .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy_name.to_string())]))
+        .build()
+        .with_lifecycle_authority(LifecycleAuthority::Adopted);
+    let spec = ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+        r#ref: git_ref.clone(),
+        path: path_str.clone(),
+        repo_ref: repo_url.clone(),
+        is_main: matches!(git_ref.as_str(), "main" | "master" | "trunk"),
+    });
+
+    let checkout = match checkouts.create(&meta, &spec).await {
+        Ok(checkout) => checkout,
+        Err(ResourceError::Conflict { .. }) => {
+            let existing = checkouts.get(&checkout_ref).await.map_err(|err| err.to_string())?;
+            if existing.metadata.lifecycle_authority().map_err(|err| err.to_string())? != Some(LifecycleAuthority::Adopted) {
+                return Err(format!("checkout {checkout_ref} already exists but is not adopted"));
+            }
+            checkouts.update(&meta, &existing.metadata.resource_version, &spec).await.map_err(|err| err.to_string())?
+        }
+        Err(err) => return Err(err.to_string()),
+    };
+    checkouts
+        .update_status(&checkout_ref, &checkout.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            path: Some(path_str),
+            commit: None,
+            message: None,
+        })
+        .await
+        .map_err(|err| err.to_string())?;
+
+    Ok((checkout_ref, repo_url, git_ref))
 }
 
 async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str) -> Option<String> {
@@ -2054,6 +2134,7 @@ impl InProcessDaemon {
             r#ref,
             project_ref,
             placement_policy,
+            adopted_checkout,
         } = &command.action
         {
             let empty_identity = empty_repo_identity();
@@ -2070,13 +2151,60 @@ impl InProcessDaemon {
                 Some(policy) => Some(policy.clone()),
                 None => default_convoy_placement_policy(&self.resource_backend, &namespace).await,
             };
+            let mut repository_url = repository_url.clone();
+            let mut r#ref = r#ref.clone();
+            let adopted_checkout_ref = match adopted_checkout {
+                Some(path) => match self.local_command_runner() {
+                    Some(runner) => match create_adopted_checkout_resource(
+                        &self.resource_backend,
+                        &namespace,
+                        name,
+                        path.as_ref(),
+                        repository_url.as_ref(),
+                        r#ref.as_ref(),
+                        runner.as_ref(),
+                    )
+                    .await
+                    {
+                        Ok((checkout_ref, inferred_repository_url, inferred_ref)) => {
+                            repository_url.get_or_insert(inferred_repository_url);
+                            r#ref.get_or_insert(inferred_ref);
+                            Some(checkout_ref)
+                        }
+                        Err(message) => {
+                            let result = flotilla_protocol::CommandValue::Error { message };
+                            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                                command_id: id,
+                                node_id: self.node_id.clone(),
+                                repo_identity: empty_identity,
+                                repo: None,
+                                result,
+                            });
+                            return Ok(id);
+                        }
+                    },
+                    None => {
+                        let result = flotilla_protocol::CommandValue::Error { message: "local command runner unavailable".to_string() };
+                        let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                            command_id: id,
+                            node_id: self.node_id.clone(),
+                            repo_identity: empty_identity,
+                            repo: None,
+                            result,
+                        });
+                        return Ok(id);
+                    }
+                },
+                None => None,
+            };
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),
                 inputs: inputs.iter().map(|(k, v)| (k.clone(), InputValue::String(v.clone()))).collect(),
                 placement_policy,
-                repository: repository_url.clone().map(|url| ConvoyRepositorySpec { url }),
-                r#ref: r#ref.clone(),
+                repository: repository_url.map(|url| ConvoyRepositorySpec { url }),
+                r#ref,
                 project_ref: project_ref.clone(),
+                adopted_checkout_ref,
             };
             let meta = InputMeta::builder().name(name.clone()).build();
             let result = match convoys.create(&meta, &spec).await {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -9,7 +9,10 @@ use flotilla_protocol::{
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, DaemonEvent, EnvironmentId,
     EnvironmentStatus, HostPath, ImageId, Issue, RepoSelector,
 };
-use flotilla_resources::{Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, TaskPhase, TaskState};
+use flotilla_resources::{
+    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoyPhase,
+    ConvoySpec, ConvoyStatus, InputMeta, LifecycleAuthority, TaskPhase, TaskState,
+};
 
 use super::*;
 use crate::{
@@ -20,7 +23,7 @@ use crate::{
     model::RepoModel,
     providers::{
         discovery::{
-            test_support::{fake_discovery, DiscoveryMockRunner},
+            test_support::{fake_discovery, git_process_discovery, init_git_repo_with_remote, DiscoveryMockRunner},
             EnvironmentAssertion, EnvironmentBag,
         },
         environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount},
@@ -618,6 +621,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
             repository: None,
             r#ref: None,
             project_ref: None,
+            adopted_checkout_ref: None,
         })
         .await
         .expect("convoy create should succeed");
@@ -679,6 +683,77 @@ async fn convoy_completion_command_updates_convoy_task_status() {
 }
 
 #[tokio::test]
+async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let checkout_path = temp.path().join("repo");
+    let remote = "git@github.com:flotilla-org/flotilla.git";
+    init_git_repo_with_remote(&checkout_path, remote);
+
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), git_process_discovery(false), HostName::local()).await;
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "convoy-adopted".to_string(),
+                workflow_ref: "scratch".to_string(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: None,
+                adopted_checkout: Some(Box::new(checkout_path.clone())),
+            },
+        })
+        .await
+        .expect("execute should return a command id");
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected event error: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for command result");
+
+    assert_eq!(result, CommandValue::ConvoyCreated { name: "convoy-adopted".to_string() });
+    let convoy = daemon.resource_backend().using::<Convoy>("flotilla").get("convoy-adopted").await.expect("convoy should exist");
+    assert_eq!(convoy.spec.repository.as_ref().map(|repo| repo.url.as_str()), Some(remote));
+    assert_eq!(convoy.spec.r#ref.as_deref(), Some("main"));
+    assert_eq!(convoy.spec.adopted_checkout_ref.as_deref(), Some("adopted-checkout-convoy-adopted"));
+
+    let checkout = daemon
+        .resource_backend()
+        .using::<ResourceCheckout>("flotilla")
+        .get("adopted-checkout-convoy-adopted")
+        .await
+        .expect("adopted checkout should exist");
+    assert_eq!(checkout.metadata.lifecycle_authority().expect("authority should parse"), Some(LifecycleAuthority::Adopted));
+    match checkout.spec {
+        ResourceCheckoutSpec::Observed(spec) => {
+            assert_eq!(spec.r#ref, "main");
+            assert_eq!(spec.path, std::fs::canonicalize(&checkout_path).expect("canonical path").display().to_string());
+            assert_eq!(spec.repo_ref, remote);
+        }
+        other => panic!("expected observed checkout spec, got {other:?}"),
+    }
+    let status = checkout.status.expect("adopted checkout should be ready");
+    assert_eq!(status.phase, ResourceCheckoutPhase::Ready);
+    assert_eq!(status.path.as_deref(), Some(std::fs::canonicalize(&checkout_path).expect("canonical path").to_string_lossy().as_ref()));
+}
+
+#[tokio::test]
 async fn convoy_completion_command_targets_configured_provisioning_namespace() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
@@ -698,6 +773,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
             repository: None,
             r#ref: None,
             project_ref: None,
+            adopted_checkout_ref: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -62,6 +62,20 @@ fn empty_input_meta(name: &str) -> InputMeta {
     }
 }
 
+async fn wait_for_command_result(events: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected event error: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("timeout waiting for command result")
+}
+
 #[test]
 fn choose_event_uses_delta_for_non_initial_changes() {
     let repo = PathBuf::from("/tmp/repo");
@@ -751,6 +765,79 @@ async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource()
     let status = checkout.status.expect("adopted checkout should be ready");
     assert_eq!(status.phase, ResourceCheckoutPhase::Ready);
     assert_eq!(status.path.as_deref(), Some(std::fs::canonicalize(&checkout_path).expect("canonical path").to_string_lossy().as_ref()));
+}
+
+#[tokio::test]
+async fn duplicate_adopted_convoy_create_does_not_repoint_existing_checkout() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let checkout_a = temp.path().join("repo-a");
+    let checkout_b = temp.path().join("repo-b");
+    let remote = "git@github.com:flotilla-org/flotilla.git";
+    init_git_repo_with_remote(&checkout_a, remote);
+    init_git_repo_with_remote(&checkout_b, remote);
+
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), git_process_discovery(false), HostName::local()).await;
+    let mut events = daemon.subscribe();
+
+    let first_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "convoy-adopted".to_string(),
+                workflow_ref: "scratch".to_string(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: None,
+                adopted_checkout: Some(Box::new(checkout_a.clone())),
+            },
+        })
+        .await
+        .expect("first execute should return a command id");
+    assert_eq!(wait_for_command_result(&mut events, first_id).await, CommandValue::ConvoyCreated { name: "convoy-adopted".to_string() });
+
+    let second_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "convoy-adopted".to_string(),
+                workflow_ref: "scratch".to_string(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: None,
+                adopted_checkout: Some(Box::new(checkout_b)),
+            },
+        })
+        .await
+        .expect("second execute should return a command id");
+    let result = wait_for_command_result(&mut events, second_id).await;
+    assert!(matches!(result, CommandValue::Error { message } if message.contains("convoy convoy-adopted already exists")));
+
+    let checkout = daemon
+        .resource_backend()
+        .using::<ResourceCheckout>("flotilla")
+        .get("adopted-checkout-convoy-adopted")
+        .await
+        .expect("adopted checkout should still exist");
+    match checkout.spec {
+        ResourceCheckoutSpec::Observed(spec) => {
+            assert_eq!(spec.path, std::fs::canonicalize(&checkout_a).expect("canonical path").display().to_string());
+        }
+        other => panic!("expected observed checkout spec, got {other:?}"),
+    }
+    let status = checkout.status.expect("adopted checkout should be ready");
+    assert_eq!(status.path.as_deref(), Some(std::fs::canonicalize(&checkout_a).expect("canonical path").to_string_lossy().as_ref()));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/convoy_projection.rs
+++ b/crates/flotilla-daemon/src/convoy_projection.rs
@@ -411,6 +411,7 @@ mod tests {
                 repository: None,
                 r#ref: None,
                 project_ref: None,
+                adopted_checkout_ref: None,
             },
             status: Some(ConvoyStatus { phase, workflow_snapshot, tasks: task_states, ..Default::default() }),
         }
@@ -427,6 +428,7 @@ mod tests {
                 repository: None,
                 r#ref: None,
                 project_ref: None,
+                adopted_checkout_ref: None,
             },
             status: Some(ConvoyStatus {
                 phase: ResConvoyPhase::Active,
@@ -467,6 +469,7 @@ mod tests {
                 repository: None,
                 r#ref: None,
                 project_ref: None,
+                adopted_checkout_ref: None,
             },
             status: Some(ConvoyStatus {
                 phase: ResConvoyPhase::Pending,

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -964,10 +964,10 @@ mod tests {
         in_process::DEFAULT_PROVISIONING_NAMESPACE as NAMESPACE,
         providers::discovery::{test_support::git_process_discovery, EnvironmentAssertion, EnvironmentBag},
     };
-    use flotilla_protocol::{Command, CommandAction};
+    use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent};
     use flotilla_resources::{
-        ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, PlacementPolicy, ProcessDefinition, ProcessSource, SqliteBackend, TaskDefinition,
-        TaskPhase, TypedResolver, WorkflowTemplate, WorkflowTemplateSpec,
+        Checkout as ResourceCheckout, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, LifecycleAuthority, PlacementPolicy,
+        ProcessDefinition, ProcessSource, SqliteBackend, TaskDefinition, TaskPhase, TypedResolver, WorkflowTemplate, WorkflowTemplateSpec,
     };
     use tempfile::TempDir;
 
@@ -1091,6 +1091,7 @@ mod tests {
                 repository: Some(ConvoyRepositorySpec { url: "https://github.com/flotilla-org/flotilla.git".to_string() }),
                 r#ref: Some("main".to_string()),
                 project_ref: None,
+                adopted_checkout_ref: None,
             })
             .await
             .expect("convoy create should succeed");
@@ -1175,6 +1176,20 @@ mod tests {
             assert!(tokio::time::Instant::now() < deadline, "timed out waiting for condition");
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
+    }
+
+    async fn wait_for_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match rx.recv().await {
+                    Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                    Ok(_) => {}
+                    Err(err) => panic!("unexpected event error: {err}"),
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for command result")
     }
 
     #[tokio::test]
@@ -1298,5 +1313,140 @@ mod tests {
         config.save_repo(&ExecutionEnvironmentPath::new(&repo));
         let daemon = sqlite_daemon(vec![repo.clone()], Arc::clone(&config)).await;
         run_stage4a_flow_reaches_running_and_completes_convoy(daemon, config, repo_default_dir, repo).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_adopted_checkout_flow_reaches_running_and_preserves_checkout_on_complete() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo_default_dir = temp.path().join("flotilla-repos");
+        std::fs::create_dir_all(&repo_default_dir).expect("repo default dir");
+        let git_repo =
+            TestGitRepo::init(temp.path().join("repo")).with_initial_commit().with_origin("git@github.com:flotilla-org/flotilla.git");
+        let repo = git_repo.path().to_path_buf();
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        config.save_repo(&ExecutionEnvironmentPath::new(&repo));
+        let daemon = sqlite_daemon(vec![repo.clone()], Arc::clone(&config)).await;
+        let host_id = daemon.local_host_id().expect("local host id").to_string();
+        let profile =
+            LocalProvisioningProfile { repo_default_dir: repo_default_dir.display().to_string(), ..manual_profile(&host_id, false) };
+        let backend = daemon.resource_backend();
+
+        register_startup_resources(&daemon, NAMESPACE, &profile).await.expect("startup registration should succeed");
+        apply_host_heartbeat(&daemon, NAMESPACE, &profile).await.expect("host heartbeat should succeed");
+
+        let state = Arc::new(ControllerRuntimeState::new(
+            Arc::clone(&daemon),
+            Arc::clone(&config),
+            passthrough_registry(),
+            None,
+            profile.host_id.clone(),
+            Some(ExecutionEnvironmentPath::new(&repo)),
+            profile.host_direct_environment_name(),
+        ));
+        let namespace_projection_state = NamespaceProjectionState::new();
+        daemon.set_namespace_projection_state(namespace_projection_state.clone()).await;
+        let controller_handles = spawn_controller_loops(
+            Arc::clone(&state),
+            NAMESPACE,
+            Duration::from_millis(25),
+            ControllerSupervision::default(),
+            namespace_projection_state,
+        );
+
+        backend
+            .clone()
+            .using::<WorkflowTemplate>(NAMESPACE)
+            .create(
+                &empty_meta("wf-a"),
+                &WorkflowTemplateSpec::builder()
+                    .inputs(Vec::new())
+                    .tasks(vec![TaskDefinition::builder()
+                        .name("implement".to_string())
+                        .processes(vec![ProcessDefinition::builder()
+                            .role("coder".to_string())
+                            .source(ProcessSource::Tool { command: "bash -lc 'echo adopted-stage4a'".to_string() })
+                            .build()])
+                        .build()])
+                    .build(),
+            )
+            .await
+            .expect("workflow template create should succeed");
+
+        let mut rx = daemon.subscribe();
+        let create_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "convoy-adopted".to_string(),
+                    workflow_ref: "wf-a".to_string(),
+                    inputs: Vec::new(),
+                    repository_url: None,
+                    r#ref: None,
+                    project_ref: None,
+                    placement_policy: Some(format!("host-direct-{host_id}")),
+                    adopted_checkout: Some(Box::new(repo.clone())),
+                },
+            })
+            .await
+            .expect("convoy create command should start");
+        assert_eq!(wait_for_command_result(&mut rx, create_id).await, CommandValue::ConvoyCreated { name: "convoy-adopted".to_string() });
+
+        let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+        wait_until(|| {
+            let convoys = convoys.clone();
+            async move {
+                matches!(
+                    convoys.get("convoy-adopted").await.ok().and_then(|convoy| convoy.status).as_ref(),
+                    Some(status)
+                        if status.phase == ConvoyPhase::Active
+                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Running)
+                )
+            }
+        })
+        .await;
+
+        let complete_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyTaskComplete {
+                    convoy: "convoy-adopted".to_string(),
+                    task: "implement".to_string(),
+                    message: Some("done".to_string()),
+                },
+            })
+            .await
+            .expect("convoy completion command should start");
+        assert_eq!(wait_for_command_result(&mut rx, complete_id).await, CommandValue::Ok);
+
+        wait_until(|| {
+            let convoys = convoys.clone();
+            async move {
+                matches!(
+                    convoys.get("convoy-adopted").await.ok().and_then(|convoy| convoy.status).as_ref(),
+                    Some(status)
+                        if status.phase == ConvoyPhase::Completed
+                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Completed)
+                )
+            }
+        })
+        .await;
+
+        let checkout = backend
+            .clone()
+            .using::<ResourceCheckout>(NAMESPACE)
+            .get("adopted-checkout-convoy-adopted")
+            .await
+            .expect("adopted checkout should remain after completion");
+        assert_eq!(checkout.metadata.lifecycle_authority().expect("authority should parse"), Some(LifecycleAuthority::Adopted));
+        assert!(backend.clone().using::<ResourceCheckout>(NAMESPACE).get("checkout-convoy-adopted-implement").await.is_err());
+
+        for handle in controller_handles {
+            handle.abort();
+            let _ = handle.await;
+        }
     }
 }

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -290,6 +290,7 @@ async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
             repository: None,
             r#ref: None,
             project_ref: None,
+            adopted_checkout_ref: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -105,6 +105,7 @@ async fn convoy_create_command_creates_convoy_resource() {
                 r#ref: None,
                 project_ref: None,
                 placement_policy: None,
+                adopted_checkout: None,
             },
         })
         .await
@@ -212,6 +213,7 @@ async fn sqlite_backed_runtime_reconciles_convoy_create_into_namespace_view() {
                 r#ref: None,
                 project_ref: None,
                 placement_policy: None,
+                adopted_checkout: None,
             },
         })
         .await

--- a/crates/flotilla-daemon/tests/convoy_projection.rs
+++ b/crates/flotilla-daemon/tests/convoy_projection.rs
@@ -37,6 +37,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         repository: None,
         r#ref: None,
         project_ref: None,
+        adopted_checkout_ref: None,
     }
 }
 

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -171,6 +171,7 @@ async fn convoy_create_carries_project_ref() {
                 r#ref: None,
                 project_ref: Some("my-project".into()),
                 placement_policy: None,
+                adopted_checkout: None,
             },
         })
         .await

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -162,6 +162,8 @@ pub enum CommandAction {
         project_ref: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         placement_policy: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        adopted_checkout: Option<Box<PathBuf>>,
     },
     WorkflowTemplateApply {
         name: String,
@@ -547,6 +549,7 @@ mod tests {
                     r#ref: Some("main".into()),
                     project_ref: Some("my-project".into()),
                     placement_policy: Some("host-direct-local".into()),
+                    adopted_checkout: None,
                 },
             },
             Command {

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -51,6 +51,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         repository: None,
         r#ref: None,
         project_ref: None,
+        adopted_checkout_ref: None,
     }
 }
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -26,6 +26,8 @@ pub struct ConvoySpec {
     /// the reconciler does not consult it. Future: substitute repository/ref from project.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adopted_checkout_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -551,7 +551,12 @@ fn create_task_workspace_outcome(convoy: &ResourceObject<Convoy>, task: &str, no
                     controller: true,
                 }])
                 .build(),
-            spec: crate::TaskWorkspaceSpec { convoy_ref: convoy.metadata.name.clone(), task: task.to_string(), placement_policy_ref },
+            spec: crate::TaskWorkspaceSpec {
+                convoy_ref: convoy.metadata.name.clone(),
+                task: task.to_string(),
+                placement_policy_ref,
+                adopted_checkout_ref: convoy.spec.adopted_checkout_ref.clone(),
+            },
         }],
         events: Vec::new(),
     })

--- a/crates/flotilla-resources/src/task_workspace.rs
+++ b/crates/flotilla-resources/src/task_workspace.rs
@@ -10,6 +10,8 @@ pub struct TaskWorkspaceSpec {
     pub convoy_ref: String,
     pub task: String,
     pub placement_policy_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adopted_checkout_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -203,6 +203,7 @@ pub fn valid_convoy_spec() -> RealConvoySpec {
         repository: None,
         r#ref: None,
         project_ref: None,
+        adopted_checkout_ref: None,
     }
 }
 

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -599,6 +599,7 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
             convoy_ref: "alpha".to_string(),
             task: "implement".to_string(),
             placement_policy_ref: "local".to_string(),
+            adopted_checkout_ref: None,
         })
         .await
         .expect("task workspace create should succeed");

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -279,6 +279,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
                 convoy_ref: "convoy-delete".to_string(),
                 task: "implement".to_string(),
                 placement_policy_ref: "laptop-docker".to_string(),
+                adopted_checkout_ref: None,
             },
         )
         .await

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -112,6 +112,7 @@ fn task_workspace_object(
             convoy_ref: convoy_name.to_string(),
             task: task.to_string(),
             placement_policy_ref: "laptop-docker".to_string(),
+            adopted_checkout_ref: None,
         },
         status: Some(TaskWorkspaceStatus {
             phase,

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -38,6 +38,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         repository: None,
         r#ref: None,
         project_ref: None,
+        adopted_checkout_ref: None,
     }
 }
 

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -63,6 +63,7 @@ async fn task_workspace_metadata_and_status_roundtrip() {
         convoy_ref: "fix-bug-123".to_string(),
         task: "implement".to_string(),
         placement_policy_ref: "docker-on-01HXYZ".to_string(),
+        adopted_checkout_ref: None,
     };
     let created = resolver.create(&task_workspace_meta("convoy-fix-bug-123-implement"), &spec).await.expect("create should succeed");
     let updated = resolver

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -46,6 +46,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         repository: None,
         r#ref: None,
         project_ref: None,
+        adopted_checkout_ref: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the first adopted-checkout path for convoy creation.

- Adds `flotilla convoy <name> create --adopt-checkout <path>` and carries the selected checkout through the command protocol.
- Creates an observed checkout resource with adopted lifecycle authority, inferring repo/ref from the checkout when they are not supplied.
- Teaches task workspace reconciliation to use adopted checkouts directly, without creating or garbage-collecting managed clone/checkout resources.
- Adds focused command/controller/core tests and a sqlite runtime e2e for create, run, complete, and preservation of the adopted checkout.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #630.