### PR TITLE
[codex] fix: enforce lifecycle authority in reconcilers

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
+++ b/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
@@ -3,7 +3,9 @@ use std::{collections::BTreeMap, marker::PhantomData};
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
-    controller::{Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
+    controller::{
+        delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
+    },
     descriptive_repo_slug, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
     DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec,
     FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority,
@@ -492,23 +494,6 @@ impl Reconciler for TaskWorkspaceReconciler {
     fn finalizer_name(&self) -> Option<&'static str> {
         Some("flotilla.work/task-workspace-teardown")
     }
-}
-
-async fn delete_lifecycle_owned_matching<T: Resource>(
-    resolver: &TypedResolver<T>,
-    selector: &BTreeMap<String, String>,
-) -> Result<(), ResourceError> {
-    let listed = resolver.list_matching_labels(selector).await?;
-    for object in listed.items {
-        if matches!(object.metadata.lifecycle_authority()?, Some(LifecycleAuthority::Observed | LifecycleAuthority::Adopted)) {
-            continue;
-        }
-        match resolver.delete(&object.metadata.name).await {
-            Ok(()) | Err(ResourceError::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    Ok(())
 }
 
 fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, String> {

--- a/crates/flotilla-core/src/data.rs
+++ b/crates/flotilla-core/src/data.rs
@@ -357,10 +357,9 @@ fn group_to_work_item(providers: &ProviderData, group: &CorrelatedGroup, group_i
         (CorrelatedAnchor::ChangeRequest(key), None, session_key.clone())
     } else if let Some(key) = session_key.clone() {
         (CorrelatedAnchor::Session(key), None, None)
-    } else if let Some(key) = agent_key.clone() {
-        (CorrelatedAnchor::Agent(key), None, None)
     } else {
-        return None;
+        let key = agent_key.clone()?;
+        (CorrelatedAnchor::Agent(key), None, None)
     };
 
     let branch = group.branch().map(|s| s.to_string());

--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -210,7 +210,7 @@ impl HostRegistry {
         let configured = self.configured_peers.read().await.clone();
         let node_connectivity = self.node_connectivity.read().await.clone();
         let mut events = Vec::new();
-        for (_environment_id, state) in self.hosts.read().await.iter() {
+        for state in self.hosts.read().await.values() {
             let environment_id = state.environment_id.clone();
             let stream_key = StreamKey::Host { environment_id: environment_id.clone() };
             let up_to_date = last_seen.get(&stream_key).is_some_and(|seq| *seq == state.seq);

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -384,9 +384,11 @@ impl<R: Reconciler> ControllerLoop<R> {
                     Err(ResourceError::NotFound { .. }) => continue,
                     Err(err) => return Err(err),
                 };
+                let lifecycle_owned = is_lifecycle_owned(object.metadata.lifecycle_authority()?);
                 if let Some(finalizer_name) = reconciler.finalizer_name() {
                     if object.metadata.deletion_timestamp.is_none()
                         && object.metadata.finalizers.iter().all(|finalizer| finalizer != finalizer_name)
+                        && lifecycle_owned
                     {
                         let meta = InputMeta::from(&object.metadata).with_added_finalizer(finalizer_name);
                         // A racing writer may win between get() and update(); rely on the resulting
@@ -397,7 +399,9 @@ impl<R: Reconciler> ControllerLoop<R> {
                     if object.metadata.deletion_timestamp.is_some()
                         && object.metadata.finalizers.iter().any(|finalizer| finalizer == finalizer_name)
                     {
-                        reconciler.run_finalizer(&object).await?;
+                        if lifecycle_owned {
+                            reconciler.run_finalizer(&object).await?;
+                        }
                         let meta = InputMeta::from(&object.metadata).without_finalizer(finalizer_name);
                         match primary.update(&meta, &object.metadata.resource_version, &object.spec).await {
                             Ok(_) | Err(ResourceError::NotFound { .. }) => {}
@@ -407,6 +411,9 @@ impl<R: Reconciler> ControllerLoop<R> {
                     }
                 }
                 if object.metadata.deletion_timestamp.is_some() {
+                    continue;
+                }
+                if !lifecycle_owned {
                     continue;
                 }
                 let deps = reconciler.fetch_dependencies(&object).await?;
@@ -465,12 +472,37 @@ impl<R: Reconciler> ControllerLoop<R> {
     }
 }
 
+fn is_lifecycle_owned(authority: Option<LifecycleAuthority>) -> bool {
+    !matches!(authority, Some(LifecycleAuthority::Observed | LifecycleAuthority::Adopted))
+}
+
 /// List every resource matching `selector` and delete it, swallowing `NotFound` from
-/// races with concurrent deletes. Used by cascading-teardown reconcilers (TaskWorkspace,
-/// Convoy) to garbage-collect their owned children before the finalizer is removed.
+/// races with concurrent deletes.
 pub async fn delete_matching<T: Resource>(resolver: &TypedResolver<T>, selector: &BTreeMap<String, String>) -> Result<(), ResourceError> {
     let listed = resolver.list_matching_labels(selector).await?;
     for object in listed.items {
+        match resolver.delete(&object.metadata.name).await {
+            Ok(()) | Err(ResourceError::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}
+
+/// List every resource matching `selector` and delete only lifecycle-owned children.
+///
+/// `Observed` and `Adopted` children may be referenced by a managed parent but their
+/// lifecycle belongs outside the parent reconciler, so cascading teardown must not
+/// delete them.
+pub async fn delete_lifecycle_owned_matching<T: Resource>(
+    resolver: &TypedResolver<T>,
+    selector: &BTreeMap<String, String>,
+) -> Result<(), ResourceError> {
+    let listed = resolver.list_matching_labels(selector).await?;
+    for object in listed.items {
+        if !is_lifecycle_owned(object.metadata.lifecycle_authority()?) {
+            continue;
+        }
         match resolver.delete(&object.metadata.name).await {
             Ok(()) | Err(ResourceError::NotFound { .. }) => {}
             Err(err) => return Err(err),

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -259,17 +259,11 @@ impl<R: Reconciler> ControllerLoop<R> {
             }
             Actuation::DeletePresentation { name } => {
                 let resolver = backend.using::<crate::Presentation>(namespace);
-                match resolver.delete(&name).await {
-                    Ok(()) | Err(ResourceError::NotFound { .. }) => Ok(()),
-                    Err(err) => Err(err),
-                }
+                Self::delete_if_lifecycle_owned(&resolver, &name).await
             }
             Actuation::DeleteTaskWorkspace { name } => {
                 let resolver = backend.using::<crate::TaskWorkspace>(namespace);
-                match resolver.delete(&name).await {
-                    Ok(()) | Err(ResourceError::NotFound { .. }) => Ok(()),
-                    Err(err) => Err(err),
-                }
+                Self::delete_if_lifecycle_owned(&resolver, &name).await
             }
         }
     }
@@ -278,6 +272,21 @@ impl<R: Reconciler> ControllerLoop<R> {
         meta.set_lifecycle_authority(LifecycleAuthority::Managed);
         match resolver.create(&meta, &spec).await {
             Ok(_) | Err(ResourceError::Conflict { .. }) => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn delete_if_lifecycle_owned<T: Resource>(resolver: &TypedResolver<T>, name: &str) -> Result<(), ResourceError> {
+        let object = match resolver.get(name).await {
+            Ok(object) => object,
+            Err(ResourceError::NotFound { .. }) => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        if !is_lifecycle_owned(object.metadata.lifecycle_authority()?) {
+            return Ok(());
+        }
+        match resolver.delete(name).await {
+            Ok(()) | Err(ResourceError::NotFound { .. }) => Ok(()),
             Err(err) => Err(err),
         }
     }
@@ -474,19 +483,6 @@ impl<R: Reconciler> ControllerLoop<R> {
 
 fn is_lifecycle_owned(authority: Option<LifecycleAuthority>) -> bool {
     !matches!(authority, Some(LifecycleAuthority::Observed | LifecycleAuthority::Adopted))
-}
-
-/// List every resource matching `selector` and delete it, swallowing `NotFound` from
-/// races with concurrent deletes.
-pub async fn delete_matching<T: Resource>(resolver: &TypedResolver<T>, selector: &BTreeMap<String, String>) -> Result<(), ResourceError> {
-    let listed = resolver.list_matching_labels(selector).await?;
-    for object in listed.items {
-        match resolver.delete(&object.metadata.name).await {
-            Ok(()) | Err(ResourceError::NotFound { .. }) => {}
-            Err(err) => return Err(err),
-        }
-    }
-    Ok(())
 }
 
 /// List every resource matching `selector` and delete only lifecycle-owned children.

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -9,7 +9,8 @@ use super::{
 use crate::{
     canonicalize_repo_url,
     controller::{
-        delete_matching, Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler, SecondaryWatch,
+        delete_lifecycle_owned_matching, Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler,
+        SecondaryWatch,
     },
     labels::{CONVOY_LABEL, TASK_LABEL},
     presentation::{Presentation, PresentationSpec},
@@ -140,10 +141,10 @@ impl Reconciler for ConvoyReconciler {
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
         let selector = BTreeMap::from([(CONVOY_LABEL.to_string(), obj.metadata.name.clone())]);
         if let Some(presentations) = &self.presentations {
-            delete_matching(presentations, &selector).await?;
+            delete_lifecycle_owned_matching(presentations, &selector).await?;
         }
         if let Some(task_workspaces) = &self.task_workspaces {
-            delete_matching(task_workspaces, &selector).await?;
+            delete_lifecycle_owned_matching(task_workspaces, &selector).await?;
         }
         Ok(())
     }

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -209,6 +209,10 @@ fn primary_meta(name: &str) -> InputMeta {
     resource_meta().name(name).call()
 }
 
+fn primary_meta_with_authority(name: &str, authority: LifecycleAuthority) -> InputMeta {
+    primary_meta(name).with_lifecycle_authority(authority)
+}
+
 fn secondary_meta(name: &str, primary: &str) -> InputMeta {
     resource_meta().name(name).labels([("flotilla.work/primary".to_string(), primary.to_string())].into_iter().collect()).call()
 }
@@ -577,6 +581,135 @@ async fn controller_loop_adds_finalizer_to_managed_resources() {
     })
     .await
     .expect("controller should attach its finalizer");
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_loop_skips_reconcile_for_observed_and_adopted_resources() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    primaries
+        .create(&primary_meta_with_authority("a-adopted", LifecycleAuthority::Adopted), &PrimarySpec { value: "one".to_string() })
+        .await
+        .expect("adopted primary create should succeed");
+    primaries
+        .create(&primary_meta_with_authority("b-observed", LifecycleAuthority::Observed), &PrimarySpec { value: "two".to_string() })
+        .await
+        .expect("observed primary create should succeed");
+    primaries.create(&primary_meta("z-managed"), &PrimarySpec { value: "three".to_string() }).await.expect("managed create should succeed");
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries,
+            secondaries: Vec::new(),
+            reconciler: RecordingReconciler { reconciled: Arc::clone(&reconciled) },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "z-managed") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("managed primary should reconcile");
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(reconciled.lock().expect("reconciled lock").as_slice(), &["z-managed".to_string()]);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_loop_does_not_add_finalizers_to_observed_or_adopted_resources() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    primaries
+        .create(&primary_meta_with_authority("a-adopted", LifecycleAuthority::Adopted), &PrimarySpec { value: "one".to_string() })
+        .await
+        .expect("adopted primary create should succeed");
+    primaries
+        .create(&primary_meta_with_authority("b-observed", LifecycleAuthority::Observed), &PrimarySpec { value: "two".to_string() })
+        .await
+        .expect("observed primary create should succeed");
+    primaries.create(&primary_meta("z-managed"), &PrimarySpec { value: "three".to_string() }).await.expect("managed create should succeed");
+
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries.clone(),
+            secondaries: Vec::new(),
+            reconciler: FinalizingReconciler { finalized: Arc::new(Mutex::new(Vec::new())) },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let object = primaries.get("z-managed").await.expect("managed primary get should succeed");
+            if object.metadata.finalizers == vec!["flotilla.work/test-finalizer".to_string()] {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("controller should attach its finalizer to managed primary");
+
+    assert!(primaries.get("a-adopted").await.expect("adopted primary get should succeed").metadata.finalizers.is_empty());
+    assert!(primaries.get("b-observed").await.expect("observed primary get should succeed").metadata.finalizers.is_empty());
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_loop_removes_existing_adopted_finalizer_without_running_teardown() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    let meta = resource_meta()
+        .name("a-adopted")
+        .finalizers(vec!["flotilla.work/test-finalizer".to_string()])
+        .deletion_timestamp(chrono::Utc::now())
+        .call()
+        .with_lifecycle_authority(LifecycleAuthority::Adopted);
+    primaries.create(&meta, &PrimarySpec { value: "one".to_string() }).await.expect("adopted primary create should succeed");
+
+    let finalized = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries.clone(),
+            secondaries: Vec::new(),
+            reconciler: FinalizingReconciler { finalized: Arc::clone(&finalized) },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if matches!(primaries.get("a-adopted").await, Err(ResourceError::NotFound { .. })) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("adopted primary should be unblocked without teardown");
+
+    assert!(finalized.lock().expect("finalized lock").is_empty());
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -177,6 +177,7 @@ impl flotilla_resources::controller::SecondaryWatch for RestartingSecondaryWatch
 #[derive(Clone)]
 struct ActuatingReconciler {
     actuation: Actuation,
+    reconciled: Option<Arc<Mutex<Vec<String>>>>,
 }
 
 impl Reconciler for ActuatingReconciler {
@@ -189,10 +190,13 @@ impl Reconciler for ActuatingReconciler {
 
     fn reconcile(
         &self,
-        _obj: &ResourceObject<Self::Resource>,
+        obj: &ResourceObject<Self::Resource>,
         _deps: &Self::Dependencies,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> ReconcileOutcome<Self::Resource> {
+        if let Some(reconciled) = &self.reconciled {
+            reconciled.lock().expect("reconciled lock").push(obj.metadata.name.clone());
+        }
         ReconcileOutcome::with_actuations(None, vec![self.actuation.clone()])
     }
 
@@ -767,6 +771,7 @@ async fn controller_loop_applies_create_presentation_actuation() {
             primary: primaries,
             secondaries: Vec::new(),
             reconciler: ActuatingReconciler {
+                reconciled: None,
                 actuation: Actuation::CreatePresentation {
                     meta: resource_meta().name("alpha-presentation").call(),
                     spec: PresentationSpec {
@@ -831,7 +836,10 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
         ControllerLoop {
             primary: primaries.clone(),
             secondaries: Vec::new(),
-            reconciler: ActuatingReconciler { actuation: Actuation::DeletePresentation { name: "alpha-presentation".to_string() } },
+            reconciler: ActuatingReconciler {
+                actuation: Actuation::DeletePresentation { name: "alpha-presentation".to_string() },
+                reconciled: None,
+            },
             resync_interval: Duration::from_secs(60),
             backend: backend.clone(),
         }
@@ -856,7 +864,10 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
         ControllerLoop {
             primary: primaries,
             secondaries: Vec::new(),
-            reconciler: ActuatingReconciler { actuation: Actuation::DeleteTaskWorkspace { name: "alpha-task".to_string() } },
+            reconciler: ActuatingReconciler {
+                actuation: Actuation::DeleteTaskWorkspace { name: "alpha-task".to_string() },
+                reconciled: None,
+            },
             resync_interval: Duration::from_secs(60),
             backend: backend.clone(),
         }
@@ -875,6 +886,98 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
     .expect("delete task workspace actuation should remove the resource");
 
     task_workspaces.delete("alpha-task").await.expect_err("resource should already be gone");
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resources() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    let presentations = backend.clone().using::<Presentation>("flotilla");
+    let task_workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    primaries.create(&primary_meta("alpha"), &PrimarySpec { value: "one".to_string() }).await.expect("primary create should succeed");
+    presentations
+        .create(
+            &resource_meta().name("adopted-presentation").call().with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &PresentationSpec {
+                convoy_ref: "alpha".to_string(),
+                presentation_policy_ref: "default".to_string(),
+                name: "alpha".to_string(),
+                process_selector: [("flotilla.work/convoy".to_string(), "alpha".to_string())].into_iter().collect(),
+            },
+        )
+        .await
+        .expect("presentation create should succeed");
+    task_workspaces
+        .create(&resource_meta().name("observed-task").call().with_lifecycle_authority(LifecycleAuthority::Observed), &TaskWorkspaceSpec {
+            convoy_ref: "alpha".to_string(),
+            task: "implement".to_string(),
+            placement_policy_ref: "local".to_string(),
+            adopted_checkout_ref: None,
+        })
+        .await
+        .expect("task workspace create should succeed");
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries.clone(),
+            secondaries: Vec::new(),
+            reconciler: ActuatingReconciler {
+                actuation: Actuation::DeletePresentation { name: "adopted-presentation".to_string() },
+                reconciled: Some(Arc::clone(&reconciled)),
+            },
+            resync_interval: Duration::from_secs(60),
+            backend: backend.clone(),
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("delete presentation actuation should run");
+    let presentation = presentations.get("adopted-presentation").await.expect("adopted presentation should remain");
+    assert_eq!(presentation.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Adopted));
+
+    harness.shutdown().await;
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries,
+            secondaries: Vec::new(),
+            reconciler: ActuatingReconciler {
+                actuation: Actuation::DeleteTaskWorkspace { name: "observed-task".to_string() },
+                reconciled: Some(Arc::clone(&reconciled)),
+            },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("delete task workspace actuation should run");
+    let task_workspace = task_workspaces.get("observed-task").await.expect("observed task workspace should remain");
+    assert_eq!(task_workspace.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -6,8 +6,8 @@ use common::{
 };
 use flotilla_resources::{
     apply_status_patch, controller::ControllerLoop, external_patches, reconcile, Convoy, ConvoyPhase, ConvoyReconciler, InMemoryBackend,
-    InputMeta, Presentation, PresentationSpec, ResourceBackend, ResourceError, TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceStatus,
-    WorkflowTemplate, CONVOY_LABEL, TASK_LABEL,
+    InputMeta, LifecycleAuthority, Presentation, PresentationSpec, ResourceBackend, ResourceError, TaskWorkspace, TaskWorkspacePhase,
+    TaskWorkspaceStatus, WorkflowTemplate, CONVOY_LABEL, TASK_LABEL,
 };
 use tokio::time::{timeout, Duration};
 
@@ -308,6 +308,96 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
         )
         .await
         .expect("presentation create should succeed");
+    workspaces
+        .create(
+            &InputMeta::builder()
+                .name("convoy-delete-adopted".to_string())
+                .labels(
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "adopted".to_string())]
+                        .into_iter()
+                        .collect(),
+                )
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &flotilla_resources::TaskWorkspaceSpec {
+                convoy_ref: "convoy-delete".to_string(),
+                task: "adopted".to_string(),
+                placement_policy_ref: "laptop-docker".to_string(),
+                adopted_checkout_ref: None,
+            },
+        )
+        .await
+        .expect("adopted task workspace create should succeed");
+    workspaces
+        .create(
+            &InputMeta::builder()
+                .name("convoy-delete-observed".to_string())
+                .labels(
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "observed".to_string())]
+                        .into_iter()
+                        .collect(),
+                )
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Observed),
+            &flotilla_resources::TaskWorkspaceSpec {
+                convoy_ref: "convoy-delete".to_string(),
+                task: "observed".to_string(),
+                placement_policy_ref: "laptop-docker".to_string(),
+                adopted_checkout_ref: None,
+            },
+        )
+        .await
+        .expect("observed task workspace create should succeed");
+    presentations
+        .create(
+            &InputMeta::builder()
+                .name("convoy-delete-adopted".to_string())
+                .labels(
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "adopted".to_string())]
+                        .into_iter()
+                        .collect(),
+                )
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &PresentationSpec {
+                convoy_ref: "convoy-delete".to_string(),
+                presentation_policy_ref: "default".to_string(),
+                name: "adopted".to_string(),
+                process_selector: [
+                    (CONVOY_LABEL.to_string(), "convoy-delete".to_string()),
+                    (TASK_LABEL.to_string(), "adopted".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            },
+        )
+        .await
+        .expect("adopted presentation create should succeed");
+    presentations
+        .create(
+            &InputMeta::builder()
+                .name("convoy-delete-observed".to_string())
+                .labels(
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "observed".to_string())]
+                        .into_iter()
+                        .collect(),
+                )
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Observed),
+            &PresentationSpec {
+                convoy_ref: "convoy-delete".to_string(),
+                presentation_policy_ref: "default".to_string(),
+                name: "observed".to_string(),
+                process_selector: [
+                    (CONVOY_LABEL.to_string(), "convoy-delete".to_string()),
+                    (TASK_LABEL.to_string(), "observed".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            },
+        )
+        .await
+        .expect("observed presentation create should succeed");
 
     let loop_task = tokio::spawn(
         ControllerLoop {
@@ -348,7 +438,48 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
         }
     })
     .await
-    .expect("convoy finalizer should delete presentation and task workspaces");
+    .expect("convoy finalizer should delete managed presentation and task workspace");
+
+    assert_eq!(
+        workspaces
+            .get("convoy-delete-adopted")
+            .await
+            .expect("adopted task workspace should remain")
+            .metadata
+            .lifecycle_authority()
+            .expect("authority label should parse"),
+        Some(LifecycleAuthority::Adopted)
+    );
+    assert_eq!(
+        workspaces
+            .get("convoy-delete-observed")
+            .await
+            .expect("observed task workspace should remain")
+            .metadata
+            .lifecycle_authority()
+            .expect("authority label should parse"),
+        Some(LifecycleAuthority::Observed)
+    );
+    assert_eq!(
+        presentations
+            .get("convoy-delete-adopted")
+            .await
+            .expect("adopted presentation should remain")
+            .metadata
+            .lifecycle_authority()
+            .expect("authority label should parse"),
+        Some(LifecycleAuthority::Adopted)
+    );
+    assert_eq!(
+        presentations
+            .get("convoy-delete-observed")
+            .await
+            .expect("observed presentation should remain")
+            .metadata
+            .lifecycle_authority()
+            .expect("authority label should parse"),
+        Some(LifecycleAuthority::Observed)
+    );
 
     loop_task.abort();
 }


### PR DESCRIPTION
## Summary
- Gate controller reconciliation/finalizer attachment on lifecycle authority so Observed and Adopted resources are not reconciled as managed resources.
- Add lifecycle-aware cascade deletion and use it for Convoy and TaskWorkspace teardown.
- Add regression coverage for skipped reconciliation/finalizers and preserving Observed/Adopted convoy children.

Closes #615

## Validation
- cargo +nightly-2026-03-12 fmt -- --check
- cargo test -p flotilla-resources --test controller_loop --test convoy_in_memory --locked
- cargo test -p flotilla-controllers --test task_workspace_reconciler --locked
- cargo clippy -p flotilla-resources -p flotilla-controllers --all-targets --locked -- -D warnings
- cargo test --workspace --locked

## Notes
- The full workspace clippy gate was attempted, but the all-target run became stuck in TUI clippy-driver invocations with no diagnostics. The touched-crate clippy gate passed.