### PR TITLE
feat: publish observed Checkout resources

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1561,6 +1561,19 @@ impl InProcessDaemon {
             updates.push((identity, last_local_providers, re_snapshot));
         }
 
+        let namespace = self.provisioning_namespace().await;
+        for (identity, local_providers, snapshot) in &updates {
+            if snapshot.errors.iter().any(|error| error.category == "checkouts") {
+                warn!(repo = %identity.path, "skipping observed checkout reconciliation after checkout discovery failed");
+                continue;
+            }
+            if let Err(error) =
+                crate::observed_resources::reconcile_checkouts(&self.observed_resource_backend, &namespace, identity, local_providers).await
+            {
+                warn!(repo = %identity.path, %error, "failed to reconcile observed checkouts");
+            }
+        }
+
         // Apply updates under write lock and broadcast
         let mut repos = self.repos.write().await;
         for (identity, last_local_providers, re_snapshot) in updates {

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod host_summary;
 pub mod in_process;
 pub mod merge;
 pub mod model;
+pub(crate) mod observed_resources;
 pub mod path_context;
 pub mod path_policy;
 pub mod provider_data;

--- a/crates/flotilla-core/src/observed_resources.rs
+++ b/crates/flotilla-core/src/observed_resources.rs
@@ -1,0 +1,115 @@
+use std::collections::{BTreeMap, HashMap};
+
+use flotilla_protocol::{qualified_path::QualifiedPath, ProviderData, RepoIdentity};
+use flotilla_resources::{
+    descriptive_repo_slug, repo_key, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority,
+    ObservedCheckoutSpec, ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
+};
+use sha2::{Digest, Sha256};
+
+/// Publish the checkout facts discovered for one local repository into the
+/// daemon's ephemeral observed-resource store.
+///
+/// The legacy `ProviderData` remains the input during the observer reshape,
+/// so it can continue feeding Plane A while the same refresh projects its
+/// checkout facts into the resource store.
+pub async fn reconcile_checkouts(
+    backend: &ResourceBackend,
+    namespace: &str,
+    repo_identity: &RepoIdentity,
+    providers: &ProviderData,
+) -> Result<(), ResourceError> {
+    let canonical_repo = canonical_repo_url(repo_identity);
+    let repo_key = repo_key(&canonical_repo);
+    let repo_ref = descriptive_repo_slug(&canonical_repo);
+    let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
+    let selector = BTreeMap::from([
+        (AUTHORITY_LABEL.to_string(), LifecycleAuthority::Observed.as_label_value().to_string()),
+        (REPO_KEY_LABEL.to_string(), repo_key.clone()),
+    ]);
+    let mut existing: HashMap<_, _> = checkouts
+        .list_matching_labels(&selector)
+        .await?
+        .items
+        .into_iter()
+        .map(|checkout| (checkout.metadata.name.clone(), checkout))
+        .collect();
+
+    for (path, checkout) in &providers.checkouts {
+        let name = observed_checkout_name(&repo_key, path);
+        let meta = observed_checkout_meta(&name, &repo_key, &repo_ref);
+        let spec = ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
+            r#ref: checkout.branch.clone(),
+            path: path.path.to_string_lossy().into_owned(),
+            repo_ref: repo_ref.clone(),
+            is_main: checkout.is_main,
+        });
+
+        match existing.remove(&name) {
+            Some(current) if current.spec == spec && current.metadata.labels == meta.labels => {}
+            Some(current) => {
+                checkouts.update(&meta, &current.metadata.resource_version, &spec).await?;
+            }
+            None => {
+                checkouts.create(&meta, &spec).await?;
+            }
+        }
+    }
+
+    for stale_name in existing.into_keys() {
+        checkouts.delete(&stale_name).await?;
+    }
+
+    Ok(())
+}
+
+fn canonical_repo_url(identity: &RepoIdentity) -> String {
+    format!("https://{}/{}", identity.authority, identity.path.trim_start_matches('/'))
+}
+
+fn observed_checkout_meta(name: &str, repo_key: &str, repo_ref: &str) -> InputMeta {
+    InputMeta::builder()
+        .name(name.to_string())
+        .labels(BTreeMap::from([(REPO_KEY_LABEL.to_string(), repo_key.to_string()), (REPO_LABEL.to_string(), repo_ref.to_string())]))
+        .build()
+        .with_lifecycle_authority(LifecycleAuthority::Observed)
+}
+
+fn observed_checkout_name(repo_key: &str, path: &QualifiedPath) -> String {
+    let mut hash = Sha256::new();
+    hash.update(b"observed-checkout-v1\0");
+    hash.update(repo_key.as_bytes());
+    hash.update([0]);
+    hash.update(path.to_string().as_bytes());
+    let digest = format!("{:x}", hash.finalize());
+    format!("checkout-{}", &digest[..54])
+}
+
+#[cfg(test)]
+mod tests {
+    use flotilla_protocol::{
+        qualified_path::{HostId, QualifiedPath},
+        HostName, RepoIdentity,
+    };
+
+    use super::{canonical_repo_url, observed_checkout_name};
+
+    #[test]
+    fn observed_checkout_names_are_stable_and_host_scoped() {
+        let path = "/workspace/flotilla";
+        let first = observed_checkout_name("repo-key", &QualifiedPath::host(HostId::new("host-a"), path));
+        let second = observed_checkout_name("repo-key", &QualifiedPath::host(HostId::new("host-a"), path));
+        let other_host = observed_checkout_name("repo-key", &QualifiedPath::from_host_name(&HostName::new("host-b"), path));
+
+        assert_eq!(first, second);
+        assert_ne!(first, other_host);
+        assert!(first.len() <= 63);
+    }
+
+    #[test]
+    fn canonical_repo_url_preserves_the_remote_identity() {
+        let identity = RepoIdentity { authority: "github.com".to_string(), path: "flotilla-org/flotilla".to_string() };
+
+        assert_eq!(canonical_repo_url(&identity), "https://github.com/flotilla-org/flotilla");
+    }
+}

--- a/crates/flotilla-core/src/observed_resources.rs
+++ b/crates/flotilla-core/src/observed_resources.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use flotilla_protocol::{qualified_path::QualifiedPath, ProviderData, RepoIdentity};
 use flotilla_resources::{
-    descriptive_repo_slug, repo_key, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority,
-    ObservedCheckoutSpec, ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
+    canonicalize_repo_url, descriptive_repo_slug, repo_key, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta,
+    LifecycleAuthority, ObservedCheckoutSpec, ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
 };
 use sha2::{Digest, Sha256};
 
@@ -19,7 +19,7 @@ pub async fn reconcile_checkouts(
     repo_identity: &RepoIdentity,
     providers: &ProviderData,
 ) -> Result<(), ResourceError> {
-    let canonical_repo = canonical_repo_url(repo_identity);
+    let canonical_repo = canonical_repo_url(repo_identity).map_err(ResourceError::invalid)?;
     let repo_key = repo_key(&canonical_repo);
     let repo_ref = descriptive_repo_slug(&canonical_repo);
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
@@ -63,8 +63,11 @@ pub async fn reconcile_checkouts(
     Ok(())
 }
 
-fn canonical_repo_url(identity: &RepoIdentity) -> String {
-    format!("https://{}/{}", identity.authority, identity.path.trim_start_matches('/'))
+fn canonical_repo_url(identity: &RepoIdentity) -> Result<String, String> {
+    if identity.authority == "unknown" {
+        return Err("cannot derive observed checkout identity from an unknown repository remote".to_string());
+    }
+    canonicalize_repo_url(&format!("https://{}/{}", identity.authority, identity.path.trim_start_matches('/')))
 }
 
 fn observed_checkout_meta(name: &str, repo_key: &str, repo_ref: &str) -> InputMeta {
@@ -89,10 +92,14 @@ fn observed_checkout_name(repo_key: &str, path: &QualifiedPath) -> String {
 mod tests {
     use flotilla_protocol::{
         qualified_path::{HostId, QualifiedPath},
-        HostName, RepoIdentity,
+        HostName, ProviderData, RepoIdentity,
+    };
+    use flotilla_resources::{
+        Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InMemoryBackend, InputMeta, ObservedCheckoutSpec,
+        ResourceBackend, ResourceError,
     };
 
-    use super::{canonical_repo_url, observed_checkout_name};
+    use super::{canonical_repo_url, observed_checkout_name, reconcile_checkouts};
 
     #[test]
     fn observed_checkout_names_are_stable_and_host_scoped() {
@@ -107,9 +114,52 @@ mod tests {
     }
 
     #[test]
-    fn canonical_repo_url_preserves_the_remote_identity() {
+    fn canonical_repo_url_normalizes_the_remote_identity() {
         let identity = RepoIdentity { authority: "github.com".to_string(), path: "flotilla-org/flotilla".to_string() };
 
-        assert_eq!(canonical_repo_url(&identity), "https://github.com/flotilla-org/flotilla");
+        assert_eq!(canonical_repo_url(&identity).expect("canonical repo URL"), "https://github.com/flotilla-org/flotilla");
+    }
+
+    #[test]
+    fn canonical_repo_url_normalizes_authority_case() {
+        let identity = RepoIdentity { authority: "GitHub.com".to_string(), path: "flotilla-org/flotilla".to_string() };
+
+        assert_eq!(canonical_repo_url(&identity).expect("canonical repo URL"), "https://github.com/flotilla-org/flotilla");
+    }
+
+    #[test]
+    fn canonical_repo_url_rejects_unknown_repo_identity() {
+        let identity = RepoIdentity { authority: "unknown".to_string(), path: "not-a-remote".to_string() };
+
+        assert!(canonical_repo_url(&identity).is_err());
+    }
+
+    #[tokio::test]
+    async fn unknown_repo_identity_leaves_existing_observed_checkouts_untouched() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::observed());
+        let checkouts = backend.using::<ResourceCheckout>("flotilla");
+        checkouts
+            .create(
+                &InputMeta::builder().name("existing".to_string()).build(),
+                &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
+                    r#ref: "main".to_string(),
+                    path: "/workspace/repo".to_string(),
+                    repo_ref: "existing-repo".to_string(),
+                    is_main: true,
+                }),
+            )
+            .await
+            .expect("existing checkout should be created");
+
+        let result = reconcile_checkouts(
+            &backend,
+            "flotilla",
+            &RepoIdentity { authority: "unknown".to_string(), path: "not-a-remote".to_string() },
+            &ProviderData::default(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(ResourceError::Invalid { .. })));
+        assert_eq!(checkouts.list().await.expect("checkout list should succeed").items.len(), 1);
     }
 }

--- a/crates/flotilla-core/src/observed_resources.rs
+++ b/crates/flotilla-core/src/observed_resources.rs
@@ -64,8 +64,8 @@ pub async fn reconcile_checkouts(
 }
 
 fn canonical_repo_url(identity: &RepoIdentity) -> Result<String, String> {
-    if identity.authority == "unknown" {
-        return Err("cannot derive observed checkout identity from an unknown repository remote".to_string());
+    if matches!(identity.authority.as_str(), "local" | "unknown") {
+        return Err("cannot derive observed checkout identity without a recognized repository remote".to_string());
     }
     canonicalize_repo_url(&format!("https://{}/{}", identity.authority, identity.path.trim_start_matches('/')))
 }
@@ -130,6 +130,13 @@ mod tests {
     #[test]
     fn canonical_repo_url_rejects_unknown_repo_identity() {
         let identity = RepoIdentity { authority: "unknown".to_string(), path: "not-a-remote".to_string() };
+
+        assert!(canonical_repo_url(&identity).is_err());
+    }
+
+    #[test]
+    fn canonical_repo_url_rejects_local_path_identity() {
+        let identity = RepoIdentity { authority: "local".to_string(), path: "/Users/alice/dev/project".to_string() };
 
         assert!(canonical_repo_url(&identity).is_err());
     }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -40,6 +40,10 @@ use flotilla_protocol::{
     Issue, NodeId, NodeInfo, PeerConnectionState, ProviderData, RepoIdentity, RepoSelector, StreamKey, SystemInfo, ToolInventory,
     TopologyRoute, WorkItemKind,
 };
+use flotilla_resources::{
+    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec,
+    REPO_KEY_LABEL, REPO_LABEL,
+};
 use tokio::sync::Notify;
 
 struct FixedRemoteHostDetector {
@@ -1631,6 +1635,105 @@ async fn local_direct_repo_refresh_stamps_discovered_checkout_environment_id() {
     let checkout =
         snapshot.providers.checkouts.values().find(|checkout| checkout.branch == "main").expect("local checkout should be present");
     assert_eq!(checkout.environment_id.as_ref(), Some(daemon.local_environment_id()));
+}
+
+#[tokio::test]
+async fn repo_refresh_reconciles_observed_checkouts() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo = temp.path().join("repo");
+    let feature_path = temp.path().join("feature");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let state = FakeVcsState::builder(repo.clone())
+        .branch("main", true)
+        .checkout("main")
+        .is_main(true)
+        .path(&repo)
+        .build()
+        .checkout("feature")
+        .path(&feature_path)
+        .build()
+        .build();
+    let mut discovery = fake_vcs_discovery(Arc::clone(&state));
+    discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
+
+    let daemon =
+        InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let mut events = daemon.subscribe();
+
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+    let first = observed.list().await.expect("observed checkout list should succeed");
+    assert_eq!(first.items.len(), 2);
+
+    let main = first
+        .items
+        .iter()
+        .find(|checkout| matches!(&checkout.spec, ResourceCheckoutSpec::Observed(spec) if spec.is_main))
+        .expect("main observed checkout should exist");
+    let feature = first
+        .items
+        .iter()
+        .find(|checkout| matches!(&checkout.spec, ResourceCheckoutSpec::Observed(spec) if !spec.is_main))
+        .expect("feature observed checkout should exist");
+    let feature_name = feature.metadata.name.clone();
+    let feature_path_string = feature_path.to_string_lossy().to_string();
+    let repo_key = main.metadata.labels.get(REPO_KEY_LABEL).expect("observed checkout should carry a repo key").clone();
+    assert_eq!(main.metadata.labels.get(REPO_LABEL).map(String::as_str), Some("github-com-owner-repo"));
+    assert_eq!(main.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
+    match &main.spec {
+        ResourceCheckoutSpec::Observed(spec) => assert_eq!(spec.repo_ref, "github-com-owner-repo"),
+        other => panic!("expected observed checkout spec, got {other:?}"),
+    }
+
+    {
+        let mut state = state.write().expect("fake VCS state should not be poisoned");
+        let feature = state.checkouts.iter_mut().find(|(_, checkout)| checkout.branch == "feature").expect("feature checkout");
+        feature.1.branch = "feature-renamed".to_string();
+        state.checkouts.retain(|(_, checkout)| checkout.branch != "main");
+    }
+
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+    let second = observed.list().await.expect("updated observed checkout list should succeed");
+    assert_eq!(second.items.len(), 1);
+    assert_eq!(second.items[0].metadata.name, feature_name, "checkout identity should follow its stable path");
+    match &second.items[0].spec {
+        ResourceCheckoutSpec::Observed(ObservedCheckoutSpec { r#ref, path, repo_ref, is_main }) => {
+            assert_eq!(r#ref, "feature-renamed");
+            assert_eq!(path, &feature_path_string);
+            assert_eq!(repo_ref, "github-com-owner-repo");
+            assert!(!is_main);
+        }
+        other => panic!("expected observed checkout spec, got {other:?}"),
+    }
+
+    observed
+        .create(
+            &InputMeta::builder()
+                .name("adopted-checkout-feature".to_string())
+                .labels(std::collections::BTreeMap::from([
+                    (flotilla_resources::AUTHORITY_LABEL.to_string(), LifecycleAuthority::Adopted.as_label_value().to_string()),
+                    (REPO_KEY_LABEL.to_string(), repo_key),
+                ]))
+                .build(),
+            &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: "feature-renamed".to_string(),
+                path: feature_path_string,
+                repo_ref: "github-com-owner-repo".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("adopted checkout should be creatable");
+
+    {
+        let mut state = state.write().expect("fake VCS state should not be poisoned");
+        state.checkouts.clear();
+    }
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+    let third = observed.list().await.expect("final observed checkout list should succeed");
+    assert_eq!(third.items.len(), 1, "adopted checkout must not be deleted by observed reconciliation");
+    assert_eq!(third.items[0].metadata.name, "adopted-checkout-feature");
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/src/labels.rs
+++ b/crates/flotilla-resources/src/labels.rs
@@ -7,6 +7,7 @@ pub const CONVOY_LABEL: &str = "flotilla.work/convoy";
 pub const TASK_LABEL: &str = "flotilla.work/task";
 pub const TASK_WORKSPACE_LABEL: &str = "flotilla.work/task_workspace";
 pub const ROLE_LABEL: &str = "flotilla.work/role";
+pub const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
 pub const TASK_ORDINAL_LABEL: &str = "flotilla.work/task_ordinal";
 pub const PROCESS_ORDINAL_LABEL: &str = "flotilla.work/process_ordinal";
 pub const REPO_LABEL: &str = "flotilla.work/repo";

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -41,8 +41,8 @@ pub use host::{Host, HostSpec, HostStatus, HostStatusPatch};
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use labels::{
-    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, TASK_LABEL,
-    TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, REPO_KEY_LABEL, REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL,
+    TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
 };
 pub use placement_policy::{
     DockerCheckoutStrategy, DockerPerTaskPlacementPolicySpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,


### PR DESCRIPTION
## Summary

- publish each refreshed local checkout as an observed `Checkout` resource in the ephemeral store
- reconcile create, update, and deletion by stable path-derived resource identity while preserving adopted resources
- retain the existing `ProviderData` path during the Plane-A transition and cover the projection at the daemon boundary

Closes #614.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`
- `cargo clippy -p flotilla-core -p flotilla-resources --all-targets --locked -- -D warnings`

## Known baseline failures

The full workspace gates currently stop on unrelated existing failures:

- workspace clippy: duplicated `#[cfg(test)]` in `flotilla-daemon/src/runtime/test_git_repo.rs`
- workspace tests: `tests/flotillad_binary.rs` cannot find the expected root `flotillad` binary target
