### PR TITLE
docs: requirements-first placement + agentic-first orchestration (ADRs 0007-0008)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,22 +31,52 @@ set" / "new branch" framing.
 _Avoid_: Job, pipeline, attachable set.
 
 **Leg**:
-A workflow stage within a **Convoy** — one node of its DAG. A Leg executes
-aboard a **Vessel** and is completed explicitly, not by process exit. Often
-implicit: a trivial convoy has a single implicit Leg, and Legs may stay out of
-the UX until workflow patterns settle.
+The *control side* of a **Convoy** — a broad (often implicit) phase of the
+workflow: the script, not the cast. A Leg carries the prompts and information
+routing given to promptable **Crew**, and is materialised by **zero or more
+Vessels** (e.g. one test Leg fanning across four platforms). Completed
+explicitly, not by process exit. Legs may stay out of the UX until workflow
+patterns settle; ad-hoc communication outside the script is not prohibited.
 _Avoid_: Task (retired — it conflated stage with placement; code types such as
 `TaskSummary`/`TaskWorkspace` keep the old name until renamed opportunistically),
 Step, pod.
 
+**VesselRequirement**:
+A declaration that a **Vessel** matching some abstract requirements (platform,
+capabilities, sandbox quality, affinity) must exist for a **Leg** — the runtime
+primitive placement resolution works on, and the fan-out unit (one requirement
+may materialise several Vessels). Authored by any orchestrator: a workflow
+template, an **orchestrating agent** (tool call), or a human (CLI pins / the
+picker). Templates carry abstract requirements only; launch-time **pins**
+(host=X, reuse hull Y, adopt this checkout) and fleet-level **PlacementPolicy**
+preferences merge at resolution (pins > requirements > policy preferences;
+unsatisfiable = loud failure, no silent fallback).
+_Avoid_: placement (the act, not the declaration), recipe, target.
+
 **Vessel**:
-The placement unit a **Leg** executes aboard — an (environment + checkout) unit
-on some host, hosting a **Crew**. Its lifecycle is independent of Legs: it may be
+The placement unit work executes aboard — an (environment + checkout) unit
+on some host, hosting a **Crew**; materialised to satisfy a
+**VesselRequirement**. Its lifecycle is independent of Legs: it may be
 provisioned (Managed), **adopted** (an existing worktree, per **Lifecycle
 Authority**), kept *warm* between Legs, or revisited by later Legs in loopy
 workflows (e.g. a main dev vessel that fans out to platform-test vessels and
-collates results across iterations).
+collates results across iterations). The Crew aboard the Vessels are the
+dramatis personae; the Legs are the script.
 _Avoid_: Task, TaskWorkspace, workspace, container.
+
+**Hull**:
+An allocated but **uncrewed** Vessel-precursor: an **Environment** plus an
+established filesystem/checkout, no processes yet. **Vessel = Hull + Crew.**
+(Portfolio-defined term; see the project-map glossary.)
+_Avoid_: empty vessel, workspace, berth.
+
+**Clyde**:
+(Future extraction; portfolio-defined.) A per-host service owning the full
+lifecycle of **Hulls**: given Vessel requirements it allocates, maintains, and
+tears down the backing Hull. Flotilla's vessel reconciliation trends toward
+"tell Clyde the desired state." Boundary edges (token install, agent config,
+network setup) deliberately unpinned.
+_Avoid_: Astillero (renamed 2026-07-06), sandbox aggregator.
 
 **Crew**:
 The set of **Processes** (agents and terminals, typically a cleat pool) running

--- a/docs/adr/0007-requirements-first-placement.md
+++ b/docs/adr/0007-requirements-first-placement.md
@@ -1,0 +1,55 @@
+# Requirements-first placement; VesselRequirement is the runtime primitive
+
+**Status:** Accepted
+**Date:** 2026-07-07
+
+Vessel allocation is **requirements-first, not recipe-first**. A
+**VesselRequirement** declares what a Vessel must provide — platform
+(`os`, `arch`), capabilities (`gpu`, `sandbox-quality`, `gui: recordable`,
+entitlements/signing, profiling tools), and affinity (same hull as another
+leg, reuse a warm hull, adopt a specific checkout) — and a **resolver**
+matches it against available substrate to produce a concrete hull spec,
+which hull allocation (**Clyde**, a future extraction) materialises.
+Recipes are a strict subset: a fully-pinned requirement.
+
+## Structure
+
+- **Three sources merge at resolution**, in strict precedence:
+  **pins** (launch-time: `host=feta`, `reuse hull Y`, `--adopt-checkout`)
+  **> template requirements** (abstract only — never host names; images are a
+  hull-recipe detail on the resolver side, not a template concern)
+  **> PlacementPolicy preferences** (fleet-level resolver configuration:
+  defaults, preferences, cost rules).
+  An unsatisfiable merge is a **loud resolution failure** — no silent fallback.
+- **VesselRequirement is a first-class runtime primitive** (resource + API),
+  authored by any orchestrator: a declarative template, an orchestrating agent
+  issuing tool calls (ADR 0008), or a human (the CLI/picker is sugar that emits
+  a hand-authored request with pins). The old AttachableSet-era
+  `ProvisioningTarget` picker collapses into pins; env-reuse (`=env_id`)
+  becomes an affinity requirement.
+- **Fan-out**: one requirement may materialise several Vessels
+  (`forall: platform in …`). The platform matrix belongs on the **Project**
+  (what this island targets), keeping templates fleet-portable and runs
+  reproducible; fleet-derived ranges ("everywhere we can, min N") are a
+  designed-for later resolver expression.
+- **Requirements describe the Hull**; crew-side selectors
+  (`capability: code` → concrete agent) are a separate axis resolved the same
+  requirements-first way (v1: simple lookup).
+- **Leg is the control side** — script, prompts, info-routing — and is
+  materialised by zero or more Vessels; it is not itself placed.
+
+## Consequences
+
+- `PlacementPolicy` is reborn as **resolver configuration**; the current
+  one-named-policy-per-convoy field (and its fragile lexicographic default) is
+  transitional and eventually dies.
+- Requirements vocabulary starts as a small closed set (host pin, env kind,
+  reuse/affinity, platform triple) and grows only from demonstrated need —
+  the capability ontology is the known rathole.
+- Nothing is built immediately: the M1 dogfood path continues on the seeded
+  policies. First implementation slice, when scheduled: requirements
+  vocabulary v1 + deterministic resolver v1 replacing the policy-name
+  plumbing.
+- Clyde's boundary edges (token install, agent config, network setup — or a
+  privileged crew member finishing setup; "refit" of a warm hull) are
+  deliberately unpinned; see the project-map glossary.

--- a/docs/adr/0008-agentic-first-orchestration.md
+++ b/docs/adr/0008-agentic-first-orchestration.md
@@ -1,0 +1,54 @@
+# Agentic-first orchestration; workflows are harvested as programs, not authored as YAML
+
+**Status:** Accepted
+**Date:** 2026-07-07
+
+We deliberately do **not** grow the declarative WorkflowTemplate language ahead
+of practice. The primary intended author of convoys for real projects is an
+**orchestrating agent** that works out the right workflow with intelligence —
+issuing **VesselRequirement** requests as tool calls (ADR 0007) and routing
+information between crews via prompts and ordinary git (result branches,
+fetch-and-collate) — because the hard parts of a workflow (what to prompt each
+crew, what data flows back) are trivial to express in prompts and a research
+project to formalise declaratively. Formal semantics are **harvested from
+dynamic practice**, not designed ahead of it.
+
+## Structure
+
+- **Three authors, one mechanism.** Declarative templates (kept as minimal as
+  today's: DAG + briefs), orchestrating agents, and humans (CLI/picker) all
+  author the same runtime primitives: convoy, Leg (script/prompt-routing
+  metadata), VesselRequirement.
+- **Extraction target: programs.** When a convoy shape recurs, it is frozen not
+  as YAML but as a **script/program** — exactly what agents are good at
+  producing. This pulls a **Python and/or TypeScript client SDK** forward
+  (sooner rather than later), tracking the CLI surface closely. Simple
+  workflow programs stay simply analysable; some will be very dynamic.
+- **Inter-leg data flow stays deliberately unformalised** (prompts + git)
+  until patterns recur.
+
+## Open: durable execution
+
+Long-lived workflow *programs* must survive restarts and resume "replayed up
+to the current decision" — the temporal.io problem. Recorded as open, with
+three candidate shapes rather than a decision:
+
+1. **Level-triggered idempotent programs** that re-derive position from
+   observed convoy/resource state (the k8s-controller answer; no determinism
+   constraints).
+2. **Event-sourced replay** against the resource store's own log —
+   `resourceVersion`/watch is already the replication log (ADR 0002), so the
+   journal substrate exists.
+3. **Agent-transcript-as-state** for agent-orchestrated convoys: resumption is
+   re-prompting with current state, not deterministic replay.
+
+Avoid importing temporal's determinism constraints unless (1) and (3) prove
+insufficient.
+
+## Consequences
+
+- Issue #624 (agentic/dynamic convoy launch) is promoted from parked Brainstorm
+  to the intended orchestration path.
+- A client SDK (Python/TS) becomes a tracked near-term direction.
+- The WorkflowTemplate language accepts new features only when harvested
+  practice has already made their semantics obvious.


### PR DESCRIPTION
Outcome of the placement-policy grill (2026-07-07). Docs only.

- **ADR 0007** — placement is **requirements-first**: a **VesselRequirement** (runtime primitive, authored by template / orchestrating agent / human picker) is resolved against substrate — pins > template requirements > policy preferences, loud failure on unsatisfiable. Platform fan-out matrix lives on **Project**. PlacementPolicy becomes resolver configuration; the per-convoy named-policy field is transitional. Hull materialisation trends toward **Clyde** (portfolio extraction; boundary edges deliberately unpinned).
- **ADR 0008** — orchestration is **agentic-first**: agents author convoys via VesselRequirement tool calls + prompt/git data routing; declarative WorkflowTemplate stays minimal; recurring shapes are harvested as **programs** (pulls a Python/TS SDK forward, #646); durable execution recorded as open (level-triggered vs event-sourced vs transcript-as-state).
- **CONTEXT.md** — Leg = the script (control side, zero-or-more Vessels); VesselRequirement, Hull, Clyde entries; 'dramatis personae' framing on Vessel.

Refs #604; promotes #624; files #646.