### PR TITLE
fix: accept scp repo urls with ssh aliases

### DIFF
--- a/crates/flotilla-resources/src/provisioning_identity.rs
+++ b/crates/flotilla-resources/src/provisioning_identity.rs
@@ -12,9 +12,15 @@ pub fn canonicalize_repo_url(url: &str) -> Result<String, String> {
         let without_user = rest.strip_prefix("git@").unwrap_or(rest);
         format!("https://{without_user}")
     } else if let Some((user_host, path)) = trimmed.split_once(':') {
-        if !trimmed.contains("://") && user_host.contains('@') {
+        if !trimmed.contains("://") && !user_host.contains('/') && !user_host.is_empty() && !path.is_empty() {
             let host = user_host.rsplit_once('@').map(|(_, host)| host).unwrap_or(user_host);
-            format!("https://{host}/{path}")
+            if host.is_empty() {
+                trimmed.to_string()
+            } else {
+                // This intentionally accepts ssh-config aliases. The resulting identity
+                // is local to that alias; #645 tracks the broader repo-identity wrinkle.
+                format!("https://{host}/{path}")
+            }
         } else {
             trimmed.to_string()
         }
@@ -98,6 +104,10 @@ mod tests {
             "https://github.com/flotilla-org/flotilla"
         );
         assert_eq!(
+            canonicalize_repo_url("forgejo-manchego:robert/dinghy.git").expect("ssh alias canonicalization"),
+            "https://forgejo-manchego/robert/dinghy"
+        );
+        assert_eq!(
             canonicalize_repo_url("ssh://git@GitHub.com/flotilla-org/flotilla/").expect("ssh url canonicalization"),
             "https://github.com/flotilla-org/flotilla"
         );
@@ -105,6 +115,14 @@ mod tests {
             canonicalize_repo_url("https://GitHub.com/flotilla-org/flotilla.git").expect("https canonicalization"),
             "https://github.com/flotilla-org/flotilla"
         );
+    }
+
+    #[test]
+    fn rejects_degenerate_scp_like_repo_urls() {
+        assert!(canonicalize_repo_url(":robert/dinghy.git").is_err());
+        assert!(canonicalize_repo_url("git@:robert/dinghy.git").is_err());
+        assert!(canonicalize_repo_url("forgejo-manchego:").is_err());
+        assert!(canonicalize_repo_url("forgejo/alias:robert/dinghy.git").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes repo URL canonicalization for scp-style Git remotes that use an ssh-config alias without a user part, such as `forgejo-manchego:robert/dinghy.git`.

## Root Cause

`canonicalize_repo_url` only treated scheme-less `host:path` syntax as scp-style when the left side contained `@`, so bare aliases fell through and later failed as unsupported repo URLs.

## Changes

- Accept scheme-less `[user@]host:path` when the host segment has no `/`, matching Git's scp-style heuristic.
- Preserve existing `ssh://` and `https://` behavior.
- Add a note that alias-derived identities remain local to the alias until broader repo-identity work resolves that wrinkle.
- Add unit coverage for the bare ssh alias form and degenerate scp-like guard paths.

Closes #642.
Follow-up: #645 tracks machine-independent repo identity for SSH aliases.

## Validation

- `cargo test -p flotilla-resources --locked provisioning_identity::tests -- --nocapture`
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
