### PR TITLE
fix: interpolate workflow commands at bootstrap

### DIFF
--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -16,8 +16,8 @@ use crate::{
     resource::ResourceObject,
     status_patch::StatusPatch,
     task_workspace::{TaskWorkspace, TaskWorkspacePhase},
-    workflow_template::{validate, ValidationError, WorkflowTemplate},
-    InputMeta, OwnerReference, PlacementStatus, Resource, ResourceError, TypedResolver,
+    workflow_template::{validate, visit_template_tokens, ProcessDefinition, ProcessSource, ValidationError, WorkflowTemplate},
+    InputMeta, InputValue, OwnerReference, PlacementStatus, Resource, ResourceError, TypedResolver,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -259,7 +259,7 @@ fn bootstrap_outcome(
         .tasks
         .iter()
         .flat_map(|task| task.processes.iter())
-        .any(|process| matches!(process.source, crate::ProcessSource::Agent { .. }))
+        .any(|process| matches!(process.source, ProcessSource::Agent { .. }))
     {
         return InternalReconcileOutcome {
             patch: Some(controller_patches::fail_init(ConvoyPhase::Failed, STAGE_4A_AGENT_MESSAGE.to_string(), now)),
@@ -283,7 +283,11 @@ fn bootstrap_outcome(
             .spec
             .tasks
             .iter()
-            .map(|task| SnapshotTask { name: task.name.clone(), depends_on: task.depends_on.clone(), processes: task.processes.clone() })
+            .map(|task| SnapshotTask {
+                name: task.name.clone(),
+                depends_on: task.depends_on.clone(),
+                processes: task.processes.iter().map(|process| instantiate_process(convoy, process)).collect(),
+            })
             .collect(),
     };
     let tasks = template
@@ -313,6 +317,61 @@ fn bootstrap_outcome(
         )),
         actuations: Vec::new(),
         events: Vec::new(),
+    }
+}
+
+fn instantiate_process(convoy: &ResourceObject<Convoy>, process: &ProcessDefinition) -> ProcessDefinition {
+    let mut process = process.clone();
+    match &mut process.source {
+        ProcessSource::Agent { prompt, .. } => {
+            if let Some(prompt) = prompt {
+                *prompt = interpolate_template_text(convoy, prompt);
+            }
+        }
+        ProcessSource::Tool { command } => {
+            *command = interpolate_template_text(convoy, command);
+        }
+    }
+    process
+}
+
+fn interpolate_template_text(convoy: &ResourceObject<Convoy>, text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut search_from = 0;
+    visit_template_tokens(text, |token| {
+        output.push_str(&text[search_from..token.open]);
+        match token.end {
+            Some(end) => {
+                if let Some(value) = interpolation_value(convoy, token.text) {
+                    output.push_str(&value);
+                } else {
+                    output.push_str(&text[token.open..end]);
+                }
+                search_from = end;
+            }
+            None => {
+                output.push_str(&text[token.open..]);
+                search_from = text.len();
+            }
+        }
+    });
+    output.push_str(&text[search_from..]);
+    output
+}
+
+fn interpolation_value(convoy: &ResourceObject<Convoy>, token: &str) -> Option<String> {
+    let segments = token.split('.').collect::<Vec<_>>();
+    match segments.as_slice() {
+        ["inputs", input_name] => convoy.spec.inputs.get(*input_name).map(input_value_string),
+        ["workflow", "name"] => Some(convoy.metadata.name.clone()),
+        ["workflow", "namespace"] => Some(convoy.metadata.namespace.clone()),
+        _ => None,
+    }
+}
+
+fn input_value_string(value: &InputValue) -> String {
+    match value {
+        InputValue::String(value) => value.clone(),
     }
 }
 

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -125,6 +125,12 @@ enum VisitState {
     Visited,
 }
 
+pub(crate) struct TemplateToken<'a> {
+    pub(crate) open: usize,
+    pub(crate) text: &'a str,
+    pub(crate) end: Option<usize>,
+}
+
 pub fn validate(spec: &WorkflowTemplateSpec) -> Result<(), Vec<ValidationError>> {
     let mut errors = Vec::new();
     let declared_inputs = collect_inputs(spec, &mut errors);
@@ -267,6 +273,17 @@ fn validate_template_text(
     declared_inputs: &BTreeSet<String>,
     errors: &mut Vec<ValidationError>,
 ) {
+    visit_template_tokens(text, |token| match token.end {
+        Some(_) => validate_token(token.text, location, declared_inputs, errors),
+        None => {
+            if is_owned_token(token.text) {
+                push_error(errors, ValidationError::MalformedInterpolation { location: location.clone(), text: token.text.to_string() });
+            }
+        }
+    });
+}
+
+pub(crate) fn visit_template_tokens<'a>(text: &'a str, mut visit: impl FnMut(TemplateToken<'a>)) {
     let mut search_from = 0;
     while let Some(open_offset) = text[search_from..].find("{{") {
         let open = search_from + open_offset;
@@ -274,14 +291,12 @@ fn validate_template_text(
         match text[token_start..].find("}}") {
             Some(close_offset) => {
                 let token_end = token_start + close_offset;
-                validate_token(&text[token_start..token_end], location, declared_inputs, errors);
-                search_from = token_end + 2;
+                let end = token_end + 2;
+                visit(TemplateToken { open, text: &text[token_start..token_end], end: Some(end) });
+                search_from = end;
             }
             None => {
-                let token = &text[token_start..];
-                if is_owned_token(token) {
-                    push_error(errors, ValidationError::MalformedInterpolation { location: location.clone(), text: token.to_string() });
-                }
+                visit(TemplateToken { open, text: &text[token_start..], end: None });
                 break;
             }
         }

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -11,8 +11,8 @@ use flotilla_resources::{
     canonicalize_repo_url,
     controller::{Actuation, Reconciler},
     controller_patches, reconcile, repo_key, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, InMemoryBackend,
-    InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ResourceBackend, TaskPhase, TaskWorkspace, TaskWorkspacePhase,
-    TaskWorkspaceSpec, TaskWorkspaceStatus, ValidationError, WorkflowTemplate, CONVOY_LABEL, TASK_LABEL,
+    InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ProcessSource, ResourceBackend, TaskPhase, TaskWorkspace,
+    TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, ValidationError, WorkflowTemplate, CONVOY_LABEL, TASK_LABEL,
 };
 
 async fn reconcile_once_with_resources(
@@ -189,6 +189,25 @@ fn bootstrap_from_valid_template_returns_bootstrap_patch() {
 
     assert_eq!(outcome.patch, Some(expected_patch));
     assert!(outcome.events.is_empty());
+}
+
+#[test]
+fn bootstrap_interpolates_tool_process_commands() {
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
+    let mut template = tool_only_workflow_template_object("review-and-fix");
+    if let ProcessSource::Tool { command } = &mut template.spec.tasks[0].processes[0].source {
+        *command = "printf '{{workflow.namespace}}/{{workflow.name}}/{{inputs.feature}}/{{inputs.branch}}/{{.metadata.name}}'".to_string();
+    }
+
+    let outcome = reconcile(&convoy, Some(&template), timestamp(10));
+
+    let Some(ConvoyStatusPatch::Bootstrap { workflow_snapshot, .. }) = outcome.patch else {
+        panic!("expected bootstrap patch");
+    };
+    let ProcessSource::Tool { command } = &workflow_snapshot.tasks[0].processes[0].source else {
+        panic!("expected tool process");
+    };
+    assert_eq!(command, "printf 'flotilla/convoy-a/Retry logic/fix-retry-logic/{{.metadata.name}}'");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- instantiate workflow snapshot processes during convoy bootstrap instead of copying raw template processes
- interpolate owned workflow/input placeholders in agent prompts and tool commands
- leave foreign template syntax intact so downstream systems can still consume it

## Root cause
Scratch workflow validation accepted `{{workflow.*}}` and `{{inputs.*}}` placeholders in process commands, but bootstrap copied template processes directly into the `WorkflowSnapshot`. The resulting terminal session command still contained the raw placeholders.

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo test -p flotilla-resources --locked --test convoy_reconcile bootstrap_interpolates_tool_process_commands -- --nocapture`
- `cargo test -p flotilla-resources --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #643