### PR TITLE
fix: preserve qualified checkout paths

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -14,8 +14,9 @@ use std::{
 };
 
 use flotilla_protocol::{
-    arg::Arg, qualified_path::QualifiedPath, CheckoutTarget, Command, CommandAction, CommandValue, HostName, NodeId, PreparedWorkspace,
-    ResolvedPaneCommand,
+    arg::Arg,
+    qualified_path::{PathQualifier, QualifiedPath},
+    CheckoutTarget, Command, CommandAction, CommandValue, HostName, NodeId, PreparedWorkspace, ResolvedPaneCommand,
 };
 use tracing::{debug, error, info};
 
@@ -79,20 +80,21 @@ struct CheckoutFlow<'a> {
     registry: &'a ProviderRegistry,
     providers_data: &'a ProviderData,
     local_host: &'a HostName,
+    new_checkout_qualifier: PathQualifier,
     /// When true, skip host-side validation and de-duplication.
     /// Environment checkouts delegate validation to `CloneCheckoutManager`.
     is_environment: bool,
 }
 
 impl<'a> CheckoutFlow<'a> {
-    fn existing_checkout_path(&self) -> Option<ExecutionEnvironmentPath> {
+    fn existing_checkout_path(&self) -> Option<QualifiedPath> {
         if self.is_environment {
             // Environment namespaces are independent — host checkouts don't apply
             return None;
         }
         self.providers_data.checkouts.iter().find_map(|(hp, co)| {
             if checkout_is_local_owned(hp, self.local_host) && co.branch == self.branch {
-                Some(ExecutionEnvironmentPath::new(&hp.path))
+                Some(hp.clone())
             } else {
                 None
             }
@@ -106,7 +108,7 @@ impl<'a> CheckoutFlow<'a> {
             if matches!(self.intent, CheckoutIntent::FreshBranch) {
                 return Err(format!("branch already exists: {}", self.branch));
             }
-            return Ok(CommandValue::CheckoutCreated { branch: self.branch.to_string(), path: path.into_path_buf() });
+            return Ok(CommandValue::CheckoutCreated { branch: self.branch.to_string(), path });
         }
 
         // In environment context, skip host-side branch validation — the
@@ -117,7 +119,10 @@ impl<'a> CheckoutFlow<'a> {
         }
 
         let path = checkout_service.create_checkout(self.repo_root, self.branch, self.create_branch).await?;
-        Ok(CommandValue::CheckoutCreated { branch: self.branch.to_string(), path: path.into_path_buf() })
+        Ok(CommandValue::CheckoutCreated {
+            branch: self.branch.to_string(),
+            path: QualifiedPath { qualifier: self.new_checkout_qualifier.clone(), path: path.into_path_buf() },
+        })
     }
 }
 
@@ -649,7 +654,9 @@ impl StepResolver for ExecutorStepResolver {
                 let repo_root = prior
                     .iter()
                     .find_map(|o| match o {
-                        StepOutcome::CompletedWith(CommandValue::CheckoutCreated { path, .. }) => Some(ExecutionEnvironmentPath::new(path)),
+                        StepOutcome::CompletedWith(CommandValue::CheckoutCreated { path, .. }) => {
+                            Some(ExecutionEnvironmentPath::new(&path.path))
+                        }
                         _ => None,
                     })
                     .unwrap_or_else(|| ExecutionEnvironmentPath::new("/workspace"));
@@ -675,11 +682,15 @@ impl StepResolver for ExecutorStepResolver {
                     registry: effective_registry.as_ref(),
                     providers_data: effective_providers_data.as_ref(),
                     local_host: &self.local_host,
+                    new_checkout_qualifier: context_environment_id.as_ref().map_or_else(
+                        || PathQualifier::Host(self.environment_manager.local_host_id().clone()),
+                        |env_id| PathQualifier::Environment(env_id.clone()),
+                    ),
                     is_environment: context_environment_id.is_some(),
                 };
                 let result = checkout_flow.checkout_created_result().await?;
                 if let CommandValue::CheckoutCreated { ref path, .. } = result {
-                    info!(checkout_path = %path.display(), "created checkout");
+                    info!(checkout_path = %path, "created checkout");
                 }
                 Ok(StepOutcome::CompletedWith(result))
             }
@@ -782,7 +793,7 @@ impl StepResolver for ExecutorStepResolver {
                 } else {
                     prior.iter().find_map(|o| match o {
                         StepOutcome::CompletedWith(CommandValue::CheckoutCreated { branch, path }) => {
-                            Some((ExecutionEnvironmentPath::new(path), branch.clone(), None))
+                            Some((ExecutionEnvironmentPath::new(&path.path), branch.clone(), Some(path.clone())))
                         }
                         _ => None,
                     })

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -40,7 +40,7 @@ fn desc(name: &str) -> ProviderDescriptor {
 use async_trait::async_trait;
 use flotilla_protocol::{
     arg::Arg,
-    qualified_path::HostId,
+    qualified_path::{HostId, QualifiedPath},
     test_support::{TestCheckout, TestIssue, TestSession},
     CheckoutSelector, CheckoutTarget, Command, CommandAction, CommandValue, HostName, HostPath, NodeId, PreparedTerminalCommand,
     RepoSelector, ResolvedPaneCommand, TerminalStatus,
@@ -2422,7 +2422,7 @@ async fn checkout_plan_end_to_end_creates_workspace() {
         runner,
         env: Arc::new(crate::providers::discovery::test_support::TestEnvVars::default()),
         config_base: cb,
-        attachable_store: attachable,
+        attachable_store: attachable.clone(),
         daemon_socket_path: None,
         local_node_id: local_node_id(),
         local_host: lh.clone(),
@@ -2441,6 +2441,11 @@ async fn checkout_plan_end_to_end_creates_workspace() {
         calls.iter().any(|c| c.starts_with("create_workspace") || c.starts_with("select_workspace")),
         "should create or select workspace from prior outcome: {calls:?}"
     );
+
+    let expected_checkout = QualifiedPath::host(HostId::new("test-local-host-id"), "/repo/wt-feat-x");
+    let store = attachable.lock().expect("attachable store lock");
+    let matching_sets = store.sets_for_checkout(&expected_checkout);
+    assert_eq!(matching_sets.len(), 1, "new checkout should create one attachable set with its stable qualified path");
 }
 
 #[tokio::test]
@@ -2561,7 +2566,10 @@ async fn checkout_plan_preserves_checkout_created_when_workspace_step_fails() {
         _ => panic!("expected steps"),
     };
 
-    assert_eq!(result, CommandValue::CheckoutCreated { branch: "feat-x".into(), path: PathBuf::from("/repo/wt-feat-x") });
+    assert_eq!(result, CommandValue::CheckoutCreated {
+        branch: "feat-x".into(),
+        path: QualifiedPath::host(HostId::new("test-local-host-id"), "/repo/wt-feat-x"),
+    });
 }
 
 #[tokio::test]
@@ -3261,8 +3269,10 @@ async fn executor_step_resolver_prepare_workspace_produces_prepared_workspace() 
         environment_manager: empty_environment_manager().await,
     };
 
-    let prior =
-        vec![StepOutcome::CompletedWith(CommandValue::CheckoutCreated { branch: "feat".into(), path: PathBuf::from("/repo/wt-feat") })];
+    let prior = vec![StepOutcome::CompletedWith(CommandValue::CheckoutCreated {
+        branch: "feat".into(),
+        path: QualifiedPath::host(HostId::new("test-local-host-id"), "/repo/wt-feat"),
+    })];
     let action = StepAction::PrepareWorkspace { label: "feat".into(), checkout_path: None, display_host: None };
     let context = StepExecutionContext::Host(local_node_id());
     let outcome = resolver.resolve("create workspace", &context, action, &prior).await;
@@ -3621,7 +3631,7 @@ async fn executor_step_resolver_prepare_workspace_uses_manager_container_name_fo
 
     let prior = vec![StepOutcome::CompletedWith(CommandValue::CheckoutCreated {
         branch: "feat".into(),
-        path: PathBuf::from("/workspace/wt-feat"),
+        path: QualifiedPath::environment(env_id.clone(), "/workspace/wt-feat"),
     })];
     let action = StepAction::PrepareWorkspace { label: "feat".into(), checkout_path: None, display_host: Some(HostName::new("feta")) };
     let context = StepExecutionContext::Environment(local_node_id(), env_id.clone());
@@ -3630,6 +3640,7 @@ async fn executor_step_resolver_prepare_workspace_uses_manager_container_name_fo
     match outcome {
         Ok(StepOutcome::Produced(CommandValue::PreparedWorkspace(prepared))) => {
             assert_eq!(prepared.display_host, Some(HostName::new("feta")));
+            assert_eq!(prepared.checkout_key, Some(QualifiedPath::environment(env_id.clone(), "/workspace/wt-feat")));
             assert_eq!(prepared.environment_id, Some(env_id));
             assert_eq!(prepared.container_name.as_deref(), Some("mock-container"));
         }

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -3282,6 +3282,7 @@ async fn executor_step_resolver_prepare_workspace_produces_prepared_workspace() 
             assert_eq!(prepared.target_node_id, local_node_id());
             assert_eq!(prepared.display_host, None);
             assert_eq!(prepared.checkout_path, PathBuf::from("/repo/wt-feat"));
+            assert_eq!(prepared.checkout_key, Some(QualifiedPath::host(HostId::new("test-local-host-id"), "/repo/wt-feat")));
             assert!(!prepared.prepared_commands.is_empty(), "default workspace template should produce commands");
         }
         other => panic!("expected PreparedWorkspace outcome, got {other:?}"),

--- a/crates/flotilla-core/src/step/tests.rs
+++ b/crates/flotilla-core/src/step/tests.rs
@@ -1,5 +1,6 @@
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
+use flotilla_protocol::qualified_path::{HostId, QualifiedPath};
 use tokio::sync::{Mutex, Notify};
 
 use super::*;
@@ -254,7 +255,10 @@ async fn skipped_step_continues() {
 async fn completed_with_overrides_result() {
     let (cancel, tx) = setup();
     let resolver = TestResolver::new(vec![
-        Ok(StepOutcome::CompletedWith(CommandValue::CheckoutCreated { branch: "feat/x".into(), path: PathBuf::from("/repo/wt-feat-x") })),
+        Ok(StepOutcome::CompletedWith(CommandValue::CheckoutCreated {
+            branch: "feat/x".into(),
+            path: QualifiedPath::host(HostId::new("host-a"), "/repo/wt-feat-x"),
+        })),
         Ok(StepOutcome::Completed),
     ]);
     let plan = StepPlan::new(vec![make_step("step-a"), make_step("step-b")]);
@@ -270,7 +274,10 @@ async fn completed_with_overrides_result() {
         &resolver,
     )
     .await;
-    assert_eq!(result, CommandValue::CheckoutCreated { branch: "feat/x".into(), path: PathBuf::from("/repo/wt-feat-x") });
+    assert_eq!(result, CommandValue::CheckoutCreated {
+        branch: "feat/x".into(),
+        path: QualifiedPath::host(HostId::new("host-a"), "/repo/wt-feat-x"),
+    });
 }
 
 #[tokio::test]
@@ -340,7 +347,10 @@ async fn produced_does_not_override_final_result() {
 async fn later_failure_preserves_earlier_completed_with() {
     let (cancel, tx) = setup();
     let resolver = TestResolver::new(vec![
-        Ok(StepOutcome::CompletedWith(CommandValue::CheckoutCreated { branch: "feat/x".into(), path: PathBuf::from("/repo/wt-feat-x") })),
+        Ok(StepOutcome::CompletedWith(CommandValue::CheckoutCreated {
+            branch: "feat/x".into(),
+            path: QualifiedPath::host(HostId::new("host-a"), "/repo/wt-feat-x"),
+        })),
         Err("workspace failed".into()),
     ]);
     let plan = StepPlan::new(vec![make_step("step-a"), make_step("step-b")]);
@@ -356,7 +366,10 @@ async fn later_failure_preserves_earlier_completed_with() {
         &resolver,
     )
     .await;
-    assert_eq!(result, CommandValue::CheckoutCreated { branch: "feat/x".into(), path: PathBuf::from("/repo/wt-feat-x") });
+    assert_eq!(result, CommandValue::CheckoutCreated {
+        branch: "feat/x".into(),
+        path: QualifiedPath::host(HostId::new("host-a"), "/repo/wt-feat-x"),
+    });
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -19,11 +19,11 @@ use flotilla_core::{
     },
 };
 use flotilla_protocol::{
-    AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachableId, Checkout, CheckoutTarget, Command, CommandAction,
-    CommandPeerEvent, CommandValue, ConfigLabel, DaemonEvent, EnvironmentId, HostName, HostPath, HostSummary, Message, NodeId, NodeInfo,
-    PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage, PreparedWorkspace, ProviderData, RepoIdentity, RepoSelector,
-    Request, Response, ResponseResult, RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey,
-    VectorClock, PROTOCOL_VERSION,
+    qualified_path::QualifiedPath, AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachableId, Checkout, CheckoutTarget,
+    Command, CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, DaemonEvent, EnvironmentId, HostName, HostPath, HostSummary,
+    Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage, PreparedWorkspace, ProviderData,
+    RepoIdentity, RepoSelector, Request, Response, ResponseResult, RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome,
+    StepStatus, StreamKey, VectorClock, PROTOCOL_VERSION,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
@@ -1072,14 +1072,14 @@ async fn remote_checkout_completion_runs_workspace_step_on_presentation_host() {
         .complete_remote_step(request_id, NodeId::new("feta"), vec![
             StepOutcome::CompletedWith(CommandValue::CheckoutCreated {
                 branch: "feat-workspace-local".into(),
-                path: PathBuf::from("/srv/feta/repo/wt-feat-workspace-local"),
+                path: QualifiedPath::from_host_name(&HostName::new("feta"), "/srv/feta/repo/wt-feat-workspace-local"),
             }),
             StepOutcome::Produced(CommandValue::PreparedWorkspace(PreparedWorkspace {
                 label: "feat-workspace-local@feta".into(),
                 target_node_id: NodeId::new("feta"),
                 display_host: Some(HostName::new("feta")),
                 checkout_path: PathBuf::from("/srv/feta/repo/wt-feat-workspace-local"),
-                checkout_key: None,
+                checkout_key: Some(QualifiedPath::from_host_name(&HostName::new("feta"), "/srv/feta/repo/wt-feat-workspace-local")),
                 attachable_set_id: None,
                 environment_id: None,
                 container_name: None,
@@ -1124,7 +1124,7 @@ async fn remote_checkout_completion_runs_workspace_step_on_presentation_host() {
 
     assert_eq!(finished, CommandValue::CheckoutCreated {
         branch: "feat-workspace-local".into(),
-        path: PathBuf::from("/srv/feta/repo/wt-feat-workspace-local"),
+        path: QualifiedPath::from_host_name(&HostName::new("feta"), "/srv/feta/repo/wt-feat-workspace-local"),
     });
 
     let created_workspaces = workspace_manager.workspaces.lock().await.clone();
@@ -1852,7 +1852,7 @@ async fn execute_forwarded_prepare_terminal_returns_terminal_prepared() {
     match checkout_result {
         CommandValue::CheckoutCreated { branch, path } => {
             assert_eq!(branch, "feat-remote");
-            assert!(path.ends_with("repo.feat-remote"), "unexpected checkout path: {}", path.display());
+            assert!(path.path.ends_with("repo.feat-remote"), "unexpected checkout path: {path}");
         }
         other => panic!("expected checkout creation, got {other:?}"),
     };

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -322,7 +322,7 @@ pub enum CommandValue {
     },
     CheckoutCreated {
         branch: String,
-        path: PathBuf,
+        path: QualifiedPath,
     },
     CheckoutRemoved {
         branch: String,
@@ -693,7 +693,10 @@ mod tests {
             CommandValue::RepoTracked { path: PathBuf::from("/new/repo"), resolved_from: None },
             CommandValue::RepoUntracked { path: PathBuf::from("/old/repo") },
             CommandValue::Refreshed { repos: vec![PathBuf::from("/repo-a"), PathBuf::from("/repo-b")] },
-            CommandValue::CheckoutCreated { branch: "feat-new".into(), path: PathBuf::from("/repos/project/wt-1") },
+            CommandValue::CheckoutCreated {
+                branch: "feat-new".into(),
+                path: QualifiedPath::host(HostId::new("host-a"), "/repos/project/wt-1"),
+            },
             CommandValue::CheckoutRemoved { branch: "feat-old".into() },
             CommandValue::TerminalPrepared {
                 repo_identity: repo_identity(),
@@ -885,7 +888,7 @@ mod tests {
 
     #[test]
     fn command_result_uses_snake_case_tag() {
-        let result = CommandValue::CheckoutCreated { branch: "x".into(), path: PathBuf::from("/tmp/x") };
+        let result = CommandValue::CheckoutCreated { branch: "x".into(), path: QualifiedPath::host(HostId::new("host-a"), "/tmp/x") };
         let json = serde_json::to_value(&result).expect("serialize");
         assert_eq!(json.get("kind").and_then(|v| v.as_str()), Some("checkout_created"));
     }

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -296,7 +296,7 @@ fn daemon_event_command_finished_roundtrip() {
         node_id: NodeId::new("desktop"),
         repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
         repo: Some(PathBuf::from("/tmp/repo")),
-        result: CommandValue::CheckoutCreated { branch: "feat-x".into(), path: PathBuf::from("/tmp/repo/feat-x") },
+        result: CommandValue::CheckoutCreated { branch: "feat-x".into(), path: qp("/tmp/repo/feat-x") },
     };
     let json = serde_json::to_string(&event).expect("serialize");
     let decoded: DaemonEvent = serde_json::from_str(&json).expect("deserialize");
@@ -309,7 +309,7 @@ fn daemon_event_command_finished_roundtrip() {
             match result {
                 CommandValue::CheckoutCreated { branch, path } => {
                     assert_eq!(branch, "feat-x");
-                    assert_eq!(path, PathBuf::from("/tmp/repo/feat-x"));
+                    assert_eq!(path, qp("/tmp/repo/feat-x"));
                 }
                 other => panic!("expected CheckoutCreated, got {:?}", other),
             }

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -165,7 +165,11 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
 mod tests {
     use std::path::PathBuf;
 
-    use flotilla_protocol::{arg::Arg, CheckoutStatus, NodeId, RepoIdentity, ResolvedPaneCommand, WorkItemIdentity};
+    use flotilla_protocol::{
+        arg::Arg,
+        qualified_path::{HostId, QualifiedPath},
+        CheckoutStatus, NodeId, RepoIdentity, ResolvedPaneCommand, WorkItemIdentity,
+    };
 
     use super::*;
     use crate::app::{test_support::stub_app, ui_state::BranchInputKind};
@@ -244,7 +248,10 @@ mod tests {
     #[test]
     fn checkout_created_does_not_set_status_message() {
         let mut app = stub_app();
-        handle_result(CommandValue::CheckoutCreated { branch: "feat-new".into(), path: PathBuf::from("/tmp/wt") }, &mut app);
+        handle_result(
+            CommandValue::CheckoutCreated { branch: "feat-new".into(), path: QualifiedPath::host(HostId::new("host-a"), "/tmp/wt") },
+            &mut app,
+        );
         assert!(app.model.status_message.is_none());
         assert!(app.proto_commands.take_next().is_none());
     }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -12,8 +12,10 @@ use flotilla_core::{
     },
 };
 use flotilla_protocol::{
-    provider_data::Issue, qualified_path::HostId, Change, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostSummary, ImageId, NodeId,
-    NodeInfo, ProvisioningTarget, RepoSelector, WorkItemIdentity,
+    provider_data::Issue,
+    qualified_path::{HostId, QualifiedPath},
+    Change, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostSummary, ImageId, NodeId, NodeInfo, ProvisioningTarget, RepoSelector,
+    WorkItemIdentity,
 };
 use tempfile::tempdir;
 use test_support::*;
@@ -1023,7 +1025,10 @@ fn local_checkout_created_does_not_queue_workspace() {
         node_id: NodeId::new("my-desktop"),
         repo_identity,
         repo: Some(repo_path),
-        result: CommandValue::CheckoutCreated { branch: "feat".into(), path: PathBuf::from("/tmp/repo/wt-feat") },
+        result: CommandValue::CheckoutCreated {
+            branch: "feat".into(),
+            path: QualifiedPath::host(HostId::new("local-host"), "/tmp/repo/wt-feat"),
+        },
     });
 
     assert!(app.proto_commands.take_next().is_none(), "workspace creation is now handled by checkout plan, not TUI");
@@ -1043,7 +1048,10 @@ fn remote_checkout_created_does_not_queue_workspace() {
         node_id: NodeId::new("remote-a"),
         repo_identity,
         repo: Some(repo_path),
-        result: CommandValue::CheckoutCreated { branch: "feat".into(), path: PathBuf::from("/remote/wt-feat") },
+        result: CommandValue::CheckoutCreated {
+            branch: "feat".into(),
+            path: QualifiedPath::host(HostId::new("remote-host"), "/remote/wt-feat"),
+        },
     });
 
     assert!(app.proto_commands.take_next().is_none(), "remote checkout should not auto-create local workspace");

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -373,6 +373,7 @@ mod command_result_human {
 
     use flotilla_protocol::{
         commands::{CheckoutStatus, CommandValue},
+        qualified_path::{HostId, QualifiedPath},
         FleetListResponse, FleetListRow, FleetReplicaStatus, FleetStaleness, HostName, NodeId, PreparedWorkspace,
     };
 
@@ -426,7 +427,8 @@ mod command_result_human {
 
     #[test]
     fn checkout_created() {
-        let result = CommandValue::CheckoutCreated { branch: "feat-new".into(), path: PathBuf::from("/tmp/wt") };
+        let result =
+            CommandValue::CheckoutCreated { branch: "feat-new".into(), path: QualifiedPath::host(HostId::new("host-a"), "/tmp/wt") };
         let output = format_command_result(&result);
         assert!(output.contains("checkout created"), "should say checkout created");
         assert!(output.contains("feat-new"), "should include branch name");


### PR DESCRIPTION
## Summary

- make `CheckoutCreated` carry a `QualifiedPath` instead of a raw `PathBuf`
- preserve existing checkout identities and qualify newly created checkouts from their host or environment execution context
- forward that identity through workspace preparation so attachable sets and presentation bindings correlate to the same checkout
- add host and environment regression coverage and update protocol consumers

## Why

Creating a checkout followed by opening its workspace could produce two attachable sets for the same filesystem path. The terminal-bearing set used a legacy host-name qualifier, while the presentation binding used the stable host-ID qualifier, leaving the original repo-tab attachable set unopenable.

The qualifier was lost because `CheckoutCreated` carried only a `PathBuf`; `PrepareWorkspace` therefore persisted a fallback host-name-qualified key. Carrying `QualifiedPath` through the step outcome makes the identity loss unrepresentable.

## Impact

New host checkouts use the stable host ID, provisioned checkouts use their environment ID, and existing checkout keys remain unchanged. Existing duplicate registry entries are intentionally not migrated.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check --workspace --all-targets --locked`
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p flotilla-core --locked` — 973 passed
- `CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test -p flotilla-protocol --locked` — 219 passed

Clippy reaches all changed crates but is currently blocked by the pre-existing duplicated `#[cfg(test)]` attribute in `crates/flotilla-daemon/src/runtime/test_git_repo.rs`.
