### PR TITLE
[codex] Resolve attach through recursive next hop

### DIFF
--- a/crates/flotilla-core/src/hop_chain/remote.rs
+++ b/crates/flotilla-core/src/hop_chain/remote.rs
@@ -81,6 +81,25 @@ impl SshRemoteHopResolver {
         args.push(Arg::Quoted(info.target.clone()));
         args
     }
+
+    /// Build a single SSH hop that runs `command` on `host`.
+    ///
+    /// Unlike `resolve_wrap`, this intentionally does not inspect or wrap an
+    /// already-resolved inner action. Store-backed recursive attach uses this
+    /// to emit one next-hop command and lets the next daemon resolve the
+    /// following hop locally. The command still runs through a login shell so
+    /// user-installed tools such as `flotilla` under `~/.cargo/bin` are found.
+    pub fn one_hop_command_args(&self, host: &HostName, command: Vec<Arg>) -> Result<Vec<Arg>, String> {
+        let info = self.ssh_info(host)?;
+        let mut ssh_args = self.ssh_prefix_args(&info);
+        ssh_args.push(Arg::NestedCommand(vec![
+            Arg::Literal("${SHELL:-/bin/sh}".into()),
+            Arg::Literal("-l".into()),
+            Arg::Literal("-c".into()),
+            Arg::NestedCommand(command),
+        ]));
+        Ok(ssh_args)
+    }
 }
 
 impl RemoteHopResolver for SshRemoteHopResolver {

--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -162,6 +162,50 @@ impl HostRegistry {
         build_topology(&self.local_node, &routes, &configured)
     }
 
+    pub(crate) async fn next_hop_host_for_target_host(&self, target_host: &HostName) -> Result<Option<HostName>, String> {
+        let local_host_name = self.local_host_summary.read().await.host_name.clone().unwrap_or_else(HostName::local);
+        let hosts = self.hosts.read().await;
+        let mut host_names_by_node: HashMap<NodeId, HostName> = hosts
+            .values()
+            .filter(|state| !state.removed)
+            .filter_map(|state| {
+                state.summary.as_ref().and_then(|summary| summary.host_name.clone()).map(|host| (state.node_id.clone(), host))
+            })
+            .collect();
+        host_names_by_node.insert(self.local_node.node_id.clone(), local_host_name);
+
+        let mut target_nodes: Vec<_> =
+            host_names_by_node.iter().filter_map(|(node, host)| (host == target_host).then_some(node.clone())).collect();
+        target_nodes.sort();
+        target_nodes.dedup();
+
+        let target_node = match target_nodes.as_slice() {
+            [] => return Ok(None),
+            [node] => node,
+            _ => return Err(format!("host name '{target_host}' matches multiple routed nodes")),
+        };
+
+        let routes = self.topology_routes.read().await;
+        let Some(route) = routes.iter().find(|route| route.target.node_id == *target_node) else {
+            return Ok(None);
+        };
+        let next_hop_node = if route.connected {
+            &route.next_hop.node_id
+        } else if let Some(fallback) = route.fallbacks.first() {
+            // PeerManager emits fallbacks most-recently learned first, matching
+            // its route promotion policy.
+            &fallback.node_id
+        } else {
+            return Err(format!("unreachable next hop for host '{target_host}'"));
+        };
+
+        host_names_by_node
+            .get(next_hop_node)
+            .cloned()
+            .ok_or_else(|| format!("unreachable next hop for host '{target_host}': no host summary for node {next_hop_node}"))
+            .map(Some)
+    }
+
     pub(crate) async fn replay_host_events(&self, last_seen: &HashMap<StreamKey, u64>) -> Vec<DaemonEvent> {
         let configured = self.configured_peers.read().await.clone();
         let node_connectivity = self.node_connectivity.read().await.clone();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -39,6 +39,7 @@ use crate::{
     environment_manager::EnvironmentManager,
     executor,
     executor::checkout::{checkout_matches_scope, CheckoutResolutionScope},
+    hop_chain::remote::ssh_resolver_from_config,
     host_identity::{
         resolve_local_environment_state_dir, resolve_local_host_id, resolve_local_node_id, resolve_or_create_environment_id,
         resolve_or_create_remote_environment_id, resolve_or_create_remote_host_id,
@@ -2001,7 +2002,7 @@ impl InProcessDaemon {
             0 => Err(format!("no attach target matching '{reference}'")),
             1 => {
                 let (_label, session) = matches.remove(0);
-                self.attach_command_for_session(&session).await
+                self.attach_command_for_session(reference, &session).await
             }
             _ => {
                 let mut labels: Vec<_> = matches.into_iter().map(|(label, _)| label).collect();
@@ -2014,6 +2015,7 @@ impl InProcessDaemon {
 
     async fn attach_command_for_session(
         &self,
+        reference: &str,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
     ) -> Result<String, String> {
         let namespace = self.provisioning_namespace().await;
@@ -2030,8 +2032,38 @@ impl InProcessDaemon {
             .or_else(|| environment.spec.docker.as_ref().map(|spec| spec.host_ref.as_str()))
             .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
         let target_host = self.target_host_for_resource_ref(host_ref);
+        if target_host != self.host_name {
+            return self.recursive_attach_command_for_remote(&target_host, reference).await;
+        }
+
+        self.local_attach_command_for_session(session, &environment).await
+    }
+
+    async fn recursive_attach_command_for_remote(&self, target_host: &HostName, reference: &str) -> Result<String, String> {
+        let next_hop = self.host_registry.next_hop_host_for_target_host(target_host).await?.unwrap_or_else(|| target_host.clone());
+        if next_hop == self.host_name {
+            return Err(format!("unreachable next hop for host '{target_host}': route points back to local host"));
+        }
+
+        let resolver = ssh_resolver_from_config(self.config.base_path())?;
+        let command = vec![
+            flotilla_protocol::arg::Arg::Literal("flotilla".to_string()),
+            flotilla_protocol::arg::Arg::Literal("attach".to_string()),
+            flotilla_protocol::arg::Arg::Quoted(reference.to_string()),
+        ];
+        let args = resolver
+            .one_hop_command_args(&next_hop, command)
+            .map_err(|err| format!("unreachable next hop '{next_hop}' for host '{target_host}': {err}"))?;
+        Ok(flotilla_protocol::arg::flatten(&args, 0))
+    }
+
+    async fn local_attach_command_for_session(
+        &self,
+        session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
+        environment: &flotilla_resources::ResourceObject<ResourceEnvironment>,
+    ) -> Result<String, String> {
         let cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
-        let registry = self.registry_for_resource_environment(&environment, cwd.as_path()).await?;
+        let registry = self.registry_for_resource_environment(environment, cwd.as_path()).await?;
         let pool = registry
             .terminal_pools
             .get(&session.spec.pool)
@@ -2040,19 +2072,26 @@ impl InProcessDaemon {
         let session_name =
             session.status.as_ref().and_then(|status| status.session_id.as_deref()).unwrap_or(session.metadata.name.as_str());
         let attach_args = pool.attach_args(session_name, &session.spec.command, &cwd, &Vec::new())?;
-        let command = ResolvedPaneCommand { role: session.spec.role.clone(), args: attach_args };
-        let environment_id = environment.spec.docker.as_ref().map(|_| EnvironmentId::new(session.spec.env_ref.clone()));
-        let container_name = environment.status.as_ref().and_then(|status| status.docker_container_id.as_deref());
-        let resolved = executor::workspace::resolve_prepared_commands_via_hop_chain(
-            &target_host,
-            cwd.as_path(),
-            &[command],
-            self.config.base_path().as_path(),
-            &self.host_name,
-            environment_id.as_ref(),
-            container_name,
-        )?;
-        resolved.into_iter().next().map(|(_, command)| command).ok_or_else(|| "attach command resolution produced no command".to_string())
+        if environment.spec.docker.is_some() {
+            let command = ResolvedPaneCommand { role: session.spec.role.clone(), args: attach_args };
+            let environment_id = EnvironmentId::new(session.spec.env_ref.clone());
+            let container_name = environment.status.as_ref().and_then(|status| status.docker_container_id.as_deref());
+            let resolved = executor::workspace::resolve_prepared_commands_via_hop_chain(
+                &self.host_name,
+                cwd.as_path(),
+                &[command],
+                self.config.base_path().as_path(),
+                &self.host_name,
+                Some(&environment_id),
+                container_name,
+            )?;
+            return resolved
+                .into_iter()
+                .next()
+                .map(|(_, command)| command)
+                .ok_or_else(|| "attach command resolution produced no command".to_string());
+        }
+        Ok(flotilla_protocol::arg::flatten(&attach_args, 0))
     }
 
     fn target_host_for_resource_ref(&self, host_ref: &str) -> HostName {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
 
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, DaemonEvent, EnvironmentId,
-    EnvironmentStatus, HostPath, ImageId, Issue, RepoSelector,
+    EnvironmentStatus, HostEnvironment, HostPath, HostSummary, ImageId, Issue, RepoSelector, SystemInfo, ToolInventory, TopologyRoute,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoyPhase,
@@ -106,6 +106,58 @@ async fn create_local_attach_environment(daemon: &InProcessDaemon) -> String {
         .await
         .expect("environment should be created");
     env_name
+}
+
+async fn create_remote_attach_environment(daemon: &InProcessDaemon, host: &str) -> String {
+    let env_name = format!("host-direct-{host}");
+    daemon
+        .resource_backend()
+        .using::<ResourceEnvironment>("flotilla")
+        .create(&empty_input_meta(&env_name), &ResourceEnvironmentSpec {
+            host_direct: Some(HostDirectEnvironmentSpec { host_ref: host.to_string(), repo_default_dir: "/tmp".to_string() }),
+            docker: None,
+        })
+        .await
+        .expect("remote environment should be created");
+    env_name
+}
+
+fn write_attach_hosts_config(config_base: &Path, hosts: &[(&str, &str, Option<&str>)]) {
+    let mut toml = "[ssh]\nmultiplex = false\n".to_string();
+    for (label, hostname, user) in hosts {
+        toml.push_str(&format!(
+            "\n[hosts.{label}]\nhostname = \"{hostname}\"\nexpected_host_name = \"{label}\"\ndaemon_socket = \"/tmp/flotilla.sock\"\n"
+        ));
+        if let Some(user) = user {
+            toml.push_str(&format!("user = \"{user}\"\n"));
+        }
+    }
+    std::fs::write(config_base.join("hosts.toml"), toml).expect("write hosts config");
+}
+
+async fn publish_attach_host_summary(daemon: &InProcessDaemon, node_name: &str, host_name: &str) {
+    daemon
+        .host_registry
+        .publish_peer_summary(
+            HostSummary {
+                environment_id: EnvironmentId::host(HostId::new(format!("{node_name}-{host_name}-host"))),
+                host_name: Some(HostName::new(host_name)),
+                node: node(node_name),
+                system: SystemInfo {
+                    home_dir: Some(PathBuf::from("/home/test")),
+                    os: Some("linux".to_string()),
+                    arch: Some("aarch64".to_string()),
+                    cpu_count: Some(4),
+                    memory_total_mb: Some(8192),
+                    environment: HostEnvironment::BareMetal,
+                },
+                inventory: ToolInventory::default(),
+                providers: vec![],
+                environments: vec![],
+            },
+            &|_| {},
+        )
+        .await;
 }
 
 async fn create_running_attach_session(
@@ -222,6 +274,107 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
         .expect("attach query should execute");
 
     assert_eq!(result, CommandValue::AttachCommandResolved { command: "attach cleat-session-1".to_string() });
+}
+
+#[tokio::test]
+async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_remote_attach_environment(&daemon, "feta").await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "remote-provider-session",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "command should target the next host over SSH: {command}");
+    assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
+    assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach: {command}");
+    assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
+    assert!(!command.contains("remote-provider-session"), "remote hop must not include terminal-provider attach args: {command}");
+    assert_eq!(command.matches("flotilla attach").count(), 1, "command should contain exactly one recursive attach invocation: {command}");
+}
+
+#[tokio::test]
+async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    publish_attach_host_summary(&daemon, "feta", "feta").await;
+    publish_attach_host_summary(&daemon, "gouda", "gouda").await;
+    daemon
+        .set_topology_routes(vec![TopologyRoute {
+            target: node("gouda"),
+            next_hop: node("feta"),
+            direct: false,
+            connected: true,
+            fallbacks: vec![],
+        }])
+        .await;
+
+    let env_ref = create_remote_attach_environment(&daemon, "gouda").await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "gouda-provider-session",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "command should target the routed next hop: {command}");
+    assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
+    assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach on the next hop: {command}");
+    assert!(!command.contains("gouda.local"), "command should not try to jump directly to the final host: {command}");
+    assert!(!command.contains("gouda-provider-session"), "command should not embed final terminal-provider attach args: {command}");
 }
 
 #[tokio::test]
@@ -347,6 +500,111 @@ async fn attach_query_reports_no_matching_reference() {
         .expect("attach query should execute");
 
     assert_eq!(result, CommandValue::Error { message: "no attach target matching 'missing'".to_string() });
+}
+
+#[tokio::test]
+async fn attach_query_reports_unreachable_next_hop_for_remote_session_without_host_config() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_remote_attach_environment(&daemon, "missing-host").await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
+        .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::Error { message } = result else {
+        panic!("expected unreachable next-hop error, got {result:?}");
+    };
+    assert!(message.contains("unreachable next hop 'missing-host'"), "message should identify the unreachable next hop: {message}");
+    assert!(message.contains("unknown remote host"), "message should include the host config lookup failure: {message}");
+}
+
+#[tokio::test]
+async fn attach_query_reports_route_that_points_back_to_local_host() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    publish_attach_host_summary(&daemon, "feta", "feta").await;
+    daemon
+        .set_topology_routes(vec![TopologyRoute {
+            target: node("feta"),
+            next_hop: NodeInfo::new(daemon.node_id().clone(), "local"),
+            direct: false,
+            connected: true,
+            fallbacks: vec![],
+        }])
+        .await;
+
+    let env_ref = create_remote_attach_environment(&daemon, "feta").await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
+        .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::Error {
+        message: "unreachable next hop for host 'feta': route points back to local host".to_string()
+    });
+}
+
+#[tokio::test]
+async fn attach_query_reports_ambiguous_routed_host_name() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    publish_attach_host_summary(&daemon, "feta-a", "feta").await;
+    publish_attach_host_summary(&daemon, "feta-b", "feta").await;
+
+    let env_ref = create_remote_attach_environment(&daemon, "feta").await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
+        .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::Error { message: "host name 'feta' matches multiple routed nodes".to_string() });
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -1284,17 +1284,16 @@ impl PeerManager {
         let mut routes: Vec<_> = self
             .routes
             .iter()
-            .map(|(target, route)| TopologyRoute {
-                target: self.node_info_for(target),
-                next_hop: self.node_info_for(&route.primary.next_hop),
-                direct: route.primary.next_hop == *target,
-                connected: self.route_hop_is_live(&route.primary),
-                fallbacks: route
-                    .fallbacks
-                    .iter()
-                    .filter(|hop| self.route_hop_is_live(hop))
-                    .map(|hop| self.node_info_for(&hop.next_hop))
-                    .collect(),
+            .map(|(target, route)| {
+                let mut fallbacks: Vec<_> = route.fallbacks.iter().filter(|hop| self.route_hop_is_live(hop)).collect();
+                fallbacks.sort_by_key(|hop| std::cmp::Reverse(hop.learned_epoch));
+                TopologyRoute {
+                    target: self.node_info_for(target),
+                    next_hop: self.node_info_for(&route.primary.next_hop),
+                    direct: route.primary.next_hop == *target,
+                    connected: self.route_hop_is_live(&route.primary),
+                    fallbacks: fallbacks.into_iter().map(|hop| self.node_info_for(&hop.next_hop)).collect(),
+                }
             })
             .collect();
         routes.sort_by(|a, b| a.target.node_id.cmp(&b.target.node_id));

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -868,6 +868,52 @@ async fn accepted_snapshot_refreshes_route_primary_to_live_hop() {
 }
 
 #[tokio::test]
+async fn topology_routes_sort_fallbacks_by_most_recently_learned() {
+    let mut mgr = PeerManager::new(NodeId::new("local"));
+    let relay_a_generation =
+        accepted_generation(mgr.activate_connection(NodeId::new("relay-a"), MockPeerSender::discard(), ConnectionMeta {
+            direction: ConnectionDirection::Inbound,
+            config_label: None,
+            expected_peer: None,
+            config_backed: false,
+        }));
+    let relay_b_generation =
+        accepted_generation(mgr.activate_connection(NodeId::new("relay-b"), MockPeerSender::discard(), ConnectionMeta {
+            direction: ConnectionDirection::Inbound,
+            config_label: None,
+            expected_peer: None,
+            config_backed: false,
+        }));
+    let relay_c_generation =
+        accepted_generation(mgr.activate_connection(NodeId::new("relay-c"), MockPeerSender::discard(), ConnectionMeta {
+            direction: ConnectionDirection::Inbound,
+            config_label: None,
+            expected_peer: None,
+            config_backed: false,
+        }));
+
+    mgr.routes.insert(NodeId::new("target"), RouteState {
+        primary: RouteHop { next_hop: NodeId::new("relay-a"), next_hop_generation: relay_a_generation, learned_epoch: 30 },
+        fallbacks: vec![
+            RouteHop { next_hop: NodeId::new("relay-b"), next_hop_generation: relay_b_generation, learned_epoch: 10 },
+            RouteHop { next_hop: NodeId::new("relay-c"), next_hop_generation: relay_c_generation, learned_epoch: 20 },
+        ],
+        candidates: Vec::new(),
+    });
+
+    let route = mgr
+        .topology_routes()
+        .into_iter()
+        .find(|route| route.target.node_id == NodeId::new("target"))
+        .expect("target route should be exposed");
+
+    assert_eq!(route.fallbacks.iter().map(|node| node.node_id.clone()).collect::<Vec<_>>(), vec![
+        NodeId::new("relay-c"),
+        NodeId::new("relay-b"),
+    ]);
+}
+
+#[tokio::test]
 async fn disconnect_peer_keeps_unrelated_pending_resync_requests() {
     let mut mgr = PeerManager::new(NodeId::new("local"));
     let _ = accepted_generation(mgr.activate_connection(NodeId::new("target"), MockPeerSender::discard(), ConnectionMeta {


### PR DESCRIPTION
## Summary

Closes #637.

- Change store-backed attach so remote sessions resolve to a single recursive next-hop command instead of a flattened provider attach chain.
- Use topology routes to choose the immediate next-hop host when the target host is reachable transitively.
- Keep local attach using terminal-provider attach args, preserving the existing local Docker environment wrapping path.
- Add tests for local attach, one-hop remote attach, routed multi-hop shape, and unreachable next-hop errors.

## Tests

- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked