### PR TITLE
[codex] fix: show crewless convoys in fleet list

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2213,6 +2213,8 @@ impl InProcessDaemon {
                             row
                         })
                         .collect();
+                    // Replica rows from current daemons already include crewless rows via local_fleet_rows.
+                    // Keep the namespace payload as a secondary source for direct snapshots; existing rows win.
                     append_crewless_convoy_rows(&mut rows, &namespace, &snapshot.namespaces, &snapshot_host, staleness);
                     self.fleet_replica_cache.write().await.insert(host, FleetReplicaCacheEntry {
                         rows,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{
     arg::{flatten, Arg},
+    namespace::{ConvoyPhase, ConvoySummary, NamespaceSnapshot},
     qualified_path::QualifiedPath,
     Command, CorrelationKey, DaemonEvent, DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot,
     FleetReplicaStatus, FleetStaleness, HostListResponse, HostName, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId,
@@ -284,13 +285,13 @@ fn session_status_label(phase: Option<ResourceTerminalSessionPhase>) -> String {
     }
 }
 
-fn convoy_state_label(convoy: &flotilla_protocol::namespace::ConvoySummary) -> String {
+fn convoy_state_label(convoy: &ConvoySummary) -> String {
     let phase = match convoy.phase {
-        flotilla_protocol::namespace::ConvoyPhase::Pending => "pending",
-        flotilla_protocol::namespace::ConvoyPhase::Active => "active",
-        flotilla_protocol::namespace::ConvoyPhase::Completed => "completed",
-        flotilla_protocol::namespace::ConvoyPhase::Failed => "failed",
-        flotilla_protocol::namespace::ConvoyPhase::Cancelled => "cancelled",
+        ConvoyPhase::Pending => "pending",
+        ConvoyPhase::Active => "active",
+        ConvoyPhase::Completed => "completed",
+        ConvoyPhase::Failed => "failed",
+        ConvoyPhase::Cancelled => "cancelled",
     };
     match convoy.message.as_deref().filter(|message| !message.trim().is_empty()) {
         Some(message) => format!("{phase}: {message}"),
@@ -300,13 +301,17 @@ fn convoy_state_label(convoy: &flotilla_protocol::namespace::ConvoySummary) -> S
 
 fn append_crewless_convoy_rows(
     rows: &mut Vec<FleetListRow>,
-    namespaces: &[flotilla_protocol::namespace::NamespaceSnapshot],
+    target_namespace: &str,
+    namespaces: &[NamespaceSnapshot],
     host: &HostName,
     staleness: FleetStaleness,
 ) {
     let mut convoys_with_crew: HashSet<String> = rows.iter().map(|row| row.convoy.clone()).collect();
-    for namespace in namespaces {
-        for convoy in &namespace.convoys {
+    for snapshot in namespaces {
+        if snapshot.namespace != target_namespace {
+            continue;
+        }
+        for convoy in &snapshot.convoys {
             if !convoys_with_crew.insert(convoy.name.clone()) {
                 continue;
             }
@@ -2187,6 +2192,7 @@ impl InProcessDaemon {
 
     pub async fn refresh_fleet_replicas_once(&self) -> Result<(), String> {
         let hosts = self.config.load_hosts()?;
+        let namespace = self.provisioning_namespace().await;
         let runner = self.local_command_runner().ok_or_else(|| "local command runner unavailable".to_string())?;
         for (label, remote) in &hosts.hosts {
             let host = HostName::new(remote.expected_host_name.clone());
@@ -2207,7 +2213,7 @@ impl InProcessDaemon {
                             row
                         })
                         .collect();
-                    append_crewless_convoy_rows(&mut rows, &snapshot.namespaces, &snapshot_host, staleness);
+                    append_crewless_convoy_rows(&mut rows, &namespace, &snapshot.namespaces, &snapshot_host, staleness);
                     self.fleet_replica_cache.write().await.insert(host, FleetReplicaCacheEntry {
                         rows,
                         last_sync: Some(now),
@@ -2301,7 +2307,7 @@ impl InProcessDaemon {
             });
         }
         let namespaces = self.namespace_projection_state().await.all_snapshots().await;
-        append_crewless_convoy_rows(&mut rows, &namespaces, &self.host_name, FleetStaleness::Local);
+        append_crewless_convoy_rows(&mut rows, namespace, &namespaces, &self.host_name, FleetStaleness::Local);
         rows.sort_by(|left, right| {
             (&left.convoy, left.host.as_str(), &left.vessel, &left.crew).cmp(&(
                 &right.convoy,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -284,6 +284,45 @@ fn session_status_label(phase: Option<ResourceTerminalSessionPhase>) -> String {
     }
 }
 
+fn convoy_state_label(convoy: &flotilla_protocol::namespace::ConvoySummary) -> String {
+    let phase = match convoy.phase {
+        flotilla_protocol::namespace::ConvoyPhase::Pending => "pending",
+        flotilla_protocol::namespace::ConvoyPhase::Active => "active",
+        flotilla_protocol::namespace::ConvoyPhase::Completed => "completed",
+        flotilla_protocol::namespace::ConvoyPhase::Failed => "failed",
+        flotilla_protocol::namespace::ConvoyPhase::Cancelled => "cancelled",
+    };
+    match convoy.message.as_deref().filter(|message| !message.trim().is_empty()) {
+        Some(message) => format!("{phase}: {message}"),
+        None => phase.to_string(),
+    }
+}
+
+fn append_crewless_convoy_rows(
+    rows: &mut Vec<FleetListRow>,
+    namespaces: &[flotilla_protocol::namespace::NamespaceSnapshot],
+    host: &HostName,
+    staleness: FleetStaleness,
+) {
+    let mut convoys_with_crew: HashSet<String> = rows.iter().map(|row| row.convoy.clone()).collect();
+    for namespace in namespaces {
+        for convoy in &namespace.convoys {
+            if !convoys_with_crew.insert(convoy.name.clone()) {
+                continue;
+            }
+            rows.push(FleetListRow {
+                convoy: convoy.name.clone(),
+                vessel: "-".to_string(),
+                authority: None,
+                crew: "-".to_string(),
+                crew_state: convoy_state_label(convoy),
+                host: host.clone(),
+                staleness: staleness.clone(),
+            });
+        }
+    }
+}
+
 fn resource_environment_host_ref(environment: &flotilla_resources::ResourceObject<ResourceEnvironment>) -> Option<&str> {
     environment
         .spec
@@ -2158,13 +2197,19 @@ impl InProcessDaemon {
                     let now = Utc::now();
                     let snapshot_host = snapshot.host;
                     let generation = snapshot.generation;
-                    let rows = snapshot.rows.into_iter().map(|mut row| {
-                        row.host = snapshot_host.clone();
-                        row.staleness = FleetStaleness::Fresh { last_sync: now };
-                        row
-                    });
+                    let staleness = FleetStaleness::Fresh { last_sync: now };
+                    let mut rows: Vec<_> = snapshot
+                        .rows
+                        .into_iter()
+                        .map(|mut row| {
+                            row.host = snapshot_host.clone();
+                            row.staleness = staleness.clone();
+                            row
+                        })
+                        .collect();
+                    append_crewless_convoy_rows(&mut rows, &snapshot.namespaces, &snapshot_host, staleness);
                     self.fleet_replica_cache.write().await.insert(host, FleetReplicaCacheEntry {
-                        rows: rows.collect(),
+                        rows,
                         last_sync: Some(now),
                         generation,
                         last_error: None,
@@ -2255,6 +2300,8 @@ impl InProcessDaemon {
                 staleness: FleetStaleness::Local,
             });
         }
+        let namespaces = self.namespace_projection_state().await.all_snapshots().await;
+        append_crewless_convoy_rows(&mut rows, &namespaces, &self.host_name, FleetStaleness::Local);
         rows.sort_by(|left, right| {
             (&left.convoy, left.host.as_str(), &left.vessel, &left.crew).cmp(&(
                 &right.convoy,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -634,6 +634,62 @@ async fn replica_refresh_reports_crewless_convoys_from_namespace_snapshots() {
     assert!(matches!(row.staleness, FleetStaleness::Fresh { .. }));
 }
 
+#[tokio::test]
+async fn replica_refresh_dedupes_crewless_rows_already_present_in_snapshot_rows() {
+    use flotilla_protocol::namespace::{ConvoyId, ConvoyPhase as WireConvoyPhase, ConvoySummary, NamespaceSnapshot};
+
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let summary = ConvoySummary {
+        id: ConvoyId::new("flotilla", "remote-failed"),
+        namespace: "flotilla".into(),
+        name: "remote-failed".into(),
+        workflow_ref: "scratch".into(),
+        phase: WireConvoyPhase::Failed,
+        message: Some("missing input 'topic'".into()),
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: true,
+    };
+    let snapshot = FleetReplicaSnapshot {
+        host: HostName::new("feta"),
+        generation: Some("gen-1".to_string()),
+        rows: vec![FleetListRow {
+            convoy: "remote-failed".to_string(),
+            vessel: "-".to_string(),
+            authority: None,
+            crew: "-".to_string(),
+            crew_state: "failed: missing input 'topic'".to_string(),
+            host: HostName::new("feta"),
+            staleness: FleetStaleness::Local,
+        }],
+        namespaces: vec![NamespaceSnapshot { seq: 3, namespace: "flotilla".into(), convoys: vec![summary] }],
+    };
+    let runner = Arc::new(QueuedOutputRunner::new(vec![CommandOutput {
+        stdout: serde_json::to_string(&snapshot).expect("serialize snapshot"),
+        stderr: String::new(),
+        success: true,
+    }]));
+    let mut discovery =
+        fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(Arc::new(FakeTerminalPool::new())));
+    discovery.runner = runner;
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), discovery, HostName::local()).await;
+
+    daemon.refresh_fleet_replicas_once().await.expect("refresh should succeed");
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+
+    assert_eq!(response.rows.len(), 1);
+    assert_eq!(response.rows[0].convoy, "remote-failed");
+    assert_eq!(response.rows[0].crew, "-");
+}
+
 #[test]
 fn choose_event_uses_delta_for_non_initial_changes() {
     let repo = PathBuf::from("/tmp/repo");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -360,6 +360,50 @@ async fn fleet_list_reports_store_backed_local_sessions_with_authority() {
 }
 
 #[tokio::test]
+async fn fleet_list_reports_local_crewless_failed_convoys() {
+    use flotilla_protocol::namespace::{ConvoyId, ConvoyPhase as WireConvoyPhase, ConvoySummary};
+
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let projection_state = daemon.namespace_projection_state().await;
+    let summary = ConvoySummary {
+        id: ConvoyId::new("flotilla", "convoy-failed"),
+        namespace: "flotilla".into(),
+        name: "convoy-failed".into(),
+        workflow_ref: "scratch".into(),
+        phase: WireConvoyPhase::Failed,
+        message: Some("missing input 'topic'".into()),
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: true,
+    };
+    {
+        let mut namespaces = projection_state.write().await;
+        let view = namespaces.entry("flotilla".into()).or_default();
+        view.convoys.insert(summary.id.clone(), summary);
+        view.seq = 1;
+    }
+
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+
+    assert_eq!(response.rows.len(), 1);
+    let row = &response.rows[0];
+    assert_eq!(row.convoy, "convoy-failed");
+    assert_eq!(row.vessel, "-");
+    assert_eq!(row.crew, "-");
+    assert_eq!(row.crew_state, "failed: missing input 'topic'");
+    assert_eq!(row.host, daemon.host_name);
+    assert_eq!(row.staleness, FleetStaleness::Local);
+}
+
+#[tokio::test]
 async fn fleet_list_preserves_stale_rows_when_replica_is_unreachable() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
@@ -455,6 +499,59 @@ async fn replica_refresh_replaces_rows_when_generation_changes() {
     assert_eq!(response.replicas.len(), 1);
     assert!(response.replicas[0].reachable);
     assert_eq!(response.replicas[0].generation.as_deref(), Some("gen-2"));
+}
+
+#[tokio::test]
+async fn replica_refresh_reports_crewless_convoys_from_namespace_snapshots() {
+    use flotilla_protocol::namespace::{ConvoyId, ConvoyPhase as WireConvoyPhase, ConvoySummary, NamespaceSnapshot};
+
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let summary = ConvoySummary {
+        id: ConvoyId::new("flotilla", "remote-failed"),
+        namespace: "flotilla".into(),
+        name: "remote-failed".into(),
+        workflow_ref: "scratch".into(),
+        phase: WireConvoyPhase::Failed,
+        message: Some("missing input 'topic'".into()),
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: true,
+    };
+    let snapshot = FleetReplicaSnapshot {
+        host: HostName::new("feta"),
+        generation: Some("gen-1".to_string()),
+        rows: vec![],
+        namespaces: vec![NamespaceSnapshot { seq: 3, namespace: "flotilla".into(), convoys: vec![summary] }],
+    };
+    let runner = Arc::new(QueuedOutputRunner::new(vec![CommandOutput {
+        stdout: serde_json::to_string(&snapshot).expect("serialize snapshot"),
+        stderr: String::new(),
+        success: true,
+    }]));
+    let mut discovery =
+        fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(Arc::new(FakeTerminalPool::new())));
+    discovery.runner = runner;
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), discovery, HostName::local()).await;
+
+    daemon.refresh_fleet_replicas_once().await.expect("refresh should succeed");
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+
+    assert_eq!(response.rows.len(), 1);
+    let row = &response.rows[0];
+    assert_eq!(row.convoy, "remote-failed");
+    assert_eq!(row.vessel, "-");
+    assert_eq!(row.crew, "-");
+    assert_eq!(row.crew_state, "failed: missing input 'topic'");
+    assert_eq!(row.host, HostName::new("feta"));
+    assert!(matches!(row.staleness, FleetStaleness::Fresh { .. }));
 }
 
 #[test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -389,6 +389,24 @@ async fn fleet_list_reports_local_crewless_failed_convoys() {
         let view = namespaces.entry("flotilla".into()).or_default();
         view.convoys.insert(summary.id.clone(), summary);
         view.seq = 1;
+
+        let leaked = ConvoySummary {
+            id: ConvoyId::new("other", "other-failed"),
+            namespace: "other".into(),
+            name: "other-failed".into(),
+            workflow_ref: "scratch".into(),
+            phase: WireConvoyPhase::Failed,
+            message: Some("wrong namespace".into()),
+            repo_hint: None,
+            tasks: vec![],
+            started_at: None,
+            finished_at: None,
+            observed_workflow_ref: None,
+            initializing: true,
+        };
+        let other = namespaces.entry("other".into()).or_default();
+        other.convoys.insert(leaked.id.clone(), leaked);
+        other.seq = 1;
     }
 
     let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
@@ -401,6 +419,50 @@ async fn fleet_list_reports_local_crewless_failed_convoys() {
     assert_eq!(row.crew_state, "failed: missing input 'topic'");
     assert_eq!(row.host, daemon.host_name);
     assert_eq!(row.staleness, FleetStaleness::Local);
+}
+
+#[tokio::test]
+async fn fleet_list_does_not_add_crewless_row_when_convoy_has_crew() {
+    use flotilla_protocol::namespace::{ConvoyId, ConvoyPhase as WireConvoyPhase, ConvoySummary};
+
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
+        .await;
+
+    let projection_state = daemon.namespace_projection_state().await;
+    let summary = ConvoySummary {
+        id: ConvoyId::new("flotilla", "convoy-a"),
+        namespace: "flotilla".into(),
+        name: "convoy-a".into(),
+        workflow_ref: "scratch".into(),
+        phase: WireConvoyPhase::Active,
+        message: None,
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: false,
+    };
+    {
+        let mut namespaces = projection_state.write().await;
+        let view = namespaces.entry("flotilla".into()).or_default();
+        view.convoys.insert(summary.id.clone(), summary);
+        view.seq = 1;
+    }
+
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+
+    assert_eq!(response.rows.len(), 1);
+    assert_eq!(response.rows[0].convoy, "convoy-a");
+    assert_eq!(response.rows[0].crew, "implement/coder");
+    assert_eq!(response.rows[0].crew_state, "running");
 }
 
 #[tokio::test]
@@ -525,11 +587,29 @@ async fn replica_refresh_reports_crewless_convoys_from_namespace_snapshots() {
         observed_workflow_ref: None,
         initializing: true,
     };
+    let leaked = ConvoySummary {
+        id: ConvoyId::new("other", "other-failed"),
+        namespace: "other".into(),
+        name: "other-failed".into(),
+        workflow_ref: "scratch".into(),
+        phase: WireConvoyPhase::Failed,
+        message: Some("wrong namespace".into()),
+        repo_hint: None,
+        tasks: vec![],
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: None,
+        initializing: true,
+    };
     let snapshot = FleetReplicaSnapshot {
         host: HostName::new("feta"),
         generation: Some("gen-1".to_string()),
         rows: vec![],
-        namespaces: vec![NamespaceSnapshot { seq: 3, namespace: "flotilla".into(), convoys: vec![summary] }],
+        namespaces: vec![NamespaceSnapshot { seq: 3, namespace: "flotilla".into(), convoys: vec![summary] }, NamespaceSnapshot {
+            seq: 3,
+            namespace: "other".into(),
+            convoys: vec![leaked],
+        }],
     };
     let runner = Arc::new(QueuedOutputRunner::new(vec![CommandOutput {
         stdout: serde_json::to_string(&snapshot).expect("serialize snapshot"),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -525,6 +525,28 @@ mod command_result_human {
     }
 
     #[test]
+    fn fleet_list_shows_crewless_failed_convoy() {
+        let result = CommandValue::FleetList(Box::new(FleetListResponse {
+            rows: vec![FleetListRow {
+                convoy: "convoy-failed".into(),
+                vessel: "-".into(),
+                authority: None,
+                crew: "-".into(),
+                crew_state: "failed: missing input 'topic'".into(),
+                host: HostName::new("kiwi"),
+                staleness: FleetStaleness::Local,
+            }],
+            replicas: vec![],
+        }));
+
+        let output = format_command_result(&result);
+
+        assert!(!output.contains("No crew sessions found."));
+        assert!(output.contains("convoy-failed"));
+        assert!(output.contains("failed: missing input 'topic'"));
+    }
+
+    #[test]
     fn prepared_workspace_is_internal_step_result() {
         let result = CommandValue::PreparedWorkspace(PreparedWorkspace {
             label: "feat".into(),


### PR DESCRIPTION
## Summary
- Show crewless convoys in `flotilla ls` by synthesizing `Crew -` rows from namespace snapshots
- Preserve failed/pending convoy truth in local and replica-backed fleet listings
- Keep human CLI output from reporting “No crew sessions found” when a convoy exists without crew

Closes #653

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo test -p flotilla-core --locked crewless`
- `cargo test -p flotilla-tui --locked fleet_list_shows_crewless_failed_convoy`