### PR TITLE
Provision agent crews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,6 +1270,7 @@ name = "flotilla-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bon",
  "bytes",
  "chrono",
  "color-eyre",

--- a/crates/flotilla-commands/src/commands/crew.rs
+++ b/crates/flotilla-commands/src/commands/crew.rs
@@ -1,0 +1,165 @@
+use clap::{Parser, Subcommand};
+use flotilla_protocol::{Command, CommandAction, CrewCommandContext};
+
+use crate::{
+    quote_value,
+    resolved::{HostResolution, RepoContext},
+    Resolved,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
+#[command(about = "Communicate with crew members")]
+pub struct CrewNoun {
+    /// Target crew role, or `list`
+    pub subject: String,
+    #[command(subcommand)]
+    pub verb: Option<CrewVerb>,
+    /// Explicit crew identity (normally read from FLOTILLA_CREW_ID)
+    #[arg(long)]
+    pub crew_id: Option<String>,
+    #[arg(long)]
+    pub namespace: Option<String>,
+    #[arg(long)]
+    pub convoy: Option<String>,
+    #[arg(long)]
+    pub vessel: Option<String>,
+    #[arg(long)]
+    pub role: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
+pub enum CrewVerb {
+    /// Ensure the target is running and deliver it a message
+    Handoff {
+        #[arg(long)]
+        message: String,
+    },
+}
+
+impl CrewNoun {
+    pub fn resolve_with_crew_id(self, ambient_crew_id: Option<String>) -> Result<Resolved, String> {
+        let context = CrewCommandContext::builder()
+            .maybe_crew_id(self.crew_id.or(ambient_crew_id))
+            .maybe_namespace(self.namespace)
+            .maybe_convoy(self.convoy)
+            .maybe_vessel(self.vessel)
+            .maybe_role(self.role)
+            .build();
+        let action = match (self.subject.as_str(), self.verb) {
+            ("list", None) => CommandAction::QueryCrewList { context },
+            ("list", Some(_)) => return Err("`flotilla crew list` does not accept a verb".to_string()),
+            (_, Some(CrewVerb::Handoff { message })) => CommandAction::CrewHandoff { context, target: self.subject, message },
+            (_, None) => return Err("crew target requires a verb (for example: handoff)".to_string()),
+        };
+        Ok(Resolved::NeedsContext {
+            command: Command { node_id: None, provisioning_target: None, context_repo: None, action },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        })
+    }
+
+    pub fn resolve(self) -> Result<Resolved, String> {
+        self.resolve_with_crew_id(None)
+    }
+}
+
+impl std::fmt::Display for CrewNoun {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "crew {}", self.subject)?;
+        for (flag, value) in [
+            ("--crew-id", self.crew_id.as_ref()),
+            ("--namespace", self.namespace.as_ref()),
+            ("--convoy", self.convoy.as_ref()),
+            ("--vessel", self.vessel.as_ref()),
+            ("--role", self.role.as_ref()),
+        ] {
+            if let Some(value) = value {
+                write!(f, " {flag} {}", quote_value(value))?;
+            }
+        }
+        if let Some(CrewVerb::Handoff { message }) = &self.verb {
+            write!(f, " handoff --message {}", quote_value(message))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use flotilla_protocol::{CommandAction, CrewCommandContext};
+
+    use super::CrewNoun;
+    use crate::{test_utils::assert_round_trip, Resolved};
+
+    fn action(noun: CrewNoun, ambient_crew_id: Option<&str>) -> CommandAction {
+        let resolved = noun.resolve_with_crew_id(ambient_crew_id.map(str::to_string)).expect("resolve crew command");
+        let Resolved::NeedsContext { command, .. } = resolved else {
+            panic!("crew command should resolve locally");
+        };
+        command.action
+    }
+
+    #[test]
+    fn list_uses_ambient_crew_identity() {
+        let noun = CrewNoun::try_parse_from(["crew", "list"]).expect("parse list");
+        assert_eq!(action(noun, Some("crew-123")), CommandAction::QueryCrewList {
+            context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() }
+        });
+    }
+
+    #[test]
+    fn handoff_preserves_target_and_message() {
+        let noun = CrewNoun::try_parse_from(["crew", "reviewer", "handoff", "--message", "Review commit abc123"]).expect("parse handoff");
+        assert_eq!(action(noun, Some("crew-123")), CommandAction::CrewHandoff {
+            context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
+            target: "reviewer".into(),
+            message: "Review commit abc123".into(),
+        });
+    }
+
+    #[test]
+    fn explicit_coordinates_are_a_human_fallback() {
+        let noun = CrewNoun::try_parse_from([
+            "crew",
+            "list",
+            "--namespace",
+            "flotilla",
+            "--convoy",
+            "demo",
+            "--vessel",
+            "demo-implement",
+            "--role",
+            "coder",
+        ])
+        .expect("parse fallback");
+        assert_eq!(action(noun, None), CommandAction::QueryCrewList {
+            context: CrewCommandContext {
+                crew_id: None,
+                namespace: Some("flotilla".into()),
+                convoy: Some("demo".into()),
+                vessel: Some("demo-implement".into()),
+                role: Some("coder".into()),
+            }
+        });
+    }
+
+    #[test]
+    fn handoff_with_explicit_context_round_trips() {
+        assert_round_trip::<CrewNoun>(&[
+            "crew",
+            "reviewer",
+            "--namespace",
+            "flotilla",
+            "--convoy",
+            "demo",
+            "--vessel",
+            "demo-implement",
+            "--role",
+            "coder",
+            "handoff",
+            "--message",
+            "review-abc123",
+        ]);
+    }
+}

--- a/crates/flotilla-commands/src/commands/mod.rs
+++ b/crates/flotilla-commands/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod checkout;
 pub mod convoy;
 pub mod cr;
+pub mod crew;
 pub mod environment;
 pub mod host;
 pub mod issue;

--- a/crates/flotilla-commands/src/noun.rs
+++ b/crates/flotilla-commands/src/noun.rs
@@ -4,8 +4,8 @@ use clap::Subcommand;
 
 use crate::{
     commands::{
-        agent::AgentNoun, checkout::CheckoutNoun, convoy::ConvoyNoun, cr::CrNoun, environment::EnvironmentNoun, issue::IssueNoun,
-        project::ProjectNoun, repo::RepoNoun, workflow_template::WorkflowTemplateNoun, workspace::WorkspaceNoun,
+        agent::AgentNoun, checkout::CheckoutNoun, convoy::ConvoyNoun, cr::CrNoun, crew::CrewNoun, environment::EnvironmentNoun,
+        issue::IssueNoun, project::ProjectNoun, repo::RepoNoun, workflow_template::WorkflowTemplateNoun, workspace::WorkspaceNoun,
     },
     Resolved,
 };
@@ -18,6 +18,7 @@ pub enum NounCommand {
     Environment(EnvironmentNoun),
     Checkout(CheckoutNoun),
     Convoy(ConvoyNoun),
+    Crew(CrewNoun),
     Cr(CrNoun),
     Issue(IssueNoun),
     Agent(AgentNoun),
@@ -34,6 +35,7 @@ impl NounCommand {
             NounCommand::Environment(noun) => noun.resolve(),
             NounCommand::Checkout(noun) => noun.resolve(),
             NounCommand::Convoy(noun) => noun.resolve(),
+            NounCommand::Crew(noun) => noun.resolve(),
             NounCommand::Cr(noun) => noun.resolve(),
             NounCommand::Issue(noun) => noun.resolve(),
             NounCommand::Agent(noun) => noun.resolve(),
@@ -51,6 +53,7 @@ impl fmt::Display for NounCommand {
             NounCommand::Environment(noun) => write!(f, "{noun}"),
             NounCommand::Checkout(noun) => write!(f, "{noun}"),
             NounCommand::Convoy(noun) => write!(f, "{noun}"),
+            NounCommand::Crew(noun) => write!(f, "{noun}"),
             NounCommand::Cr(noun) => write!(f, "{noun}"),
             NounCommand::Issue(noun) => write!(f, "{noun}"),
             NounCommand::Agent(noun) => write!(f, "{noun}"),

--- a/crates/flotilla-controllers/Cargo.toml
+++ b/crates/flotilla-controllers/Cargo.toml
@@ -10,6 +10,7 @@ flotilla-protocol = { path = "../flotilla-protocol" }
 flotilla-resources = { path = "../flotilla-resources" }
 tokio = { workspace = true }
 async-trait = { workspace = true }
+bon = { workspace = true }
 tracing = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 dirs = "6"
@@ -17,5 +18,4 @@ sha2 = "0.10"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-bon = { workspace = true }
 rstest = { workspace = true }

--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -8,7 +8,7 @@ use flotilla_core::{
         vcs::{CloneInspection, CloneProvisioner},
     },
 };
-use flotilla_resources::{DockerEnvironmentSpec, FreshCloneCheckoutSpec, TerminalSessionSpec};
+use flotilla_resources::{DockerEnvironmentSpec, FreshCloneCheckoutSpec, TerminalSessionSource, TerminalSessionSpec};
 
 pub struct CloneActuator {
     provisioner: Arc<dyn CloneProvisioner>,
@@ -61,7 +61,10 @@ impl TerminalActuator {
 
     pub async fn ensure_session(&self, name: &str, spec: &TerminalSessionSpec, env_vars: &[(String, String)]) -> Result<(), String> {
         let env_vars = env_vars.to_vec();
-        self.pool.ensure_session(name, &spec.command, &ExecutionEnvironmentPath::new(spec.cwd.clone()), &env_vars).await
+        let TerminalSessionSource::Tool { command } = &spec.source else {
+            return Err("agent sessions require an AgentAdapter-aware runtime".to_string());
+        };
+        self.pool.ensure_session(name, command, &ExecutionEnvironmentPath::new(spec.cwd.clone()), &env_vars).await
     }
 }
 

--- a/crates/flotilla-controllers/src/reconcilers/presentation.rs
+++ b/crates/flotilla-controllers/src/reconcilers/presentation.rs
@@ -23,7 +23,7 @@ use flotilla_protocol::{arg, EnvironmentId};
 use flotilla_resources::{
     controller::{LabelJoinWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
     Environment, Host, Presentation, PresentationStatus, PresentationStatusPatch, ResourceBackend, ResourceError, ResourceObject,
-    TerminalSession, TypedResolver, CONVOY_LABEL,
+    TerminalSession, TerminalSessionPhase, TypedResolver, CONVOY_LABEL,
 };
 use sha2::{Digest, Sha256};
 use tracing::warn;
@@ -251,10 +251,9 @@ impl<R> PresentationReconciler<R> {
             .or_else(|| registry.terminal_pools.preferred().cloned())
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
 
-        let session_name =
-            session.status.as_ref().and_then(|status| status.session_id.as_deref()).unwrap_or(session.metadata.name.as_str());
         let session_cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
-        let attach_args = pool.attach_args(session_name, &session.spec.command, &session_cwd, &Vec::new())?;
+        let attach_target = flotilla_resources::terminal_session_attach_target(session)?;
+        let attach_args = pool.attach_args(attach_target.session_id, attach_target.launch_command, &session_cwd, &Vec::new())?;
         let attach_command = self.build_attach_command(session, &environment, host_ref, attach_args)?;
 
         Ok(ResolvedProcess { role: session.spec.role.clone(), labels: session.metadata.labels.clone(), attach_command })
@@ -329,7 +328,14 @@ where
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
         let listed = self.terminal_sessions.list_matching_labels(&obj.spec.process_selector).await?;
-        let mut sessions: Vec<_> = listed.items.into_iter().filter(|session| session.metadata.deletion_timestamp.is_none()).collect();
+        let mut sessions: Vec<_> = listed
+            .items
+            .into_iter()
+            .filter(|session| {
+                session.metadata.deletion_timestamp.is_none()
+                    && session.status.as_ref().is_some_and(|status| status.phase == TerminalSessionPhase::Running)
+            })
+            .collect();
         sessions.sort_by(|left, right| session_sort_key(left).cmp(&session_sort_key(right)));
 
         let previous = previous_workspace(obj.status.as_ref());

--- a/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
+++ b/crates/flotilla-controllers/src/reconcilers/task_workspace.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use chrono::{DateTime, Utc};
+use flotilla_core::agent_adapter::{build_crew_brief, CrewBriefMember};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{
@@ -9,10 +10,9 @@ use flotilla_resources::{
     descriptive_repo_slug, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
     DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec,
     FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority,
-    OwnerReference, PlacementPolicy, PlacementPolicySpec, ProcessDefinition, ProcessSource, Resource, ResourceBackend, ResourceError,
-    ResourceObject, TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceStatusPatch, TerminalSession, TerminalSessionPhase,
-    TerminalSessionSpec, TypedResolver, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL,
-    TASK_WORKSPACE_LABEL,
+    OwnerReference, PlacementPolicy, PlacementPolicySpec, ProcessSource, Resource, ResourceBackend, ResourceError, ResourceObject,
+    TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceStatusPatch, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase,
+    TerminalSessionSpec, TypedResolver, TASK_WORKSPACE_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -26,6 +26,7 @@ pub struct TaskWorkspaceReconciler {
     clones: TypedResolver<Clone>,
     checkouts: TypedResolver<Checkout>,
     terminal_sessions: TypedResolver<TerminalSession>,
+    namespace: String,
 }
 
 impl TaskWorkspaceReconciler {
@@ -37,6 +38,7 @@ impl TaskWorkspaceReconciler {
             clones: backend.clone().using::<Clone>(namespace),
             checkouts: backend.clone().using::<Checkout>(namespace),
             terminal_sessions: backend.using::<TerminalSession>(namespace),
+            namespace: namespace.to_string(),
         }
     }
 
@@ -406,23 +408,27 @@ impl Reconciler for TaskWorkspaceReconciler {
             }
         };
 
+        let first_agent_index = task.processes.iter().position(|process| matches!(process.source, ProcessSource::Agent { .. }));
         let mut terminal_refs = Vec::new();
         for (process_index, process) in task.processes.iter().enumerate() {
-            let command = match &process.source {
-                ProcessSource::Tool { command } => command.clone(),
-                ProcessSource::Agent { .. } => {
-                    return Ok(TaskWorkspaceDeps::failed(format!(
-                        "task {} contains agent process {}; Stage 4a supports tool processes only",
-                        obj.spec.task, process.role
-                    )))
-                }
-            };
-
-            let terminal_name = terminal_name(&obj.metadata.name, &process.role);
-            terminal_refs.push(terminal_name.clone());
+            let should_start = matches!(process.source, ProcessSource::Tool { .. }) || first_agent_index == Some(process_index);
+            let identity = TerminalSessionIdentity::builder()
+                .vessel(obj.metadata.name.clone())
+                .convoy(obj.spec.convoy_ref.clone())
+                .leg(obj.spec.task.clone())
+                .role(process.role.clone())
+                .task_index(task_index)
+                .process_index(process_index)
+                .labels(process.labels.clone())
+                .build();
+            let terminal_name = identity.name();
             match self.terminal_sessions.get(&terminal_name).await {
                 Ok(existing) => {
-                    if existing.status.as_ref().map(|status| status.phase) == Some(TerminalSessionPhase::Stopped) {
+                    terminal_refs.push(terminal_name.clone());
+                    let phase = existing.status.as_ref().map(|status| status.phase);
+                    if phase == Some(TerminalSessionPhase::Failed)
+                        || (phase == Some(TerminalSessionPhase::Stopped) && matches!(process.source, ProcessSource::Tool { .. }))
+                    {
                         let message = existing
                             .status
                             .as_ref()
@@ -430,17 +436,54 @@ impl Reconciler for TaskWorkspaceReconciler {
                             .unwrap_or_else(|| format!("terminal session {terminal_name} stopped"));
                         return Ok(TaskWorkspaceDeps::failed(message));
                     }
-                    if existing.status.as_ref().map(|status| status.phase) != Some(TerminalSessionPhase::Running) {
+                    if phase == Some(TerminalSessionPhase::Stopped) {
+                        continue;
+                    }
+                    if should_start && phase != Some(TerminalSessionPhase::Running) {
                         return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
                     }
                 }
                 Err(ResourceError::NotFound { .. }) => {
+                    if !should_start {
+                        continue;
+                    }
+                    let source = match &process.source {
+                        ProcessSource::Tool { command } => flotilla_resources::TerminalSessionSource::Tool { command: command.clone() },
+                        ProcessSource::Agent { selector, prompt } => {
+                            let context = flotilla_resources::TerminalCrewContext {
+                                namespace: self.namespace.clone(),
+                                convoy: obj.spec.convoy_ref.clone(),
+                                vessel: obj.metadata.name.clone(),
+                            };
+                            let members = task
+                                .processes
+                                .iter()
+                                .enumerate()
+                                .map(|(index, member)| CrewBriefMember {
+                                    role: member.role.clone(),
+                                    state: if matches!(member.source, ProcessSource::Tool { .. }) || first_agent_index == Some(index) {
+                                        "active"
+                                    } else {
+                                        "latent"
+                                    }
+                                    .to_string(),
+                                    is_agent: matches!(member.source, ProcessSource::Agent { .. }),
+                                })
+                                .collect::<Vec<_>>();
+                            flotilla_resources::TerminalSessionSource::Agent {
+                                selector: selector.clone(),
+                                brief: build_crew_brief(&context, &obj.spec.task, &process.role, prompt.as_deref(), &members),
+                                context,
+                                message: None,
+                            }
+                        }
+                    };
                     actuations.push(Actuation::CreateTerminalSession {
-                        meta: owned_child_meta(&terminal_name, obj, build_session_labels(obj, process, task_index, process_index)),
+                        meta: identity.input_meta(),
                         spec: TerminalSessionSpec {
                             env_ref: resolved_environment_ref.clone(),
                             role: process.role.clone(),
-                            command,
+                            source,
                             cwd: strategy.terminal_cwd(&checkout_ready_path),
                             pool: strategy.pool().to_string(),
                         },
@@ -548,10 +591,6 @@ fn checkout_name(task_workspace_name: &str) -> String {
     format!("checkout-{task_workspace_name}")
 }
 
-fn terminal_name(task_workspace_name: &str, role: &str) -> String {
-    format!("terminal-{task_workspace_name}-{role}")
-}
-
 fn checkout_target_path(repo_default_dir: &str, repo_slug: &str, task_workspace_name: &str) -> String {
     format!("{}/{}.{}", repo_default_dir.trim_end_matches('/'), repo_slug, task_workspace_name)
 }
@@ -568,22 +607,6 @@ fn owned_child_meta(name: &str, workspace: &ResourceObject<TaskWorkspace>, mut e
             controller: true,
         }])
         .build()
-}
-
-fn build_session_labels(
-    workspace: &ResourceObject<TaskWorkspace>,
-    process: &ProcessDefinition,
-    task_index: usize,
-    process_index: usize,
-) -> BTreeMap<String, String> {
-    let mut labels = process.labels.clone();
-    labels.insert(TASK_WORKSPACE_LABEL.to_string(), workspace.metadata.name.clone());
-    labels.insert(ROLE_LABEL.to_string(), process.role.clone());
-    labels.insert(CONVOY_LABEL.to_string(), workspace.spec.convoy_ref.clone());
-    labels.insert(TASK_LABEL.to_string(), workspace.spec.task.clone());
-    labels.insert(TASK_ORDINAL_LABEL.to_string(), format!("{task_index:03}"));
-    labels.insert(PROCESS_ORDINAL_LABEL.to_string(), format!("{process_index:03}"));
-    labels
 }
 
 impl PlacementStrategy {

--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -8,16 +8,30 @@ use flotilla_resources::{
     TerminalSessionStatusPatch, TypedResolver,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct TerminalRuntimeState {
     pub session_id: String,
     pub pid: Option<i64>,
     pub started_at: DateTime<Utc>,
+    pub crew: Option<flotilla_resources::CrewSessionStatus>,
+    pub launch_command: String,
+    pub delivered_message_id: Option<String>,
 }
 
 #[async_trait]
 pub trait TerminalRuntime: Send + Sync {
     async fn ensure_session(&self, name: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<TerminalRuntimeState, String>;
+    async fn session_is_running(&self, _session_id: &str, _spec: &flotilla_resources::TerminalSessionSpec) -> Result<bool, String> {
+        Ok(true)
+    }
+    async fn deliver_message(
+        &self,
+        _session_id: &str,
+        _spec: &flotilla_resources::TerminalSessionSpec,
+        _message: &str,
+    ) -> Result<(), String> {
+        Err("terminal runtime does not support crew message delivery".to_string())
+    }
     async fn kill_session(&self, session_id: &str) -> Result<(), String>;
 }
 
@@ -36,6 +50,8 @@ pub enum TerminalDeps {
     None,
     Waiting,
     Running(TerminalRuntimeState),
+    MessageDelivered(String),
+    Stopped,
     Failed(String),
 }
 
@@ -47,7 +63,29 @@ where
     type Dependencies = TerminalDeps;
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
-        if obj.status.as_ref().map(|status| status.phase).unwrap_or(TerminalSessionPhase::Starting) != TerminalSessionPhase::Starting {
+        let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(TerminalSessionPhase::Starting);
+        if phase == TerminalSessionPhase::Running {
+            let session_id = obj
+                .status
+                .as_ref()
+                .and_then(|status| status.session_id.as_deref())
+                .ok_or_else(|| ResourceError::other("running terminal session has no session id"))?;
+            let running = self.runtime.session_is_running(session_id, &obj.spec).await.map_err(ResourceError::other)?;
+            if !running {
+                return Ok(TerminalDeps::Stopped);
+            }
+            if let flotilla_resources::TerminalSessionSource::Agent { message: Some(message), .. } = &obj.spec.source {
+                if obj.status.as_ref().and_then(|status| status.delivered_message_id.as_deref()) != Some(message.id.as_str()) {
+                    // Delivery is deliberately at-least-once. A crash after the pool accepts the
+                    // message but before MarkMessageDelivered is persisted may redeliver it; losing
+                    // a handoff is worse, and exactly-once requires acknowledgement by the agent.
+                    self.runtime.deliver_message(session_id, &obj.spec, &message.text).await.map_err(ResourceError::other)?;
+                    return Ok(TerminalDeps::MessageDelivered(message.id.clone()));
+                }
+            }
+            return Ok(TerminalDeps::None);
+        }
+        if phase != TerminalSessionPhase::Starting {
             return Ok(TerminalDeps::None);
         }
 
@@ -72,22 +110,36 @@ where
         deps: &Self::Dependencies,
         now: chrono::DateTime<chrono::Utc>,
     ) -> ReconcileOutcome<Self::Resource> {
-        let patch =
-            if obj.status.as_ref().map(|status| status.phase).unwrap_or(TerminalSessionPhase::Starting) == TerminalSessionPhase::Starting {
-                match deps {
-                    TerminalDeps::Running(state) => Some(TerminalSessionStatusPatch::MarkRunning {
-                        session_id: state.session_id.clone(),
-                        pid: state.pid,
-                        started_at: state.started_at,
-                    }),
-                    TerminalDeps::Failed(message) => {
-                        Some(TerminalSessionStatusPatch::MarkFailed { message: message.clone(), stopped_at: Some(now) })
-                    }
-                    TerminalDeps::Waiting | TerminalDeps::None => None,
+        let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(TerminalSessionPhase::Starting);
+        let patch = match phase {
+            TerminalSessionPhase::Starting => match deps {
+                TerminalDeps::Running(state) => Some(TerminalSessionStatusPatch::MarkRunning {
+                    session_id: state.session_id.clone(),
+                    pid: state.pid,
+                    started_at: state.started_at,
+                    crew: state.crew.clone(),
+                    launch_command: state.launch_command.clone(),
+                    delivered_message_id: state.delivered_message_id.clone(),
+                }),
+                TerminalDeps::Failed(message) => {
+                    Some(TerminalSessionStatusPatch::MarkFailed { message: message.clone(), stopped_at: Some(now) })
                 }
-            } else {
-                None
-            };
+                TerminalDeps::Waiting | TerminalDeps::None | TerminalDeps::Stopped | TerminalDeps::MessageDelivered(_) => None,
+            },
+            TerminalSessionPhase::Running if matches!(deps, TerminalDeps::Stopped) => Some(TerminalSessionStatusPatch::MarkStopped {
+                stopped_at: now,
+                inner_command_status: Some(flotilla_resources::InnerCommandStatus::Exited),
+                inner_exit_code: None,
+                message: None,
+            }),
+            TerminalSessionPhase::Running => match deps {
+                TerminalDeps::MessageDelivered(message_id) => {
+                    Some(TerminalSessionStatusPatch::MarkMessageDelivered { message_id: message_id.clone() })
+                }
+                _ => None,
+            },
+            TerminalSessionPhase::Stopped | TerminalSessionPhase::Failed => None,
+        };
 
         ReconcileOutcome::new(patch)
     }

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -123,7 +123,7 @@ async fn terminal_actuator_uses_literal_command_and_cwd() {
     let spec = TerminalSessionSpec {
         env_ref: "env-a".to_string(),
         role: "coder".to_string(),
-        command: "cargo test".to_string(),
+        source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
         cwd: "/workspace".to_string(),
         pool: "cleat".to_string(),
     };

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -288,7 +288,7 @@ pub async fn create_stopped_terminal(
         .create(&meta(&fixture.name), &TerminalSessionSpec {
             env_ref: fixture.env_ref,
             role: fixture.role,
-            command: fixture.command,
+            source: flotilla_resources::TerminalSessionSource::Tool { command: fixture.command.clone() },
             cwd: fixture.cwd,
             pool: fixture.pool,
         })
@@ -304,6 +304,9 @@ pub async fn create_stopped_terminal(
             inner_command_status: Some(flotilla_resources::InnerCommandStatus::Exited),
             inner_exit_code: Some(1),
             message: Some(fixture.message),
+            crew: None,
+            launch_command: Some(fixture.command),
+            delivered_message_id: None,
         })
         .await
         .expect("terminal status update should succeed");

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -199,6 +199,46 @@ async fn first_apply_marks_presentation_active() {
 }
 
 #[tokio::test]
+async fn presentation_uses_running_sessions_and_ignores_stopped_crew() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_host(&backend, HOST_REF).await;
+    create_ready_host_direct_env(&backend, "env-a").await;
+    create_running_terminal(
+        &backend,
+        "term-running",
+        "env-a",
+        BTreeMap::from([
+            (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+        ]),
+    )
+    .await;
+    create_running_terminal(
+        &backend,
+        "term-stopped",
+        "env-a",
+        BTreeMap::from([
+            (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (PROCESS_ORDINAL_LABEL.to_string(), "001".to_string()),
+        ]),
+    )
+    .await;
+    mark_terminal_stopped(&backend, "term-stopped").await;
+    let presentation = create_presentation(&backend, "presentation-a", "default").await;
+    let runtime = Arc::new(FakePresentationRuntime::default());
+    let reconciler = reconciler(Arc::clone(&runtime), backend.clone());
+
+    reconciler.fetch_dependencies(&presentation).await.expect("stopped crew should not prevent presentation");
+
+    let apply_calls = runtime.apply_calls.lock().expect("apply calls lock");
+    assert_eq!(apply_calls.len(), 1);
+    assert_eq!(apply_calls[0].processes.len(), 1);
+    assert_eq!(apply_calls[0].processes[0].attach_command, "attach term-running");
+}
+
+#[tokio::test]
 async fn unchanged_world_is_a_no_op() {
     let backend = ResourceBackend::InMemory(Default::default());
     create_ready_host(&backend, HOST_REF).await;
@@ -594,15 +634,32 @@ async fn create_running_terminal(backend: &ResourceBackend, name: &str, env_ref:
         .create(&common::controller_meta().name(name).labels(labels).call(), &TerminalSessionSpec {
             env_ref: env_ref.to_string(),
             role: "main".to_string(),
-            command: "bash".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: "bash".to_string() },
             cwd: "/workspace/repo".to_string(),
             pool: "fake".to_string(),
         })
         .await
         .expect("session create should succeed");
     let mut status = TerminalSessionStatus::default();
-    TerminalSessionStatusPatch::MarkRunning { session_id: name.to_string(), pid: Some(42), started_at: Utc::now() }.apply(&mut status);
+    TerminalSessionStatusPatch::MarkRunning {
+        session_id: name.to_string(),
+        pid: Some(42),
+        started_at: Utc::now(),
+        crew: None,
+        launch_command: "bash".to_string(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
     sessions.update_status(name, &created.metadata.resource_version, &status).await.expect("session status update should succeed");
+}
+
+async fn mark_terminal_stopped(backend: &ResourceBackend, name: &str) {
+    let sessions = backend.clone().using::<TerminalSession>(NAMESPACE);
+    let session = sessions.get(name).await.expect("session get should succeed");
+    let mut status = session.status.expect("running session should have status");
+    TerminalSessionStatusPatch::MarkStopped { stopped_at: Utc::now(), inner_command_status: None, inner_exit_code: None, message: None }
+        .apply(&mut status);
+    sessions.update_status(name, &session.metadata.resource_version, &status).await.expect("session status update should succeed");
 }
 
 async fn create_presentation(backend: &ResourceBackend, name: &str, policy_ref: &str) -> flotilla_resources::ResourceObject<Presentation> {

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -93,7 +93,14 @@ struct FakeTerminalRuntime;
 #[async_trait]
 impl TerminalRuntime for FakeTerminalRuntime {
     async fn ensure_session(&self, name: &str, _spec: &flotilla_resources::TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
-        Ok(TerminalRuntimeState { session_id: format!("session-{name}"), pid: Some(42), started_at: Utc::now() })
+        Ok(TerminalRuntimeState {
+            session_id: format!("session-{name}"),
+            pid: Some(42),
+            started_at: Utc::now(),
+            crew: None,
+            launch_command: "bash".to_string(),
+            delivered_message_id: None,
+        })
     }
 
     async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
@@ -343,7 +350,7 @@ async fn terminal_session_controller_marks_session_running() {
         .create(&controller_meta().name("term-a").call(), &flotilla_resources::TerminalSessionSpec {
             env_ref: "host-direct-01HXYZ".to_string(),
             role: "coder".to_string(),
-            command: "cargo test".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
             cwd: "/workspace".to_string(),
             pool: "cleat".to_string(),
         })
@@ -402,7 +409,7 @@ async fn presentation_controller_marks_presentation_active_for_live_convoy_sessi
             &flotilla_resources::TerminalSessionSpec {
                 env_ref: "host-direct-01HXYZ".to_string(),
                 role: "coder".to_string(),
-                command: "cargo test".to_string(),
+                source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
                 cwd: "/Users/alice/dev/flotilla-repos/convoy-a".to_string(),
                 pool: "cleat".to_string(),
             },
@@ -416,6 +423,9 @@ async fn presentation_controller_marks_presentation_active_for_live_convoy_sessi
                 session_id: "term-a".to_string(),
                 pid: Some(42),
                 started_at: Utc::now(),
+                crew: None,
+                launch_command: "cargo test".to_string(),
+                delivered_message_id: None,
             }
             .apply(&mut status);
             status
@@ -556,7 +566,7 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
             &flotilla_resources::TerminalSessionSpec {
                 env_ref: "host-direct-01HXYZ".to_string(),
                 role: "coder".to_string(),
-                command: "cargo test".to_string(),
+                source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
                 cwd: "/Users/alice/dev/flotilla-repos/workspace-delete".to_string(),
                 pool: "cleat".to_string(),
             },

--- a/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
+++ b/crates/flotilla-controllers/tests/task_workspace_reconciler.rs
@@ -15,9 +15,10 @@ use flotilla_resources::{
     Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
     DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, LifecycleAuthority,
-    ObservedCheckoutSpec, PlacementPolicySpec, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError, SnapshotTask,
-    TaskWorkspace, TaskWorkspaceSpec, TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, WorkflowSnapshot,
-    CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    ObservedCheckoutSpec, PlacementPolicySpec, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError, Selector, SnapshotTask,
+    TaskWorkspace, TaskWorkspaceSpec, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, WorkflowSnapshot, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL,
+    TASK_WORKSPACE_LABEL,
 };
 use rstest::rstest;
 
@@ -292,6 +293,74 @@ async fn adopted_checkout_ref_reuses_checkout_without_creating_clone_or_checkout
                     && spec.cwd == "/Users/alice/dev/flotilla-existing"
         )
     }));
+}
+
+#[tokio::test]
+async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents_remain_latent() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-crew", "implement", REPO_URL, GIT_REF).await;
+    let mut status = convoy.status.expect("convoy status");
+    status.workflow_snapshot.as_mut().expect("workflow snapshot").tasks[0].processes = vec![
+        ProcessDefinition::builder()
+            .role("coder".to_string())
+            .source(ProcessSource::Agent {
+                selector: Selector { capability: "coding".to_string() },
+                prompt: Some("Implement issue 668.".to_string()),
+            })
+            .build(),
+        ProcessDefinition::builder()
+            .role("reviewer".to_string())
+            .source(ProcessSource::Agent {
+                selector: Selector { capability: "review".to_string() },
+                prompt: Some("Review the coder's work.".to_string()),
+            })
+            .build(),
+    ];
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .update_status("convoy-crew", &convoy.metadata.resource_version, &status)
+        .await
+        .expect("update convoy crew");
+    create_host_direct_policy(&backend, NAMESPACE, "policy-crew", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    create_ready_adopted_checkout(&backend, NAMESPACE, "adopted-checkout-convoy-crew", "/Users/alice/dev/flotilla-existing").await;
+    let workspace = backend
+        .clone()
+        .using::<TaskWorkspace>(NAMESPACE)
+        .create(&task_workspace_meta("workspace-crew", REPO_URL), &TaskWorkspaceSpec {
+            convoy_ref: "convoy-crew".to_string(),
+            task: "implement".to_string(),
+            placement_policy_ref: "policy-crew".to_string(),
+            adopted_checkout_ref: Some("adopted-checkout-convoy-crew".to_string()),
+        })
+        .await
+        .expect("workspace create");
+
+    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps");
+    let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
+
+    let Actuation::CreateTerminalSession { spec, .. } = outcome.actuations.first().expect("coder session actuation") else {
+        panic!("expected terminal session actuation");
+    };
+    let TerminalSessionSource::Agent { selector, brief, context, message } = &spec.source else {
+        panic!("expected structured agent launch");
+    };
+    assert_eq!(selector.capability, "coding");
+    assert_eq!(brief.path, ".flotilla/briefs/coder.md");
+    assert!(brief.content.contains("You are `coder` in convoy `convoy-crew`"));
+    assert!(brief.content.contains("- `coder`: active"));
+    assert!(brief.content.contains("- `reviewer`: latent"));
+    assert!(brief.content.contains("flotilla crew reviewer handoff --message"));
+    assert!(brief.content.ends_with("Implement issue 668.\n"));
+    assert_eq!(context.namespace, NAMESPACE);
+    assert_eq!(context.vessel, "workspace-crew");
+    assert_eq!(message, &None);
+    assert!(outcome
+        .actuations
+        .iter()
+        .all(|actuation| { !matches!(actuation, Actuation::CreateTerminalSession { spec, .. } if spec.role == "reviewer") }));
 }
 
 #[tokio::test]
@@ -612,7 +681,7 @@ async fn create_running_terminal(
         .create(&meta(name), &TerminalSessionSpec {
             env_ref: env_ref.to_string(),
             role: role.to_string(),
-            command: command.to_string(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: command.to_string() },
             cwd: cwd.to_string(),
             pool: pool.to_string(),
         })
@@ -628,6 +697,9 @@ async fn create_running_terminal(
             inner_command_status: Some(InnerCommandStatus::Running),
             inner_exit_code: None,
             message: None,
+            crew: None,
+            launch_command: Some(command.to_string()),
+            delivered_message_id: None,
         })
         .await
         .expect("terminal status update should succeed");
@@ -741,7 +813,7 @@ async fn create_labeled_terminal(backend: &ResourceBackend, namespace: &str, nam
         .create(&labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())]), &TerminalSessionSpec {
             env_ref: host_direct_env_name(),
             role: "coder".to_string(),
-            command: "cargo test".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
             cwd: format!("/Users/alice/dev/flotilla-repos/{workspace_name}"),
             pool: "cleat".to_string(),
         })

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use chrono::Utc;
@@ -39,7 +39,7 @@ async fn terminal_session_failure_uses_injected_now_for_stopped_at() {
         .create(&meta("term-a"), &TerminalSessionSpec {
             env_ref: "env-a".to_string(),
             role: "coder".to_string(),
-            command: "cargo test".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
             cwd: "/workspace".to_string(),
             pool: "cleat".to_string(),
         })
@@ -63,6 +63,150 @@ struct FailingTerminalRuntime;
 impl TerminalRuntime for FailingTerminalRuntime {
     async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
         Err("boom".to_string())
+    }
+
+    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn a_disappeared_running_session_is_observed_as_stopped() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
+    let created = sessions
+        .create(&meta("term-a"), &TerminalSessionSpec {
+            env_ref: "env-a".to_string(),
+            role: "coder".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Agent {
+                selector: flotilla_resources::Selector { capability: "coding".to_string() },
+                brief: flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into() },
+                context: flotilla_resources::TerminalCrewContext {
+                    namespace: "flotilla".into(),
+                    convoy: "demo".into(),
+                    vessel: "demo-implement".into(),
+                },
+                message: None,
+            },
+            cwd: "/workspace".to_string(),
+            pool: "cleat".to_string(),
+        })
+        .await
+        .expect("session");
+    let mut status = flotilla_resources::TerminalSessionStatus::default();
+    flotilla_resources::TerminalSessionStatusPatch::MarkRunning {
+        session_id: "cleat-session".into(),
+        pid: None,
+        started_at: Utc::now(),
+        crew: None,
+        launch_command: "codex".into(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
+    let session = sessions.update_status("term-a", &created.metadata.resource_version, &status).await.expect("running session");
+    let reconciler = TerminalSessionReconciler::new(Arc::new(MissingTerminalRuntime), backend, "flotilla");
+
+    let deps = reconciler.fetch_dependencies(&session).await.expect("observe session");
+    let now = Utc::now();
+    let outcome = reconciler.reconcile(&session, &deps, now);
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::TerminalSessionStatusPatch::MarkStopped { stopped_at, .. }) if stopped_at == now
+    ));
+}
+
+struct MissingTerminalRuntime;
+
+#[async_trait]
+impl TerminalRuntime for MissingTerminalRuntime {
+    async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+        panic!("running sessions should be observed, not ensured")
+    }
+
+    async fn session_is_running(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<bool, String> {
+        Ok(false)
+    }
+
+    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn a_message_queued_during_startup_is_delivered_after_the_session_becomes_running() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
+    let created = sessions
+        .create(&meta("term-a"), &TerminalSessionSpec {
+            env_ref: "env-a".to_string(),
+            role: "reviewer".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Agent {
+                selector: flotilla_resources::Selector { capability: "review".to_string() },
+                brief: flotilla_resources::TerminalBrief { path: ".flotilla/briefs/reviewer.md".into(), content: "brief".into() },
+                context: flotilla_resources::TerminalCrewContext {
+                    namespace: "flotilla".into(),
+                    convoy: "demo".into(),
+                    vessel: "demo-review".into(),
+                },
+                message: Some(flotilla_resources::TerminalCrewMessage {
+                    id: "message-new".into(),
+                    text: "Review the amended commit".into(),
+                }),
+            },
+            cwd: "/workspace".to_string(),
+            pool: "cleat".to_string(),
+        })
+        .await
+        .expect("session");
+    let mut status = flotilla_resources::TerminalSessionStatus::default();
+    flotilla_resources::TerminalSessionStatusPatch::MarkRunning {
+        session_id: "cleat-session".into(),
+        pid: None,
+        started_at: Utc::now(),
+        crew: None,
+        launch_command: "claude".into(),
+        delivered_message_id: Some("message-old".into()),
+    }
+    .apply(&mut status);
+    let session = sessions.update_status("term-a", &created.metadata.resource_version, &status).await.expect("running session");
+    let runtime = Arc::new(DeliveringTerminalRuntime::default());
+    let reconciler = TerminalSessionReconciler::new(Arc::clone(&runtime), backend, "flotilla");
+
+    let deps = reconciler.fetch_dependencies(&session).await.expect("observe pending message");
+    assert_eq!(runtime.delivered.lock().expect("delivered mutex").as_slice(), &[(
+        "cleat-session".to_string(),
+        "Review the amended commit".to_string()
+    )]);
+    let outcome = reconciler.reconcile(&session, &deps, Utc::now());
+    assert!(matches!(
+        &outcome.patch,
+        Some(flotilla_resources::TerminalSessionStatusPatch::MarkMessageDelivered { message_id }) if message_id == "message-new"
+    ));
+    let mut acknowledged_status = session.status.clone().expect("status");
+    outcome.patch.expect("acknowledgement patch").apply(&mut acknowledged_status);
+    let acknowledged =
+        sessions.update_status("term-a", &session.metadata.resource_version, &acknowledged_status).await.expect("acknowledge message");
+
+    let deps = reconciler.fetch_dependencies(&acknowledged).await.expect("observe acknowledged message");
+    assert!(matches!(deps, flotilla_controllers::reconcilers::terminal_session::TerminalDeps::None));
+    assert_eq!(runtime.delivered.lock().expect("delivered mutex").len(), 1);
+}
+
+#[derive(Default)]
+struct DeliveringTerminalRuntime {
+    delivered: Mutex<Vec<(String, String)>>,
+}
+
+#[async_trait]
+impl TerminalRuntime for DeliveringTerminalRuntime {
+    async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+        panic!("running sessions should not be ensured")
+    }
+
+    async fn deliver_message(&self, session_id: &str, _spec: &TerminalSessionSpec, message: &str) -> Result<(), String> {
+        self.delivered.lock().expect("delivered mutex").push((session_id.to_string(), message.to_string()));
+        Ok(())
     }
 
     async fn kill_session(&self, _session_id: &str) -> Result<(), String> {

--- a/crates/flotilla-core/Cargo.toml
+++ b/crates/flotilla-core/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }
+bon = { workspace = true }
 tracing = { workspace = true }
 indexmap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -1,0 +1,248 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use async_trait::async_trait;
+use flotilla_protocol::arg::{flatten, Arg};
+use flotilla_resources::TerminalBrief;
+
+use crate::{
+    path_context::ExecutionEnvironmentPath,
+    providers::{discovery::EnvironmentBag, CommandRunner},
+};
+
+pub const TRUSTED_IMPLICIT_STANCE: &str = "trusted-implicit";
+
+pub fn crew_brief_path(role: &str) -> String {
+    let file_name: String = role
+        .chars()
+        .map(|character| if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') { character } else { '_' })
+        .collect();
+    format!(".flotilla/briefs/{}.md", if file_name.is_empty() { "crew" } else { &file_name })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrewBriefMember {
+    pub role: String,
+    pub state: String,
+    pub is_agent: bool,
+}
+
+pub fn build_crew_brief(
+    context: &flotilla_resources::TerminalCrewContext,
+    leg: &str,
+    role: &str,
+    prompt: Option<&str>,
+    members: &[CrewBriefMember],
+) -> flotilla_resources::TerminalBrief {
+    let mut content = format!(
+        "# Flotilla crew brief\n\nYou are `{role}` in convoy `{}`, aboard vessel `{}` for leg `{leg}`.\n\n## Crew\n\n",
+        context.convoy, context.vessel
+    );
+    for member in members {
+        content.push_str(&format!("- `{}`: {}\n", member.role, member.state));
+    }
+    content.push_str("\nRun `flotilla crew list` for current crew state.\n");
+    for member in members.iter().filter(|member| member.is_agent && member.role != role) {
+        content.push_str(&format!("Hand off to {} with `flotilla crew {} handoff --message '...'`.\n", member.role, member.role));
+    }
+    content.push_str(&format!(
+        "Leg completion is separate: `flotilla convoy {} leg {leg} complete`.\n\n## Assignment\n\n{}\n",
+        context.convoy,
+        prompt.unwrap_or("No additional assignment was provided.")
+    ));
+    flotilla_resources::TerminalBrief { path: crew_brief_path(role), content }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentLaunchRequest {
+    pub role: String,
+    pub model: Option<String>,
+    pub brief: TerminalBrief,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentLaunchPlan {
+    pub command: String,
+    pub env: Vec<(String, String)>,
+    pub stance: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentRequirement {
+    pub adapter: String,
+    pub model: Option<String>,
+}
+
+pub struct CapabilityTable {
+    requirements: BTreeMap<String, AgentRequirement>,
+}
+
+impl CapabilityTable {
+    pub fn seeded() -> Self {
+        Self {
+            requirements: BTreeMap::from([
+                ("coding".into(), AgentRequirement { adapter: "codex".into(), model: None }),
+                ("code".into(), AgentRequirement { adapter: "codex".into(), model: None }),
+                ("review".into(), AgentRequirement { adapter: "claude-code".into(), model: Some("opus".into()) }),
+                ("code-review".into(), AgentRequirement { adapter: "claude-code".into(), model: Some("opus".into()) }),
+            ]),
+        }
+    }
+
+    pub fn resolve(&self, capability: &str) -> Result<&AgentRequirement, String> {
+        self.requirements.get(capability).ok_or_else(|| format!("unknown agent capability `{capability}`"))
+    }
+}
+
+impl Default for CapabilityTable {
+    fn default() -> Self {
+        Self::seeded()
+    }
+}
+
+#[async_trait]
+pub trait AgentAdapter: Send + Sync {
+    fn id(&self) -> &'static str;
+    async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String>;
+    fn deliver_brief(&self, brief: &TerminalBrief) -> String {
+        format!("Read your crew brief at {} and follow it.", brief.path)
+    }
+    fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String>;
+}
+
+struct CliAgentAdapter {
+    id: &'static str,
+    binary: String,
+    runner: Arc<dyn CommandRunner>,
+    autonomy_args: &'static [&'static str],
+}
+
+impl CliAgentAdapter {
+    fn command(&self, request: &AgentLaunchRequest) -> String {
+        let mut args = vec![Arg::Literal(self.binary.clone())];
+        args.extend(self.autonomy_args.iter().map(|arg| Arg::Literal((*arg).into())));
+        if let Some(model) = &request.model {
+            args.extend([Arg::Literal("--model".into()), Arg::Literal(model.clone())]);
+        }
+        args.push(Arg::Quoted(self.deliver_brief(&request.brief)));
+        flatten(&args, 0)
+    }
+}
+
+#[async_trait]
+impl AgentAdapter for CliAgentAdapter {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+
+    async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
+        self.runner.write_file(&cwd.as_path().join(&brief.path), &brief.content).await
+    }
+
+    fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String> {
+        Ok(AgentLaunchPlan { command: self.command(request), env: Vec::new(), stance: TRUSTED_IMPLICIT_STANCE.into() })
+    }
+}
+
+#[derive(Default)]
+pub struct AgentAdapterRegistry {
+    adapters: BTreeMap<String, Arc<dyn AgentAdapter>>,
+}
+
+impl AgentAdapterRegistry {
+    pub fn discover(env: &EnvironmentBag, runner: Arc<dyn CommandRunner>) -> Self {
+        let mut registry = Self::default();
+        if let Some(binary) = env.find_binary("claude") {
+            registry.insert(Arc::new(CliAgentAdapter {
+                id: "claude-code",
+                binary: binary.as_path().display().to_string(),
+                runner: Arc::clone(&runner),
+                autonomy_args: &["--dangerously-skip-permissions"],
+            }));
+        }
+        if let Some(binary) = env.find_binary("codex") {
+            registry.insert(Arc::new(CliAgentAdapter {
+                id: "codex",
+                binary: binary.as_path().display().to_string(),
+                runner,
+                autonomy_args: &["--dangerously-bypass-approvals-and-sandbox"],
+            }));
+        }
+        registry
+    }
+
+    pub fn insert(&mut self, adapter: Arc<dyn AgentAdapter>) {
+        self.adapters.insert(adapter.id().to_string(), adapter);
+    }
+
+    pub fn get(&self, id: &str) -> Option<&Arc<dyn AgentAdapter>> {
+        self.adapters.get(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::{
+        agent_adapter::{AgentAdapterRegistry, AgentLaunchRequest, CapabilityTable},
+        path_context::ExecutionEnvironmentPath,
+        providers::{
+            discovery::{EnvironmentAssertion, EnvironmentBag},
+            testing::MockRunner,
+        },
+    };
+
+    fn discovered_registry() -> AgentAdapterRegistry {
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::binary("claude", "/tools/claude"))
+            .with(EnvironmentAssertion::binary("codex", "/tools/codex"));
+        AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(vec![])))
+    }
+
+    #[test]
+    fn capability_resolution_selects_harness_and_model_without_exposing_harnesses_to_templates() {
+        let table = CapabilityTable::seeded();
+
+        let coding = table.resolve("coding").expect("coding requirement");
+        assert_eq!(coding.adapter, "codex");
+        assert_eq!(coding.model.as_deref(), None);
+
+        let review = table.resolve("review").expect("review requirement");
+        assert_eq!(review.adapter, "claude-code");
+        assert_eq!(review.model.as_deref(), Some("opus"));
+        assert_eq!(table.resolve("code").expect("ADR code alias").adapter, "codex");
+        assert_eq!(table.resolve("code-review").expect("example review alias").adapter, "claude-code");
+
+        assert_eq!(table.resolve("architect").expect_err("unknown capability must fail"), "unknown agent capability `architect`");
+    }
+
+    #[tokio::test]
+    async fn adapters_prepare_the_canonical_brief_and_launch_with_only_a_short_pointer() {
+        let registry = discovered_registry();
+        let cwd = ExecutionEnvironmentPath::new("/workspace");
+        let brief = flotilla_resources::TerminalBrief {
+            path: ".flotilla/briefs/coder.md".into(),
+            content: "protocol preamble\n\nImplement the issue.".into(),
+        };
+
+        let codex = registry.get("codex").expect("codex adapter");
+        codex.prepare(&cwd, &brief).await.expect("prepare brief");
+        let plan =
+            codex.launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief: brief.clone() }).expect("codex launch plan");
+        assert_eq!(
+            plan.command,
+            "/tools/codex --dangerously-bypass-approvals-and-sandbox 'Read your crew brief at .flotilla/briefs/coder.md and follow it.'"
+        );
+        assert!(!plan.command.contains("Implement the issue"));
+        assert_eq!(plan.stance, "trusted-implicit");
+
+        let claude = registry.get("claude-code").expect("claude adapter");
+        let plan =
+            claude.launch(&AgentLaunchRequest { role: "reviewer".into(), model: Some("opus".into()), brief }).expect("claude launch plan");
+        assert_eq!(
+            plan.command,
+            "/tools/claude --dangerously-skip-permissions --model opus 'Read your crew brief at .flotilla/briefs/coder.md and follow it.'"
+        );
+        assert!(!plan.command.contains("Implement the issue"));
+    }
+}

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -309,6 +309,7 @@ pub async fn build_plan(
 
         // Daemon-level commands should not reach build_plan.
         CommandAction::ConvoyLegComplete { .. }
+        | CommandAction::CrewHandoff { .. }
         | CommandAction::ConvoyCreate { .. }
         | CommandAction::WorkflowTemplateApply { .. }
         | CommandAction::ProjectCreate { .. }
@@ -321,6 +322,7 @@ pub async fn build_plan(
         | CommandAction::QueryRepoWork { .. }
         | CommandAction::QueryHostList {}
         | CommandAction::QueryFleetList {}
+        | CommandAction::QueryCrewList { .. }
         | CommandAction::QueryFleetReplicaSnapshot {}
         | CommandAction::QueryHostStatus { .. }
         | CommandAction::QueryHostProviders { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -19,19 +19,22 @@ use flotilla_protocol::{
     arg::{flatten, Arg},
     panel::{PanelSnapshot, PanelValue},
     qualified_path::QualifiedPath,
-    Command, CorrelationKey, DaemonEvent, DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot,
-    FleetReplicaStatus, FleetStaleness, HostListResponse, HostName, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId,
-    NodeInfo, PeerConnectionState, ProviderData, ProviderInfo, RepoDelta, RepoDetailResponse, RepoInfo, RepoProvidersResponse,
-    RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse, StreamKey, SystemInfo, ToolInventory,
-    TopologyResponse, TopologyRoute,
+    Command, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId,
+    FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
+    HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, ProviderData, ProviderInfo, RepoDelta,
+    RepoDetailResponse, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse,
+    StreamKey, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute,
 };
 use flotilla_resources::{
-    apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, Checkout as ResourceCheckout,
-    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus,
-    Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue,
-    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec,
-    ResourceBackend, ResourceError, TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, TASK_LABEL, TASK_WORKSPACE_LABEL,
+    apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, terminal_session_attach_target,
+    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec,
+    Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue, LifecycleAuthority,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ProcessSource, Project, ProjectRepositorySpec, ProjectSpec,
+    Resource, ResourceBackend, ResourceError, TaskWorkspace, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionStatusPatch, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, TASK_LABEL,
+    TASK_WORKSPACE_LABEL,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -282,6 +285,7 @@ fn session_status_label(phase: Option<ResourceTerminalSessionPhase>) -> String {
         Some(ResourceTerminalSessionPhase::Starting) | None => "starting".to_string(),
         Some(ResourceTerminalSessionPhase::Running) => "running".to_string(),
         Some(ResourceTerminalSessionPhase::Stopped) => "stopped".to_string(),
+        Some(ResourceTerminalSessionPhase::Failed) => "failed".to_string(),
     }
 }
 
@@ -765,6 +769,64 @@ struct FleetReplicaCacheEntry {
     last_sync: Option<DateTime<Utc>>,
     generation: Option<String>,
     last_error: Option<String>,
+}
+
+#[derive(bon::Builder)]
+struct ResolvedCrewContext {
+    namespace: String,
+    convoy: String,
+    vessel: String,
+    leg: String,
+    caller_session: Option<flotilla_resources::ResourceObject<ResourceTerminalSession>>,
+}
+
+fn input_meta_from_resource<T: Resource>(resource: &flotilla_resources::ResourceObject<T>) -> InputMeta {
+    InputMeta::builder()
+        .name(resource.metadata.name.clone())
+        .labels(resource.metadata.labels.clone())
+        .annotations(resource.metadata.annotations.clone())
+        .owner_references(resource.metadata.owner_references.clone())
+        .finalizers(resource.metadata.finalizers.clone())
+        .maybe_deletion_timestamp(resource.metadata.deletion_timestamp)
+        .build()
+}
+
+fn handoff_crew_brief(context: &ResolvedCrewContext, target: &str, prompt: Option<&str>, members: &[CrewListMember]) -> TerminalBrief {
+    crate::agent_adapter::build_crew_brief(
+        &TerminalCrewContext { namespace: context.namespace.clone(), convoy: context.convoy.clone(), vessel: context.vessel.clone() },
+        &context.leg,
+        target,
+        prompt,
+        &members
+            .iter()
+            .map(|member| crate::agent_adapter::CrewBriefMember {
+                role: member.role.clone(),
+                state: if member.role == target { "active".to_string() } else { member.state.clone() },
+                is_agent: member.kind == "agent",
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn pending_crew_message(text: &str) -> TerminalCrewMessage {
+    TerminalCrewMessage { id: uuid::Uuid::new_v4().to_string(), text: text.to_string() }
+}
+
+async fn queue_pending_crew_message(
+    sessions: &flotilla_resources::TypedResolver<ResourceTerminalSession>,
+    existing: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
+    message: &str,
+) -> Result<(), String> {
+    let mut spec = existing.spec.clone();
+    let TerminalSessionSource::Agent { message: pending, .. } = &mut spec.source else {
+        return Err(format!("crew target `{}` is not an agent session", existing.spec.role));
+    };
+    *pending = Some(pending_crew_message(message));
+    sessions
+        .update(&input_meta_from_resource(existing), &existing.metadata.resource_version, &spec)
+        .await
+        .map(|_| ())
+        .map_err(|err| err.to_string())
 }
 
 pub struct InProcessDaemon {
@@ -2200,6 +2262,218 @@ impl InProcessDaemon {
         Ok(FleetListResponse { rows, replicas })
     }
 
+    async fn resolve_crew_context(&self, requested: &CrewCommandContext) -> Result<ResolvedCrewContext, String> {
+        let provisioning_namespace = self.provisioning_namespace().await;
+        let namespace = requested.namespace.clone().unwrap_or_else(|| provisioning_namespace.clone());
+        if namespace != provisioning_namespace {
+            return Err(format!("crew namespace `{namespace}` is not served by this daemon"));
+        }
+        let sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace);
+        let session_list = sessions.list().await.map_err(|err| err.to_string())?.items;
+
+        if let Some(crew_id) = requested.crew_id.as_deref() {
+            let session = session_list
+                .into_iter()
+                .find(|session| session.status.as_ref().and_then(|status| status.crew.as_ref()).is_some_and(|crew| crew.id == crew_id))
+                .ok_or_else(|| format!("unknown FLOTILLA_CREW_ID `{crew_id}`"))?;
+            let (convoy, vessel) = match &session.spec.source {
+                TerminalSessionSource::Agent { context, .. } => (context.convoy.clone(), context.vessel.clone()),
+                TerminalSessionSource::Tool { .. } => {
+                    return Err(format!("crew identity `{crew_id}` belongs to a non-agent process"));
+                }
+            };
+            return self.resolved_crew_context(namespace, convoy, vessel, Some(session)).await;
+        }
+
+        let convoy = requested
+            .convoy
+            .clone()
+            .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel, and --role".to_string())?;
+        let vessel = requested
+            .vessel
+            .clone()
+            .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel, and --role".to_string())?;
+        let role =
+            requested.role.clone().ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel, and --role".to_string())?;
+        let caller = session_list.into_iter().find(|session| {
+            session.spec.role == role && session.metadata.labels.get(TASK_WORKSPACE_LABEL).map(String::as_str) == Some(vessel.as_str())
+        });
+        self.resolved_crew_context(namespace, convoy, vessel, caller).await
+    }
+
+    async fn resolved_crew_context(
+        &self,
+        namespace: String,
+        convoy: String,
+        vessel: String,
+        caller_session: Option<flotilla_resources::ResourceObject<ResourceTerminalSession>>,
+    ) -> Result<ResolvedCrewContext, String> {
+        let workspace =
+            self.resource_backend.clone().using::<TaskWorkspace>(&namespace).get(&vessel).await.map_err(|err| err.to_string())?;
+        if workspace.spec.convoy_ref != convoy {
+            return Err(format!("vessel `{vessel}` does not belong to convoy `{convoy}`"));
+        }
+        Ok(ResolvedCrewContext::builder()
+            .namespace(namespace)
+            .convoy(convoy)
+            .vessel(vessel)
+            .leg(workspace.spec.task)
+            .maybe_caller_session(caller_session)
+            .build())
+    }
+
+    pub async fn crew_list_internal(&self, requested: &CrewCommandContext) -> Result<CrewListResponse, String> {
+        let context = self.resolve_crew_context(requested).await?;
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&context.namespace);
+        let convoy = convoys.get(&context.convoy).await.map_err(|err| err.to_string())?;
+        let task = convoy
+            .status
+            .as_ref()
+            .and_then(|status| status.workflow_snapshot.as_ref())
+            .and_then(|snapshot| snapshot.tasks.iter().find(|task| task.name == context.leg))
+            .ok_or_else(|| format!("leg `{}` is missing from convoy `{}`", context.leg, context.convoy))?;
+        let sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&context.namespace);
+        let by_role: HashMap<_, _> = sessions
+            .list_matching_labels(&BTreeMap::from([(TASK_WORKSPACE_LABEL.to_string(), context.vessel.clone())]))
+            .await
+            .map_err(|err| err.to_string())?
+            .items
+            .into_iter()
+            .map(|session| (session.spec.role.clone(), session))
+            .collect();
+        let members = task
+            .processes
+            .iter()
+            .map(|process| {
+                let session = by_role.get(&process.role);
+                let state = match session.and_then(|session| session.status.as_ref().map(|status| status.phase)) {
+                    Some(ResourceTerminalSessionPhase::Starting) => "starting",
+                    Some(ResourceTerminalSessionPhase::Running) => "active",
+                    Some(ResourceTerminalSessionPhase::Stopped) => "stopped",
+                    Some(ResourceTerminalSessionPhase::Failed) => "failed",
+                    None if matches!(process.source, ProcessSource::Agent { .. }) => "latent",
+                    None => "pending",
+                };
+                let crew = session.and_then(|session| session.status.as_ref()).and_then(|status| status.crew.as_ref());
+                CrewListMember::builder()
+                    .role(process.role.clone())
+                    .kind(if matches!(process.source, ProcessSource::Agent { .. }) { "agent" } else { "tool" }.to_string())
+                    .state(state.to_string())
+                    .maybe_adapter(crew.map(|crew| crew.adapter.clone()))
+                    .maybe_model(crew.and_then(|crew| crew.model.clone()))
+                    .maybe_stance(crew.map(|crew| crew.stance.clone()))
+                    .build()
+            })
+            .collect();
+        Ok(CrewListResponse::builder().convoy(context.convoy).vessel(context.vessel).leg(context.leg).members(members).build())
+    }
+
+    pub async fn crew_handoff_internal(&self, requested: &CrewCommandContext, target: &str, message: &str) -> Result<(), String> {
+        let context = self.resolve_crew_context(requested).await?;
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&context.namespace);
+        let convoy = convoys.get(&context.convoy).await.map_err(|err| err.to_string())?;
+        let (task_index, task) = convoy
+            .status
+            .as_ref()
+            .and_then(|status| status.workflow_snapshot.as_ref())
+            .and_then(|snapshot| snapshot.tasks.iter().enumerate().find(|(_, task)| task.name == context.leg))
+            .ok_or_else(|| format!("leg `{}` is missing from convoy `{}`", context.leg, context.convoy))?;
+        let (process_index, process) = task
+            .processes
+            .iter()
+            .enumerate()
+            .find(|(_, process)| process.role == target)
+            .ok_or_else(|| format!("crew target `{target}` is not defined for leg `{}`", context.leg))?;
+        let ProcessSource::Agent { selector, prompt } = &process.source else {
+            return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
+        };
+
+        let sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&context.namespace);
+        let identity = TerminalSessionIdentity::builder()
+            .vessel(context.vessel.clone())
+            .convoy(context.convoy.clone())
+            .leg(context.leg.clone())
+            .role(target.to_string())
+            .task_index(task_index)
+            .process_index(process_index)
+            .labels(process.labels.clone())
+            .build();
+        let terminal_name = identity.name();
+        match sessions.get(&terminal_name).await {
+            Ok(existing) => match existing.status.as_ref().map(|status| status.phase) {
+                Some(ResourceTerminalSessionPhase::Running) => self.deliver_to_crew_session(&existing, message).await,
+                Some(ResourceTerminalSessionPhase::Stopped) => {
+                    queue_pending_crew_message(&sessions, &existing, message).await?;
+                    apply_resource_status_patch(&sessions, &terminal_name, &TerminalSessionStatusPatch::MarkStarting)
+                        .await
+                        .map(|_| ())
+                        .map_err(|err| err.to_string())
+                }
+                Some(ResourceTerminalSessionPhase::Failed) => {
+                    Err(format!("crew target `{target}` failed provisioning and cannot be revived"))
+                }
+                Some(ResourceTerminalSessionPhase::Starting) | None => queue_pending_crew_message(&sessions, &existing, message).await,
+            },
+            Err(ResourceError::NotFound { .. }) => {
+                let anchor = if let Some(caller) = context.caller_session.as_ref() {
+                    caller.clone()
+                } else {
+                    sessions
+                        .list_matching_labels(&BTreeMap::from([(TASK_WORKSPACE_LABEL.to_string(), context.vessel.clone())]))
+                        .await
+                        .map_err(|err| err.to_string())?
+                        .items
+                        .into_iter()
+                        .next()
+                        .ok_or_else(|| format!("vessel `{}` has no active session to anchor the handoff", context.vessel))?
+                };
+                let current = self.crew_list_internal(requested).await?;
+                let brief = handoff_crew_brief(&context, target, prompt.as_deref(), &current.members);
+                sessions
+                    .create(&identity.input_meta(), &flotilla_resources::TerminalSessionSpec {
+                        env_ref: anchor.spec.env_ref,
+                        role: target.to_string(),
+                        source: TerminalSessionSource::Agent {
+                            selector: selector.clone(),
+                            brief,
+                            context: TerminalCrewContext { namespace: context.namespace, convoy: context.convoy, vessel: context.vessel },
+                            message: Some(pending_crew_message(message)),
+                        },
+                        cwd: anchor.spec.cwd,
+                        pool: anchor.spec.pool,
+                    })
+                    .await
+                    .map(|_| ())
+                    .map_err(|err| err.to_string())
+            }
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    async fn deliver_to_crew_session(
+        &self,
+        session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
+        message: &str,
+    ) -> Result<(), String> {
+        let namespace = session.metadata.namespace.clone();
+        let environment = self
+            .resource_backend
+            .clone()
+            .using::<ResourceEnvironment>(&namespace)
+            .get(&session.spec.env_ref)
+            .await
+            .map_err(|err| err.to_string())?;
+        let registry = self.registry_for_resource_environment(&environment, Path::new(&session.spec.cwd)).await?;
+        let pool = registry
+            .terminal_pools
+            .get(&session.spec.pool)
+            .map(|(_, pool)| Arc::clone(pool))
+            .or_else(|| registry.terminal_pools.preferred().cloned())
+            .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
+        let session_id = session.status.as_ref().and_then(|status| status.session_id.as_deref()).unwrap_or(session.metadata.name.as_str());
+        pool.deliver(session_id, message, true).await
+    }
+
     pub async fn refresh_fleet_replicas_once(&self) -> Result<(), String> {
         let hosts = self.config.load_hosts()?;
         let namespace = self.provisioning_namespace().await;
@@ -2482,9 +2756,8 @@ impl InProcessDaemon {
             .get(&session.spec.pool)
             .map(|(_, pool)| Arc::clone(pool))
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
-        let session_name =
-            session.status.as_ref().and_then(|status| status.session_id.as_deref()).unwrap_or(session.metadata.name.as_str());
-        let attach_args = pool.attach_args(session_name, &session.spec.command, &cwd, &Vec::new())?;
+        let attach_target = terminal_session_attach_target(session)?;
+        let attach_args = pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?;
         if environment.spec.docker.is_some() {
             let command = ResolvedPaneCommand { role: session.spec.role.clone(), args: attach_args };
             let environment_id = EnvironmentId::new(session.spec.env_ref.clone());
@@ -2699,6 +2972,29 @@ impl InProcessDaemon {
                 node_id: self.node_id.clone(),
                 repo_identity,
                 repo: Some(repo_path),
+                result,
+            });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::CrewHandoff { context, target, message } = &command.action {
+            let empty_identity = empty_repo_identity();
+            let _ = self.event_tx.send(DaemonEvent::CommandStarted {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity.clone(),
+                repo: None,
+                description: command.description().to_string(),
+            });
+            let result = match self.crew_handoff_internal(context, target, message).await {
+                Ok(()) => flotilla_protocol::CommandValue::Ok,
+                Err(message) => flotilla_protocol::CommandValue::Error { message },
+            };
+            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity,
+                repo: None,
                 result,
             });
             return Ok(id);
@@ -3323,6 +3619,10 @@ impl DaemonHandle for InProcessDaemon {
             }
             CommandAction::QueryFleetList {} => match self.fleet_list_internal().await {
                 Ok(v) => Ok(flotilla_protocol::CommandValue::FleetList(Box::new(v))),
+                Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
+            },
+            CommandAction::QueryCrewList { context } => match self.crew_list_internal(context).await {
+                Ok(v) => Ok(flotilla_protocol::CommandValue::CrewList(Box::new(v))),
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
             },
             CommandAction::QueryFleetReplicaSnapshot {} => match self.fleet_replica_snapshot_internal().await {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -8,16 +8,19 @@ use async_trait::async_trait;
 use flotilla_protocol::{
     panel::{PanelRow, PanelSnapshot, PanelValue, ResourceRef},
     qualified_path::{HostId, QualifiedPath},
-    AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, DaemonEvent, EnvironmentId,
-    EnvironmentStatus, HostEnvironment, HostPath, HostSummary, ImageId, Issue, RepoSelector, SystemInfo, ToolInventory, TopologyRoute,
+    AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent,
+    EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostSummary, ImageId, Issue, RepoSelector, SystemInfo, ToolInventory,
+    TopologyRoute,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, Environment as ResourceEnvironment,
     EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec, InputMeta, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, TaskPhase, TaskState, TerminalSession as ResourceTerminalSession,
-    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSpec as ResourceTerminalSessionSpec,
-    TerminalSessionStatus as ResourceTerminalSessionStatus, CONVOY_LABEL, ROLE_LABEL, TASK_LABEL, TASK_WORKSPACE_LABEL,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, ProcessDefinition, ProcessSource, Selector, SnapshotTask, TaskPhase, TaskState,
+    TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TerminalBrief, TerminalCrewContext,
+    TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource,
+    TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus, WorkflowSnapshot,
+    CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
 };
 
 use super::*;
@@ -124,9 +127,16 @@ async fn wait_for_command_result(events: &mut tokio::sync::broadcast::Receiver<D
 }
 
 async fn new_attach_test_daemon(config_base: &Path) -> Arc<InProcessDaemon> {
+    new_attach_test_daemon_with_pool(config_base).await.0
+}
+
+async fn new_attach_test_daemon_with_pool(config_base: &Path) -> (Arc<InProcessDaemon>, Arc<FakeTerminalPool>) {
     let terminal_pool = Arc::new(FakeTerminalPool::new());
-    let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(terminal_pool));
-    InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), discovery, HostName::local()).await
+    let discovery = fake_discovery_with_provider_set(
+        FakeDiscoveryProviders::new().with_terminal_pool(Arc::clone(&terminal_pool) as Arc<dyn crate::providers::terminal::TerminalPool>),
+    );
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), discovery, HostName::local()).await;
+    (daemon, terminal_pool)
 }
 
 async fn create_local_attach_environment(daemon: &InProcessDaemon) -> String {
@@ -234,7 +244,7 @@ async fn create_running_attach_session_with_pool(
             &ResourceTerminalSessionSpec {
                 env_ref: env_ref.to_string(),
                 role: role.to_string(),
-                command: "bash".to_string(),
+                source: flotilla_resources::TerminalSessionSource::Tool { command: "bash".to_string() },
                 cwd: "/repo".to_string(),
                 pool: pool.to_string(),
             },
@@ -279,6 +289,250 @@ async fn create_adopted_checkout_for_convoy(daemon: &InProcessDaemon, convoy: &s
         })
         .await
         .expect("adopted checkout should be ready");
+}
+
+async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
+    let convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    let convoy = convoys
+        .create(&empty_input_meta("demo"), &ConvoySpec {
+            workflow_ref: "coding-review".into(),
+            inputs: BTreeMap::new(),
+            placement_policy: None,
+            repository: None,
+            r#ref: None,
+            project_ref: None,
+            adopted_checkout_ref: None,
+        })
+        .await
+        .expect("create convoy");
+    let processes = vec![
+        ProcessDefinition::builder()
+            .role("coder".to_string())
+            .source(ProcessSource::Agent {
+                selector: Selector { capability: "coding".into() },
+                prompt: Some("Implement the change.".into()),
+            })
+            .build(),
+        ProcessDefinition::builder()
+            .role("reviewer".to_string())
+            .source(ProcessSource::Agent { selector: Selector { capability: "review".into() }, prompt: Some("Review the change.".into()) })
+            .build(),
+    ];
+    convoys
+        .update_status("demo", &convoy.metadata.resource_version, &ConvoyStatus {
+            workflow_snapshot: Some(WorkflowSnapshot {
+                tasks: vec![SnapshotTask { name: "prepare".into(), depends_on: Vec::new(), processes: Vec::new() }, SnapshotTask {
+                    name: "implement".into(),
+                    depends_on: Vec::new(),
+                    processes,
+                }],
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect("update convoy status");
+
+    let workspaces = daemon.resource_backend().using::<TaskWorkspace>("flotilla");
+    let workspace = workspaces
+        .create(
+            &input_meta_with_labels(
+                "demo-implement",
+                BTreeMap::from([(CONVOY_LABEL.into(), "demo".into()), (TASK_LABEL.into(), "implement".into())]),
+            ),
+            &TaskWorkspaceSpec {
+                convoy_ref: "demo".into(),
+                task: "implement".into(),
+                placement_policy_ref: "host-direct".into(),
+                adopted_checkout_ref: None,
+            },
+        )
+        .await
+        .expect("create workspace");
+    workspaces
+        .update_status("demo-implement", &workspace.metadata.resource_version, &TaskWorkspaceStatus {
+            phase: TaskWorkspacePhase::Ready,
+            environment_ref: Some(env_ref.into()),
+            terminal_session_refs: vec!["terminal-demo-implement-coder".into()],
+            ..Default::default()
+        })
+        .await
+        .expect("update workspace status");
+
+    let terminals = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let coder = terminals
+        .create(
+            &input_meta_with_labels(
+                "terminal-demo-implement-coder",
+                BTreeMap::from([
+                    (CONVOY_LABEL.into(), "demo".into()),
+                    (TASK_LABEL.into(), "implement".into()),
+                    (TASK_WORKSPACE_LABEL.into(), "demo-implement".into()),
+                    (ROLE_LABEL.into(), "coder".into()),
+                ]),
+            ),
+            &ResourceTerminalSessionSpec {
+                env_ref: env_ref.into(),
+                role: "coder".into(),
+                source: TerminalSessionSource::Agent {
+                    selector: Selector { capability: "coding".into() },
+                    brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "coder brief".into() },
+                    context: TerminalCrewContext { namespace: "flotilla".into(), convoy: "demo".into(), vessel: "demo-implement".into() },
+                    message: None,
+                },
+                cwd: "/repo".into(),
+                pool: "fake-terminals".into(),
+            },
+        )
+        .await
+        .expect("create coder session");
+    terminals
+        .update_status("terminal-demo-implement-coder", &coder.metadata.resource_version, &ResourceTerminalSessionStatus {
+            phase: ResourceTerminalSessionPhase::Running,
+            session_id: Some("session-coder".into()),
+            crew: Some(flotilla_resources::CrewSessionStatus {
+                id: "crew-coder".into(),
+                adapter: "codex".into(),
+                model: None,
+                stance: "trusted-implicit".into(),
+            }),
+            launch_command: Some("codex".into()),
+            ..Default::default()
+        })
+        .await
+        .expect("run coder session");
+}
+
+#[tokio::test]
+async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+    let context = CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() };
+
+    let response = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryCrewList { context: context.clone() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("crew list query");
+    let CommandValue::CrewList(response) = response else { panic!("expected crew list") };
+    assert_eq!(response.members.iter().map(|member| (member.role.as_str(), member.state.as_str())).collect::<Vec<_>>(), vec![
+        ("coder", "active"),
+        ("reviewer", "latent")
+    ]);
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::CrewHandoff { context, target: "reviewer".into(), message: "Review commit abc123".into() },
+        })
+        .await
+        .expect("handoff command");
+    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
+    let reviewer = daemon
+        .resource_backend()
+        .using::<ResourceTerminalSession>("flotilla")
+        .get("terminal-demo-implement-reviewer")
+        .await
+        .expect("reviewer session should be defined");
+    assert!(
+        matches!(reviewer.spec.source, TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Review commit abc123")
+    );
+    assert_eq!(reviewer.metadata.labels.get(TASK_ORDINAL_LABEL).map(String::as_str), Some("001"));
+    assert_eq!(reviewer.metadata.labels.get(PROCESS_ORDINAL_LABEL).map(String::as_str), Some("001"));
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::CrewHandoff {
+                context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
+                target: "reviewer".into(),
+                message: "Use the amended commit".into(),
+            },
+        })
+        .await
+        .expect("handoff while reviewer is starting");
+    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
+    let reviewer = daemon
+        .resource_backend()
+        .using::<ResourceTerminalSession>("flotilla")
+        .get("terminal-demo-implement-reviewer")
+        .await
+        .expect("reviewer session should still exist");
+    assert!(matches!(
+        reviewer.spec.source,
+        TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Use the amended commit"
+    ));
+
+    let explicit_context = CrewCommandContext {
+        crew_id: None,
+        namespace: Some("flotilla".into()),
+        convoy: Some("demo".into()),
+        vessel: Some("demo-implement".into()),
+        role: Some("reviewer".into()),
+    };
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::CrewHandoff {
+                context: explicit_context.clone(),
+                target: "coder".into(),
+                message: "Address the review findings".into(),
+            },
+        })
+        .await
+        .expect("handoff to active coder");
+    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
+    assert_eq!(terminal_pool.delivered.lock().await.as_slice(), &[(
+        "session-coder".to_string(),
+        "Address the review findings".to_string(),
+        true
+    )]);
+
+    let terminals = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let coder = terminals.get("terminal-demo-implement-coder").await.expect("coder");
+    terminals
+        .update_status("terminal-demo-implement-coder", &coder.metadata.resource_version, &ResourceTerminalSessionStatus {
+            phase: ResourceTerminalSessionPhase::Stopped,
+            session_id: Some("session-coder".into()),
+            crew: coder.status.as_ref().and_then(|status| status.crew.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("stop coder");
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::CrewHandoff { context: explicit_context, target: "coder".into(), message: "Resume after review".into() },
+        })
+        .await
+        .expect("revive coder");
+    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
+    let coder = terminals.get("terminal-demo-implement-coder").await.expect("restarting coder");
+    assert_eq!(coder.status.expect("coder status").phase, ResourceTerminalSessionPhase::Starting);
+    assert!(
+        matches!(coder.spec.source, TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Resume after review")
+    );
 }
 
 #[test]
@@ -685,6 +939,73 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
         .expect("attach query should execute");
 
     assert_eq!(result, CommandValue::AttachCommandResolved { command: "attach cleat-session-1".to_string() });
+}
+
+#[tokio::test]
+async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    let sessions = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let created = sessions
+        .create(
+            &input_meta_with_labels(
+                "terminal-convoy-a-implement-coder",
+                BTreeMap::from([
+                    (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+                    (TASK_LABEL.to_string(), "implement".to_string()),
+                    (TASK_WORKSPACE_LABEL.to_string(), "convoy-a-implement".to_string()),
+                    (ROLE_LABEL.to_string(), "coder".to_string()),
+                ]),
+            ),
+            &ResourceTerminalSessionSpec {
+                env_ref,
+                role: "coder".to_string(),
+                source: TerminalSessionSource::Agent {
+                    selector: Selector { capability: "coding".to_string() },
+                    brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into() },
+                    context: TerminalCrewContext {
+                        namespace: "flotilla".into(),
+                        convoy: "convoy-a".into(),
+                        vessel: "convoy-a-implement".into(),
+                    },
+                    message: None,
+                },
+                cwd: "/repo".to_string(),
+                pool: "fake-terminals".to_string(),
+            },
+        )
+        .await
+        .expect("starting agent session");
+    sessions
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &ResourceTerminalSessionStatus {
+            phase: ResourceTerminalSessionPhase::Running,
+            session_id: Some("agent-session".to_string()),
+            launch_command: None,
+            ..Default::default()
+        })
+        .await
+        .expect("malformed running status");
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    assert_eq!(result, CommandValue::Error {
+        message: "agent terminal session terminal-convoy-a-implement-coder has no recorded launch command".to_string()
+    });
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent_adapter;
 pub mod agents;
 pub mod aggregator_projection;
 pub mod attachable;

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 use futures::stream;
 
 use crate::{
+    agent_adapter::AgentAdapterRegistry,
     attachable::{shared_file_backed_attachable_store, SharedAttachableStore},
     config::ConfigStore,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
@@ -483,6 +484,7 @@ impl FactoryRegistry {
         }
 
         let mut registry = ProviderRegistry::new();
+        registry.agent_adapters = AgentAdapterRegistry::discover(env, Arc::clone(&runner));
 
         for (desc, p) in probe_category(&self.vcs, env, config, repo_root, &runner).await {
             registry.vcs.insert(desc.implementation.clone(), desc, p);

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -235,6 +235,11 @@ impl CommandRunner for DiscoveryMockRunner {
         let mut files = self.files.lock().expect("lock poisoned");
         Ok(files.entry(path.to_path_buf()).or_insert_with(|| content.to_owned()).clone())
     }
+
+    async fn write_file(&self, path: &Path, content: &str) -> Result<(), String> {
+        self.files.lock().expect("lock poisoned").insert(path.to_path_buf(), content.to_owned());
+        Ok(())
+    }
 }
 /// Build a `DiscoveryRuntime` that uses no-op env and a minimal fake runner
 /// (only responds to `git --version`). Avoids probing ambient host tools.
@@ -701,6 +706,15 @@ impl PresentationManager for FakePresentationManager {
 pub struct FakeTerminalPool {
     pub sessions: Arc<TokioMutex<Vec<super::super::terminal::TerminalSession>>>,
     pub killed: Arc<TokioMutex<Vec<String>>>,
+    pub delivered: Arc<TokioMutex<Vec<(String, String, bool)>>>,
+    pub ensured: Arc<TokioMutex<Vec<EnsuredTerminalSession>>>,
+}
+
+pub struct EnsuredTerminalSession {
+    pub session_name: String,
+    pub command: String,
+    pub cwd: ExecutionEnvironmentPath,
+    pub env_vars: super::super::terminal::TerminalEnvVars,
 }
 
 impl Default for FakeTerminalPool {
@@ -711,16 +725,29 @@ impl Default for FakeTerminalPool {
 
 impl FakeTerminalPool {
     pub fn new() -> Self {
-        Self { sessions: Arc::new(TokioMutex::new(Vec::new())), killed: Arc::new(TokioMutex::new(Vec::new())) }
+        Self {
+            sessions: Arc::new(TokioMutex::new(Vec::new())),
+            killed: Arc::new(TokioMutex::new(Vec::new())),
+            delivered: Arc::new(TokioMutex::new(Vec::new())),
+            ensured: Arc::new(TokioMutex::new(Vec::new())),
+        }
     }
 
     pub async fn add_sessions(&self, sessions: Vec<super::super::terminal::TerminalSession>) {
         self.sessions.lock().await.extend(sessions);
     }
+
+    pub async fn remove_session(&self, session_name: &str) {
+        self.sessions.lock().await.retain(|session| session.session_name != session_name);
+    }
 }
 
 #[async_trait::async_trait]
 impl TerminalPool for FakeTerminalPool {
+    fn tracks_session_liveness(&self) -> bool {
+        true
+    }
+
     async fn list_sessions(&self) -> Result<Vec<super::super::terminal::TerminalSession>, String> {
         Ok(self.sessions.lock().await.clone())
     }
@@ -730,12 +757,18 @@ impl TerminalPool for FakeTerminalPool {
         session_name: &str,
         command: &str,
         cwd: &ExecutionEnvironmentPath,
-        _env_vars: &super::super::terminal::TerminalEnvVars,
+        env_vars: &super::super::terminal::TerminalEnvVars,
     ) -> Result<(), String> {
         let mut sessions = self.sessions.lock().await;
         if sessions.iter().any(|s| s.session_name == session_name) {
             return Ok(());
         }
+        self.ensured.lock().await.push(EnsuredTerminalSession {
+            session_name: session_name.to_string(),
+            command: command.to_string(),
+            cwd: cwd.clone(),
+            env_vars: env_vars.clone(),
+        });
         sessions.push(super::super::terminal::TerminalSession {
             session_name: session_name.to_string(),
             status: TerminalStatus::Running,
@@ -757,6 +790,12 @@ impl TerminalPool for FakeTerminalPool {
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {
         self.killed.lock().await.push(session_name.to_string());
+        self.sessions.lock().await.retain(|session| session.session_name != session_name);
+        Ok(())
+    }
+
+    async fn deliver(&self, session_name: &str, text: &str, submit: bool) -> Result<(), String> {
+        self.delivered.lock().await.push((session_name.to_string(), text.to_string(), submit));
         Ok(())
     }
 }

--- a/crates/flotilla-core/src/providers/environment/runner.rs
+++ b/crates/flotilla-core/src/providers/environment/runner.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use uuid::Uuid;
 
 use crate::providers::{
-    helper_exec_script, install_managed_helper_script, ChannelLabel, CommandOutput, CommandRunner, FLOTILLA_HELPER_NAME,
-    FLOTILLA_HELPER_SCRIPT,
+    atomic_write_script, helper_exec_script, install_managed_helper_script, ChannelLabel, CommandOutput, CommandRunner,
+    FLOTILLA_HELPER_NAME, FLOTILLA_HELPER_SCRIPT,
 };
 
 /// A `CommandRunner` decorator that executes all commands inside a Docker container
@@ -42,6 +42,13 @@ impl CommandRunner for DockerEnvironmentRunner {
         self.inner.run_output("docker", &docker_args, Path::new("/"), label).await
     }
 
+    async fn run_with_input(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel, input: &[u8]) -> Result<String, String> {
+        let cwd_str = cwd.to_string_lossy();
+        let mut docker_args = vec!["exec", "-i", "-w", &cwd_str, &self.container_name, cmd];
+        docker_args.extend_from_slice(args);
+        self.inner.run_with_input("docker", &docker_args, Path::new("/"), label, input).await
+    }
+
     async fn exists(&self, cmd: &str, _args: &[&str]) -> bool {
         let docker_args = ["exec", &self.container_name, "which", cmd];
         self.inner.run("docker", &docker_args, Path::new("/"), &ChannelLabel::Noop).await.is_ok()
@@ -58,6 +65,12 @@ impl CommandRunner for DockerEnvironmentRunner {
         owned_args.extend(["sh".to_string(), "-lc".to_string(), helper_script]);
         let arg_refs: Vec<&str> = owned_args.iter().map(String::as_str).collect();
         self.inner.run("docker", &arg_refs, Path::new("/"), &ChannelLabel::Noop).await
+    }
+
+    async fn write_file(&self, path: &Path, content: &str) -> Result<(), String> {
+        let script = atomic_write_script(path, &Uuid::new_v4().to_string())?;
+        let args = ["exec", "-i", &self.container_name, "sh", "-lc", script.as_str()];
+        self.inner.run_with_input("docker", &args, Path::new("/"), &ChannelLabel::Noop, content.as_bytes()).await.map(|_| ())
     }
 }
 
@@ -103,5 +116,20 @@ mod tests {
         assert!(script.contains("exec 'flotilla-helper' 'ensure-file-if-absent'"));
         assert!(script.contains("'/app/config/shpool.toml'"));
         assert!(script.contains("'key = true\n'"));
+    }
+
+    #[tokio::test]
+    async fn write_file_keeps_content_out_of_docker_argv() {
+        let inner = Arc::new(MockRunner::new(vec![Ok(String::new())]));
+        let runner = DockerEnvironmentRunner::new("my-container".into(), inner.clone());
+
+        runner.write_file(Path::new("/app/.flotilla/briefs/coder.md"), "secret assignment").await.expect("write_file");
+
+        let calls = inner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "docker");
+        assert!(calls[0].1.iter().all(|arg| !arg.contains("secret assignment")));
+        assert!(calls[0].1.contains(&"-i".to_string()));
+        assert!(calls[0].1.last().expect("write script").contains("cat > \"$tmp\""));
     }
 }

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -162,6 +162,18 @@ pub(crate) fn helper_exec_script(helper_path: &str, subcommand: &str, args: &[&s
     Ok(parts.join(" "))
 }
 
+pub(crate) fn atomic_write_script(path: &Path, temp_suffix: &str) -> Result<String, String> {
+    let parent = path.parent().ok_or_else(|| format!("file path has no parent: {}", path.display()))?;
+    let target = path.to_string_lossy();
+    let temporary = format!("{target}.flotilla-tmp-{temp_suffix}");
+    Ok(format!(
+        "set -eu; mkdir -p {}; tmp={}; trap 'rm -f \"$tmp\"' EXIT; cat > \"$tmp\"; mv \"$tmp\" {}; trap - EXIT",
+        flotilla_protocol::arg::shell_quote(&parent.to_string_lossy()),
+        flotilla_protocol::arg::shell_quote(&temporary),
+        flotilla_protocol::arg::shell_quote(&target),
+    ))
+}
+
 pub(crate) async fn install_managed_helper_script(
     runner: &dyn CommandRunner,
     command: &str,
@@ -202,6 +214,20 @@ pub trait CommandRunner: Send + Sync {
     /// `Err` only if the process could not be spawned at all.
     async fn run_output(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<CommandOutput, String>;
 
+    /// Run a command with bytes supplied on stdin. The input is deliberately
+    /// separate from argv so sensitive content cannot leak into process lists
+    /// or recorded command transcripts.
+    async fn run_with_input(
+        &self,
+        _cmd: &str,
+        _args: &[&str],
+        _cwd: &Path,
+        _label: &ChannelLabel,
+        _input: &[u8],
+    ) -> Result<String, String> {
+        Err("command runner does not support stdin input".to_string())
+    }
+
     /// Check if a command is available by running it.
     async fn exists(&self, cmd: &str, args: &[&str]) -> bool;
 
@@ -209,6 +235,12 @@ pub trait CommandRunner: Send + Sync {
     /// file contents. Existing files are preserved.
     async fn ensure_file(&self, _path: &Path, content: &str) -> Result<String, String> {
         Ok(content.to_owned())
+    }
+
+    /// Atomically replace `path` with `content`. Implementations must transport
+    /// the content outside argv and command transcripts.
+    async fn write_file(&self, _path: &Path, _content: &str) -> Result<(), String> {
+        Err("command runner does not support secure file writes".to_string())
     }
 }
 
@@ -247,6 +279,31 @@ impl CommandRunner for ProcessCommandRunner {
         })
     }
 
+    async fn run_with_input(&self, cmd: &str, args: &[&str], cwd: &Path, _label: &ChannelLabel, input: &[u8]) -> Result<String, String> {
+        use tokio::io::AsyncWriteExt;
+
+        let mut child = tokio::process::Command::new(cmd)
+            .args(args)
+            .current_dir(cwd)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| e.to_string())?;
+        let mut stdin = child.stdin.take().expect("piped stdin should be available");
+        let write_input = async move {
+            stdin.write_all(input).await.map_err(|e| e.to_string())?;
+            stdin.shutdown().await.map_err(|e| e.to_string())
+        };
+        let wait_for_output = async move { child.wait_with_output().await.map_err(|e| e.to_string()) };
+        let ((), output) = tokio::try_join!(write_input, wait_for_output)?;
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).to_string())
+        }
+    }
+
     async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
         tokio::process::Command::new(cmd)
             .args(args)
@@ -276,6 +333,15 @@ impl CommandRunner for ProcessCommandRunner {
             }
             Err(err) => Err(format!("open {}: {err}", path.display())),
         }
+    }
+
+    async fn write_file(&self, path: &Path, content: &str) -> Result<(), String> {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| format!("create_dir_all {}: {e}", parent.display()))?;
+        }
+        let temporary = path.with_extension(format!("flotilla-tmp-{}", uuid::Uuid::new_v4()));
+        tokio::fs::write(&temporary, content).await.map_err(|e| format!("write {}: {e}", temporary.display()))?;
+        tokio::fs::rename(&temporary, path).await.map_err(|e| format!("rename {} to {}: {e}", temporary.display(), path.display()))
     }
 }
 
@@ -455,8 +521,23 @@ pub(crate) mod testing {
             }
         }
 
+        async fn run_with_input(
+            &self,
+            cmd: &str,
+            args: &[&str],
+            cwd: &Path,
+            label: &ChannelLabel,
+            _input: &[u8],
+        ) -> Result<String, String> {
+            self.run(cmd, args, cwd, label).await
+        }
+
         async fn exists(&self, _cmd: &str, _args: &[&str]) -> bool {
             true
+        }
+
+        async fn write_file(&self, _path: &Path, _content: &str) -> Result<(), String> {
+            Ok(())
         }
     }
 
@@ -490,6 +571,41 @@ pub(crate) mod testing {
         let on_disk = std::fs::read_to_string(&path).expect("read back");
         assert_eq!(ensured, "existing = true\n");
         assert_eq!(on_disk, "existing = true\n");
+    }
+
+    #[tokio::test]
+    async fn process_runner_write_file_replaces_existing_contents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested/brief.md");
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        std::fs::write(&path, "old brief").expect("seed file");
+
+        let runner = super::ProcessCommandRunner;
+        runner.write_file(&path, "new secret brief").await.expect("write_file");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("read back"), "new secret brief");
+    }
+
+    #[tokio::test]
+    async fn process_runner_run_with_input_drains_output_while_writing_stdin() {
+        let runner = super::ProcessCommandRunner;
+        let input = vec![b'x'; 131_072];
+
+        let output = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            runner.run_with_input(
+                "sh",
+                &["-c", "dd if=/dev/zero bs=131072 count=1 2>/dev/null; cat >/dev/null"],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+                &input,
+            ),
+        )
+        .await
+        .expect("stdin writing and output draining must not deadlock")
+        .expect("child command");
+
+        assert_eq!(output.len(), 131_072);
     }
 }
 

--- a/crates/flotilla-core/src/providers/registry.rs
+++ b/crates/flotilla-core/src/providers/registry.rs
@@ -2,16 +2,19 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 
-use crate::providers::{
-    ai_utility::AiUtility,
-    change_request::ChangeRequestTracker,
-    coding_agent::CloudAgentService,
-    discovery::{ProviderDescriptor, ServiceDescriptor},
-    issue_query::IssueQueryService,
-    issue_tracker::IssueProvider,
-    presentation::PresentationManager,
-    terminal::TerminalPool,
-    vcs::{CheckoutManager, CloneProvisioner, Vcs},
+use crate::{
+    agent_adapter::AgentAdapterRegistry,
+    providers::{
+        ai_utility::AiUtility,
+        change_request::ChangeRequestTracker,
+        coding_agent::CloudAgentService,
+        discovery::{ProviderDescriptor, ServiceDescriptor},
+        issue_query::IssueQueryService,
+        issue_tracker::IssueProvider,
+        presentation::PresentationManager,
+        terminal::TerminalPool,
+        vcs::{CheckoutManager, CloneProvisioner, Vcs},
+    },
 };
 
 /// Common accessors shared by all descriptor types.
@@ -152,6 +155,7 @@ impl<D, T: ?Sized> Default for TypedSet<D, T> {
 }
 
 pub struct ProviderRegistry {
+    pub agent_adapters: AgentAdapterRegistry,
     pub vcs: ProviderSet<dyn Vcs>,
     pub clone_provisioners: ProviderSet<dyn CloneProvisioner>,
     pub checkout_managers: ProviderSet<dyn CheckoutManager>,
@@ -168,6 +172,7 @@ pub struct ProviderRegistry {
 impl ProviderRegistry {
     pub fn new() -> Self {
         Self {
+            agent_adapters: AgentAdapterRegistry::default(),
             vcs: ProviderSet::new(),
             clone_provisioners: ProviderSet::new(),
             checkout_managers: ProviderSet::new(),

--- a/crates/flotilla-core/src/providers/replay.rs
+++ b/crates/flotilla-core/src/providers/replay.rs
@@ -492,8 +492,16 @@ impl CommandRunner for ReplayRunner {
         Ok(CommandOutput { stdout: stdout.unwrap_or_default(), stderr: stderr.unwrap_or_default(), success: exit_code == 0 })
     }
 
+    async fn run_with_input(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel, _input: &[u8]) -> Result<String, String> {
+        self.run(cmd, args, cwd, label).await
+    }
+
     async fn exists(&self, _cmd: &str, _args: &[&str]) -> bool {
         true
+    }
+
+    async fn write_file(&self, _path: &Path, _content: &str) -> Result<(), String> {
+        Ok(())
     }
 }
 
@@ -724,11 +732,37 @@ impl CommandRunner for RecordingRunner {
         result
     }
 
+    async fn run_with_input(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel, input: &[u8]) -> Result<String, String> {
+        let result = self.inner.run_with_input(cmd, args, cwd, label, input).await;
+
+        let request = ChannelRequest::Command { cmd, args };
+        let default = DefaultLabeler.label_for(&request);
+        let explicit = explicit_label(label, &default);
+        let (stdout, stderr, exit_code) = match &result {
+            Ok(out) => (Some(out.clone()), None, 0),
+            Err(err) => (None, Some(err.clone()), 1),
+        };
+        self.session.record(Interaction::Command {
+            label: explicit,
+            cmd: cmd.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            cwd: cwd.to_string_lossy().to_string(),
+            stdout,
+            stderr,
+            exit_code,
+        });
+        result
+    }
+
     /// Delegates to the real runner without recording. `ReplayRunner::exists()`
     /// always returns `true`, so the recording/replay asymmetry is intentional:
     /// `exists()` gates capability checks, not provider data.
     async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
         self.inner.exists(cmd, args).await
+    }
+
+    async fn write_file(&self, path: &Path, content: &str) -> Result<(), String> {
+        self.inner.write_file(path, content).await
     }
 }
 

--- a/crates/flotilla-core/src/providers/ssh_runner.rs
+++ b/crates/flotilla-core/src/providers/ssh_runner.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use uuid::Uuid;
 
 use crate::providers::{
-    helper_exec_script, install_managed_helper_script, ChannelLabel, CommandOutput, CommandRunner, FLOTILLA_HELPER_NAME,
-    FLOTILLA_HELPER_SCRIPT,
+    atomic_write_script, helper_exec_script, install_managed_helper_script, ChannelLabel, CommandOutput, CommandRunner,
+    FLOTILLA_HELPER_NAME, FLOTILLA_HELPER_SCRIPT,
 };
 
 /// Command runner that executes commands on a remote host over SSH.
@@ -69,6 +69,12 @@ impl CommandRunner for SshCommandRunner {
         self.runner.run_output("ssh", &ssh_args, Path::new("/"), label).await
     }
 
+    async fn run_with_input(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel, input: &[u8]) -> Result<String, String> {
+        let script = self.remote_exec_script(cmd, args, cwd);
+        let ssh_args = self.ssh_shell_args(&script);
+        self.runner.run_with_input("ssh", &ssh_args, Path::new("/"), label, input).await
+    }
+
     async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
         self.execute(cmd, args, Path::new("/"), &ChannelLabel::Noop).await.is_ok()
     }
@@ -84,6 +90,12 @@ impl CommandRunner for SshCommandRunner {
         owned_args.extend(["sh".to_string(), "-lc".to_string(), helper_script]);
         let arg_refs: Vec<&str> = owned_args.iter().map(String::as_str).collect();
         self.runner.run("ssh", &arg_refs, Path::new("/"), &ChannelLabel::Noop).await
+    }
+
+    async fn write_file(&self, path: &Path, content: &str) -> Result<(), String> {
+        let script = atomic_write_script(path, &Uuid::new_v4().to_string())?;
+        let ssh_args = self.ssh_shell_args(&script);
+        self.runner.run_with_input("ssh", &ssh_args, Path::new("/"), &ChannelLabel::Noop, content.as_bytes()).await.map(|_| ())
     }
 }
 
@@ -102,6 +114,7 @@ mod tests {
 
     struct RecordingRunner {
         calls: Mutex<Vec<(String, Vec<String>, PathBuf)>>,
+        inputs: Mutex<Vec<Vec<u8>>>,
         run_results: Mutex<VecDeque<Result<String, String>>>,
         run_output_result: Mutex<Option<Result<CommandOutput, String>>>,
     }
@@ -112,15 +125,29 @@ mod tests {
         }
 
         fn with_run_results(results: Vec<Result<String, String>>) -> Self {
-            Self { calls: Mutex::new(Vec::new()), run_results: Mutex::new(results.into()), run_output_result: Mutex::new(None) }
+            Self {
+                calls: Mutex::new(Vec::new()),
+                inputs: Mutex::new(Vec::new()),
+                run_results: Mutex::new(results.into()),
+                run_output_result: Mutex::new(None),
+            }
         }
 
         fn with_run_output_result(result: Result<CommandOutput, String>) -> Self {
-            Self { calls: Mutex::new(Vec::new()), run_results: Mutex::new(VecDeque::new()), run_output_result: Mutex::new(Some(result)) }
+            Self {
+                calls: Mutex::new(Vec::new()),
+                inputs: Mutex::new(Vec::new()),
+                run_results: Mutex::new(VecDeque::new()),
+                run_output_result: Mutex::new(Some(result)),
+            }
         }
 
         fn calls(&self) -> Vec<(String, Vec<String>, PathBuf)> {
             self.calls.lock().expect("calls mutex").clone()
+        }
+
+        fn inputs(&self) -> Vec<Vec<u8>> {
+            self.inputs.lock().expect("inputs mutex").clone()
         }
     }
 
@@ -142,6 +169,23 @@ mod tests {
                 cwd.to_path_buf(),
             ));
             self.run_output_result.lock().expect("run_output_result mutex").take().expect("run output result not configured")
+        }
+
+        async fn run_with_input(
+            &self,
+            cmd: &str,
+            args: &[&str],
+            cwd: &Path,
+            _label: &ChannelLabel,
+            input: &[u8],
+        ) -> Result<String, String> {
+            self.calls.lock().expect("calls mutex").push((
+                cmd.to_string(),
+                args.iter().map(|arg| (*arg).to_string()).collect(),
+                cwd.to_path_buf(),
+            ));
+            self.inputs.lock().expect("inputs mutex").push(input.to_vec());
+            self.run_results.lock().expect("run_results mutex").pop_front().expect("run result not configured")
         }
 
         async fn exists(&self, _cmd: &str, _args: &[&str]) -> bool {
@@ -266,5 +310,19 @@ mod tests {
         let error = runner.run("git", &["status"], Path::new("/repo"), &ChannelLabel::Noop).await;
 
         assert_eq!(error.unwrap_err(), "ssh failed");
+    }
+
+    #[tokio::test]
+    async fn write_file_transports_content_on_stdin_not_argv() {
+        let inner = std::sync::Arc::new(RecordingRunner::with_run_result(Ok(String::new())));
+        let runner = SshCommandRunner::new("alice@feta.local", false, inner.clone());
+
+        runner.write_file(Path::new("/repo/.flotilla/briefs/coder.md"), "secret assignment").await.expect("write_file");
+
+        let calls = inner.calls();
+        let args = ssh_call_args(&calls);
+        assert!(args.iter().all(|arg| !arg.contains("secret assignment")));
+        assert_eq!(inner.inputs(), vec![b"secret assignment".to_vec()]);
+        assert!(args.last().expect("remote script").contains("cat > \"$tmp\""));
     }
 }

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -48,6 +48,10 @@ impl CleatTerminalPool {
 
 #[async_trait]
 impl TerminalPool for CleatTerminalPool {
+    fn tracks_session_liveness(&self) -> bool {
+        true
+    }
+
     async fn list_sessions(&self) -> Result<Vec<TerminalSession>, String> {
         let output = run!(self.runner, &self.binary, &["list", "--json"], Path::new("/"))?;
         let sessions = Self::parse_list_output(&output)?;
@@ -126,6 +130,15 @@ impl TerminalPool for CleatTerminalPool {
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {
         run!(self.runner, &self.binary, &["kill", session_name], Path::new("/"))?;
+        Ok(())
+    }
+
+    async fn deliver(&self, session_name: &str, text: &str, submit: bool) -> Result<(), String> {
+        let mut args = vec!["send", session_name, text];
+        if submit {
+            args.push("--submit");
+        }
+        run!(self.runner, &self.binary, &args, Path::new("/"))?;
         Ok(())
     }
 }
@@ -239,6 +252,18 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].0, "cleat");
         assert_eq!(calls[0].1, vec!["kill", "my-session"]);
+    }
+
+    #[tokio::test]
+    async fn deliver_submits_text_to_the_existing_session() {
+        let runner = Arc::new(MockRunner::new(vec![Ok(String::new())]));
+        let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
+
+        pool.deliver("reviewer-session", "Please review commit abc123", true).await.expect("deliver message");
+
+        let calls = runner.calls();
+        assert_eq!(calls[0].0, "cleat");
+        assert_eq!(calls[0].1, vec!["send", "reviewer-session", "Please review commit abc123", "--submit"]);
     }
 
     // ── attach_args tests ──────────────────────────────────────────

--- a/crates/flotilla-core/src/providers/terminal/mod.rs
+++ b/crates/flotilla-core/src/providers/terminal/mod.rs
@@ -25,6 +25,10 @@ pub struct TerminalSession {
 /// No store, no identity management — the `TerminalManager` handles those concerns.
 #[async_trait]
 pub trait TerminalPool: Send + Sync {
+    fn tracks_session_liveness(&self) -> bool {
+        false
+    }
+
     async fn list_sessions(&self) -> Result<Vec<TerminalSession>, String>;
     async fn ensure_session(
         &self,
@@ -58,4 +62,10 @@ pub trait TerminalPool: Send + Sync {
     }
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String>;
+
+    /// Deliver text to a running session. This trait grows only for concrete
+    /// flotilla consumers; it is not intended to mirror a pool backend's API.
+    async fn deliver(&self, _session_name: &str, _text: &str, _submit: bool) -> Result<(), String> {
+        Err("terminal pool does not support delivery".to_string())
+    }
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -13,6 +13,7 @@ use flotilla_controllers::reconcilers::{
     TerminalRuntimeState, TerminalSessionReconciler,
 };
 use flotilla_core::{
+    agent_adapter::{AgentLaunchRequest, CapabilityTable},
     aggregator_projection::AggregatorProjectionState,
     config::ConfigStore,
     in_process::InProcessDaemon,
@@ -21,6 +22,7 @@ use flotilla_core::{
         discovery::{EnvironmentAssertion, EnvironmentBag},
         environment::{CreateOpts, EnvironmentHandle, ProvisionedMount},
         registry::ProviderRegistry,
+        terminal::TerminalPool,
         vcs::{CloneProvisioner, GitCloneProvisioner},
         ChannelLabel, CommandRunner,
     },
@@ -31,7 +33,7 @@ use flotilla_resources::{
     ConvoyReconciler, DockerCheckoutStrategy, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
     InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError,
-    ResourceObject, TaskDefinition, TaskWorkspace, WorkflowTemplate, WorkflowTemplateSpec,
+    ResourceObject, TaskDefinition, TaskWorkspace, TerminalSessionSource, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -923,13 +925,83 @@ impl TerminalRuntime for TerminalControllerRuntime {
             .or_else(|| registry.terminal_pools.preferred().cloned())
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", spec.pool, spec.env_ref))?;
 
-        pool.ensure_session(name, &spec.command, &ExecutionEnvironmentPath::new(&spec.cwd), &Vec::new()).await?;
+        let cwd = ExecutionEnvironmentPath::new(&spec.cwd);
+        let (command, env, crew, initial_message) = match &spec.source {
+            TerminalSessionSource::Tool { command } => (command.clone(), Vec::new(), None, None),
+            TerminalSessionSource::Agent { selector, brief, context, message } => {
+                let requirement = CapabilityTable::seeded().resolve(&selector.capability)?.clone();
+                let adapter = registry
+                    .agent_adapters
+                    .get(&requirement.adapter)
+                    .ok_or_else(|| format!("agent adapter {} unavailable for environment {}", requirement.adapter, spec.env_ref))?;
+                adapter.prepare(&cwd, brief).await?;
+                let plan = adapter.launch(&AgentLaunchRequest {
+                    role: spec.role.clone(),
+                    model: requirement.model.clone(),
+                    brief: brief.clone(),
+                })?;
+                let crew_id = uuid::Uuid::new_v4().to_string();
+                let crew = flotilla_resources::CrewSessionStatus::builder()
+                    .id(crew_id.clone())
+                    .adapter(requirement.adapter)
+                    .maybe_model(requirement.model)
+                    .stance(plan.stance)
+                    .build();
+                let mut env = plan.env;
+                env.extend([
+                    ("FLOTILLA_CREW_ID".to_string(), crew_id),
+                    ("FLOTILLA_CONVOY".to_string(), context.convoy.clone()),
+                    ("FLOTILLA_VESSEL".to_string(), context.vessel.clone()),
+                    ("FLOTILLA_CREW_ROLE".to_string(), spec.role.clone()),
+                    ("FLOTILLA_NAMESPACE".to_string(), context.namespace.clone()),
+                ]);
+                (plan.command, env, Some(crew), message.clone())
+            }
+        };
+
+        if matches!(spec.source, TerminalSessionSource::Agent { .. }) {
+            self.state.active_sessions.lock().await.remove(name);
+            if pool.list_sessions().await?.iter().any(|session| session.session_name == name) {
+                pool.kill_session(name).await?;
+            }
+        }
+        pool.ensure_session(name, &command, &cwd, &env).await?;
+        let delivered_message_id = initial_message.as_ref().map(|message| message.id.clone());
+        if let Some(message) = initial_message {
+            if let Err(err) = pool.deliver(name, &message.text, true).await {
+                let _ = pool.kill_session(name).await;
+                return Err(format!("deliver initial crew message: {err}"));
+            }
+        }
         self.state
             .active_sessions
             .lock()
             .await
             .insert(name.to_string(), ActiveSession { env_ref: spec.env_ref.clone(), pool: spec.pool.clone() });
-        Ok(TerminalRuntimeState { session_id: name.to_string(), pid: None, started_at: Utc::now() })
+        Ok(TerminalRuntimeState::builder()
+            .session_id(name.to_string())
+            .maybe_pid(None)
+            .started_at(Utc::now())
+            .maybe_crew(crew)
+            .launch_command(command)
+            .maybe_delivered_message_id(delivered_message_id)
+            .build())
+    }
+
+    async fn session_is_running(&self, session_id: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<bool, String> {
+        let pool = self.pool_for_spec(spec)?;
+        if !pool.tracks_session_liveness() {
+            return Ok(true);
+        }
+        let running = pool.list_sessions().await?.iter().any(|session| session.session_name == session_id);
+        if !running {
+            self.state.active_sessions.lock().await.remove(session_id);
+        }
+        Ok(running)
+    }
+
+    async fn deliver_message(&self, session_id: &str, spec: &flotilla_resources::TerminalSessionSpec, message: &str) -> Result<(), String> {
+        self.pool_for_spec(spec)?.deliver(session_id, message, true).await
     }
 
     async fn kill_session(&self, session_id: &str) -> Result<(), String> {
@@ -956,6 +1028,16 @@ impl TerminalControllerRuntime {
             .daemon
             .environment_registry_for_environment(&EnvironmentId::new(env_ref.to_string()))
             .ok_or_else(|| format!("provider registry unavailable for environment {env_ref}"))
+    }
+
+    fn pool_for_spec(&self, spec: &flotilla_resources::TerminalSessionSpec) -> Result<Arc<dyn TerminalPool>, String> {
+        let registry = self.registry_for_env(&spec.env_ref)?;
+        registry
+            .terminal_pools
+            .get(&spec.pool)
+            .map(|(_, pool)| Arc::clone(pool))
+            .or_else(|| registry.terminal_pools.preferred().cloned())
+            .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", spec.pool, spec.env_ref))
     }
 }
 
@@ -1005,12 +1087,16 @@ mod tests {
         config::ConfigStore,
         daemon::DaemonHandle,
         in_process::DEFAULT_PROVISIONING_NAMESPACE as NAMESPACE,
-        providers::discovery::{test_support::git_process_discovery, EnvironmentAssertion, EnvironmentBag},
+        providers::discovery::{
+            test_support::{fake_discovery_with_provider_set, git_process_discovery, FakeDiscoveryProviders, FakeTerminalPool},
+            EnvironmentAssertion, EnvironmentBag,
+        },
     };
-    use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent};
+    use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent};
     use flotilla_resources::{
         Checkout as ResourceCheckout, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, LifecycleAuthority, PlacementPolicy,
-        ProcessDefinition, ProcessSource, SqliteBackend, TaskDefinition, TaskPhase, TypedResolver, WorkflowTemplate, WorkflowTemplateSpec,
+        ProcessDefinition, ProcessSource, Selector, SqliteBackend, TaskDefinition, TaskPhase, TerminalSession, TerminalSessionPhase,
+        TypedResolver, WorkflowTemplate, WorkflowTemplateSpec,
     };
     use tempfile::TempDir;
 
@@ -1070,6 +1156,25 @@ mod tests {
         std::fs::create_dir_all(config.state_dir()).expect("state dir");
         let backend = ResourceBackend::Sqlite(SqliteBackend::open(config.state_dir().join("resources.sqlite")).expect("sqlite backend"));
         daemon_with_backend(tracked_repos, config, backend).await
+    }
+
+    async fn crew_daemon(config: Arc<ConfigStore>) -> (Arc<InProcessDaemon>, Arc<FakeTerminalPool>) {
+        let pool = Arc::new(FakeTerminalPool::new());
+        let discovery = fake_discovery_with_provider_set(
+            FakeDiscoveryProviders::new()
+                .with_terminal_pool(Arc::clone(&pool) as Arc<dyn flotilla_core::providers::terminal::TerminalPool>),
+        );
+        let daemon = InProcessDaemon::new(Vec::new(), config, discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        daemon
+            .replace_local_environment_bag_for_test(
+                EnvironmentBag::new()
+                    .with(EnvironmentAssertion::env_var("HOME", "/Users/tester"))
+                    .with(EnvironmentAssertion::binary("git", "/usr/bin/git"))
+                    .with(EnvironmentAssertion::binary("codex", "/tools/codex"))
+                    .with(EnvironmentAssertion::binary("claude", "/tools/claude")),
+            )
+            .expect("crew environment bag");
+        (daemon, pool)
     }
 
     async fn run_stage4a_flow_reaches_running_and_completes_convoy(
@@ -1349,6 +1454,428 @@ mod tests {
         config.save_repo(&ExecutionEnvironmentPath::new(&repo));
         let daemon = sqlite_daemon(vec![repo.clone()], Arc::clone(&config)).await;
         run_stage4a_flow_reaches_running_and_completes_convoy(daemon, config, repo_default_dir, repo).await;
+    }
+
+    #[tokio::test]
+    async fn starting_agent_replaces_a_pool_session_left_by_a_previous_daemon_runtime() {
+        let temp = TempDir::new().expect("tempdir");
+        let config_path = temp.path().join("config");
+        std::fs::create_dir_all(&config_path).expect("config dir");
+        std::fs::write(config_path.join("daemon.toml"), "machine_id = \"dinghy-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_path));
+        let (daemon, pool) = crew_daemon(Arc::clone(&config)).await;
+        let local_registry = probe_local_provider_registry(&daemon, &config).await.expect("crew provider registry");
+        let profile = build_local_profile(&daemon, &local_registry).expect("local profile");
+        let state = Arc::new(ControllerRuntimeState::new(
+            Arc::clone(&daemon),
+            config,
+            local_registry,
+            None,
+            profile.host_id.clone(),
+            None,
+            profile.host_direct_environment_name(),
+        ));
+        let session_name = "terminal-demo-implement-coder";
+        pool.add_sessions(vec![flotilla_core::providers::terminal::TerminalSession {
+            session_name: session_name.to_string(),
+            status: flotilla_protocol::TerminalStatus::Running,
+            command: Some("old codex process with stale crew identity".to_string()),
+            working_directory: Some(ExecutionEnvironmentPath::new("/repo")),
+        }])
+        .await;
+        let runtime = TerminalControllerRuntime { state };
+        let spec = flotilla_resources::TerminalSessionSpec {
+            env_ref: profile.host_direct_environment_name(),
+            role: "coder".to_string(),
+            source: TerminalSessionSource::Agent {
+                selector: Selector { capability: "coding".to_string() },
+                brief: flotilla_resources::TerminalBrief {
+                    path: ".flotilla/briefs/coder.md".to_string(),
+                    content: "Implement the issue.".to_string(),
+                },
+                context: flotilla_resources::TerminalCrewContext {
+                    namespace: NAMESPACE.to_string(),
+                    convoy: "demo".to_string(),
+                    vessel: "demo-implement".to_string(),
+                },
+                message: None,
+            },
+            cwd: "/repo".to_string(),
+            pool: "fake-terminals".to_string(),
+        };
+
+        let launched = runtime.ensure_session(session_name, &spec).await.expect("replace stale session");
+
+        assert_eq!(pool.killed.lock().await.as_slice(), &[session_name.to_string()]);
+        assert_eq!(pool.ensured.lock().await.len(), 1, "the fresh agent command must actually be launched");
+        assert!(launched.crew.is_some(), "the replacement gets a fresh crew identity");
+    }
+
+    #[tokio::test]
+    async fn crew_provisioning_runs_coder_reviewer_handoffs_and_rejects_unknown_capabilities() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = TestGitRepo::init(temp.path().join("repo"))
+            .with_initial_commit()
+            .with_origin("git@github.com:flotilla-org/flotilla.git")
+            .path()
+            .to_path_buf();
+        let config_path = temp.path().join("config");
+        std::fs::create_dir_all(&config_path).expect("config dir");
+        std::fs::write(config_path.join("daemon.toml"), "machine_id = \"dinghy-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_path));
+        let (daemon, pool) = crew_daemon(Arc::clone(&config)).await;
+        let local_registry = probe_local_provider_registry(&daemon, &config).await.expect("crew provider registry");
+        assert!(local_registry.agent_adapters.get("codex").is_some());
+        assert!(local_registry.agent_adapters.get("claude-code").is_some());
+        let profile = build_local_profile(&daemon, &local_registry).expect("local profile");
+        let backend = daemon.resource_backend();
+
+        register_startup_resources(&daemon, NAMESPACE, &profile).await.expect("startup resources");
+        apply_host_heartbeat(&daemon, NAMESPACE, &profile).await.expect("host heartbeat");
+        let state = Arc::new(ControllerRuntimeState::new(
+            Arc::clone(&daemon),
+            Arc::clone(&config),
+            local_registry,
+            None,
+            profile.host_id.clone(),
+            Some(ExecutionEnvironmentPath::new(&repo)),
+            profile.host_direct_environment_name(),
+        ));
+        let controller_handles =
+            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(20), ControllerSupervision::default());
+
+        backend
+            .clone()
+            .using::<WorkflowTemplate>(NAMESPACE)
+            .create(
+                &empty_meta("crew-workflow"),
+                &WorkflowTemplateSpec::builder()
+                    .inputs(Vec::new())
+                    .tasks(vec![TaskDefinition::builder()
+                        .name("implement".to_string())
+                        .processes(vec![
+                            ProcessDefinition::builder()
+                                .role("coder".to_string())
+                                .source(ProcessSource::Agent {
+                                    selector: Selector { capability: "coding".to_string() },
+                                    prompt: Some(
+                                        "Implement issue 668 without leaking this full brief into the launch command.".to_string(),
+                                    ),
+                                })
+                                .build(),
+                            ProcessDefinition::builder()
+                                .role("reviewer".to_string())
+                                .source(ProcessSource::Agent {
+                                    selector: Selector { capability: "review".to_string() },
+                                    prompt: Some("Review the coder's work.".to_string()),
+                                })
+                                .build(),
+                            ProcessDefinition::builder()
+                                .role("watcher".to_string())
+                                .source(ProcessSource::Tool { command: "cargo test --watch".to_string() })
+                                .build(),
+                        ])
+                        .build()])
+                    .build(),
+            )
+            .await
+            .expect("crew workflow");
+
+        let mut rx = daemon.subscribe();
+        let create_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "crew-convoy".to_string(),
+                    workflow_ref: "crew-workflow".to_string(),
+                    inputs: Vec::new(),
+                    repository_url: Some("https://github.com/flotilla-org/flotilla.git".to_string()),
+                    r#ref: Some("main".to_string()),
+                    project_ref: None,
+                    placement_policy: Some(profile.host_direct_policy_name()),
+                    adopted_checkout: Some(Box::new(repo.clone())),
+                },
+            })
+            .await
+            .expect("create crew convoy");
+        assert_eq!(wait_for_command_result(&mut rx, create_id).await, CommandValue::ConvoyCreated { name: "crew-convoy".to_string() });
+
+        let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+        wait_until(|| {
+            let convoys = convoys.clone();
+            async move {
+                matches!(
+                    convoys.get("crew-convoy").await.ok().and_then(|convoy| convoy.status).as_ref(),
+                    Some(status)
+                        if status.phase == ConvoyPhase::Active
+                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Running)
+                )
+            }
+        })
+        .await;
+
+        let terminals = backend.clone().using::<TerminalSession>(NAMESPACE);
+        let coder = terminals
+            .list()
+            .await
+            .expect("terminal list")
+            .items
+            .into_iter()
+            .find(|session| session.spec.role == "coder")
+            .expect("coder session");
+        let coder_id = coder.status.as_ref().and_then(|status| status.crew.as_ref()).expect("coder identity").id.clone();
+        assert_eq!(coder.status.as_ref().and_then(|status| status.crew.as_ref()).map(|crew| crew.adapter.as_str()), Some("codex"));
+        assert!(terminals.list().await.expect("terminal list").items.iter().any(|session| session.spec.role == "watcher"));
+        assert!(terminals.list().await.expect("terminal list").items.iter().all(|session| session.spec.role != "reviewer"));
+        let ensured = pool.ensured.lock().await;
+        let coder_launch = ensured.iter().find(|launch| launch.session_name.ends_with("-coder")).expect("coder launch");
+        assert!(coder_launch.command.contains("--dangerously-bypass-approvals-and-sandbox"));
+        assert!(!coder_launch.command.contains("without leaking this full brief"));
+        assert!(coder_launch.env_vars.iter().any(|(key, value)| key == "FLOTILLA_CREW_ID" && value == &coder_id));
+        drop(ensured);
+
+        let crew_context = CrewCommandContext { crew_id: Some(coder_id.clone()), ..Default::default() };
+        let crew_list = daemon
+            .execute_query(
+                Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::QueryCrewList { context: crew_context.clone() },
+                },
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .expect("crew list");
+        let CommandValue::CrewList(crew_list) = crew_list else { panic!("expected crew list") };
+        assert_eq!(crew_list.members.iter().map(|member| (member.role.as_str(), member.state.as_str())).collect::<Vec<_>>(), vec![
+            ("coder", "active"),
+            ("reviewer", "latent"),
+            ("watcher", "active")
+        ]);
+
+        let mut rx = daemon.subscribe();
+        let handoff_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::CrewHandoff {
+                    context: crew_context,
+                    target: "reviewer".to_string(),
+                    message: "Review commit abc123".to_string(),
+                },
+            })
+            .await
+            .expect("handoff reviewer");
+        assert_eq!(wait_for_command_result(&mut rx, handoff_id).await, CommandValue::Ok);
+        wait_until(|| {
+            let terminals = terminals.clone();
+            async move {
+                terminals
+                    .list()
+                    .await
+                    .ok()
+                    .and_then(|list| list.items.into_iter().find(|session| session.spec.role == "reviewer"))
+                    .and_then(|session| session.status)
+                    .is_some_and(|status| status.phase == TerminalSessionPhase::Running)
+            }
+        })
+        .await;
+        let reviewer = terminals
+            .list()
+            .await
+            .expect("terminal list")
+            .items
+            .into_iter()
+            .find(|session| session.spec.role == "reviewer")
+            .expect("reviewer session");
+        let reviewer_id = reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).expect("reviewer identity").id.clone();
+        assert_eq!(reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).map(|crew| crew.adapter.as_str()), Some("claude-code"));
+        assert!(pool
+            .delivered
+            .lock()
+            .await
+            .iter()
+            .any(|(session, text, submit)| session.ends_with("-reviewer") && text == "Review commit abc123" && *submit));
+
+        let mut rx = daemon.subscribe();
+        let hand_back_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::CrewHandoff {
+                    context: CrewCommandContext { crew_id: Some(reviewer_id.clone()), ..Default::default() },
+                    target: "coder".to_string(),
+                    message: "Address the review findings".to_string(),
+                },
+            })
+            .await
+            .expect("hand back to coder");
+        assert_eq!(wait_for_command_result(&mut rx, hand_back_id).await, CommandValue::Ok);
+        assert!(pool
+            .delivered
+            .lock()
+            .await
+            .iter()
+            .any(|(session, text, submit)| session.ends_with("-coder") && text == "Address the review findings" && *submit));
+
+        pool.remove_session(&coder.metadata.name).await;
+        wait_until(|| {
+            let terminals = terminals.clone();
+            let name = coder.metadata.name.clone();
+            async move {
+                terminals
+                    .get(&name)
+                    .await
+                    .ok()
+                    .and_then(|session| session.status)
+                    .is_some_and(|status| status.phase == TerminalSessionPhase::Stopped)
+            }
+        })
+        .await;
+        assert!(matches!(
+            convoys.get("crew-convoy").await.expect("crew convoy").status.and_then(|status| status.tasks.get("implement").cloned()),
+            Some(task) if task.phase == TaskPhase::Running
+        ));
+        let stopped_list = daemon
+            .execute_query(
+                Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::QueryCrewList {
+                        context: CrewCommandContext { crew_id: Some(reviewer_id.clone()), ..Default::default() },
+                    },
+                },
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .expect("stopped crew list");
+        let CommandValue::CrewList(stopped_list) = stopped_list else { panic!("expected stopped crew list") };
+        assert_eq!(stopped_list.members.iter().find(|member| member.role == "coder").map(|member| member.state.as_str()), Some("stopped"));
+        let mut rx = daemon.subscribe();
+        let revive_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::CrewHandoff {
+                    context: CrewCommandContext { crew_id: Some(reviewer_id), ..Default::default() },
+                    target: "coder".to_string(),
+                    message: "Resume after review".to_string(),
+                },
+            })
+            .await
+            .expect("revive coder");
+        assert_eq!(wait_for_command_result(&mut rx, revive_id).await, CommandValue::Ok);
+        wait_until(|| {
+            let terminals = terminals.clone();
+            let name = coder.metadata.name.clone();
+            let old_id = coder_id.clone();
+            async move {
+                terminals
+                    .get(&name)
+                    .await
+                    .ok()
+                    .and_then(|session| session.status)
+                    .and_then(|status| status.crew)
+                    .is_some_and(|crew| crew.id != old_id)
+            }
+        })
+        .await;
+
+        let attach = daemon.resolve_attach_command_internal("crew-convoy/implement/coder").await.expect("attach coder");
+        assert!(attach.contains("attach terminal-crew-convoy-implement-coder"));
+
+        let mut rx = daemon.subscribe();
+        let complete_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyLegComplete {
+                    convoy: "crew-convoy".to_string(),
+                    leg: "implement".to_string(),
+                    message: Some("human accepted the crew's work".to_string()),
+                },
+            })
+            .await
+            .expect("complete crew leg");
+        assert_eq!(wait_for_command_result(&mut rx, complete_id).await, CommandValue::Ok);
+        wait_until(|| {
+            let convoys = convoys.clone();
+            async move {
+                convoys
+                    .get("crew-convoy")
+                    .await
+                    .ok()
+                    .and_then(|convoy| convoy.status)
+                    .is_some_and(|status| status.phase == ConvoyPhase::Completed)
+            }
+        })
+        .await;
+
+        backend
+            .clone()
+            .using::<WorkflowTemplate>(NAMESPACE)
+            .create(
+                &empty_meta("unknown-capability"),
+                &WorkflowTemplateSpec::builder()
+                    .inputs(Vec::new())
+                    .tasks(vec![TaskDefinition::builder()
+                        .name("implement".to_string())
+                        .processes(vec![ProcessDefinition::builder()
+                            .role("architect".to_string())
+                            .source(ProcessSource::Agent { selector: Selector { capability: "architect".to_string() }, prompt: None })
+                            .build()])
+                        .build()])
+                    .build(),
+            )
+            .await
+            .expect("unknown capability workflow");
+        let mut rx = daemon.subscribe();
+        let create_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "unknown-convoy".to_string(),
+                    workflow_ref: "unknown-capability".to_string(),
+                    inputs: Vec::new(),
+                    repository_url: Some("https://github.com/flotilla-org/flotilla.git".to_string()),
+                    r#ref: Some("main".to_string()),
+                    project_ref: None,
+                    placement_policy: Some(profile.host_direct_policy_name()),
+                    adopted_checkout: Some(Box::new(repo)),
+                },
+            })
+            .await
+            .expect("create unknown convoy");
+        assert_eq!(wait_for_command_result(&mut rx, create_id).await, CommandValue::ConvoyCreated { name: "unknown-convoy".to_string() });
+        wait_until(|| {
+            let convoys = convoys.clone();
+            async move {
+                convoys
+                    .get("unknown-convoy")
+                    .await
+                    .ok()
+                    .and_then(|convoy| convoy.status)
+                    .is_some_and(|status| status.phase == ConvoyPhase::Failed)
+            }
+        })
+        .await;
+        let failed = convoys.get("unknown-convoy").await.expect("unknown convoy").status.expect("unknown status");
+        assert_eq!(failed.tasks.get("implement").and_then(|task| task.message.as_deref()), Some("unknown agent capability `architect`"));
+
+        for handle in controller_handles {
+            handle.abort();
+            let _ = handle.await;
+        }
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime/test_git_repo.rs
+++ b/crates/flotilla-daemon/src/runtime/test_git_repo.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -7,8 +7,8 @@ use crate::{
     issue_query::{IssueQuery, IssueResultPage},
     qualified_path::QualifiedPath,
     query::{
-        FleetListResponse, FleetReplicaSnapshot, HostListResponse, HostProvidersResponse, HostStatusResponse, RepoDetailResponse,
-        RepoProvidersResponse, RepoWorkResponse,
+        CrewCommandContext, CrewListResponse, FleetListResponse, FleetReplicaSnapshot, HostListResponse, HostProvidersResponse,
+        HostStatusResponse, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse,
     },
     AttachableSetId, RepoIdentity,
 };
@@ -155,6 +155,11 @@ pub enum CommandAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
     },
+    CrewHandoff {
+        context: CrewCommandContext,
+        target: String,
+        message: String,
+    },
     ConvoyCreate {
         name: String,
         workflow_ref: String,
@@ -236,6 +241,9 @@ pub enum CommandAction {
         target_environment_id: crate::EnvironmentId,
     },
     QueryFleetList {},
+    QueryCrewList {
+        context: CrewCommandContext,
+    },
     QueryFleetReplicaSnapshot {},
 }
 
@@ -251,6 +259,7 @@ impl CommandAction {
                 | CommandAction::QueryHostStatus { .. }
                 | CommandAction::QueryHostProviders { .. }
                 | CommandAction::QueryFleetList {}
+                | CommandAction::QueryCrewList { .. }
                 | CommandAction::QueryFleetReplicaSnapshot {}
                 | CommandAction::Attach { .. }
                 | CommandAction::QueryIssues { .. }
@@ -281,6 +290,7 @@ impl Command {
             CommandAction::ArchiveSession { .. } => "Archiving session...",
             CommandAction::GenerateBranchName { .. } => "Generating branch name...",
             CommandAction::ConvoyLegComplete { .. } => "Completing convoy leg...",
+            CommandAction::CrewHandoff { .. } => "Handing off to crew member...",
             CommandAction::ConvoyCreate { .. } => "Creating convoy...",
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
             CommandAction::ProjectCreate { .. } => "Creating project...",
@@ -299,6 +309,7 @@ impl Command {
             CommandAction::QueryHostStatus { .. } => "query host status",
             CommandAction::QueryHostProviders { .. } => "query host providers",
             CommandAction::QueryFleetList {} => "query fleet list",
+            CommandAction::QueryCrewList { .. } => "query crew list",
             CommandAction::QueryFleetReplicaSnapshot {} => "query fleet replica snapshot",
         }
     }
@@ -359,6 +370,7 @@ pub enum CommandValue {
     HostStatus(Box<HostStatusResponse>),
     HostProviders(Box<HostProvidersResponse>),
     FleetList(Box<FleetListResponse>),
+    CrewList(Box<CrewListResponse>),
     FleetReplicaSnapshot(Box<FleetReplicaSnapshot>),
     ImageEnsured {
         image: crate::ImageId,
@@ -415,8 +427,9 @@ mod tests {
     use crate::{
         arg::Arg,
         query::{
-            FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse,
-            HostProvidersResponse, HostStatusResponse, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse,
+            CrewListMember, CrewListResponse, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness,
+            HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse, RepoDetailResponse, RepoProvidersResponse,
+            RepoWorkResponse,
         },
         test_helpers::assert_json_roundtrip,
         AttachableSetId, HostEnvironment, HostProviderStatus, HostSummary, NodeId, NodeInfo, PeerConnectionState, RepoIdentity, SystemInfo,
@@ -563,6 +576,16 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
+                action: CommandAction::CrewHandoff {
+                    context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
+                    target: "reviewer".into(),
+                    message: "review this".into(),
+                },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
                 action: CommandAction::ConvoyCreate {
                     name: "my-convoy".into(),
                     workflow_ref: "scratch".into(),
@@ -628,6 +651,14 @@ mod tests {
             },
             Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryHostList {} },
             Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryFleetList {} },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryCrewList {
+                    context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
+                },
+            },
             Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryFleetReplicaSnapshot {} },
             Command {
                 node_id: None,
@@ -828,6 +859,19 @@ mod tests {
                     last_sync: None,
                     generation: None,
                     message: Some("not synced".into()),
+                }],
+            })),
+            CommandValue::CrewList(Box::new(CrewListResponse {
+                convoy: "convoy-a".into(),
+                vessel: "convoy-a-implement".into(),
+                leg: "implement".into(),
+                members: vec![CrewListMember {
+                    role: "coder".into(),
+                    kind: "agent".into(),
+                    state: "active".into(),
+                    adapter: Some("codex".into()),
+                    model: None,
+                    stance: Some("trusted-implicit".into()),
                 }],
             })),
             CommandValue::FleetReplicaSnapshot(Box::new(FleetReplicaSnapshot {

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -89,9 +89,10 @@ pub use provider_data::{
     WorkingTreeStatus, Workspace,
 };
 pub use query::{
-    DiscoveryEntry, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry,
-    HostListResponse, HostProvidersResponse, HostStatusResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse,
-    RepoProvidersResponse, RepoSummary, RepoWorkResponse, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
+    CrewCommandContext, CrewListMember, CrewListResponse, DiscoveryEntry, FleetListResponse, FleetListRow, FleetReplicaSnapshot,
+    FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse, ProviderHealthMap,
+    ProviderInfo, RepoDetailResponse, RepoProvidersResponse, RepoSummary, RepoWorkResponse, StatusResponse, TopologyResponse,
+    TopologyRoute, UnmetRequirementInfo,
 };
 use serde::{Deserialize, Serialize};
 
@@ -107,7 +108,7 @@ pub use snapshot::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -12,6 +12,41 @@ use crate::{
 /// "change_request"). Inner key: provider name. Value: healthy.
 pub type ProviderHealthMap = HashMap<String, HashMap<String, bool>>;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct CrewCommandContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crew_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub convoy: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vessel: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct CrewListResponse {
+    pub convoy: String,
+    pub vessel: String,
+    pub leg: String,
+    pub members: Vec<CrewListMember>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct CrewListMember {
+    pub role: String,
+    pub kind: String,
+    pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adapter: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stance: Option<String>,
+}
+
 // --- status ---
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -22,7 +22,6 @@ use crate::{
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
-const STAGE_4A_AGENT_MESSAGE: &str = "Stage 4a supports tool processes only; agent processes require selector resolution (Stage 4b).";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReconcileOutcome {
@@ -252,20 +251,6 @@ fn bootstrap_outcome(
             )),
             actuations: Vec::new(),
             events: vec![ConvoyEvent::TemplateInvalid { name: template.metadata.name.clone(), errors }],
-        };
-    }
-
-    if template
-        .spec
-        .tasks
-        .iter()
-        .flat_map(|task| task.processes.iter())
-        .any(|process| matches!(process.source, ProcessSource::Agent { .. }))
-    {
-        return InternalReconcileOutcome {
-            patch: Some(controller_patches::fail_init(ConvoyPhase::Failed, STAGE_4A_AGENT_MESSAGE.to_string(), now)),
-            actuations: Vec::new(),
-            events: Vec::new(),
         };
     }
 

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -59,7 +59,9 @@ pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};
 pub use task_workspace::{TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TaskWorkspaceStatusPatch};
 pub use terminal_session::{
-    InnerCommandStatus, TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
+    terminal_session_attach_target, CrewSessionStatus, InnerCommandStatus, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    TerminalSession, TerminalSessionAttachTarget, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource,
+    TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
 };
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
 pub use workflow_template::{

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -1,17 +1,119 @@
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch};
+use crate::{
+    resource::define_resource, status_patch::StatusPatch, InputMeta, OwnerReference, Resource, ResourceObject, Selector, TaskWorkspace,
+    CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+};
 
 define_resource!(TerminalSession, "terminalsessions", TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch);
+
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
+pub struct TerminalSessionIdentity {
+    pub vessel: String,
+    pub convoy: String,
+    pub leg: String,
+    pub role: String,
+    pub task_index: usize,
+    pub process_index: usize,
+    #[builder(default)]
+    pub labels: BTreeMap<String, String>,
+}
+
+impl TerminalSessionIdentity {
+    pub fn name(&self) -> String {
+        format!("terminal-{}-{}", self.vessel, self.role)
+    }
+
+    pub fn input_meta(&self) -> InputMeta {
+        let mut labels = self.labels.clone();
+        labels.extend([
+            (CONVOY_LABEL.to_string(), self.convoy.clone()),
+            (TASK_LABEL.to_string(), self.leg.clone()),
+            (TASK_WORKSPACE_LABEL.to_string(), self.vessel.clone()),
+            (ROLE_LABEL.to_string(), self.role.clone()),
+            (TASK_ORDINAL_LABEL.to_string(), format!("{:03}", self.task_index)),
+            (PROCESS_ORDINAL_LABEL.to_string(), format!("{:03}", self.process_index)),
+        ]);
+        InputMeta::builder()
+            .name(self.name())
+            .labels(labels)
+            .owner_references(vec![OwnerReference {
+                api_version: format!("{}/{}", TaskWorkspace::API_PATHS.group, TaskWorkspace::API_PATHS.version),
+                kind: TaskWorkspace::API_PATHS.kind.to_string(),
+                name: self.vessel.clone(),
+                controller: true,
+            }])
+            .build()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalSessionAttachTarget<'a> {
+    pub session_id: &'a str,
+    pub launch_command: &'a str,
+}
+
+pub fn terminal_session_attach_target(session: &ResourceObject<TerminalSession>) -> Result<TerminalSessionAttachTarget<'_>, String> {
+    let status = session
+        .status
+        .as_ref()
+        .filter(|status| status.phase == TerminalSessionPhase::Running)
+        .ok_or_else(|| format!("terminal session {} is not running and cannot be attached", session.metadata.name))?;
+    let session_id =
+        status.session_id.as_deref().ok_or_else(|| format!("running terminal session {} has no session id", session.metadata.name))?;
+    let launch_command = status.launch_command.as_deref().or(match &session.spec.source {
+        TerminalSessionSource::Tool { command } => Some(command.as_str()),
+        TerminalSessionSource::Agent { .. } => None,
+    });
+    let launch_command =
+        launch_command.ok_or_else(|| format!("agent terminal session {} has no recorded launch command", session.metadata.name))?;
+    Ok(TerminalSessionAttachTarget { session_id, launch_command })
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TerminalSessionSpec {
     pub env_ref: String,
     pub role: String,
-    pub command: String,
+    pub source: TerminalSessionSource,
     pub cwd: String,
     pub pool: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TerminalSessionSource {
+    Tool {
+        command: String,
+    },
+    Agent {
+        selector: Selector,
+        brief: TerminalBrief,
+        context: TerminalCrewContext,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        message: Option<TerminalCrewMessage>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalBrief {
+    pub path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalCrewContext {
+    pub namespace: String,
+    pub convoy: String,
+    pub vessel: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalCrewMessage {
+    pub id: String,
+    pub text: String,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,6 +122,7 @@ pub enum TerminalSessionPhase {
     Starting,
     Running,
     Stopped,
+    Failed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -45,14 +148,36 @@ pub struct TerminalSessionStatus {
     pub inner_exit_code: Option<i32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crew: Option<CrewSessionStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launch_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivered_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct CrewSessionStatus {
+    pub id: String,
+    pub adapter: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub stance: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TerminalSessionStatusPatch {
+    MarkStarting,
     MarkRunning {
         session_id: String,
         pid: Option<i64>,
         started_at: DateTime<Utc>,
+        crew: Option<CrewSessionStatus>,
+        launch_command: String,
+        delivered_message_id: Option<String>,
+    },
+    MarkMessageDelivered {
+        message_id: String,
     },
     MarkStopped {
         stopped_at: DateTime<Utc>,
@@ -69,14 +194,21 @@ pub enum TerminalSessionStatusPatch {
 impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
     fn apply(&self, status: &mut TerminalSessionStatus) {
         match self {
-            Self::MarkRunning { session_id, pid, started_at } => {
+            Self::MarkStarting => {
+                *status = TerminalSessionStatus::default();
+            }
+            Self::MarkRunning { session_id, pid, started_at, crew, launch_command, delivered_message_id } => {
                 status.phase = TerminalSessionPhase::Running;
                 status.session_id = Some(session_id.clone());
                 status.pid = *pid;
                 status.started_at = Some(*started_at);
                 status.inner_command_status = Some(InnerCommandStatus::Running);
                 status.message = None;
+                status.crew = crew.clone();
+                status.launch_command = Some(launch_command.clone());
+                status.delivered_message_id = delivered_message_id.clone();
             }
+            Self::MarkMessageDelivered { message_id } => status.delivered_message_id = Some(message_id.clone()),
             Self::MarkStopped { stopped_at, inner_command_status, inner_exit_code, message } => {
                 status.phase = TerminalSessionPhase::Stopped;
                 status.stopped_at = Some(*stopped_at);
@@ -85,7 +217,7 @@ impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
                 status.message = message.clone();
             }
             Self::MarkFailed { message, stopped_at } => {
-                status.phase = TerminalSessionPhase::Stopped;
+                status.phase = TerminalSessionPhase::Failed;
                 status.stopped_at = *stopped_at;
                 status.message = Some(message.clone());
             }

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -513,17 +513,20 @@ fn snapshot_state_allows_advancement_without_template() {
 }
 
 #[test]
-fn bootstrap_rejects_agent_processes_in_stage_4a() {
+fn bootstrap_preserves_agent_processes_for_runtime_resolution() {
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), None);
     let template = valid_workflow_template_object("review-and-fix");
 
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
-    assert!(matches!(
-        outcome.patch,
-        Some(ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, ref message, .. })
-            if message == "Stage 4a supports tool processes only; agent processes require selector resolution (Stage 4b)."
-    ));
+    let Some(ConvoyStatusPatch::Bootstrap { workflow_snapshot, .. }) = outcome.patch else {
+        panic!("agent workflow should bootstrap");
+    };
+    let ProcessSource::Agent { selector, prompt } = &workflow_snapshot.tasks[0].processes[0].source else {
+        panic!("agent source should survive in the workflow snapshot");
+    };
+    assert_eq!(selector.capability, "code");
+    assert_eq!(prompt.as_deref(), Some("Convoy convoy-a - implement Retry logic on branch fix-retry-logic."));
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -5,8 +5,9 @@ use common::{owner_reference, resource_meta};
 use flotilla_resources::{
     Checkout, CheckoutSpec, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentMount,
     EnvironmentMountMode, EnvironmentSpec, FreshCloneCheckoutSpec, Host, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, InMemoryBackend, PlacementPolicy, PlacementPolicySpec, ResourceBackend, TaskWorkspace,
-    TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus,
+    HostDirectPlacementPolicySpec, InMemoryBackend, PlacementPolicy, PlacementPolicySpec, ResourceBackend, Selector, TaskWorkspace,
+    TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TerminalBrief, TerminalCrewContext, TerminalSession, TerminalSessionSource,
+    TerminalSessionSpec,
 };
 
 fn placement_meta(name: &str) -> flotilla_resources::InputMeta {
@@ -127,6 +128,29 @@ async fn environment_and_checkout_specs_serialize_through_in_memory_backend() {
 fn host_direct_environment_spec_is_constructible() {
     let _ = Host;
     let _ = HostDirectEnvironmentSpec { host_ref: "01HXYZ".to_string(), repo_default_dir: "/Users/alice/dev/flotilla-repos".to_string() };
+}
+
+#[tokio::test]
+async fn agent_terminal_session_preserves_structured_launch_and_canonical_brief() {
+    let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<TerminalSession>("flotilla");
+    let spec = TerminalSessionSpec {
+        env_ref: "host-direct-dinghy".into(),
+        role: "coder".into(),
+        source: TerminalSessionSource::Agent {
+            selector: Selector { capability: "coding".into() },
+            brief: TerminalBrief {
+                path: ".flotilla/briefs/coder.md".into(),
+                content: "You are coder in convoy demo.\n\nImplement the change.".into(),
+            },
+            context: TerminalCrewContext { namespace: "flotilla".into(), convoy: "demo".into(), vessel: "demo-implement".into() },
+            message: None,
+        },
+        cwd: "/workspace".into(),
+        pool: "cleat".into(),
+    };
+
+    let created = resolver.create(&resource_meta().name("demo-implement-coder").call(), &spec).await.expect("create session");
+    assert_eq!(created.spec.source, spec.source);
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -66,7 +66,15 @@ fn terminal_session_status_patch_marks_running_and_stopped() {
     let started_at = Utc::now();
     let stopped_at = Utc::now();
 
-    TerminalSessionStatusPatch::MarkRunning { session_id: "abc123".to_string(), pid: Some(12345), started_at }.apply(&mut status);
+    TerminalSessionStatusPatch::MarkRunning {
+        session_id: "abc123".to_string(),
+        pid: Some(12345),
+        started_at,
+        crew: None,
+        launch_command: "bash".to_string(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
     assert_eq!(status.phase, TerminalSessionPhase::Running);
     assert_eq!(status.session_id.as_deref(), Some("abc123"));
     assert_eq!(status.pid, Some(12345));
@@ -81,6 +89,23 @@ fn terminal_session_status_patch_marks_running_and_stopped() {
     assert_eq!(status.phase, TerminalSessionPhase::Stopped);
     assert_eq!(status.inner_command_status, Some(InnerCommandStatus::Exited));
     assert_eq!(status.inner_exit_code, Some(1));
+}
+
+#[test]
+fn terminal_session_failure_is_distinct_from_a_stopped_crew_member_and_can_restart() {
+    let mut status = TerminalSessionStatus::default();
+
+    TerminalSessionStatusPatch::MarkFailed { message: "unknown agent capability `architect`".to_string(), stopped_at: Some(Utc::now()) }
+        .apply(&mut status);
+    assert_eq!(status.phase, TerminalSessionPhase::Failed);
+    assert_eq!(status.message.as_deref(), Some("unknown agent capability `architect`"));
+
+    TerminalSessionStatusPatch::MarkStarting.apply(&mut status);
+    assert_eq!(status.phase, TerminalSessionPhase::Starting);
+    assert_eq!(status.session_id, None);
+    assert_eq!(status.started_at, None);
+    assert_eq!(status.stopped_at, None);
+    assert_eq!(status.message, None);
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -135,6 +135,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         | CommandValue::HostStatus(_)
         | CommandValue::HostProviders(_)
         | CommandValue::FleetList(_)
+        | CommandValue::CrewList(_)
         | CommandValue::FleetReplicaSnapshot(_) => {
             tracing::warn!("query result reached TUI handler — should be handled by CLI");
         }

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, path::Path};
 use comfy_table::{presets::UTF8_FULL_CONDENSED, Cell, Table};
 use flotilla_core::daemon::DaemonHandle;
 use flotilla_protocol::{
-    output::OutputFormat, Command, CommandValue, DaemonEvent, EnvironmentInfo, EnvironmentStatus, FleetListResponse, FleetStaleness,
-    HostProvidersResponse, HostStatusResponse, NodeInfo, PeerConnectionState, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse,
-    StatusResponse, StreamKey, TopologyResponse,
+    output::OutputFormat, Command, CommandValue, CrewListResponse, DaemonEvent, EnvironmentInfo, EnvironmentStatus, FleetListResponse,
+    FleetStaleness, HostProvidersResponse, HostStatusResponse, NodeInfo, PeerConnectionState, RepoDetailResponse, RepoProvidersResponse,
+    RepoWorkResponse, StatusResponse, StreamKey, TopologyResponse,
 };
 
 use crate::socket::SocketDaemon;
@@ -303,6 +303,23 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
     out
 }
 
+fn format_crew_list_human(response: &CrewListResponse) -> String {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL_CONDENSED);
+    table.set_header(vec!["Role", "Kind", "State", "Adapter", "Model", "Stance"]);
+    for member in &response.members {
+        table.add_row(vec![
+            Cell::new(&member.role),
+            Cell::new(&member.kind),
+            Cell::new(&member.state),
+            Cell::new(member.adapter.as_deref().unwrap_or("-")),
+            Cell::new(member.model.as_deref().unwrap_or("-")),
+            Cell::new(member.stance.as_deref().unwrap_or("-")),
+        ]);
+    }
+    format!("Convoy: {}  Vessel: {}  Leg: {}\n{}\n", response.convoy, response.vessel, response.leg, table)
+}
+
 /// Extract a short display name from a repo path (last path component).
 /// Falls back to the full path display for root or non-UTF-8 paths,
 /// matching `flotilla_core::model::repo_name`.
@@ -360,6 +377,7 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::HostStatus(status) => format_host_status_human(status),
         CommandValue::HostProviders(providers) => format_host_providers_human(providers),
         CommandValue::FleetList(fleet) => format_fleet_list_human(fleet),
+        CommandValue::CrewList(crew) => format_crew_list_human(crew),
         CommandValue::FleetReplicaSnapshot(_) => "fleet replica snapshot".to_string(),
         CommandValue::ImageEnsured { image } => format!("image ensured: {image}"),
         CommandValue::EnvironmentCreated { env_id } => format!("environment created: {env_id}"),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -373,7 +373,8 @@ mod command_result_human {
 
     use flotilla_protocol::{
         commands::{CheckoutStatus, CommandValue},
-        FleetListResponse, FleetListRow, FleetReplicaStatus, FleetStaleness, HostName, NodeId, PreparedWorkspace,
+        CrewListMember, CrewListResponse, FleetListResponse, FleetListRow, FleetReplicaStatus, FleetStaleness, HostName, NodeId,
+        PreparedWorkspace,
     };
 
     use crate::cli::format_command_result;
@@ -544,6 +545,42 @@ mod command_result_human {
         assert!(!output.contains("No crew sessions found."));
         assert!(output.contains("convoy-failed"));
         assert!(output.contains("failed: missing input 'topic'"));
+    }
+
+    #[test]
+    fn crew_list_shows_defined_and_runtime_state() {
+        let result = CommandValue::CrewList(Box::new(CrewListResponse {
+            convoy: "convoy-a".into(),
+            vessel: "convoy-a-implement".into(),
+            leg: "implement".into(),
+            members: vec![
+                CrewListMember {
+                    role: "coder".into(),
+                    kind: "agent".into(),
+                    state: "active".into(),
+                    adapter: Some("codex".into()),
+                    model: None,
+                    stance: Some("trusted-implicit".into()),
+                },
+                CrewListMember {
+                    role: "reviewer".into(),
+                    kind: "agent".into(),
+                    state: "latent".into(),
+                    adapter: None,
+                    model: None,
+                    stance: None,
+                },
+            ],
+        }));
+
+        let output = format_command_result(&result);
+
+        assert!(output.contains("Convoy: convoy-a"));
+        assert!(output.contains("coder"));
+        assert!(output.contains("active"));
+        assert!(output.contains("reviewer"));
+        assert!(output.contains("latent"));
+        assert!(output.contains("trusted-implicit"));
     }
 
     #[test]

--- a/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_open.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_open.snap
@@ -29,6 +29,6 @@ expression: output
   env                Manage environments
   checkout           Manage checkouts
   convoy             Manage convoys
+  crew               Communicate with crew members
   cr                 Code review
   pr                 Code review
-  issue              Issues

--- a/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_selection.snap
+++ b/crates/flotilla-tui/tests/snapshots/snapshots__command_palette_selection.snap
@@ -29,6 +29,6 @@ expression: output
   env                Manage environments
   checkout           Manage checkouts
   convoy             Manage convoys
+  crew               Communicate with crew members
   cr                 Code review
   pr                 Code review
-  issue              Issues

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,8 @@ enum SubCommand {
     Checkout(flotilla_commands::commands::checkout::CheckoutNoun),
     /// Manage convoys
     Convoy(flotilla_commands::commands::convoy::ConvoyNoun),
+    /// Communicate with crew members
+    Crew(flotilla_commands::commands::crew::CrewNoun),
     /// Code review (alias on CrNoun itself, not duplicated here)
     Cr(flotilla_commands::commands::cr::CrNoun),
     /// Issues
@@ -194,6 +196,10 @@ async fn main() -> Result<()> {
         Some(SubCommand::Environment(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
         Some(SubCommand::Checkout(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
         Some(SubCommand::Convoy(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
+        Some(SubCommand::Crew(noun)) => {
+            let crew_id = std::env::var("FLOTILLA_CREW_ID").ok();
+            dispatch(noun.resolve_with_crew_id(crew_id).map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await
+        }
         Some(SubCommand::Cr(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
         Some(SubCommand::Issue(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
         Some(SubCommand::Agent(noun)) => dispatch(noun.resolve().map_err(|e| color_eyre::eyre::eyre!(e))?, &cli, format).await,
@@ -1001,6 +1007,16 @@ mod tests {
     fn cli_parses_convoy_noun() {
         let cli = Cli::try_parse_from(["flotilla", "convoy", "convoy-a", "leg", "implement", "complete"]).expect("convoy cli should parse");
         assert!(matches!(cli.command, Some(SubCommand::Convoy(_))));
+    }
+
+    #[test]
+    fn cli_parses_crew_list_and_handoff_grammar() {
+        let list = Cli::try_parse_from(["flotilla", "crew", "list"]).expect("crew list should parse");
+        assert!(matches!(list.command, Some(SubCommand::Crew(_))));
+
+        let handoff = Cli::try_parse_from(["flotilla", "crew", "reviewer", "handoff", "--message", "Review commit abc123"])
+            .expect("crew handoff should parse");
+        assert!(matches!(handoff.command, Some(SubCommand::Crew(_))));
     }
 
     #[test]

--- a/tests/flotillad_binary.rs
+++ b/tests/flotillad_binary.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 #[test]
 fn installed_package_exposes_flotillad_binary() {
-    let flotillad = std::env::var("CARGO_BIN_EXE_flotillad").expect("root package should build a flotillad binary target");
+    let flotillad = env!("CARGO_BIN_EXE_flotillad");
     let status = Command::new(flotillad).arg("--help").status().expect("flotillad help should run");
 
     assert!(status.success(), "flotillad --help should succeed");


### PR DESCRIPTION
Closes #668.

## What changed

- add Claude Code and Codex agent adapters with capability-based harness/model resolution
- provision agent processes as crew `TerminalSession` resources alongside tool processes
- deliver durable crew briefs through stdin-backed scripts without exposing brief contents in argv or recordings
- add `flotilla crew list` and `flotilla crew handoff`, including latent crew activation, stopped-session revival, and idempotent message acknowledgement
- distinguish failed provisioning from intentionally stopped crew members
- support attaching to running agent sessions while rejecting incomplete launch state
- replace stale pool sessions after daemon restarts and centralize terminal identity/ordinal metadata construction
- bump the protocol version and add end-to-end coverage for coder → reviewer → coder handoffs, revival, and unknown capabilities

## Why

Workflow templates could already describe `ProcessSource::Agent`, but the task-workspace reconciler rejected those processes. This completes the runtime half of ADR 0010 so workflows can provision coding and review agents as durable, addressable crew members.

## Impact

Agent and tool processes can now coexist in a leg. Agent briefs stay out of command-line arguments, crew handoffs survive reconciliation, stopped members can be revived without marking the leg failed, and attach resolves to the actual running agent command.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo dylint --all -- --all-targets` (existing advisory path-length warnings only)

Final standards and specification reviews found no material gaps or hard documented-standard violations.
