### PR TITLE
feat: add store-backed fleet listing

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -320,6 +320,8 @@ pub async fn build_plan(
         | CommandAction::QueryRepoProviders { .. }
         | CommandAction::QueryRepoWork { .. }
         | CommandAction::QueryHostList {}
+        | CommandAction::QueryFleetList {}
+        | CommandAction::QueryFleetReplicaSnapshot {}
         | CommandAction::QueryHostStatus { .. }
         | CommandAction::QueryHostProviders { .. }
         | CommandAction::Attach { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -14,11 +14,13 @@ use std::{
 };
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use flotilla_protocol::{
-    qualified_path::QualifiedPath, Command, CorrelationKey, DaemonEvent, DeltaEntry, EnvironmentId, HostListResponse, HostName,
-    HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, ProviderData, ProviderInfo, RepoDelta,
-    RepoDetailResponse, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse,
-    StreamKey, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute,
+    qualified_path::QualifiedPath, Command, CorrelationKey, DaemonEvent, DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow,
+    FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName, HostProvidersResponse, HostStatusResponse,
+    HostSummary, NodeId, NodeInfo, PeerConnectionState, ProviderData, ProviderInfo, RepoDelta, RepoDetailResponse, RepoInfo,
+    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse, StreamKey, SystemInfo,
+    ToolInventory, TopologyResponse, TopologyRoute,
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Checkout as ResourceCheckout,
@@ -33,7 +35,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    config::{ConfigStore, StaticEnvironmentConfig},
+    config::{ConfigStore, RemoteHostConfig, StaticEnvironmentConfig},
     convert::snapshot_to_proto,
     daemon::DaemonHandle,
     environment_manager::EnvironmentManager,
@@ -248,6 +250,71 @@ fn attach_reference_label(session_name: &str, labels: &BTreeMap<String, String>)
         (Some(convoy), None, Some(role)) => format!("{convoy}/{role} ({session_name})"),
         (Some(convoy), None, None) => format!("{convoy} ({session_name})"),
         _ => session_name.to_string(),
+    }
+}
+
+fn session_status_label(phase: Option<ResourceTerminalSessionPhase>) -> String {
+    match phase {
+        Some(ResourceTerminalSessionPhase::Starting) | None => "starting".to_string(),
+        Some(ResourceTerminalSessionPhase::Running) => "running".to_string(),
+        Some(ResourceTerminalSessionPhase::Stopped) => "stopped".to_string(),
+    }
+}
+
+fn resource_environment_host_ref(environment: &flotilla_resources::ResourceObject<ResourceEnvironment>) -> Option<&str> {
+    environment
+        .spec
+        .host_direct
+        .as_ref()
+        .map(|spec| spec.host_ref.as_str())
+        .or_else(|| environment.spec.docker.as_ref().map(|spec| spec.host_ref.as_str()))
+}
+
+fn ssh_destination(remote: &RemoteHostConfig) -> String {
+    match remote.user.as_deref() {
+        Some(user) if !user.is_empty() => format!("{user}@{}", remote.hostname),
+        _ => remote.hostname.clone(),
+    }
+}
+
+fn fleet_replica_ssh_args(remote: &RemoteHostConfig, multiplex: bool) -> Vec<String> {
+    let mut args = vec!["-T".to_string(), "-o".to_string(), "BatchMode=yes".to_string()];
+    if multiplex {
+        args.extend([
+            "-o".to_string(),
+            "ControlMaster=auto".to_string(),
+            "-o".to_string(),
+            "ControlPath=/tmp/flotilla-ssh-%C".to_string(),
+            "-o".to_string(),
+            "ControlPersist=60".to_string(),
+        ]);
+    }
+    args.push(ssh_destination(remote));
+    args.push("${SHELL:-/bin/sh}".to_string());
+    args.push("-l".to_string());
+    args.push("-c".to_string());
+    args.push(format!(
+        "cd / && exec {} {} {} {} {}",
+        flotilla_protocol::arg::shell_quote("flotilla"),
+        flotilla_protocol::arg::shell_quote("--socket"),
+        flotilla_protocol::arg::shell_quote(remote.daemon_socket.as_str()),
+        flotilla_protocol::arg::shell_quote("--json"),
+        flotilla_protocol::arg::shell_quote("replica-snapshot"),
+    ));
+    args
+}
+
+fn replica_staleness(entry: &FleetReplicaCacheEntry, now: DateTime<Utc>) -> FleetStaleness {
+    if let Some(message) = &entry.last_error {
+        return FleetStaleness::Unreachable { last_sync: entry.last_sync, message: message.clone() };
+    }
+    let Some(last_sync) = entry.last_sync else {
+        return FleetStaleness::Unreachable { last_sync: None, message: "replica has never synced".to_string() };
+    };
+    if now.signed_duration_since(last_sync).num_seconds() > FLEET_REPLICA_FRESH_SECS {
+        FleetStaleness::Stale { last_sync }
+    } else {
+        FleetStaleness::Fresh { last_sync }
     }
 }
 
@@ -614,6 +681,14 @@ fn collect_linked_issue_ids(providers: &ProviderData) -> Vec<String> {
     ids.into_iter().collect()
 }
 
+#[derive(Debug, Clone)]
+struct FleetReplicaCacheEntry {
+    rows: Vec<FleetListRow>,
+    last_sync: Option<DateTime<Utc>>,
+    generation: Option<String>,
+    last_error: Option<String>,
+}
+
 pub struct InProcessDaemon {
     repos: RwLock<HashMap<flotilla_protocol::RepoIdentity, RepoState>>,
     repo_order: RwLock<Vec<flotilla_protocol::RepoIdentity>>,
@@ -666,12 +741,15 @@ pub struct InProcessDaemon {
     /// looking up the Convoy whose task is being marked complete). Set by the
     /// daemon runtime at startup; defaults to [`DEFAULT_PROVISIONING_NAMESPACE`].
     provisioning_namespace: RwLock<String>,
+    fleet_replica_cache: RwLock<HashMap<HostName, FleetReplicaCacheEntry>>,
 }
 
 /// Default provisioning namespace used until [`InProcessDaemon::set_provisioning_namespace`]
 /// is called. Matches `RuntimeOptions::namespace`'s default so tests that construct
 /// the daemon directly hit the same namespace the runtime uses.
 pub const DEFAULT_PROVISIONING_NAMESPACE: &str = "flotilla";
+const FLEET_REPLICA_FRESH_SECS: i64 = 90;
+const FLEET_REPLICA_REFRESH_TIMEOUT: Duration = Duration::from_secs(2);
 
 impl InProcessDaemon {
     /// Create a new in-process daemon tracking the given repo paths.
@@ -796,6 +874,7 @@ impl InProcessDaemon {
             observed_resource_backend: ResourceBackend::InMemory(InMemoryBackend::observed()),
             namespace_projection_state: RwLock::new(NamespaceProjectionState::new()),
             provisioning_namespace: RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
+            fleet_replica_cache: RwLock::new(HashMap::new()),
         });
 
         // Spawn self-driving poll loop with a Weak reference.
@@ -1973,6 +2052,182 @@ impl InProcessDaemon {
         Ok(response)
     }
 
+    pub async fn fleet_replica_snapshot_internal(&self) -> Result<FleetReplicaSnapshot, String> {
+        let namespace = self.provisioning_namespace().await;
+        let (rows, generation) = self.local_fleet_rows(&namespace).await?;
+        let namespaces = self.namespace_projection_state().await.all_snapshots().await;
+        Ok(FleetReplicaSnapshot { host: self.host_name.clone(), generation, rows, namespaces })
+    }
+
+    pub async fn fleet_list_internal(&self) -> Result<FleetListResponse, String> {
+        let namespace = self.provisioning_namespace().await;
+        let (mut rows, _generation) = self.local_fleet_rows(&namespace).await?;
+        let mut replicas = Vec::new();
+        let now = Utc::now();
+        let configured_hosts = self.config.load_hosts().map(|hosts| hosts.hosts).unwrap_or_default();
+        let cache = self.fleet_replica_cache.read().await;
+
+        for (label, remote) in configured_hosts {
+            let host = HostName::new(remote.expected_host_name);
+            match cache.get(&host) {
+                Some(entry) => {
+                    let staleness = replica_staleness(entry, now);
+                    rows.extend(entry.rows.iter().cloned().map(|mut row| {
+                        row.staleness = staleness.clone();
+                        row
+                    }));
+                    replicas.push(FleetReplicaStatus {
+                        host,
+                        reachable: entry.last_error.is_none(),
+                        last_sync: entry.last_sync,
+                        generation: entry.generation.clone(),
+                        message: entry.last_error.clone(),
+                    });
+                }
+                None => {
+                    replicas.push(FleetReplicaStatus {
+                        host,
+                        reachable: false,
+                        last_sync: None,
+                        generation: None,
+                        message: Some(format!("replica source '{label}' has not synced yet")),
+                    });
+                }
+            }
+        }
+
+        rows.sort_by(|left, right| {
+            (&left.convoy, left.host.as_str(), &left.vessel, &left.crew).cmp(&(
+                &right.convoy,
+                right.host.as_str(),
+                &right.vessel,
+                &right.crew,
+            ))
+        });
+        replicas.sort_by(|left, right| left.host.as_str().cmp(right.host.as_str()));
+        Ok(FleetListResponse { rows, replicas })
+    }
+
+    pub async fn refresh_fleet_replicas_once(&self) -> Result<(), String> {
+        let hosts = self.config.load_hosts()?;
+        let runner = self.local_command_runner().ok_or_else(|| "local command runner unavailable".to_string())?;
+        for (label, remote) in &hosts.hosts {
+            let host = HostName::new(remote.expected_host_name.clone());
+            let multiplex = hosts.resolved_ssh_multiplex(label);
+            let result = self.fetch_fleet_replica_snapshot(remote, multiplex, Arc::clone(&runner)).await;
+            match result {
+                Ok(snapshot) => {
+                    let now = Utc::now();
+                    let snapshot_host = snapshot.host;
+                    let generation = snapshot.generation;
+                    let rows = snapshot.rows.into_iter().map(|mut row| {
+                        row.host = snapshot_host.clone();
+                        row.staleness = FleetStaleness::Fresh { last_sync: now };
+                        row
+                    });
+                    self.fleet_replica_cache.write().await.insert(host, FleetReplicaCacheEntry {
+                        rows: rows.collect(),
+                        last_sync: Some(now),
+                        generation,
+                        last_error: None,
+                    });
+                }
+                Err(message) => {
+                    let mut cache = self.fleet_replica_cache.write().await;
+                    cache.entry(host).and_modify(|entry| entry.last_error = Some(message.clone())).or_insert_with(|| {
+                        FleetReplicaCacheEntry { rows: Vec::new(), last_sync: None, generation: None, last_error: Some(message) }
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn fetch_fleet_replica_snapshot(
+        &self,
+        remote: &RemoteHostConfig,
+        multiplex: bool,
+        runner: Arc<dyn CommandRunner>,
+    ) -> Result<FleetReplicaSnapshot, String> {
+        let args = fleet_replica_ssh_args(remote, multiplex);
+        let arg_refs: Vec<_> = args.iter().map(String::as_str).collect();
+        let output =
+            tokio::time::timeout(FLEET_REPLICA_REFRESH_TIMEOUT, runner.run_output("ssh", &arg_refs, Path::new("/"), &ChannelLabel::Noop))
+                .await
+                .map_err(|_| format!("replica snapshot timed out after {}s", FLEET_REPLICA_REFRESH_TIMEOUT.as_secs()))?
+                .map_err(|err| format!("replica snapshot ssh failed: {err}"))?;
+        if !output.success {
+            let message = if output.stderr.trim().is_empty() { output.stdout.trim() } else { output.stderr.trim() };
+            return Err(format!("replica snapshot command failed: {message}"));
+        }
+        serde_json::from_str(output.stdout.trim()).map_err(|err| format!("replica snapshot parse failed: {err}"))
+    }
+
+    async fn local_fleet_rows(&self, namespace: &str) -> Result<(Vec<FleetListRow>, Option<String>), String> {
+        let terminal_sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(namespace);
+        let environments = self.resource_backend.clone().using::<ResourceEnvironment>(namespace);
+        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(namespace);
+
+        let session_list = terminal_sessions.list().await.map_err(|err| err.to_string())?;
+        let environment_map: HashMap<_, _> = environments
+            .list()
+            .await
+            .map_err(|err| err.to_string())?
+            .items
+            .into_iter()
+            .map(|environment| (environment.metadata.name.clone(), environment))
+            .collect();
+        let mut authority_by_convoy = HashMap::new();
+        for checkout in checkouts.list().await.map_err(|err| err.to_string())?.items {
+            let Some(convoy) = checkout.metadata.labels.get(CONVOY_LABEL).cloned() else {
+                continue;
+            };
+            let authority = checkout
+                .metadata
+                .lifecycle_authority()
+                .map_err(|err| err.to_string())?
+                .map(|authority| authority.as_label_value().to_string());
+            if authority.is_some() {
+                authority_by_convoy.insert(convoy, authority);
+            }
+        }
+
+        let mut rows = Vec::new();
+        for session in session_list.items {
+            let labels = &session.metadata.labels;
+            let convoy = labels.get(CONVOY_LABEL).cloned().unwrap_or_else(|| "-".to_string());
+            let task = labels.get(TASK_LABEL).cloned();
+            let role = labels.get(ROLE_LABEL).cloned().unwrap_or_else(|| session.spec.role.clone());
+            let crew = match task {
+                Some(task) => format!("{task}/{role}"),
+                None => role,
+            };
+            let host = environment_map
+                .get(&session.spec.env_ref)
+                .and_then(|environment| resource_environment_host_ref(environment))
+                .map(|host_ref| self.target_host_for_resource_ref(host_ref))
+                .unwrap_or_else(|| self.host_name.clone());
+            rows.push(FleetListRow {
+                convoy: convoy.clone(),
+                vessel: session.spec.env_ref.clone(),
+                authority: authority_by_convoy.get(&convoy).cloned().flatten(),
+                crew,
+                crew_state: session_status_label(session.status.as_ref().map(|status| status.phase)),
+                host,
+                staleness: FleetStaleness::Local,
+            });
+        }
+        rows.sort_by(|left, right| {
+            (&left.convoy, left.host.as_str(), &left.vessel, &left.crew).cmp(&(
+                &right.convoy,
+                right.host.as_str(),
+                &right.vessel,
+                &right.crew,
+            ))
+        });
+        Ok((rows, session_list.generation))
+    }
+
     pub async fn resolve_attach_command_internal(&self, reference: &str) -> Result<String, String> {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
@@ -2908,6 +3163,14 @@ impl DaemonHandle for InProcessDaemon {
                     Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
                 }
             }
+            CommandAction::QueryFleetList {} => match self.fleet_list_internal().await {
+                Ok(v) => Ok(flotilla_protocol::CommandValue::FleetList(Box::new(v))),
+                Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
+            },
+            CommandAction::QueryFleetReplicaSnapshot {} => match self.fleet_replica_snapshot_internal().await {
+                Ok(v) => Ok(flotilla_protocol::CommandValue::FleetReplicaSnapshot(Box::new(v))),
+                Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
+            },
             CommandAction::Attach { reference } => match self.resolve_attach_command_internal(reference).await {
                 Ok(command) => Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command }),
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -16,11 +16,13 @@ use std::{
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{
-    qualified_path::QualifiedPath, Command, CorrelationKey, DaemonEvent, DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow,
-    FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName, HostProvidersResponse, HostStatusResponse,
-    HostSummary, NodeId, NodeInfo, PeerConnectionState, ProviderData, ProviderInfo, RepoDelta, RepoDetailResponse, RepoInfo,
-    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse, StreamKey, SystemInfo,
-    ToolInventory, TopologyResponse, TopologyRoute,
+    arg::{flatten, Arg},
+    qualified_path::QualifiedPath,
+    Command, CorrelationKey, DaemonEvent, DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot,
+    FleetReplicaStatus, FleetStaleness, HostListResponse, HostName, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId,
+    NodeInfo, PeerConnectionState, ProviderData, ProviderInfo, RepoDelta, RepoDetailResponse, RepoInfo, RepoProvidersResponse,
+    RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse, StreamKey, SystemInfo, ToolInventory,
+    TopologyResponse, TopologyRoute,
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Checkout as ResourceCheckout,
@@ -278,7 +280,15 @@ fn ssh_destination(remote: &RemoteHostConfig) -> String {
 }
 
 fn fleet_replica_ssh_args(remote: &RemoteHostConfig, multiplex: bool) -> Vec<String> {
-    let mut args = vec!["-T".to_string(), "-o".to_string(), "BatchMode=yes".to_string()];
+    let mut args = vec![
+        "-T".to_string(),
+        "-o".to_string(),
+        "BatchMode=yes".to_string(),
+        "-o".to_string(),
+        format!("ConnectTimeout={}", FLEET_REPLICA_REFRESH_TIMEOUT.as_secs()),
+        "-o".to_string(),
+        "ConnectionAttempts=1".to_string(),
+    ];
     if multiplex {
         args.extend([
             "-o".to_string(),
@@ -290,17 +300,24 @@ fn fleet_replica_ssh_args(remote: &RemoteHostConfig, multiplex: bool) -> Vec<Str
         ]);
     }
     args.push(ssh_destination(remote));
-    args.push("${SHELL:-/bin/sh}".to_string());
-    args.push("-l".to_string());
-    args.push("-c".to_string());
-    args.push(format!(
-        "cd / && exec {} {} {} {} {}",
-        flotilla_protocol::arg::shell_quote("flotilla"),
-        flotilla_protocol::arg::shell_quote("--socket"),
-        flotilla_protocol::arg::shell_quote(remote.daemon_socket.as_str()),
-        flotilla_protocol::arg::shell_quote("--json"),
-        flotilla_protocol::arg::shell_quote("replica-snapshot"),
-    ));
+    let snapshot_command = vec![
+        Arg::Literal("cd".to_string()),
+        Arg::Quoted("/".to_string()),
+        Arg::Literal("&&".to_string()),
+        Arg::Literal("exec".to_string()),
+        Arg::Literal("flotilla".to_string()),
+        Arg::Literal("--socket".to_string()),
+        Arg::Quoted(remote.daemon_socket.clone()),
+        Arg::Literal("--json".to_string()),
+        Arg::Quoted("replica-snapshot".to_string()),
+    ];
+    let login_wrapper = vec![
+        Arg::Literal("${SHELL:-/bin/sh}".to_string()),
+        Arg::Literal("-l".to_string()),
+        Arg::Literal("-c".to_string()),
+        Arg::NestedCommand(snapshot_command),
+    ];
+    args.push(flatten(&login_wrapper, 0));
     args
 }
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -246,6 +246,53 @@ async fn create_adopted_checkout_for_convoy(daemon: &InProcessDaemon, convoy: &s
         .expect("adopted checkout should be ready");
 }
 
+#[test]
+fn fleet_replica_ssh_args_wraps_snapshot_command_in_remote_login_shell() {
+    let remote = crate::config::RemoteHostConfig {
+        hostname: "feta.local".to_string(),
+        expected_host_name: "feta".to_string(),
+        expected_node_id: None,
+        user: Some("alice".to_string()),
+        daemon_socket: "/tmp/flotilla.sock".to_string(),
+        ssh_multiplex: None,
+    };
+
+    let args = fleet_replica_ssh_args(&remote, false);
+
+    assert_eq!(&args[..5], ["-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=2"]);
+    assert_eq!(args[5], "-o");
+    assert_eq!(args[6], "ConnectionAttempts=1");
+    assert_eq!(args[7], "alice@feta.local");
+    assert_eq!(args.len(), 9);
+
+    let remote_command = args.last().expect("remote command arg");
+    assert!(remote_command.starts_with("${SHELL:-/bin/sh} -l -c "), "remote command should start with login shell: {remote_command}");
+    assert!(remote_command.contains("exec flotilla --socket"), "remote command should execute flotilla: {remote_command}");
+    assert!(remote_command.contains("/tmp/flotilla.sock"), "remote command should include socket: {remote_command}");
+    assert!(remote_command.contains("replica-snapshot"), "remote command should include hidden subcommand: {remote_command}");
+    assert!(!args.iter().any(|arg| arg == "&&"), "shell operators must not be separate SSH argv elements: {args:?}");
+}
+
+#[test]
+fn fleet_replica_ssh_args_preserves_multiplex_options() {
+    let remote = crate::config::RemoteHostConfig {
+        hostname: "feta.local".to_string(),
+        expected_host_name: "feta".to_string(),
+        expected_node_id: None,
+        user: None,
+        daemon_socket: "/tmp/flotilla.sock".to_string(),
+        ssh_multiplex: None,
+    };
+
+    let args = fleet_replica_ssh_args(&remote, true);
+
+    assert!(args.windows(2).any(|window| window == ["-o", "ControlMaster=auto"]));
+    assert!(args.windows(2).any(|window| window == ["-o", "ControlPath=/tmp/flotilla-ssh-%C"]));
+    assert!(args.windows(2).any(|window| window == ["-o", "ControlPersist=60"]));
+    assert_eq!(args[13], "feta.local");
+    assert!(args[14].starts_with("${SHELL:-/bin/sh} -l -c "));
+}
+
 struct QueuedOutputRunner {
     outputs: Mutex<VecDeque<CommandOutput>>,
 }
@@ -268,9 +315,10 @@ impl CommandRunner for QueuedOutputRunner {
 
     async fn run_output(&self, cmd: &str, args: &[&str], _cwd: &Path, _label: &ChannelLabel) -> Result<CommandOutput, String> {
         assert_eq!(cmd, "ssh");
+        assert!(args.contains(&"ConnectTimeout=2"), "replica fetch should bound ssh connection time: {args:?}");
         assert!(
-            args.contains(&"${SHELL:-/bin/sh}") && args.windows(2).any(|window| window == ["-l", "-c"]),
-            "replica fetch should run through the remote login shell: {args:?}"
+            args.last().is_some_and(|arg| arg.starts_with("${SHELL:-/bin/sh} -l -c ") && arg.contains("exec flotilla")),
+            "replica fetch should pass one remote command through the remote login shell: {args:?}"
         );
         self.outputs.lock().expect("outputs mutex").pop_front().ok_or_else(|| "no queued output".to_string())
     }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1,7 +1,7 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, VecDeque},
     path::{Path, PathBuf},
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use async_trait::async_trait;
@@ -11,9 +11,10 @@ use flotilla_protocol::{
     EnvironmentStatus, HostEnvironment, HostPath, HostSummary, ImageId, Issue, RepoSelector, SystemInfo, ToolInventory, TopologyRoute,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoyPhase,
-    ConvoySpec, ConvoyStatus, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec,
-    InputMeta, LifecycleAuthority, TaskPhase, TaskState, TerminalSession as ResourceTerminalSession,
+    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, Environment as ResourceEnvironment,
+    EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec, InputMeta, LifecycleAuthority,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, TaskPhase, TaskState, TerminalSession as ResourceTerminalSession,
     TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSpec as ResourceTerminalSessionSpec,
     TerminalSessionStatus as ResourceTerminalSessionStatus, CONVOY_LABEL, ROLE_LABEL, TASK_LABEL, TASK_WORKSPACE_LABEL,
 };
@@ -34,7 +35,7 @@ use crate::{
             EnvironmentAssertion, EnvironmentBag,
         },
         environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount},
-        CommandRunner,
+        ChannelLabel, CommandOutput, CommandRunner,
     },
 };
 
@@ -213,6 +214,199 @@ async fn create_running_attach_session_with_pool(
         })
         .await
         .expect("terminal session should be running");
+}
+
+async fn create_adopted_checkout_for_convoy(daemon: &InProcessDaemon, convoy: &str) {
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let checkout_name = format!("adopted-checkout-{convoy}");
+    let created = checkouts
+        .create(
+            &InputMeta::builder()
+                .name(checkout_name.clone())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+                r#ref: "main".to_string(),
+                path: "/repo".to_string(),
+                repo_ref: "git@example.com:owner/repo.git".to_string(),
+                is_main: true,
+            }),
+        )
+        .await
+        .expect("adopted checkout should be created");
+    checkouts
+        .update_status(&checkout_name, &created.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            path: Some("/repo".to_string()),
+            commit: None,
+            message: None,
+        })
+        .await
+        .expect("adopted checkout should be ready");
+}
+
+struct QueuedOutputRunner {
+    outputs: Mutex<VecDeque<CommandOutput>>,
+}
+
+impl QueuedOutputRunner {
+    fn new(outputs: Vec<CommandOutput>) -> Self {
+        Self { outputs: Mutex::new(outputs.into()) }
+    }
+}
+
+#[async_trait]
+impl CommandRunner for QueuedOutputRunner {
+    async fn run(&self, cmd: &str, args: &[&str], _cwd: &Path, _label: &ChannelLabel) -> Result<String, String> {
+        if cmd == "git" && args == ["--version"] {
+            Ok("git version 2.43.0".to_string())
+        } else {
+            Err(format!("QueuedOutputRunner: no run response for {cmd} {}", args.join(" ")))
+        }
+    }
+
+    async fn run_output(&self, cmd: &str, args: &[&str], _cwd: &Path, _label: &ChannelLabel) -> Result<CommandOutput, String> {
+        assert_eq!(cmd, "ssh");
+        assert!(
+            args.contains(&"${SHELL:-/bin/sh}") && args.windows(2).any(|window| window == ["-l", "-c"]),
+            "replica fetch should run through the remote login shell: {args:?}"
+        );
+        self.outputs.lock().expect("outputs mutex").pop_front().ok_or_else(|| "no queued output".to_string())
+    }
+
+    async fn exists(&self, _cmd: &str, _args: &[&str]) -> bool {
+        false
+    }
+}
+
+#[tokio::test]
+async fn fleet_list_reports_store_backed_local_sessions_with_authority() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_adopted_checkout_for_convoy(&daemon, "convoy-a").await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
+        .await;
+
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+
+    assert!(response.replicas.is_empty());
+    assert_eq!(response.rows.len(), 1);
+    let row = &response.rows[0];
+    assert_eq!(row.convoy, "convoy-a");
+    assert_eq!(row.vessel, env_ref);
+    assert_eq!(row.authority.as_deref(), Some("adopted"));
+    assert_eq!(row.crew, "implement/coder");
+    assert_eq!(row.crew_state, "running");
+    assert_eq!(row.host, daemon.host_name);
+    assert_eq!(row.staleness, FleetStaleness::Local);
+
+    let snapshot = daemon.fleet_replica_snapshot_internal().await.expect("fleet replica snapshot should succeed");
+    assert_eq!(snapshot.host, daemon.host_name);
+    assert_eq!(snapshot.rows, response.rows);
+}
+
+#[tokio::test]
+async fn fleet_list_preserves_stale_rows_when_replica_is_unreachable() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let last_sync = Utc::now() - chrono::Duration::seconds(FLEET_REPLICA_FRESH_SECS + 1);
+    daemon.fleet_replica_cache.write().await.insert(HostName::new("feta"), FleetReplicaCacheEntry {
+        rows: vec![FleetListRow {
+            convoy: "convoy-remote".to_string(),
+            vessel: "remote-env".to_string(),
+            authority: None,
+            crew: "implement/coder".to_string(),
+            crew_state: "running".to_string(),
+            host: HostName::new("feta"),
+            staleness: FleetStaleness::Local,
+        }],
+        last_sync: Some(last_sync),
+        generation: Some("gen-1".to_string()),
+        last_error: Some("connection refused".to_string()),
+    });
+
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+
+    assert_eq!(response.rows.len(), 1);
+    assert!(matches!(
+        &response.rows[0].staleness,
+        FleetStaleness::Unreachable { last_sync: Some(sync), ref message } if *sync == last_sync && message == "connection refused"
+    ));
+    assert_eq!(response.replicas.len(), 1);
+    assert_eq!(response.replicas[0].host, HostName::new("feta"));
+    assert!(!response.replicas[0].reachable);
+    assert_eq!(response.replicas[0].last_sync, Some(last_sync));
+    assert_eq!(response.replicas[0].generation.as_deref(), Some("gen-1"));
+    assert_eq!(response.replicas[0].message.as_deref(), Some("connection refused"));
+}
+
+#[tokio::test]
+async fn replica_refresh_replaces_rows_when_generation_changes() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let first = FleetReplicaSnapshot {
+        host: HostName::new("feta"),
+        generation: Some("gen-1".to_string()),
+        rows: vec![FleetListRow {
+            convoy: "old-convoy".to_string(),
+            vessel: "old-env".to_string(),
+            authority: None,
+            crew: "implement/coder".to_string(),
+            crew_state: "running".to_string(),
+            host: HostName::new("feta"),
+            staleness: FleetStaleness::Local,
+        }],
+        namespaces: vec![],
+    };
+    let second = FleetReplicaSnapshot {
+        host: HostName::new("feta"),
+        generation: Some("gen-2".to_string()),
+        rows: vec![FleetListRow {
+            convoy: "new-convoy".to_string(),
+            vessel: "new-env".to_string(),
+            authority: Some("adopted".to_string()),
+            crew: "reviewer".to_string(),
+            crew_state: "stopped".to_string(),
+            host: HostName::new("feta"),
+            staleness: FleetStaleness::Local,
+        }],
+        namespaces: vec![],
+    };
+    let runner = Arc::new(QueuedOutputRunner::new(vec![
+        CommandOutput { stdout: serde_json::to_string(&first).expect("serialize first snapshot"), stderr: String::new(), success: true },
+        CommandOutput { stdout: serde_json::to_string(&second).expect("serialize second snapshot"), stderr: String::new(), success: true },
+    ]));
+    let mut discovery =
+        fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(Arc::new(FakeTerminalPool::new())));
+    discovery.runner = runner;
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), discovery, HostName::local()).await;
+
+    daemon.refresh_fleet_replicas_once().await.expect("first refresh should succeed");
+    daemon.refresh_fleet_replicas_once().await.expect("second refresh should succeed");
+
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+    assert_eq!(response.rows.len(), 1);
+    assert_eq!(response.rows[0].convoy, "new-convoy");
+    assert_eq!(response.rows[0].authority.as_deref(), Some("adopted"));
+    assert!(matches!(&response.rows[0].staleness, FleetStaleness::Fresh { .. }));
+    assert_eq!(response.replicas.len(), 1);
+    assert!(response.replicas[0].reachable);
+    assert_eq!(response.replicas[0].generation.as_deref(), Some("gen-2"));
 }
 
 #[test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -97,8 +97,10 @@ impl DaemonRuntime {
         register_startup_resources(&daemon, &options.namespace, &profile).await?;
         apply_host_heartbeat(&daemon, &options.namespace, &profile).await?;
 
-        let mut tasks =
-            vec![spawn_heartbeat_task(Arc::clone(&daemon), options.namespace.clone(), profile.clone(), options.heartbeat_interval)];
+        let mut tasks = vec![
+            spawn_heartbeat_task(Arc::clone(&daemon), options.namespace.clone(), profile.clone(), options.heartbeat_interval),
+            spawn_replica_refresh_task(Arc::clone(&daemon), options.heartbeat_interval),
+        ];
 
         if options.start_controllers {
             let local_repo_root = daemon.tracked_repo_paths().await.into_iter().next().map(ExecutionEnvironmentPath::new);
@@ -462,6 +464,19 @@ fn spawn_heartbeat_task(
             ticker.tick().await;
             if let Err(err) = apply_host_heartbeat(&daemon, &namespace, &profile).await {
                 warn!(%err, "failed to publish host heartbeat");
+            }
+        }
+    })
+}
+
+fn spawn_replica_refresh_task(daemon: Arc<InProcessDaemon>, interval: Duration) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            if let Err(err) = daemon.refresh_fleet_replicas_once().await {
+                warn!(%err, "failed to refresh fleet replicas");
             }
         }
     })

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -6,7 +6,10 @@ use crate::{
     arg::Arg,
     issue_query::{IssueQuery, IssueResultPage},
     qualified_path::QualifiedPath,
-    query::{HostListResponse, HostProvidersResponse, HostStatusResponse, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse},
+    query::{
+        FleetListResponse, FleetReplicaSnapshot, HostListResponse, HostProvidersResponse, HostStatusResponse, RepoDetailResponse,
+        RepoProvidersResponse, RepoWorkResponse,
+    },
     AttachableSetId, RepoIdentity,
 };
 #[cfg(test)]
@@ -232,6 +235,8 @@ pub enum CommandAction {
     QueryHostProviders {
         target_environment_id: crate::EnvironmentId,
     },
+    QueryFleetList {},
+    QueryFleetReplicaSnapshot {},
 }
 
 impl CommandAction {
@@ -245,6 +250,8 @@ impl CommandAction {
                 | CommandAction::QueryHostList {}
                 | CommandAction::QueryHostStatus { .. }
                 | CommandAction::QueryHostProviders { .. }
+                | CommandAction::QueryFleetList {}
+                | CommandAction::QueryFleetReplicaSnapshot {}
                 | CommandAction::Attach { .. }
                 | CommandAction::QueryIssues { .. }
                 | CommandAction::QueryIssueFetchByIds { .. }
@@ -291,6 +298,8 @@ impl Command {
             CommandAction::QueryHostList {} => "query host list",
             CommandAction::QueryHostStatus { .. } => "query host status",
             CommandAction::QueryHostProviders { .. } => "query host providers",
+            CommandAction::QueryFleetList {} => "query fleet list",
+            CommandAction::QueryFleetReplicaSnapshot {} => "query fleet replica snapshot",
         }
     }
 }
@@ -349,6 +358,8 @@ pub enum CommandValue {
     HostList(Box<HostListResponse>),
     HostStatus(Box<HostStatusResponse>),
     HostProviders(Box<HostProvidersResponse>),
+    FleetList(Box<FleetListResponse>),
+    FleetReplicaSnapshot(Box<FleetReplicaSnapshot>),
     ImageEnsured {
         image: crate::ImageId,
     },
@@ -404,8 +415,8 @@ mod tests {
     use crate::{
         arg::Arg,
         query::{
-            HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse, RepoDetailResponse, RepoProvidersResponse,
-            RepoWorkResponse,
+            FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse,
+            HostProvidersResponse, HostStatusResponse, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse,
         },
         test_helpers::assert_json_roundtrip,
         AttachableSetId, HostEnvironment, HostProviderStatus, HostSummary, NodeId, NodeInfo, PeerConnectionState, RepoIdentity, SystemInfo,
@@ -616,6 +627,8 @@ mod tests {
                 action: CommandAction::QueryRepoWork { repo: RepoSelector::Path(PathBuf::from("/repo")) },
             },
             Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryHostList {} },
+            Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryFleetList {} },
+            Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryFleetReplicaSnapshot {} },
             Command {
                 node_id: None,
                 provisioning_target: None,
@@ -798,6 +811,38 @@ mod tests {
                     environments: vec![],
                 },
                 visible_environments: vec![],
+            })),
+            CommandValue::FleetList(Box::new(FleetListResponse {
+                rows: vec![FleetListRow {
+                    convoy: "convoy-a".into(),
+                    vessel: "vessel-a".into(),
+                    authority: Some("adopted".into()),
+                    crew: "implement/main".into(),
+                    crew_state: "running".into(),
+                    host: crate::HostName::new("desktop"),
+                    staleness: FleetStaleness::Local,
+                }],
+                replicas: vec![FleetReplicaStatus {
+                    host: crate::HostName::new("feta"),
+                    reachable: false,
+                    last_sync: None,
+                    generation: None,
+                    message: Some("not synced".into()),
+                }],
+            })),
+            CommandValue::FleetReplicaSnapshot(Box::new(FleetReplicaSnapshot {
+                host: crate::HostName::new("desktop"),
+                generation: Some("7".into()),
+                rows: vec![FleetListRow {
+                    convoy: "convoy-a".into(),
+                    vessel: "vessel-a".into(),
+                    authority: None,
+                    crew: "main".into(),
+                    crew_state: "exited".into(),
+                    host: crate::HostName::new("desktop"),
+                    staleness: FleetStaleness::Local,
+                }],
+                namespaces: vec![],
             })),
             CommandValue::ImageEnsured { image: crate::ImageId::new("sha256:abc123") },
             CommandValue::EnvironmentCreated { env_id: crate::EnvironmentId::new("env-1") },

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -89,9 +89,9 @@ pub use provider_data::{
     WorkingTreeStatus, Workspace,
 };
 pub use query::{
-    DiscoveryEntry, HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse, ProviderHealthMap, ProviderInfo,
-    RepoDetailResponse, RepoProvidersResponse, RepoSummary, RepoWorkResponse, StatusResponse, TopologyResponse, TopologyRoute,
-    UnmetRequirementInfo,
+    DiscoveryEntry, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry,
+    HostListResponse, HostProvidersResponse, HostStatusResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse,
+    RepoProvidersResponse, RepoSummary, RepoWorkResponse, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, path::PathBuf};
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    namespace::NamespaceSnapshot,
     snapshot::{ProviderError, WorkItem},
     EnvironmentInfo, HostName, HostSummary, NodeInfo, PeerConnectionState,
 };
@@ -78,6 +80,66 @@ pub struct RepoWorkResponse {
     pub path: PathBuf,
     pub slug: Option<String>,
     pub work_items: Vec<WorkItem>,
+}
+
+// --- fleet listing / replicas ---
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetListResponse {
+    pub rows: Vec<FleetListRow>,
+    #[serde(default)]
+    pub replicas: Vec<FleetReplicaStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetListRow {
+    pub convoy: String,
+    pub vessel: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority: Option<String>,
+    pub crew: String,
+    pub crew_state: String,
+    pub host: HostName,
+    pub staleness: FleetStaleness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FleetStaleness {
+    Local,
+    Fresh {
+        last_sync: DateTime<Utc>,
+    },
+    Stale {
+        last_sync: DateTime<Utc>,
+    },
+    Unreachable {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        last_sync: Option<DateTime<Utc>>,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReplicaStatus {
+    pub host: HostName,
+    pub reachable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_sync: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FleetReplicaSnapshot {
+    pub host: HostName,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
+    pub rows: Vec<FleetListRow>,
+    #[serde(default)]
+    pub namespaces: Vec<NamespaceSnapshot>,
 }
 
 // --- host / topology ---

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -133,7 +133,9 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         | CommandValue::RepoWork(_)
         | CommandValue::HostList(_)
         | CommandValue::HostStatus(_)
-        | CommandValue::HostProviders(_) => {
+        | CommandValue::HostProviders(_)
+        | CommandValue::FleetList(_)
+        | CommandValue::FleetReplicaSnapshot(_) => {
             tracing::warn!("query result reached TUI handler — should be handled by CLI");
         }
         CommandValue::ImageEnsured { .. } | CommandValue::EnvironmentCreated { .. } | CommandValue::EnvironmentSpecRead { .. } => {

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, path::Path};
 use comfy_table::{presets::UTF8_FULL_CONDENSED, Cell, Table};
 use flotilla_core::daemon::DaemonHandle;
 use flotilla_protocol::{
-    output::OutputFormat, Command, CommandValue, DaemonEvent, EnvironmentInfo, EnvironmentStatus, HostProvidersResponse,
-    HostStatusResponse, NodeInfo, PeerConnectionState, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse, StatusResponse,
-    StreamKey, TopologyResponse,
+    output::OutputFormat, Command, CommandValue, DaemonEvent, EnvironmentInfo, EnvironmentStatus, FleetListResponse, FleetStaleness,
+    HostProvidersResponse, HostStatusResponse, NodeInfo, PeerConnectionState, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse,
+    StatusResponse, StreamKey, TopologyResponse,
 };
 
 use crate::socket::SocketDaemon;
@@ -242,6 +242,67 @@ fn format_topology_human(response: &TopologyResponse) -> String {
     out
 }
 
+fn format_fleet_staleness(staleness: &FleetStaleness) -> String {
+    match staleness {
+        FleetStaleness::Local => "local".to_string(),
+        FleetStaleness::Fresh { last_sync } => format!("fresh ({})", last_sync.format("%H:%M:%S")),
+        FleetStaleness::Stale { last_sync } => format!("stale ({})", last_sync.format("%H:%M:%S")),
+        FleetStaleness::Unreachable { last_sync, message } => match last_sync {
+            Some(last_sync) => format!("unreachable ({}, {})", last_sync.format("%H:%M:%S"), message),
+            None => format!("unreachable ({message})"),
+        },
+    }
+}
+
+fn format_fleet_list_human(response: &FleetListResponse) -> String {
+    let mut out = String::new();
+    if response.rows.is_empty() {
+        out.push_str("No crew sessions found.\n");
+    } else {
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL_CONDENSED);
+        table.set_header(vec!["Convoy", "Vessel", "Crew", "State", "Host", "Staleness"]);
+        for row in &response.rows {
+            let vessel = match &row.authority {
+                Some(authority) => format!("{} ({authority})", row.vessel),
+                None => row.vessel.clone(),
+            };
+            table.add_row(vec![
+                Cell::new(&row.convoy),
+                Cell::new(vessel),
+                Cell::new(&row.crew),
+                Cell::new(&row.crew_state),
+                Cell::new(row.host.as_str()),
+                Cell::new(format_fleet_staleness(&row.staleness)),
+            ]);
+        }
+        out.push_str(&table.to_string());
+        out.push('\n');
+    }
+
+    if response.replicas.iter().any(|replica| !replica.reachable) {
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL_CONDENSED);
+        table.set_header(vec!["Replica", "Status", "Last Sync", "Generation"]);
+        for replica in &response.replicas {
+            if replica.reachable {
+                continue;
+            }
+            table.add_row(vec![
+                Cell::new(replica.host.as_str()),
+                Cell::new(replica.message.as_deref().unwrap_or("unreachable")),
+                Cell::new(replica.last_sync.map(|ts| ts.to_rfc3339()).unwrap_or_else(|| "-".to_string())),
+                Cell::new(replica.generation.as_deref().unwrap_or("-")),
+            ]);
+        }
+        out.push_str("\nReplica status:\n");
+        out.push_str(&table.to_string());
+        out.push('\n');
+    }
+
+    out
+}
+
 /// Extract a short display name from a repo path (last path component).
 /// Falls back to the full path display for root or non-UTF-8 paths,
 /// matching `flotilla_core::model::repo_name`.
@@ -298,6 +359,8 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::HostList(hosts) => format_host_list_human(hosts),
         CommandValue::HostStatus(status) => format_host_status_human(status),
         CommandValue::HostProviders(providers) => format_host_providers_human(providers),
+        CommandValue::FleetList(fleet) => format_fleet_list_human(fleet),
+        CommandValue::FleetReplicaSnapshot(_) => "fleet replica snapshot".to_string(),
         CommandValue::ImageEnsured { image } => format!("image ensured: {image}"),
         CommandValue::EnvironmentCreated { env_id } => format!("environment created: {env_id}"),
         CommandValue::EnvironmentSpecRead { .. } => "environment spec read".to_string(),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -373,7 +373,7 @@ mod command_result_human {
 
     use flotilla_protocol::{
         commands::{CheckoutStatus, CommandValue},
-        HostName, NodeId, PreparedWorkspace,
+        FleetListResponse, FleetListRow, FleetReplicaStatus, FleetStaleness, HostName, NodeId, PreparedWorkspace,
     };
 
     use crate::cli::format_command_result;
@@ -490,6 +490,38 @@ mod command_result_human {
     #[test]
     fn cancelled() {
         assert_eq!(format_command_result(&CommandValue::Cancelled), "cancelled");
+    }
+
+    #[test]
+    fn fleet_list() {
+        let result = CommandValue::FleetList(Box::new(FleetListResponse {
+            rows: vec![FleetListRow {
+                convoy: "convoy-a".into(),
+                vessel: "env-a".into(),
+                authority: Some("adopted".into()),
+                crew: "implement/coder".into(),
+                crew_state: "running".into(),
+                host: HostName::new("feta"),
+                staleness: FleetStaleness::Unreachable { last_sync: None, message: "connection refused".into() },
+            }],
+            replicas: vec![FleetReplicaStatus {
+                host: HostName::new("feta"),
+                reachable: false,
+                last_sync: None,
+                generation: Some("gen-1".into()),
+                message: Some("connection refused".into()),
+            }],
+        }));
+
+        let output = format_command_result(&result);
+
+        assert!(output.contains("Convoy"));
+        assert!(output.contains("convoy-a"));
+        assert!(output.contains("env-a (adopted)"));
+        assert!(output.contains("implement/coder"));
+        assert!(output.contains("unreachable"));
+        assert!(output.contains("Replica status"));
+        assert!(output.contains("connection refused"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,11 +56,16 @@ enum SubCommand {
     Watch,
     /// Show the daemon's current multi-host routing view
     Topology,
+    /// List convoy vessels and crew sessions
+    Ls,
     /// Attach to a running convoy crew session
     Attach {
         /// Convoy, task, role, terminal session, or unique prefix
         reference: String,
     },
+    /// Emit this host's store-backed fleet replica snapshot
+    #[command(hide = true)]
+    ReplicaSnapshot,
     /// Receive agent hook events (called by agent hook systems)
     Hook {
         /// Agent harness name (e.g. claude-code, codex, gemini)
@@ -179,7 +184,9 @@ async fn main() -> Result<()> {
         Some(SubCommand::Status) => run_status(&cli, format).await,
         Some(SubCommand::Watch) => run_watch(&cli, format).await,
         Some(SubCommand::Topology) => run_topology_command(&cli, format).await,
+        Some(SubCommand::Ls) => run_fleet_list(&cli, format).await,
         Some(SubCommand::Attach { reference }) => run_attach(&cli, &reference, format).await,
+        Some(SubCommand::ReplicaSnapshot) => run_replica_snapshot(&cli).await,
         Some(SubCommand::Hook { harness, event_type }) => run_hook(&cli, &harness, &event_type).await,
         Some(SubCommand::Hooks { command }) => run_hooks_command(&command).await,
 
@@ -392,6 +399,35 @@ async fn run_attach(cli: &Cli, reference: &str, format: OutputFormat) -> Result<
         },
         CommandValue::Error { message } => Err(color_eyre::eyre::eyre!(message)),
         other => Err(color_eyre::eyre::eyre!("unexpected attach response: {other:?}")),
+    }
+}
+
+async fn run_fleet_list(cli: &Cli, format: OutputFormat) -> Result<()> {
+    run_control_command(
+        cli,
+        Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryFleetList {} },
+        format,
+    )
+    .await
+}
+
+async fn run_replica_snapshot(cli: &Cli) -> Result<()> {
+    reset_sigpipe();
+    let daemon = connect_daemon(cli).await?;
+    let result = daemon
+        .execute_query(
+            Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryFleetReplicaSnapshot {} },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .map_err(|e| color_eyre::eyre::eyre!(e))?;
+    match result {
+        CommandValue::FleetReplicaSnapshot(snapshot) => {
+            println!("{}", flotilla_protocol::output::json_pretty(&*snapshot));
+            Ok(())
+        }
+        CommandValue::Error { message } => Err(color_eyre::eyre::eyre!(message)),
+        other => Err(color_eyre::eyre::eyre!("unexpected replica snapshot response: {other:?}")),
     }
 }
 
@@ -898,6 +934,12 @@ mod tests {
         let cli = Cli::try_parse_from(["flotilla", "topology", "--json"]).expect("topology json should parse");
         assert!(matches!(cli.command, Some(SubCommand::Topology)));
         assert!(cli.json);
+    }
+
+    #[test]
+    fn cli_parses_ls_subcommand() {
+        let cli = Cli::try_parse_from(["flotilla", "ls"]).expect("ls cli should parse");
+        assert!(matches!(cli.command, Some(SubCommand::Ls)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `flotilla ls` as a store-backed fleet listing command
- add a hidden `flotilla replica-snapshot` query for remote cache refreshes
- list local terminal sessions from resource-store state and join convoy/task/role labels, environment host refs, and adopted checkout authority
- maintain a configured-host replica cache with explicit fresh/stale/unreachable status and generation replacement
- start a daemon background refresh task for configured replica hosts

Closes #632.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
