### PR TITLE
Bound resource store and daemon log growth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,7 @@ dependencies = [
  "flotilla-transport",
  "futures",
  "indexmap",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,15 +728,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,7 +1313,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "visibility",
@@ -1411,7 +1401,6 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
  "tui-input",
  "tui-tree-widget",
@@ -4151,14 +4140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
- "time-macros",
 ]
 
 [[package]]
@@ -4166,16 +4153,6 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
 
 [[package]]
 name = "tinystr"
@@ -4378,18 +4355,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -203,11 +203,20 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
         .await;
 
     let workspace = workspaces.get("workspace-a").await.expect("workspace get should succeed");
+    let ready_resource_version = workspace.metadata.resource_version.clone();
     let status = workspace.status.expect("workspace status should be present");
     assert_eq!(status.phase, TaskWorkspacePhase::Ready);
     assert_eq!(status.environment_ref.as_deref(), Some("host-direct-01HXYZ"));
     assert_eq!(status.checkout_ref.as_deref(), Some("checkout-workspace-a"));
     assert_eq!(status.terminal_session_refs, vec!["terminal-workspace-a-coder".to_string()]);
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let steady = workspaces.get("workspace-a").await.expect("ready workspace should remain readable");
+    assert_eq!(
+        steady.metadata.resource_version, ready_resource_version,
+        "steady-state reconciliation must not create new resource versions"
+    );
+    assert_eq!(steady.status.expect("steady workspace status").ready_at, status.ready_at);
 
     harness.shutdown().await;
 }
@@ -725,6 +734,7 @@ async fn create_ready_host(backend: &ResourceBackend, name: &str) {
             capabilities: Default::default(),
             heartbeat_at: Some(Utc::now()),
             ready: true,
+            resource_store: None,
         })
         .await
         .expect("host status update should succeed");

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod host_identity;
 pub(crate) mod host_registry;
 pub mod host_summary;
 pub mod in_process;
+pub mod log_file;
 pub mod merge;
 pub mod model;
 pub mod path_context;

--- a/crates/flotilla-core/src/log_file.rs
+++ b/crates/flotilla-core/src/log_file.rs
@@ -1,0 +1,140 @@
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+pub const DEFAULT_MAX_LOG_BYTES: u64 = 10 * 1024 * 1024;
+pub const DEFAULT_MAX_LOG_ARCHIVES: usize = 4;
+
+pub type LockedSizeRotatingFile = Mutex<SizeRotatingFile>;
+
+pub fn bounded_log_writer(directory: &Path, file_name: &str) -> io::Result<LockedSizeRotatingFile> {
+    SizeRotatingFile::open(directory, file_name, DEFAULT_MAX_LOG_BYTES, DEFAULT_MAX_LOG_ARCHIVES).map(Mutex::new)
+}
+
+#[derive(Debug)]
+pub struct SizeRotatingFile {
+    path: PathBuf,
+    max_bytes: u64,
+    max_archives: usize,
+    file: Option<File>,
+    current_bytes: u64,
+}
+
+impl SizeRotatingFile {
+    pub fn open(directory: &Path, file_name: &str, max_bytes: u64, max_archives: usize) -> io::Result<Self> {
+        if max_bytes == 0 {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "rotating log max_bytes must be greater than zero"));
+        }
+        fs::create_dir_all(directory)?;
+        let path = directory.join(file_name);
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let current_bytes = file.metadata()?.len();
+        Ok(Self { path, max_bytes, max_archives, file: Some(file), current_bytes })
+    }
+
+    fn archive_path(&self, index: usize) -> PathBuf {
+        let mut archived_name = self.path.as_os_str().to_os_string();
+        archived_name.push(format!(".{index}"));
+        PathBuf::from(archived_name)
+    }
+
+    fn rotate_if_needed(&mut self, incoming_bytes: usize) -> io::Result<()> {
+        if self.current_bytes == 0 || self.current_bytes.saturating_add(incoming_bytes as u64) <= self.max_bytes {
+            return Ok(());
+        }
+        self.rotate()
+    }
+
+    fn rotate(&mut self) -> io::Result<()> {
+        if let Some(mut file) = self.file.take() {
+            file.flush()?;
+        }
+
+        if self.max_archives == 0 {
+            match fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err),
+            }
+        } else {
+            let oldest = self.archive_path(self.max_archives);
+            match fs::remove_file(oldest) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err),
+            }
+            for index in (1..self.max_archives).rev() {
+                let from = self.archive_path(index);
+                if from.exists() {
+                    fs::rename(from, self.archive_path(index + 1))?;
+                }
+            }
+            if self.path.exists() {
+                fs::rename(&self.path, self.archive_path(1))?;
+            }
+        }
+
+        self.file = Some(OpenOptions::new().create(true).write(true).truncate(true).open(&self.path)?);
+        self.current_bytes = 0;
+        Ok(())
+    }
+}
+
+impl Write for SizeRotatingFile {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        self.rotate_if_needed(buffer.len())?;
+        let remaining = self.max_bytes.saturating_sub(self.current_bytes) as usize;
+        let written = self.file.as_mut().expect("rotating log file should always be open").write(&buffer[..buffer.len().min(remaining)])?;
+        self.current_bytes = self.current_bytes.saturating_add(written as u64);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file.as_mut().expect("rotating log file should always be open").flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, io::Write};
+
+    use tempfile::tempdir;
+
+    use super::SizeRotatingFile;
+
+    #[test]
+    fn rotates_by_size_and_removes_archives_beyond_limit() {
+        let dir = tempdir().expect("tempdir");
+        let mut writer = SizeRotatingFile::open(dir.path(), "daemon.log", 8, 2).expect("open rotating log");
+
+        writer.write_all(b"123456").expect("first write");
+        writer.write_all(b"abcdef").expect("second write rotates");
+        writer.write_all(b"ghijkl").expect("third write rotates");
+        writer.write_all(b"mnopqr").expect("fourth write rotates and evicts oldest archive");
+        writer.flush().expect("flush");
+
+        assert_eq!(fs::read(dir.path().join("daemon.log")).expect("current log"), b"mnopqr");
+        assert_eq!(fs::read(dir.path().join("daemon.log.1")).expect("newest archive"), b"ghijkl");
+        assert_eq!(fs::read(dir.path().join("daemon.log.2")).expect("oldest retained archive"), b"abcdef");
+        assert!(!dir.path().join("daemon.log.3").exists());
+    }
+
+    #[test]
+    fn splits_a_single_oversized_write_without_exceeding_file_limit() {
+        let dir = tempdir().expect("tempdir");
+        let mut writer = SizeRotatingFile::open(dir.path(), "daemon.log", 4, 2).expect("open rotating log");
+
+        writer.write_all(b"abcdefghij").expect("oversized write");
+        writer.flush().expect("flush");
+
+        assert_eq!(fs::read(dir.path().join("daemon.log")).expect("current log"), b"ij");
+        assert_eq!(fs::read(dir.path().join("daemon.log.1")).expect("newest archive"), b"efgh");
+        assert_eq!(fs::read(dir.path().join("daemon.log.2")).expect("oldest archive"), b"abcd");
+    }
+}

--- a/crates/flotilla-core/src/log_file.rs
+++ b/crates/flotilla-core/src/log_file.rs
@@ -31,7 +31,11 @@ impl SizeRotatingFile {
         fs::create_dir_all(directory)?;
         let path = directory.join(file_name);
         let file = OpenOptions::new().create(true).append(true).open(&path)?;
-        let current_bytes = file.metadata()?.len();
+        let mut current_bytes = file.metadata()?.len();
+        if current_bytes > max_bytes {
+            file.set_len(0)?;
+            current_bytes = 0;
+        }
         Ok(Self { path, max_bytes, max_archives, file: Some(file), current_bytes })
     }
 
@@ -49,10 +53,30 @@ impl SizeRotatingFile {
     }
 
     fn rotate(&mut self) -> io::Result<()> {
-        if let Some(mut file) = self.file.take() {
-            file.flush()?;
+        let fallback =
+            self.file.as_ref().ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "rotating log file is unavailable"))?.try_clone()?;
+        self.file.as_mut().ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "rotating log file is unavailable"))?.flush()?;
+        drop(self.file.take());
+
+        if let Err(err) = self.rotate_files() {
+            self.restore_fallback(fallback);
+            return Err(err);
         }
 
+        match OpenOptions::new().create(true).write(true).truncate(true).open(&self.path) {
+            Ok(file) => {
+                self.file = Some(file);
+                self.current_bytes = 0;
+                Ok(())
+            }
+            Err(err) => {
+                self.restore_fallback(fallback);
+                Err(err)
+            }
+        }
+    }
+
+    fn rotate_files(&self) -> io::Result<()> {
         if self.max_archives == 0 {
             match fs::remove_file(&self.path) {
                 Ok(()) => {}
@@ -76,10 +100,12 @@ impl SizeRotatingFile {
                 fs::rename(&self.path, self.archive_path(1))?;
             }
         }
-
-        self.file = Some(OpenOptions::new().create(true).write(true).truncate(true).open(&self.path)?);
-        self.current_bytes = 0;
         Ok(())
+    }
+
+    fn restore_fallback(&mut self, fallback: File) {
+        self.current_bytes = fallback.metadata().map_or(0, |metadata| metadata.len());
+        self.file = Some(fallback);
     }
 }
 
@@ -90,13 +116,17 @@ impl Write for SizeRotatingFile {
         }
         self.rotate_if_needed(buffer.len())?;
         let remaining = self.max_bytes.saturating_sub(self.current_bytes) as usize;
-        let written = self.file.as_mut().expect("rotating log file should always be open").write(&buffer[..buffer.len().min(remaining)])?;
+        let written = self
+            .file
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "rotating log file is unavailable"))?
+            .write(&buffer[..buffer.len().min(remaining)])?;
         self.current_bytes = self.current_bytes.saturating_add(written as u64);
         Ok(written)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.file.as_mut().expect("rotating log file should always be open").flush()
+        self.file.as_mut().ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "rotating log file is unavailable"))?.flush()
     }
 }
 
@@ -136,5 +166,30 @@ mod tests {
         assert_eq!(fs::read(dir.path().join("daemon.log")).expect("current log"), b"ij");
         assert_eq!(fs::read(dir.path().join("daemon.log.1")).expect("newest archive"), b"efgh");
         assert_eq!(fs::read(dir.path().join("daemon.log.2")).expect("oldest archive"), b"abcd");
+    }
+
+    #[test]
+    fn rotation_error_keeps_current_file_usable() {
+        let dir = tempdir().expect("tempdir");
+        let mut writer = SizeRotatingFile::open(dir.path(), "daemon.log", 4, 1).expect("open rotating log");
+        writer.write_all(b"abcd").expect("fill current log");
+        fs::create_dir(dir.path().join("daemon.log.1")).expect("block archive path with directory");
+
+        writer.write_all(b"e").expect_err("rotation should report blocked archive path");
+        writer.flush().expect("failed rotation must restore the current file handle");
+
+        fs::remove_dir(dir.path().join("daemon.log.1")).expect("remove archive obstruction");
+        writer.write_all(b"f").expect("writer should recover after obstruction is removed");
+    }
+
+    #[test]
+    fn opening_an_oversized_existing_log_restores_the_size_bound() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("daemon.log");
+        fs::write(&path, b"abcdefghij").expect("seed oversized log");
+
+        let _writer = SizeRotatingFile::open(dir.path(), "daemon.log", 4, 1).expect("open rotating log");
+
+        assert!(fs::metadata(path).expect("current log metadata").len() <= 4);
     }
 }

--- a/crates/flotilla-daemon/Cargo.toml
+++ b/crates/flotilla-daemon/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-tracing-appender = "0.2.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 futures = "0.3"

--- a/crates/flotilla-daemon/Cargo.toml
+++ b/crates/flotilla-daemon/Cargo.toml
@@ -31,6 +31,7 @@ visibility = "0.1.1"
 
 [dev-dependencies]
 indexmap = { workspace = true }
+rusqlite = { version = "0.32", features = ["bundled"] }
 tempfile = "3"
 flotilla-core = { path = "../flotilla-core", features = ["test-support"] }
 flotilla-daemon = { path = ".", features = ["test-support"] }

--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -1,6 +1,8 @@
 use std::{path::Path, sync::Arc, time::Duration};
 
-use flotilla_core::{config::ConfigStore, path_context::DaemonHostPath, providers::discovery::DiscoveryRuntime};
+use flotilla_core::{
+    config::ConfigStore, log_file::bounded_log_writer, path_context::DaemonHostPath, providers::discovery::DiscoveryRuntime,
+};
 use tracing::info;
 
 use crate::{runtime::DaemonRuntime, server::DaemonServer};
@@ -15,7 +17,7 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
         |f, d| f.add_directive(d.parse().expect("valid directive")),
     );
     let _ = std::fs::create_dir_all(state_dir);
-    let file_appender = tracing_appender::rolling::never(state_dir, "daemon.log");
+    let file_appender = bounded_log_writer(state_dir, "daemon.log").map_err(|err| format!("open bounded daemon log: {err}"))?;
     tracing_subscriber::fmt().with_writer(file_appender).with_ansi(false).with_env_filter(filter).try_init().ok();
 
     let timeout = if timeout_secs == 0 { Duration::from_secs(u64::MAX) } else { Duration::from_secs(timeout_secs) };

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -489,10 +489,22 @@ fn spawn_replica_refresh_task(daemon: Arc<InProcessDaemon>, interval: Duration) 
 
 async fn apply_host_heartbeat(daemon: &Arc<InProcessDaemon>, namespace: &str, profile: &LocalProvisioningProfile) -> Result<(), String> {
     ensure_host_exists(&daemon.resource_backend(), namespace, &profile.host_id).await?;
-    let hosts = daemon.resource_backend().using::<Host>(namespace);
+    let backend = daemon.resource_backend();
+    let hosts = backend.using::<Host>(namespace);
     let host = hosts.get(&profile.host_id).await.map_err(|err| err.to_string())?;
     let summary = daemon.local_host_summary().await;
-    let status = HostStatus { capabilities: host_capabilities(&summary, profile), heartbeat_at: Some(Utc::now()), ready: true };
+    let resource_store = backend.diagnostics().await.map_err(|err| err.to_string())?;
+    if let Some(diagnostics) = resource_store.filter(|diagnostics| !diagnostics.event_log_within_retention()) {
+        warn!(
+            event_count = diagnostics.event_count,
+            object_count = diagnostics.object_count,
+            store_count = diagnostics.store_count,
+            max_retained_events = diagnostics.max_retained_events,
+            "resource event log exceeds retention bound",
+        );
+    }
+    let status =
+        HostStatus { capabilities: host_capabilities(&summary, profile), heartbeat_at: Some(Utc::now()), ready: true, resource_store };
     hosts.update_status(&profile.host_id, &host.metadata.resource_version, &status).await.map(|_| ()).map_err(|err| err.to_string())
 }
 
@@ -1244,6 +1256,10 @@ mod tests {
         assert!(status.ready, "heartbeat should mark host ready");
         assert_eq!(status.capabilities.get("docker"), Some(&json!(false)));
         assert_eq!(status.capabilities.get("terminal_pools"), Some(&json!(["passthrough"])));
+        assert!(
+            status.resource_store.expect("heartbeat should publish resource store diagnostics").event_log_within_retention(),
+            "heartbeat should report a bounded resource event log"
+        );
 
         heartbeat.abort();
         let _ = heartbeat.await;

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -494,13 +494,14 @@ async fn apply_host_heartbeat(daemon: &Arc<InProcessDaemon>, namespace: &str, pr
     let host = hosts.get(&profile.host_id).await.map_err(|err| err.to_string())?;
     let summary = daemon.local_host_summary().await;
     let resource_store = backend.diagnostics().await.map_err(|err| err.to_string())?;
-    if let Some(diagnostics) = resource_store.filter(|diagnostics| !diagnostics.event_log_within_retention()) {
+    if let Some(diagnostics) = resource_store.as_ref().filter(|diagnostics| !diagnostics.warnings.is_empty()) {
         warn!(
             event_count = diagnostics.event_count,
             object_count = diagnostics.object_count,
-            store_count = diagnostics.store_count,
+            resource_stream_count = diagnostics.resource_stream_count,
             max_retained_events = diagnostics.max_retained_events,
-            "resource event log exceeds retention bound",
+            warnings = ?diagnostics.warnings,
+            "resource event log tripwire triggered",
         );
     }
     let status =
@@ -1166,6 +1167,25 @@ mod tests {
         let host = backend.clone().using::<Host>(NAMESPACE).get(&host_id).await.expect("host should exist after startup");
         assert!(host.status.is_some(), "startup heartbeat should publish host status");
 
+        let workspaces = backend.clone().using::<TaskWorkspace>(NAMESPACE);
+        let sqlite_path = config.state_dir().as_path().join("resources.sqlite");
+        let idle_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut previous_idle_sample = None;
+        loop {
+            let workspace = workspaces.get("convoy-a-implement").await.expect("steady workspace should remain");
+            let sample = (
+                workspace.metadata.resource_version,
+                workspace.status.expect("steady workspace status").ready_at,
+                sqlite_path.exists().then(|| sqlite_max_event_rowid(&sqlite_path)),
+            );
+            if previous_idle_sample.as_ref() == Some(&sample) {
+                break;
+            }
+            assert!(tokio::time::Instant::now() < idle_deadline, "resource store did not reach an idle fixed point");
+            previous_idle_sample = Some(sample);
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
         daemon
             .execute(Command {
                 node_id: None,
@@ -1209,6 +1229,13 @@ mod tests {
             assert!(tokio::time::Instant::now() < deadline, "timed out waiting for host status");
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
+    }
+
+    fn sqlite_max_event_rowid(path: &Path) -> u64 {
+        let connection = rusqlite::Connection::open(path).expect("open SQLite store for idle inspection");
+        connection
+            .query_row("SELECT COALESCE(MAX(rowid), 0) FROM resource_events", [], |row| row.get(0))
+            .expect("read maximum resource event rowid")
     }
 
     async fn wait_until<F, Fut>(mut condition: F)

--- a/crates/flotilla-daemon/src/runtime/test_git_repo.rs
+++ b/crates/flotilla-daemon/src/runtime/test_git_repo.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -5,6 +5,7 @@ use crate::{
     http::HttpBackend,
     in_memory::InMemoryBackend,
     resource::{InputMeta, Resource, ResourceObject},
+    retention::ResourceStoreDiagnostics,
     sqlite::SqliteBackend,
     watch::{ResourceList, WatchStart, WatchStream},
 };
@@ -29,6 +30,14 @@ pub enum ResourceBackend {
 impl ResourceBackend {
     pub fn using<T: Resource>(&self, namespace: &str) -> TypedResolver<T> {
         TypedResolver { backend: self.clone(), namespace: namespace.to_string(), _marker: PhantomData }
+    }
+
+    pub async fn diagnostics(&self) -> Result<Option<ResourceStoreDiagnostics>, ResourceError> {
+        match self {
+            Self::InMemory(backend) => backend.diagnostics().await.map(Some),
+            Self::Http(_) => Ok(None),
+            Self::Sqlite(backend) => backend.diagnostics().await.map(Some),
+        }
     }
 }
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -178,45 +178,47 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                 status.observed_workflows = Some(observed_workflows.clone());
                 status.tasks = tasks.clone();
                 status.phase = *phase;
-                status.started_at = *started_at;
+                if let Some(started_at) = started_at {
+                    status.started_at.get_or_insert(*started_at);
+                }
             }
             Self::FailInit { phase, message, finished_at } => {
                 status.phase = *phase;
                 status.message = Some(message.clone());
-                status.finished_at = Some(*finished_at);
+                status.finished_at.get_or_insert(*finished_at);
             }
             Self::AdvanceTasksToReady { ready } => {
                 for (task, ready_at) in ready {
                     if let Some(state) = status.tasks.get_mut(task) {
                         state.phase = TaskPhase::Ready;
-                        state.ready_at = Some(*ready_at);
+                        state.ready_at.get_or_insert(*ready_at);
                     }
                 }
             }
             Self::FailConvoy { cancelled_tasks, finished_at, message } => {
                 status.phase = ConvoyPhase::Failed;
-                status.finished_at = Some(*finished_at);
+                status.finished_at.get_or_insert(*finished_at);
                 status.message = message.clone();
                 for (task, cancelled_at) in cancelled_tasks {
                     if let Some(state) = status.tasks.get_mut(task) {
                         state.phase = TaskPhase::Cancelled;
-                        state.finished_at = Some(*cancelled_at);
+                        state.finished_at.get_or_insert(*cancelled_at);
                     }
                 }
             }
             Self::RollUpPhase { phase, started_at, finished_at } => {
                 status.phase = *phase;
                 if let Some(started_at) = started_at {
-                    status.started_at = Some(*started_at);
+                    status.started_at.get_or_insert(*started_at);
                 }
                 if let Some(finished_at) = finished_at {
-                    status.finished_at = Some(*finished_at);
+                    status.finished_at.get_or_insert(*finished_at);
                 }
             }
             Self::TaskLaunching { task, started_at, placement } => {
                 if let Some(state) = status.tasks.get_mut(task) {
                     state.phase = TaskPhase::Launching;
-                    state.started_at = Some(*started_at);
+                    state.started_at.get_or_insert(*started_at);
                     state.placement = Some(placement.clone());
                 }
             }
@@ -228,21 +230,21 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
             Self::MarkTaskCompleted { task, finished_at, message } => {
                 if let Some(state) = status.tasks.get_mut(task) {
                     state.phase = TaskPhase::Completed;
-                    state.finished_at = Some(*finished_at);
+                    state.finished_at.get_or_insert(*finished_at);
                     state.message = message.clone();
                 }
             }
             Self::MarkTaskFailed { task, finished_at, message } => {
                 if let Some(state) = status.tasks.get_mut(task) {
                     state.phase = TaskPhase::Failed;
-                    state.finished_at = Some(*finished_at);
+                    state.finished_at.get_or_insert(*finished_at);
                     state.message = Some(message.clone());
                 }
             }
             Self::MarkTaskCancelled { task, finished_at } => {
                 if let Some(state) = status.tasks.get_mut(task) {
                     state.phase = TaskPhase::Cancelled;
-                    state.finished_at = Some(*finished_at);
+                    state.finished_at.get_or_insert(*finished_at);
                 }
             }
         }

--- a/crates/flotilla-resources/src/error.rs
+++ b/crates/flotilla-resources/src/error.rs
@@ -5,6 +5,7 @@ pub enum ResourceError {
     NotFound { name: String },
     Conflict { name: String, message: String },
     Invalid { message: String },
+    WatchExpired { requested_version: String, compacted_through: String },
     Unauthorized { message: String },
     Other { message: String },
 }
@@ -41,6 +42,9 @@ impl fmt::Display for ResourceError {
             Self::NotFound { name } => write!(f, "resource not found: {name}"),
             Self::Conflict { name, message } => write!(f, "resource conflict for {name}: {message}"),
             Self::Invalid { message } => write!(f, "invalid resource: {message}"),
+            Self::WatchExpired { requested_version, compacted_through } => {
+                write!(f, "watch resourceVersion {requested_version} expired; events through {compacted_through} were compacted")
+            }
             Self::Unauthorized { message } => write!(f, "unauthorized: {message}"),
             Self::Other { message } => f.write_str(message),
         }

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch};
+use crate::{resource::define_resource, retention::ResourceStoreDiagnostics, status_patch::StatusPatch};
 
 define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch);
 
@@ -18,6 +18,8 @@ pub struct HostStatus {
     pub heartbeat_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub ready: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_store: Option<ResourceStoreDiagnostics>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -10,7 +10,7 @@ define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch);
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostSpec {}
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct HostStatus {
     #[serde(default)]
     pub capabilities: BTreeMap<String, serde_json::Value>,

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -11,6 +11,7 @@ use tokio::sync::{mpsc, Mutex};
 use crate::{
     error::ResourceError,
     resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
+    retention::{EventRetention, ResourceStoreDiagnostics},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
 };
 
@@ -20,6 +21,7 @@ type StoreKey = (String, String, String, String);
 pub struct InMemoryBackend {
     stores: Arc<Mutex<HashMap<StoreKey, ResourceStore>>>,
     generation: Option<String>,
+    event_retention: EventRetention,
 }
 
 #[derive(Debug)]
@@ -27,8 +29,8 @@ struct ResourceStore {
     objects: HashMap<String, Value>,
     next_version: u64,
     watchers: Vec<mpsc::UnboundedSender<StoredEvent>>,
-    // TODO: compact the event log if this backend starts serving long-lived scenarios.
     event_log: Vec<StoredEvent>,
+    compacted_through: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -56,7 +58,14 @@ impl ResourceStore {
         version
     }
 
-    fn push_event(&mut self, event: StoredEvent) {
+    fn push_event(&mut self, event: StoredEvent, retention: EventRetention) {
+        let excess = self.event_log.len().saturating_add(1).saturating_sub(retention.max_events_per_store());
+        if excess > 0 {
+            if let Some(last_removed) = self.event_log.get(excess - 1) {
+                self.compacted_through = last_removed.version;
+            }
+            self.event_log.drain(..excess);
+        }
         self.event_log.push(event.clone());
         self.watchers.retain(|watcher| watcher.send(event.clone()).is_ok());
     }
@@ -64,13 +73,28 @@ impl ResourceStore {
 
 impl Default for ResourceStore {
     fn default() -> Self {
-        Self { objects: HashMap::new(), next_version: 1, watchers: Vec::new(), event_log: Vec::new() }
+        Self { objects: HashMap::new(), next_version: 1, watchers: Vec::new(), event_log: Vec::new(), compacted_through: 0 }
     }
 }
 
 impl InMemoryBackend {
     pub fn observed() -> Self {
-        Self { stores: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()) }
+        Self { stores: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()), event_retention: EventRetention::default() }
+    }
+
+    pub fn with_event_retention(event_retention: EventRetention) -> Self {
+        Self { stores: Arc::default(), generation: None, event_retention }
+    }
+
+    pub fn observed_with_event_retention(event_retention: EventRetention) -> Self {
+        Self { stores: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()), event_retention }
+    }
+
+    pub(crate) async fn diagnostics(&self) -> Result<ResourceStoreDiagnostics, ResourceError> {
+        let stores = self.stores.lock().await;
+        let object_count = stores.values().map(|store| store.objects.len() as u64).sum();
+        let event_count = stores.values().map(|store| store.event_log.len() as u64).sum();
+        Ok(ResourceStoreDiagnostics::new(object_count, event_count, stores.len() as u64, self.event_retention))
     }
 
     fn store_key<T: Resource>(namespace: &str) -> StoreKey {
@@ -199,7 +223,7 @@ impl InMemoryBackend {
 
             let encoded = Self::encode_object(&object)?;
             store.objects.insert(meta.name.clone(), encoded.clone());
-            store.push_event(StoredEvent { version, kind: StoredEventKind::Added, object: encoded });
+            store.push_event(StoredEvent { version, kind: StoredEventKind::Added, object: encoded }, self.event_retention);
             Ok(object)
         })
         .await
@@ -218,6 +242,9 @@ impl InMemoryBackend {
             if object.metadata.resource_version != resource_version {
                 return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
             }
+            if object.matches_update(meta, spec)? {
+                return Ok(object);
+            }
 
             let version = store.allocate_version();
             object.metadata.resource_version = version.to_string();
@@ -231,10 +258,10 @@ impl InMemoryBackend {
             let encoded = Self::encode_object(&object)?;
             if object.metadata.deletion_timestamp.is_some() && object.metadata.finalizers.is_empty() {
                 store.objects.remove(&meta.name);
-                store.push_event(StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded });
+                store.push_event(StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded }, self.event_retention);
             } else {
                 store.objects.insert(meta.name.clone(), encoded.clone());
-                store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded });
+                store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded }, self.event_retention);
             }
             Ok(object)
         })
@@ -254,6 +281,9 @@ impl InMemoryBackend {
             if object.metadata.resource_version != resource_version {
                 return Err(ResourceError::conflict(name, "stale resourceVersion"));
             }
+            if object.matches_status(status)? {
+                return Ok(object);
+            }
 
             let version = store.allocate_version();
             object.metadata.resource_version = version.to_string();
@@ -261,7 +291,7 @@ impl InMemoryBackend {
 
             let encoded = Self::encode_object(&object)?;
             store.objects.insert(name.to_string(), encoded.clone());
-            store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded });
+            store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded }, self.event_retention);
             Ok(object)
         })
         .await
@@ -277,13 +307,13 @@ impl InMemoryBackend {
                 object.metadata.deletion_timestamp = Some(Utc::now());
                 let encoded = Self::encode_object(&object)?;
                 store.objects.insert(name.to_string(), encoded.clone());
-                store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded });
+                store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded }, self.event_retention);
                 return Ok(());
             }
 
             let encoded = Self::encode_object(&object)?;
             store.objects.remove(name);
-            store.push_event(StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded });
+            store.push_event(StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded }, self.event_retention);
             Ok(())
         })
         .await
@@ -322,6 +352,12 @@ impl InMemoryBackend {
                     )
                 }
             };
+            if replay_from.is_some_and(|version| version < store.compacted_through) {
+                return Err(ResourceError::WatchExpired {
+                    requested_version: replay_from.expect("checked replay version").to_string(),
+                    compacted_through: store.compacted_through.to_string(),
+                });
+            }
             let replay = match replay_from {
                 Some(version) => store.event_log.iter().filter(|event| event.version > version).cloned().collect(),
                 None => Vec::new(),

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -59,7 +59,7 @@ impl ResourceStore {
     }
 
     fn push_event(&mut self, event: StoredEvent, retention: EventRetention) {
-        let excess = self.event_log.len().saturating_add(1).saturating_sub(retention.max_events_per_store());
+        let excess = self.event_log.len().saturating_add(1).saturating_sub(retention.max_events_per_resource_stream());
         if excess > 0 {
             if let Some(last_removed) = self.event_log.get(excess - 1) {
                 self.compacted_through = last_removed.version;
@@ -94,7 +94,8 @@ impl InMemoryBackend {
         let stores = self.stores.lock().await;
         let object_count = stores.values().map(|store| store.objects.len() as u64).sum();
         let event_count = stores.values().map(|store| store.event_log.len() as u64).sum();
-        Ok(ResourceStoreDiagnostics::new(object_count, event_count, stores.len() as u64, self.event_retention))
+        let resource_stream_count = stores.values().filter(|store| store.current_version() > 0).count() as u64;
+        Ok(ResourceStoreDiagnostics::new(object_count, event_count, resource_stream_count, self.event_retention))
     }
 
     fn store_key<T: Resource>(namespace: &str) -> StoreKey {

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -56,7 +56,7 @@ pub use resource::{
     api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,
     OwnerReference, Resource, ResourceObject,
 };
-pub use retention::{EventRetention, ResourceStoreDiagnostics};
+pub use retention::{EventRetention, ResourceStoreDiagnostics, ResourceStoreWarning};
 pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};
 pub use task_workspace::{TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TaskWorkspaceStatusPatch};

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -14,6 +14,7 @@ mod presentation;
 mod project;
 mod provisioning_identity;
 mod resource;
+mod retention;
 mod sqlite;
 mod status_patch;
 mod task_workspace;
@@ -55,6 +56,7 @@ pub use resource::{
     api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,
     OwnerReference, Resource, ResourceObject,
 };
+pub use retention::{EventRetention, ResourceStoreDiagnostics};
 pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};
 pub use task_workspace::{TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TaskWorkspaceStatusPatch};

--- a/crates/flotilla-resources/src/presentation.rs
+++ b/crates/flotilla-resources/src/presentation.rs
@@ -51,11 +51,16 @@ impl StatusPatch<PresentationStatus> for PresentationStatusPatch {
     fn apply(&self, status: &mut PresentationStatus) {
         match self {
             Self::MarkActive { presentation_manager, workspace_ref, spec_hash, ready_at } => {
+                let was_active = status.phase == PresentationPhase::Active;
                 status.phase = PresentationPhase::Active;
                 status.observed_presentation_manager = Some(presentation_manager.clone());
                 status.observed_workspace_ref = Some(workspace_ref.clone());
                 status.observed_spec_hash = Some(spec_hash.clone());
-                status.ready_at = Some(*ready_at);
+                if !was_active {
+                    status.ready_at = Some(*ready_at);
+                } else {
+                    status.ready_at.get_or_insert(*ready_at);
+                }
                 status.message = None;
             }
             Self::MarkTornDown { message } => {

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -139,6 +139,27 @@ pub struct ResourceObject<T: Resource> {
 }
 
 impl<T: Resource> ResourceObject<T> {
+    pub(crate) fn matches_update(&self, meta: &InputMeta, spec: &T::Spec) -> Result<bool, ResourceError> {
+        let current_spec =
+            serde_json::to_value(&self.spec).map_err(|err| ResourceError::decode(format!("serialize current spec: {err}")))?;
+        let requested_spec = serde_json::to_value(spec).map_err(|err| ResourceError::decode(format!("serialize requested spec: {err}")))?;
+        Ok(self.metadata.name == meta.name
+            && self.metadata.labels == meta.labels
+            && self.metadata.annotations == meta.annotations
+            && self.metadata.owner_references == meta.owner_references
+            && self.metadata.finalizers == meta.finalizers
+            && self.metadata.deletion_timestamp == meta.deletion_timestamp
+            && current_spec == requested_spec)
+    }
+
+    pub(crate) fn matches_status(&self, status: &T::Status) -> Result<bool, ResourceError> {
+        let Some(current_status) = &self.status else { return Ok(false) };
+        let current =
+            serde_json::to_value(current_status).map_err(|err| ResourceError::decode(format!("serialize current status: {err}")))?;
+        let requested = serde_json::to_value(status).map_err(|err| ResourceError::decode(format!("serialize requested status: {err}")))?;
+        Ok(current == requested)
+    }
+
     pub fn to_k8s_object(&self) -> K8sResourceObject<T> {
         K8sResourceObject {
             api_version: api_version(T::API_PATHS),

--- a/crates/flotilla-resources/src/retention.rs
+++ b/crates/flotilla-resources/src/retention.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ResourceError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventRetention {
+    max_events_per_store: usize,
+}
+
+impl EventRetention {
+    pub const DEFAULT_MAX_EVENTS_PER_STORE: usize = 1_024;
+
+    pub fn new(max_events_per_store: usize) -> Result<Self, ResourceError> {
+        if max_events_per_store == 0 {
+            return Err(ResourceError::invalid("event retention must keep at least one event per store"));
+        }
+        Ok(Self { max_events_per_store })
+    }
+
+    pub(crate) fn max_events_per_store(self) -> usize {
+        self.max_events_per_store
+    }
+}
+
+impl Default for EventRetention {
+    fn default() -> Self {
+        Self { max_events_per_store: Self::DEFAULT_MAX_EVENTS_PER_STORE }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceStoreDiagnostics {
+    pub object_count: u64,
+    pub event_count: u64,
+    pub store_count: u64,
+    pub max_retained_events: u64,
+}
+
+impl ResourceStoreDiagnostics {
+    pub(crate) fn new(object_count: u64, event_count: u64, store_count: u64, retention: EventRetention) -> Self {
+        Self {
+            object_count,
+            event_count,
+            store_count,
+            max_retained_events: store_count.saturating_mul(retention.max_events_per_store() as u64),
+        }
+    }
+
+    pub fn event_log_within_retention(self) -> bool {
+        self.event_count <= self.max_retained_events
+    }
+}

--- a/crates/flotilla-resources/src/retention.rs
+++ b/crates/flotilla-resources/src/retention.rs
@@ -4,49 +4,77 @@ use crate::ResourceError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventRetention {
-    max_events_per_store: usize,
+    max_events_per_resource_stream: usize,
 }
 
 impl EventRetention {
-    pub const DEFAULT_MAX_EVENTS_PER_STORE: usize = 1_024;
+    pub const DEFAULT_MAX_EVENTS_PER_RESOURCE_STREAM: usize = 1_024;
 
-    pub fn new(max_events_per_store: usize) -> Result<Self, ResourceError> {
-        if max_events_per_store == 0 {
-            return Err(ResourceError::invalid("event retention must keep at least one event per store"));
+    pub fn new(max_events_per_resource_stream: usize) -> Result<Self, ResourceError> {
+        if max_events_per_resource_stream == 0 {
+            return Err(ResourceError::invalid("event retention must keep at least one event per resource stream"));
         }
-        Ok(Self { max_events_per_store })
+        Ok(Self { max_events_per_resource_stream })
     }
 
-    pub(crate) fn max_events_per_store(self) -> usize {
-        self.max_events_per_store
+    pub(crate) fn max_events_per_resource_stream(self) -> usize {
+        self.max_events_per_resource_stream
     }
 }
 
 impl Default for EventRetention {
     fn default() -> Self {
-        Self { max_events_per_store: Self::DEFAULT_MAX_EVENTS_PER_STORE }
+        Self { max_events_per_resource_stream: Self::DEFAULT_MAX_EVENTS_PER_RESOURCE_STREAM }
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceStoreWarning {
+    EventRetentionExceeded,
+    ExcessiveEventToObjectRatio,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ResourceStoreDiagnostics {
     pub object_count: u64,
     pub event_count: u64,
-    pub store_count: u64,
+    pub resource_stream_count: u64,
     pub max_retained_events: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<ResourceStoreWarning>,
 }
 
 impl ResourceStoreDiagnostics {
-    pub(crate) fn new(object_count: u64, event_count: u64, store_count: u64, retention: EventRetention) -> Self {
-        Self {
-            object_count,
-            event_count,
-            store_count,
-            max_retained_events: store_count.saturating_mul(retention.max_events_per_store() as u64),
+    const EVENT_TO_OBJECT_WARNING_MULTIPLIER: u64 = 10_000;
+
+    pub(crate) fn new(object_count: u64, event_count: u64, resource_stream_count: u64, retention: EventRetention) -> Self {
+        let max_retained_events = resource_stream_count.saturating_mul(retention.max_events_per_resource_stream() as u64);
+        let mut warnings = Vec::new();
+        if event_count > max_retained_events {
+            warnings.push(ResourceStoreWarning::EventRetentionExceeded);
         }
+        let ratio_baseline = object_count.max(resource_stream_count).max(1);
+        if event_count > ratio_baseline.saturating_mul(Self::EVENT_TO_OBJECT_WARNING_MULTIPLIER) {
+            warnings.push(ResourceStoreWarning::ExcessiveEventToObjectRatio);
+        }
+        Self { object_count, event_count, resource_stream_count, max_retained_events, warnings }
     }
 
-    pub fn event_log_within_retention(self) -> bool {
+    pub fn event_log_within_retention(&self) -> bool {
         self.event_count <= self.max_retained_events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EventRetention, ResourceStoreDiagnostics, ResourceStoreWarning};
+
+    #[test]
+    fn incident_scale_event_object_ratio_surfaces_explicit_warnings() {
+        let diagnostics = ResourceStoreDiagnostics::new(20, 56_870_000, 20, EventRetention::default());
+
+        assert!(diagnostics.warnings.contains(&ResourceStoreWarning::EventRetentionExceeded));
+        assert!(diagnostics.warnings.contains(&ResourceStoreWarning::ExcessiveEventToObjectRatio));
     }
 }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -136,13 +136,14 @@ impl SqliteBackend {
             )
             .map_err(|err| ResourceError::other(format!("initialize sqlite resource store: {err}")))?;
         let startup_diagnostics = Self::diagnostics_from_connection(&connection, event_retention)?;
-        if !startup_diagnostics.event_log_within_retention() {
+        if !startup_diagnostics.warnings.is_empty() {
             tracing::warn!(
                 event_count = startup_diagnostics.event_count,
                 object_count = startup_diagnostics.object_count,
-                store_count = startup_diagnostics.store_count,
+                resource_stream_count = startup_diagnostics.resource_stream_count,
                 max_retained_events = startup_diagnostics.max_retained_events,
-                "resource event log exceeds retention bound; compacting on startup",
+                warnings = ?startup_diagnostics.warnings,
+                "resource event log tripwire triggered on startup; compacting",
             );
         }
         Self::compact_existing_events(&mut connection, event_retention)?;
@@ -176,10 +177,10 @@ impl SqliteBackend {
         let event_count = connection
             .query_row("SELECT COUNT(*) FROM resource_events", [], |row| row.get::<_, u64>(0))
             .map_err(|err| Self::map_sqlite(err, "count sqlite resource events"))?;
-        let store_count = connection
+        let resource_stream_count = connection
             .query_row("SELECT COUNT(*) FROM resource_sequences", [], |row| row.get::<_, u64>(0))
-            .map_err(|err| Self::map_sqlite(err, "count sqlite resource stores"))?;
-        Ok(ResourceStoreDiagnostics::new(object_count, event_count, store_count, event_retention))
+            .map_err(|err| Self::map_sqlite(err, "count sqlite resource streams"))?;
+        Ok(ResourceStoreDiagnostics::new(object_count, event_count, resource_stream_count, event_retention))
     }
 
     fn clone_through_serde<T>(value: &T) -> Result<T, ResourceError>
@@ -274,7 +275,7 @@ impl SqliteBackend {
         current_version: u64,
         event_retention: EventRetention,
     ) -> Result<(), ResourceError> {
-        let compacted_through = current_version.saturating_sub(event_retention.max_events_per_store() as u64);
+        let compacted_through = current_version.saturating_sub(event_retention.max_events_per_resource_stream() as u64);
         if compacted_through == 0 {
             return Ok(());
         }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     path::Path,
     sync::{Arc, Mutex, MutexGuard},
+    time::Duration,
 };
 
 use chrono::Utc;
@@ -13,6 +14,7 @@ use tokio::sync::mpsc;
 use crate::{
     error::ResourceError,
     resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
+    retention::{EventRetention, ResourceStoreDiagnostics},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
 };
 
@@ -27,6 +29,7 @@ pub struct SqliteBackend {
     // if controller contention shows up in practice.
     connection: Arc<Mutex<Connection>>,
     watchers: Arc<Mutex<WatchersByStore>>,
+    event_retention: EventRetention,
 }
 
 #[derive(Debug, Clone)]
@@ -63,16 +66,30 @@ impl StoredEventKind {
 
 impl SqliteBackend {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, ResourceError> {
+        Self::open_with_event_retention(path, EventRetention::default())
+    }
+
+    pub fn open_with_event_retention(path: impl AsRef<Path>, event_retention: EventRetention) -> Result<Self, ResourceError> {
         let connection = Connection::open(path).map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
-        Self::from_connection(connection)
+        Self::from_connection(connection, event_retention)
     }
 
     pub fn open_in_memory() -> Result<Self, ResourceError> {
-        let connection = Connection::open_in_memory().map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
-        Self::from_connection(connection)
+        Self::open_in_memory_with_event_retention(EventRetention::default())
     }
 
-    fn from_connection(connection: Connection) -> Result<Self, ResourceError> {
+    pub fn open_in_memory_with_event_retention(event_retention: EventRetention) -> Result<Self, ResourceError> {
+        let connection = Connection::open_in_memory().map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
+        Self::from_connection(connection, event_retention)
+    }
+
+    fn from_connection(mut connection: Connection, event_retention: EventRetention) -> Result<Self, ResourceError> {
+        connection
+            .busy_timeout(Duration::from_secs(5))
+            .map_err(|err| ResourceError::other(format!("configure sqlite resource store busy timeout: {err}")))?;
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .map_err(|err| ResourceError::other(format!("configure sqlite resource store WAL mode: {err}")))?;
         connection
             .execute_batch(
                 r#"
@@ -96,8 +113,6 @@ impl SqliteBackend {
                     PRIMARY KEY (group_name, version, kind, namespace, name)
                 );
 
-                -- TODO: add event-log pruning once watch retention requirements
-                -- are clearer for long-running embedded daemons.
                 CREATE TABLE IF NOT EXISTS resource_events (
                     group_name TEXT NOT NULL,
                     version TEXT NOT NULL,
@@ -108,10 +123,30 @@ impl SqliteBackend {
                     body_json TEXT NOT NULL,
                     PRIMARY KEY (group_name, version, kind, namespace, event_version)
                 );
+
+                CREATE TABLE IF NOT EXISTS resource_event_compaction (
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    compacted_through INTEGER NOT NULL,
+                    PRIMARY KEY (group_name, version, kind, namespace)
+                );
                 "#,
             )
             .map_err(|err| ResourceError::other(format!("initialize sqlite resource store: {err}")))?;
-        Ok(Self { connection: Arc::new(Mutex::new(connection)), watchers: Arc::new(Mutex::new(HashMap::new())) })
+        let startup_diagnostics = Self::diagnostics_from_connection(&connection, event_retention)?;
+        if !startup_diagnostics.event_log_within_retention() {
+            tracing::warn!(
+                event_count = startup_diagnostics.event_count,
+                object_count = startup_diagnostics.object_count,
+                store_count = startup_diagnostics.store_count,
+                max_retained_events = startup_diagnostics.max_retained_events,
+                "resource event log exceeds retention bound; compacting on startup",
+            );
+        }
+        Self::compact_existing_events(&mut connection, event_retention)?;
+        Ok(Self { connection: Arc::new(Mutex::new(connection)), watchers: Arc::new(Mutex::new(HashMap::new())), event_retention })
     }
 
     fn store_key<T: Resource>(namespace: &str) -> StoreKey {
@@ -124,6 +159,27 @@ impl SqliteBackend {
 
     fn lock_watchers(&self) -> Result<MutexGuard<'_, WatchersByStore>, ResourceError> {
         self.watchers.lock().map_err(|_| ResourceError::other("sqlite resource watch lock poisoned"))
+    }
+
+    pub(crate) async fn diagnostics(&self) -> Result<ResourceStoreDiagnostics, ResourceError> {
+        let connection = self.lock_connection()?;
+        Self::diagnostics_from_connection(&connection, self.event_retention)
+    }
+
+    fn diagnostics_from_connection(
+        connection: &Connection,
+        event_retention: EventRetention,
+    ) -> Result<ResourceStoreDiagnostics, ResourceError> {
+        let object_count = connection
+            .query_row("SELECT COUNT(*) FROM resource_objects", [], |row| row.get::<_, u64>(0))
+            .map_err(|err| Self::map_sqlite(err, "count sqlite resource objects"))?;
+        let event_count = connection
+            .query_row("SELECT COUNT(*) FROM resource_events", [], |row| row.get::<_, u64>(0))
+            .map_err(|err| Self::map_sqlite(err, "count sqlite resource events"))?;
+        let store_count = connection
+            .query_row("SELECT COUNT(*) FROM resource_sequences", [], |row| row.get::<_, u64>(0))
+            .map_err(|err| Self::map_sqlite(err, "count sqlite resource stores"))?;
+        Ok(ResourceStoreDiagnostics::new(object_count, event_count, store_count, event_retention))
     }
 
     fn clone_through_serde<T>(value: &T) -> Result<T, ResourceError>
@@ -198,6 +254,7 @@ impl SqliteBackend {
         event_version: u64,
         kind: StoredEventKind,
         body_json: &str,
+        event_retention: EventRetention,
     ) -> Result<(), ResourceError> {
         tx.execute(
             r#"
@@ -207,7 +264,56 @@ impl SqliteBackend {
             params![key.0, key.1, key.2, key.3, event_version, kind.as_str(), body_json],
         )
         .map_err(|err| Self::map_sqlite(err, "insert sqlite resource event"))?;
+        Self::compact_events(tx, key, event_version, event_retention)?;
         Ok(())
+    }
+
+    fn compact_events(
+        tx: &rusqlite::Transaction<'_>,
+        key: &StoreKey,
+        current_version: u64,
+        event_retention: EventRetention,
+    ) -> Result<(), ResourceError> {
+        let compacted_through = current_version.saturating_sub(event_retention.max_events_per_store() as u64);
+        if compacted_through == 0 {
+            return Ok(());
+        }
+        tx.execute(
+            r#"
+            DELETE FROM resource_events
+            WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND event_version <= ?5
+            "#,
+            params![key.0, key.1, key.2, key.3, compacted_through],
+        )
+        .map_err(|err| Self::map_sqlite(err, "compact sqlite resource events"))?;
+        tx.execute(
+            r#"
+            INSERT INTO resource_event_compaction (group_name, version, kind, namespace, compacted_through)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(group_name, version, kind, namespace)
+            DO UPDATE SET compacted_through = MAX(compacted_through, excluded.compacted_through)
+            "#,
+            params![key.0, key.1, key.2, key.3, compacted_through],
+        )
+        .map_err(|err| Self::map_sqlite(err, "record sqlite resource event compaction"))?;
+        Ok(())
+    }
+
+    fn compact_existing_events(connection: &mut Connection, event_retention: EventRetention) -> Result<(), ResourceError> {
+        let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource event startup compaction"))?;
+        let stores = {
+            let mut statement = tx
+                .prepare("SELECT group_name, version, kind, namespace, next_version - 1 FROM resource_sequences")
+                .map_err(|err| Self::map_sqlite(err, "prepare sqlite resource event startup compaction"))?;
+            let rows = statement
+                .query_map([], |row| Ok(((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?), row.get::<_, u64>(4)?)))
+                .map_err(|err| Self::map_sqlite(err, "query sqlite resource event startup compaction"))?;
+            rows.collect::<Result<Vec<_>, _>>().map_err(|err| Self::map_sqlite(err, "read sqlite resource event startup compaction row"))?
+        };
+        for (key, current_version) in stores {
+            Self::compact_events(&tx, &key, current_version, event_retention)?;
+        }
+        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource event startup compaction"))
     }
 
     fn notify_watchers(&self, key: &StoreKey, event: StoredEvent) {
@@ -330,7 +436,7 @@ impl SqliteBackend {
             params![key.0, key.1, key.2, key.3, meta.name, version, body_json],
         )
         .map_err(|err| Self::map_sqlite(err, "insert sqlite resource object"))?;
-        Self::insert_event(&tx, &key, version, StoredEventKind::Added, &body_json)?;
+        Self::insert_event(&tx, &key, version, StoredEventKind::Added, &body_json, self.event_retention)?;
         tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource create"))?;
         self.notify_watchers(&key, StoredEvent { kind: StoredEventKind::Added, object: encoded });
         Ok(object)
@@ -350,6 +456,9 @@ impl SqliteBackend {
         let mut object = existing.ok_or_else(|| ResourceError::not_found(&meta.name))?;
         if object.metadata.resource_version != resource_version {
             return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
+        }
+        if object.matches_update(meta, spec)? {
+            return Ok(object);
         }
 
         let version = Self::allocate_version(&tx, &key)?;
@@ -377,7 +486,7 @@ impl SqliteBackend {
             Self::upsert_object(&tx, &key, &meta.name, version, &body_json)?;
             StoredEventKind::Modified
         };
-        Self::insert_event(&tx, &key, version, event_kind, &body_json)?;
+        Self::insert_event(&tx, &key, version, event_kind, &body_json, self.event_retention)?;
         tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource update"))?;
         self.notify_watchers(&key, StoredEvent { kind: event_kind, object: encoded });
         Ok(object)
@@ -398,6 +507,9 @@ impl SqliteBackend {
         if object.metadata.resource_version != resource_version {
             return Err(ResourceError::conflict(name, "stale resourceVersion"));
         }
+        if object.matches_status(status)? {
+            return Ok(object);
+        }
 
         let version = Self::allocate_version(&tx, &key)?;
         object.metadata.resource_version = version.to_string();
@@ -406,7 +518,7 @@ impl SqliteBackend {
         let encoded = Self::encode_object(&object)?;
         let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
         Self::upsert_object(&tx, &key, name, version, &body_json)?;
-        Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json)?;
+        Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, self.event_retention)?;
         tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource status update"))?;
         self.notify_watchers(&key, StoredEvent { kind: StoredEventKind::Modified, object: encoded });
         Ok(object)
@@ -426,7 +538,7 @@ impl SqliteBackend {
             let encoded = Self::encode_object(&object)?;
             let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
             Self::upsert_object(&tx, &key, name, version, &body_json)?;
-            Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json)?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, self.event_retention)?;
             (StoredEventKind::Modified, encoded)
         } else {
             let encoded = Self::encode_object(&object)?;
@@ -439,7 +551,7 @@ impl SqliteBackend {
                 params![key.0, key.1, key.2, key.3, name],
             )
             .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
-            Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json)?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json, self.event_retention)?;
             (StoredEventKind::Deleted, encoded)
         };
         tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource delete"))?;
@@ -461,11 +573,12 @@ impl SqliteBackend {
         let (sender, receiver) = mpsc::unbounded_channel();
         let replay = {
             let conn = self.lock_connection()?;
-            self.lock_watchers()?.entry(key.clone()).or_default().push(sender);
-            match replay_from {
+            let replay = match replay_from {
                 Some(version) => Self::replay_events(&conn, &key, version)?,
                 None => Vec::new(),
-            }
+            };
+            self.lock_watchers()?.entry(key.clone()).or_default().push(sender);
+            replay
         };
 
         let replay_stream = stream::iter(replay.into_iter().map(Self::decode_event::<T>));
@@ -519,6 +632,24 @@ impl SqliteBackend {
     }
 
     fn replay_events(conn: &Connection, key: &StoreKey, replay_from: u64) -> Result<Vec<StoredEvent>, ResourceError> {
+        let compacted_through = conn
+            .query_row(
+                r#"
+                SELECT compacted_through FROM resource_event_compaction
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4
+                "#,
+                params![key.0, key.1, key.2, key.3],
+                |row| row.get::<_, u64>(0),
+            )
+            .optional()
+            .map_err(|err| Self::map_sqlite(err, "read sqlite resource event compaction floor"))?
+            .unwrap_or(0);
+        if replay_from < compacted_through {
+            return Err(ResourceError::WatchExpired {
+                requested_version: replay_from.to_string(),
+                compacted_through: compacted_through.to_string(),
+            });
+        }
         let mut statement = conn
             .prepare(
                 r#"

--- a/crates/flotilla-resources/src/task_workspace.rs
+++ b/crates/flotilla-resources/src/task_workspace.rs
@@ -60,7 +60,7 @@ impl StatusPatch<TaskWorkspaceStatus> for TaskWorkspaceStatusPatch {
                 status.phase = TaskWorkspacePhase::Provisioning;
                 status.observed_policy_ref = Some(observed_policy_ref.clone());
                 status.observed_policy_version = Some(observed_policy_version.clone());
-                status.started_at = Some(*started_at);
+                status.started_at.get_or_insert(*started_at);
                 status.message = None;
             }
             Self::MarkReady { environment_ref, checkout_ref, terminal_session_refs, ready_at } => {
@@ -68,7 +68,7 @@ impl StatusPatch<TaskWorkspaceStatus> for TaskWorkspaceStatusPatch {
                 status.environment_ref = environment_ref.clone();
                 status.checkout_ref = checkout_ref.clone();
                 status.terminal_session_refs = terminal_session_refs.clone();
-                status.ready_at = Some(*ready_at);
+                status.ready_at.get_or_insert(*ready_at);
                 status.message = None;
             }
             Self::MarkTearingDown => {

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -73,20 +73,22 @@ impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
                 status.phase = TerminalSessionPhase::Running;
                 status.session_id = Some(session_id.clone());
                 status.pid = *pid;
-                status.started_at = Some(*started_at);
+                status.started_at.get_or_insert(*started_at);
                 status.inner_command_status = Some(InnerCommandStatus::Running);
                 status.message = None;
             }
             Self::MarkStopped { stopped_at, inner_command_status, inner_exit_code, message } => {
                 status.phase = TerminalSessionPhase::Stopped;
-                status.stopped_at = Some(*stopped_at);
+                status.stopped_at.get_or_insert(*stopped_at);
                 status.inner_command_status = *inner_command_status;
                 status.inner_exit_code = *inner_exit_code;
                 status.message = message.clone();
             }
             Self::MarkFailed { message, stopped_at } => {
                 status.phase = TerminalSessionPhase::Stopped;
-                status.stopped_at = *stopped_at;
+                if let Some(stopped_at) = stopped_at {
+                    status.stopped_at.get_or_insert(*stopped_at);
+                }
                 status.message = Some(message.clone());
             }
         }

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -291,6 +291,35 @@ pub async fn assert_watch_retention_expires_only_versions_below_floor_with_backe
     });
 }
 
+pub async fn assert_consumer_relists_after_expired_watch_and_converges_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
+    let first = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
+    let second = resolver
+        .update(&F::meta("alpha"), &first.metadata.resource_version, &F::updated_spec())
+        .await
+        .expect("first update should succeed");
+    let third =
+        resolver.update(&F::meta("alpha"), &second.metadata.resource_version, &F::spec()).await.expect("second update should succeed");
+    resolver.update(&F::meta("alpha"), &third.metadata.resource_version, &F::updated_spec()).await.expect("third update should succeed");
+
+    assert!(matches!(
+        resolver.watch(WatchStart::FromVersion(first.metadata.resource_version)).await,
+        Err(ResourceError::WatchExpired { .. })
+    ));
+
+    let relisted = resolver.list().await.expect("expired consumer should relist");
+    let mut local = relisted.items.into_iter().next().expect("relisted object");
+    let mut resumed =
+        resolver.watch(WatchStart::FromVersion(relisted.resource_version)).await.expect("consumer should resume from relisted version");
+    let latest =
+        resolver.update(&F::meta("alpha"), &local.metadata.resource_version, &F::spec()).await.expect("post-relist update should succeed");
+    let event = resumed.next().await.expect("post-relist event").expect("post-relist event should decode");
+    let WatchEvent::Modified(object) = event else { panic!("expected post-relist modified event") };
+    local = object;
+
+    assert_eq!(local.metadata.resource_version, latest.metadata.resource_version);
+}
+
 pub async fn assert_store_diagnostics_report_retained_events_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
     let resolver = resolver::<F>(backend.clone(), "flotilla");
     let first = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
@@ -303,9 +332,23 @@ pub async fn assert_store_diagnostics_report_retained_events_with_backend<F: Res
     let diagnostics = backend.diagnostics().await.expect("diagnostics should succeed").expect("embedded backend should report diagnostics");
     assert_eq!(diagnostics.object_count, 1);
     assert_eq!(diagnostics.event_count, 2);
-    assert_eq!(diagnostics.store_count, 1);
+    assert_eq!(diagnostics.resource_stream_count, 1);
     assert_eq!(diagnostics.max_retained_events, 2);
     assert!(diagnostics.event_log_within_retention());
+    assert!(diagnostics.warnings.is_empty());
+}
+
+pub async fn assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend<F: ResourceContractFixture>(
+    backend: ResourceBackend,
+) {
+    let resolver = resolver::<F>(backend.clone(), "flotilla");
+    let _watch = resolver.watch(WatchStart::Now).await.expect("watch should start");
+
+    let diagnostics = backend.diagnostics().await.expect("diagnostics should succeed").expect("embedded diagnostics");
+    assert_eq!(diagnostics.object_count, 0);
+    assert_eq!(diagnostics.event_count, 0);
+    assert_eq!(diagnostics.resource_stream_count, 0);
+    assert_eq!(diagnostics.max_retained_events, 0);
 }
 
 pub async fn assert_namespace_isolation_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -135,6 +135,40 @@ pub async fn assert_stale_resource_version_conflicts<F: ResourceContractFixture>
     assert_stale_resource_version_conflicts_with_backend::<F>(in_memory_backend()).await;
 }
 
+pub async fn assert_identical_update_is_noop_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
+    let meta = F::meta("alpha");
+    let spec = F::spec();
+    let created = resolver.create(&meta, &spec).await.expect("create should succeed");
+    let mut watch = resolver.watch(WatchStart::FromVersion(created.metadata.resource_version.clone())).await.expect("watch should succeed");
+
+    let unchanged = resolver.update(&meta, &created.metadata.resource_version, &spec).await.expect("identical update should succeed");
+
+    assert_eq!(unchanged.metadata.resource_version, created.metadata.resource_version);
+    assert!(timeout(Duration::from_millis(100), watch.next()).await.is_err(), "identical update should not emit a watch event");
+}
+
+pub async fn assert_identical_status_update_is_noop_with_backend<F: ResourceContractFixture>(backend: ResourceBackend)
+where
+    <F::Resource as Resource>::Status: Default,
+{
+    let resolver = resolver::<F>(backend, "flotilla");
+    let created = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
+    let status = <F::Resource as Resource>::Status::default();
+    let status_written =
+        resolver.update_status("alpha", &created.metadata.resource_version, &status).await.expect("initial status update should succeed");
+    let mut watch =
+        resolver.watch(WatchStart::FromVersion(status_written.metadata.resource_version.clone())).await.expect("watch should succeed");
+
+    let unchanged = resolver
+        .update_status("alpha", &status_written.metadata.resource_version, &status)
+        .await
+        .expect("identical status update should succeed");
+
+    assert_eq!(unchanged.metadata.resource_version, status_written.metadata.resource_version);
+    assert!(timeout(Duration::from_millis(100), watch.next()).await.is_err(), "identical status update should not emit a watch event");
+}
+
 pub async fn assert_delete_emits_event_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
     let resolver = resolver::<F>(backend, "flotilla");
     let created = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
@@ -221,6 +255,57 @@ pub async fn assert_watch_now_semantics_with_backend<F: ResourceContractFixture>
 
 pub async fn assert_watch_now_semantics<F: ResourceContractFixture>() {
     assert_watch_now_semantics_with_backend::<F>(in_memory_backend()).await;
+}
+
+pub async fn assert_watch_retention_expires_only_versions_below_floor_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
+    let created = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
+    let second = resolver
+        .update(&F::meta("alpha"), &created.metadata.resource_version, &F::updated_spec())
+        .await
+        .expect("first update should succeed");
+    let third =
+        resolver.update(&F::meta("alpha"), &second.metadata.resource_version, &F::spec()).await.expect("second update should succeed");
+    let fourth = resolver
+        .update(&F::meta("alpha"), &third.metadata.resource_version, &F::updated_spec())
+        .await
+        .expect("third update should succeed");
+
+    let mut retained = resolver
+        .watch(WatchStart::FromVersion(second.metadata.resource_version.clone()))
+        .await
+        .expect("watch at compaction floor should succeed");
+    for expected_version in [&third.metadata.resource_version, &fourth.metadata.resource_version] {
+        let event = retained.next().await.expect("retained event").expect("retained event should decode");
+        let WatchEvent::Modified(object) = event else { panic!("expected retained modified event") };
+        assert_eq!(&object.metadata.resource_version, expected_version);
+    }
+
+    let expired = resolver
+        .watch(WatchStart::FromVersion(created.metadata.resource_version.clone()))
+        .await
+        .expect_err("watch below compaction floor should expire");
+    assert_eq!(expired, ResourceError::WatchExpired {
+        requested_version: created.metadata.resource_version,
+        compacted_through: second.metadata.resource_version,
+    });
+}
+
+pub async fn assert_store_diagnostics_report_retained_events_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend.clone(), "flotilla");
+    let first = resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");
+    let second = resolver
+        .update(&F::meta("alpha"), &first.metadata.resource_version, &F::updated_spec())
+        .await
+        .expect("first update should succeed");
+    resolver.update(&F::meta("alpha"), &second.metadata.resource_version, &F::spec()).await.expect("second update should succeed");
+
+    let diagnostics = backend.diagnostics().await.expect("diagnostics should succeed").expect("embedded backend should report diagnostics");
+    assert_eq!(diagnostics.object_count, 1);
+    assert_eq!(diagnostics.event_count, 2);
+    assert_eq!(diagnostics.store_count, 1);
+    assert_eq!(diagnostics.max_retained_events, 2);
+    assert!(diagnostics.event_log_within_retention());
 }
 
 pub async fn assert_namespace_isolation_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -211,3 +211,50 @@ fn external_completion_marks_task_complete_without_touching_convoy_phase() {
     assert_eq!(status.tasks["review"].finished_at, Some(ts(50)));
     assert_eq!(status.tasks["review"].message.as_deref(), Some("done"));
 }
+
+#[test]
+fn convoy_lifecycle_timestamps_are_set_once_per_transition() {
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Pending,
+        workflow_snapshot: Some(sample_snapshot()),
+        tasks: BTreeMap::from([("implement".to_string(), pending_task())]),
+        message: None,
+        started_at: None,
+        finished_at: None,
+        observed_workflow_ref: Some("review-and-fix".to_string()),
+        observed_workflows: Some(BTreeMap::new()),
+    };
+
+    ConvoyStatusPatch::AdvanceTasksToReady { ready: BTreeMap::from([("implement".to_string(), ts(10))]) }.apply(&mut status);
+    ConvoyStatusPatch::AdvanceTasksToReady { ready: BTreeMap::from([("implement".to_string(), ts(11))]) }.apply(&mut status);
+    assert_eq!(status.tasks["implement"].ready_at, Some(ts(10)));
+
+    ConvoyStatusPatch::TaskLaunching {
+        task: "implement".to_string(),
+        started_at: ts(20),
+        placement: flotilla_resources::PlacementStatus::default(),
+    }
+    .apply(&mut status);
+    ConvoyStatusPatch::TaskLaunching {
+        task: "implement".to_string(),
+        started_at: ts(21),
+        placement: flotilla_resources::PlacementStatus::default(),
+    }
+    .apply(&mut status);
+    assert_eq!(status.tasks["implement"].started_at, Some(ts(20)));
+
+    ConvoyStatusPatch::MarkTaskCompleted { task: "implement".to_string(), finished_at: ts(30), message: Some("done".to_string()) }
+        .apply(&mut status);
+    ConvoyStatusPatch::MarkTaskCompleted { task: "implement".to_string(), finished_at: ts(31), message: Some("still done".to_string()) }
+        .apply(&mut status);
+    assert_eq!(status.tasks["implement"].finished_at, Some(ts(30)));
+    assert_eq!(status.tasks["implement"].message.as_deref(), Some("still done"));
+
+    ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Active, started_at: Some(ts(40)), finished_at: None }.apply(&mut status);
+    ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Active, started_at: Some(ts(41)), finished_at: None }.apply(&mut status);
+    assert_eq!(status.started_at, Some(ts(40)));
+
+    ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, started_at: None, finished_at: Some(ts(50)) }.apply(&mut status);
+    ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, started_at: None, finished_at: Some(ts(51)) }.apply(&mut status);
+    assert_eq!(status.finished_at, Some(ts(50)));
+}

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -4,12 +4,15 @@ use std::collections::BTreeMap;
 
 use common::{
     contract::{
-        assert_create_get_list_roundtrip, assert_delete_emits_event, assert_metadata_roundtrip, assert_namespace_isolation,
-        assert_stale_resource_version_conflicts, assert_watch_from_version_replays, assert_watch_now_semantics, ConvoyFixture,
+        assert_create_get_list_roundtrip, assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend,
+        assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip, assert_namespace_isolation,
+        assert_stale_resource_version_conflicts, assert_store_diagnostics_report_retained_events_with_backend,
+        assert_watch_from_version_replays, assert_watch_now_semantics,
+        assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
     },
     convoy_meta, convoy_spec,
 };
-use flotilla_resources::{Convoy, InMemoryBackend, InputMeta, ResourceBackend};
+use flotilla_resources::{Convoy, EventRetention, InMemoryBackend, InputMeta, ResourceBackend};
 use rstest::rstest;
 
 fn resolver(namespace: &str) -> flotilla_resources::TypedResolver<Convoy> {
@@ -35,6 +38,20 @@ async fn update_requires_current_resource_version(#[case] _fixture: ConvoyFixtur
 #[rstest]
 #[case(ConvoyFixture)]
 #[tokio::test]
+async fn identical_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
+    assert_identical_update_is_noop_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn identical_status_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
+    assert_identical_status_update_is_noop_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
 async fn delete_emits_deleted_event(#[case] _fixture: ConvoyFixture) {
     assert_delete_emits_event::<ConvoyFixture>().await;
 }
@@ -51,6 +68,24 @@ async fn watch_from_version_replays_gaplessly_after_list(#[case] _fixture: Convo
 #[tokio::test]
 async fn watch_now_only_sees_future_events(#[case] _fixture: ConvoyFixture) {
     assert_watch_now_semantics::<ConvoyFixture>().await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn watch_below_retention_floor_expires(#[case] _fixture: ConvoyFixture) {
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
+    assert_watch_retention_expires_only_versions_below_floor_with_backend::<ConvoyFixture>(backend).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn diagnostics_report_bounded_event_log(#[case] _fixture: ConvoyFixture) {
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
+    assert_store_diagnostics_report_retained_events_with_backend::<ConvoyFixture>(backend).await;
 }
 
 #[rstest]
@@ -167,4 +202,31 @@ async fn observed_backend_rejects_bare_watch_resume_without_generation() {
         .expect_err("observed watch resume should require generation");
 
     assert!(matches!(err, flotilla_resources::ResourceError::Invalid { .. }));
+}
+
+#[tokio::test]
+async fn observed_backend_expires_compacted_version_within_current_generation() {
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::observed_with_event_retention(retention));
+    let resolver = backend.using::<Convoy>("flotilla");
+    let created = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create");
+    let second =
+        resolver.update(&convoy_meta("alpha"), &created.metadata.resource_version, &convoy_spec("template-b")).await.expect("first update");
+    let third =
+        resolver.update(&convoy_meta("alpha"), &second.metadata.resource_version, &convoy_spec("template-c")).await.expect("second update");
+    resolver.update(&convoy_meta("alpha"), &third.metadata.resource_version, &convoy_spec("template-d")).await.expect("third update");
+    let generation = resolver.list().await.expect("list").generation.expect("observed generation");
+
+    let err = resolver
+        .watch(flotilla_resources::WatchStart::FromVersionInGeneration {
+            generation,
+            resource_version: created.metadata.resource_version.clone(),
+        })
+        .await
+        .expect_err("compacted version should expire");
+
+    assert_eq!(err, flotilla_resources::ResourceError::WatchExpired {
+        requested_version: created.metadata.resource_version,
+        compacted_through: second.metadata.resource_version,
+    });
 }

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -4,10 +4,11 @@ use std::collections::BTreeMap;
 
 use common::{
     contract::{
-        assert_create_get_list_roundtrip, assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend,
-        assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip, assert_namespace_isolation,
-        assert_stale_resource_version_conflicts, assert_store_diagnostics_report_retained_events_with_backend,
-        assert_watch_from_version_replays, assert_watch_now_semantics,
+        assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip,
+        assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
+        assert_metadata_roundtrip, assert_namespace_isolation, assert_stale_resource_version_conflicts,
+        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays, assert_watch_now_semantics,
+        assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
     },
     convoy_meta, convoy_spec,
@@ -82,10 +83,29 @@ async fn watch_below_retention_floor_expires(#[case] _fixture: ConvoyFixture) {
 #[rstest]
 #[case(ConvoyFixture)]
 #[tokio::test]
+async fn expired_watch_consumer_relists_and_converges(#[case] _fixture: ConvoyFixture) {
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
+    assert_consumer_relists_after_expired_watch_and_converges_with_backend::<ConvoyFixture>(backend).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
 async fn diagnostics_report_bounded_event_log(#[case] _fixture: ConvoyFixture) {
     let retention = EventRetention::new(2).expect("valid retention");
     let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
     assert_store_diagnostics_report_retained_events_with_backend::<ConvoyFixture>(backend).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn watch_only_diagnostics_match_mutation_based_stream_semantics(#[case] _fixture: ConvoyFixture) {
+    assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(
+        InMemoryBackend::default(),
+    ))
+    .await;
 }
 
 #[rstest]

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{TimeZone, Utc};
 use flotilla_resources::{
     CheckoutPhase, CheckoutStatus, CheckoutStatusPatch, ClonePhase, CloneStatus, CloneStatusPatch, EnvironmentPhase, EnvironmentStatus,
     EnvironmentStatusPatch, HostStatus, HostStatusPatch, InnerCommandStatus, PresentationPhase, PresentationStatus,
@@ -63,13 +63,20 @@ fn checkout_status_patch_marks_ready_and_failed() {
 #[test]
 fn terminal_session_status_patch_marks_running_and_stopped() {
     let mut status = TerminalSessionStatus::default();
-    let started_at = Utc::now();
-    let stopped_at = Utc::now();
+    let started_at = Utc.timestamp_opt(10, 0).single().expect("timestamp");
+    let stopped_at = Utc.timestamp_opt(20, 0).single().expect("timestamp");
 
     TerminalSessionStatusPatch::MarkRunning { session_id: "abc123".to_string(), pid: Some(12345), started_at }.apply(&mut status);
+    TerminalSessionStatusPatch::MarkRunning {
+        session_id: "abc123".to_string(),
+        pid: Some(12345),
+        started_at: Utc.timestamp_opt(11, 0).single().expect("timestamp"),
+    }
+    .apply(&mut status);
     assert_eq!(status.phase, TerminalSessionPhase::Running);
     assert_eq!(status.session_id.as_deref(), Some("abc123"));
     assert_eq!(status.pid, Some(12345));
+    assert_eq!(status.started_at, Some(started_at));
 
     TerminalSessionStatusPatch::MarkStopped {
         stopped_at,
@@ -78,16 +85,27 @@ fn terminal_session_status_patch_marks_running_and_stopped() {
         message: Some("process exited".to_string()),
     }
     .apply(&mut status);
+    TerminalSessionStatusPatch::MarkStopped {
+        stopped_at: Utc.timestamp_opt(21, 0).single().expect("timestamp"),
+        inner_command_status: Some(InnerCommandStatus::Exited),
+        inner_exit_code: Some(1),
+        message: Some("process exited".to_string()),
+    }
+    .apply(&mut status);
     assert_eq!(status.phase, TerminalSessionPhase::Stopped);
     assert_eq!(status.inner_command_status, Some(InnerCommandStatus::Exited));
     assert_eq!(status.inner_exit_code, Some(1));
+    assert_eq!(status.stopped_at, Some(stopped_at));
+
+    TerminalSessionStatusPatch::MarkFailed { message: "still stopped".to_string(), stopped_at: None }.apply(&mut status);
+    assert_eq!(status.stopped_at, Some(stopped_at), "a later patch without a timestamp must not erase the transition time");
 }
 
 #[test]
 fn task_workspace_status_patch_marks_provisioning_ready_and_failed() {
     let mut status = TaskWorkspaceStatus::default();
-    let started_at = Utc::now();
-    let ready_at = Utc::now();
+    let started_at = Utc.timestamp_opt(10, 0).single().expect("timestamp");
+    let ready_at = Utc.timestamp_opt(20, 0).single().expect("timestamp");
 
     TaskWorkspaceStatusPatch::MarkProvisioning {
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
@@ -97,6 +115,14 @@ fn task_workspace_status_patch_marks_provisioning_ready_and_failed() {
     .apply(&mut status);
     assert_eq!(status.phase, TaskWorkspacePhase::Provisioning);
     assert_eq!(status.observed_policy_ref.as_deref(), Some("docker-on-01HXYZ"));
+
+    TaskWorkspaceStatusPatch::MarkProvisioning {
+        observed_policy_ref: "docker-on-01HXYZ".to_string(),
+        observed_policy_version: "13".to_string(),
+        started_at: Utc.timestamp_opt(11, 0).single().expect("timestamp"),
+    }
+    .apply(&mut status);
+    assert_eq!(status.started_at, Some(started_at), "reconcile must not restamp an in-progress transition");
 
     TaskWorkspaceStatusPatch::MarkReady {
         environment_ref: Some("env-a".to_string()),
@@ -108,6 +134,15 @@ fn task_workspace_status_patch_marks_provisioning_ready_and_failed() {
     assert_eq!(status.phase, TaskWorkspacePhase::Ready);
     assert_eq!(status.terminal_session_refs.len(), 2);
 
+    TaskWorkspaceStatusPatch::MarkReady {
+        environment_ref: Some("env-a".to_string()),
+        checkout_ref: Some("checkout-a".to_string()),
+        terminal_session_refs: vec!["term-a".to_string(), "term-b".to_string()],
+        ready_at: Utc.timestamp_opt(21, 0).single().expect("timestamp"),
+    }
+    .apply(&mut status);
+    assert_eq!(status.ready_at, Some(ready_at), "reconcile must not restamp an established Ready transition");
+
     TaskWorkspaceStatusPatch::MarkFailed { message: "clone failed".to_string() }.apply(&mut status);
     assert_eq!(status.phase, TaskWorkspacePhase::Failed);
     assert_eq!(status.message.as_deref(), Some("clone failed"));
@@ -116,7 +151,7 @@ fn task_workspace_status_patch_marks_provisioning_ready_and_failed() {
 #[test]
 fn presentation_status_patch_marks_active_torn_down_and_failed() {
     let mut status = PresentationStatus::default();
-    let ready_at = Utc::now();
+    let ready_at = Utc.timestamp_opt(10, 0).single().expect("timestamp");
 
     PresentationStatusPatch::MarkActive {
         presentation_manager: "tmux".to_string(),
@@ -125,10 +160,18 @@ fn presentation_status_patch_marks_active_torn_down_and_failed() {
         ready_at,
     }
     .apply(&mut status);
+    PresentationStatusPatch::MarkActive {
+        presentation_manager: "tmux".to_string(),
+        workspace_ref: "ws-456".to_string(),
+        spec_hash: "hash-def".to_string(),
+        ready_at: Utc.timestamp_opt(11, 0).single().expect("timestamp"),
+    }
+    .apply(&mut status);
     assert_eq!(status.phase, PresentationPhase::Active);
     assert_eq!(status.observed_presentation_manager.as_deref(), Some("tmux"));
-    assert_eq!(status.observed_workspace_ref.as_deref(), Some("ws-123"));
-    assert_eq!(status.observed_spec_hash.as_deref(), Some("hash-abc"));
+    assert_eq!(status.observed_workspace_ref.as_deref(), Some("ws-456"));
+    assert_eq!(status.observed_spec_hash.as_deref(), Some("hash-def"));
+    assert_eq!(status.ready_at, Some(ready_at), "an in-place presentation refresh is not a new Active transition");
     assert_eq!(status.message, None);
 
     PresentationStatusPatch::MarkTornDown { message: Some("create failed after replace".to_string()) }.apply(&mut status);
@@ -137,6 +180,16 @@ fn presentation_status_patch_marks_active_torn_down_and_failed() {
     assert_eq!(status.observed_workspace_ref, None);
     assert_eq!(status.observed_spec_hash, None);
     assert_eq!(status.message.as_deref(), Some("create failed after replace"));
+
+    let reactivated_at = Utc.timestamp_opt(12, 0).single().expect("timestamp");
+    PresentationStatusPatch::MarkActive {
+        presentation_manager: "tmux".to_string(),
+        workspace_ref: "ws-789".to_string(),
+        spec_hash: "hash-ghi".to_string(),
+        ready_at: reactivated_at,
+    }
+    .apply(&mut status);
+    assert_eq!(status.ready_at, Some(reactivated_at), "TornDown to Active is a new transition");
 
     PresentationStatusPatch::MarkFailed { message: "unknown policy".to_string() }.apply(&mut status);
     assert_eq!(status.phase, PresentationPhase::Failed);

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -2,13 +2,16 @@ mod common;
 
 use common::{
     contract::{
-        assert_create_get_list_roundtrip_with_backend, assert_delete_emits_event_with_backend, assert_metadata_roundtrip_with_backend,
-        assert_namespace_isolation_with_backend, assert_stale_resource_version_conflicts_with_backend,
-        assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend, ConvoyFixture,
+        assert_create_get_list_roundtrip_with_backend, assert_delete_emits_event_with_backend,
+        assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
+        assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
+        assert_stale_resource_version_conflicts_with_backend, assert_store_diagnostics_report_retained_events_with_backend,
+        assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend,
+        assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
     },
     convoy_meta, convoy_spec,
 };
-use flotilla_resources::{Convoy, ResourceBackend, SqliteBackend, WatchEvent, WatchStart};
+use flotilla_resources::{Convoy, EventRetention, ResourceBackend, SqliteBackend, WatchEvent, WatchStart};
 use futures::StreamExt;
 use rstest::rstest;
 use tempfile::tempdir;
@@ -35,6 +38,20 @@ async fn update_requires_current_resource_version(#[case] _fixture: ConvoyFixtur
 #[rstest]
 #[case(ConvoyFixture)]
 #[tokio::test]
+async fn identical_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
+    assert_identical_update_is_noop_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn identical_status_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
+    assert_identical_status_update_is_noop_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
 async fn delete_emits_deleted_event(#[case] _fixture: ConvoyFixture) {
     assert_delete_emits_event_with_backend::<ConvoyFixture>(backend()).await;
 }
@@ -51,6 +68,26 @@ async fn watch_from_version_replays_gaplessly_after_list(#[case] _fixture: Convo
 #[tokio::test]
 async fn watch_now_only_sees_future_events(#[case] _fixture: ConvoyFixture) {
     assert_watch_now_semantics_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn watch_below_retention_floor_expires(#[case] _fixture: ConvoyFixture) {
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend =
+        ResourceBackend::Sqlite(SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"));
+    assert_watch_retention_expires_only_versions_below_floor_with_backend::<ConvoyFixture>(backend).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn diagnostics_report_bounded_event_log(#[case] _fixture: ConvoyFixture) {
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend =
+        ResourceBackend::Sqlite(SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"));
+    assert_store_diagnostics_report_retained_events_with_backend::<ConvoyFixture>(backend).await;
 }
 
 #[rstest]
@@ -92,6 +129,21 @@ async fn objects_and_resource_versions_survive_restart() {
     assert_eq!(updated.metadata.resource_version, "2");
 }
 
+#[test]
+fn file_backend_enables_wal_and_busy_timeout() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+    let backend = SqliteBackend::open(&path).expect("sqlite backend should open");
+
+    let connection = rusqlite::Connection::open(&path).expect("inspection connection should open");
+    let journal_mode: String = connection.query_row("PRAGMA journal_mode", [], |row| row.get(0)).expect("read journal mode");
+    let busy_timeout_ms: u64 = connection.query_row("PRAGMA busy_timeout", [], |row| row.get(0)).expect("read busy timeout");
+
+    assert_eq!(journal_mode, "wal");
+    assert_eq!(busy_timeout_ms, 5_000);
+    drop(backend);
+}
+
 #[tokio::test]
 async fn watch_from_version_replays_events_persisted_before_restart() {
     let dir = tempdir().expect("tempdir");
@@ -120,4 +172,46 @@ async fn watch_from_version_replays_events_persisted_before_restart() {
         WatchEvent::Modified(object) => assert_eq!(object.metadata.resource_version, updated.metadata.resource_version),
         other => panic!("expected modified event, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn reopening_with_smaller_retention_compacts_existing_events_and_persists_floor() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should open"));
+    let resolver = backend.using::<Convoy>("flotilla");
+    let first = resolver.create(&convoy_meta("alpha"), &convoy_spec("template-a")).await.expect("create");
+    let second =
+        resolver.update(&convoy_meta("alpha"), &first.metadata.resource_version, &convoy_spec("template-b")).await.expect("first update");
+    let third =
+        resolver.update(&convoy_meta("alpha"), &second.metadata.resource_version, &convoy_spec("template-c")).await.expect("second update");
+    resolver.update(&convoy_meta("alpha"), &third.metadata.resource_version, &convoy_spec("template-d")).await.expect("third update");
+    drop(resolver);
+    drop(backend);
+
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend = ResourceBackend::Sqlite(
+        SqliteBackend::open_with_event_retention(&path, retention).expect("sqlite backend should reopen with smaller retention"),
+    );
+    let resolver = backend.using::<Convoy>("flotilla");
+    let expired = resolver
+        .watch(WatchStart::FromVersion(first.metadata.resource_version.clone()))
+        .await
+        .expect_err("startup compaction should expire old version");
+    assert_eq!(expired, flotilla_resources::ResourceError::WatchExpired {
+        requested_version: first.metadata.resource_version,
+        compacted_through: second.metadata.resource_version,
+    });
+
+    drop(resolver);
+    drop(backend);
+    let backend = ResourceBackend::Sqlite(
+        SqliteBackend::open_with_event_retention(&path, retention).expect("sqlite backend should reopen after compaction"),
+    );
+    let resolver = backend.using::<Convoy>("flotilla");
+    assert!(matches!(
+        resolver.watch(WatchStart::FromVersion("1".to_string())).await,
+        Err(flotilla_resources::ResourceError::WatchExpired { compacted_through, .. }) if compacted_through == "2"
+    ));
 }

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -2,11 +2,12 @@ mod common;
 
 use common::{
     contract::{
-        assert_create_get_list_roundtrip_with_backend, assert_delete_emits_event_with_backend,
-        assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
-        assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
+        assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip_with_backend,
+        assert_delete_emits_event_with_backend, assert_identical_status_update_is_noop_with_backend,
+        assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
         assert_stale_resource_version_conflicts_with_backend, assert_store_diagnostics_report_retained_events_with_backend,
         assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend,
+        assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
     },
     convoy_meta, convoy_spec,
@@ -83,11 +84,28 @@ async fn watch_below_retention_floor_expires(#[case] _fixture: ConvoyFixture) {
 #[rstest]
 #[case(ConvoyFixture)]
 #[tokio::test]
+async fn expired_watch_consumer_relists_and_converges(#[case] _fixture: ConvoyFixture) {
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend =
+        ResourceBackend::Sqlite(SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"));
+    assert_consumer_relists_after_expired_watch_and_converges_with_backend::<ConvoyFixture>(backend).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
 async fn diagnostics_report_bounded_event_log(#[case] _fixture: ConvoyFixture) {
     let retention = EventRetention::new(2).expect("valid retention");
     let backend =
         ResourceBackend::Sqlite(SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"));
     assert_store_diagnostics_report_retained_events_with_backend::<ConvoyFixture>(backend).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn watch_only_diagnostics_match_mutation_based_stream_semantics(#[case] _fixture: ConvoyFixture) {
+    assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend::<ConvoyFixture>(backend()).await;
 }
 
 #[rstest]

--- a/crates/flotilla-tui/Cargo.toml
+++ b/crates/flotilla-tui/Cargo.toml
@@ -27,7 +27,6 @@ dirs = "6"
 catppuccin = { version = "2", features = ["ratatui"] }
 crokey = "1.4"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
-tracing-appender = "0.2.4"
 time = { version = "0.3.47", features = ["local-offset"] }
 futures = "0.3"
 comfy-table = "7.2.2"

--- a/crates/flotilla-tui/src/event_log.rs
+++ b/crates/flotilla-tui/src/event_log.rs
@@ -239,7 +239,7 @@ impl tracing::field::Visit for MessageVisitor {
 pub fn init_with_dir(log_dir: &std::path::Path) {
     let _ = std::fs::create_dir_all(log_dir);
 
-    let file_appender = tracing_appender::rolling::never(log_dir, "tui.log");
+    let file_appender = flotilla_core::log_file::bounded_log_writer(log_dir, "tui.log").expect("open bounded TUI log");
 
     let file_layer = tracing_subscriber::fmt::layer().with_writer(file_appender).with_ansi(false).with_target(false);
 

--- a/tests/flotillad_binary.rs
+++ b/tests/flotillad_binary.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 #[test]
 fn installed_package_exposes_flotillad_binary() {
-    let flotillad = std::env::var("CARGO_BIN_EXE_flotillad").expect("root package should build a flotillad binary target");
+    let flotillad = env!("CARGO_BIN_EXE_flotillad");
     let status = Command::new(flotillad).arg("--help").status().expect("flotillad help should run");
 
     assert!(status.success(), "flotillad --help should succeed");


### PR DESCRIPTION
Closes #672.

## Summary

- suppress semantic no-op resource and status updates so idle reconcilers do not advance resource versions or append events
- keep lifecycle timestamps stable unless their associated phase actually transitions
- bound retained events per resource stream, persist SQLite compaction floors, and return a typed expiry error for lagging watches
- enable SQLite WAL mode and a busy timeout
- publish resource-store diagnostics and explicit growth tripwires through host status and tracing
- cap daemon log files with size-based rotation
- repair the repository-wide Clippy and binary integration-test gates

## Root cause

Reconcilers could repeatedly write semantically unchanged resources. Each write advanced the resource version, appended a SQLite event, and refreshed lifecycle timestamps, allowing an idle daemon to grow its database and logs indefinitely.

## Impact

Idle resource state now converges to a fixed point. Resource history and daemon logs have explicit bounds, and operators can observe retention and event-to-object warnings. A watcher that falls behind compaction receives `WatchExpired`; production controller and aggregator loops recover through their existing supervised list-and-watch restart.

## Follow-ups

- #678 preserves typed watch expiry through HTTP 410 and explores in-place relisting instead of whole-loop restart.
- #679 defines timestamp reset semantics before retryable resource lifecycles are introduced.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
