### PR TITLE
fix: resolve attach from fleet replicas

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -255,6 +255,27 @@ fn attach_reference_label(session_name: &str, labels: &BTreeMap<String, String>)
     }
 }
 
+fn fleet_row_attach_reference_keys(row: &FleetListRow) -> Vec<String> {
+    let mut refs = vec![row.convoy.clone(), row.vessel.clone(), row.crew.clone()];
+    if row.crew != "-" {
+        refs.push(format!("{}/{}", row.convoy, row.crew));
+        if let Some((_task, role)) = row.crew.rsplit_once('/') {
+            refs.push(role.to_string());
+        }
+    }
+    refs.sort();
+    refs.dedup();
+    refs
+}
+
+fn fleet_row_attach_reference_label(row: &FleetListRow) -> String {
+    if row.crew == "-" {
+        format!("{} ({})", row.convoy, row.host)
+    } else {
+        format!("{}/{} ({})", row.convoy, row.crew, row.host)
+    }
+}
+
 fn session_status_label(phase: Option<ResourceTerminalSessionPhase>) -> String {
     match phase {
         Some(ResourceTerminalSessionPhase::Starting) | None => "starting".to_string(),
@@ -2250,6 +2271,20 @@ impl InProcessDaemon {
             return Err("attach reference is required".to_string());
         }
 
+        enum AttachMatch {
+            Local(Box<flotilla_resources::ResourceObject<ResourceTerminalSession>>),
+            Replica { host: HostName },
+        }
+
+        impl AttachMatch {
+            async fn resolve(self, daemon: &InProcessDaemon, reference: &str) -> Result<String, String> {
+                match self {
+                    Self::Local(session) => daemon.attach_command_for_session(reference, &session).await,
+                    Self::Replica { host } => daemon.recursive_attach_command_for_remote(&host, reference).await,
+                }
+            }
+        }
+
         let namespace = self.provisioning_namespace().await;
         let terminal_sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace);
         let sessions = terminal_sessions.list().await.map_err(|err| err.to_string())?.items;
@@ -2263,18 +2298,43 @@ impl InProcessDaemon {
             let refs = attach_reference_keys(&session.metadata.name, &session.metadata.labels);
             let label = attach_reference_label(&session.metadata.name, &session.metadata.labels);
             if refs.iter().any(|candidate| candidate == reference) {
-                exact.push((label, session));
+                exact.push((label, AttachMatch::Local(Box::new(session))));
             } else if refs.iter().any(|candidate| candidate.starts_with(reference)) {
-                prefix.push((label, session));
+                prefix.push((label, AttachMatch::Local(Box::new(session))));
             }
         }
+
+        let configured_replica_hosts: HashSet<HostName> = self
+            .config
+            .load_hosts()
+            .map(|hosts| hosts.hosts.into_values().map(|remote| HostName::new(remote.expected_host_name)).collect())
+            .unwrap_or_default();
+        let cache = self.fleet_replica_cache.read().await;
+        for host in configured_replica_hosts {
+            if let Some(entry) = cache.get(&host) {
+                for row in &entry.rows {
+                    if row.crew_state != "running" {
+                        continue;
+                    }
+                    let refs = fleet_row_attach_reference_keys(row);
+                    let label = fleet_row_attach_reference_label(row);
+                    let target = AttachMatch::Replica { host: row.host.clone() };
+                    if refs.iter().any(|candidate| candidate == reference) {
+                        exact.push((label, target));
+                    } else if refs.iter().any(|candidate| candidate.starts_with(reference)) {
+                        prefix.push((label, target));
+                    }
+                }
+            }
+        }
+        drop(cache);
 
         let mut matches = if exact.is_empty() { prefix } else { exact };
         match matches.len() {
             0 => Err(format!("no attach target matching '{reference}'")),
             1 => {
-                let (_label, session) = matches.remove(0);
-                self.attach_command_for_session(reference, &session).await
+                let (_label, target) = matches.remove(0);
+                target.resolve(self, reference).await
             }
             _ => {
                 let mut labels: Vec<_> = matches.into_iter().map(|(label, _)| label).collect();

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -564,6 +564,115 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
 }
 
 #[tokio::test]
+async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    daemon.fleet_replica_cache.write().await.insert(HostName::new("feta"), FleetReplicaCacheEntry {
+        rows: vec![FleetListRow {
+            convoy: "convoy-a".to_string(),
+            vessel: "remote-env".to_string(),
+            authority: None,
+            crew: "implement/coder".to_string(),
+            crew_state: "running".to_string(),
+            host: HostName::new("feta"),
+            staleness: FleetStaleness::Stale { last_sync: Utc::now() - chrono::Duration::seconds(FLEET_REPLICA_FRESH_SECS + 1) },
+        }],
+        last_sync: Some(Utc::now() - chrono::Duration::seconds(FLEET_REPLICA_FRESH_SECS + 1)),
+        generation: Some("gen-1".to_string()),
+        last_error: Some("connection refused".to_string()),
+    });
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "command should target the replica host over SSH: {command}");
+    assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
+    assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach: {command}");
+    assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "bare role should resolve through the replica host: {command}");
+    assert!(command.contains("flotilla attach"), "bare role should recursively invoke flotilla attach: {command}");
+    assert!(command.contains("coder"), "command should preserve the original bare role reference: {command}");
+}
+
+#[tokio::test]
+async fn attach_query_ignores_fleet_replica_hosts_that_are_not_configured() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    daemon.fleet_replica_cache.write().await.insert(HostName::new("removed"), FleetReplicaCacheEntry {
+        rows: vec![FleetListRow {
+            convoy: "convoy-a".to_string(),
+            vessel: "removed-env".to_string(),
+            authority: None,
+            crew: "implement/coder".to_string(),
+            crew_state: "running".to_string(),
+            host: HostName::new("removed"),
+            staleness: FleetStaleness::Fresh { last_sync: Utc::now() },
+        }],
+        last_sync: Some(Utc::now()),
+        generation: Some("gen-1".to_string()),
+        last_error: None,
+    });
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "removed-env".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::Error { message } = result else {
+        panic!("expected attach error, got {result:?}");
+    };
+    assert_eq!(message, "no attach target matching 'removed-env'");
+}
+
+#[tokio::test]
 async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,7 +397,16 @@ async fn run_attach(cli: &Cli, reference: &str, format: OutputFormat) -> Result<
             }
             OutputFormat::Human => exec_attach_command(&command),
         },
-        CommandValue::Error { message } => Err(color_eyre::eyre::eyre!(message)),
+        CommandValue::Error { message } => match format {
+            OutputFormat::Json => {
+                println!("{}", flotilla_protocol::output::json_pretty(&CommandValue::Error { message: message.clone() }));
+                Err(color_eyre::eyre::eyre!(message))
+            }
+            OutputFormat::Human => {
+                eprintln!("{message}");
+                std::process::exit(1);
+            }
+        },
         other => Err(color_eyre::eyre::eyre!("unexpected attach response: {other:?}")),
     }
 }


### PR DESCRIPTION
## Summary

- Teach attach resolution to consider running sessions from the fleet replica cache, not just local `ResourceTerminalSession` rows.
- Resolve replica matches as one recursive next-hop attach command so stale or currently unreachable cached rows still forward to the owning host.
- Keep replica attach visibility consistent with configured `hosts.toml` entries and local bare-role matching behavior.
- Print human attach errors as a plain one-line message instead of a color-eyre report.

## Root Cause

`flotilla ls` could show remote fleet replicas from another host, but `flotilla attach <ref>` only searched the local terminal-session store. That made visible cross-host sessions fail with `no attach target matching ...`.

## Validation

- `cargo test -p flotilla-core --locked attach_query_resolves_fleet_replica_session_as_one_recursive_hop -- --nocapture`
- `cargo test -p flotilla-core --locked attach_query_ignores_fleet_replica_hosts_that_are_not_configured -- --nocapture`
- `cargo test -p flotilla-core --locked attach_query -- --nocapture`
- `cargo test -p flotilla-core --locked`
- `cargo +nightly-2026-03-12 fmt --check`
- `git diff --check`
- `cargo clippy -p flotilla-core --all-targets --locked -- -D warnings`
- CI passed: Format, Clippy, Test, claude-review

Closes #654