### PR TITLE
[codex] Add store-backed attach command

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -6,7 +6,7 @@
 pub(crate) mod checkout;
 mod session_actions;
 mod terminals;
-mod workspace;
+pub(crate) mod workspace;
 
 use std::{
     path::{Path, PathBuf},
@@ -322,6 +322,7 @@ pub async fn build_plan(
         | CommandAction::QueryHostList {}
         | CommandAction::QueryHostStatus { .. }
         | CommandAction::QueryHostProviders { .. }
+        | CommandAction::Attach { .. }
         | CommandAction::QueryIssues { .. }
         | CommandAction::QueryIssueFetchByIds { .. }
         | CommandAction::QueryIssueOpenInBrowser { .. } => {

--- a/crates/flotilla-core/src/executor/workspace.rs
+++ b/crates/flotilla-core/src/executor/workspace.rs
@@ -320,7 +320,7 @@ fn workspace_attach_request_from_config(config: crate::providers::types::Workspa
 ///
 /// For each `ResolvedPaneCommand`, builds a `HopPlan` via `HopPlanBuilder::build_for_prepared_command`,
 /// resolves it with `SshRemoteHopResolver` + `AlwaysWrap`, and flattens the resulting `Command` to a string.
-fn resolve_prepared_commands_via_hop_chain(
+pub(crate) fn resolve_prepared_commands_via_hop_chain(
     target_host: &HostName,
     checkout_path: &Path,
     commands: &[ResolvedPaneCommand],

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -17,15 +17,16 @@ use async_trait::async_trait;
 use flotilla_protocol::{
     qualified_path::QualifiedPath, Command, CorrelationKey, DaemonEvent, DeltaEntry, EnvironmentId, HostListResponse, HostName,
     HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, ProviderData, ProviderInfo, RepoDelta,
-    RepoDetailResponse, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, StatusResponse, StreamKey,
-    SystemInfo, ToolInventory, TopologyResponse, TopologyRoute,
+    RepoDetailResponse, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse,
+    StreamKey, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute,
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Checkout as ResourceCheckout,
     CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus,
-    Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, InMemoryBackend, InputMeta, InputValue, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, ResourceBackend,
-    ResourceError, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL,
+    Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec,
+    ResourceBackend, ResourceError, TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, TASK_LABEL, TASK_WORKSPACE_LABEL,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -205,6 +206,48 @@ fn fallback_repo_identity(path: &Path) -> flotilla_protocol::RepoIdentity {
 
 fn empty_repo_identity() -> flotilla_protocol::RepoIdentity {
     flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() }
+}
+
+fn attach_reference_keys(session_name: &str, labels: &BTreeMap<String, String>) -> Vec<String> {
+    let mut refs = vec![session_name.to_string()];
+
+    let convoy = labels.get(CONVOY_LABEL);
+    let task = labels.get(TASK_LABEL);
+    let role = labels.get(ROLE_LABEL);
+    let task_workspace = labels.get(TASK_WORKSPACE_LABEL);
+
+    if let Some(convoy) = convoy {
+        refs.push(convoy.clone());
+    }
+    if let Some(task_workspace) = task_workspace {
+        refs.push(task_workspace.clone());
+    }
+    if let (Some(convoy), Some(task)) = (convoy, task) {
+        refs.push(format!("{convoy}/{task}"));
+    }
+    if let (Some(convoy), Some(task), Some(role)) = (convoy, task, role) {
+        refs.push(format!("{convoy}/{task}/{role}"));
+    }
+    if let (Some(task_workspace), Some(role)) = (task_workspace, role) {
+        refs.push(format!("{task_workspace}/{role}"));
+    }
+    if let Some(role) = role {
+        refs.push(role.clone());
+    }
+
+    refs.sort();
+    refs.dedup();
+    refs
+}
+
+fn attach_reference_label(session_name: &str, labels: &BTreeMap<String, String>) -> String {
+    match (labels.get(CONVOY_LABEL), labels.get(TASK_LABEL), labels.get(ROLE_LABEL)) {
+        (Some(convoy), Some(task), Some(role)) => format!("{convoy}/{task}/{role} ({session_name})"),
+        (Some(convoy), Some(task), None) => format!("{convoy}/{task} ({session_name})"),
+        (Some(convoy), None, Some(role)) => format!("{convoy}/{role} ({session_name})"),
+        (Some(convoy), None, None) => format!("{convoy} ({session_name})"),
+        _ => session_name.to_string(),
+    }
 }
 
 fn parse_and_validate_workflow_template_yaml(yaml: &str) -> Result<WorkflowTemplateSpec, String> {
@@ -1929,6 +1972,128 @@ impl InProcessDaemon {
         Ok(response)
     }
 
+    pub async fn resolve_attach_command_internal(&self, reference: &str) -> Result<String, String> {
+        if reference.trim().is_empty() {
+            return Err("attach reference is required".to_string());
+        }
+
+        let namespace = self.provisioning_namespace().await;
+        let terminal_sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace);
+        let sessions = terminal_sessions.list().await.map_err(|err| err.to_string())?.items;
+        let mut exact = Vec::new();
+        let mut prefix = Vec::new();
+
+        for session in sessions {
+            if session.status.as_ref().map(|status| status.phase) != Some(ResourceTerminalSessionPhase::Running) {
+                continue;
+            }
+            let refs = attach_reference_keys(&session.metadata.name, &session.metadata.labels);
+            let label = attach_reference_label(&session.metadata.name, &session.metadata.labels);
+            if refs.iter().any(|candidate| candidate == reference) {
+                exact.push((label, session));
+            } else if refs.iter().any(|candidate| candidate.starts_with(reference)) {
+                prefix.push((label, session));
+            }
+        }
+
+        let mut matches = if exact.is_empty() { prefix } else { exact };
+        match matches.len() {
+            0 => Err(format!("no attach target matching '{reference}'")),
+            1 => {
+                let (_label, session) = matches.remove(0);
+                self.attach_command_for_session(&session).await
+            }
+            _ => {
+                let mut labels: Vec<_> = matches.into_iter().map(|(label, _)| label).collect();
+                labels.sort();
+                labels.dedup();
+                Err(format!("attach reference '{reference}' is ambiguous: {}", labels.join(", ")))
+            }
+        }
+    }
+
+    async fn attach_command_for_session(
+        &self,
+        session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
+    ) -> Result<String, String> {
+        let namespace = self.provisioning_namespace().await;
+        let environments = self.resource_backend.clone().using::<ResourceEnvironment>(&namespace);
+        let environment = environments
+            .get(&session.spec.env_ref)
+            .await
+            .map_err(|err| format!("environment {} lookup failed: {err}", session.spec.env_ref))?;
+        let host_ref = environment
+            .spec
+            .host_direct
+            .as_ref()
+            .map(|spec| spec.host_ref.as_str())
+            .or_else(|| environment.spec.docker.as_ref().map(|spec| spec.host_ref.as_str()))
+            .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
+        let target_host = self.target_host_for_resource_ref(host_ref);
+        let cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
+        let registry = self.registry_for_resource_environment(&environment, cwd.as_path()).await?;
+        let pool = registry
+            .terminal_pools
+            .get(&session.spec.pool)
+            .map(|(_, pool)| Arc::clone(pool))
+            .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
+        let session_name =
+            session.status.as_ref().and_then(|status| status.session_id.as_deref()).unwrap_or(session.metadata.name.as_str());
+        let attach_args = pool.attach_args(session_name, &session.spec.command, &cwd, &Vec::new())?;
+        let command = ResolvedPaneCommand { role: session.spec.role.clone(), args: attach_args };
+        let environment_id = environment.spec.docker.as_ref().map(|_| EnvironmentId::new(session.spec.env_ref.clone()));
+        let container_name = environment.status.as_ref().and_then(|status| status.docker_container_id.as_deref());
+        let resolved = executor::workspace::resolve_prepared_commands_via_hop_chain(
+            &target_host,
+            cwd.as_path(),
+            &[command],
+            self.config.base_path().as_path(),
+            &self.host_name,
+            environment_id.as_ref(),
+            container_name,
+        )?;
+        resolved.into_iter().next().map(|(_, command)| command).ok_or_else(|| "attach command resolution produced no command".to_string())
+    }
+
+    fn target_host_for_resource_ref(&self, host_ref: &str) -> HostName {
+        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_ref) {
+            self.host_name.clone()
+        } else {
+            HostName::new(host_ref)
+        }
+    }
+
+    async fn registry_for_resource_environment(
+        &self,
+        environment: &flotilla_resources::ResourceObject<ResourceEnvironment>,
+        cwd: &Path,
+    ) -> Result<Arc<crate::providers::registry::ProviderRegistry>, String> {
+        let environment_id = if let Some(host_direct) = environment.spec.host_direct.as_ref() {
+            if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_direct.host_ref) {
+                self.local_environment_id.clone()
+            } else {
+                EnvironmentId::new(environment.metadata.name.clone())
+            }
+        } else {
+            EnvironmentId::new(environment.metadata.name.clone())
+        };
+
+        if let Some(registry) = self.environment_registry_for_environment(&environment_id) {
+            return Ok(registry);
+        }
+
+        discover_repo_for_environment(
+            &self.environment_manager,
+            &self.discovery,
+            &self.config,
+            &self.local_environment_id,
+            &environment_id,
+            cwd,
+        )
+        .await
+        .map(|result| Arc::new(result.registry))
+    }
+
     async fn refresh_local_host_summary(&self) -> HostSummary {
         let summary = crate::host_summary::build_local_host_summary(
             &self.node_id,
@@ -2704,6 +2869,10 @@ impl DaemonHandle for InProcessDaemon {
                     Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
                 }
             }
+            CommandAction::Attach { reference } => match self.resolve_attach_command_internal(reference).await {
+                Ok(command) => Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command }),
+                Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
+            },
             CommandAction::QueryIssues { repo, params, page, count } => {
                 let repo_path = self.resolve_repo_selector(repo).await?;
                 let service = self.get_issue_query_service(&repo_path).await?;

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    path::Path,
     sync::{Arc, OnceLock},
 };
 
@@ -11,7 +12,10 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoyPhase,
-    ConvoySpec, ConvoyStatus, InputMeta, LifecycleAuthority, TaskPhase, TaskState,
+    ConvoySpec, ConvoyStatus, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec,
+    InputMeta, LifecycleAuthority, TaskPhase, TaskState, TerminalSession as ResourceTerminalSession,
+    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSpec as ResourceTerminalSessionSpec,
+    TerminalSessionStatus as ResourceTerminalSessionStatus, CONVOY_LABEL, ROLE_LABEL, TASK_LABEL, TASK_WORKSPACE_LABEL,
 };
 
 use super::*;
@@ -23,7 +27,10 @@ use crate::{
     model::RepoModel,
     providers::{
         discovery::{
-            test_support::{fake_discovery, git_process_discovery, init_git_repo_with_remote, DiscoveryMockRunner},
+            test_support::{
+                fake_discovery, fake_discovery_with_provider_set, git_process_discovery, init_git_repo_with_remote, DiscoveryMockRunner,
+                FakeDiscoveryProviders, FakeTerminalPool,
+            },
             EnvironmentAssertion, EnvironmentBag,
         },
         environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount},
@@ -62,6 +69,10 @@ fn empty_input_meta(name: &str) -> InputMeta {
     }
 }
 
+fn input_meta_with_labels(name: &str, labels: BTreeMap<String, String>) -> InputMeta {
+    InputMeta { labels, ..empty_input_meta(name) }
+}
+
 async fn wait_for_command_result(events: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {
@@ -74,6 +85,82 @@ async fn wait_for_command_result(events: &mut tokio::sync::broadcast::Receiver<D
     })
     .await
     .expect("timeout waiting for command result")
+}
+
+async fn new_attach_test_daemon(config_base: &Path) -> Arc<InProcessDaemon> {
+    let terminal_pool = Arc::new(FakeTerminalPool::new());
+    let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(terminal_pool));
+    InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), discovery, HostName::local()).await
+}
+
+async fn create_local_attach_environment(daemon: &InProcessDaemon) -> String {
+    let host_id = daemon.local_host_id().expect("daemon should have a local host id");
+    let env_name = format!("host-direct-{host_id}");
+    daemon
+        .resource_backend()
+        .using::<ResourceEnvironment>("flotilla")
+        .create(&empty_input_meta(&env_name), &ResourceEnvironmentSpec {
+            host_direct: Some(HostDirectEnvironmentSpec { host_ref: host_id.to_string(), repo_default_dir: "/tmp".to_string() }),
+            docker: None,
+        })
+        .await
+        .expect("environment should be created");
+    env_name
+}
+
+async fn create_running_attach_session(
+    daemon: &InProcessDaemon,
+    env_ref: &str,
+    name: &str,
+    session_id: &str,
+    convoy: &str,
+    task: &str,
+    role: &str,
+) {
+    create_running_attach_session_with_pool(daemon, env_ref, name, session_id, convoy, task, role, "fake-terminals").await;
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_running_attach_session_with_pool(
+    daemon: &InProcessDaemon,
+    env_ref: &str,
+    name: &str,
+    session_id: &str,
+    convoy: &str,
+    task: &str,
+    role: &str,
+    pool: &str,
+) {
+    let terminals = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let created = terminals
+        .create(
+            &input_meta_with_labels(
+                name,
+                BTreeMap::from([
+                    (CONVOY_LABEL.to_string(), convoy.to_string()),
+                    (TASK_LABEL.to_string(), task.to_string()),
+                    (TASK_WORKSPACE_LABEL.to_string(), format!("{convoy}-{task}")),
+                    (ROLE_LABEL.to_string(), role.to_string()),
+                ]),
+            ),
+            &ResourceTerminalSessionSpec {
+                env_ref: env_ref.to_string(),
+                role: role.to_string(),
+                command: "bash".to_string(),
+                cwd: "/repo".to_string(),
+                pool: pool.to_string(),
+            },
+        )
+        .await
+        .expect("terminal session should be created");
+    terminals
+        .update_status(name, &created.metadata.resource_version, &ResourceTerminalSessionStatus {
+            phase: ResourceTerminalSessionPhase::Running,
+            session_id: Some(session_id.to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("terminal session should be running");
 }
 
 #[test]
@@ -99,6 +186,228 @@ fn choose_event_uses_delta_for_non_initial_changes() {
         changes: vec![flotilla_protocol::Change::Branch { key: "feature/x".into(), op: flotilla_protocol::EntryOp::Removed }],
     };
     assert!(matches!(choose_event(snapshot, non_empty), DaemonEvent::RepoDelta(_)));
+}
+
+#[tokio::test]
+async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "cleat-session-1",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::AttachCommandResolved { command: "attach cleat-session-1".to_string() });
+}
+
+#[tokio::test]
+async fn attach_query_prefers_exact_reference_over_prefix_matches() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "session-exact",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-alpha-implement-coder",
+        "session-prefix",
+        "convoy-alpha",
+        "implement",
+        "coder",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::AttachCommandResolved { command: "attach session-exact".to_string() });
+}
+
+#[tokio::test]
+async fn attach_query_rejects_ambiguous_prefix() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-alpha-implement-coder",
+        "session-alpha",
+        "convoy-alpha",
+        "implement",
+        "coder",
+    )
+    .await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-amber-implement-coder",
+        "session-amber",
+        "convoy-amber",
+        "implement",
+        "coder",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::Error { message } = result else {
+        panic!("expected ambiguous attach error, got {result:?}");
+    };
+    assert!(message.contains("ambiguous"), "message should explain ambiguity: {message}");
+    assert!(message.contains("convoy-alpha/implement/coder"), "message should include first candidate: {message}");
+    assert!(message.contains("convoy-amber/implement/coder"), "message should include second candidate: {message}");
+}
+
+#[tokio::test]
+async fn attach_query_reports_no_matching_reference() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
+        .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "missing".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::Error { message: "no attach target matching 'missing'".to_string() });
+}
+
+#[tokio::test]
+async fn attach_query_rejects_empty_reference() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::Error { message: "attach reference is required".to_string() });
+}
+
+#[tokio::test]
+async fn attach_query_errors_when_recorded_terminal_pool_is_unavailable() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session_with_pool(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "session-a",
+        "convoy-a",
+        "implement",
+        "coder",
+        "missing-terminals",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::Error { message: format!("terminal pool missing-terminals unavailable for environment {env_ref}") });
 }
 
 #[test]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -102,6 +102,9 @@ pub enum CommandAction {
     SelectWorkspace {
         ws_ref: String,
     },
+    Attach {
+        reference: String,
+    },
     PrepareTerminalForCheckout {
         checkout_path: PathBuf,
         /// Role→command mappings from the requesting host's template.
@@ -242,6 +245,7 @@ impl CommandAction {
                 | CommandAction::QueryHostList {}
                 | CommandAction::QueryHostStatus { .. }
                 | CommandAction::QueryHostProviders { .. }
+                | CommandAction::Attach { .. }
                 | CommandAction::QueryIssues { .. }
                 | CommandAction::QueryIssueFetchByIds { .. }
                 | CommandAction::QueryIssueOpenInBrowser { .. }
@@ -255,6 +259,7 @@ impl Command {
             CommandAction::CreateWorkspaceForCheckout { .. } => "Creating workspace...",
             CommandAction::CreateWorkspaceFromPreparedTerminal { .. } => "Creating workspace...",
             CommandAction::SelectWorkspace { .. } => "Switching workspace...",
+            CommandAction::Attach { .. } => "Resolving attach target...",
             CommandAction::PrepareTerminalForCheckout { .. } => "Preparing terminal...",
             CommandAction::Checkout { target, .. } => match target {
                 CheckoutTarget::Branch(_) => "Checking out branch...",
@@ -487,6 +492,12 @@ mod tests {
                 provisioning_target: None,
                 context_repo: None,
                 action: CommandAction::SelectWorkspace { ws_ref: "ws://1".into() },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a".into() },
             },
             Command {
                 node_id: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,11 @@ enum SubCommand {
     Watch,
     /// Show the daemon's current multi-host routing view
     Topology,
+    /// Attach to a running convoy crew session
+    Attach {
+        /// Convoy, task, role, terminal session, or unique prefix
+        reference: String,
+    },
     /// Receive agent hook events (called by agent hook systems)
     Hook {
         /// Agent harness name (e.g. claude-code, codex, gemini)
@@ -174,6 +179,7 @@ async fn main() -> Result<()> {
         Some(SubCommand::Status) => run_status(&cli, format).await,
         Some(SubCommand::Watch) => run_watch(&cli, format).await,
         Some(SubCommand::Topology) => run_topology_command(&cli, format).await,
+        Some(SubCommand::Attach { reference }) => run_attach(&cli, &reference, format).await,
         Some(SubCommand::Hook { harness, event_type }) => run_hook(&cli, &harness, &event_type).await,
         Some(SubCommand::Hooks { command }) => run_hooks_command(&command).await,
 
@@ -358,6 +364,55 @@ async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) 
     reset_sigpipe();
     let daemon = connect_daemon(cli).await?;
     flotilla_tui::cli::run_command(&*daemon, command, format).await.map_err(|e| color_eyre::eyre::eyre!(e))
+}
+
+async fn run_attach(cli: &Cli, reference: &str, format: OutputFormat) -> Result<()> {
+    reset_sigpipe();
+    let daemon = connect_daemon(cli).await?;
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: reference.to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!(e))?;
+
+    match result {
+        CommandValue::AttachCommandResolved { command } => match format {
+            OutputFormat::Json => {
+                println!("{}", flotilla_protocol::output::json_pretty(&CommandValue::AttachCommandResolved { command }));
+                Ok(())
+            }
+            OutputFormat::Human => exec_attach_command(&command),
+        },
+        CommandValue::Error { message } => Err(color_eyre::eyre::eyre!(message)),
+        other => Err(color_eyre::eyre::eyre!("unexpected attach response: {other:?}")),
+    }
+}
+
+#[cfg(unix)]
+fn exec_attach_command(command: &str) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+
+    Err(std::process::Command::new("sh").arg("-lc").arg(command).exec().into())
+}
+
+#[cfg(not(unix))]
+fn exec_attach_command(command: &str) -> Result<()> {
+    let status = std::process::Command::new("sh").arg("-lc").arg(command).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(color_eyre::eyre::eyre!(
+            "attach command exited with status {}",
+            status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
+        ))
+    }
 }
 
 async fn resolve_host_target(cli: &Cli, subject: &HostName) -> Result<(EnvironmentId, flotilla_protocol::NodeId)> {
@@ -843,6 +898,12 @@ mod tests {
         let cli = Cli::try_parse_from(["flotilla", "topology", "--json"]).expect("topology json should parse");
         assert!(matches!(cli.command, Some(SubCommand::Topology)));
         assert!(cli.json);
+    }
+
+    #[test]
+    fn cli_parses_attach_subcommand() {
+        let cli = Cli::try_parse_from(["flotilla", "attach", "convoy-a/implement/coder"]).expect("attach cli should parse");
+        assert!(matches!(cli.command, Some(SubCommand::Attach { reference }) if reference == "convoy-a/implement/coder"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add top-level `flotilla attach <ref>` and protocol `CommandAction::Attach`
- resolve running `TerminalSession` resources by exact ref or unique prefix, then compose terminal attach via the existing hop-chain wrapper
- cover local attach resolution, exact-over-prefix matching, ambiguous prefixes, protocol roundtrip, and CLI parsing

Closes #631.
Follow-up recursive next-hop attach design filed as #637.

## Tests

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
