### PR TITLE
docs: PersistentAgent model — Governor, Bosun, residency, memory (ADR 0009)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,8 +60,9 @@ on some host, hosting a **Crew**; materialised to satisfy a
 provisioned (Managed), **adopted** (an existing worktree, per **Lifecycle
 Authority**), kept *warm* between Legs, or revisited by later Legs in loopy
 workflows (e.g. a main dev vessel that fans out to platform-test vessels and
-collates results across iterations). The Crew aboard the Vessels are the
-dramatis personae; the Legs are the script.
+collates results across iterations). A Vessel may also be **free-floating** —
+attached to no Convoy at all — e.g. housing a **PersistentAgent**. The Crew
+aboard the Vessels are the dramatis personae; the Legs are the script.
 _Avoid_: Task, TaskWorkspace, workspace, container.
 
 **Hull**:
@@ -217,11 +218,44 @@ attach), with its own availability rules, resolving to a control-plane command.
 The reusable action model shared by all **Surfaces**.
 _Avoid_: Command (the resolved wire form), keybinding, button.
 
+**PersistentAgent**:
+The resource kind for a long-lived agent that operates the fleet rather than
+writing code. One kind for all roles (role is a label); its spec carries a
+charter, a scope (its island's namespace), a **VesselRequirement** for its
+residency, and a **memory ref**. A reconciler keeps it materialised — today a
+**free-floating Vessel** running a harness; later possibly a direct agent loop
+(a different materialisation, not a different concept).
+_Avoid_: Meta-agent-as-a-kind (Meta-agent is the concept, this is the resource),
+Officer, bot, daemon.
+
+**Governor**:
+The **PersistentAgent** role stewarding an **Island**: reads its repos but does
+not edit source or raise its own PRs; maintains issues and docs; watches
+upstreams; launches convoys for its own project only. Frontier-class Governors
+may orchestrate simple convoys directly, spinning up a **Bosun** for complex
+ones. The aspiration is instilled stewardship — improving quality, looking out
+for updates.
+_Avoid_: Repo bot, maintainer-agent.
+
+**Bosun**:
+The **PersistentAgent** role scoped to a single **Convoy**: the orchestrating
+agent (ADR 0008) that chivvies it along — continuation, unsticking, rewind —
+issuing **VesselRequirements** and routing information between crews.
+_Avoid_: Orchestrator (generic), pipeline runner.
+
+**Agent Memory**:
+A **PersistentAgent**'s durable state: a *directory that survives
+re-materialisation*, referenced from its spec and materialised into whatever
+the agent inhabits. Backing is deliberately pluggable — local filesystem (the
+solo-machine starter), a git repo (e.g. the lab hub), object storage (the
+enterprise destination). Never the island repo itself.
+_Avoid_: Scratch space (it is durable), transcript (that is the harness's).
+
 **Meta-agent**:
-A persistent agent that operates the fleet rather than writing code — allocation
-(Quartermaster), accounting (Purser), stewardship (Governor), presentation
-(Yeoman), discipline/continuation (Bosun). A future layer above observer +
-control plane.
+The concept of a persistent agent that operates the fleet rather than writing
+code — stewardship (Governor), convoy-driving (Bosun), allocation
+(Quartermaster), accounting (Purser), presentation (Yeoman). Realised as
+**PersistentAgent** resources; Governor and Bosun arrive first.
 _Avoid_: Bot, assistant.
 
 ## External Collaborators

--- a/docs/adr/0009-persistent-agents.md
+++ b/docs/adr/0009-persistent-agents.md
@@ -1,0 +1,74 @@
+# PersistentAgent: one kind, vessel residency, island-scoped authority, pluggable memory
+
+**Status:** Accepted
+**Date:** 2026-07-07
+
+Persistent agents (the meta-agent layer) arrive earlier than planned because
+agentic-first orchestration (ADR 0008) needs an orchestrating agent to exist.
+They are modelled as **one resource kind, `PersistentAgent`**, with the role as
+a label — `governor` and `bosun` first; quartermaster/purser/yeoman later.
+
+## Structure
+
+- **Spec**: charter (duties/prompt refs), scope (its island's namespace), a
+  **VesselRequirement** for its residency (ADR 0007), and a **memory ref**.
+- **Residency**: a reconciler keeps the agent materialised in a
+  **free-floating (convoyless) Vessel** running a harness — reusing the vessel
+  mechanism for deployment/isolation rather than inventing another. A later
+  "direct agent loop" (no unix environment, internal tools only) is an
+  alternate *materialisation* of the same resource — a different resolver
+  answer, not a model change. Always-on placement (e.g. an always-on host) is
+  just a requirement, never a hard-coded host name.
+- **Roles**:
+  - **Governor** (island steward): reads its repos, **never edits source or
+    raises its own PRs**; maintains issues and docs; watches upstreams (e.g.
+    fork-tracking); launches convoys **for its own project only**.
+    Frontier-class Governors may drive simple convoys directly and spin up a
+    Bosun for complex ones.
+  - **Bosun** (convoy-scoped): the ADR 0008 orchestrating agent — chivvies a
+    convoy along (continuation, unsticking, rewind), issuing
+    VesselRequirements and routing information between crews.
+- **Authority / blast radius**: three layers, all real —
+  1. **Charter** (guidance; worthless against confusion, still written),
+  2. **Credential scoping** (read-only git; issues/docs-write forge token; no
+     PR scope),
+  3. **Control-plane scoping**: **namespace ≈ island/Project is the authz
+     boundary**; the agent's daemon access is a per-agent minted scoped
+     endpoint (the porthole capability-token pattern; the first instance of
+     the long-mooted restricted-secrets/key-issuing direction).
+  **v1 is deliberately fast-and-loose** (ambient credentials) while the
+  concept is dogfooded; the holistic story — short-lived credential issuance,
+  hand-off between agents, porthole capability tokens, proxying services whose
+  tokens aren't fine-grained enough — is recorded as direction (Purser/Clyde
+  territory), not designed now.
+- **Memory**: a durable *directory that survives re-materialisation*,
+  referenced from the spec and materialised into whatever the agent inhabits.
+  Backing is **pluggable**: local filesystem (the solo-machine starter — no
+  infra dependency), a git repo (what we dogfood, on the lab hub), object
+  storage (the enterprise destination). Explicitly rejected: the island repo
+  itself (pollutes project history, tangles the Governor's read-only stance,
+  impractical for OSS forks; the bare-branch/git-notes variant is noted and
+  parked as fiddly). Memory sync in/out of hulls lands on the same
+  deliberately-unpinned Clyde boundary edge as token injection.
+- **Triggers/schedules stay charter-side** initially: the agent wakes itself
+  (harness cron/loop) and decides — "check upstream for changes" is a charter
+  duty, not a flotilla Trigger subsystem. Formalise only from harvested
+  practice (ADR 0008 discipline).
+
+## Why
+
+- A first-class kind (vs "a vessel someone started") buys: respawn-across-
+  reboot ownership, representation while the vessel is down, charter upgrades
+  as spec changes, dashboard identity, and the free later swap to non-vessel
+  materialisations.
+- Namespace ≈ island gives Governors a crisp blast radius using scoping the
+  store already has.
+- An auditable memory directory (especially git-backed) is the closest
+  observable proxy for whether "stewardship" is actually being instilled.
+
+## Consequences
+
+- New kind + small reconciler (TaskWorkspace-shaped), unscheduled — sequenced
+  after the observer reshape unless dogfooding pulls it forward.
+- The convoy-create path gains "created-by: agent" attribution eventually.
+- Purser acquires its first concrete mandate (credential issuance direction).


### PR DESCRIPTION
Outcome of the persistent-agents grill (2026-07-07, follows ADRs 0007/0008). Docs only.

- **One `PersistentAgent` kind**, role as a label — **Governor** (island steward: issues/docs yes, source/PRs no, convoys for its own island only) and **Bosun** (convoy-scoped orchestrating agent) first.
- **Residency = a free-floating (convoyless) Vessel** maintained by a reconciler via a VesselRequirement — reusing vessel deployment/isolation; a later direct agent loop is an alternate materialisation, not a new concept.
- **Authority**: namespace ≈ island is the blast radius; charter / scoped credentials / per-agent minted control-plane endpoints as the three layers — **v1 deliberately fast-and-loose**, holistic short-lived-credential story recorded as direction (Purser/Clyde).
- **Agent memory**: a durable directory that survives re-materialisation; backing pluggable (local fs / git repo / object storage), island repo explicitly rejected.
- Triggers stay charter-side (harness cron), per ADR 0008 harvest discipline.

Refs #604, #624.