### PR TITLE
refactor: rename task/leg vocabulary to vessel/work

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,9 +25,13 @@ repository/codebase. The concrete form of the **Island** metaphor.
 _Avoid_: Repo (a Project may span more than the bare git remote), Workspace.
 
 **Convoy**:
-A named instance of a workflow — the primary unit of *launched* work. A DAG of
-**Legs** that cooperate to accomplish something. Replaces the older "attachable
-set" / "new branch" framing.
+A named instance of a workflow — the primary unit of *launched* work. What a
+convoy *declares* is a DAG of **VesselRequirements** — vessels with crew
+rosters, gated by `depends_on` — that cooperate to accomplish something; the
+fine-grained crew workflow is conversational (handoffs, briefs), not declared,
+and **Legs** stay implicit until they materialise *(corrected 2026-07-11, #680
+grill; this entry previously said "a DAG of Legs")*. Replaces the older
+"attachable set" / "new branch" framing.
 _Avoid_: Job, pipeline, attachable set.
 
 **Leg**:
@@ -45,14 +49,18 @@ Step, pod.
 
 **VesselRequirement**:
 A declaration that a **Vessel** matching some abstract requirements (platform,
-capabilities, sandbox quality, affinity) must exist for a **Leg** — the runtime
-primitive placement resolution works on, and the fan-out unit (one requirement
-may materialise several Vessels). Authored by any orchestrator: a workflow
-template, an **orchestrating agent** (tool call), or a human (CLI pins / the
-picker). Templates carry abstract requirements only; launch-time **pins**
-(host=X, reuse hull Y, adopt this checkout) and fleet-level **PlacementPolicy**
-preferences merge at resolution (pins > requirements > policy preferences;
-unsatisfiable = loud failure, no silent fallback).
+capabilities, sandbox quality, affinity) must exist — the runtime primitive
+placement resolution works on. **One requirement ↔ one Vessel (at a time) is
+an invariant**: the requirement is *not* the fan-out unit; fan-out is
+*authored* — an orchestrating agent or embedded script emits several concrete
+requirements with unique names — never a field on the requirement *(amended
+2026-07-11, #680 grill; previously described as "the fan-out unit")*. Authored
+by any orchestrator: a workflow template, an **orchestrating agent** (tool
+call), or a human (CLI pins / the picker). Templates carry abstract
+requirements only; launch-time **pins** (host=X, reuse hull Y, adopt this
+checkout) and fleet-level **PlacementPolicy** preferences merge at resolution
+(pins > requirements > policy preferences; unsatisfiable = loud failure, no
+silent fallback).
 _Avoid_: placement (the act, not the declaration), recipe, target.
 
 **Vessel**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,8 +37,10 @@ routing given to promptable **Crew**, and is materialised by **zero or more
 Vessels** (e.g. one test Leg fanning across four platforms). Completed
 explicitly, not by process exit. Legs may stay out of the UX until workflow
 patterns settle; ad-hoc communication outside the script is not prohibited.
-_Avoid_: Task (retired — it conflated stage with placement; code types such as
-`TaskSummary`/`TaskWorkspace` keep the old name until renamed opportunistically),
+_Avoid_: Task (retired — it conflated stage with placement; the task-era code
+types were renamed in #680: `TaskWorkspace`→`Vessel`, `TaskState`→`WorkState`,
+`SnapshotTask`/`TaskDefinition`→`VesselRequirement`; "leg" appears nowhere in
+code — reserved until Legs materialise, likely as phases of crew activity),
 Step, pod.
 
 **VesselRequirement**:

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -21,8 +21,8 @@ pub struct ConvoyNoun {
 
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum ConvoyVerb {
-    /// Manage convoy legs
-    Leg(ConvoyLegNoun),
+    /// Manage the work aboard a convoy's vessels
+    Work(ConvoyWorkNoun),
     /// Create a convoy from a workflow template
     Create {
         /// Workflow template to instantiate
@@ -62,19 +62,19 @@ fn resolve_adopted_checkout(path: PathBuf) -> Result<Box<PathBuf>, String> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
-pub struct ConvoyLegNoun {
-    /// Leg name
+pub struct ConvoyWorkNoun {
+    /// Vessel (work) name within the convoy
     pub subject: String,
 
     #[command(subcommand)]
-    pub verb: ConvoyLegVerb,
+    pub verb: ConvoyWorkVerb,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
-pub enum ConvoyLegVerb {
-    /// Mark a convoy leg complete
+pub enum ConvoyWorkVerb {
+    /// Mark the work aboard a vessel complete
     Complete {
-        /// Optional completion message recorded on the leg
+        /// Optional completion message recorded on the work entry
         #[arg(long)]
         message: Option<String>,
     },
@@ -83,13 +83,13 @@ pub enum ConvoyLegVerb {
 impl ConvoyNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
         match self.verb {
-            ConvoyVerb::Leg(leg) => match leg.verb {
-                ConvoyLegVerb::Complete { message } => Ok(Resolved::NeedsContext {
+            ConvoyVerb::Work(work) => match work.verb {
+                ConvoyWorkVerb::Complete { message } => Ok(Resolved::NeedsContext {
                     command: Command {
                         node_id: None,
                         provisioning_target: None,
                         context_repo: None,
-                        action: CommandAction::ConvoyLegComplete { convoy: self.subject, leg: leg.subject, message },
+                        action: CommandAction::ConvoyWorkComplete { convoy: self.subject, work: work.subject, message },
                     },
                     repo: RepoContext::None,
                     host: HostResolution::Local,
@@ -124,10 +124,10 @@ impl std::fmt::Display for ConvoyNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "convoy {}", self.subject)?;
         match &self.verb {
-            ConvoyVerb::Leg(leg) => {
-                write!(f, " leg {}", leg.subject)?;
-                match &leg.verb {
-                    ConvoyLegVerb::Complete { message } => {
+            ConvoyVerb::Work(work) => {
+                write!(f, " work {}", work.subject)?;
+                match &work.verb {
+                    ConvoyWorkVerb::Complete { message } => {
                         write!(f, " complete")?;
                         if let Some(message) = message {
                             write!(f, " --message {message}")?;
@@ -178,14 +178,14 @@ mod tests {
     }
 
     #[test]
-    fn convoy_leg_complete_resolves() {
-        let resolved = parse(&["convoy", "convoy-a", "leg", "implement", "complete"]).resolve().expect("resolve");
+    fn convoy_work_complete_resolves() {
+        let resolved = parse(&["convoy", "convoy-a", "work", "implement", "complete"]).resolve().expect("resolve");
         assert_eq!(resolved, Resolved::NeedsContext {
             command: Command {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ConvoyLegComplete { convoy: "convoy-a".into(), leg: "implement".into(), message: None },
+                action: CommandAction::ConvoyWorkComplete { convoy: "convoy-a".into(), work: "implement".into(), message: None },
             },
             repo: RepoContext::None,
             host: HostResolution::Local,
@@ -193,16 +193,16 @@ mod tests {
     }
 
     #[test]
-    fn convoy_leg_complete_with_message_resolves() {
-        let resolved = parse(&["convoy", "convoy-a", "leg", "implement", "complete", "--message", "done"]).resolve().expect("resolve");
+    fn convoy_work_complete_with_message_resolves() {
+        let resolved = parse(&["convoy", "convoy-a", "work", "implement", "complete", "--message", "done"]).resolve().expect("resolve");
         assert_eq!(resolved, Resolved::NeedsContext {
             command: Command {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ConvoyLegComplete {
+                action: CommandAction::ConvoyWorkComplete {
                     convoy: "convoy-a".into(),
-                    leg: "implement".into(),
+                    work: "implement".into(),
                     message: Some("done".into()),
                 },
             },
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn round_trip_complete() {
-        assert_round_trip::<ConvoyNoun>(&["convoy", "convoy-a", "leg", "implement", "complete"]);
+        assert_round_trip::<ConvoyNoun>(&["convoy", "convoy-a", "work", "implement", "complete"]);
     }
 
     #[test]

--- a/crates/flotilla-commands/src/commands/crew.rs
+++ b/crates/flotilla-commands/src/commands/crew.rs
@@ -21,8 +21,9 @@ pub struct CrewNoun {
     pub namespace: Option<String>,
     #[arg(long)]
     pub convoy: Option<String>,
-    #[arg(long)]
-    pub vessel: Option<String>,
+    /// Vessel resource name (e.g. `myconvoy-implement`)
+    #[arg(long = "vessel-ref")]
+    pub vessel_ref: Option<String>,
     #[arg(long)]
     pub role: Option<String>,
 }
@@ -42,7 +43,7 @@ impl CrewNoun {
             .maybe_crew_id(self.crew_id.or(ambient_crew_id))
             .maybe_namespace(self.namespace)
             .maybe_convoy(self.convoy)
-            .maybe_vessel(self.vessel)
+            .maybe_vessel_ref(self.vessel_ref)
             .maybe_role(self.role)
             .build();
         let action = match (self.subject.as_str(), self.verb) {
@@ -70,7 +71,7 @@ impl std::fmt::Display for CrewNoun {
             ("--crew-id", self.crew_id.as_ref()),
             ("--namespace", self.namespace.as_ref()),
             ("--convoy", self.convoy.as_ref()),
-            ("--vessel", self.vessel.as_ref()),
+            ("--vessel-ref", self.vessel_ref.as_ref()),
             ("--role", self.role.as_ref()),
         ] {
             if let Some(value) = value {
@@ -127,7 +128,7 @@ mod tests {
             "flotilla",
             "--convoy",
             "demo",
-            "--vessel",
+            "--vessel-ref",
             "demo-implement",
             "--role",
             "coder",
@@ -138,7 +139,7 @@ mod tests {
                 crew_id: None,
                 namespace: Some("flotilla".into()),
                 convoy: Some("demo".into()),
-                vessel: Some("demo-implement".into()),
+                vessel_ref: Some("demo-implement".into()),
                 role: Some("coder".into()),
             }
         });
@@ -153,7 +154,7 @@ mod tests {
             "flotilla",
             "--convoy",
             "demo",
-            "--vessel",
+            "--vessel-ref",
             "demo-implement",
             "--role",
             "coder",

--- a/crates/flotilla-commands/src/commands/workflow_template.rs
+++ b/crates/flotilla-commands/src/commands/workflow_template.rs
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn apply_reads_file_into_spec_yaml() {
         let tmp = tempfile::NamedTempFile::new().expect("tempfile");
-        std::fs::write(tmp.path(), "tasks: []\n").expect("write");
+        std::fs::write(tmp.path(), "vessels: []\n").expect("write");
         let path = tmp.path().to_string_lossy().to_string();
 
         let resolved = parse(&["workflow-template", "scratch", "apply", "--file", &path]).resolve().expect("resolve");
@@ -87,7 +87,7 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::WorkflowTemplateApply { name: "scratch".into(), spec_yaml: "tasks: []\n".into() },
+                action: CommandAction::WorkflowTemplateApply { name: "scratch".into(), spec_yaml: "vessels: []\n".into() },
             },
             repo: RepoContext::None,
             host: HostResolution::Local,

--- a/crates/flotilla-controllers/src/reconcilers/mod.rs
+++ b/crates/flotilla-controllers/src/reconcilers/mod.rs
@@ -2,8 +2,8 @@ pub mod checkout;
 pub mod clone;
 pub mod environment;
 pub mod presentation;
-pub mod task_workspace;
 pub mod terminal_session;
+pub mod vessel;
 
 pub use checkout::{CheckoutReconciler, CheckoutRuntime};
 pub use clone::{CloneReconciler, CloneRuntime};
@@ -13,5 +13,5 @@ pub use presentation::{
     PresentationPolicy, PresentationPolicyRegistry, PresentationReconciler, PresentationRuntime, PreviousWorkspace,
     ProviderPresentationRuntime, RenderedWorkspace, ResolvedProcess,
 };
-pub use task_workspace::{TaskWorkspaceDeps, TaskWorkspaceReconciler};
 pub use terminal_session::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
+pub use vessel::{VesselDeps, VesselReconciler};

--- a/crates/flotilla-controllers/src/reconcilers/presentation.rs
+++ b/crates/flotilla-controllers/src/reconcilers/presentation.rs
@@ -40,7 +40,7 @@ pub trait PresentationRuntime: Send + Sync {
 pub struct PresentationPlan {
     pub policy: String,
     pub name: String,
-    pub processes: Vec<ResolvedProcess>,
+    pub crew: Vec<ResolvedProcess>,
     pub presentation_local_cwd: ExecutionEnvironmentPath,
     pub previous: Option<PreviousWorkspace>,
     pub spec_hash: String,
@@ -366,7 +366,7 @@ where
         let plan = PresentationPlan {
             policy: obj.spec.presentation_policy_ref.clone(),
             name: obj.spec.name.clone(),
-            processes,
+            crew: processes,
             presentation_local_cwd: self.hop_chain.presentation_local_cwd(),
             previous,
             spec_hash,
@@ -439,10 +439,8 @@ impl PresentationRuntime for ProviderPresentationRuntime {
             .presentation_managers
             .preferred_with_desc()
             .ok_or_else(|| ApplyPresentationError::Failed("no presentation manager configured".to_string()))?;
-        let rendered = policy.render(&plan.processes, &PolicyContext {
-            name: plan.name.clone(),
-            presentation_local_cwd: plan.presentation_local_cwd.clone(),
-        });
+        let rendered = policy
+            .render(&plan.crew, &PolicyContext { name: plan.name.clone(), presentation_local_cwd: plan.presentation_local_cwd.clone() });
 
         let mut tore_down_previous = false;
         if let Some(previous) = &plan.previous {
@@ -578,8 +576,8 @@ fn has_any_observed_state(status: Option<&PresentationStatus>) -> bool {
 
 fn session_sort_key(session: &ResourceObject<TerminalSession>) -> (&str, &str, &str) {
     (
-        session.metadata.labels.get(flotilla_resources::TASK_ORDINAL_LABEL).map(String::as_str).unwrap_or(""),
-        session.metadata.labels.get(flotilla_resources::PROCESS_ORDINAL_LABEL).map(String::as_str).unwrap_or(""),
+        session.metadata.labels.get(flotilla_resources::VESSEL_ORDINAL_LABEL).map(String::as_str).unwrap_or(""),
+        session.metadata.labels.get(flotilla_resources::CREW_ORDINAL_LABEL).map(String::as_str).unwrap_or(""),
         session.metadata.name.as_str(),
     )
 }

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -8,18 +8,18 @@ use flotilla_resources::{
         delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
     },
     descriptive_repo_slug, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
-    DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec,
-    FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority,
-    OwnerReference, PlacementPolicy, PlacementPolicySpec, ProcessSource, Resource, ResourceBackend, ResourceError, ResourceObject,
-    TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceStatusPatch, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase,
-    TerminalSessionSpec, TypedResolver, TASK_WORKSPACE_LABEL,
+    CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase,
+    EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
+    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Resource, ResourceBackend, ResourceError, ResourceObject,
+    TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase,
+    VesselStatusPatch, VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
 const REPO_LABEL: &str = "flotilla.work/repo";
 const ENV_LABEL: &str = "flotilla.work/env";
 
-pub struct TaskWorkspaceReconciler {
+pub struct VesselReconciler {
     convoys: TypedResolver<Convoy>,
     placement_policies: TypedResolver<PlacementPolicy>,
     environments: TypedResolver<Environment>,
@@ -29,7 +29,7 @@ pub struct TaskWorkspaceReconciler {
     namespace: String,
 }
 
-impl TaskWorkspaceReconciler {
+impl VesselReconciler {
     pub fn new(backend: ResourceBackend, namespace: &str) -> Self {
         Self {
             convoys: backend.clone().using::<Convoy>(namespace),
@@ -42,12 +42,12 @@ impl TaskWorkspaceReconciler {
         }
     }
 
-    pub fn secondary_watches() -> Vec<Box<dyn SecondaryWatch<Primary = TaskWorkspace>>> {
+    pub fn secondary_watches() -> Vec<Box<dyn SecondaryWatch<Primary = Vessel>>> {
         vec![
-            Box::new(LabelMappedWatch::<Environment, TaskWorkspace> { label_key: TASK_WORKSPACE_LABEL, _marker: PhantomData }),
-            Box::new(LabelMappedWatch::<Checkout, TaskWorkspace> { label_key: TASK_WORKSPACE_LABEL, _marker: PhantomData }),
-            Box::new(LabelMappedWatch::<TerminalSession, TaskWorkspace> { label_key: TASK_WORKSPACE_LABEL, _marker: PhantomData }),
-            Box::new(LabelJoinWatch::<Clone, TaskWorkspace> { label_key: REPO_KEY_LABEL, _marker: PhantomData }),
+            Box::new(LabelMappedWatch::<Environment, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
+            Box::new(LabelMappedWatch::<Checkout, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
+            Box::new(LabelMappedWatch::<TerminalSession, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
+            Box::new(LabelJoinWatch::<Clone, Vessel> { label_key: REPO_KEY_LABEL, _marker: PhantomData }),
         ]
     }
 }
@@ -85,21 +85,17 @@ enum PlannedPatch {
 }
 
 #[derive(Debug, Clone)]
-pub struct TaskWorkspaceDeps {
+pub struct VesselDeps {
     patch: PlannedPatch,
     actuations: Vec<Actuation>,
 }
 
-impl TaskWorkspaceDeps {
+impl VesselDeps {
     fn none() -> Self {
         Self { patch: PlannedPatch::None, actuations: Vec::new() }
     }
 
-    fn provisioning(
-        obj: &ResourceObject<TaskWorkspace>,
-        placement_policy: &ResourceObject<PlacementPolicy>,
-        actuations: Vec<Actuation>,
-    ) -> Self {
+    fn provisioning(obj: &ResourceObject<Vessel>, placement_policy: &ResourceObject<PlacementPolicy>, actuations: Vec<Actuation>) -> Self {
         Self { patch: provisioning_patch(obj, placement_policy), actuations }
     }
 
@@ -112,55 +108,53 @@ impl TaskWorkspaceDeps {
     }
 }
 
-impl Reconciler for TaskWorkspaceReconciler {
-    type Resource = TaskWorkspace;
-    type Dependencies = TaskWorkspaceDeps;
+impl Reconciler for VesselReconciler {
+    type Resource = Vessel;
+    type Dependencies = VesselDeps;
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
-        if obj.status.as_ref().map(|status| status.phase) == Some(TaskWorkspacePhase::Failed) {
-            return Ok(TaskWorkspaceDeps::none());
+        if obj.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed) {
+            return Ok(VesselDeps::none());
         }
 
         let convoy = match self.convoys.get(&obj.spec.convoy_ref).await {
             Ok(convoy) => convoy,
-            Err(ResourceError::NotFound { .. }) => {
-                return Ok(TaskWorkspaceDeps::failed(format!("convoy {} not found", obj.spec.convoy_ref)))
-            }
+            Err(ResourceError::NotFound { .. }) => return Ok(VesselDeps::failed(format!("convoy {} not found", obj.spec.convoy_ref))),
             Err(err) => return Err(err),
         };
         let placement_policy = match self.placement_policies.get(&obj.spec.placement_policy_ref).await {
             Ok(policy) => policy,
             Err(ResourceError::NotFound { .. }) => {
-                return Ok(TaskWorkspaceDeps::failed(format!("placement policy {} not found", obj.spec.placement_policy_ref)))
+                return Ok(VesselDeps::failed(format!("placement policy {} not found", obj.spec.placement_policy_ref)))
             }
             Err(err) => return Err(err),
         };
         let strategy = match placement_strategy(&placement_policy.spec) {
             Ok(strategy) => strategy,
-            Err(message) => return Ok(TaskWorkspaceDeps::failed(message)),
+            Err(message) => return Ok(VesselDeps::failed(message)),
         };
 
         let (task_index, task) = match convoy
             .status
             .as_ref()
             .and_then(|status| status.workflow_snapshot.as_ref())
-            .and_then(|snapshot| snapshot.tasks.iter().enumerate().find(|(_, task)| task.name == obj.spec.task))
+            .and_then(|snapshot| snapshot.vessels.iter().enumerate().find(|(_, vessel)| vessel.name == obj.spec.vessel_name))
         {
             Some((task_index, task)) => (task_index, task),
-            None => return Ok(TaskWorkspaceDeps::failed(format!("task {} missing from convoy snapshot", obj.spec.task))),
+            None => return Ok(VesselDeps::failed(format!("vessel {} missing from convoy snapshot", obj.spec.vessel_name))),
         };
 
         let repo_url = match convoy.spec.repository.as_ref().map(|repository| repository.url.clone()) {
             Some(url) => url,
-            None => return Ok(TaskWorkspaceDeps::failed("convoy repository URL is missing".to_string())),
+            None => return Ok(VesselDeps::failed("convoy repository URL is missing".to_string())),
         };
         let git_ref = match convoy.spec.r#ref.clone() {
             Some(git_ref) => git_ref,
-            None => return Ok(TaskWorkspaceDeps::failed("convoy ref is missing".to_string())),
+            None => return Ok(VesselDeps::failed("convoy ref is missing".to_string())),
         };
         let canonical_repo = match canonicalize_repo_url(&repo_url) {
             Ok(url) => url,
-            Err(err) => return Ok(TaskWorkspaceDeps::failed(err)),
+            Err(err) => return Ok(VesselDeps::failed(err)),
         };
         let repo_key = repo_key(&canonical_repo);
         let repo_slug = descriptive_repo_slug(&canonical_repo);
@@ -173,16 +167,16 @@ impl Reconciler for TaskWorkspaceReconciler {
             let clone_env = match self.environments.get(&clone_env_ref).await {
                 Ok(environment) => environment,
                 Err(ResourceError::NotFound { .. }) => {
-                    return Ok(TaskWorkspaceDeps::failed(format!("host-direct environment {clone_env_ref} not found")))
+                    return Ok(VesselDeps::failed(format!("host-direct environment {clone_env_ref} not found")))
                 }
                 Err(err) => return Err(err),
             };
             let clone_env_spec = match clone_env.spec.host_direct.as_ref() {
                 Some(spec) => spec,
-                None => return Ok(TaskWorkspaceDeps::failed(format!("environment {clone_env_ref} is not a host_direct environment"))),
+                None => return Ok(VesselDeps::failed(format!("environment {clone_env_ref} is not a host_direct environment"))),
             };
             if clone_env.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
             }
 
             let clone_name = format!("clone-{}", clone_key(&canonical_repo, &clone_env_ref));
@@ -191,10 +185,10 @@ impl Reconciler for TaskWorkspaceReconciler {
                 Ok(existing) => {
                     let existing_repo = match canonicalize_repo_url(&existing.spec.url) {
                         Ok(url) => url,
-                        Err(err) => return Ok(TaskWorkspaceDeps::failed(err)),
+                        Err(err) => return Ok(VesselDeps::failed(err)),
                     };
                     if existing_repo != canonical_repo || existing.spec.env_ref != clone_env_ref {
-                        return Ok(TaskWorkspaceDeps::failed(format!("clone {clone_name} does not match expected repo/env tuple")));
+                        return Ok(VesselDeps::failed(format!("clone {clone_name} does not match expected repo/env tuple")));
                     }
                     if existing.status.as_ref().map(|status| status.phase) == Some(ClonePhase::Failed) {
                         let message = existing
@@ -202,10 +196,10 @@ impl Reconciler for TaskWorkspaceReconciler {
                             .as_ref()
                             .and_then(|status| status.message.clone())
                             .unwrap_or_else(|| format!("clone {clone_name} failed"));
-                        return Ok(TaskWorkspaceDeps::failed(message));
+                        return Ok(VesselDeps::failed(message));
                     }
                     if existing.status.as_ref().map(|status| status.phase) != Some(ClonePhase::Ready) {
-                        return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                        return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                     }
                 }
                 Err(ResourceError::NotFound { .. }) => {
@@ -220,7 +214,7 @@ impl Reconciler for TaskWorkspaceReconciler {
                             .build(),
                         spec: CloneSpec { url: repo_url.clone(), env_ref: clone_env_ref.clone(), path: clone_path },
                     });
-                    return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                    return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                 }
                 Err(err) => return Err(err),
             }
@@ -241,10 +235,10 @@ impl Reconciler for TaskWorkspaceReconciler {
                                 .as_ref()
                                 .and_then(|status| status.message.clone())
                                 .unwrap_or_else(|| format!("environment {env_name} failed"));
-                            return Ok(TaskWorkspaceDeps::failed(message));
+                            return Ok(VesselDeps::failed(message));
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                            return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                            return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                         }
                     }
                     Err(ResourceError::NotFound { .. }) => {
@@ -260,7 +254,7 @@ impl Reconciler for TaskWorkspaceReconciler {
                                 }),
                             },
                         });
-                        return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                        return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                     }
                     Err(err) => return Err(err),
                 }
@@ -275,13 +269,13 @@ impl Reconciler for TaskWorkspaceReconciler {
                 let clone_env = match self.environments.get(&clone_env_ref).await {
                     Ok(environment) => environment,
                     Err(ResourceError::NotFound { .. }) => {
-                        return Ok(TaskWorkspaceDeps::failed(format!("host-direct environment {clone_env_ref} not found")))
+                        return Ok(VesselDeps::failed(format!("host-direct environment {clone_env_ref} not found")))
                     }
                     Err(err) => return Err(err),
                 };
                 let clone_env_spec = match clone_env.spec.host_direct.as_ref() {
                     Some(spec) => spec,
-                    None => return Ok(TaskWorkspaceDeps::failed(format!("environment {clone_env_ref} is not a host_direct environment"))),
+                    None => return Ok(VesselDeps::failed(format!("environment {clone_env_ref} is not a host_direct environment"))),
                 };
                 checkout_target_path(&clone_env_spec.repo_default_dir, &repo_slug, &obj.metadata.name)
             }
@@ -292,7 +286,7 @@ impl Reconciler for TaskWorkspaceReconciler {
         match self.checkouts.get(&checkout_name).await {
             Ok(existing) => {
                 if adopted_checkout_ref.is_some() && existing.metadata.lifecycle_authority()? != Some(LifecycleAuthority::Adopted) {
-                    return Ok(TaskWorkspaceDeps::failed(format!("checkout {checkout_name} is not adopted")));
+                    return Ok(VesselDeps::failed(format!("checkout {checkout_name} is not adopted")));
                 }
                 if existing.status.as_ref().map(|status| status.phase) == Some(CheckoutPhase::Failed) {
                     let message = existing
@@ -300,7 +294,7 @@ impl Reconciler for TaskWorkspaceReconciler {
                         .as_ref()
                         .and_then(|status| status.message.clone())
                         .unwrap_or_else(|| format!("checkout {checkout_name} failed"));
-                    return Ok(TaskWorkspaceDeps::failed(message));
+                    return Ok(VesselDeps::failed(message));
                 }
                 if existing.status.as_ref().map(|status| status.phase) == Some(CheckoutPhase::Ready) {
                     let Some(path) = existing
@@ -309,16 +303,16 @@ impl Reconciler for TaskWorkspaceReconciler {
                         .and_then(|status| status.path.clone())
                         .or_else(|| existing.spec.target_path().map(str::to_string))
                     else {
-                        return Ok(TaskWorkspaceDeps::failed(format!("checkout {checkout_name} is ready but has no target path")));
+                        return Ok(VesselDeps::failed(format!("checkout {checkout_name} is ready but has no target path")));
                     };
                     checkout_ready_path = path;
                 } else {
-                    return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                    return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                 }
             }
             Err(ResourceError::NotFound { .. }) => {
                 if adopted_checkout_ref.is_some() {
-                    return Ok(TaskWorkspaceDeps::failed(format!("adopted checkout {checkout_name} not found")));
+                    return Ok(VesselDeps::failed(format!("adopted checkout {checkout_name} not found")));
                 }
                 let spec = match &strategy {
                     PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
@@ -341,7 +335,7 @@ impl Reconciler for TaskWorkspaceReconciler {
                     meta: owned_child_meta(&checkout_name, obj, BTreeMap::from([(ENV_LABEL.to_string(), env_ref)])),
                     spec,
                 });
-                return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
             }
             Err(err) => return Err(err),
         }
@@ -352,15 +346,15 @@ impl Reconciler for TaskWorkspaceReconciler {
                 let environment = match self.environments.get(&env_name).await {
                     Ok(environment) => environment,
                     Err(ResourceError::NotFound { .. }) => {
-                        return Ok(TaskWorkspaceDeps::failed(format!("host-direct environment {env_name} not found")))
+                        return Ok(VesselDeps::failed(format!("host-direct environment {env_name} not found")))
                     }
                     Err(err) => return Err(err),
                 };
                 if environment.status.as_ref().map(|status| status.phase) == Some(EnvironmentPhase::Failed) {
-                    return Ok(TaskWorkspaceDeps::failed(format!("environment {env_name} failed")));
+                    return Ok(VesselDeps::failed(format!("environment {env_name} failed")));
                 }
                 if environment.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                    return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                    return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                 }
                 env_name
             }
@@ -374,10 +368,10 @@ impl Reconciler for TaskWorkspaceReconciler {
                                 .as_ref()
                                 .and_then(|status| status.message.clone())
                                 .unwrap_or_else(|| format!("environment {env_name} failed"));
-                            return Ok(TaskWorkspaceDeps::failed(message));
+                            return Ok(VesselDeps::failed(message));
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                            return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                            return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                         }
                     }
                     Err(ResourceError::NotFound { .. }) => {
@@ -397,7 +391,7 @@ impl Reconciler for TaskWorkspaceReconciler {
                                 }),
                             },
                         });
-                        return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                        return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                     }
                     Err(err) => return Err(err),
                 }
@@ -408,17 +402,17 @@ impl Reconciler for TaskWorkspaceReconciler {
             }
         };
 
-        let first_agent_index = task.processes.iter().position(|process| matches!(process.source, ProcessSource::Agent { .. }));
+        let first_agent_index = task.crew.iter().position(|process| matches!(process.source, CrewSource::Agent { .. }));
         let mut terminal_refs = Vec::new();
-        for (process_index, process) in task.processes.iter().enumerate() {
-            let should_start = matches!(process.source, ProcessSource::Tool { .. }) || first_agent_index == Some(process_index);
+        for (process_index, process) in task.crew.iter().enumerate() {
+            let should_start = matches!(process.source, CrewSource::Tool { .. }) || first_agent_index == Some(process_index);
             let identity = TerminalSessionIdentity::builder()
-                .vessel(obj.metadata.name.clone())
+                .vessel_ref(obj.metadata.name.clone())
                 .convoy(obj.spec.convoy_ref.clone())
-                .leg(obj.spec.task.clone())
+                .vessel(obj.spec.vessel_name.clone())
                 .role(process.role.clone())
-                .task_index(task_index)
-                .process_index(process_index)
+                .vessel_index(task_index)
+                .crew_index(process_index)
                 .labels(process.labels.clone())
                 .build();
             let terminal_name = identity.name();
@@ -427,20 +421,20 @@ impl Reconciler for TaskWorkspaceReconciler {
                     terminal_refs.push(terminal_name.clone());
                     let phase = existing.status.as_ref().map(|status| status.phase);
                     if phase == Some(TerminalSessionPhase::Failed)
-                        || (phase == Some(TerminalSessionPhase::Stopped) && matches!(process.source, ProcessSource::Tool { .. }))
+                        || (phase == Some(TerminalSessionPhase::Stopped) && matches!(process.source, CrewSource::Tool { .. }))
                     {
                         let message = existing
                             .status
                             .as_ref()
                             .and_then(|status| status.message.clone())
                             .unwrap_or_else(|| format!("terminal session {terminal_name} stopped"));
-                        return Ok(TaskWorkspaceDeps::failed(message));
+                        return Ok(VesselDeps::failed(message));
                     }
                     if phase == Some(TerminalSessionPhase::Stopped) {
                         continue;
                     }
                     if should_start && phase != Some(TerminalSessionPhase::Running) {
-                        return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                        return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                     }
                 }
                 Err(ResourceError::NotFound { .. }) => {
@@ -448,31 +442,31 @@ impl Reconciler for TaskWorkspaceReconciler {
                         continue;
                     }
                     let source = match &process.source {
-                        ProcessSource::Tool { command } => flotilla_resources::TerminalSessionSource::Tool { command: command.clone() },
-                        ProcessSource::Agent { selector, prompt } => {
+                        CrewSource::Tool { command } => flotilla_resources::TerminalSessionSource::Tool { command: command.clone() },
+                        CrewSource::Agent { selector, prompt } => {
                             let context = flotilla_resources::TerminalCrewContext {
                                 namespace: self.namespace.clone(),
                                 convoy: obj.spec.convoy_ref.clone(),
-                                vessel: obj.metadata.name.clone(),
+                                vessel_ref: obj.metadata.name.clone(),
                             };
                             let members = task
-                                .processes
+                                .crew
                                 .iter()
                                 .enumerate()
                                 .map(|(index, member)| CrewBriefMember {
                                     role: member.role.clone(),
-                                    state: if matches!(member.source, ProcessSource::Tool { .. }) || first_agent_index == Some(index) {
+                                    state: if matches!(member.source, CrewSource::Tool { .. }) || first_agent_index == Some(index) {
                                         "active"
                                     } else {
                                         "latent"
                                     }
                                     .to_string(),
-                                    is_agent: matches!(member.source, ProcessSource::Agent { .. }),
+                                    is_agent: matches!(member.source, CrewSource::Agent { .. }),
                                 })
                                 .collect::<Vec<_>>();
                             flotilla_resources::TerminalSessionSource::Agent {
                                 selector: selector.clone(),
-                                brief: build_crew_brief(&context, &obj.spec.task, &process.role, prompt.as_deref(), &members),
+                                brief: build_crew_brief(&context, &obj.spec.vessel_name, &process.role, prompt.as_deref(), &members),
                                 context,
                                 message: None,
                             }
@@ -488,13 +482,13 @@ impl Reconciler for TaskWorkspaceReconciler {
                             pool: strategy.pool().to_string(),
                         },
                     });
-                    return Ok(TaskWorkspaceDeps::provisioning(obj, &placement_policy, actuations));
+                    return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                 }
                 Err(err) => return Err(err),
             }
         }
 
-        Ok(TaskWorkspaceDeps::ready(resolved_environment_ref, checkout_name, terminal_refs, actuations))
+        Ok(VesselDeps::ready(resolved_environment_ref, checkout_name, terminal_refs, actuations))
     }
 
     fn reconcile(
@@ -505,27 +499,25 @@ impl Reconciler for TaskWorkspaceReconciler {
     ) -> ReconcileOutcome<Self::Resource> {
         let patch = match &deps.patch {
             PlannedPatch::None => None,
-            PlannedPatch::Provisioning { observed_policy_ref, observed_policy_version } => {
-                Some(TaskWorkspaceStatusPatch::MarkProvisioning {
-                    observed_policy_ref: observed_policy_ref.clone(),
-                    observed_policy_version: observed_policy_version.clone(),
-                    started_at: now,
-                })
-            }
-            PlannedPatch::Ready { environment_ref, checkout_ref, terminal_session_refs } => Some(TaskWorkspaceStatusPatch::MarkReady {
+            PlannedPatch::Provisioning { observed_policy_ref, observed_policy_version } => Some(VesselStatusPatch::MarkProvisioning {
+                observed_policy_ref: observed_policy_ref.clone(),
+                observed_policy_version: observed_policy_version.clone(),
+                started_at: now,
+            }),
+            PlannedPatch::Ready { environment_ref, checkout_ref, terminal_session_refs } => Some(VesselStatusPatch::MarkReady {
                 environment_ref: Some(environment_ref.clone()),
                 checkout_ref: Some(checkout_ref.clone()),
                 terminal_session_refs: terminal_session_refs.clone(),
                 ready_at: now,
             }),
-            PlannedPatch::Failed { message } => Some(TaskWorkspaceStatusPatch::MarkFailed { message: message.clone() }),
+            PlannedPatch::Failed { message } => Some(VesselStatusPatch::MarkFailed { message: message.clone() }),
         };
 
         ReconcileOutcome::with_actuations(patch, deps.actuations.clone())
     }
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
-        let selector = BTreeMap::from([(TASK_WORKSPACE_LABEL.to_string(), obj.metadata.name.clone())]);
+        let selector = BTreeMap::from([(VESSEL_REF_LABEL.to_string(), obj.metadata.name.clone())]);
 
         delete_lifecycle_owned_matching(&self.terminal_sessions, &selector).await?;
         delete_lifecycle_owned_matching(&self.checkouts, &selector).await?;
@@ -535,7 +527,7 @@ impl Reconciler for TaskWorkspaceReconciler {
     }
 
     fn finalizer_name(&self) -> Option<&'static str> {
-        Some("flotilla.work/task-workspace-teardown")
+        Some("flotilla.work/vessel-workspace-teardown")
     }
 }
 
@@ -568,8 +560,8 @@ fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, S
     Err("placement policy must define exactly one supported strategy".to_string())
 }
 
-fn provisioning_patch(obj: &ResourceObject<TaskWorkspace>, placement_policy: &ResourceObject<PlacementPolicy>) -> PlannedPatch {
-    if obj.status.as_ref().map(|status| status.phase) == Some(TaskWorkspacePhase::Provisioning) {
+fn provisioning_patch(obj: &ResourceObject<Vessel>, placement_policy: &ResourceObject<PlacementPolicy>) -> PlannedPatch {
+    if obj.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Provisioning) {
         PlannedPatch::None
     } else {
         PlannedPatch::Provisioning {
@@ -583,26 +575,26 @@ fn host_direct_environment_name(host_ref: &str) -> String {
     format!("host-direct-{host_ref}")
 }
 
-fn environment_name(task_workspace_name: &str) -> String {
-    format!("env-{task_workspace_name}")
+fn environment_name(vessel_name: &str) -> String {
+    format!("env-{vessel_name}")
 }
 
-fn checkout_name(task_workspace_name: &str) -> String {
-    format!("checkout-{task_workspace_name}")
+fn checkout_name(vessel_name: &str) -> String {
+    format!("checkout-{vessel_name}")
 }
 
-fn checkout_target_path(repo_default_dir: &str, repo_slug: &str, task_workspace_name: &str) -> String {
-    format!("{}/{}.{}", repo_default_dir.trim_end_matches('/'), repo_slug, task_workspace_name)
+fn checkout_target_path(repo_default_dir: &str, repo_slug: &str, vessel_name: &str) -> String {
+    format!("{}/{}.{}", repo_default_dir.trim_end_matches('/'), repo_slug, vessel_name)
 }
 
-fn owned_child_meta(name: &str, workspace: &ResourceObject<TaskWorkspace>, mut extra_labels: BTreeMap<String, String>) -> InputMeta {
-    extra_labels.insert(TASK_WORKSPACE_LABEL.to_string(), workspace.metadata.name.clone());
+fn owned_child_meta(name: &str, workspace: &ResourceObject<Vessel>, mut extra_labels: BTreeMap<String, String>) -> InputMeta {
+    extra_labels.insert(VESSEL_REF_LABEL.to_string(), workspace.metadata.name.clone());
     InputMeta::builder()
         .name(name.to_string())
         .labels(extra_labels)
         .owner_references(vec![OwnerReference {
-            api_version: format!("{}/{}", TaskWorkspace::API_PATHS.group, TaskWorkspace::API_PATHS.version),
-            kind: TaskWorkspace::API_PATHS.kind.to_string(),
+            api_version: format!("{}/{}", Vessel::API_PATHS.group, Vessel::API_PATHS.version),
+            kind: Vessel::API_PATHS.kind.to_string(),
             name: workspace.metadata.name.clone(),
             controller: true,
         }])

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -134,13 +134,13 @@ impl Reconciler for VesselReconciler {
             Err(message) => return Ok(VesselDeps::failed(message)),
         };
 
-        let (task_index, task) = match convoy
+        let (vessel_index, requirement) = match convoy
             .status
             .as_ref()
             .and_then(|status| status.workflow_snapshot.as_ref())
             .and_then(|snapshot| snapshot.vessels.iter().enumerate().find(|(_, vessel)| vessel.name == obj.spec.vessel_name))
         {
-            Some((task_index, task)) => (task_index, task),
+            Some((vessel_index, requirement)) => (vessel_index, requirement),
             None => return Ok(VesselDeps::failed(format!("vessel {} missing from convoy snapshot", obj.spec.vessel_name))),
         };
 
@@ -402,17 +402,17 @@ impl Reconciler for VesselReconciler {
             }
         };
 
-        let first_agent_index = task.crew.iter().position(|process| matches!(process.source, CrewSource::Agent { .. }));
+        let first_agent_index = requirement.crew.iter().position(|process| matches!(process.source, CrewSource::Agent { .. }));
         let mut terminal_refs = Vec::new();
-        for (process_index, process) in task.crew.iter().enumerate() {
-            let should_start = matches!(process.source, CrewSource::Tool { .. }) || first_agent_index == Some(process_index);
+        for (crew_index, process) in requirement.crew.iter().enumerate() {
+            let should_start = matches!(process.source, CrewSource::Tool { .. }) || first_agent_index == Some(crew_index);
             let identity = TerminalSessionIdentity::builder()
                 .vessel_ref(obj.metadata.name.clone())
                 .convoy(obj.spec.convoy_ref.clone())
                 .vessel(obj.spec.vessel_name.clone())
                 .role(process.role.clone())
-                .vessel_index(task_index)
-                .crew_index(process_index)
+                .vessel_index(vessel_index)
+                .crew_index(crew_index)
                 .labels(process.labels.clone())
                 .build();
             let terminal_name = identity.name();
@@ -449,7 +449,7 @@ impl Reconciler for VesselReconciler {
                                 convoy: obj.spec.convoy_ref.clone(),
                                 vessel_ref: obj.metadata.name.clone(),
                             };
-                            let members = task
+                            let members = requirement
                                 .crew
                                 .iter()
                                 .enumerate()

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -5,11 +5,11 @@ use std::{collections::BTreeMap, future::Future, time::Duration};
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     canonicalize_repo_url, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, Clone, ClonePhase, CloneSpec, CloneStatus,
-    Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, DockerCheckoutStrategy, DockerEnvironmentSpec,
+    Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
     DockerPerTaskPlacementPolicySpec, Environment, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus, HostDirectEnvironmentSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, PlacementPolicy, PlacementPolicySpec, ProcessDefinition,
-    ProcessSource, ResourceBackend, SnapshotTask, TaskWorkspace, TaskWorkspaceSpec, TerminalSession, TerminalSessionPhase,
-    TerminalSessionSpec, TerminalSessionStatus, WorkflowSnapshot,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend,
+    TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec,
+    WorkflowSnapshot,
 };
 use tokio::{
     task::JoinHandle,
@@ -43,7 +43,7 @@ pub fn labeled_meta(name: &str, labels: impl IntoIterator<Item = (String, String
     controller_meta().name(name).labels(labels.into_iter().collect()).call()
 }
 
-pub fn task_workspace_meta(name: &str, repo_url: &str) -> InputMeta {
+pub fn vessel_meta(name: &str, repo_url: &str) -> InputMeta {
     let canonical_repo = canonicalize_repo_url(repo_url).expect("repo URL should canonicalize");
     controller_meta().name(name).labels([("flotilla.work/repo-key".to_string(), repo_key(&canonical_repo))].into_iter().collect()).call()
 }
@@ -72,12 +72,12 @@ pub async fn create_convoy_with_single_task(
     convoys
         .update_status(name, &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
-                tasks: vec![SnapshotTask {
+                vessels: vec![VesselRequirement {
                     name: task.to_string(),
                     depends_on: Vec::new(),
-                    processes: vec![ProcessDefinition::builder()
+                    crew: vec![CrewSpec::builder()
                         .role("coder".to_string())
-                        .source(ProcessSource::Tool { command: "cargo test".to_string() })
+                        .source(CrewSource::Tool { command: "cargo test".to_string() })
                         .build()],
                 }],
             }),
@@ -96,12 +96,12 @@ pub async fn create_workspace(
     task: &str,
     placement_policy_ref: &str,
     repo_url: &str,
-) -> flotilla_resources::ResourceObject<TaskWorkspace> {
-    let workspaces = backend.clone().using::<TaskWorkspace>(namespace);
+) -> flotilla_resources::ResourceObject<Vessel> {
+    let workspaces = backend.clone().using::<Vessel>(namespace);
     workspaces
-        .create(&task_workspace_meta(name, repo_url), &TaskWorkspaceSpec {
+        .create(&vessel_meta(name, repo_url), &VesselSpec {
             convoy_ref: convoy_ref.to_string(),
-            task: task.to_string(),
+            vessel_name: task.to_string(),
             placement_policy_ref: placement_policy_ref.to_string(),
             adopted_checkout_ref: None,
         })

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -28,8 +28,8 @@ use flotilla_protocol::arg::Arg;
 use flotilla_resources::{
     controller::Reconciler, Environment, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, Host, HostDirectEnvironmentSpec,
     HostSpec, HostStatus, HostStatusPatch, Presentation, PresentationSpec, PresentationStatus, PresentationStatusPatch, ResourceBackend,
-    StatusPatch, TerminalSession, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, CONVOY_LABEL,
-    PROCESS_ORDINAL_LABEL, TASK_ORDINAL_LABEL,
+    StatusPatch, TerminalSession, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, CONVOY_LABEL, CREW_ORDINAL_LABEL,
+    VESSEL_ORDINAL_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -175,8 +175,8 @@ async fn first_apply_marks_presentation_active() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
         ]),
     )
     .await;
@@ -189,8 +189,8 @@ async fn first_apply_marks_presentation_active() {
 
     let plan = runtime.apply_calls.lock().expect("apply calls lock").clone();
     assert_eq!(plan.len(), 1);
-    assert_eq!(plan[0].processes.len(), 1);
-    assert_eq!(plan[0].processes[0].attach_command, "attach term-a");
+    assert_eq!(plan[0].crew.len(), 1);
+    assert_eq!(plan[0].crew[0].attach_command, "attach term-a");
     assert!(matches!(
         outcome.patch,
         Some(PresentationStatusPatch::MarkActive { ref presentation_manager, ref workspace_ref, .. })
@@ -209,8 +209,8 @@ async fn presentation_uses_running_sessions_and_ignores_stopped_crew() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
         ]),
     )
     .await;
@@ -220,8 +220,8 @@ async fn presentation_uses_running_sessions_and_ignores_stopped_crew() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "001".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "001".to_string()),
         ]),
     )
     .await;
@@ -234,8 +234,8 @@ async fn presentation_uses_running_sessions_and_ignores_stopped_crew() {
 
     let apply_calls = runtime.apply_calls.lock().expect("apply calls lock");
     assert_eq!(apply_calls.len(), 1);
-    assert_eq!(apply_calls[0].processes.len(), 1);
-    assert_eq!(apply_calls[0].processes[0].attach_command, "attach term-running");
+    assert_eq!(apply_calls[0].crew.len(), 1);
+    assert_eq!(apply_calls[0].crew[0].attach_command, "attach term-running");
 }
 
 #[tokio::test]
@@ -249,8 +249,8 @@ async fn unchanged_world_is_a_no_op() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
         ]),
     )
     .await;
@@ -283,8 +283,8 @@ async fn sorted_session_determinism_uses_task_and_process_ordinals() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "001".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "001".to_string()),
         ]),
     )
     .await;
@@ -294,8 +294,8 @@ async fn sorted_session_determinism_uses_task_and_process_ordinals() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
         ]),
     )
     .await;
@@ -306,7 +306,7 @@ async fn sorted_session_determinism_uses_task_and_process_ordinals() {
     reconciler.fetch_dependencies(&presentation).await.expect("deps should load");
 
     let apply_calls = runtime.apply_calls.lock().expect("apply calls lock");
-    assert_eq!(apply_calls[0].processes.iter().map(|process| process.attach_command.as_str()).collect::<Vec<_>>(), vec![
+    assert_eq!(apply_calls[0].crew.iter().map(|process| process.attach_command.as_str()).collect::<Vec<_>>(), vec![
         "attach term-a",
         "attach term-b"
     ]);
@@ -348,8 +348,8 @@ async fn retry_from_clean_slate_clears_previous_workspace_before_retry() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
         ]),
     )
     .await;
@@ -405,8 +405,8 @@ async fn unknown_policy_fails_without_runtime_invocation() {
         "env-a",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
         ]),
     )
     .await;
@@ -461,8 +461,8 @@ async fn working_directory_fallback_is_separate_from_session_cwd() {
         "docker-env",
         BTreeMap::from([
             (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-            (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-            (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
         ]),
     )
     .await;
@@ -476,8 +476,8 @@ async fn working_directory_fallback_is_separate_from_session_cwd() {
     let plan = &apply_calls[0];
     assert_eq!(plan.presentation_local_cwd.as_path(), dirs::home_dir().expect("home dir").as_path());
     assert_ne!(plan.presentation_local_cwd.as_path(), PathBuf::from("/workspace/repo").as_path());
-    assert!(plan.processes[0].attach_command.contains("/workspace/repo"));
-    assert!(plan.processes[0].attach_command.contains("container-docker-env"));
+    assert!(plan.crew[0].attach_command.contains("/workspace/repo"));
+    assert!(plan.crew[0].attach_command.contains("container-docker-env"));
 }
 
 #[tokio::test]
@@ -503,7 +503,7 @@ async fn provider_runtime_replaces_across_managers() {
         .apply(&PresentationPlan {
             policy: "default".to_string(),
             name: "convoy-a".to_string(),
-            processes: vec![resolved_process("main", "attach term-a")],
+            crew: vec![resolved_process("main", "attach term-a")],
             presentation_local_cwd: flotilla_core::path_context::ExecutionEnvironmentPath::new("/tmp"),
             previous: Some(flotilla_controllers::reconcilers::PreviousWorkspace {
                 presentation_manager: "old".to_string(),
@@ -543,7 +543,7 @@ async fn provider_runtime_returns_retry_from_clean_slate_after_delete_then_creat
         .apply(&PresentationPlan {
             policy: "default".to_string(),
             name: "convoy-a".to_string(),
-            processes: vec![resolved_process("main", "attach term-a")],
+            crew: vec![resolved_process("main", "attach term-a")],
             presentation_local_cwd: flotilla_core::path_context::ExecutionEnvironmentPath::new("/tmp"),
             previous: Some(flotilla_controllers::reconcilers::PreviousWorkspace {
                 presentation_manager: "old".to_string(),

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -14,8 +14,8 @@ use common::{
 };
 use flotilla_controllers::reconcilers::{
     CheckoutReconciler, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime, EnvironmentReconciler, HopChainContext,
-    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, TaskWorkspaceReconciler, TerminalRuntime,
-    TerminalRuntimeState, TerminalSessionReconciler,
+    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, TerminalRuntime, TerminalRuntimeState,
+    TerminalSessionReconciler, VesselReconciler,
 };
 use flotilla_core::{
     path_context::DaemonHostPath,
@@ -32,8 +32,8 @@ use flotilla_resources::{
     clone_key, controller::ControllerLoop, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec,
     DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host,
     HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation, PresentationPhase, PresentationSpec, ResourceBackend, ResourceError,
-    StatusPatch, TaskWorkspace, TaskWorkspacePhase, TerminalSession, TerminalSessionPhase, CONVOY_LABEL, PROCESS_ORDINAL_LABEL,
-    TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL,
+    VESSEL_REF_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -196,14 +196,14 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
 
     let harness = full_controller_harness(backend.clone());
 
-    let workspaces = backend.clone().using::<TaskWorkspace>(NAMESPACE);
+    let workspaces = backend.clone().using::<Vessel>(NAMESPACE);
     harness
         .wait_until(Duration::from_secs(3), || {
             let workspaces = workspaces.clone();
             async move {
                 matches!(
                     workspaces.get("workspace-a").await.ok().and_then(|workspace| workspace.status).map(|status| status.phase),
-                    Some(TaskWorkspacePhase::Ready)
+                    Some(VesselPhase::Ready)
                 )
             }
         })
@@ -212,7 +212,7 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
     let workspace = workspaces.get("workspace-a").await.expect("workspace get should succeed");
     let ready_resource_version = workspace.metadata.resource_version.clone();
     let status = workspace.status.expect("workspace status should be present");
-    assert_eq!(status.phase, TaskWorkspacePhase::Ready);
+    assert_eq!(status.phase, VesselPhase::Ready);
     assert_eq!(status.environment_ref.as_deref(), Some("host-direct-01HXYZ"));
     assert_eq!(status.checkout_ref.as_deref(), Some("checkout-workspace-a"));
     assert_eq!(status.terminal_session_refs, vec!["terminal-workspace-a-coder".to_string()]);
@@ -408,8 +408,8 @@ async fn presentation_controller_marks_presentation_active_for_live_convoy_sessi
                 .labels(
                     [
                         (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-                        (TASK_ORDINAL_LABEL.to_string(), "000".to_string()),
-                        (PROCESS_ORDINAL_LABEL.to_string(), "000".to_string()),
+                        (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+                        (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
                     ]
                     .into_iter()
                     .collect(),
@@ -516,7 +516,7 @@ async fn presentation_controller_marks_presentation_active_for_live_convoy_sessi
 }
 
 #[tokio::test]
-async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete() {
+async fn vessel_controller_finalizer_deletes_labeled_children_on_delete() {
     let backend = ResourceBackend::InMemory(Default::default());
     create_workspace(
         &backend,
@@ -535,7 +535,7 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
         .create(
             &controller_meta()
                 .name("env-workspace-delete")
-                .labels([(TASK_WORKSPACE_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
+                .labels([(VESSEL_REF_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
                 .call(),
             &EnvironmentSpec {
                 host_direct: Some(HostDirectEnvironmentSpec {
@@ -553,7 +553,7 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
         .create(
             &controller_meta()
                 .name("checkout-workspace-delete")
-                .labels([(TASK_WORKSPACE_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
+                .labels([(VESSEL_REF_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
                 .call(),
             &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
                 env_ref: "host-direct-01HXYZ".to_string(),
@@ -570,7 +570,7 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
         .create(
             &controller_meta()
                 .name("terminal-workspace-delete-coder")
-                .labels([(TASK_WORKSPACE_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
+                .labels([(VESSEL_REF_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
                 .call(),
             &flotilla_resources::TerminalSessionSpec {
                 env_ref: "host-direct-01HXYZ".to_string(),
@@ -583,7 +583,7 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
         .await
         .expect("terminal create should succeed");
 
-    let workspaces = backend.clone().using::<TaskWorkspace>(NAMESPACE);
+    let workspaces = backend.clone().using::<Vessel>(NAMESPACE);
     let environments = backend.clone().using::<Environment>(NAMESPACE);
     let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
     let terminals = backend.clone().using::<TerminalSession>(NAMESPACE);
@@ -591,8 +591,8 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
     harness.spawn(
         ControllerLoop {
             primary: workspaces.clone(),
-            secondaries: TaskWorkspaceReconciler::secondary_watches(),
-            reconciler: TaskWorkspaceReconciler::new(backend.clone(), NAMESPACE),
+            secondaries: VesselReconciler::secondary_watches(),
+            reconciler: VesselReconciler::new(backend.clone(), NAMESPACE),
             resync_interval: Duration::from_millis(50),
             backend: backend.clone(),
         }
@@ -605,7 +605,7 @@ async fn task_workspace_controller_finalizer_deletes_labeled_children_on_delete(
             async move {
                 matches!(
                     workspaces.get("workspace-delete").await,
-                    Ok(workspace) if workspace.metadata.finalizers == vec!["flotilla.work/task-workspace-teardown".to_string()]
+                    Ok(workspace) if workspace.metadata.finalizers == vec!["flotilla.work/vessel-workspace-teardown".to_string()]
                 )
             }
         })
@@ -725,9 +725,9 @@ fn full_controller_harness(backend: ResourceBackend) -> ControllerLoopHarness {
     );
     harness.spawn(
         ControllerLoop {
-            primary: backend.clone().using::<TaskWorkspace>(NAMESPACE),
-            secondaries: TaskWorkspaceReconciler::secondary_watches(),
-            reconciler: TaskWorkspaceReconciler::new(backend.clone(), NAMESPACE),
+            primary: backend.clone().using::<Vessel>(NAMESPACE),
+            secondaries: VesselReconciler::secondary_watches(),
+            reconciler: VesselReconciler::new(backend.clone(), NAMESPACE),
             resync_interval: Duration::from_millis(50),
             backend,
         }

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -84,7 +84,7 @@ async fn a_disappeared_running_session_is_observed_as_stopped() {
                 context: flotilla_resources::TerminalCrewContext {
                     namespace: "flotilla".into(),
                     convoy: "demo".into(),
-                    vessel: "demo-implement".into(),
+                    vessel_ref: "demo-implement".into(),
                 },
                 message: None,
             },
@@ -147,7 +147,7 @@ async fn a_message_queued_during_startup_is_delivered_after_the_session_becomes_
                 context: flotilla_resources::TerminalCrewContext {
                     namespace: "flotilla".into(),
                     convoy: "demo".into(),
-                    vessel: "demo-review".into(),
+                    vessel_ref: "demo-review".into(),
                 },
                 message: Some(flotilla_resources::TerminalCrewMessage {
                     id: "message-new".into(),

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -6,19 +6,18 @@ use chrono::Utc;
 use common::{
     create_convoy_with_single_task, create_docker_worktree_policy, create_host_direct_policy, create_policy, create_ready_checkout,
     create_ready_clone, create_ready_docker_environment, create_ready_host_direct_environment, create_stopped_terminal, create_workspace,
-    labeled_meta, meta, task_workspace_meta, DockerWorktreePolicyFixture, ReadyCheckoutFixture, StoppedTerminalFixture,
+    labeled_meta, meta, vessel_meta, DockerWorktreePolicyFixture, ReadyCheckoutFixture, StoppedTerminalFixture,
 };
-use flotilla_controllers::reconcilers::TaskWorkspaceReconciler;
+use flotilla_controllers::reconcilers::VesselReconciler;
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{Actuation, Reconciler},
     Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
-    DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec,
+    CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, LifecycleAuthority,
-    ObservedCheckoutSpec, PlacementPolicySpec, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError, Selector, SnapshotTask,
-    TaskWorkspace, TaskWorkspaceSpec, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
-    TerminalSessionStatus, WorkflowSnapshot, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL,
-    TASK_WORKSPACE_LABEL,
+    ObservedCheckoutSpec, PlacementPolicySpec, ResourceBackend, ResourceError, Selector, TerminalSession, TerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkflowSnapshot,
+    CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
@@ -33,13 +32,13 @@ async fn missing_placement_policy_marks_workspace_failed() {
     create_convoy_with_single_task(&backend, NAMESPACE, "convoy-a", "implement", REPO_URL, GIT_REF).await;
     let workspace = create_workspace(&backend, NAMESPACE, "workspace-a", "convoy-a", "implement", "policy-missing", REPO_URL).await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
 
     assert!(matches!(
         outcome.patch,
-        Some(flotilla_resources::TaskWorkspaceStatusPatch::MarkFailed { ref message })
+        Some(flotilla_resources::VesselStatusPatch::MarkFailed { ref message })
             if message.contains("placement policy policy-missing not found")
     ));
 }
@@ -56,7 +55,7 @@ async fn reuses_existing_clone_by_deterministic_name() {
     create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/Users/alice/dev/flotilla-repos/clone").await;
     let workspace = create_workspace(&backend, NAMESPACE, "workspace-b", "convoy-b", "implement", "policy-a", REPO_URL).await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
 
@@ -93,7 +92,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
     create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/Users/alice/dev/flotilla-repos/clone").await;
     let workspace = create_workspace(&backend, NAMESPACE, "workspace-c", "convoy-c", "implement", "policy-worktree", REPO_URL).await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend.clone(), NAMESPACE);
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
     assert!(outcome.actuations.iter().any(|actuation| matches!(actuation, Actuation::CreateCheckout { .. })));
@@ -116,7 +115,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
             .build(),
     )
     .await;
-    let current = backend.clone().using::<TaskWorkspace>(NAMESPACE).get("workspace-c").await.expect("workspace get should succeed");
+    let current = backend.clone().using::<Vessel>(NAMESPACE).get("workspace-c").await.expect("workspace get should succeed");
     let deps = reconciler.fetch_dependencies(&current).await.expect("deps should reload");
     let outcome = reconciler.reconcile(&current, &deps, chrono::Utc::now());
 
@@ -247,13 +246,13 @@ async fn child_failure_propagates_to_workspace_failure() {
     .await;
     let workspace = create_workspace(&backend, NAMESPACE, "workspace-f", "convoy-f", "implement", "policy-f", REPO_URL).await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
 
     assert!(matches!(
         outcome.patch,
-        Some(flotilla_resources::TaskWorkspaceStatusPatch::MarkFailed { ref message }) if message == "boom"
+        Some(flotilla_resources::VesselStatusPatch::MarkFailed { ref message }) if message == "boom"
     ));
 }
 
@@ -266,17 +265,17 @@ async fn adopted_checkout_ref_reuses_checkout_without_creating_clone_or_checkout
     create_ready_adopted_checkout(&backend, NAMESPACE, "adopted-checkout-convoy-adopted", "/Users/alice/dev/flotilla-existing").await;
     let workspace = backend
         .clone()
-        .using::<TaskWorkspace>(NAMESPACE)
-        .create(&task_workspace_meta("workspace-adopted", REPO_URL), &TaskWorkspaceSpec {
+        .using::<Vessel>(NAMESPACE)
+        .create(&vessel_meta("workspace-adopted", REPO_URL), &VesselSpec {
             convoy_ref: "convoy-adopted".to_string(),
-            task: "implement".to_string(),
+            vessel_name: "implement".to_string(),
             placement_policy_ref: "policy-adopted".to_string(),
             adopted_checkout_ref: Some("adopted-checkout-convoy-adopted".to_string()),
         })
         .await
         .expect("workspace create should succeed");
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
 
@@ -300,17 +299,17 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
     let backend = ResourceBackend::InMemory(Default::default());
     let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-crew", "implement", REPO_URL, GIT_REF).await;
     let mut status = convoy.status.expect("convoy status");
-    status.workflow_snapshot.as_mut().expect("workflow snapshot").tasks[0].processes = vec![
-        ProcessDefinition::builder()
+    status.workflow_snapshot.as_mut().expect("workflow snapshot").vessels[0].crew = vec![
+        CrewSpec::builder()
             .role("coder".to_string())
-            .source(ProcessSource::Agent {
+            .source(CrewSource::Agent {
                 selector: Selector { capability: "coding".to_string() },
                 prompt: Some("Implement issue 668.".to_string()),
             })
             .build(),
-        ProcessDefinition::builder()
+        CrewSpec::builder()
             .role("reviewer".to_string())
-            .source(ProcessSource::Agent {
+            .source(CrewSource::Agent {
                 selector: Selector { capability: "review".to_string() },
                 prompt: Some("Review the coder's work.".to_string()),
             })
@@ -327,17 +326,17 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
     create_ready_adopted_checkout(&backend, NAMESPACE, "adopted-checkout-convoy-crew", "/Users/alice/dev/flotilla-existing").await;
     let workspace = backend
         .clone()
-        .using::<TaskWorkspace>(NAMESPACE)
-        .create(&task_workspace_meta("workspace-crew", REPO_URL), &TaskWorkspaceSpec {
+        .using::<Vessel>(NAMESPACE)
+        .create(&vessel_meta("workspace-crew", REPO_URL), &VesselSpec {
             convoy_ref: "convoy-crew".to_string(),
-            task: "implement".to_string(),
+            vessel_name: "implement".to_string(),
             placement_policy_ref: "policy-crew".to_string(),
             adopted_checkout_ref: Some("adopted-checkout-convoy-crew".to_string()),
         })
         .await
         .expect("workspace create");
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps");
     let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
 
@@ -355,7 +354,7 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
     assert!(brief.content.contains("flotilla crew reviewer handoff --message"));
     assert!(brief.content.ends_with("Implement issue 668.\n"));
     assert_eq!(context.namespace, NAMESPACE);
-    assert_eq!(context.vessel, "workspace-crew");
+    assert_eq!(context.vessel_ref, "workspace-crew");
     assert_eq!(message, &None);
     assert!(outcome
         .actuations
@@ -377,13 +376,13 @@ async fn observed_checkout_at_managed_name_marks_workspace_failed() {
     let workspace =
         create_workspace(&backend, NAMESPACE, "workspace-observed", "convoy-observed", "implement", "policy-observed", REPO_URL).await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
 
     assert!(matches!(
         outcome.patch,
-        Some(flotilla_resources::TaskWorkspaceStatusPatch::MarkFailed { ref message })
+        Some(flotilla_resources::VesselStatusPatch::MarkFailed { ref message })
             if message == "checkout checkout-workspace-observed is ready but has no target path"
     ));
 }
@@ -397,7 +396,7 @@ async fn run_finalizer_deletes_all_labeled_children() {
     create_labeled_checkout(&backend, NAMESPACE, "checkout-workspace-finalize", "workspace-finalize").await;
     create_labeled_terminal(&backend, NAMESPACE, "terminal-workspace-finalize-coder", "workspace-finalize").await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend.clone(), NAMESPACE);
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
     reconciler.run_finalizer(&workspace).await.expect("finalizer should succeed");
 
     assert!(matches!(
@@ -422,7 +421,7 @@ async fn run_finalizer_preserves_adopted_checkout() {
     create_labeled_adopted_checkout(&backend, NAMESPACE, "checkout-workspace-adopted", "workspace-adopted").await;
     create_labeled_terminal(&backend, NAMESPACE, "terminal-workspace-adopted-coder", "workspace-adopted").await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend.clone(), NAMESPACE);
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
     reconciler.run_finalizer(&workspace).await.expect("finalizer should succeed");
 
     let checkout =
@@ -441,7 +440,7 @@ async fn run_finalizer_ignores_missing_children_and_cleans_partial_workspace() {
 
     create_labeled_environment(&backend, NAMESPACE, "env-workspace-partial", "workspace-partial").await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend.clone(), NAMESPACE);
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
     reconciler.run_finalizer(&workspace).await.expect("finalizer should succeed");
 
     assert!(matches!(
@@ -490,7 +489,7 @@ async fn terminal_session_actuation_includes_system_and_user_labels() {
     .await;
     let workspace = create_workspace(&backend, NAMESPACE, "workspace-labels", "convoy-labels", "review", "policy-labels", REPO_URL).await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
 
@@ -507,11 +506,11 @@ async fn terminal_session_actuation_includes_system_and_user_labels() {
     assert_eq!(terminal.0.labels.get("service").map(String::as_str), Some("api"));
     assert_eq!(terminal.0.labels.get("team").map(String::as_str), Some("platform"));
     assert_eq!(terminal.0.labels.get(CONVOY_LABEL).map(String::as_str), Some("convoy-labels"));
-    assert_eq!(terminal.0.labels.get(TASK_LABEL).map(String::as_str), Some("review"));
-    assert_eq!(terminal.0.labels.get(TASK_WORKSPACE_LABEL).map(String::as_str), Some("workspace-labels"));
+    assert_eq!(terminal.0.labels.get(VESSEL_LABEL).map(String::as_str), Some("review"));
+    assert_eq!(terminal.0.labels.get(VESSEL_REF_LABEL).map(String::as_str), Some("workspace-labels"));
     assert_eq!(terminal.0.labels.get(ROLE_LABEL).map(String::as_str), Some("test"));
-    assert_eq!(terminal.0.labels.get(TASK_ORDINAL_LABEL).map(String::as_str), Some("001"));
-    assert_eq!(terminal.0.labels.get(PROCESS_ORDINAL_LABEL).map(String::as_str), Some("001"));
+    assert_eq!(terminal.0.labels.get(VESSEL_ORDINAL_LABEL).map(String::as_str), Some("001"));
+    assert_eq!(terminal.0.labels.get(CREW_ORDINAL_LABEL).map(String::as_str), Some("001"));
 }
 
 async fn assert_terminal_cwd_for_strategy(
@@ -563,7 +562,7 @@ async fn assert_terminal_cwd_for_strategy(
     .await;
     let workspace = create_workspace(&backend, NAMESPACE, workspace_name, "convoy-cwd", "implement", "policy-cwd", REPO_URL).await;
 
-    let reconciler = TaskWorkspaceReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
 
@@ -623,35 +622,35 @@ async fn create_convoy_with_labeled_processes(
     convoys
         .update_status(name, &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
-                tasks: vec![
-                    SnapshotTask {
+                vessels: vec![
+                    VesselRequirement {
                         name: "implement".to_string(),
                         depends_on: Vec::new(),
-                        processes: vec![ProcessDefinition::builder()
+                        crew: vec![CrewSpec::builder()
                             .role("coder".to_string())
-                            .source(ProcessSource::Tool { command: "cargo fmt --check".to_string() })
+                            .source(CrewSource::Tool { command: "cargo fmt --check".to_string() })
                             .build()],
                     },
-                    SnapshotTask {
+                    VesselRequirement {
                         name: "review".to_string(),
                         depends_on: vec!["implement".to_string()],
-                        processes: vec![
-                            ProcessDefinition::builder()
+                        crew: vec![
+                            CrewSpec::builder()
                                 .role("build".to_string())
-                                .source(ProcessSource::Tool { command: "cargo check".to_string() })
+                                .source(CrewSource::Tool { command: "cargo check".to_string() })
                                 .build(),
-                            ProcessDefinition::builder()
+                            CrewSpec::builder()
                                 .role("test".to_string())
-                                .source(ProcessSource::Tool { command: "cargo test".to_string() })
+                                .source(CrewSource::Tool { command: "cargo test".to_string() })
                                 .labels(BTreeMap::from([
                                     ("service".to_string(), "api".to_string()),
                                     ("team".to_string(), "platform".to_string()),
                                     (CONVOY_LABEL.to_string(), "wrong-convoy".to_string()),
-                                    (TASK_LABEL.to_string(), "wrong-task".to_string()),
-                                    (TASK_WORKSPACE_LABEL.to_string(), "wrong-workspace".to_string()),
+                                    (VESSEL_LABEL.to_string(), "wrong-task".to_string()),
+                                    (VESSEL_REF_LABEL.to_string(), "wrong-workspace".to_string()),
                                     (ROLE_LABEL.to_string(), "wrong-role".to_string()),
-                                    (TASK_ORDINAL_LABEL.to_string(), "999".to_string()),
-                                    (PROCESS_ORDINAL_LABEL.to_string(), "999".to_string()),
+                                    (VESSEL_ORDINAL_LABEL.to_string(), "999".to_string()),
+                                    (CREW_ORDINAL_LABEL.to_string(), "999".to_string()),
                                 ]))
                                 .build(),
                         ],
@@ -710,7 +709,7 @@ async fn create_labeled_environment(backend: &ResourceBackend, namespace: &str, 
     backend
         .clone()
         .using::<Environment>(namespace)
-        .create(&labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())]), &EnvironmentSpec {
+        .create(&labeled_meta(name, [(VESSEL_REF_LABEL.to_string(), workspace_name.to_string())]), &EnvironmentSpec {
             host_direct: Some(HostDirectEnvironmentSpec {
                 host_ref: HOST_REF.to_string(),
                 repo_default_dir: "/Users/alice/dev/flotilla-repos".to_string(),
@@ -726,7 +725,7 @@ async fn create_labeled_checkout(backend: &ResourceBackend, namespace: &str, nam
         .clone()
         .using::<Checkout>(namespace)
         .create(
-            &labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())]),
+            &labeled_meta(name, [(VESSEL_REF_LABEL.to_string(), workspace_name.to_string())]),
             &CheckoutSpec::Worktree(worktree_checkout_spec(
                 &host_direct_env_name(),
                 GIT_REF,
@@ -743,7 +742,7 @@ async fn create_labeled_adopted_checkout(backend: &ResourceBackend, namespace: &
         .clone()
         .using::<Checkout>(namespace)
         .create(
-            &labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())])
+            &labeled_meta(name, [(VESSEL_REF_LABEL.to_string(), workspace_name.to_string())])
                 .with_lifecycle_authority(LifecycleAuthority::Adopted),
             &CheckoutSpec::Observed(ObservedCheckoutSpec {
                 r#ref: GIT_REF.to_string(),
@@ -810,7 +809,7 @@ async fn create_labeled_terminal(backend: &ResourceBackend, namespace: &str, nam
     backend
         .clone()
         .using::<TerminalSession>(namespace)
-        .create(&labeled_meta(name, [(TASK_WORKSPACE_LABEL.to_string(), workspace_name.to_string())]), &TerminalSessionSpec {
+        .create(&labeled_meta(name, [(VESSEL_REF_LABEL.to_string(), workspace_name.to_string())]), &TerminalSessionSpec {
             env_ref: host_direct_env_name(),
             role: "coder".to_string(),
             source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -28,14 +28,14 @@ pub struct CrewBriefMember {
 
 pub fn build_crew_brief(
     context: &flotilla_resources::TerminalCrewContext,
-    leg: &str,
+    vessel: &str,
     role: &str,
     prompt: Option<&str>,
     members: &[CrewBriefMember],
 ) -> flotilla_resources::TerminalBrief {
     let mut content = format!(
-        "# Flotilla crew brief\n\nYou are `{role}` in convoy `{}`, aboard vessel `{}` for leg `{leg}`.\n\n## Crew\n\n",
-        context.convoy, context.vessel
+        "# Flotilla crew brief\n\nYou are `{role}` in convoy `{}`, aboard vessel `{vessel}` (`{}`).\n\n## Crew\n\n",
+        context.convoy, context.vessel_ref
     );
     for member in members {
         content.push_str(&format!("- `{}`: {}\n", member.role, member.state));
@@ -45,7 +45,7 @@ pub fn build_crew_brief(
         content.push_str(&format!("Hand off to {} with `flotilla crew {} handoff --message '...'`.\n", member.role, member.role));
     }
     content.push_str(&format!(
-        "Leg completion is separate: `flotilla convoy {} leg {leg} complete`.\n\n## Assignment\n\n{}\n",
+        "Completing the work is separate: `flotilla convoy {} work {vessel} complete`.\n\n## Assignment\n\n{}\n",
         context.convoy,
         prompt.unwrap_or("No additional assignment was provided.")
     ));

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -60,7 +60,7 @@ fn panel_snapshot(seq: u64, rows: Vec<PanelRow>) -> PanelSnapshot {
                 ],
                 intents: vec![
                     IntentDefinition::new("attach", "Attach", IntentKind::Attach),
-                    IntentDefinition::new("complete-leg", "Complete leg", IntentKind::CompleteLeg),
+                    IntentDefinition::new("complete-work", "Complete work", IntentKind::CompleteWork),
                 ],
                 rows,
             }],

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -131,7 +131,7 @@ pub struct KeysConfig {
     #[serde(default)]
     pub convoys: HashMap<String, String>,
     #[serde(default)]
-    pub convoy_tasks: HashMap<String, String>,
+    pub convoy_vessels: HashMap<String, String>,
     #[serde(default)]
     pub action_menu: HashMap<String, String>,
     #[serde(default)]

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -313,7 +313,7 @@ pub async fn build_plan(
         }])),
 
         // Daemon-level commands should not reach build_plan.
-        CommandAction::ConvoyLegComplete { .. }
+        CommandAction::ConvoyWorkComplete { .. }
         | CommandAction::CrewHandoff { .. }
         | CommandAction::ConvoyCreate { .. }
         | CommandAction::WorkflowTemplateApply { .. }

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -1933,7 +1933,7 @@ async fn teleport_session_uses_session_as_name_when_no_branch() {
 #[tokio::test]
 async fn daemon_level_commands_return_error() {
     let daemon_commands = vec![
-        CommandAction::ConvoyLegComplete { convoy: "convoy-a".to_string(), leg: "implement".to_string(), message: None },
+        CommandAction::ConvoyWorkComplete { convoy: "convoy-a".to_string(), work: "implement".to_string(), message: None },
         CommandAction::TrackRepoPath { path: PathBuf::from("/repo") },
         CommandAction::UntrackRepo { repo: RepoSelector::Path(PathBuf::from("/repo")) },
         CommandAction::Refresh { repo: None },

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -28,13 +28,12 @@ use flotilla_protocol::{
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, terminal_session_attach_target,
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec,
+    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, CrewSource,
     Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ProcessSource, Project, ProjectRepositorySpec, ProjectSpec,
-    Resource, ResourceBackend, ResourceError, TaskWorkspace, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
-    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionStatusPatch, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, TASK_LABEL,
-    TASK_WORKSPACE_LABEL,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, Resource,
+    ResourceBackend, ResourceError, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
+    Vessel, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -221,15 +220,15 @@ fn attach_reference_keys(session_name: &str, labels: &BTreeMap<String, String>) 
     let mut refs = vec![session_name.to_string()];
 
     let convoy = labels.get(CONVOY_LABEL);
-    let task = labels.get(TASK_LABEL);
+    let task = labels.get(VESSEL_LABEL);
     let role = labels.get(ROLE_LABEL);
-    let task_workspace = labels.get(TASK_WORKSPACE_LABEL);
+    let vessel = labels.get(VESSEL_REF_LABEL);
 
     if let Some(convoy) = convoy {
         refs.push(convoy.clone());
     }
-    if let Some(task_workspace) = task_workspace {
-        refs.push(task_workspace.clone());
+    if let Some(vessel) = vessel {
+        refs.push(vessel.clone());
     }
     if let (Some(convoy), Some(task)) = (convoy, task) {
         refs.push(format!("{convoy}/{task}"));
@@ -237,8 +236,8 @@ fn attach_reference_keys(session_name: &str, labels: &BTreeMap<String, String>) 
     if let (Some(convoy), Some(task), Some(role)) = (convoy, task, role) {
         refs.push(format!("{convoy}/{task}/{role}"));
     }
-    if let (Some(task_workspace), Some(role)) = (task_workspace, role) {
-        refs.push(format!("{task_workspace}/{role}"));
+    if let (Some(vessel), Some(role)) = (vessel, role) {
+        refs.push(format!("{vessel}/{role}"));
     }
     if let Some(role) = role {
         refs.push(role.clone());
@@ -250,7 +249,7 @@ fn attach_reference_keys(session_name: &str, labels: &BTreeMap<String, String>) 
 }
 
 fn attach_reference_label(session_name: &str, labels: &BTreeMap<String, String>) -> String {
-    match (labels.get(CONVOY_LABEL), labels.get(TASK_LABEL), labels.get(ROLE_LABEL)) {
+    match (labels.get(CONVOY_LABEL), labels.get(VESSEL_LABEL), labels.get(ROLE_LABEL)) {
         (Some(convoy), Some(task), Some(role)) => format!("{convoy}/{task}/{role} ({session_name})"),
         (Some(convoy), Some(task), None) => format!("{convoy}/{task} ({session_name})"),
         (Some(convoy), None, Some(role)) => format!("{convoy}/{role} ({session_name})"),
@@ -775,8 +774,8 @@ struct FleetReplicaCacheEntry {
 struct ResolvedCrewContext {
     namespace: String,
     convoy: String,
+    vessel_ref: String,
     vessel: String,
-    leg: String,
     caller_session: Option<flotilla_resources::ResourceObject<ResourceTerminalSession>>,
 }
 
@@ -793,8 +792,12 @@ fn input_meta_from_resource<T: Resource>(resource: &flotilla_resources::Resource
 
 fn handoff_crew_brief(context: &ResolvedCrewContext, target: &str, prompt: Option<&str>, members: &[CrewListMember]) -> TerminalBrief {
     crate::agent_adapter::build_crew_brief(
-        &TerminalCrewContext { namespace: context.namespace.clone(), convoy: context.convoy.clone(), vessel: context.vessel.clone() },
-        &context.leg,
+        &TerminalCrewContext {
+            namespace: context.namespace.clone(),
+            convoy: context.convoy.clone(),
+            vessel_ref: context.vessel_ref.clone(),
+        },
+        &context.vessel,
         target,
         prompt,
         &members
@@ -1125,7 +1128,7 @@ impl InProcessDaemon {
     }
 
     /// Override the provisioning namespace used for daemon-side resource lookups
-    /// (e.g. `ConvoyLegComplete`). Called by the daemon runtime at startup with
+    /// (e.g. `ConvoyWorkComplete`). Called by the daemon runtime at startup with
     /// `RuntimeOptions::namespace`.
     pub async fn set_provisioning_namespace(&self, namespace: String) {
         *self.provisioning_namespace.write().await = namespace;
@@ -2289,48 +2292,49 @@ impl InProcessDaemon {
                 .into_iter()
                 .find(|session| session.status.as_ref().and_then(|status| status.crew.as_ref()).is_some_and(|crew| crew.id == crew_id))
                 .ok_or_else(|| format!("unknown FLOTILLA_CREW_ID `{crew_id}`"))?;
-            let (convoy, vessel) = match &session.spec.source {
-                TerminalSessionSource::Agent { context, .. } => (context.convoy.clone(), context.vessel.clone()),
+            let (convoy, vessel_ref) = match &session.spec.source {
+                TerminalSessionSource::Agent { context, .. } => (context.convoy.clone(), context.vessel_ref.clone()),
                 TerminalSessionSource::Tool { .. } => {
                     return Err(format!("crew identity `{crew_id}` belongs to a non-agent process"));
                 }
             };
-            return self.resolved_crew_context(namespace, convoy, vessel, Some(session)).await;
+            return self.resolved_crew_context(namespace, convoy, vessel_ref, Some(session)).await;
         }
 
         let convoy = requested
             .convoy
             .clone()
-            .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel, and --role".to_string())?;
-        let vessel = requested
-            .vessel
+            .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel-ref, and --role".to_string())?;
+        let vessel_ref = requested
+            .vessel_ref
             .clone()
-            .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel, and --role".to_string())?;
-        let role =
-            requested.role.clone().ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel, and --role".to_string())?;
+            .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel-ref, and --role".to_string())?;
+        let role = requested
+            .role
+            .clone()
+            .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel-ref, and --role".to_string())?;
         let caller = session_list.into_iter().find(|session| {
-            session.spec.role == role && session.metadata.labels.get(TASK_WORKSPACE_LABEL).map(String::as_str) == Some(vessel.as_str())
+            session.spec.role == role && session.metadata.labels.get(VESSEL_REF_LABEL).map(String::as_str) == Some(vessel_ref.as_str())
         });
-        self.resolved_crew_context(namespace, convoy, vessel, caller).await
+        self.resolved_crew_context(namespace, convoy, vessel_ref, caller).await
     }
 
     async fn resolved_crew_context(
         &self,
         namespace: String,
         convoy: String,
-        vessel: String,
+        vessel_ref: String,
         caller_session: Option<flotilla_resources::ResourceObject<ResourceTerminalSession>>,
     ) -> Result<ResolvedCrewContext, String> {
-        let workspace =
-            self.resource_backend.clone().using::<TaskWorkspace>(&namespace).get(&vessel).await.map_err(|err| err.to_string())?;
+        let workspace = self.resource_backend.clone().using::<Vessel>(&namespace).get(&vessel_ref).await.map_err(|err| err.to_string())?;
         if workspace.spec.convoy_ref != convoy {
-            return Err(format!("vessel `{vessel}` does not belong to convoy `{convoy}`"));
+            return Err(format!("vessel `{vessel_ref}` does not belong to convoy `{convoy}`"));
         }
         Ok(ResolvedCrewContext::builder()
             .namespace(namespace)
             .convoy(convoy)
-            .vessel(vessel)
-            .leg(workspace.spec.task)
+            .vessel_ref(vessel_ref)
+            .vessel(workspace.spec.vessel_name)
             .maybe_caller_session(caller_session)
             .build())
     }
@@ -2343,11 +2347,11 @@ impl InProcessDaemon {
             .status
             .as_ref()
             .and_then(|status| status.workflow_snapshot.as_ref())
-            .and_then(|snapshot| snapshot.tasks.iter().find(|task| task.name == context.leg))
-            .ok_or_else(|| format!("leg `{}` is missing from convoy `{}`", context.leg, context.convoy))?;
+            .and_then(|snapshot| snapshot.vessels.iter().find(|vessel| vessel.name == context.vessel))
+            .ok_or_else(|| format!("vessel `{}` is missing from convoy `{}`", context.vessel, context.convoy))?;
         let sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&context.namespace);
         let by_role: HashMap<_, _> = sessions
-            .list_matching_labels(&BTreeMap::from([(TASK_WORKSPACE_LABEL.to_string(), context.vessel.clone())]))
+            .list_matching_labels(&BTreeMap::from([(VESSEL_REF_LABEL.to_string(), context.vessel_ref.clone())]))
             .await
             .map_err(|err| err.to_string())?
             .items
@@ -2355,7 +2359,7 @@ impl InProcessDaemon {
             .map(|session| (session.spec.role.clone(), session))
             .collect();
         let members = task
-            .processes
+            .crew
             .iter()
             .map(|process| {
                 let session = by_role.get(&process.role);
@@ -2364,13 +2368,13 @@ impl InProcessDaemon {
                     Some(ResourceTerminalSessionPhase::Running) => "active",
                     Some(ResourceTerminalSessionPhase::Stopped) => "stopped",
                     Some(ResourceTerminalSessionPhase::Failed) => "failed",
-                    None if matches!(process.source, ProcessSource::Agent { .. }) => "latent",
+                    None if matches!(process.source, CrewSource::Agent { .. }) => "latent",
                     None => "pending",
                 };
                 let crew = session.and_then(|session| session.status.as_ref()).and_then(|status| status.crew.as_ref());
                 CrewListMember::builder()
                     .role(process.role.clone())
-                    .kind(if matches!(process.source, ProcessSource::Agent { .. }) { "agent" } else { "tool" }.to_string())
+                    .kind(if matches!(process.source, CrewSource::Agent { .. }) { "agent" } else { "tool" }.to_string())
                     .state(state.to_string())
                     .maybe_adapter(crew.map(|crew| crew.adapter.clone()))
                     .maybe_model(crew.and_then(|crew| crew.model.clone()))
@@ -2378,7 +2382,12 @@ impl InProcessDaemon {
                     .build()
             })
             .collect();
-        Ok(CrewListResponse::builder().convoy(context.convoy).vessel(context.vessel).leg(context.leg).members(members).build())
+        Ok(CrewListResponse::builder()
+            .convoy(context.convoy)
+            .vessel_ref(context.vessel_ref)
+            .vessel(context.vessel)
+            .members(members)
+            .build())
     }
 
     pub async fn crew_handoff_internal(&self, requested: &CrewCommandContext, target: &str, message: &str) -> Result<(), String> {
@@ -2389,26 +2398,26 @@ impl InProcessDaemon {
             .status
             .as_ref()
             .and_then(|status| status.workflow_snapshot.as_ref())
-            .and_then(|snapshot| snapshot.tasks.iter().enumerate().find(|(_, task)| task.name == context.leg))
-            .ok_or_else(|| format!("leg `{}` is missing from convoy `{}`", context.leg, context.convoy))?;
+            .and_then(|snapshot| snapshot.vessels.iter().enumerate().find(|(_, vessel)| vessel.name == context.vessel))
+            .ok_or_else(|| format!("vessel `{}` is missing from convoy `{}`", context.vessel, context.convoy))?;
         let (process_index, process) = task
-            .processes
+            .crew
             .iter()
             .enumerate()
             .find(|(_, process)| process.role == target)
-            .ok_or_else(|| format!("crew target `{target}` is not defined for leg `{}`", context.leg))?;
-        let ProcessSource::Agent { selector, prompt } = &process.source else {
+            .ok_or_else(|| format!("crew target `{target}` is not defined for vessel `{}`", context.vessel))?;
+        let CrewSource::Agent { selector, prompt } = &process.source else {
             return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
         };
 
         let sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&context.namespace);
         let identity = TerminalSessionIdentity::builder()
-            .vessel(context.vessel.clone())
+            .vessel_ref(context.vessel_ref.clone())
             .convoy(context.convoy.clone())
-            .leg(context.leg.clone())
+            .vessel(context.vessel.clone())
             .role(target.to_string())
-            .task_index(task_index)
-            .process_index(process_index)
+            .vessel_index(task_index)
+            .crew_index(process_index)
             .labels(process.labels.clone())
             .build();
         let terminal_name = identity.name();
@@ -2432,13 +2441,13 @@ impl InProcessDaemon {
                     caller.clone()
                 } else {
                     sessions
-                        .list_matching_labels(&BTreeMap::from([(TASK_WORKSPACE_LABEL.to_string(), context.vessel.clone())]))
+                        .list_matching_labels(&BTreeMap::from([(VESSEL_REF_LABEL.to_string(), context.vessel_ref.clone())]))
                         .await
                         .map_err(|err| err.to_string())?
                         .items
                         .into_iter()
                         .next()
-                        .ok_or_else(|| format!("vessel `{}` has no active session to anchor the handoff", context.vessel))?
+                        .ok_or_else(|| format!("vessel `{}` has no active session to anchor the handoff", context.vessel_ref))?
                 };
                 let current = self.crew_list_internal(requested).await?;
                 let brief = handoff_crew_brief(&context, target, prompt.as_deref(), &current.members);
@@ -2449,7 +2458,11 @@ impl InProcessDaemon {
                         source: TerminalSessionSource::Agent {
                             selector: selector.clone(),
                             brief,
-                            context: TerminalCrewContext { namespace: context.namespace, convoy: context.convoy, vessel: context.vessel },
+                            context: TerminalCrewContext {
+                                namespace: context.namespace,
+                                convoy: context.convoy,
+                                vessel_ref: context.vessel_ref,
+                            },
                             message: Some(pending_crew_message(message)),
                         },
                         cwd: anchor.spec.cwd,
@@ -2600,7 +2613,7 @@ impl InProcessDaemon {
         for session in session_list.items {
             let labels = &session.metadata.labels;
             let convoy = labels.get(CONVOY_LABEL).cloned().unwrap_or_else(|| "-".to_string());
-            let task = labels.get(TASK_LABEL).cloned();
+            let task = labels.get(VESSEL_LABEL).cloned();
             let role = labels.get(ROLE_LABEL).cloned().unwrap_or_else(|| session.spec.role.clone());
             let crew = match task {
                 Some(task) => format!("{task}/{role}"),
@@ -3013,7 +3026,7 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ConvoyLegComplete { convoy, leg, message } = &command.action {
+        if let flotilla_protocol::CommandAction::ConvoyWorkComplete { convoy, work, message } = &command.action {
             let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
                 command_id: id,
@@ -3027,14 +3040,14 @@ impl InProcessDaemon {
             let result = match convoys.get(convoy).await {
                 Ok(current) => match current.status.as_ref() {
                     None => flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} has no status") },
-                    Some(status) if !status.tasks.contains_key(leg) => {
-                        flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} does not contain leg {leg}") }
+                    Some(status) if !status.work.contains_key(work) => {
+                        flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} does not contain work {work}") }
                     }
                     Some(_) => {
                         match apply_resource_status_patch(
                             &convoys,
                             convoy,
-                            &convoy_external_patches::mark_task_completed(leg.clone(), chrono::Utc::now(), message.clone()),
+                            &convoy_external_patches::mark_work_completed(work.clone(), chrono::Utc::now(), message.clone()),
                         )
                         .await
                         {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -14,13 +14,13 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, Environment as ResourceEnvironment,
-    EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec, InputMeta, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, ProcessDefinition, ProcessSource, Selector, SnapshotTask, TaskPhase, TaskState,
-    TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TerminalBrief, TerminalCrewContext,
+    CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec,
+    Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec, InputMeta,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, Selector, TerminalBrief, TerminalCrewContext,
     TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource,
-    TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus, WorkflowSnapshot,
-    CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus, Vessel, VesselPhase,
+    VesselRequirement, VesselSpec, VesselStatus, WorkPhase, WorkState, WorkflowSnapshot, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL,
+    VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 use super::*;
@@ -236,8 +236,8 @@ async fn create_running_attach_session_with_pool(
                 name,
                 BTreeMap::from([
                     (CONVOY_LABEL.to_string(), convoy.to_string()),
-                    (TASK_LABEL.to_string(), task.to_string()),
-                    (TASK_WORKSPACE_LABEL.to_string(), format!("{convoy}-{task}")),
+                    (VESSEL_LABEL.to_string(), task.to_string()),
+                    (VESSEL_REF_LABEL.to_string(), format!("{convoy}-{task}")),
                     (ROLE_LABEL.to_string(), role.to_string()),
                 ]),
             ),
@@ -306,25 +306,22 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
         .await
         .expect("create convoy");
     let processes = vec![
-        ProcessDefinition::builder()
+        CrewSpec::builder()
             .role("coder".to_string())
-            .source(ProcessSource::Agent {
-                selector: Selector { capability: "coding".into() },
-                prompt: Some("Implement the change.".into()),
-            })
+            .source(CrewSource::Agent { selector: Selector { capability: "coding".into() }, prompt: Some("Implement the change.".into()) })
             .build(),
-        ProcessDefinition::builder()
+        CrewSpec::builder()
             .role("reviewer".to_string())
-            .source(ProcessSource::Agent { selector: Selector { capability: "review".into() }, prompt: Some("Review the change.".into()) })
+            .source(CrewSource::Agent { selector: Selector { capability: "review".into() }, prompt: Some("Review the change.".into()) })
             .build(),
     ];
     convoys
         .update_status("demo", &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
-                tasks: vec![SnapshotTask { name: "prepare".into(), depends_on: Vec::new(), processes: Vec::new() }, SnapshotTask {
+                vessels: vec![VesselRequirement { name: "prepare".into(), depends_on: Vec::new(), crew: Vec::new() }, VesselRequirement {
                     name: "implement".into(),
                     depends_on: Vec::new(),
-                    processes,
+                    crew: processes,
                 }],
             }),
             ..Default::default()
@@ -332,16 +329,16 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
         .await
         .expect("update convoy status");
 
-    let workspaces = daemon.resource_backend().using::<TaskWorkspace>("flotilla");
+    let workspaces = daemon.resource_backend().using::<Vessel>("flotilla");
     let workspace = workspaces
         .create(
             &input_meta_with_labels(
                 "demo-implement",
-                BTreeMap::from([(CONVOY_LABEL.into(), "demo".into()), (TASK_LABEL.into(), "implement".into())]),
+                BTreeMap::from([(CONVOY_LABEL.into(), "demo".into()), (VESSEL_LABEL.into(), "implement".into())]),
             ),
-            &TaskWorkspaceSpec {
+            &VesselSpec {
                 convoy_ref: "demo".into(),
-                task: "implement".into(),
+                vessel_name: "implement".into(),
                 placement_policy_ref: "host-direct".into(),
                 adopted_checkout_ref: None,
             },
@@ -349,8 +346,8 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
         .await
         .expect("create workspace");
     workspaces
-        .update_status("demo-implement", &workspace.metadata.resource_version, &TaskWorkspaceStatus {
-            phase: TaskWorkspacePhase::Ready,
+        .update_status("demo-implement", &workspace.metadata.resource_version, &VesselStatus {
+            phase: VesselPhase::Ready,
             environment_ref: Some(env_ref.into()),
             terminal_session_refs: vec!["terminal-demo-implement-coder".into()],
             ..Default::default()
@@ -365,8 +362,8 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
                 "terminal-demo-implement-coder",
                 BTreeMap::from([
                     (CONVOY_LABEL.into(), "demo".into()),
-                    (TASK_LABEL.into(), "implement".into()),
-                    (TASK_WORKSPACE_LABEL.into(), "demo-implement".into()),
+                    (VESSEL_LABEL.into(), "implement".into()),
+                    (VESSEL_REF_LABEL.into(), "demo-implement".into()),
                     (ROLE_LABEL.into(), "coder".into()),
                 ]),
             ),
@@ -376,7 +373,11 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
                 source: TerminalSessionSource::Agent {
                     selector: Selector { capability: "coding".into() },
                     brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "coder brief".into() },
-                    context: TerminalCrewContext { namespace: "flotilla".into(), convoy: "demo".into(), vessel: "demo-implement".into() },
+                    context: TerminalCrewContext {
+                        namespace: "flotilla".into(),
+                        convoy: "demo".into(),
+                        vessel_ref: "demo-implement".into(),
+                    },
                     message: None,
                 },
                 cwd: "/repo".into(),
@@ -449,8 +450,8 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
     assert!(
         matches!(reviewer.spec.source, TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Review commit abc123")
     );
-    assert_eq!(reviewer.metadata.labels.get(TASK_ORDINAL_LABEL).map(String::as_str), Some("001"));
-    assert_eq!(reviewer.metadata.labels.get(PROCESS_ORDINAL_LABEL).map(String::as_str), Some("001"));
+    assert_eq!(reviewer.metadata.labels.get(VESSEL_ORDINAL_LABEL).map(String::as_str), Some("001"));
+    assert_eq!(reviewer.metadata.labels.get(CREW_ORDINAL_LABEL).map(String::as_str), Some("001"));
 
     let mut events = daemon.subscribe();
     let command_id = daemon
@@ -482,7 +483,7 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
         crew_id: None,
         namespace: Some("flotilla".into()),
         convoy: Some("demo".into()),
-        vessel: Some("demo-implement".into()),
+        vessel_ref: Some("demo-implement".into()),
         role: Some("reviewer".into()),
     };
     let mut events = daemon.subscribe();
@@ -956,8 +957,8 @@ async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command(
                 "terminal-convoy-a-implement-coder",
                 BTreeMap::from([
                     (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-                    (TASK_LABEL.to_string(), "implement".to_string()),
-                    (TASK_WORKSPACE_LABEL.to_string(), "convoy-a-implement".to_string()),
+                    (VESSEL_LABEL.to_string(), "implement".to_string()),
+                    (VESSEL_REF_LABEL.to_string(), "convoy-a-implement".to_string()),
                     (ROLE_LABEL.to_string(), "coder".to_string()),
                 ]),
             ),
@@ -970,7 +971,7 @@ async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command(
                     context: TerminalCrewContext {
                         namespace: "flotilla".into(),
                         convoy: "convoy-a".into(),
-                        vessel: "convoy-a-implement".into(),
+                        vessel_ref: "convoy-a-implement".into(),
                     },
                     message: None,
                 },
@@ -2053,8 +2054,8 @@ async fn convoy_completion_command_updates_convoy_task_status() {
         .update_status("convoy-a", &created.metadata.resource_version, &ConvoyStatus {
             phase: ConvoyPhase::Active,
             workflow_snapshot: None,
-            tasks: [("implement".to_string(), TaskState {
-                phase: TaskPhase::Running,
+            work: [("implement".to_string(), WorkState {
+                phase: WorkPhase::Running,
                 ready_at: None,
                 started_at: None,
                 finished_at: None,
@@ -2078,9 +2079,9 @@ async fn convoy_completion_command_updates_convoy_task_status() {
             node_id: None,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ConvoyLegComplete {
+            action: CommandAction::ConvoyWorkComplete {
                 convoy: "convoy-a".to_string(),
-                leg: "implement".to_string(),
+                work: "implement".to_string(),
                 message: Some("done".to_string()),
             },
         })
@@ -2102,8 +2103,8 @@ async fn convoy_completion_command_updates_convoy_task_status() {
     assert_eq!(result, CommandValue::Ok);
     let convoy = convoys.get("convoy-a").await.expect("convoy get should succeed");
     let status = convoy.status.expect("convoy status should exist");
-    assert_eq!(status.tasks["implement"].phase, TaskPhase::Completed);
-    assert_eq!(status.tasks["implement"].message.as_deref(), Some("done"));
+    assert_eq!(status.work["implement"].phase, WorkPhase::Completed);
+    assert_eq!(status.work["implement"].message.as_deref(), Some("done"));
 }
 
 #[tokio::test]
@@ -2278,8 +2279,8 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
         .update_status("convoy-a", &created.metadata.resource_version, &ConvoyStatus {
             phase: ConvoyPhase::Active,
             workflow_snapshot: None,
-            tasks: [("implement".to_string(), TaskState {
-                phase: TaskPhase::Running,
+            work: [("implement".to_string(), WorkState {
+                phase: WorkPhase::Running,
                 ready_at: None,
                 started_at: None,
                 finished_at: None,
@@ -2303,9 +2304,9 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
             node_id: None,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ConvoyLegComplete {
+            action: CommandAction::ConvoyWorkComplete {
                 convoy: "convoy-a".to_string(),
-                leg: "implement".to_string(),
+                work: "implement".to_string(),
                 message: Some("done".to_string()),
             },
         })
@@ -2327,7 +2328,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
     assert_eq!(result, CommandValue::Ok);
     let convoy = convoys.get("convoy-a").await.expect("convoy get should succeed");
     let status = convoy.status.expect("convoy status should exist");
-    assert_eq!(status.tasks["implement"].phase, TaskPhase::Completed);
+    assert_eq!(status.work["implement"].phase, WorkPhase::Completed);
 
     // The default namespace must NOT contain the convoy — completion should target
     // only the configured provisioning namespace, not the legacy hardcoded one.

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2103,7 +2103,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
     assert_eq!(result, CommandValue::Ok);
     let convoy = convoys.get("convoy-a").await.expect("convoy get should succeed");
     let status = convoy.status.expect("convoy status should exist");
-    assert_eq!(status.work["implement"].phase, WorkPhase::Completed);
+    assert_eq!(status.work["implement"].phase, WorkPhase::Complete);
     assert_eq!(status.work["implement"].message.as_deref(), Some("done"));
 }
 
@@ -2328,7 +2328,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
     assert_eq!(result, CommandValue::Ok);
     let convoy = convoys.get("convoy-a").await.expect("convoy get should succeed");
     let status = convoy.status.expect("convoy status should exist");
-    assert_eq!(status.work["implement"].phase, WorkPhase::Completed);
+    assert_eq!(status.work["implement"].phase, WorkPhase::Complete);
 
     // The default namespace must NOT contain the convoy — completion should target
     // only the configured provisioning namespace, not the legacy hardcoded one.

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -402,7 +402,7 @@ fn work_phase_label(phase: ResourceWorkPhase) -> &'static str {
         ResourceWorkPhase::Ready => "ready",
         ResourceWorkPhase::Launching => "launching",
         ResourceWorkPhase::Running => "running",
-        ResourceWorkPhase::Completed => "completed",
+        ResourceWorkPhase::Complete => "complete",
         ResourceWorkPhase::Failed => "failed",
         ResourceWorkPhase::Cancelled => "cancelled",
     }

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -8,9 +8,9 @@ use flotilla_protocol::{
     DaemonEvent, FleetReplicaSnapshot, HostName,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, Presentation, ProcessSource, Resource, ResourceError,
-    ResourceList, ResourceObject, SnapshotTask, TaskPhase as ResourceLegPhase, TaskState, TypedResolver, WatchEvent, WatchStart,
-    CONVOY_LABEL, TASK_LABEL,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Presentation, Resource, ResourceError, ResourceList,
+    ResourceObject, TypedResolver, VesselRequirement, WatchEvent, WatchStart, WorkPhase as ResourceLegPhase, WorkState, CONVOY_LABEL,
+    VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::broadcast;
@@ -118,8 +118,8 @@ impl Aggregator {
     fn apply_presentation(&mut self, presentation: &ResourceObject<Presentation>) -> Option<(String, String)> {
         let namespace = presentation.metadata.namespace.clone();
         let convoy = presentation.metadata.labels.get(CONVOY_LABEL)?.clone();
-        let leg = presentation.metadata.labels.get(TASK_LABEL)?.clone();
-        let key = (namespace.clone(), convoy.clone(), leg);
+        let vessel = presentation.metadata.labels.get(VESSEL_LABEL)?.clone();
+        let key = (namespace.clone(), convoy.clone(), vessel);
         match presentation.status.as_ref().and_then(|status| status.observed_workspace_ref.clone()) {
             Some(workspace_ref) => {
                 self.presentation_workspaces.insert(key, workspace_ref);
@@ -137,9 +137,9 @@ impl Aggregator {
             WatchEvent::Deleted(presentation) => {
                 let namespace = presentation.metadata.namespace.clone();
                 let convoy = presentation.metadata.labels.get(CONVOY_LABEL).cloned();
-                let leg = presentation.metadata.labels.get(TASK_LABEL).cloned();
-                if let (Some(convoy), Some(leg)) = (convoy, leg) {
-                    self.presentation_workspaces.remove(&(namespace.clone(), convoy.clone(), leg));
+                let vessel = presentation.metadata.labels.get(VESSEL_LABEL).cloned();
+                if let (Some(convoy), Some(vessel)) = (convoy, vessel) {
+                    self.presentation_workspaces.remove(&(namespace.clone(), convoy.clone(), vessel));
                     Some((namespace, convoy))
                 } else {
                     None
@@ -156,8 +156,8 @@ impl Aggregator {
             let mut view = self.state.write().await;
             let Some(row) = view.local_rows.get_mut(&reference) else { return };
             for child in &mut row.children {
-                let Some(leg) = child.values.get("name").and_then(PanelValue::as_str) else { continue };
-                child.intents = self.intents_for_leg(namespace, convoy, leg);
+                let Some(vessel) = child.values.get("name").and_then(PanelValue::as_str) else { continue };
+                child.intents = self.intents_for_vessel(namespace, convoy, vessel);
             }
             let changed = row.clone();
             view.seq = view.seq.saturating_add(1);
@@ -273,12 +273,13 @@ impl Aggregator {
         ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
     }
 
-    fn intents_for_leg(&self, namespace: &str, convoy: &str, leg: &str) -> Vec<RowIntent> {
+    fn intents_for_vessel(&self, namespace: &str, convoy: &str, vessel: &str) -> Vec<RowIntent> {
+        let attach_ref = self.presentation_workspaces.get(&(namespace.to_string(), convoy.to_string(), vessel.to_string())).cloned();
         let mut intents = Vec::new();
-        if let Some(workspace_ref) = self.presentation_workspaces.get(&(namespace.to_string(), convoy.to_string(), leg.to_string())) {
-            intents.push(RowIntent::vessel("attach", workspace_ref, self.local_host.clone()));
+        if let Some(attach_ref) = attach_ref.clone() {
+            intents.push(RowIntent::vessel("attach", namespace, convoy, vessel, self.local_host.clone(), Some(attach_ref)));
         }
-        intents.push(RowIntent::leg("complete-leg", namespace, convoy, leg, self.local_host.clone()));
+        intents.push(RowIntent::vessel("complete-work", namespace, convoy, vessel, self.local_host.clone(), None));
         intents
     }
 
@@ -293,10 +294,10 @@ impl Aggregator {
             .and_then(|status| status.workflow_snapshot.as_ref())
             .map(|snapshot| {
                 snapshot
-                    .tasks
+                    .vessels
                     .iter()
                     .map(|definition| {
-                        self.summarize_leg(&resource, definition, status.and_then(|status| status.tasks.get(&definition.name)))
+                        self.summarize_vessel(&resource, definition, status.and_then(|status| status.work.get(&definition.name)))
                     })
                     .collect()
             })
@@ -317,15 +318,15 @@ impl Aggregator {
         PanelRow { resource, values, intents: Vec::new(), children, depends_on: Vec::new() }
     }
 
-    fn summarize_leg(&self, convoy_ref: &ResourceRef, definition: &SnapshotTask, state: Option<&TaskState>) -> PanelRow {
-        let resource = convoy_ref.subresource(format!("legs/{}", definition.name));
+    fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> PanelRow {
+        let resource = convoy_ref.subresource(format!("vessels/{}", definition.name));
         let crew = definition
-            .processes
+            .crew
             .iter()
             .map(|process| {
                 let command_preview = match &process.source {
-                    ProcessSource::Tool { command } => command.clone(),
-                    ProcessSource::Agent { selector, prompt } => prompt.clone().unwrap_or_else(|| selector.capability.clone()),
+                    CrewSource::Tool { command } => command.clone(),
+                    CrewSource::Agent { selector, prompt } => prompt.clone().unwrap_or_else(|| selector.capability.clone()),
                 };
                 PanelValue::Map(BTreeMap::from([
                     ("role".to_string(), PanelValue::String(process.role.clone())),
@@ -345,8 +346,8 @@ impl Aggregator {
         insert_optional_timestamp(&mut values, "started_at", state.and_then(|state| state.started_at));
         insert_optional_timestamp(&mut values, "finished_at", state.and_then(|state| state.finished_at));
         insert_optional_string(&mut values, "message", state.and_then(|state| state.message.clone()));
-        let depends_on = definition.depends_on.iter().map(|name| convoy_ref.subresource(format!("legs/{name}"))).collect();
-        let intents = self.intents_for_leg(&convoy_ref.namespace, &convoy_ref.name, &definition.name);
+        let depends_on = definition.depends_on.iter().map(|name| convoy_ref.subresource(format!("vessels/{name}"))).collect();
+        let intents = self.intents_for_vessel(&convoy_ref.namespace, &convoy_ref.name, &definition.name);
         PanelRow { resource, values, intents, children: Vec::new(), depends_on }
     }
 }
@@ -367,7 +368,7 @@ fn set_row_host(row: &mut PanelRow, host: &HostName) {
     }
     for intent in &mut row.intents {
         match &mut intent.target {
-            IntentTarget::Vessel { host: intent_host, .. } | IntentTarget::Leg { host: intent_host, .. } => {
+            IntentTarget::Vessel { host: intent_host, .. } => {
                 *intent_host = host.clone();
             }
         }

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -9,7 +9,7 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Presentation, Resource, ResourceError, ResourceList,
-    ResourceObject, TypedResolver, VesselRequirement, WatchEvent, WatchStart, WorkPhase as ResourceLegPhase, WorkState, CONVOY_LABEL,
+    ResourceObject, TypedResolver, VesselRequirement, WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL,
     VESSEL_LABEL,
 };
 use futures::StreamExt;
@@ -338,7 +338,7 @@ impl Aggregator {
             ("name".to_string(), PanelValue::String(definition.name.clone())),
             (
                 "phase".to_string(),
-                PanelValue::String(leg_phase_label(state.map(|state| state.phase).unwrap_or(ResourceLegPhase::Pending)).into()),
+                PanelValue::String(work_phase_label(state.map(|state| state.phase).unwrap_or(ResourceWorkPhase::Pending)).into()),
             ),
             ("crew".to_string(), PanelValue::List(crew)),
         ]);
@@ -396,15 +396,15 @@ fn convoy_is_initializing(status: Option<&ConvoyStatus>) -> bool {
     status.is_none_or(|status| status.workflow_snapshot.is_none() && !convoy_phase_is_terminal(status.phase))
 }
 
-fn leg_phase_label(phase: ResourceLegPhase) -> &'static str {
+fn work_phase_label(phase: ResourceWorkPhase) -> &'static str {
     match phase {
-        ResourceLegPhase::Pending => "pending",
-        ResourceLegPhase::Ready => "ready",
-        ResourceLegPhase::Launching => "launching",
-        ResourceLegPhase::Running => "running",
-        ResourceLegPhase::Completed => "completed",
-        ResourceLegPhase::Failed => "failed",
-        ResourceLegPhase::Cancelled => "cancelled",
+        ResourceWorkPhase::Pending => "pending",
+        ResourceWorkPhase::Ready => "ready",
+        ResourceWorkPhase::Launching => "launching",
+        ResourceWorkPhase::Running => "running",
+        ResourceWorkPhase::Completed => "completed",
+        ResourceWorkPhase::Failed => "failed",
+        ResourceWorkPhase::Cancelled => "cancelled",
     }
 }
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1312,7 +1312,7 @@ mod tests {
                     convoys.get("convoy-a").await.ok().and_then(|convoy| convoy.status).as_ref(),
                     Some(status)
                         if status.phase == ConvoyPhase::Completed
-                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Completed)
+                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Complete)
                 )
             }
         })
@@ -2028,7 +2028,7 @@ mod tests {
                     convoys.get("convoy-adopted").await.ok().and_then(|convoy| convoy.status).as_ref(),
                     Some(status)
                         if status.phase == ConvoyPhase::Completed
-                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Completed)
+                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Complete)
                 )
             }
         })

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{
     CheckoutReconciler, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime, EnvironmentReconciler, HopChainContext,
-    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, TaskWorkspaceReconciler, TerminalRuntime,
-    TerminalRuntimeState, TerminalSessionReconciler,
+    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, TerminalRuntime, TerminalRuntimeState,
+    TerminalSessionReconciler, VesselReconciler,
 };
 use flotilla_core::{
     agent_adapter::{AgentLaunchRequest, CapabilityTable},
@@ -30,10 +30,10 @@ use flotilla_core::{
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, repo_key, Clone, CloneSpec, Convoy,
-    ConvoyReconciler, DockerCheckoutStrategy, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec, Host,
+    ConvoyReconciler, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
-    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, ProcessDefinition, ProcessSource, ResourceBackend, ResourceError,
-    ResourceObject, TaskDefinition, TaskWorkspace, TerminalSessionSource, WorkflowTemplate, WorkflowTemplateSpec,
+    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, ResourceBackend, ResourceError, ResourceObject, TerminalSessionSource,
+    Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -269,11 +269,11 @@ fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
         "scratch",
         WorkflowTemplateSpec::builder()
             .inputs(vec![InputDefinition { name: "topic".to_string(), description: Some("Short label for this convoy".into()) }])
-            .tasks(vec![TaskDefinition::builder()
+            .vessels(vec![VesselRequirement::builder()
                 .name("work".to_string())
-                .processes(vec![ProcessDefinition::builder()
+                .crew(vec![CrewSpec::builder()
                     .role("shell".to_string())
-                    .source(ProcessSource::Tool {
+                    .source(CrewSource::Tool {
                         command: r#"bash -c 'echo "Convoy {{workflow.name}} ({{inputs.topic}})"; exec bash'"#.to_string(),
                     })
                     .build()])
@@ -640,14 +640,14 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let supervision = supervision.clone();
             async move {
-                supervise("task_workspace", supervision, move || {
+                supervise("vessel", supervision, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     async move {
                         ControllerLoop {
-                            primary: backend.clone().using::<TaskWorkspace>(&namespace_string),
-                            secondaries: TaskWorkspaceReconciler::secondary_watches(),
-                            reconciler: TaskWorkspaceReconciler::new(backend.clone(), &namespace_string),
+                            primary: backend.clone().using::<Vessel>(&namespace_string),
+                            secondaries: VesselReconciler::secondary_watches(),
+                            reconciler: VesselReconciler::new(backend.clone(), &namespace_string),
                             resync_interval: controller_resync_interval,
                             backend,
                         }
@@ -719,7 +719,7 @@ fn spawn_controller_loops(
                             primary: backend.clone().using::<Convoy>(&namespace_string),
                             secondaries: ConvoyReconciler::secondary_watches(),
                             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(&namespace_string))
-                                .with_task_workspaces(backend.clone().using::<TaskWorkspace>(&namespace_string))
+                                .with_vessels(backend.clone().using::<Vessel>(&namespace_string))
                                 .with_presentations(backend.clone().using::<Presentation>(&namespace_string)),
                             resync_interval: controller_resync_interval,
                             backend,
@@ -964,7 +964,7 @@ impl TerminalRuntime for TerminalControllerRuntime {
                 env.extend([
                     ("FLOTILLA_CREW_ID".to_string(), crew_id),
                     ("FLOTILLA_CONVOY".to_string(), context.convoy.clone()),
-                    ("FLOTILLA_VESSEL".to_string(), context.vessel.clone()),
+                    ("FLOTILLA_VESSEL".to_string(), context.vessel_ref.clone()),
                     ("FLOTILLA_CREW_ROLE".to_string(), spec.role.clone()),
                     ("FLOTILLA_NAMESPACE".to_string(), context.namespace.clone()),
                 ]);
@@ -1107,9 +1107,9 @@ mod tests {
     };
     use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent};
     use flotilla_resources::{
-        Checkout as ResourceCheckout, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, LifecycleAuthority, PlacementPolicy,
-        ProcessDefinition, ProcessSource, Selector, SqliteBackend, TaskDefinition, TaskPhase, TerminalSession, TerminalSessionPhase,
-        TypedResolver, WorkflowTemplate, WorkflowTemplateSpec,
+        Checkout as ResourceCheckout, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
+        PlacementPolicy, Selector, SqliteBackend, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WorkPhase,
+        WorkflowTemplate, WorkflowTemplateSpec,
     };
     use tempfile::TempDir;
 
@@ -1224,11 +1224,11 @@ mod tests {
                 &empty_meta("wf-a"),
                 &WorkflowTemplateSpec::builder()
                     .inputs(Vec::new())
-                    .tasks(vec![TaskDefinition::builder()
+                    .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())
-                        .processes(vec![ProcessDefinition::builder()
+                        .crew(vec![CrewSpec::builder()
                             .role("coder".to_string())
-                            .source(ProcessSource::Tool { command: "bash -lc 'echo stage4a'".to_string() })
+                            .source(CrewSource::Tool { command: "bash -lc 'echo stage4a'".to_string() })
                             .build()])
                         .build()])
                     .build(),
@@ -1257,14 +1257,14 @@ mod tests {
                 convoys.get("convoy-a").await.ok().and_then(|convoy| convoy.status).as_ref(),
                 Some(status)
                     if status.phase == ConvoyPhase::Active
-                        && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Running)
+                        && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Running)
             ) {
                 break;
             }
             if tokio::time::Instant::now() >= run_deadline {
                 let convoy = convoys.get("convoy-a").await.expect("convoy should exist");
-                let workspace = backend.clone().using::<TaskWorkspace>(NAMESPACE).list().await.expect("workspace list should succeed");
-                panic!("convoy did not reach running state: convoy={convoy:?} task_workspaces={workspace:?}");
+                let workspace = backend.clone().using::<Vessel>(NAMESPACE).list().await.expect("workspace list should succeed");
+                panic!("convoy did not reach running state: convoy={convoy:?} vessels={workspace:?}");
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
@@ -1272,7 +1272,7 @@ mod tests {
         let host = backend.clone().using::<Host>(NAMESPACE).get(&host_id).await.expect("host should exist after startup");
         assert!(host.status.is_some(), "startup heartbeat should publish host status");
 
-        let workspaces = backend.clone().using::<TaskWorkspace>(NAMESPACE);
+        let workspaces = backend.clone().using::<Vessel>(NAMESPACE);
         let sqlite_path = config.state_dir().as_path().join("resources.sqlite");
         let idle_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         let mut previous_idle_sample = None;
@@ -1296,9 +1296,9 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ConvoyLegComplete {
+                action: CommandAction::ConvoyWorkComplete {
                     convoy: "convoy-a".to_string(),
-                    leg: "implement".to_string(),
+                    work: "implement".to_string(),
                     message: Some("done".to_string()),
                 },
             })
@@ -1312,7 +1312,7 @@ mod tests {
                     convoys.get("convoy-a").await.ok().and_then(|convoy| convoy.status).as_ref(),
                     Some(status)
                         if status.phase == ConvoyPhase::Completed
-                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Completed)
+                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Completed)
                 )
             }
         })
@@ -1539,7 +1539,7 @@ mod tests {
                 context: flotilla_resources::TerminalCrewContext {
                     namespace: NAMESPACE.to_string(),
                     convoy: "demo".to_string(),
-                    vessel: "demo-implement".to_string(),
+                    vessel_ref: "demo-implement".to_string(),
                 },
                 message: None,
             },
@@ -1594,28 +1594,28 @@ mod tests {
                 &empty_meta("crew-workflow"),
                 &WorkflowTemplateSpec::builder()
                     .inputs(Vec::new())
-                    .tasks(vec![TaskDefinition::builder()
+                    .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())
-                        .processes(vec![
-                            ProcessDefinition::builder()
+                        .crew(vec![
+                            CrewSpec::builder()
                                 .role("coder".to_string())
-                                .source(ProcessSource::Agent {
+                                .source(CrewSource::Agent {
                                     selector: Selector { capability: "coding".to_string() },
                                     prompt: Some(
                                         "Implement issue 668 without leaking this full brief into the launch command.".to_string(),
                                     ),
                                 })
                                 .build(),
-                            ProcessDefinition::builder()
+                            CrewSpec::builder()
                                 .role("reviewer".to_string())
-                                .source(ProcessSource::Agent {
+                                .source(CrewSource::Agent {
                                     selector: Selector { capability: "review".to_string() },
                                     prompt: Some("Review the coder's work.".to_string()),
                                 })
                                 .build(),
-                            ProcessDefinition::builder()
+                            CrewSpec::builder()
                                 .role("watcher".to_string())
-                                .source(ProcessSource::Tool { command: "cargo test --watch".to_string() })
+                                .source(CrewSource::Tool { command: "cargo test --watch".to_string() })
                                 .build(),
                         ])
                         .build()])
@@ -1653,7 +1653,7 @@ mod tests {
                     convoys.get("crew-convoy").await.ok().and_then(|convoy| convoy.status).as_ref(),
                     Some(status)
                         if status.phase == ConvoyPhase::Active
-                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Running)
+                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Running)
                 )
             }
         })
@@ -1781,8 +1781,8 @@ mod tests {
         })
         .await;
         assert!(matches!(
-            convoys.get("crew-convoy").await.expect("crew convoy").status.and_then(|status| status.tasks.get("implement").cloned()),
-            Some(task) if task.phase == TaskPhase::Running
+            convoys.get("crew-convoy").await.expect("crew convoy").status.and_then(|status| status.work.get("implement").cloned()),
+            Some(task) if task.phase == WorkPhase::Running
         ));
         let stopped_list = daemon
             .execute_query(
@@ -1840,14 +1840,14 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ConvoyLegComplete {
+                action: CommandAction::ConvoyWorkComplete {
                     convoy: "crew-convoy".to_string(),
-                    leg: "implement".to_string(),
+                    work: "implement".to_string(),
                     message: Some("human accepted the crew's work".to_string()),
                 },
             })
             .await
-            .expect("complete crew leg");
+            .expect("complete work");
         assert_eq!(wait_for_command_result(&mut rx, complete_id).await, CommandValue::Ok);
         wait_until(|| {
             let convoys = convoys.clone();
@@ -1869,11 +1869,11 @@ mod tests {
                 &empty_meta("unknown-capability"),
                 &WorkflowTemplateSpec::builder()
                     .inputs(Vec::new())
-                    .tasks(vec![TaskDefinition::builder()
+                    .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())
-                        .processes(vec![ProcessDefinition::builder()
+                        .crew(vec![CrewSpec::builder()
                             .role("architect".to_string())
-                            .source(ProcessSource::Agent { selector: Selector { capability: "architect".to_string() }, prompt: None })
+                            .source(CrewSource::Agent { selector: Selector { capability: "architect".to_string() }, prompt: None })
                             .build()])
                         .build()])
                     .build(),
@@ -1913,7 +1913,7 @@ mod tests {
         })
         .await;
         let failed = convoys.get("unknown-convoy").await.expect("unknown convoy").status.expect("unknown status");
-        assert_eq!(failed.tasks.get("implement").and_then(|task| task.message.as_deref()), Some("unknown agent capability `architect`"));
+        assert_eq!(failed.work.get("implement").and_then(|task| task.message.as_deref()), Some("unknown agent capability `architect`"));
 
         for handle in controller_handles {
             handle.abort();
@@ -1959,11 +1959,11 @@ mod tests {
                 &empty_meta("wf-a"),
                 &WorkflowTemplateSpec::builder()
                     .inputs(Vec::new())
-                    .tasks(vec![TaskDefinition::builder()
+                    .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())
-                        .processes(vec![ProcessDefinition::builder()
+                        .crew(vec![CrewSpec::builder()
                             .role("coder".to_string())
-                            .source(ProcessSource::Tool { command: "bash -lc 'echo adopted-stage4a'".to_string() })
+                            .source(CrewSource::Tool { command: "bash -lc 'echo adopted-stage4a'".to_string() })
                             .build()])
                         .build()])
                     .build(),
@@ -2000,7 +2000,7 @@ mod tests {
                     convoys.get("convoy-adopted").await.ok().and_then(|convoy| convoy.status).as_ref(),
                     Some(status)
                         if status.phase == ConvoyPhase::Active
-                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Running)
+                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Running)
                 )
             }
         })
@@ -2011,9 +2011,9 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ConvoyLegComplete {
+                action: CommandAction::ConvoyWorkComplete {
                     convoy: "convoy-adopted".to_string(),
-                    leg: "implement".to_string(),
+                    work: "implement".to_string(),
                     message: Some("done".to_string()),
                 },
             })
@@ -2028,7 +2028,7 @@ mod tests {
                     convoys.get("convoy-adopted").await.ok().and_then(|convoy| convoy.status).as_ref(),
                     Some(status)
                         if status.phase == ConvoyPhase::Completed
-                            && matches!(status.tasks.get("implement"), Some(task) if task.phase == TaskPhase::Completed)
+                            && matches!(status.work.get("implement"), Some(task) if task.phase == WorkPhase::Completed)
                 )
             }
         })

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -83,8 +83,8 @@ async fn scratch_workflow_template_is_seeded_at_startup() {
     let templates = backend.using::<WorkflowTemplate>("flotilla");
     let scratch = templates.get("scratch").await.expect("scratch template should be seeded");
     assert_eq!(scratch.metadata.name, "scratch");
-    assert_eq!(scratch.spec.tasks.len(), 1);
-    assert_eq!(scratch.spec.tasks[0].name, "work");
+    assert_eq!(scratch.spec.vessels.len(), 1);
+    assert_eq!(scratch.spec.vessels[0].name, "work");
 }
 
 #[tokio::test]
@@ -140,15 +140,15 @@ async fn workflow_template_apply_creates_then_updates() {
             context_repo: None,
             action: CommandAction::WorkflowTemplateApply {
                 name: "custom".into(),
-                spec_yaml: "tasks:\n  - name: only\n    processes:\n      - role: shell\n        command: 'echo first'\n".into(),
+                spec_yaml: "vessels:\n  - name: only\n    crew:\n      - role: shell\n        command: 'echo first'\n".into(),
             },
         })
         .await
         .expect("execute create");
     assert_eq!(await_command_result(&mut rx, id).await, CommandValue::WorkflowTemplateApplied { name: "custom".into() });
     let v1 = templates.get("custom").await.expect("template should exist");
-    let v1_command = match &v1.spec.tasks[0].processes[0].source {
-        flotilla_resources::ProcessSource::Tool { command } => command.clone(),
+    let v1_command = match &v1.spec.vessels[0].crew[0].source {
+        flotilla_resources::CrewSource::Tool { command } => command.clone(),
         _ => panic!("expected tool process"),
     };
     assert_eq!(v1_command, "echo first");
@@ -161,15 +161,15 @@ async fn workflow_template_apply_creates_then_updates() {
             context_repo: None,
             action: CommandAction::WorkflowTemplateApply {
                 name: "custom".into(),
-                spec_yaml: "tasks:\n  - name: only\n    processes:\n      - role: shell\n        command: 'echo updated'\n".into(),
+                spec_yaml: "vessels:\n  - name: only\n    crew:\n      - role: shell\n        command: 'echo updated'\n".into(),
             },
         })
         .await
         .expect("execute update");
     assert_eq!(await_command_result(&mut rx, id).await, CommandValue::WorkflowTemplateApplied { name: "custom".into() });
     let v2 = templates.get("custom").await.expect("template should still exist");
-    let v2_command = match &v2.spec.tasks[0].processes[0].source {
-        flotilla_resources::ProcessSource::Tool { command } => command.clone(),
+    let v2_command = match &v2.spec.vessels[0].crew[0].source {
+        flotilla_resources::CrewSource::Tool { command } => command.clone(),
         _ => panic!("expected tool process"),
     };
     assert_eq!(v2_command, "echo updated");

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -149,9 +149,9 @@ pub enum CommandAction {
     GenerateBranchName {
         issue_keys: Vec<String>,
     },
-    ConvoyLegComplete {
+    ConvoyWorkComplete {
         convoy: String,
-        leg: String,
+        work: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
     },
@@ -289,7 +289,7 @@ impl Command {
             CommandAction::LinkIssuesToChangeRequest { .. } => "Linking issues...",
             CommandAction::ArchiveSession { .. } => "Archiving session...",
             CommandAction::GenerateBranchName { .. } => "Generating branch name...",
-            CommandAction::ConvoyLegComplete { .. } => "Completing convoy leg...",
+            CommandAction::ConvoyWorkComplete { .. } => "Completing work...",
             CommandAction::CrewHandoff { .. } => "Handing off to crew member...",
             CommandAction::ConvoyCreate { .. } => "Creating convoy...",
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
@@ -566,9 +566,9 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ConvoyLegComplete {
+                action: CommandAction::ConvoyWorkComplete {
                     convoy: "convoy-a".into(),
-                    leg: "implement".into(),
+                    work: "implement".into(),
                     message: Some("done".into()),
                 },
             },
@@ -601,7 +601,7 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::WorkflowTemplateApply { name: "scratch".into(), spec_yaml: "tasks: []\n".into() },
+                action: CommandAction::WorkflowTemplateApply { name: "scratch".into(), spec_yaml: "vessels: []\n".into() },
             },
             Command {
                 node_id: None,
@@ -866,8 +866,8 @@ mod tests {
             })),
             CommandValue::CrewList(Box::new(CrewListResponse {
                 convoy: "convoy-a".into(),
-                vessel: "convoy-a-implement".into(),
-                leg: "implement".into(),
+                vessel_ref: "convoy-a-implement".into(),
+                vessel: "implement".into(),
                 members: vec![CrewListMember {
                     role: "coder".into(),
                     kind: "agent".into(),

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -108,7 +108,7 @@ pub use snapshot::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -552,10 +552,10 @@ fn panel_stream_round_trips_a_resource_backed_leg_dag() {
     };
 
     let convoy_ref = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "fix-bug-123");
-    let implement_ref = convoy_ref.subresource("legs/implement");
-    let review_ref = convoy_ref.subresource("legs/review");
+    let implement_ref = convoy_ref.subresource("vessels/implement");
+    let review_ref = convoy_ref.subresource("vessels/review");
     let attach = IntentDefinition::new("attach", "Attach", IntentKind::Attach);
-    let complete = IntentDefinition::new("complete-leg", "Complete leg", IntentKind::CompleteLeg);
+    let complete = IntentDefinition::new("complete-work", "Complete work", IntentKind::CompleteWork);
     let panel = PanelView {
         id: PanelId::new("convoys"),
         title: "Convoys".into(),
@@ -578,8 +578,8 @@ fn panel_stream_round_trips_a_resource_backed_leg_dag() {
                         ("phase".into(), PanelValue::String("running".into())),
                     ]),
                     intents: vec![
-                        RowIntent::vessel("attach", "ws-1", HostName::new("local")),
-                        RowIntent::leg("complete-leg", "flotilla", "fix-bug-123", "implement", HostName::new("local")),
+                        RowIntent::vessel("attach", "flotilla", "fix-bug-123", "implement", HostName::new("local"), Some("ws-1".into())),
+                        RowIntent::vessel("complete-work", "flotilla", "fix-bug-123", "implement", HostName::new("local"), None),
                     ],
                     children: vec![],
                     depends_on: vec![],

--- a/crates/flotilla-protocol/src/panel.rs
+++ b/crates/flotilla-protocol/src/panel.rs
@@ -148,7 +148,7 @@ impl PanelColumn {
 #[serde(rename_all = "snake_case")]
 pub enum IntentKind {
     Attach,
-    CompleteLeg,
+    CompleteWork,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -167,8 +167,16 @@ impl IntentDefinition {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum IntentTarget {
-    Vessel { attach_ref: String, host: HostName },
-    Leg { namespace: String, convoy: String, leg: String, host: HostName },
+    /// One row entity: the vessel (within-convoy name) plus, when a running
+    /// session exists, the attach reference to reach it.
+    Vessel {
+        namespace: String,
+        convoy: String,
+        vessel: String,
+        host: HostName,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attach_ref: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -178,20 +186,17 @@ pub struct RowIntent {
 }
 
 impl RowIntent {
-    pub fn vessel(intent_id: impl Into<String>, attach_ref: impl Into<String>, host: HostName) -> Self {
-        Self { intent_id: intent_id.into(), target: IntentTarget::Vessel { attach_ref: attach_ref.into(), host } }
-    }
-
-    pub fn leg(
+    pub fn vessel(
         intent_id: impl Into<String>,
         namespace: impl Into<String>,
         convoy: impl Into<String>,
-        leg: impl Into<String>,
+        vessel: impl Into<String>,
         host: HostName,
+        attach_ref: Option<String>,
     ) -> Self {
         Self {
             intent_id: intent_id.into(),
-            target: IntentTarget::Leg { namespace: namespace.into(), convoy: convoy.into(), leg: leg.into(), host },
+            target: IntentTarget::Vessel { namespace: namespace.into(), convoy: convoy.into(), vessel: vessel.into(), host, attach_ref },
         }
     }
 }

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -21,7 +21,7 @@ pub struct CrewCommandContext {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub convoy: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub vessel: Option<String>,
+    pub vessel_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
 }
@@ -29,8 +29,8 @@ pub struct CrewCommandContext {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct CrewListResponse {
     pub convoy: String,
+    pub vessel_ref: String,
     pub vessel: String,
-    pub leg: String,
     pub members: Vec<CrewListMember>,
 }
 

--- a/crates/flotilla-resources/examples/convoy_controller.rs
+++ b/crates/flotilla-resources/examples/convoy_controller.rs
@@ -1,12 +1,12 @@
 use std::{env, path::PathBuf, sync::Arc, time::Duration};
 
 use flotilla_controllers::reconcilers::{
-    HopChainContext, PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, TaskWorkspaceReconciler,
+    HopChainContext, PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, VesselReconciler,
 };
 use flotilla_core::{path_context::DaemonHostPath, providers::registry::ProviderRegistry, HostName};
 use flotilla_resources::{
-    controller::ControllerLoop, ensure_crd, ensure_namespace, Convoy, ConvoyReconciler, HttpBackend, Presentation, ResourceBackend,
-    TaskWorkspace, WorkflowTemplate,
+    controller::ControllerLoop, ensure_crd, ensure_namespace, Convoy, ConvoyReconciler, HttpBackend, Presentation, ResourceBackend, Vessel,
+    WorkflowTemplate,
 };
 use tracing::info;
 
@@ -41,13 +41,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ensure_namespace(&backend, &namespace).await?;
     ensure_crd(&backend, include_str!("../src/crds/workflow_template.crd.yaml")).await?;
     ensure_crd(&backend, include_str!("../src/crds/convoy.crd.yaml")).await?;
-    ensure_crd(&backend, include_str!("../src/crds/task_workspace.crd.yaml")).await?;
+    ensure_crd(&backend, include_str!("../src/crds/vessel.crd.yaml")).await?;
     ensure_crd(&backend, include_str!("../src/crds/presentation.crd.yaml")).await?;
 
     let backend = ResourceBackend::Http(backend);
     let convoys = backend.clone().using::<Convoy>(&namespace);
     let templates = backend.clone().using::<WorkflowTemplate>(&namespace);
-    let task_workspaces = backend.clone().using::<TaskWorkspace>(&namespace);
+    let vessels = backend.clone().using::<Vessel>(&namespace);
     let presentations = backend.clone().using::<Presentation>(&namespace);
     let empty_registry = Arc::new(ProviderRegistry::new());
     let policies = Arc::new(PresentationPolicyRegistry::with_defaults());
@@ -57,9 +57,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::try_join!(
         async {
             ControllerLoop {
-                primary: task_workspaces,
-                secondaries: TaskWorkspaceReconciler::secondary_watches(),
-                reconciler: TaskWorkspaceReconciler::new(backend.clone(), &namespace),
+                primary: vessels,
+                secondaries: VesselReconciler::secondary_watches(),
+                reconciler: VesselReconciler::new(backend.clone(), &namespace),
                 resync_interval: Duration::from_secs(60),
                 backend: backend.clone(),
             }
@@ -92,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 primary: convoys,
                 secondaries: ConvoyReconciler::secondary_watches(),
                 reconciler: ConvoyReconciler::new(templates)
-                    .with_task_workspaces(convoy_backend.clone().using::<TaskWorkspace>(&namespace))
+                    .with_vessels(convoy_backend.clone().using::<Vessel>(&namespace))
                     .with_presentations(convoy_backend.clone().using::<Presentation>(&namespace)),
                 resync_interval: Duration::from_secs(60),
                 backend: convoy_backend,

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -32,8 +32,8 @@ fn load_workflow_spec() -> Result<WorkflowTemplateSpec, Box<dyn std::error::Erro
 
 fn updated_workflow_spec() -> WorkflowTemplateSpec {
     let mut spec = load_workflow_spec().expect("sample workflow should parse");
-    if let flotilla_resources::ProcessSource::Tool { command } = &mut spec.tasks[0].processes[1].source {
-        *command = "cargo check --all-targets".to_string();
+    if let flotilla_resources::CrewSource::Tool { command } = &mut spec.vessels[0].crew[1].source {
+        "cargo check --all-targets".clone_into(command);
     }
     spec
 }
@@ -118,7 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .update_status(&created_convoy.metadata.name, &created_convoy.metadata.resource_version, &ConvoyStatus {
             phase: ConvoyPhase::Active,
             workflow_snapshot: None,
-            tasks: Default::default(),
+            work: Default::default(),
             message: None,
             started_at: None,
             finished_at: None,

--- a/crates/flotilla-resources/examples/review-and-fix.yaml
+++ b/crates/flotilla-resources/examples/review-and-fix.yaml
@@ -9,9 +9,9 @@ spec:
       description: Brief description of the feature to implement
     - name: branch
       description: Target git branch
-  tasks:
+  vessels:
     - name: implement
-      processes:
+      crew:
         - role: coder
           selector:
             capability: code
@@ -23,7 +23,7 @@ spec:
     - name: review
       depends_on:
         - implement
-      processes:
+      crew:
         - role: reviewer
           selector:
             capability: code-review

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -20,8 +20,8 @@ use crate::{
     labels::LifecycleAuthority,
     presentation::PresentationSpec,
     resource::{InputMeta, Resource, ResourceObject},
-    task_workspace::TaskWorkspaceSpec,
     terminal_session::TerminalSessionSpec,
+    vessel::VesselSpec,
     watch::{WatchEvent, WatchStart},
 };
 
@@ -73,10 +73,10 @@ pub enum Actuation {
     CreateClone { meta: InputMeta, spec: CloneSpec },
     CreateCheckout { meta: InputMeta, spec: CheckoutSpec },
     CreateTerminalSession { meta: InputMeta, spec: TerminalSessionSpec },
-    CreateTaskWorkspace { meta: InputMeta, spec: TaskWorkspaceSpec },
+    CreateVessel { meta: InputMeta, spec: VesselSpec },
     CreatePresentation { meta: InputMeta, spec: PresentationSpec },
     DeletePresentation { name: String },
-    DeleteTaskWorkspace { name: String },
+    DeleteVessel { name: String },
 }
 
 pub trait SecondaryWatch: Send + Sync {
@@ -249,8 +249,8 @@ impl<R: Reconciler> ControllerLoop<R> {
                 let resolver = backend.using::<crate::TerminalSession>(namespace);
                 Self::create_if_missing(&resolver, meta, spec).await
             }
-            Actuation::CreateTaskWorkspace { meta, spec } => {
-                let resolver = backend.using::<crate::TaskWorkspace>(namespace);
+            Actuation::CreateVessel { meta, spec } => {
+                let resolver = backend.using::<crate::Vessel>(namespace);
                 Self::create_if_missing(&resolver, meta, spec).await
             }
             Actuation::CreatePresentation { meta, spec } => {
@@ -261,8 +261,8 @@ impl<R: Reconciler> ControllerLoop<R> {
                 let resolver = backend.using::<crate::Presentation>(namespace);
                 Self::delete_if_lifecycle_owned(&resolver, &name).await
             }
-            Actuation::DeleteTaskWorkspace { name } => {
-                let resolver = backend.using::<crate::TaskWorkspace>(namespace);
+            Actuation::DeleteVessel { name } => {
+                let resolver = backend.using::<crate::Vessel>(namespace);
                 Self::delete_if_lifecycle_owned(&resolver, &name).await
             }
         }

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::ProcessDefinition};
+use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement};
 
 mod reconcile;
 
@@ -48,8 +48,11 @@ pub struct ConvoyStatus {
     pub phase: ConvoyPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow_snapshot: Option<WorkflowSnapshot>,
+    /// Work aboard each declared vessel, keyed by vessel (requirement) name.
+    /// Today written by explicit completion; becomes a roll-up over crew-level
+    /// work state later (flotilla#681).
     #[serde(default)]
-    pub tasks: BTreeMap<String, TaskState>,
+    pub work: BTreeMap<String, WorkState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -64,15 +67,7 @@ pub struct ConvoyStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkflowSnapshot {
-    pub tasks: Vec<SnapshotTask>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SnapshotTask {
-    pub name: String,
-    #[serde(default)]
-    pub depends_on: Vec<String>,
-    pub processes: Vec<ProcessDefinition>,
+    pub vessels: Vec<VesselRequirement>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -86,8 +81,8 @@ pub enum ConvoyPhase {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TaskState {
-    pub phase: TaskPhase,
+pub struct WorkState {
+    pub phase: WorkPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ready_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -101,7 +96,7 @@ pub struct TaskState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum TaskPhase {
+pub enum WorkPhase {
     Pending,
     Ready,
     Launching,
@@ -123,7 +118,7 @@ pub enum ConvoyStatusPatch {
         workflow_snapshot: WorkflowSnapshot,
         observed_workflow_ref: String,
         observed_workflows: BTreeMap<String, String>,
-        tasks: BTreeMap<String, TaskState>,
+        work: BTreeMap<String, WorkState>,
         phase: ConvoyPhase,
         started_at: Option<DateTime<Utc>>,
     },
@@ -132,11 +127,11 @@ pub enum ConvoyStatusPatch {
         message: String,
         finished_at: DateTime<Utc>,
     },
-    AdvanceTasksToReady {
+    AdvanceWorkToReady {
         ready: BTreeMap<String, DateTime<Utc>>,
     },
     FailConvoy {
-        cancelled_tasks: BTreeMap<String, DateTime<Utc>>,
+        cancelled_work: BTreeMap<String, DateTime<Utc>>,
         finished_at: DateTime<Utc>,
         message: Option<String>,
     },
@@ -145,26 +140,26 @@ pub enum ConvoyStatusPatch {
         started_at: Option<DateTime<Utc>>,
         finished_at: Option<DateTime<Utc>>,
     },
-    TaskLaunching {
-        task: String,
+    WorkLaunching {
+        work: String,
         started_at: DateTime<Utc>,
         placement: PlacementStatus,
     },
-    TaskRunning {
-        task: String,
+    WorkRunning {
+        work: String,
     },
-    MarkTaskCompleted {
-        task: String,
+    MarkWorkCompleted {
+        work: String,
         finished_at: DateTime<Utc>,
         message: Option<String>,
     },
-    MarkTaskFailed {
-        task: String,
+    MarkWorkFailed {
+        work: String,
         finished_at: DateTime<Utc>,
         message: String,
     },
-    MarkTaskCancelled {
-        task: String,
+    MarkWorkCancelled {
+        work: String,
         finished_at: DateTime<Utc>,
     },
 }
@@ -172,11 +167,11 @@ pub enum ConvoyStatusPatch {
 impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
     fn apply(&self, status: &mut ConvoyStatus) {
         match self {
-            Self::Bootstrap { workflow_snapshot, observed_workflow_ref, observed_workflows, tasks, phase, started_at } => {
+            Self::Bootstrap { workflow_snapshot, observed_workflow_ref, observed_workflows, work, phase, started_at } => {
                 status.workflow_snapshot = Some(workflow_snapshot.clone());
                 status.observed_workflow_ref = Some(observed_workflow_ref.clone());
                 status.observed_workflows = Some(observed_workflows.clone());
-                status.tasks = tasks.clone();
+                status.work = work.clone();
                 status.phase = *phase;
                 if let Some(started_at) = started_at {
                     status.started_at.get_or_insert(*started_at);
@@ -187,21 +182,21 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                 status.message = Some(message.clone());
                 status.finished_at.get_or_insert(*finished_at);
             }
-            Self::AdvanceTasksToReady { ready } => {
-                for (task, ready_at) in ready {
-                    if let Some(state) = status.tasks.get_mut(task) {
-                        state.phase = TaskPhase::Ready;
+            Self::AdvanceWorkToReady { ready } => {
+                for (work, ready_at) in ready {
+                    if let Some(state) = status.work.get_mut(work) {
+                        state.phase = WorkPhase::Ready;
                         state.ready_at.get_or_insert(*ready_at);
                     }
                 }
             }
-            Self::FailConvoy { cancelled_tasks, finished_at, message } => {
+            Self::FailConvoy { cancelled_work, finished_at, message } => {
                 status.phase = ConvoyPhase::Failed;
                 status.finished_at.get_or_insert(*finished_at);
                 status.message = message.clone();
-                for (task, cancelled_at) in cancelled_tasks {
-                    if let Some(state) = status.tasks.get_mut(task) {
-                        state.phase = TaskPhase::Cancelled;
+                for (work, cancelled_at) in cancelled_work {
+                    if let Some(state) = status.work.get_mut(work) {
+                        state.phase = WorkPhase::Cancelled;
                         state.finished_at.get_or_insert(*cancelled_at);
                     }
                 }
@@ -215,35 +210,35 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                     status.finished_at.get_or_insert(*finished_at);
                 }
             }
-            Self::TaskLaunching { task, started_at, placement } => {
-                if let Some(state) = status.tasks.get_mut(task) {
-                    state.phase = TaskPhase::Launching;
+            Self::WorkLaunching { work, started_at, placement } => {
+                if let Some(state) = status.work.get_mut(work) {
+                    state.phase = WorkPhase::Launching;
                     state.started_at.get_or_insert(*started_at);
                     state.placement = Some(placement.clone());
                 }
             }
-            Self::TaskRunning { task } => {
-                if let Some(state) = status.tasks.get_mut(task) {
-                    state.phase = TaskPhase::Running;
+            Self::WorkRunning { work } => {
+                if let Some(state) = status.work.get_mut(work) {
+                    state.phase = WorkPhase::Running;
                 }
             }
-            Self::MarkTaskCompleted { task, finished_at, message } => {
-                if let Some(state) = status.tasks.get_mut(task) {
-                    state.phase = TaskPhase::Completed;
+            Self::MarkWorkCompleted { work, finished_at, message } => {
+                if let Some(state) = status.work.get_mut(work) {
+                    state.phase = WorkPhase::Completed;
                     state.finished_at.get_or_insert(*finished_at);
                     state.message = message.clone();
                 }
             }
-            Self::MarkTaskFailed { task, finished_at, message } => {
-                if let Some(state) = status.tasks.get_mut(task) {
-                    state.phase = TaskPhase::Failed;
+            Self::MarkWorkFailed { work, finished_at, message } => {
+                if let Some(state) = status.work.get_mut(work) {
+                    state.phase = WorkPhase::Failed;
                     state.finished_at.get_or_insert(*finished_at);
                     state.message = Some(message.clone());
                 }
             }
-            Self::MarkTaskCancelled { task, finished_at } => {
-                if let Some(state) = status.tasks.get_mut(task) {
-                    state.phase = TaskPhase::Cancelled;
+            Self::MarkWorkCancelled { work, finished_at } => {
+                if let Some(state) = status.work.get_mut(work) {
+                    state.phase = WorkPhase::Cancelled;
                     state.finished_at.get_or_insert(*finished_at);
                 }
             }
@@ -258,27 +253,27 @@ pub mod controller_patches {
         workflow_snapshot: WorkflowSnapshot,
         observed_workflow_ref: String,
         observed_workflows: BTreeMap<String, String>,
-        tasks: BTreeMap<String, TaskState>,
+        work: BTreeMap<String, WorkState>,
         phase: ConvoyPhase,
         started_at: Option<DateTime<Utc>>,
     ) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::Bootstrap { workflow_snapshot, observed_workflow_ref, observed_workflows, tasks, phase, started_at }
+        ConvoyStatusPatch::Bootstrap { workflow_snapshot, observed_workflow_ref, observed_workflows, work, phase, started_at }
     }
 
     pub fn fail_init(phase: ConvoyPhase, message: String, finished_at: DateTime<Utc>) -> ConvoyStatusPatch {
         ConvoyStatusPatch::FailInit { phase, message, finished_at }
     }
 
-    pub fn advance_tasks_to_ready(ready: BTreeMap<String, DateTime<Utc>>) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::AdvanceTasksToReady { ready }
+    pub fn advance_work_to_ready(ready: BTreeMap<String, DateTime<Utc>>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::AdvanceWorkToReady { ready }
     }
 
     pub fn fail_convoy(
-        cancelled_tasks: BTreeMap<String, DateTime<Utc>>,
+        cancelled_work: BTreeMap<String, DateTime<Utc>>,
         finished_at: DateTime<Utc>,
         message: Option<String>,
     ) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::FailConvoy { cancelled_tasks, finished_at, message }
+        ConvoyStatusPatch::FailConvoy { cancelled_work, finished_at, message }
     }
 
     pub fn roll_up_phase(phase: ConvoyPhase, started_at: Option<DateTime<Utc>>, finished_at: Option<DateTime<Utc>>) -> ConvoyStatusPatch {
@@ -289,27 +284,27 @@ pub mod controller_patches {
 pub mod provisioning_patches {
     use super::*;
 
-    pub fn task_launching(task: String, started_at: DateTime<Utc>, placement: PlacementStatus) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::TaskLaunching { task, started_at, placement }
+    pub fn work_launching(work: String, started_at: DateTime<Utc>, placement: PlacementStatus) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::WorkLaunching { work, started_at, placement }
     }
 
-    pub fn task_running(task: String) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::TaskRunning { task }
+    pub fn work_running(work: String) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::WorkRunning { work }
     }
 }
 
 pub mod external_patches {
     use super::*;
 
-    pub fn mark_task_completed(task: String, finished_at: DateTime<Utc>, message: Option<String>) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::MarkTaskCompleted { task, finished_at, message }
+    pub fn mark_work_completed(work: String, finished_at: DateTime<Utc>, message: Option<String>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::MarkWorkCompleted { work, finished_at, message }
     }
 
-    pub fn mark_task_failed(task: String, finished_at: DateTime<Utc>, message: String) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::MarkTaskFailed { task, finished_at, message }
+    pub fn mark_work_failed(work: String, finished_at: DateTime<Utc>, message: String) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::MarkWorkFailed { work, finished_at, message }
     }
 
-    pub fn mark_task_cancelled(task: String, finished_at: DateTime<Utc>) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::MarkTaskCancelled { task, finished_at }
+    pub fn mark_work_cancelled(work: String, finished_at: DateTime<Utc>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::MarkWorkCancelled { work, finished_at }
     }
 }

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -101,7 +101,7 @@ pub enum WorkPhase {
     Ready,
     Launching,
     Running,
-    Completed,
+    Complete,
     Failed,
     Cancelled,
 }
@@ -224,7 +224,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
             }
             Self::MarkWorkCompleted { work, finished_at, message } => {
                 if let Some(state) = status.work.get_mut(work) {
-                    state.phase = WorkPhase::Completed;
+                    state.phase = WorkPhase::Complete;
                     state.finished_at.get_or_insert(*finished_at);
                     state.message = message.clone();
                 }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -386,7 +386,7 @@ fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option
     }
 
     Some(InternalReconcileOutcome {
-        patch: Some(controller_patches::fail_convoy(cancelled_work, now, Some("task failure detected".to_string()))),
+        patch: Some(controller_patches::fail_convoy(cancelled_work, now, Some("work failure detected".to_string()))),
         actuations: Vec::new(),
         events,
     })
@@ -654,7 +654,7 @@ fn workspace_failure_message(workspace: &ResourceObject<Vessel>) -> String {
         .status
         .as_ref()
         .and_then(|status| status.message.clone())
-        .unwrap_or_else(|| format!("task workspace {} failed", workspace.metadata.name))
+        .unwrap_or_else(|| format!("vessel {} failed", workspace.metadata.name))
 }
 
 fn placement_status(workspace: &ResourceObject<Vessel>) -> PlacementStatus {

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -361,7 +361,7 @@ fn input_value_string(value: &InputValue) -> String {
 }
 
 fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
-    let any_failed = status.work.values().any(|task| task.phase == WorkPhase::Failed);
+    let any_failed = status.work.values().any(|state| state.phase == WorkPhase::Failed);
     if !any_failed {
         return None;
     }
@@ -370,7 +370,7 @@ fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option
         .work
         .iter()
         .filter_map(|(name, state)| match state.phase {
-            WorkPhase::Completed | WorkPhase::Failed | WorkPhase::Cancelled => None,
+            WorkPhase::Complete | WorkPhase::Failed | WorkPhase::Cancelled => None,
             _ => Some((name.clone(), now)),
         })
         .collect::<BTreeMap<_, _>>();
@@ -379,9 +379,9 @@ fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option
     if status.phase != ConvoyPhase::Failed {
         events.push(ConvoyEvent::PhaseChanged { from: status.phase, to: ConvoyPhase::Failed });
     }
-    for task in cancelled_work.keys() {
-        if let Some(state) = status.work.get(task) {
-            events.push(ConvoyEvent::WorkPhaseChanged { work: task.clone(), from: state.phase, to: WorkPhase::Cancelled });
+    for work in cancelled_work.keys() {
+        if let Some(state) = status.work.get(work) {
+            events.push(ConvoyEvent::WorkPhaseChanged { work: work.clone(), from: state.phase, to: WorkPhase::Cancelled });
         }
     }
 
@@ -397,16 +397,16 @@ fn advance_ready_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Op
     let ready = snapshot
         .vessels
         .iter()
-        .filter_map(|task| {
-            let state = status.work.get(&task.name)?;
+        .filter_map(|vessel| {
+            let state = status.work.get(&vessel.name)?;
             if state.phase != WorkPhase::Pending {
                 return None;
             }
-            let all_complete = task
+            let all_complete = vessel
                 .depends_on
                 .iter()
-                .all(|dependency| matches!(status.work.get(dependency), Some(dep_state) if dep_state.phase == WorkPhase::Completed));
-            all_complete.then(|| (task.name.clone(), now))
+                .all(|dependency| matches!(status.work.get(dependency), Some(dep_state) if dep_state.phase == WorkPhase::Complete));
+            all_complete.then(|| (vessel.name.clone(), now))
         })
         .collect::<BTreeMap<_, _>>();
 
@@ -421,14 +421,14 @@ fn advance_ready_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Op
 }
 
 fn roll_up_phase_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ReconcileOutcome> {
-    if !status.work.is_empty() && status.work.values().all(|task| task.phase == WorkPhase::Completed) {
+    if !status.work.is_empty() && status.work.values().all(|state| state.phase == WorkPhase::Complete) {
         return Some(ReconcileOutcome {
             patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(now))),
             events: vec![ConvoyEvent::PhaseChanged { from: status.phase, to: ConvoyPhase::Completed }],
         });
     }
 
-    let any_progressed = status.work.values().any(|task| task.phase != WorkPhase::Pending);
+    let any_progressed = status.work.values().any(|state| state.phase != WorkPhase::Pending);
     if any_progressed && status.phase == ConvoyPhase::Pending {
         return Some(ReconcileOutcome {
             patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(now), None)),
@@ -450,29 +450,29 @@ fn vessel_outcome(
     };
 
     let mut actuations = Vec::new();
-    for task in &snapshot.vessels {
-        let Some(state) = status.work.get(&task.name) else {
+    for requirement in &snapshot.vessels {
+        let Some(state) = status.work.get(&requirement.name) else {
             continue;
         };
-        let workspace = vessels.get(&per_task_resource_name(&convoy.metadata.name, &task.name));
+        let vessel = vessels.get(&vessel_resource_name(&convoy.metadata.name, &requirement.name));
         match state.phase {
             WorkPhase::Ready => {
-                if let Some(workspace) = workspace {
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed) {
-                        return task_failed_outcome(task.name.clone(), state.phase, workspace_failure_message(workspace), now, actuations);
+                if let Some(vessel) = vessel {
+                    if vessel.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed) {
+                        return work_failed_outcome(requirement.name.clone(), state.phase, vessel_failure_message(vessel), now, actuations);
                     }
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Ready) {
+                    if vessel.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Ready) {
                         return InternalReconcileOutcome {
-                            patch: Some(provisioning_patches::work_launching(task.name.clone(), now, placement_status(workspace))),
+                            patch: Some(provisioning_patches::work_launching(requirement.name.clone(), now, placement_status(vessel))),
                             actuations,
                             events: vec![ConvoyEvent::WorkPhaseChanged {
-                                work: task.name.clone(),
+                                work: requirement.name.clone(),
                                 from: WorkPhase::Ready,
                                 to: WorkPhase::Launching,
                             }],
                         };
                     }
-                } else if let Some(outcome) = create_vessel_outcome(convoy, &task.name, now) {
+                } else if let Some(outcome) = create_vessel_outcome(convoy, &requirement.name, now) {
                     if outcome.patch.is_some() {
                         return outcome;
                     }
@@ -480,22 +480,22 @@ fn vessel_outcome(
                 }
             }
             WorkPhase::Launching => {
-                if let Some(workspace) = workspace {
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed) {
-                        return task_failed_outcome(task.name.clone(), state.phase, workspace_failure_message(workspace), now, actuations);
+                if let Some(vessel) = vessel {
+                    if vessel.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed) {
+                        return work_failed_outcome(requirement.name.clone(), state.phase, vessel_failure_message(vessel), now, actuations);
                     }
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Ready) {
+                    if vessel.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Ready) {
                         return InternalReconcileOutcome {
-                            patch: Some(provisioning_patches::work_running(task.name.clone())),
+                            patch: Some(provisioning_patches::work_running(requirement.name.clone())),
                             actuations,
                             events: vec![ConvoyEvent::WorkPhaseChanged {
-                                work: task.name.clone(),
+                                work: requirement.name.clone(),
                                 from: WorkPhase::Launching,
                                 to: WorkPhase::Running,
                             }],
                         };
                     }
-                } else if let Some(outcome) = create_vessel_outcome(convoy, &task.name, now) {
+                } else if let Some(outcome) = create_vessel_outcome(convoy, &requirement.name, now) {
                     if outcome.patch.is_some() {
                         return outcome;
                     }
@@ -503,13 +503,12 @@ fn vessel_outcome(
                 }
             }
             WorkPhase::Running => {
-                if let Some(workspace) =
-                    workspace.filter(|workspace| workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed))
+                if let Some(vessel) = vessel.filter(|vessel| vessel.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed))
                 {
-                    return task_failed_outcome(task.name.clone(), state.phase, workspace_failure_message(workspace), now, actuations);
+                    return work_failed_outcome(requirement.name.clone(), state.phase, vessel_failure_message(vessel), now, actuations);
                 }
             }
-            WorkPhase::Pending | WorkPhase::Completed | WorkPhase::Failed | WorkPhase::Cancelled => {}
+            WorkPhase::Pending | WorkPhase::Complete | WorkPhase::Failed | WorkPhase::Cancelled => {}
         }
     }
 
@@ -541,15 +540,15 @@ fn cleanup_actuations(
 
     let mut actuations = Vec::new();
 
-    for (task, state) in &predicted_status.work {
-        let resource_name = per_task_resource_name(&convoy.metadata.name, task);
+    for (work, state) in &predicted_status.work {
+        let resource_name = vessel_resource_name(&convoy.metadata.name, work);
         match state.phase {
             WorkPhase::Ready | WorkPhase::Launching | WorkPhase::Running => {
                 if !presentations.contains_key(&resource_name) {
-                    actuations.push(create_presentation_actuation(convoy, task));
+                    actuations.push(create_presentation_actuation(convoy, work));
                 }
             }
-            WorkPhase::Completed | WorkPhase::Failed | WorkPhase::Cancelled => {
+            WorkPhase::Complete | WorkPhase::Failed | WorkPhase::Cancelled => {
                 if presentations.contains_key(&resource_name) {
                     actuations.push(Actuation::DeletePresentation { name: resource_name.clone() });
                 }
@@ -564,16 +563,16 @@ fn cleanup_actuations(
     actuations
 }
 
-fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, task: &str, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
+fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, vessel: &str, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
     let placement_policy_ref = convoy.spec.placement_policy.clone()?;
     let repo_url = convoy.spec.repository.as_ref()?.url.clone();
     let canonical_repo = match canonicalize_repo_url(&repo_url) {
         Ok(canonical_repo) => canonical_repo,
         Err(message) => {
             return Some(InternalReconcileOutcome {
-                patch: Some(ConvoyStatusPatch::MarkWorkFailed { work: task.to_string(), finished_at: now, message }),
+                patch: Some(ConvoyStatusPatch::MarkWorkFailed { work: vessel.to_string(), finished_at: now, message }),
                 actuations: Vec::new(),
-                events: vec![ConvoyEvent::WorkPhaseChanged { work: task.to_string(), from: WorkPhase::Ready, to: WorkPhase::Failed }],
+                events: vec![ConvoyEvent::WorkPhaseChanged { work: vessel.to_string(), from: WorkPhase::Ready, to: WorkPhase::Failed }],
             })
         }
     };
@@ -582,10 +581,10 @@ fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, task: &str, now: DateT
         patch: None,
         actuations: vec![Actuation::CreateVessel {
             meta: crate::InputMeta::builder()
-                .name(per_task_resource_name(&convoy.metadata.name, task))
+                .name(vessel_resource_name(&convoy.metadata.name, vessel))
                 .labels(BTreeMap::from([
                     (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
-                    (VESSEL_LABEL.to_string(), task.to_string()),
+                    (VESSEL_LABEL.to_string(), vessel.to_string()),
                     (REPO_KEY_LABEL.to_string(), crate::repo_key(&canonical_repo)),
                 ]))
                 .owner_references(vec![OwnerReference {
@@ -597,7 +596,7 @@ fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, task: &str, now: DateT
                 .build(),
             spec: crate::VesselSpec {
                 convoy_ref: convoy.metadata.name.clone(),
-                vessel_name: task.to_string(),
+                vessel_name: vessel.to_string(),
                 placement_policy_ref,
                 adopted_checkout_ref: convoy.spec.adopted_checkout_ref.clone(),
             },
@@ -606,13 +605,13 @@ fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, task: &str, now: DateT
     })
 }
 
-fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, task: &str) -> Actuation {
+fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, vessel: &str) -> Actuation {
     Actuation::CreatePresentation {
         meta: InputMeta::builder()
-            .name(per_task_resource_name(&convoy.metadata.name, task))
+            .name(vessel_resource_name(&convoy.metadata.name, vessel))
             .labels(BTreeMap::from([
                 (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
-                (VESSEL_LABEL.to_string(), task.to_string()),
+                (VESSEL_LABEL.to_string(), vessel.to_string()),
             ]))
             .owner_references(vec![OwnerReference {
                 api_version: format!("{}/{}", Convoy::API_PATHS.group, Convoy::API_PATHS.version),
@@ -626,35 +625,31 @@ fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, task: &str) ->
             // Stage 4a always uses the built-in default policy. Threading a policy ref through
             // ConvoySpec remains follow-up work once convoys can choose among multiple layouts.
             presentation_policy_ref: "default".to_string(),
-            name: task.to_string(),
+            name: vessel.to_string(),
             process_selector: BTreeMap::from([
                 (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
-                (VESSEL_LABEL.to_string(), task.to_string()),
+                (VESSEL_LABEL.to_string(), vessel.to_string()),
             ]),
         },
     }
 }
 
-fn task_failed_outcome(
-    task: String,
+fn work_failed_outcome(
+    work: String,
     from: WorkPhase,
     message: String,
     now: DateTime<Utc>,
     actuations: Vec<Actuation>,
 ) -> InternalReconcileOutcome {
     InternalReconcileOutcome {
-        patch: Some(ConvoyStatusPatch::MarkWorkFailed { work: task.clone(), finished_at: now, message }),
+        patch: Some(ConvoyStatusPatch::MarkWorkFailed { work: work.clone(), finished_at: now, message }),
         actuations,
-        events: vec![ConvoyEvent::WorkPhaseChanged { work: task.clone(), from, to: WorkPhase::Failed }],
+        events: vec![ConvoyEvent::WorkPhaseChanged { work, from, to: WorkPhase::Failed }],
     }
 }
 
-fn workspace_failure_message(workspace: &ResourceObject<Vessel>) -> String {
-    workspace
-        .status
-        .as_ref()
-        .and_then(|status| status.message.clone())
-        .unwrap_or_else(|| format!("vessel {} failed", workspace.metadata.name))
+fn vessel_failure_message(vessel: &ResourceObject<Vessel>) -> String {
+    vessel.status.as_ref().and_then(|status| status.message.clone()).unwrap_or_else(|| format!("vessel {} failed", vessel.metadata.name))
 }
 
 fn placement_status(workspace: &ResourceObject<Vessel>) -> PlacementStatus {
@@ -680,10 +675,10 @@ fn insert_optional_field(fields: &mut BTreeMap<String, serde_json::Value>, key: 
     }
 }
 
-/// Per-task convoy resources (`Vessel`, `Presentation`) share the name
-/// shape `<convoy>-<task>`. Resource kinds have separate namespaces, so the
+/// Per-vessel convoy resources (`Vessel`, `Presentation`) share the name
+/// shape `<convoy>-<vessel>`. Resource kinds have separate namespaces, so the
 /// shared shape causes no collision and keeps both resources discoverable
 /// together by name.
-fn per_task_resource_name(convoy_name: &str, task: &str) -> String {
-    format!("{convoy_name}-{task}")
+fn vessel_resource_name(convoy_name: &str, vessel: &str) -> String {
+    format!("{convoy_name}-{vessel}")
 }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -4,7 +4,8 @@ use chrono::{DateTime, Utc};
 use serde_json::json;
 
 use super::{
-    controller_patches, provisioning_patches, Convoy, ConvoyPhase, ConvoyStatusPatch, SnapshotTask, TaskPhase, TaskState, WorkflowSnapshot,
+    controller_patches, provisioning_patches, Convoy, ConvoyPhase, ConvoyStatusPatch, VesselRequirement, WorkPhase, WorkState,
+    WorkflowSnapshot,
 };
 use crate::{
     canonicalize_repo_url,
@@ -12,12 +13,12 @@ use crate::{
         delete_lifecycle_owned_matching, Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler,
         SecondaryWatch,
     },
-    labels::{CONVOY_LABEL, TASK_LABEL},
+    labels::{CONVOY_LABEL, VESSEL_LABEL},
     presentation::{Presentation, PresentationSpec},
     resource::ResourceObject,
     status_patch::StatusPatch,
-    task_workspace::{TaskWorkspace, TaskWorkspacePhase},
-    workflow_template::{validate, visit_template_tokens, ProcessDefinition, ProcessSource, ValidationError, WorkflowTemplate},
+    vessel::{Vessel, VesselPhase},
+    workflow_template::{validate, visit_template_tokens, CrewSource, CrewSpec, ValidationError, WorkflowTemplate},
     InputMeta, InputValue, OwnerReference, PlacementStatus, Resource, ResourceError, TypedResolver,
 };
 
@@ -39,7 +40,7 @@ struct InternalReconcileOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConvoyEvent {
     PhaseChanged { from: ConvoyPhase, to: ConvoyPhase },
-    TaskPhaseChanged { task: String, from: TaskPhase, to: TaskPhase },
+    WorkPhaseChanged { work: String, from: WorkPhase, to: WorkPhase },
     TemplateNotFound { name: String },
     TemplateInvalid { name: String, errors: Vec<ValidationError> },
     WorkflowRefChanged { from: String, to: String },
@@ -49,24 +50,24 @@ pub enum ConvoyEvent {
 #[derive(Debug, Clone)]
 pub struct ConvoyReconciler {
     templates: TypedResolver<WorkflowTemplate>,
-    task_workspaces: Option<TypedResolver<TaskWorkspace>>,
+    vessels: Option<TypedResolver<Vessel>>,
     presentations: Option<TypedResolver<Presentation>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct ConvoyDependencies {
     template: Option<ResourceObject<WorkflowTemplate>>,
-    task_workspaces: BTreeMap<String, ResourceObject<TaskWorkspace>>,
+    vessels: BTreeMap<String, ResourceObject<Vessel>>,
     presentations: BTreeMap<String, ResourceObject<Presentation>>,
 }
 
 impl ConvoyReconciler {
     pub fn new(templates: TypedResolver<WorkflowTemplate>) -> Self {
-        Self { templates, task_workspaces: None, presentations: None }
+        Self { templates, vessels: None, presentations: None }
     }
 
-    pub fn with_task_workspaces(mut self, task_workspaces: TypedResolver<TaskWorkspace>) -> Self {
-        self.task_workspaces = Some(task_workspaces);
+    pub fn with_vessels(mut self, vessels: TypedResolver<Vessel>) -> Self {
+        self.vessels = Some(vessels);
         self
     }
 
@@ -77,7 +78,7 @@ impl ConvoyReconciler {
 
     pub fn secondary_watches() -> Vec<Box<dyn SecondaryWatch<Primary = Convoy>>> {
         vec![
-            Box::new(LabelMappedWatch::<TaskWorkspace, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
+            Box::new(LabelMappedWatch::<Vessel, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
             Box::new(LabelMappedWatch::<Presentation, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
         ]
     }
@@ -97,16 +98,14 @@ impl Reconciler for ConvoyReconciler {
                 Err(err) => return Err(err),
             }
         };
-        let task_workspaces = match &self.task_workspaces {
-            Some(task_workspaces) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => {
-                task_workspaces
-                    .list_matching_labels(&BTreeMap::from([(CONVOY_LABEL.to_string(), obj.metadata.name.clone())]))
-                    .await?
-                    .items
-                    .into_iter()
-                    .map(|workspace| (workspace.metadata.name.clone(), workspace))
-                    .collect()
-            }
+        let vessels = match &self.vessels {
+            Some(vessels) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => vessels
+                .list_matching_labels(&BTreeMap::from([(CONVOY_LABEL.to_string(), obj.metadata.name.clone())]))
+                .await?
+                .items
+                .into_iter()
+                .map(|workspace| (workspace.metadata.name.clone(), workspace))
+                .collect(),
             _ => BTreeMap::new(),
         };
         let presentations = match &self.presentations {
@@ -119,7 +118,7 @@ impl Reconciler for ConvoyReconciler {
                 .collect(),
             _ => BTreeMap::new(),
         };
-        Ok(ConvoyDependencies { template, task_workspaces, presentations })
+        Ok(ConvoyDependencies { template, vessels, presentations })
     }
 
     fn reconcile(
@@ -128,7 +127,7 @@ impl Reconciler for ConvoyReconciler {
         deps: &Self::Dependencies,
         now: DateTime<Utc>,
     ) -> ControllerReconcileOutcome<Self::Resource> {
-        let outcome = reconcile_internal(obj, deps.template.as_ref(), &deps.task_workspaces, &deps.presentations, now);
+        let outcome = reconcile_internal(obj, deps.template.as_ref(), &deps.vessels, &deps.presentations, now);
         ControllerReconcileOutcome {
             patch: outcome.patch,
             actuations: outcome.actuations,
@@ -142,8 +141,8 @@ impl Reconciler for ConvoyReconciler {
         if let Some(presentations) = &self.presentations {
             delete_lifecycle_owned_matching(presentations, &selector).await?;
         }
-        if let Some(task_workspaces) = &self.task_workspaces {
-            delete_lifecycle_owned_matching(task_workspaces, &selector).await?;
+        if let Some(vessels) = &self.vessels {
+            delete_lifecycle_owned_matching(vessels, &selector).await?;
         }
         Ok(())
     }
@@ -165,14 +164,14 @@ pub fn reconcile(
 fn reconcile_internal(
     convoy: &ResourceObject<Convoy>,
     template: Option<&ResourceObject<WorkflowTemplate>>,
-    task_workspaces: &BTreeMap<String, ResourceObject<TaskWorkspace>>,
+    vessels: &BTreeMap<String, ResourceObject<Vessel>>,
     presentations: &BTreeMap<String, ResourceObject<Presentation>>,
     now: DateTime<Utc>,
 ) -> InternalReconcileOutcome {
     let status = convoy.status.clone().unwrap_or_default();
 
     if matches!(status.phase, ConvoyPhase::Completed | ConvoyPhase::Failed | ConvoyPhase::Cancelled) {
-        return with_cleanup(convoy, &status, task_workspaces, presentations, InternalReconcileOutcome {
+        return with_cleanup(convoy, &status, vessels, presentations, InternalReconcileOutcome {
             patch: None,
             actuations: Vec::new(),
             events: Vec::new(),
@@ -181,7 +180,7 @@ fn reconcile_internal(
 
     if let Some(observed) = status.observed_workflow_ref.as_ref() {
         if observed != &convoy.spec.workflow_ref {
-            return with_cleanup(convoy, &status, task_workspaces, presentations, InternalReconcileOutcome {
+            return with_cleanup(convoy, &status, vessels, presentations, InternalReconcileOutcome {
                 patch: Some(controller_patches::fail_init(
                     ConvoyPhase::Failed,
                     "workflow_ref changed after init; not supported".to_string(),
@@ -198,16 +197,16 @@ fn reconcile_internal(
     }
 
     if let Some(outcome) = fail_fast_outcome(&status, now) {
-        return with_cleanup(convoy, &status, task_workspaces, presentations, outcome);
+        return with_cleanup(convoy, &status, vessels, presentations, outcome);
     }
 
-    let provisioning = task_workspace_outcome(convoy, &status, task_workspaces, now);
+    let provisioning = vessel_outcome(convoy, &status, vessels, now);
     if provisioning.patch.is_some() {
-        return with_cleanup(convoy, &status, task_workspaces, presentations, provisioning);
+        return with_cleanup(convoy, &status, vessels, presentations, provisioning);
     }
 
     if let Some(outcome) = advance_ready_outcome(&status, now) {
-        return with_cleanup(convoy, &status, task_workspaces, presentations, InternalReconcileOutcome {
+        return with_cleanup(convoy, &status, vessels, presentations, InternalReconcileOutcome {
             patch: outcome.patch,
             actuations: provisioning.actuations,
             events: outcome.events,
@@ -215,14 +214,14 @@ fn reconcile_internal(
     }
 
     if let Some(outcome) = roll_up_phase_outcome(&status, now) {
-        return with_cleanup(convoy, &status, task_workspaces, presentations, InternalReconcileOutcome {
+        return with_cleanup(convoy, &status, vessels, presentations, InternalReconcileOutcome {
             patch: outcome.patch,
             actuations: provisioning.actuations,
             events: outcome.events,
         });
     }
 
-    with_cleanup(convoy, &status, task_workspaces, presentations, provisioning)
+    with_cleanup(convoy, &status, vessels, presentations, provisioning)
 }
 
 fn bootstrap_outcome(
@@ -265,24 +264,24 @@ fn bootstrap_outcome(
     }
 
     let workflow_snapshot = WorkflowSnapshot {
-        tasks: template
+        vessels: template
             .spec
-            .tasks
+            .vessels
             .iter()
-            .map(|task| SnapshotTask {
-                name: task.name.clone(),
-                depends_on: task.depends_on.clone(),
-                processes: task.processes.iter().map(|process| instantiate_process(convoy, process)).collect(),
+            .map(|vessel| VesselRequirement {
+                name: vessel.name.clone(),
+                depends_on: vessel.depends_on.clone(),
+                crew: vessel.crew.iter().map(|member| instantiate_process(convoy, member)).collect(),
             })
             .collect(),
     };
-    let tasks = template
+    let work = template
         .spec
-        .tasks
+        .vessels
         .iter()
-        .map(|task| {
-            (task.name.clone(), TaskState {
-                phase: TaskPhase::Pending,
+        .map(|vessel| {
+            (vessel.name.clone(), WorkState {
+                phase: WorkPhase::Pending,
                 ready_at: None,
                 started_at: None,
                 finished_at: None,
@@ -297,7 +296,7 @@ fn bootstrap_outcome(
             workflow_snapshot,
             convoy.spec.workflow_ref.clone(),
             [(convoy.spec.workflow_ref.clone(), template.metadata.resource_version.clone())].into_iter().collect(),
-            tasks,
+            work,
             ConvoyPhase::Pending,
             None,
         )),
@@ -306,15 +305,15 @@ fn bootstrap_outcome(
     }
 }
 
-fn instantiate_process(convoy: &ResourceObject<Convoy>, process: &ProcessDefinition) -> ProcessDefinition {
+fn instantiate_process(convoy: &ResourceObject<Convoy>, process: &CrewSpec) -> CrewSpec {
     let mut process = process.clone();
     match &mut process.source {
-        ProcessSource::Agent { prompt, .. } => {
+        CrewSource::Agent { prompt, .. } => {
             if let Some(prompt) = prompt {
                 *prompt = interpolate_template_text(convoy, prompt);
             }
         }
-        ProcessSource::Tool { command } => {
+        CrewSource::Tool { command } => {
             *command = interpolate_template_text(convoy, command);
         }
     }
@@ -362,16 +361,16 @@ fn input_value_string(value: &InputValue) -> String {
 }
 
 fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
-    let any_failed = status.tasks.values().any(|task| task.phase == TaskPhase::Failed);
+    let any_failed = status.work.values().any(|task| task.phase == WorkPhase::Failed);
     if !any_failed {
         return None;
     }
 
-    let cancelled_tasks = status
-        .tasks
+    let cancelled_work = status
+        .work
         .iter()
-        .filter_map(|(name, task)| match task.phase {
-            TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled => None,
+        .filter_map(|(name, state)| match state.phase {
+            WorkPhase::Completed | WorkPhase::Failed | WorkPhase::Cancelled => None,
             _ => Some((name.clone(), now)),
         })
         .collect::<BTreeMap<_, _>>();
@@ -380,14 +379,14 @@ fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option
     if status.phase != ConvoyPhase::Failed {
         events.push(ConvoyEvent::PhaseChanged { from: status.phase, to: ConvoyPhase::Failed });
     }
-    for task in cancelled_tasks.keys() {
-        if let Some(state) = status.tasks.get(task) {
-            events.push(ConvoyEvent::TaskPhaseChanged { task: task.clone(), from: state.phase, to: TaskPhase::Cancelled });
+    for task in cancelled_work.keys() {
+        if let Some(state) = status.work.get(task) {
+            events.push(ConvoyEvent::WorkPhaseChanged { work: task.clone(), from: state.phase, to: WorkPhase::Cancelled });
         }
     }
 
     Some(InternalReconcileOutcome {
-        patch: Some(controller_patches::fail_convoy(cancelled_tasks, now, Some("task failure detected".to_string()))),
+        patch: Some(controller_patches::fail_convoy(cancelled_work, now, Some("task failure detected".to_string()))),
         actuations: Vec::new(),
         events,
     })
@@ -396,17 +395,17 @@ fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option
 fn advance_ready_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ReconcileOutcome> {
     let snapshot = status.workflow_snapshot.as_ref()?;
     let ready = snapshot
-        .tasks
+        .vessels
         .iter()
         .filter_map(|task| {
-            let state = status.tasks.get(&task.name)?;
-            if state.phase != TaskPhase::Pending {
+            let state = status.work.get(&task.name)?;
+            if state.phase != WorkPhase::Pending {
                 return None;
             }
             let all_complete = task
                 .depends_on
                 .iter()
-                .all(|dependency| matches!(status.tasks.get(dependency), Some(dep_state) if dep_state.phase == TaskPhase::Completed));
+                .all(|dependency| matches!(status.work.get(dependency), Some(dep_state) if dep_state.phase == WorkPhase::Completed));
             all_complete.then(|| (task.name.clone(), now))
         })
         .collect::<BTreeMap<_, _>>();
@@ -416,20 +415,20 @@ fn advance_ready_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Op
     }
 
     let events =
-        ready.keys().cloned().map(|task| ConvoyEvent::TaskPhaseChanged { task, from: TaskPhase::Pending, to: TaskPhase::Ready }).collect();
+        ready.keys().cloned().map(|work| ConvoyEvent::WorkPhaseChanged { work, from: WorkPhase::Pending, to: WorkPhase::Ready }).collect();
 
-    Some(ReconcileOutcome { patch: Some(controller_patches::advance_tasks_to_ready(ready)), events })
+    Some(ReconcileOutcome { patch: Some(controller_patches::advance_work_to_ready(ready)), events })
 }
 
 fn roll_up_phase_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<ReconcileOutcome> {
-    if !status.tasks.is_empty() && status.tasks.values().all(|task| task.phase == TaskPhase::Completed) {
+    if !status.work.is_empty() && status.work.values().all(|task| task.phase == WorkPhase::Completed) {
         return Some(ReconcileOutcome {
             patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Completed, None, Some(now))),
             events: vec![ConvoyEvent::PhaseChanged { from: status.phase, to: ConvoyPhase::Completed }],
         });
     }
 
-    let any_progressed = status.tasks.values().any(|task| task.phase != TaskPhase::Pending);
+    let any_progressed = status.work.values().any(|task| task.phase != WorkPhase::Pending);
     if any_progressed && status.phase == ConvoyPhase::Pending {
         return Some(ReconcileOutcome {
             patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(now), None)),
@@ -440,10 +439,10 @@ fn roll_up_phase_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Op
     None
 }
 
-fn task_workspace_outcome(
+fn vessel_outcome(
     convoy: &ResourceObject<Convoy>,
     status: &super::ConvoyStatus,
-    task_workspaces: &BTreeMap<String, ResourceObject<TaskWorkspace>>,
+    vessels: &BTreeMap<String, ResourceObject<Vessel>>,
     now: DateTime<Utc>,
 ) -> InternalReconcileOutcome {
     let Some(snapshot) = status.workflow_snapshot.as_ref() else {
@@ -451,66 +450,66 @@ fn task_workspace_outcome(
     };
 
     let mut actuations = Vec::new();
-    for task in &snapshot.tasks {
-        let Some(state) = status.tasks.get(&task.name) else {
+    for task in &snapshot.vessels {
+        let Some(state) = status.work.get(&task.name) else {
             continue;
         };
-        let workspace = task_workspaces.get(&per_task_resource_name(&convoy.metadata.name, &task.name));
+        let workspace = vessels.get(&per_task_resource_name(&convoy.metadata.name, &task.name));
         match state.phase {
-            TaskPhase::Ready => {
+            WorkPhase::Ready => {
                 if let Some(workspace) = workspace {
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(TaskWorkspacePhase::Failed) {
+                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed) {
                         return task_failed_outcome(task.name.clone(), state.phase, workspace_failure_message(workspace), now, actuations);
                     }
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(TaskWorkspacePhase::Ready) {
+                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Ready) {
                         return InternalReconcileOutcome {
-                            patch: Some(provisioning_patches::task_launching(task.name.clone(), now, placement_status(workspace))),
+                            patch: Some(provisioning_patches::work_launching(task.name.clone(), now, placement_status(workspace))),
                             actuations,
-                            events: vec![ConvoyEvent::TaskPhaseChanged {
-                                task: task.name.clone(),
-                                from: TaskPhase::Ready,
-                                to: TaskPhase::Launching,
+                            events: vec![ConvoyEvent::WorkPhaseChanged {
+                                work: task.name.clone(),
+                                from: WorkPhase::Ready,
+                                to: WorkPhase::Launching,
                             }],
                         };
                     }
-                } else if let Some(outcome) = create_task_workspace_outcome(convoy, &task.name, now) {
+                } else if let Some(outcome) = create_vessel_outcome(convoy, &task.name, now) {
                     if outcome.patch.is_some() {
                         return outcome;
                     }
                     actuations.extend(outcome.actuations);
                 }
             }
-            TaskPhase::Launching => {
+            WorkPhase::Launching => {
                 if let Some(workspace) = workspace {
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(TaskWorkspacePhase::Failed) {
+                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed) {
                         return task_failed_outcome(task.name.clone(), state.phase, workspace_failure_message(workspace), now, actuations);
                     }
-                    if workspace.status.as_ref().map(|status| status.phase) == Some(TaskWorkspacePhase::Ready) {
+                    if workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Ready) {
                         return InternalReconcileOutcome {
-                            patch: Some(provisioning_patches::task_running(task.name.clone())),
+                            patch: Some(provisioning_patches::work_running(task.name.clone())),
                             actuations,
-                            events: vec![ConvoyEvent::TaskPhaseChanged {
-                                task: task.name.clone(),
-                                from: TaskPhase::Launching,
-                                to: TaskPhase::Running,
+                            events: vec![ConvoyEvent::WorkPhaseChanged {
+                                work: task.name.clone(),
+                                from: WorkPhase::Launching,
+                                to: WorkPhase::Running,
                             }],
                         };
                     }
-                } else if let Some(outcome) = create_task_workspace_outcome(convoy, &task.name, now) {
+                } else if let Some(outcome) = create_vessel_outcome(convoy, &task.name, now) {
                     if outcome.patch.is_some() {
                         return outcome;
                     }
                     actuations.extend(outcome.actuations);
                 }
             }
-            TaskPhase::Running => {
+            WorkPhase::Running => {
                 if let Some(workspace) =
-                    workspace.filter(|workspace| workspace.status.as_ref().map(|status| status.phase) == Some(TaskWorkspacePhase::Failed))
+                    workspace.filter(|workspace| workspace.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed))
                 {
                     return task_failed_outcome(task.name.clone(), state.phase, workspace_failure_message(workspace), now, actuations);
                 }
             }
-            TaskPhase::Pending | TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled => {}
+            WorkPhase::Pending | WorkPhase::Completed | WorkPhase::Failed | WorkPhase::Cancelled => {}
         }
     }
 
@@ -520,18 +519,18 @@ fn task_workspace_outcome(
 fn with_cleanup(
     convoy: &ResourceObject<Convoy>,
     status: &super::ConvoyStatus,
-    task_workspaces: &BTreeMap<String, ResourceObject<TaskWorkspace>>,
+    vessels: &BTreeMap<String, ResourceObject<Vessel>>,
     presentations: &BTreeMap<String, ResourceObject<Presentation>>,
     mut outcome: InternalReconcileOutcome,
 ) -> InternalReconcileOutcome {
-    outcome.actuations.extend(cleanup_actuations(convoy, status, task_workspaces, presentations, outcome.patch.as_ref()));
+    outcome.actuations.extend(cleanup_actuations(convoy, status, vessels, presentations, outcome.patch.as_ref()));
     outcome
 }
 
 fn cleanup_actuations(
     convoy: &ResourceObject<Convoy>,
     status: &super::ConvoyStatus,
-    task_workspaces: &BTreeMap<String, ResourceObject<TaskWorkspace>>,
+    vessels: &BTreeMap<String, ResourceObject<Vessel>>,
     presentations: &BTreeMap<String, ResourceObject<Presentation>>,
     patch: Option<&ConvoyStatusPatch>,
 ) -> Vec<Actuation> {
@@ -542,51 +541,51 @@ fn cleanup_actuations(
 
     let mut actuations = Vec::new();
 
-    for (task, state) in &predicted_status.tasks {
+    for (task, state) in &predicted_status.work {
         let resource_name = per_task_resource_name(&convoy.metadata.name, task);
         match state.phase {
-            TaskPhase::Ready | TaskPhase::Launching | TaskPhase::Running => {
+            WorkPhase::Ready | WorkPhase::Launching | WorkPhase::Running => {
                 if !presentations.contains_key(&resource_name) {
                     actuations.push(create_presentation_actuation(convoy, task));
                 }
             }
-            TaskPhase::Completed | TaskPhase::Failed | TaskPhase::Cancelled => {
+            WorkPhase::Completed | WorkPhase::Failed | WorkPhase::Cancelled => {
                 if presentations.contains_key(&resource_name) {
                     actuations.push(Actuation::DeletePresentation { name: resource_name.clone() });
                 }
-                if task_workspaces.contains_key(&resource_name) {
-                    actuations.push(Actuation::DeleteTaskWorkspace { name: resource_name });
+                if vessels.contains_key(&resource_name) {
+                    actuations.push(Actuation::DeleteVessel { name: resource_name });
                 }
             }
-            TaskPhase::Pending => {}
+            WorkPhase::Pending => {}
         }
     }
 
     actuations
 }
 
-fn create_task_workspace_outcome(convoy: &ResourceObject<Convoy>, task: &str, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
+fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, task: &str, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
     let placement_policy_ref = convoy.spec.placement_policy.clone()?;
     let repo_url = convoy.spec.repository.as_ref()?.url.clone();
     let canonical_repo = match canonicalize_repo_url(&repo_url) {
         Ok(canonical_repo) => canonical_repo,
         Err(message) => {
             return Some(InternalReconcileOutcome {
-                patch: Some(ConvoyStatusPatch::MarkTaskFailed { task: task.to_string(), finished_at: now, message }),
+                patch: Some(ConvoyStatusPatch::MarkWorkFailed { work: task.to_string(), finished_at: now, message }),
                 actuations: Vec::new(),
-                events: vec![ConvoyEvent::TaskPhaseChanged { task: task.to_string(), from: TaskPhase::Ready, to: TaskPhase::Failed }],
+                events: vec![ConvoyEvent::WorkPhaseChanged { work: task.to_string(), from: WorkPhase::Ready, to: WorkPhase::Failed }],
             })
         }
     };
 
     Some(InternalReconcileOutcome {
         patch: None,
-        actuations: vec![Actuation::CreateTaskWorkspace {
+        actuations: vec![Actuation::CreateVessel {
             meta: crate::InputMeta::builder()
                 .name(per_task_resource_name(&convoy.metadata.name, task))
                 .labels(BTreeMap::from([
                     (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
-                    (TASK_LABEL.to_string(), task.to_string()),
+                    (VESSEL_LABEL.to_string(), task.to_string()),
                     (REPO_KEY_LABEL.to_string(), crate::repo_key(&canonical_repo)),
                 ]))
                 .owner_references(vec![OwnerReference {
@@ -596,9 +595,9 @@ fn create_task_workspace_outcome(convoy: &ResourceObject<Convoy>, task: &str, no
                     controller: true,
                 }])
                 .build(),
-            spec: crate::TaskWorkspaceSpec {
+            spec: crate::VesselSpec {
                 convoy_ref: convoy.metadata.name.clone(),
-                task: task.to_string(),
+                vessel_name: task.to_string(),
                 placement_policy_ref,
                 adopted_checkout_ref: convoy.spec.adopted_checkout_ref.clone(),
             },
@@ -611,7 +610,10 @@ fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, task: &str) ->
     Actuation::CreatePresentation {
         meta: InputMeta::builder()
             .name(per_task_resource_name(&convoy.metadata.name, task))
-            .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.metadata.name.clone()), (TASK_LABEL.to_string(), task.to_string())]))
+            .labels(BTreeMap::from([
+                (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
+                (VESSEL_LABEL.to_string(), task.to_string()),
+            ]))
             .owner_references(vec![OwnerReference {
                 api_version: format!("{}/{}", Convoy::API_PATHS.group, Convoy::API_PATHS.version),
                 kind: Convoy::API_PATHS.kind.to_string(),
@@ -627,7 +629,7 @@ fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, task: &str) ->
             name: task.to_string(),
             process_selector: BTreeMap::from([
                 (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
-                (TASK_LABEL.to_string(), task.to_string()),
+                (VESSEL_LABEL.to_string(), task.to_string()),
             ]),
         },
     }
@@ -635,19 +637,19 @@ fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, task: &str) ->
 
 fn task_failed_outcome(
     task: String,
-    from: TaskPhase,
+    from: WorkPhase,
     message: String,
     now: DateTime<Utc>,
     actuations: Vec<Actuation>,
 ) -> InternalReconcileOutcome {
     InternalReconcileOutcome {
-        patch: Some(ConvoyStatusPatch::MarkTaskFailed { task: task.clone(), finished_at: now, message }),
+        patch: Some(ConvoyStatusPatch::MarkWorkFailed { work: task.clone(), finished_at: now, message }),
         actuations,
-        events: vec![ConvoyEvent::TaskPhaseChanged { task, from, to: TaskPhase::Failed }],
+        events: vec![ConvoyEvent::WorkPhaseChanged { work: task.clone(), from, to: WorkPhase::Failed }],
     }
 }
 
-fn workspace_failure_message(workspace: &ResourceObject<TaskWorkspace>) -> String {
+fn workspace_failure_message(workspace: &ResourceObject<Vessel>) -> String {
     workspace
         .status
         .as_ref()
@@ -655,8 +657,8 @@ fn workspace_failure_message(workspace: &ResourceObject<TaskWorkspace>) -> Strin
         .unwrap_or_else(|| format!("task workspace {} failed", workspace.metadata.name))
 }
 
-fn placement_status(workspace: &ResourceObject<TaskWorkspace>) -> PlacementStatus {
-    let mut fields = BTreeMap::from([("task_workspace_ref".to_string(), json!(workspace.metadata.name))]);
+fn placement_status(workspace: &ResourceObject<Vessel>) -> PlacementStatus {
+    let mut fields = BTreeMap::from([("vessel_ref".to_string(), json!(workspace.metadata.name))]);
     if let Some(status) = workspace.status.as_ref() {
         insert_optional_field(&mut fields, "environment_ref", status.environment_ref.clone());
         insert_optional_field(&mut fields, "checkout_ref", status.checkout_ref.clone());
@@ -678,7 +680,7 @@ fn insert_optional_field(fields: &mut BTreeMap<String, serde_json::Value>, key: 
     }
 }
 
-/// Per-task convoy resources (`TaskWorkspace`, `Presentation`) share the name
+/// Per-task convoy resources (`Vessel`, `Presentation`) share the name
 /// shape `<convoy>-<task>`. Resource kinds have separate namespaces, so the
 /// shared shape causes no collision and keeps both resources discoverable
 /// together by name.

--- a/crates/flotilla-resources/src/crds/convoy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/convoy.crd.yaml
@@ -65,11 +65,11 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                   properties:
-                    tasks:
+                    vessels:
                       type: array
                       items:
                         type: object
-                        required: [name, processes]
+                        required: [name, crew]
                         properties:
                           name:
                             type: string
@@ -78,7 +78,7 @@ spec:
                             type: array
                             items:
                               type: string
-                          processes:
+                          crew:
                             type: array
                             items:
                               type: object
@@ -91,7 +91,7 @@ spec:
                 finished_at:
                   type: string
                   format: date-time
-                tasks:
+                work:
                   type: object
                   additionalProperties:
                     type: object

--- a/crates/flotilla-resources/src/crds/vessel.crd.yaml
+++ b/crates/flotilla-resources/src/crds/vessel.crd.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: taskworkspaces.flotilla.work
+  name: vessels.flotilla.work
 spec:
   group: flotilla.work
   scope: Namespaced
   names:
-    plural: taskworkspaces
-    singular: taskworkspace
-    kind: TaskWorkspace
+    plural: vessels
+    singular: vessel
+    kind: Vessel
   versions:
     - name: v1
       served: true
@@ -19,9 +19,9 @@ spec:
         - name: Convoy
           type: string
           jsonPath: .spec.convoy_ref
-        - name: Task
+        - name: Vessel
           type: string
-          jsonPath: .spec.task
+          jsonPath: .spec.vessel_name
         - name: Phase
           type: string
           jsonPath: .status.phase

--- a/crates/flotilla-resources/src/crds/workflow_template.crd.yaml
+++ b/crates/flotilla-resources/src/crds/workflow_template.crd.yaml
@@ -22,7 +22,7 @@ spec:
             spec:
               type: object
               required:
-                - tasks
+                - vessels
               properties:
                 inputs:
                   type: array
@@ -36,14 +36,14 @@ spec:
                         minLength: 1
                       description:
                         type: string
-                tasks:
+                vessels:
                   type: array
                   minItems: 1
                   items:
                     type: object
                     required:
                       - name
-                      - processes
+                      - crew
                     properties:
                       name:
                         type: string
@@ -52,7 +52,7 @@ spec:
                         type: array
                         items:
                           type: string
-                      processes:
+                      crew:
                         type: array
                         minItems: 1
                         items:

--- a/crates/flotilla-resources/src/labels.rs
+++ b/crates/flotilla-resources/src/labels.rs
@@ -4,12 +4,12 @@ use crate::error::ResourceError;
 
 pub const AUTHORITY_LABEL: &str = "flotilla.work/authority";
 pub const CONVOY_LABEL: &str = "flotilla.work/convoy";
-pub const TASK_LABEL: &str = "flotilla.work/task";
-pub const TASK_WORKSPACE_LABEL: &str = "flotilla.work/task_workspace";
+pub const VESSEL_LABEL: &str = "flotilla.work/vessel";
+pub const VESSEL_REF_LABEL: &str = "flotilla.work/vessel_ref";
 pub const ROLE_LABEL: &str = "flotilla.work/role";
 pub const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
-pub const TASK_ORDINAL_LABEL: &str = "flotilla.work/task_ordinal";
-pub const PROCESS_ORDINAL_LABEL: &str = "flotilla.work/process_ordinal";
+pub const VESSEL_ORDINAL_LABEL: &str = "flotilla.work/vessel_ordinal";
+pub const CREW_ORDINAL_LABEL: &str = "flotilla.work/crew_ordinal";
 pub const REPO_LABEL: &str = "flotilla.work/repo";
 pub const RESERVED_PREFIX: &str = "flotilla.work/";
 

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -17,8 +17,8 @@ mod resource;
 mod retention;
 mod sqlite;
 mod status_patch;
-mod task_workspace;
 mod terminal_session;
+mod vessel;
 mod watch;
 mod workflow_template;
 
@@ -30,8 +30,8 @@ pub use checkout::{
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
     controller_patches, external_patches, provisioning_patches, reconcile, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, InputValue, PlacementStatus, ReconcileOutcome, SnapshotTask,
-    TaskPhase, TaskState, WorkflowSnapshot,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, InputValue, PlacementStatus, ReconcileOutcome, WorkPhase, WorkState,
+    WorkflowSnapshot,
 };
 pub use environment::{
     DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus,
@@ -42,8 +42,8 @@ pub use host::{Host, HostSpec, HostStatus, HostStatusPatch};
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use labels::{
-    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, PROCESS_ORDINAL_LABEL, REPO_KEY_LABEL, REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL,
-    TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, CREW_ORDINAL_LABEL, REPO_KEY_LABEL, REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL,
+    VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 pub use placement_policy::{
     DockerCheckoutStrategy, DockerPerTaskPlacementPolicySpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,
@@ -59,14 +59,14 @@ pub use resource::{
 pub use retention::{EventRetention, ResourceStoreDiagnostics, ResourceStoreWarning};
 pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};
-pub use task_workspace::{TaskWorkspace, TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TaskWorkspaceStatusPatch};
 pub use terminal_session::{
     terminal_session_attach_target, CrewSessionStatus, InnerCommandStatus, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession, TerminalSessionAttachTarget, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource,
     TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
 };
+pub use vessel::{Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch};
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
 pub use workflow_template::{
-    validate, InputDefinition, InterpolationField, InterpolationLocation, ProcessDefinition, ProcessSource, Selector, TaskDefinition,
-    ValidationError, WorkflowTemplate, WorkflowTemplateSpec,
+    validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation, Selector, ValidationError,
+    VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -4,46 +4,48 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    resource::define_resource, status_patch::StatusPatch, InputMeta, OwnerReference, Resource, ResourceObject, Selector, TaskWorkspace,
-    CONVOY_LABEL, PROCESS_ORDINAL_LABEL, ROLE_LABEL, TASK_LABEL, TASK_ORDINAL_LABEL, TASK_WORKSPACE_LABEL,
+    resource::define_resource, status_patch::StatusPatch, InputMeta, OwnerReference, Resource, ResourceObject, Selector, Vessel,
+    CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 define_resource!(TerminalSession, "terminalsessions", TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch);
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct TerminalSessionIdentity {
-    pub vessel: String,
+    /// The Vessel resource name (unique in the namespace, e.g. `conv-implement`).
+    pub vessel_ref: String,
     pub convoy: String,
-    pub leg: String,
+    /// The within-convoy vessel name (the requirement / work key, e.g. `implement`).
+    pub vessel: String,
     pub role: String,
-    pub task_index: usize,
-    pub process_index: usize,
+    pub vessel_index: usize,
+    pub crew_index: usize,
     #[builder(default)]
     pub labels: BTreeMap<String, String>,
 }
 
 impl TerminalSessionIdentity {
     pub fn name(&self) -> String {
-        format!("terminal-{}-{}", self.vessel, self.role)
+        format!("terminal-{}-{}", self.vessel_ref, self.role)
     }
 
     pub fn input_meta(&self) -> InputMeta {
         let mut labels = self.labels.clone();
         labels.extend([
             (CONVOY_LABEL.to_string(), self.convoy.clone()),
-            (TASK_LABEL.to_string(), self.leg.clone()),
-            (TASK_WORKSPACE_LABEL.to_string(), self.vessel.clone()),
+            (VESSEL_LABEL.to_string(), self.vessel.clone()),
+            (VESSEL_REF_LABEL.to_string(), self.vessel_ref.clone()),
             (ROLE_LABEL.to_string(), self.role.clone()),
-            (TASK_ORDINAL_LABEL.to_string(), format!("{:03}", self.task_index)),
-            (PROCESS_ORDINAL_LABEL.to_string(), format!("{:03}", self.process_index)),
+            (VESSEL_ORDINAL_LABEL.to_string(), format!("{:03}", self.vessel_index)),
+            (CREW_ORDINAL_LABEL.to_string(), format!("{:03}", self.crew_index)),
         ]);
         InputMeta::builder()
             .name(self.name())
             .labels(labels)
             .owner_references(vec![OwnerReference {
-                api_version: format!("{}/{}", TaskWorkspace::API_PATHS.group, TaskWorkspace::API_PATHS.version),
-                kind: TaskWorkspace::API_PATHS.kind.to_string(),
-                name: self.vessel.clone(),
+                api_version: format!("{}/{}", Vessel::API_PATHS.group, Vessel::API_PATHS.version),
+                kind: Vessel::API_PATHS.kind.to_string(),
+                name: self.vessel_ref.clone(),
                 controller: true,
             }])
             .build()
@@ -107,7 +109,8 @@ pub struct TerminalBrief {
 pub struct TerminalCrewContext {
     pub namespace: String,
     pub convoy: String,
-    pub vessel: String,
+    /// The Vessel resource name.
+    pub vessel_ref: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -3,19 +3,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::StatusPatch};
 
-define_resource!(TaskWorkspace, "taskworkspaces", TaskWorkspaceSpec, TaskWorkspaceStatus, TaskWorkspaceStatusPatch);
+define_resource!(Vessel, "vessels", VesselSpec, VesselStatus, VesselStatusPatch);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TaskWorkspaceSpec {
+pub struct VesselSpec {
     pub convoy_ref: String,
-    pub task: String,
+    /// The within-convoy vessel name (the requirement / work key, e.g. `implement`).
+    pub vessel_name: String,
     pub placement_policy_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub adopted_checkout_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum TaskWorkspacePhase {
+pub enum VesselPhase {
     #[default]
     Pending,
     Provisioning,
@@ -25,8 +26,8 @@ pub enum TaskWorkspacePhase {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TaskWorkspaceStatus {
-    pub phase: TaskWorkspacePhase,
+pub struct VesselStatus {
+    pub phase: VesselPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -46,25 +47,25 @@ pub struct TaskWorkspaceStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TaskWorkspaceStatusPatch {
+pub enum VesselStatusPatch {
     MarkProvisioning { observed_policy_ref: String, observed_policy_version: String, started_at: DateTime<Utc> },
     MarkReady { environment_ref: Option<String>, checkout_ref: Option<String>, terminal_session_refs: Vec<String>, ready_at: DateTime<Utc> },
     MarkTearingDown,
     MarkFailed { message: String },
 }
 
-impl StatusPatch<TaskWorkspaceStatus> for TaskWorkspaceStatusPatch {
-    fn apply(&self, status: &mut TaskWorkspaceStatus) {
+impl StatusPatch<VesselStatus> for VesselStatusPatch {
+    fn apply(&self, status: &mut VesselStatus) {
         match self {
             Self::MarkProvisioning { observed_policy_ref, observed_policy_version, started_at } => {
-                status.phase = TaskWorkspacePhase::Provisioning;
+                status.phase = VesselPhase::Provisioning;
                 status.observed_policy_ref = Some(observed_policy_ref.clone());
                 status.observed_policy_version = Some(observed_policy_version.clone());
                 status.started_at.get_or_insert(*started_at);
                 status.message = None;
             }
             Self::MarkReady { environment_ref, checkout_ref, terminal_session_refs, ready_at } => {
-                status.phase = TaskWorkspacePhase::Ready;
+                status.phase = VesselPhase::Ready;
                 status.environment_ref = environment_ref.clone();
                 status.checkout_ref = checkout_ref.clone();
                 status.terminal_session_refs = terminal_session_refs.clone();
@@ -72,10 +73,10 @@ impl StatusPatch<TaskWorkspaceStatus> for TaskWorkspaceStatusPatch {
                 status.message = None;
             }
             Self::MarkTearingDown => {
-                status.phase = TaskWorkspacePhase::TearingDown;
+                status.phase = VesselPhase::TearingDown;
             }
             Self::MarkFailed { message } => {
-                status.phase = TaskWorkspacePhase::Failed;
+                status.phase = VesselPhase::Failed;
                 status.message = Some(message.clone());
             }
         }

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -11,7 +11,7 @@ pub struct WorkflowTemplateSpec {
     #[builder(default)]
     #[serde(default)]
     pub inputs: Vec<InputDefinition>,
-    pub tasks: Vec<TaskDefinition>,
+    pub vessels: Vec<VesselRequirement>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,19 +22,19 @@ pub struct InputDefinition {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
-pub struct TaskDefinition {
+pub struct VesselRequirement {
     pub name: String,
     #[builder(default)]
     #[serde(default)]
     pub depends_on: Vec<String>,
-    pub processes: Vec<ProcessDefinition>,
+    pub crew: Vec<CrewSpec>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
-pub struct ProcessDefinition {
+pub struct CrewSpec {
     pub role: String,
     #[serde(flatten)]
-    pub source: ProcessSource,
+    pub source: CrewSource,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
@@ -42,7 +42,7 @@ pub struct ProcessDefinition {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum ProcessSource {
+pub enum CrewSource {
     Agent {
         selector: Selector,
         #[serde(default)]
@@ -62,8 +62,8 @@ pub struct Selector {
 pub enum ValidationError {
     DuplicateTaskName { name: String },
     DuplicateRoleInTask { task: String, role: String },
-    ReservedLabelKey { task: String, role: String, key: String },
-    UnknownDependency { task: String, missing: String },
+    ReservedLabelKey { vessel: String, role: String, key: String },
+    UnknownDependency { vessel: String, missing: String },
     DependencyCycle { cycle: Vec<String> },
     DuplicateInputName { name: String },
     MalformedInterpolation { location: InterpolationLocation, text: String },
@@ -73,7 +73,7 @@ pub enum ValidationError {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterpolationLocation {
-    pub task: String,
+    pub vessel: String,
     pub role: String,
     pub field: InterpolationField,
 }
@@ -95,7 +95,7 @@ impl std::fmt::Display for InterpolationField {
 
 impl std::fmt::Display for InterpolationLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "task `{}` role `{}` {}", self.task, self.role, self.field)
+        write!(f, "vessel `{}` role `{}` {}", self.vessel, self.role, self.field)
     }
 }
 
@@ -104,10 +104,10 @@ impl std::fmt::Display for ValidationError {
         match self {
             ValidationError::DuplicateTaskName { name } => write!(f, "duplicate task name `{name}`"),
             ValidationError::DuplicateRoleInTask { task, role } => write!(f, "duplicate role `{role}` in task `{task}`"),
-            ValidationError::ReservedLabelKey { task, role, key } => {
-                write!(f, "reserved label key `{key}` on task `{task}` role `{role}`")
+            ValidationError::ReservedLabelKey { vessel, role, key } => {
+                write!(f, "reserved label key `{key}` on vessel `{vessel}` role `{role}`")
             }
-            ValidationError::UnknownDependency { task, missing } => write!(f, "task `{task}` depends on unknown task `{missing}`"),
+            ValidationError::UnknownDependency { vessel, missing } => write!(f, "vessel `{vessel}` depends on unknown vessel `{missing}`"),
             ValidationError::DependencyCycle { cycle } => write!(f, "dependency cycle: {}", cycle.join(" -> ")),
             ValidationError::DuplicateInputName { name } => write!(f, "duplicate input name `{name}`"),
             ValidationError::MalformedInterpolation { location, text } => {
@@ -136,7 +136,7 @@ pub fn validate(spec: &WorkflowTemplateSpec) -> Result<(), Vec<ValidationError>>
     let declared_inputs = collect_inputs(spec, &mut errors);
     let tasks_by_name = collect_tasks(spec, &mut errors);
 
-    for task in &spec.tasks {
+    for task in &spec.vessels {
         validate_task(task, &declared_inputs, &tasks_by_name, &mut errors);
     }
     validate_cycles(&tasks_by_name, &mut errors);
@@ -158,9 +158,9 @@ fn collect_inputs(spec: &WorkflowTemplateSpec, errors: &mut Vec<ValidationError>
     declared_inputs
 }
 
-fn collect_tasks<'a>(spec: &'a WorkflowTemplateSpec, errors: &mut Vec<ValidationError>) -> BTreeMap<String, &'a TaskDefinition> {
+fn collect_tasks<'a>(spec: &'a WorkflowTemplateSpec, errors: &mut Vec<ValidationError>) -> BTreeMap<String, &'a VesselRequirement> {
     let mut tasks_by_name = BTreeMap::new();
-    for task in &spec.tasks {
+    for task in &spec.vessels {
         if tasks_by_name.insert(task.name.clone(), task).is_some() {
             push_error(errors, ValidationError::DuplicateTaskName { name: task.name.clone() });
         }
@@ -169,19 +169,19 @@ fn collect_tasks<'a>(spec: &'a WorkflowTemplateSpec, errors: &mut Vec<Validation
 }
 
 fn validate_task(
-    task: &TaskDefinition,
+    task: &VesselRequirement,
     declared_inputs: &BTreeSet<String>,
-    tasks_by_name: &BTreeMap<String, &TaskDefinition>,
+    tasks_by_name: &BTreeMap<String, &VesselRequirement>,
     errors: &mut Vec<ValidationError>,
 ) {
     let mut roles = BTreeSet::new();
     for dependency in &task.depends_on {
         if !tasks_by_name.contains_key(dependency) {
-            push_error(errors, ValidationError::UnknownDependency { task: task.name.clone(), missing: dependency.clone() });
+            push_error(errors, ValidationError::UnknownDependency { vessel: task.name.clone(), missing: dependency.clone() });
         }
     }
 
-    for process in &task.processes {
+    for process in &task.crew {
         if !roles.insert(process.role.clone()) {
             push_error(errors, ValidationError::DuplicateRoleInTask { task: task.name.clone(), role: process.role.clone() });
         }
@@ -189,7 +189,7 @@ fn validate_task(
         for key in process.labels.keys() {
             if key.starts_with(crate::labels::RESERVED_PREFIX) {
                 push_error(errors, ValidationError::ReservedLabelKey {
-                    task: task.name.clone(),
+                    vessel: task.name.clone(),
                     role: process.role.clone(),
                     key: key.clone(),
                 });
@@ -197,19 +197,19 @@ fn validate_task(
         }
 
         match &process.source {
-            ProcessSource::Agent { prompt, .. } => {
+            CrewSource::Agent { prompt, .. } => {
                 if let Some(prompt) = prompt {
                     validate_template_text(
                         prompt,
-                        &InterpolationLocation { task: task.name.clone(), role: process.role.clone(), field: InterpolationField::Prompt },
+                        &InterpolationLocation { vessel: task.name.clone(), role: process.role.clone(), field: InterpolationField::Prompt },
                         declared_inputs,
                         errors,
                     );
                 }
             }
-            ProcessSource::Tool { command } => validate_template_text(
+            CrewSource::Tool { command } => validate_template_text(
                 command,
-                &InterpolationLocation { task: task.name.clone(), role: process.role.clone(), field: InterpolationField::Command },
+                &InterpolationLocation { vessel: task.name.clone(), role: process.role.clone(), field: InterpolationField::Command },
                 declared_inputs,
                 errors,
             ),
@@ -217,7 +217,7 @@ fn validate_task(
     }
 }
 
-fn validate_cycles(tasks_by_name: &BTreeMap<String, &TaskDefinition>, errors: &mut Vec<ValidationError>) {
+fn validate_cycles(tasks_by_name: &BTreeMap<String, &VesselRequirement>, errors: &mut Vec<ValidationError>) {
     let mut states = BTreeMap::new();
     let mut stack = Vec::new();
 
@@ -228,7 +228,7 @@ fn validate_cycles(tasks_by_name: &BTreeMap<String, &TaskDefinition>, errors: &m
 
 fn visit_task(
     task_name: &str,
-    tasks_by_name: &BTreeMap<String, &TaskDefinition>,
+    tasks_by_name: &BTreeMap<String, &VesselRequirement>,
     states: &mut BTreeMap<String, VisitState>,
     stack: &mut Vec<String>,
     errors: &mut Vec<ValidationError>,
@@ -352,36 +352,36 @@ fn push_error(errors: &mut Vec<ValidationError>, error: ValidationError) {
 #[cfg(test)]
 mod tests {
     use super::{
-        validate, InputDefinition, InterpolationField, InterpolationLocation, ProcessDefinition, ProcessSource, Selector, TaskDefinition,
-        ValidationError, WorkflowTemplateSpec,
+        validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation, Selector, ValidationError,
+        VesselRequirement, WorkflowTemplateSpec,
     };
 
     fn valid_spec() -> WorkflowTemplateSpec {
         WorkflowTemplateSpec::builder()
             .inputs(vec![InputDefinition { name: "feature".to_string(), description: None }])
-            .tasks(vec![
-                TaskDefinition::builder()
+            .vessels(vec![
+                VesselRequirement::builder()
                     .name("implement".to_string())
-                    .processes(vec![
-                        ProcessDefinition::builder()
+                    .crew(vec![
+                        CrewSpec::builder()
                             .role("coder".to_string())
-                            .source(ProcessSource::Agent {
+                            .source(CrewSource::Agent {
                                 selector: Selector { capability: "code".to_string() },
                                 prompt: Some("Implement {{inputs.feature}} for {{workflow.name}}".to_string()),
                             })
                             .build(),
-                        ProcessDefinition::builder()
+                        CrewSpec::builder()
                             .role("build".to_string())
-                            .source(ProcessSource::Tool { command: "cargo check".to_string() })
+                            .source(CrewSource::Tool { command: "cargo check".to_string() })
                             .build(),
                     ])
                     .build(),
-                TaskDefinition::builder()
+                VesselRequirement::builder()
                     .name("review".to_string())
                     .depends_on(vec!["implement".to_string()])
-                    .processes(vec![ProcessDefinition::builder()
+                    .crew(vec![CrewSpec::builder()
                         .role("reviewer".to_string())
-                        .source(ProcessSource::Agent {
+                        .source(CrewSource::Agent {
                             selector: Selector { capability: "code-review".to_string() },
                             prompt: Some("Review {{workflow.namespace}}".to_string()),
                         })
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     fn validate_rejects_duplicate_task_names() {
         let mut spec = valid_spec();
-        spec.tasks.push(spec.tasks[0].clone());
+        spec.vessels.push(spec.vessels[0].clone());
 
         let errors = validate(&spec).expect_err("duplicate task names should fail");
         assert!(errors.contains(&ValidationError::DuplicateTaskName { name: "implement".to_string() }));
@@ -403,12 +403,9 @@ mod tests {
     #[test]
     fn validate_rejects_duplicate_role_names_within_task() {
         let mut spec = valid_spec();
-        spec.tasks[0].processes.push(
-            ProcessDefinition::builder()
-                .role("coder".to_string())
-                .source(ProcessSource::Tool { command: "cargo test".to_string() })
-                .build(),
-        );
+        spec.vessels[0]
+            .crew
+            .push(CrewSpec::builder().role("coder".to_string()).source(CrewSource::Tool { command: "cargo test".to_string() }).build());
 
         let errors = validate(&spec).expect_err("duplicate role names should fail");
         assert!(errors.contains(&ValidationError::DuplicateRoleInTask { task: "implement".to_string(), role: "coder".to_string() }));
@@ -417,16 +414,16 @@ mod tests {
     #[test]
     fn validate_rejects_unknown_dependencies() {
         let mut spec = valid_spec();
-        spec.tasks[1].depends_on = vec!["missing".to_string()];
+        spec.vessels[1].depends_on = vec!["missing".to_string()];
 
         let errors = validate(&spec).expect_err("unknown dependencies should fail");
-        assert!(errors.contains(&ValidationError::UnknownDependency { task: "review".to_string(), missing: "missing".to_string() }));
+        assert!(errors.contains(&ValidationError::UnknownDependency { vessel: "review".to_string(), missing: "missing".to_string() }));
     }
 
     #[test]
     fn validate_rejects_cycles() {
         let mut spec = valid_spec();
-        spec.tasks[0].depends_on = vec!["review".to_string()];
+        spec.vessels[0].depends_on = vec!["review".to_string()];
 
         let errors = validate(&spec).expect_err("cycles should fail");
         assert!(errors.contains(&ValidationError::DependencyCycle {
@@ -446,14 +443,18 @@ mod tests {
     #[test]
     fn validate_rejects_unknown_input_references() {
         let mut spec = valid_spec();
-        spec.tasks[0].processes[0].source = ProcessSource::Agent {
+        spec.vessels[0].crew[0].source = CrewSource::Agent {
             selector: Selector { capability: "code".to_string() },
             prompt: Some("Implement {{inputs.branch}}".to_string()),
         };
 
         let errors = validate(&spec).expect_err("unknown input references should fail");
         assert!(errors.contains(&ValidationError::UnknownInputReference {
-            location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+            location: InterpolationLocation {
+                vessel: "implement".to_string(),
+                role: "coder".to_string(),
+                field: InterpolationField::Prompt
+            },
             name: "branch".to_string(),
         }));
     }
@@ -461,14 +462,18 @@ mod tests {
     #[test]
     fn validate_rejects_unknown_workflow_fields() {
         let mut spec = valid_spec();
-        spec.tasks[0].processes[0].source = ProcessSource::Agent {
+        spec.vessels[0].crew[0].source = CrewSource::Agent {
             selector: Selector { capability: "code".to_string() },
             prompt: Some("Implement {{workflow.uid}}".to_string()),
         };
 
         let errors = validate(&spec).expect_err("unknown workflow fields should fail");
         assert!(errors.contains(&ValidationError::UnknownWorkflowField {
-            location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+            location: InterpolationLocation {
+                vessel: "implement".to_string(),
+                role: "coder".to_string(),
+                field: InterpolationField::Prompt
+            },
             name: "uid".to_string(),
         }));
     }
@@ -476,18 +481,26 @@ mod tests {
     #[test]
     fn validate_rejects_malformed_owned_interpolations() {
         let mut spec = valid_spec();
-        spec.tasks[0].processes[0].source = ProcessSource::Agent {
+        spec.vessels[0].crew[0].source = CrewSource::Agent {
             selector: Selector { capability: "code".to_string() },
             prompt: Some("Implement {{inputs.feature }} and {{workflow.name.extra}}".to_string()),
         };
 
         let errors = validate(&spec).expect_err("malformed owned interpolation should fail");
         assert!(errors.contains(&ValidationError::MalformedInterpolation {
-            location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+            location: InterpolationLocation {
+                vessel: "implement".to_string(),
+                role: "coder".to_string(),
+                field: InterpolationField::Prompt
+            },
             text: "inputs.feature ".to_string(),
         }));
         assert!(errors.contains(&ValidationError::MalformedInterpolation {
-            location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+            location: InterpolationLocation {
+                vessel: "implement".to_string(),
+                role: "coder".to_string(),
+                field: InterpolationField::Prompt
+            },
             text: "workflow.name.extra".to_string(),
         }));
     }
@@ -495,8 +508,7 @@ mod tests {
     #[test]
     fn validate_allows_foreign_interpolations() {
         let mut spec = valid_spec();
-        spec.tasks[0].processes[1].source =
-            ProcessSource::Tool { command: "kubectl get pod -o go-template='{{.metadata.name}}'".to_string() };
+        spec.vessels[0].crew[1].source = CrewSource::Tool { command: "kubectl get pod -o go-template='{{.metadata.name}}'".to_string() };
 
         assert!(validate(&spec).is_ok(), "foreign interpolations should pass through");
     }

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -60,8 +60,8 @@ pub struct Selector {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
-    DuplicateTaskName { name: String },
-    DuplicateRoleInTask { task: String, role: String },
+    DuplicateVesselName { name: String },
+    DuplicateRoleInVessel { vessel: String, role: String },
     ReservedLabelKey { vessel: String, role: String, key: String },
     UnknownDependency { vessel: String, missing: String },
     DependencyCycle { cycle: Vec<String> },
@@ -102,8 +102,8 @@ impl std::fmt::Display for InterpolationLocation {
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ValidationError::DuplicateTaskName { name } => write!(f, "duplicate task name `{name}`"),
-            ValidationError::DuplicateRoleInTask { task, role } => write!(f, "duplicate role `{role}` in task `{task}`"),
+            ValidationError::DuplicateVesselName { name } => write!(f, "duplicate vessel name `{name}`"),
+            ValidationError::DuplicateRoleInVessel { vessel, role } => write!(f, "duplicate role `{role}` in vessel `{vessel}`"),
             ValidationError::ReservedLabelKey { vessel, role, key } => {
                 write!(f, "reserved label key `{key}` on vessel `{vessel}` role `{role}`")
             }
@@ -134,12 +134,12 @@ pub(crate) struct TemplateToken<'a> {
 pub fn validate(spec: &WorkflowTemplateSpec) -> Result<(), Vec<ValidationError>> {
     let mut errors = Vec::new();
     let declared_inputs = collect_inputs(spec, &mut errors);
-    let tasks_by_name = collect_tasks(spec, &mut errors);
+    let vessels_by_name = collect_vessels(spec, &mut errors);
 
     for task in &spec.vessels {
-        validate_task(task, &declared_inputs, &tasks_by_name, &mut errors);
+        validate_vessel(task, &declared_inputs, &vessels_by_name, &mut errors);
     }
-    validate_cycles(&tasks_by_name, &mut errors);
+    validate_cycles(&vessels_by_name, &mut errors);
 
     if errors.is_empty() {
         Ok(())
@@ -158,32 +158,32 @@ fn collect_inputs(spec: &WorkflowTemplateSpec, errors: &mut Vec<ValidationError>
     declared_inputs
 }
 
-fn collect_tasks<'a>(spec: &'a WorkflowTemplateSpec, errors: &mut Vec<ValidationError>) -> BTreeMap<String, &'a VesselRequirement> {
-    let mut tasks_by_name = BTreeMap::new();
+fn collect_vessels<'a>(spec: &'a WorkflowTemplateSpec, errors: &mut Vec<ValidationError>) -> BTreeMap<String, &'a VesselRequirement> {
+    let mut vessels_by_name = BTreeMap::new();
     for task in &spec.vessels {
-        if tasks_by_name.insert(task.name.clone(), task).is_some() {
-            push_error(errors, ValidationError::DuplicateTaskName { name: task.name.clone() });
+        if vessels_by_name.insert(task.name.clone(), task).is_some() {
+            push_error(errors, ValidationError::DuplicateVesselName { name: task.name.clone() });
         }
     }
-    tasks_by_name
+    vessels_by_name
 }
 
-fn validate_task(
+fn validate_vessel(
     task: &VesselRequirement,
     declared_inputs: &BTreeSet<String>,
-    tasks_by_name: &BTreeMap<String, &VesselRequirement>,
+    vessels_by_name: &BTreeMap<String, &VesselRequirement>,
     errors: &mut Vec<ValidationError>,
 ) {
     let mut roles = BTreeSet::new();
     for dependency in &task.depends_on {
-        if !tasks_by_name.contains_key(dependency) {
+        if !vessels_by_name.contains_key(dependency) {
             push_error(errors, ValidationError::UnknownDependency { vessel: task.name.clone(), missing: dependency.clone() });
         }
     }
 
     for process in &task.crew {
         if !roles.insert(process.role.clone()) {
-            push_error(errors, ValidationError::DuplicateRoleInTask { task: task.name.clone(), role: process.role.clone() });
+            push_error(errors, ValidationError::DuplicateRoleInVessel { vessel: task.name.clone(), role: process.role.clone() });
         }
 
         for key in process.labels.keys() {
@@ -217,36 +217,36 @@ fn validate_task(
     }
 }
 
-fn validate_cycles(tasks_by_name: &BTreeMap<String, &VesselRequirement>, errors: &mut Vec<ValidationError>) {
+fn validate_cycles(vessels_by_name: &BTreeMap<String, &VesselRequirement>, errors: &mut Vec<ValidationError>) {
     let mut states = BTreeMap::new();
     let mut stack = Vec::new();
 
-    for task_name in tasks_by_name.keys() {
-        visit_task(task_name, tasks_by_name, &mut states, &mut stack, errors);
+    for vessel_name in vessels_by_name.keys() {
+        visit_vessel(vessel_name, vessels_by_name, &mut states, &mut stack, errors);
     }
 }
 
-fn visit_task(
-    task_name: &str,
-    tasks_by_name: &BTreeMap<String, &VesselRequirement>,
+fn visit_vessel(
+    vessel_name: &str,
+    vessels_by_name: &BTreeMap<String, &VesselRequirement>,
     states: &mut BTreeMap<String, VisitState>,
     stack: &mut Vec<String>,
     errors: &mut Vec<ValidationError>,
 ) {
-    match states.get(task_name) {
+    match states.get(vessel_name) {
         Some(VisitState::Visited) => return,
         None => {}
         Some(VisitState::Visiting) => unreachable!("cycle detection handles visiting dependencies before recursion"),
     }
 
-    states.insert(task_name.to_string(), VisitState::Visiting);
-    stack.push(task_name.to_string());
+    states.insert(vessel_name.to_string(), VisitState::Visiting);
+    stack.push(vessel_name.to_string());
 
-    if let Some(task) = tasks_by_name.get(task_name) {
+    if let Some(task) = vessels_by_name.get(vessel_name) {
         let mut dependencies = task.depends_on.iter().map(String::as_str).collect::<Vec<_>>();
         dependencies.sort_unstable();
         for dependency in dependencies {
-            if !tasks_by_name.contains_key(dependency) {
+            if !vessels_by_name.contains_key(dependency) {
                 continue;
             }
 
@@ -259,12 +259,12 @@ fn visit_task(
                 continue;
             }
 
-            visit_task(dependency, tasks_by_name, states, stack, errors);
+            visit_vessel(dependency, vessels_by_name, states, stack, errors);
         }
     }
 
     stack.pop();
-    states.insert(task_name.to_string(), VisitState::Visited);
+    states.insert(vessel_name.to_string(), VisitState::Visited);
 }
 
 fn validate_template_text(
@@ -392,12 +392,12 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_duplicate_task_names() {
+    fn validate_rejects_duplicate_vessel_names() {
         let mut spec = valid_spec();
         spec.vessels.push(spec.vessels[0].clone());
 
-        let errors = validate(&spec).expect_err("duplicate task names should fail");
-        assert!(errors.contains(&ValidationError::DuplicateTaskName { name: "implement".to_string() }));
+        let errors = validate(&spec).expect_err("duplicate vessel names should fail");
+        assert!(errors.contains(&ValidationError::DuplicateVesselName { name: "implement".to_string() }));
     }
 
     #[test]
@@ -408,7 +408,7 @@ mod tests {
             .push(CrewSpec::builder().role("coder".to_string()).source(CrewSource::Tool { command: "cargo test".to_string() }).build());
 
         let errors = validate(&spec).expect_err("duplicate role names should fail");
-        assert!(errors.contains(&ValidationError::DuplicateRoleInTask { task: "implement".to_string(), role: "coder".to_string() }));
+        assert!(errors.contains(&ValidationError::DuplicateRoleInVessel { vessel: "implement".to_string(), role: "coder".to_string() }));
     }
 
     #[test]

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -136,8 +136,8 @@ pub fn validate(spec: &WorkflowTemplateSpec) -> Result<(), Vec<ValidationError>>
     let declared_inputs = collect_inputs(spec, &mut errors);
     let vessels_by_name = collect_vessels(spec, &mut errors);
 
-    for task in &spec.vessels {
-        validate_vessel(task, &declared_inputs, &vessels_by_name, &mut errors);
+    for vessel in &spec.vessels {
+        validate_vessel(vessel, &declared_inputs, &vessels_by_name, &mut errors);
     }
     validate_cycles(&vessels_by_name, &mut errors);
 
@@ -160,36 +160,36 @@ fn collect_inputs(spec: &WorkflowTemplateSpec, errors: &mut Vec<ValidationError>
 
 fn collect_vessels<'a>(spec: &'a WorkflowTemplateSpec, errors: &mut Vec<ValidationError>) -> BTreeMap<String, &'a VesselRequirement> {
     let mut vessels_by_name = BTreeMap::new();
-    for task in &spec.vessels {
-        if vessels_by_name.insert(task.name.clone(), task).is_some() {
-            push_error(errors, ValidationError::DuplicateVesselName { name: task.name.clone() });
+    for vessel in &spec.vessels {
+        if vessels_by_name.insert(vessel.name.clone(), vessel).is_some() {
+            push_error(errors, ValidationError::DuplicateVesselName { name: vessel.name.clone() });
         }
     }
     vessels_by_name
 }
 
 fn validate_vessel(
-    task: &VesselRequirement,
+    vessel: &VesselRequirement,
     declared_inputs: &BTreeSet<String>,
     vessels_by_name: &BTreeMap<String, &VesselRequirement>,
     errors: &mut Vec<ValidationError>,
 ) {
     let mut roles = BTreeSet::new();
-    for dependency in &task.depends_on {
+    for dependency in &vessel.depends_on {
         if !vessels_by_name.contains_key(dependency) {
-            push_error(errors, ValidationError::UnknownDependency { vessel: task.name.clone(), missing: dependency.clone() });
+            push_error(errors, ValidationError::UnknownDependency { vessel: vessel.name.clone(), missing: dependency.clone() });
         }
     }
 
-    for process in &task.crew {
+    for process in &vessel.crew {
         if !roles.insert(process.role.clone()) {
-            push_error(errors, ValidationError::DuplicateRoleInVessel { vessel: task.name.clone(), role: process.role.clone() });
+            push_error(errors, ValidationError::DuplicateRoleInVessel { vessel: vessel.name.clone(), role: process.role.clone() });
         }
 
         for key in process.labels.keys() {
             if key.starts_with(crate::labels::RESERVED_PREFIX) {
                 push_error(errors, ValidationError::ReservedLabelKey {
-                    vessel: task.name.clone(),
+                    vessel: vessel.name.clone(),
                     role: process.role.clone(),
                     key: key.clone(),
                 });
@@ -201,7 +201,11 @@ fn validate_vessel(
                 if let Some(prompt) = prompt {
                     validate_template_text(
                         prompt,
-                        &InterpolationLocation { vessel: task.name.clone(), role: process.role.clone(), field: InterpolationField::Prompt },
+                        &InterpolationLocation {
+                            vessel: vessel.name.clone(),
+                            role: process.role.clone(),
+                            field: InterpolationField::Prompt,
+                        },
                         declared_inputs,
                         errors,
                     );
@@ -209,7 +213,7 @@ fn validate_vessel(
             }
             CrewSource::Tool { command } => validate_template_text(
                 command,
-                &InterpolationLocation { vessel: task.name.clone(), role: process.role.clone(), field: InterpolationField::Command },
+                &InterpolationLocation { vessel: vessel.name.clone(), role: process.role.clone(), field: InterpolationField::Command },
                 declared_inputs,
                 errors,
             ),
@@ -242,8 +246,8 @@ fn visit_vessel(
     states.insert(vessel_name.to_string(), VisitState::Visiting);
     stack.push(vessel_name.to_string());
 
-    if let Some(task) = vessels_by_name.get(vessel_name) {
-        let mut dependencies = task.depends_on.iter().map(String::as_str).collect::<Vec<_>>();
+    if let Some(vessel) = vessels_by_name.get(vessel_name) {
+        let mut dependencies = vessel.depends_on.iter().map(String::as_str).collect::<Vec<_>>();
         dependencies.sort_unstable();
         for dependency in dependencies {
             if !vessels_by_name.contains_key(dependency) {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -76,13 +76,13 @@ impl ResourceContractFixture for WorkflowTemplateFixture {
     }
 
     fn assert_created(created: &ResourceObject<Self::Resource>) {
-        assert_eq!(created.spec.tasks.len(), 2);
+        assert_eq!(created.spec.vessels.len(), 2);
         assert!(created.status.is_none());
     }
 
     fn assert_updated(updated: &ResourceObject<Self::Resource>) {
-        match &updated.spec.tasks[0].processes[1].source {
-            flotilla_resources::ProcessSource::Tool { command } => assert_eq!(command, "cargo check --all-targets"),
+        match &updated.spec.vessels[0].crew[1].source {
+            flotilla_resources::CrewSource::Tool { command } => assert_eq!(command, "cargo check --all-targets"),
             other => panic!("expected tool process, got {other:?}"),
         }
     }
@@ -377,7 +377,7 @@ pub async fn assert_metadata_roundtrip_with_backend<F: ResourceContractFixture>(
     meta.annotations.insert("note".to_string(), "preserve-me".to_string());
     meta.owner_references = vec![OwnerReference {
         api_version: "flotilla.work/v1".to_string(),
-        kind: "TaskWorkspace".to_string(),
+        kind: "Vessel".to_string(),
         name: "alpha-implement".to_string(),
         controller: true,
     }];

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -6,9 +6,9 @@ use std::{collections::BTreeMap, future::Future, time::Duration};
 
 use chrono::{DateTime, TimeZone, Utc};
 use flotilla_resources::{
-    ApiPaths, Convoy as RealConvoy, ConvoySpec as RealConvoySpec, ConvoyStatus as RealConvoyStatus, InputDefinition, InputMeta, ObjectMeta,
-    OwnerReference, ProcessDefinition, ProcessSource, Resource, ResourceObject, Selector, StatusPatch, TaskDefinition, TaskPhase,
-    TaskState, WorkflowTemplate, WorkflowTemplateSpec,
+    ApiPaths, Convoy as RealConvoy, ConvoySpec as RealConvoySpec, ConvoyStatus as RealConvoyStatus, CrewSource, CrewSpec, InputDefinition,
+    InputMeta, ObjectMeta, OwnerReference, Resource, ResourceObject, Selector, StatusPatch, VesselRequirement, WorkPhase, WorkState,
+    WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -97,7 +97,7 @@ pub fn convoy_status(phase: flotilla_resources::ConvoyPhase) -> RealConvoyStatus
     RealConvoyStatus {
         phase,
         workflow_snapshot: None,
-        tasks: Default::default(),
+        work: Default::default(),
         message: None,
         started_at: None,
         finished_at: None,
@@ -120,39 +120,39 @@ pub fn valid_workflow_template_spec() -> WorkflowTemplateSpec {
             InputDefinition { name: "feature".to_string(), description: Some("Brief description of the feature to implement".to_string()) },
             InputDefinition { name: "branch".to_string(), description: Some("Target git branch".to_string()) },
         ])
-        .tasks(vec![
-            TaskDefinition::builder()
+        .vessels(vec![
+            VesselRequirement::builder()
                 .name("implement".to_string())
-                .processes(vec![
-                    ProcessDefinition::builder()
+                .crew(vec![
+                    CrewSpec::builder()
                         .role("coder".to_string())
-                        .source(ProcessSource::Agent {
+                        .source(CrewSource::Agent {
                             selector: Selector { capability: "code".to_string() },
                             prompt: Some(
                                 "Convoy {{workflow.name}} - implement {{inputs.feature}} on branch {{inputs.branch}}.".to_string(),
                             ),
                         })
                         .build(),
-                    ProcessDefinition::builder()
+                    CrewSpec::builder()
                         .role("build".to_string())
-                        .source(ProcessSource::Tool { command: "cargo watch -x check".to_string() })
+                        .source(CrewSource::Tool { command: "cargo watch -x check".to_string() })
                         .build(),
                 ])
                 .build(),
-            TaskDefinition::builder()
+            VesselRequirement::builder()
                 .name("review".to_string())
                 .depends_on(vec!["implement".to_string()])
-                .processes(vec![
-                    ProcessDefinition::builder()
+                .crew(vec![
+                    CrewSpec::builder()
                         .role("reviewer".to_string())
-                        .source(ProcessSource::Agent {
+                        .source(CrewSource::Agent {
                             selector: Selector { capability: "code-review".to_string() },
                             prompt: Some("Review branch {{inputs.branch}} for correctness and style.".to_string()),
                         })
                         .build(),
-                    ProcessDefinition::builder()
+                    CrewSpec::builder()
                         .role("tests".to_string())
-                        .source(ProcessSource::Tool { command: "cargo test --watch".to_string() })
+                        .source(CrewSource::Tool { command: "cargo test --watch".to_string() })
                         .build(),
                 ])
                 .build(),
@@ -162,7 +162,7 @@ pub fn valid_workflow_template_spec() -> WorkflowTemplateSpec {
 
 pub fn updated_workflow_template_spec() -> WorkflowTemplateSpec {
     let mut spec = valid_workflow_template_spec();
-    if let ProcessSource::Tool { command } = &mut spec.tasks[0].processes[1].source {
+    if let CrewSource::Tool { command } = &mut spec.vessels[0].crew[1].source {
         *command = "cargo check --all-targets".to_string();
     }
     spec
@@ -214,8 +214,8 @@ pub fn task_provisioning_convoy_spec() -> RealConvoySpec {
     spec
 }
 
-pub fn pending_task_state() -> TaskState {
-    TaskState { phase: TaskPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None }
+pub fn pending_task_state() -> WorkState {
+    WorkState { phase: WorkPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None }
 }
 
 pub fn valid_workflow_template_object(name: &str) -> ResourceObject<WorkflowTemplate> {
@@ -232,31 +232,25 @@ pub fn tool_only_workflow_template_spec() -> WorkflowTemplateSpec {
             InputDefinition { name: "feature".to_string(), description: Some("Brief description of the feature to implement".to_string()) },
             InputDefinition { name: "branch".to_string(), description: Some("Target git branch".to_string()) },
         ])
-        .tasks(vec![
-            TaskDefinition::builder()
+        .vessels(vec![
+            VesselRequirement::builder()
                 .name("implement".to_string())
-                .processes(vec![
-                    ProcessDefinition::builder()
-                        .role("coder".to_string())
-                        .source(ProcessSource::Tool { command: "cargo check".to_string() })
-                        .build(),
-                    ProcessDefinition::builder()
+                .crew(vec![
+                    CrewSpec::builder().role("coder".to_string()).source(CrewSource::Tool { command: "cargo check".to_string() }).build(),
+                    CrewSpec::builder()
                         .role("build".to_string())
-                        .source(ProcessSource::Tool { command: "cargo test --no-run".to_string() })
+                        .source(CrewSource::Tool { command: "cargo test --no-run".to_string() })
                         .build(),
                 ])
                 .build(),
-            TaskDefinition::builder()
+            VesselRequirement::builder()
                 .name("review".to_string())
                 .depends_on(vec!["implement".to_string()])
-                .processes(vec![
-                    ProcessDefinition::builder()
-                        .role("review".to_string())
-                        .source(ProcessSource::Tool { command: "cargo test".to_string() })
-                        .build(),
-                    ProcessDefinition::builder()
+                .crew(vec![
+                    CrewSpec::builder().role("review".to_string()).source(CrewSource::Tool { command: "cargo test".to_string() }).build(),
+                    CrewSpec::builder()
                         .role("lint".to_string())
-                        .source(ProcessSource::Tool { command: "cargo clippy --no-deps".to_string() })
+                        .source(CrewSource::Tool { command: "cargo clippy --no-deps".to_string() })
                         .build(),
                 ])
                 .build(),
@@ -269,19 +263,13 @@ pub fn tool_only_workflow_template_object(name: &str) -> ResourceObject<Workflow
 }
 
 pub fn bootstrapped_convoy_status() -> RealConvoyStatus {
-    let snapshot = flotilla_resources::WorkflowSnapshot {
-        tasks: valid_workflow_template_spec()
-            .tasks
-            .into_iter()
-            .map(|task| flotilla_resources::SnapshotTask { name: task.name, depends_on: task.depends_on, processes: task.processes })
-            .collect(),
-    };
-    let tasks = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
+    let snapshot = flotilla_resources::WorkflowSnapshot { vessels: valid_workflow_template_spec().vessels.into_iter().collect() };
+    let work = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
 
     RealConvoyStatus {
         phase: flotilla_resources::ConvoyPhase::Pending,
         workflow_snapshot: Some(snapshot),
-        tasks,
+        work,
         message: None,
         started_at: None,
         finished_at: None,
@@ -351,18 +339,18 @@ where
 
 pub fn bootstrapped_tool_only_convoy_status() -> RealConvoyStatus {
     let snapshot = flotilla_resources::WorkflowSnapshot {
-        tasks: tool_only_workflow_template_spec()
-            .tasks
+        vessels: tool_only_workflow_template_spec()
+            .vessels
             .into_iter()
-            .map(|task| flotilla_resources::SnapshotTask { name: task.name, depends_on: task.depends_on, processes: task.processes })
+            .map(|task| flotilla_resources::VesselRequirement { name: task.name, depends_on: task.depends_on, crew: task.crew })
             .collect(),
     };
-    let tasks = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
+    let work = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
 
     RealConvoyStatus {
         phase: flotilla_resources::ConvoyPhase::Pending,
         workflow_snapshot: Some(snapshot),
-        tasks,
+        work,
         message: None,
         started_at: None,
         finished_at: None,

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -12,7 +12,7 @@ use common::{resource_meta, TestLoopHarness};
 use flotilla_resources::{
     controller::{Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler},
     ApiPaths, InMemoryBackend, InputMeta, LifecycleAuthority, NoStatusPatch, Presentation, PresentationSpec, Resource, ResourceBackend,
-    ResourceError, ResourceObject, TaskWorkspace, TaskWorkspaceSpec, TypedResolver,
+    ResourceError, ResourceObject, TypedResolver, Vessel, VesselSpec,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{sync::mpsc, time::timeout};
@@ -810,7 +810,7 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let primaries = backend.clone().using::<PrimaryResource>("flotilla");
     let presentations = backend.clone().using::<Presentation>("flotilla");
-    let task_workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let vessels = backend.clone().using::<Vessel>("flotilla");
     primaries.create(&primary_meta("alpha"), &PrimarySpec { value: "one".to_string() }).await.expect("primary create should succeed");
     presentations
         .create(&resource_meta().name("alpha-presentation").call(), &PresentationSpec {
@@ -821,10 +821,10 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
         })
         .await
         .expect("presentation create should succeed");
-    task_workspaces
-        .create(&resource_meta().name("alpha-task").call(), &TaskWorkspaceSpec {
+    vessels
+        .create(&resource_meta().name("alpha-task").call(), &VesselSpec {
             convoy_ref: "alpha".to_string(),
-            task: "implement".to_string(),
+            vessel_name: "implement".to_string(),
             placement_policy_ref: "local".to_string(),
             adopted_checkout_ref: None,
         })
@@ -864,10 +864,7 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
         ControllerLoop {
             primary: primaries,
             secondaries: Vec::new(),
-            reconciler: ActuatingReconciler {
-                actuation: Actuation::DeleteTaskWorkspace { name: "alpha-task".to_string() },
-                reconciled: None,
-            },
+            reconciler: ActuatingReconciler { actuation: Actuation::DeleteVessel { name: "alpha-task".to_string() }, reconciled: None },
             resync_interval: Duration::from_secs(60),
             backend: backend.clone(),
         }
@@ -876,7 +873,7 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
 
     timeout(Duration::from_secs(1), async {
         loop {
-            if matches!(task_workspaces.get("alpha-task").await, Err(ResourceError::NotFound { .. })) {
+            if matches!(vessels.get("alpha-task").await, Err(ResourceError::NotFound { .. })) {
                 break;
             }
             tokio::task::yield_now().await;
@@ -885,7 +882,7 @@ async fn controller_loop_applies_delete_actuations_idempotently() {
     .await
     .expect("delete task workspace actuation should remove the resource");
 
-    task_workspaces.delete("alpha-task").await.expect_err("resource should already be gone");
+    vessels.delete("alpha-task").await.expect_err("resource should already be gone");
 
     harness.shutdown().await;
 }
@@ -895,7 +892,7 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let primaries = backend.clone().using::<PrimaryResource>("flotilla");
     let presentations = backend.clone().using::<Presentation>("flotilla");
-    let task_workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let vessels = backend.clone().using::<Vessel>("flotilla");
     primaries.create(&primary_meta("alpha"), &PrimarySpec { value: "one".to_string() }).await.expect("primary create should succeed");
     presentations
         .create(
@@ -909,10 +906,10 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
         )
         .await
         .expect("presentation create should succeed");
-    task_workspaces
-        .create(&resource_meta().name("observed-task").call().with_lifecycle_authority(LifecycleAuthority::Observed), &TaskWorkspaceSpec {
+    vessels
+        .create(&resource_meta().name("observed-task").call().with_lifecycle_authority(LifecycleAuthority::Observed), &VesselSpec {
             convoy_ref: "alpha".to_string(),
-            task: "implement".to_string(),
+            vessel_name: "implement".to_string(),
             placement_policy_ref: "local".to_string(),
             adopted_checkout_ref: None,
         })
@@ -957,7 +954,7 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
             primary: primaries,
             secondaries: Vec::new(),
             reconciler: ActuatingReconciler {
-                actuation: Actuation::DeleteTaskWorkspace { name: "observed-task".to_string() },
+                actuation: Actuation::DeleteVessel { name: "observed-task".to_string() },
                 reconciled: Some(Arc::clone(&reconciled)),
             },
             resync_interval: Duration::from_secs(60),
@@ -976,8 +973,8 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
     })
     .await
     .expect("delete task workspace actuation should run");
-    let task_workspace = task_workspaces.get("observed-task").await.expect("observed task workspace should remain");
-    assert_eq!(task_workspace.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
+    let vessel = vessels.get("observed-task").await.expect("observed task workspace should remain");
+    assert_eq!(vessel.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -6,8 +6,8 @@ use common::{
 };
 use flotilla_resources::{
     apply_status_patch, controller::ControllerLoop, external_patches, reconcile, Convoy, ConvoyPhase, ConvoyReconciler, InMemoryBackend,
-    InputMeta, LifecycleAuthority, Presentation, PresentationSpec, ResourceBackend, ResourceError, TaskWorkspace, TaskWorkspacePhase,
-    TaskWorkspaceStatus, WorkflowTemplate, CONVOY_LABEL, TASK_LABEL,
+    InputMeta, LifecycleAuthority, Presentation, PresentationSpec, ResourceBackend, ResourceError, Vessel, VesselPhase, VesselStatus,
+    WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
 };
 use tokio::time::{timeout, Duration};
 
@@ -51,23 +51,23 @@ async fn in_memory_controller_loop_drives_convoy_to_completion() {
     assert!(matches!(bootstrap, flotilla_resources::ConvoyStatusPatch::Bootstrap { .. }));
 
     let ready_implement = reconcile_once(&convoys, &templates, "convoy-a", timestamp(11)).await.expect("ready patch after bootstrap");
-    assert!(matches!(ready_implement, flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. }));
+    assert!(matches!(ready_implement, flotilla_resources::ConvoyStatusPatch::AdvanceWorkToReady { .. }));
 
     apply_status_patch(
         &convoys,
         "convoy-a",
-        &external_patches::mark_task_completed("implement".to_string(), timestamp(12), Some("implemented".to_string())),
+        &external_patches::mark_work_completed("implement".to_string(), timestamp(12), Some("implemented".to_string())),
     )
     .await
     .expect("implement completion should succeed");
 
     let ready_review = reconcile_once(&convoys, &templates, "convoy-a", timestamp(13)).await.expect("review should become ready");
-    assert!(matches!(ready_review, flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. }));
+    assert!(matches!(ready_review, flotilla_resources::ConvoyStatusPatch::AdvanceWorkToReady { .. }));
 
     apply_status_patch(
         &convoys,
         "convoy-a",
-        &external_patches::mark_task_completed("review".to_string(), timestamp(14), Some("reviewed".to_string())),
+        &external_patches::mark_work_completed("review".to_string(), timestamp(14), Some("reviewed".to_string())),
     )
     .await
     .expect("review completion should succeed");
@@ -78,8 +78,8 @@ async fn in_memory_controller_loop_drives_convoy_to_completion() {
     let final_convoy = convoys.get("convoy-a").await.expect("final convoy get should succeed");
     let final_status = final_convoy.status.expect("convoy status");
     assert_eq!(final_status.phase, ConvoyPhase::Completed);
-    assert_eq!(final_status.tasks["implement"].phase, flotilla_resources::TaskPhase::Completed);
-    assert_eq!(final_status.tasks["review"].phase, flotilla_resources::TaskPhase::Completed);
+    assert_eq!(final_status.work["implement"].phase, flotilla_resources::WorkPhase::Completed);
+    assert_eq!(final_status.work["review"].phase, flotilla_resources::WorkPhase::Completed);
 }
 
 #[tokio::test]
@@ -113,7 +113,7 @@ async fn controller_loop_drives_convoy_progression_without_manual_reconcile_call
         ControllerLoop {
             primary: convoys.clone(),
             secondaries: Vec::new(),
-            reconciler: ConvoyReconciler::new(templates.clone()).with_task_workspaces(backend.clone().using::<TaskWorkspace>("flotilla")),
+            reconciler: ConvoyReconciler::new(templates.clone()).with_vessels(backend.clone().using::<Vessel>("flotilla")),
             resync_interval: Duration::from_secs(60),
             backend: backend.clone(),
         }
@@ -127,7 +127,7 @@ async fn controller_loop_drives_convoy_progression_without_manual_reconcile_call
                 tokio::task::yield_now().await;
                 continue;
             };
-            if status.tasks.get("implement").is_some_and(|task| task.phase == flotilla_resources::TaskPhase::Ready) {
+            if status.work.get("implement").is_some_and(|task| task.phase == flotilla_resources::WorkPhase::Ready) {
                 break;
             }
             tokio::task::yield_now().await;
@@ -139,7 +139,7 @@ async fn controller_loop_drives_convoy_progression_without_manual_reconcile_call
     apply_status_patch(
         &convoys,
         "convoy-loop",
-        &external_patches::mark_task_completed("implement".to_string(), timestamp(12), Some("implemented".to_string())),
+        &external_patches::mark_work_completed("implement".to_string(), timestamp(12), Some("implemented".to_string())),
     )
     .await
     .expect("implement completion should succeed");
@@ -148,7 +148,7 @@ async fn controller_loop_drives_convoy_progression_without_manual_reconcile_call
         loop {
             let convoy = convoys.get("convoy-loop").await.expect("convoy get should succeed");
             let status = convoy.status.expect("convoy status");
-            if status.tasks.get("review").is_some_and(|task| task.phase == flotilla_resources::TaskPhase::Ready) {
+            if status.work.get("review").is_some_and(|task| task.phase == flotilla_resources::WorkPhase::Ready) {
                 break;
             }
             tokio::task::yield_now().await;
@@ -160,7 +160,7 @@ async fn controller_loop_drives_convoy_progression_without_manual_reconcile_call
     apply_status_patch(
         &convoys,
         "convoy-loop",
-        &external_patches::mark_task_completed("review".to_string(), timestamp(14), Some("reviewed".to_string())),
+        &external_patches::mark_work_completed("review".to_string(), timestamp(14), Some("reviewed".to_string())),
     )
     .await
     .expect("review completion should succeed");
@@ -182,11 +182,11 @@ async fn controller_loop_drives_convoy_progression_without_manual_reconcile_call
 }
 
 #[tokio::test]
-async fn controller_loop_advances_task_via_task_workspace_secondary_watch() {
+async fn controller_loop_advances_task_via_vessel_secondary_watch() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
     let convoys = backend.clone().using::<Convoy>("flotilla");
-    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let workspaces = backend.clone().using::<Vessel>("flotilla");
 
     let template = tool_only_workflow_template_object("review-and-fix");
     templates.create(&workflow_template_meta(&template.metadata.name), &template.spec).await.expect("template create should succeed");
@@ -196,7 +196,7 @@ async fn controller_loop_advances_task_via_task_workspace_secondary_watch() {
         ControllerLoop {
             primary: convoys.clone(),
             secondaries: ConvoyReconciler::secondary_watches(),
-            reconciler: ConvoyReconciler::new(templates.clone()).with_task_workspaces(workspaces.clone()),
+            reconciler: ConvoyReconciler::new(templates.clone()).with_vessels(workspaces.clone()),
             resync_interval: Duration::from_millis(50),
             backend: backend.clone(),
         }
@@ -216,8 +216,8 @@ async fn controller_loop_advances_task_via_task_workspace_secondary_watch() {
 
     let workspace = workspaces.get("convoy-stage4a-implement").await.expect("workspace get should succeed");
     workspaces
-        .update_status("convoy-stage4a-implement", &workspace.metadata.resource_version, &TaskWorkspaceStatus {
-            phase: TaskWorkspacePhase::Ready,
+        .update_status("convoy-stage4a-implement", &workspace.metadata.resource_version, &VesselStatus {
+            phase: VesselPhase::Ready,
             message: None,
             observed_policy_ref: Some("laptop-docker".to_string()),
             observed_policy_version: Some("17".to_string()),
@@ -237,7 +237,7 @@ async fn controller_loop_advances_task_via_task_workspace_secondary_watch() {
                 tokio::task::yield_now().await;
                 continue;
             };
-            if status.tasks.get("implement").is_some_and(|task| task.phase == flotilla_resources::TaskPhase::Running) {
+            if status.work.get("implement").is_some_and(|task| task.phase == flotilla_resources::WorkPhase::Running) {
                 break;
             }
             tokio::task::yield_now().await;
@@ -250,10 +250,10 @@ async fn controller_loop_advances_task_via_task_workspace_secondary_watch() {
 }
 
 #[tokio::test]
-async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
+async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let convoys = backend.clone().using::<Convoy>("flotilla");
-    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let workspaces = backend.clone().using::<Vessel>("flotilla");
     let presentations = backend.clone().using::<Presentation>("flotilla");
 
     let created =
@@ -261,8 +261,8 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.tasks.get_mut("implement").expect("implement").phase = flotilla_resources::TaskPhase::Running;
-    status.tasks.get_mut("implement").expect("implement").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement").phase = flotilla_resources::WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement").started_at = Some(timestamp(18));
     convoys.update_status("convoy-delete", &created.metadata.resource_version, &status).await.expect("convoy status update should succeed");
 
     workspaces
@@ -270,14 +270,14 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
             &InputMeta::builder()
                 .name("convoy-delete-implement".to_string())
                 .labels(
-                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "implement".to_string())]
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]
                         .into_iter()
                         .collect(),
                 )
                 .build(),
-            &flotilla_resources::TaskWorkspaceSpec {
+            &flotilla_resources::VesselSpec {
                 convoy_ref: "convoy-delete".to_string(),
-                task: "implement".to_string(),
+                vessel_name: "implement".to_string(),
                 placement_policy_ref: "laptop-docker".to_string(),
                 adopted_checkout_ref: None,
             },
@@ -289,7 +289,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
             &InputMeta::builder()
                 .name("convoy-delete-implement".to_string())
                 .labels(
-                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "implement".to_string())]
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]
                         .into_iter()
                         .collect(),
                 )
@@ -300,7 +300,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
                 name: "implement".to_string(),
                 process_selector: [
                     (CONVOY_LABEL.to_string(), "convoy-delete".to_string()),
-                    (TASK_LABEL.to_string(), "implement".to_string()),
+                    (VESSEL_LABEL.to_string(), "implement".to_string()),
                 ]
                 .into_iter()
                 .collect(),
@@ -313,15 +313,15 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
             &InputMeta::builder()
                 .name("convoy-delete-adopted".to_string())
                 .labels(
-                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "adopted".to_string())]
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (VESSEL_LABEL.to_string(), "adopted".to_string())]
                         .into_iter()
                         .collect(),
                 )
                 .build()
                 .with_lifecycle_authority(LifecycleAuthority::Adopted),
-            &flotilla_resources::TaskWorkspaceSpec {
+            &flotilla_resources::VesselSpec {
                 convoy_ref: "convoy-delete".to_string(),
-                task: "adopted".to_string(),
+                vessel_name: "adopted".to_string(),
                 placement_policy_ref: "laptop-docker".to_string(),
                 adopted_checkout_ref: None,
             },
@@ -333,15 +333,15 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
             &InputMeta::builder()
                 .name("convoy-delete-observed".to_string())
                 .labels(
-                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "observed".to_string())]
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (VESSEL_LABEL.to_string(), "observed".to_string())]
                         .into_iter()
                         .collect(),
                 )
                 .build()
                 .with_lifecycle_authority(LifecycleAuthority::Observed),
-            &flotilla_resources::TaskWorkspaceSpec {
+            &flotilla_resources::VesselSpec {
                 convoy_ref: "convoy-delete".to_string(),
-                task: "observed".to_string(),
+                vessel_name: "observed".to_string(),
                 placement_policy_ref: "laptop-docker".to_string(),
                 adopted_checkout_ref: None,
             },
@@ -353,7 +353,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
             &InputMeta::builder()
                 .name("convoy-delete-adopted".to_string())
                 .labels(
-                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "adopted".to_string())]
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (VESSEL_LABEL.to_string(), "adopted".to_string())]
                         .into_iter()
                         .collect(),
                 )
@@ -365,7 +365,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
                 name: "adopted".to_string(),
                 process_selector: [
                     (CONVOY_LABEL.to_string(), "convoy-delete".to_string()),
-                    (TASK_LABEL.to_string(), "adopted".to_string()),
+                    (VESSEL_LABEL.to_string(), "adopted".to_string()),
                 ]
                 .into_iter()
                 .collect(),
@@ -378,7 +378,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
             &InputMeta::builder()
                 .name("convoy-delete-observed".to_string())
                 .labels(
-                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (TASK_LABEL.to_string(), "observed".to_string())]
+                    [(CONVOY_LABEL.to_string(), "convoy-delete".to_string()), (VESSEL_LABEL.to_string(), "observed".to_string())]
                         .into_iter()
                         .collect(),
                 )
@@ -390,7 +390,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
                 name: "observed".to_string(),
                 process_selector: [
                     (CONVOY_LABEL.to_string(), "convoy-delete".to_string()),
-                    (TASK_LABEL.to_string(), "observed".to_string()),
+                    (VESSEL_LABEL.to_string(), "observed".to_string()),
                 ]
                 .into_iter()
                 .collect(),
@@ -404,7 +404,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
             primary: convoys.clone(),
             secondaries: ConvoyReconciler::secondary_watches(),
             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla"))
-                .with_task_workspaces(workspaces.clone())
+                .with_vessels(workspaces.clone())
                 .with_presentations(presentations.clone()),
             resync_interval: Duration::from_millis(50),
             backend: backend.clone(),
@@ -488,7 +488,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_task_workspaces() {
 async fn controller_loop_creates_one_presentation_per_active_task() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let convoys = backend.clone().using::<Convoy>("flotilla");
-    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let workspaces = backend.clone().using::<Vessel>("flotilla");
     let presentations = backend.clone().using::<Presentation>("flotilla");
     let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
 
@@ -497,19 +497,17 @@ async fn controller_loop_creates_one_presentation_per_active_task() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.tasks.get_mut("implement").expect("implement task").phase = flotilla_resources::TaskPhase::Running;
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
-    status.tasks.get_mut("review").expect("review task").phase = flotilla_resources::TaskPhase::Ready;
-    status.tasks.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = flotilla_resources::WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("review").expect("review task").phase = flotilla_resources::WorkPhase::Ready;
+    status.work.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
     convoys.update_status("convoy-multi", &created.metadata.resource_version, &status).await.expect("convoy status update should succeed");
 
     let loop_task = tokio::spawn(
         ControllerLoop {
             primary: convoys.clone(),
             secondaries: ConvoyReconciler::secondary_watches(),
-            reconciler: ConvoyReconciler::new(templates.clone())
-                .with_task_workspaces(workspaces.clone())
-                .with_presentations(presentations.clone()),
+            reconciler: ConvoyReconciler::new(templates.clone()).with_vessels(workspaces.clone()).with_presentations(presentations.clone()),
             resync_interval: Duration::from_millis(50),
             backend: backend.clone(),
         }
@@ -530,13 +528,13 @@ async fn controller_loop_creates_one_presentation_per_active_task() {
     .map(|(implement, review)| {
         assert_eq!(implement.spec.name, "implement");
         assert_eq!(implement.spec.process_selector.get(CONVOY_LABEL).map(String::as_str), Some("convoy-multi"));
-        assert_eq!(implement.spec.process_selector.get(TASK_LABEL).map(String::as_str), Some("implement"));
-        assert_eq!(implement.metadata.labels.get(TASK_LABEL).map(String::as_str), Some("implement"));
+        assert_eq!(implement.spec.process_selector.get(VESSEL_LABEL).map(String::as_str), Some("implement"));
+        assert_eq!(implement.metadata.labels.get(VESSEL_LABEL).map(String::as_str), Some("implement"));
 
         assert_eq!(review.spec.name, "review");
         assert_eq!(review.spec.process_selector.get(CONVOY_LABEL).map(String::as_str), Some("convoy-multi"));
-        assert_eq!(review.spec.process_selector.get(TASK_LABEL).map(String::as_str), Some("review"));
-        assert_eq!(review.metadata.labels.get(TASK_LABEL).map(String::as_str), Some("review"));
+        assert_eq!(review.spec.process_selector.get(VESSEL_LABEL).map(String::as_str), Some("review"));
+        assert_eq!(review.metadata.labels.get(VESSEL_LABEL).map(String::as_str), Some("review"));
     })
     .expect("controller loop should create one presentation per active task");
 

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -78,8 +78,8 @@ async fn in_memory_controller_loop_drives_convoy_to_completion() {
     let final_convoy = convoys.get("convoy-a").await.expect("final convoy get should succeed");
     let final_status = final_convoy.status.expect("convoy status");
     assert_eq!(final_status.phase, ConvoyPhase::Completed);
-    assert_eq!(final_status.work["implement"].phase, flotilla_resources::WorkPhase::Completed);
-    assert_eq!(final_status.work["review"].phase, flotilla_resources::WorkPhase::Completed);
+    assert_eq!(final_status.work["implement"].phase, flotilla_resources::WorkPhase::Complete);
+    assert_eq!(final_status.work["review"].phase, flotilla_resources::WorkPhase::Complete);
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -305,7 +305,7 @@ fn fan_in_waits_until_all_dependencies_complete() {
         ],
     });
     status.work.insert("verify".to_string(), pending_task_state());
-    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Complete;
     status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
     status.work.get_mut("verify").expect("verify").phase = WorkPhase::Running;
     status.work.get_mut("verify").expect("verify").started_at = Some(timestamp(9));
@@ -315,7 +315,7 @@ fn fan_in_waits_until_all_dependencies_complete() {
     let first = reconcile(&convoy, None, timestamp(20));
     assert_eq!(first.patch, Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(timestamp(20)), None)));
 
-    status.work.get_mut("verify").expect("verify").phase = WorkPhase::Completed;
+    status.work.get_mut("verify").expect("verify").phase = WorkPhase::Complete;
     status.work.get_mut("verify").expect("verify").finished_at = Some(timestamp(10));
     status.phase = ConvoyPhase::Active;
 
@@ -355,7 +355,7 @@ fn all_completed_rolls_up_to_completed() {
     let mut status = bootstrapped_convoy_status();
     status.phase = ConvoyPhase::Active;
     for task in status.work.values_mut() {
-        task.phase = WorkPhase::Completed;
+        task.phase = WorkPhase::Complete;
         task.finished_at = Some(timestamp(12));
     }
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
@@ -371,7 +371,7 @@ fn terminal_completed_convoy_reconciles_to_noop() {
     status.phase = ConvoyPhase::Completed;
     status.finished_at = Some(timestamp(40));
     for task in status.work.values_mut() {
-        task.phase = WorkPhase::Completed;
+        task.phase = WorkPhase::Complete;
         task.finished_at = Some(timestamp(12));
     }
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
@@ -465,7 +465,7 @@ fn fail_fast_emits_phase_and_task_phase_change_events() {
 #[test]
 fn roll_up_to_active_emits_phase_change_event() {
     let mut status = bootstrapped_convoy_status();
-    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Complete;
     status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
     status.work.get_mut("review").expect("review").phase = WorkPhase::Running;
     status.work.get_mut("review").expect("review").started_at = Some(timestamp(9));
@@ -494,7 +494,7 @@ fn workflow_ref_change_after_init_fails_defensively() {
 #[test]
 fn snapshot_state_allows_advancement_without_template() {
     let mut status = bootstrapped_convoy_status();
-    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Complete;
     status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
 
@@ -687,7 +687,7 @@ async fn completed_convoy_emits_presentation_and_workspace_deletes() {
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
     for task in status.work.values_mut() {
-        task.phase = WorkPhase::Completed;
+        task.phase = WorkPhase::Complete;
         task.finished_at = Some(timestamp(19));
     }
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
@@ -730,7 +730,7 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
     status.phase = ConvoyPhase::Completed;
     status.finished_at = Some(timestamp(20));
     for task in status.work.values_mut() {
-        task.phase = WorkPhase::Completed;
+        task.phase = WorkPhase::Complete;
         task.finished_at = Some(timestamp(19));
     }
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
@@ -765,7 +765,7 @@ async fn terminal_completed_convoy_without_observed_presentation_does_not_emit_s
     status.phase = ConvoyPhase::Completed;
     status.finished_at = Some(timestamp(20));
     for task in status.work.values_mut() {
-        task.phase = WorkPhase::Completed;
+        task.phase = WorkPhase::Complete;
         task.finished_at = Some(timestamp(19));
     }
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
@@ -872,7 +872,7 @@ async fn one_task_completed_deletes_only_that_presentation() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Complete;
     status.work.get_mut("implement").expect("implement task").finished_at = Some(timestamp(19));
     status.work.get_mut("review").expect("review task").phase = WorkPhase::Running;
     status.work.get_mut("review").expect("review task").started_at = Some(timestamp(18));

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -10,22 +10,22 @@ use common::{
 use flotilla_resources::{
     canonicalize_repo_url,
     controller::{Actuation, Reconciler},
-    controller_patches, reconcile, repo_key, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, InMemoryBackend,
-    InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ProcessSource, ResourceBackend, TaskPhase, TaskWorkspace,
-    TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, ValidationError, WorkflowTemplate, CONVOY_LABEL, TASK_LABEL,
+    controller_patches, reconcile, repo_key, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, CrewSource,
+    InMemoryBackend, InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ResourceBackend, ValidationError, Vessel,
+    VesselPhase, VesselSpec, VesselStatus, WorkPhase, WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
 };
 
 async fn reconcile_once_with_resources(
     convoy: &flotilla_resources::ResourceObject<Convoy>,
     template: Option<&flotilla_resources::ResourceObject<WorkflowTemplate>>,
-    workspaces: Vec<flotilla_resources::ResourceObject<TaskWorkspace>>,
+    workspaces: Vec<flotilla_resources::ResourceObject<Vessel>>,
     presentations: Vec<flotilla_resources::ResourceObject<Presentation>>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> flotilla_resources::controller::ReconcileOutcome<Convoy> {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
     let convoys = backend.clone().using::<Convoy>("flotilla");
-    let task_workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let vessels = backend.clone().using::<Vessel>("flotilla");
     let presentations_resolver = backend.clone().using::<Presentation>("flotilla");
 
     if let Some(template) = template {
@@ -41,12 +41,12 @@ async fn reconcile_once_with_resources(
     }
 
     for workspace in workspaces {
-        let created = task_workspaces
-            .create(&task_workspace_meta(&workspace.metadata.name, &workspace.spec.convoy_ref, &workspace.spec.task), &workspace.spec)
+        let created = vessels
+            .create(&vessel_meta(&workspace.metadata.name, &workspace.spec.convoy_ref, &workspace.spec.vessel_name), &workspace.spec)
             .await
             .expect("workspace create should succeed");
         if let Some(status) = workspace.status.as_ref() {
-            task_workspaces
+            vessels
                 .update_status(&workspace.metadata.name, &created.metadata.resource_version, status)
                 .await
                 .expect("workspace status update should succeed");
@@ -70,20 +70,19 @@ async fn reconcile_once_with_resources(
     }
 
     let current = convoys.get(&convoy.metadata.name).await.expect("convoy get should succeed");
-    let reconciler = ConvoyReconciler::new(templates.clone())
-        .with_task_workspaces(task_workspaces.clone())
-        .with_presentations(presentations_resolver.clone());
+    let reconciler =
+        ConvoyReconciler::new(templates.clone()).with_vessels(vessels.clone()).with_presentations(presentations_resolver.clone());
     let deps = reconciler.fetch_dependencies(&current).await.expect("dependency fetch should succeed");
     reconciler.reconcile(&current, &deps, now)
 }
 
-fn task_workspace_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
+fn vessel_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
     let canonical_repo = canonicalize_repo_url("git@github.com:flotilla-org/flotilla.git").expect("repo url should canonicalize");
     InputMeta {
         name: name.to_string(),
         labels: [
             ("flotilla.work/convoy".to_string(), convoy_name.to_string()),
-            ("flotilla.work/task".to_string(), task.to_string()),
+            ("flotilla.work/vessel".to_string(), task.to_string()),
             ("flotilla.work/repo-key".to_string(), repo_key(&canonical_repo)),
         ]
         .into_iter()
@@ -100,21 +99,16 @@ fn task_workspace_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
     }
 }
 
-fn task_workspace_object(
-    convoy_name: &str,
-    task: &str,
-    phase: TaskWorkspacePhase,
-    message: Option<&str>,
-) -> flotilla_resources::ResourceObject<TaskWorkspace> {
+fn vessel_object(convoy_name: &str, task: &str, phase: VesselPhase, message: Option<&str>) -> flotilla_resources::ResourceObject<Vessel> {
     flotilla_resources::ResourceObject {
         metadata: common::object_meta(&format!("{convoy_name}-{task}"), "flotilla", "17"),
-        spec: TaskWorkspaceSpec {
+        spec: VesselSpec {
             convoy_ref: convoy_name.to_string(),
-            task: task.to_string(),
+            vessel_name: task.to_string(),
             placement_policy_ref: "laptop-docker".to_string(),
             adopted_checkout_ref: None,
         },
-        status: Some(TaskWorkspaceStatus {
+        status: Some(VesselStatus {
             phase,
             message: message.map(str::to_string),
             observed_policy_ref: Some("laptop-docker".to_string()),
@@ -123,7 +117,7 @@ fn task_workspace_object(
             checkout_ref: Some(format!("checkout-{task}")),
             terminal_session_refs: vec![format!("terminal-{task}-coder")],
             started_at: Some(timestamp(16)),
-            ready_at: (phase == TaskWorkspacePhase::Ready).then(|| timestamp(18)),
+            ready_at: (phase == VesselPhase::Ready).then(|| timestamp(18)),
         }),
     }
 }
@@ -131,7 +125,7 @@ fn task_workspace_object(
 fn presentation_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
     InputMeta::builder()
         .name(name.to_string())
-        .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy_name.to_string()), (TASK_LABEL.to_string(), task.to_string())]))
+        .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy_name.to_string()), (VESSEL_LABEL.to_string(), task.to_string())]))
         .owner_references(vec![OwnerReference {
             api_version: "flotilla.work/v1".to_string(),
             kind: "Convoy".to_string(),
@@ -150,7 +144,7 @@ fn presentation_object(convoy_name: &str, task: &str) -> flotilla_resources::Res
             name: task.to_string(),
             process_selector: BTreeMap::from([
                 (CONVOY_LABEL.to_string(), convoy_name.to_string()),
-                (TASK_LABEL.to_string(), task.to_string()),
+                (VESSEL_LABEL.to_string(), task.to_string()),
             ]),
         },
         status: None,
@@ -165,14 +159,14 @@ fn bootstrap_from_valid_template_returns_bootstrap_patch() {
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
     let expected_snapshot = flotilla_resources::WorkflowSnapshot {
-        tasks: template
+        vessels: template
             .spec
-            .tasks
+            .vessels
             .iter()
-            .map(|task| flotilla_resources::SnapshotTask {
+            .map(|task| flotilla_resources::VesselRequirement {
                 name: task.name.clone(),
                 depends_on: task.depends_on.clone(),
-                processes: task.processes.clone(),
+                crew: task.crew.clone(),
             })
             .collect(),
     };
@@ -195,7 +189,7 @@ fn bootstrap_from_valid_template_returns_bootstrap_patch() {
 fn bootstrap_interpolates_tool_process_commands() {
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
     let mut template = tool_only_workflow_template_object("review-and-fix");
-    if let ProcessSource::Tool { command } = &mut template.spec.tasks[0].processes[0].source {
+    if let CrewSource::Tool { command } = &mut template.spec.vessels[0].crew[0].source {
         *command = "printf '{{workflow.namespace}}/{{workflow.name}}/{{inputs.feature}}/{{inputs.branch}}/{{.metadata.name}}'".to_string();
     }
 
@@ -204,7 +198,7 @@ fn bootstrap_interpolates_tool_process_commands() {
     let Some(ConvoyStatusPatch::Bootstrap { workflow_snapshot, .. }) = outcome.patch else {
         panic!("expected bootstrap patch");
     };
-    let ProcessSource::Tool { command } = &workflow_snapshot.tasks[0].processes[0].source else {
+    let CrewSource::Tool { command } = &workflow_snapshot.vessels[0].crew[0].source else {
         panic!("expected tool process");
     };
     assert_eq!(command, "printf 'flotilla/convoy-a/Retry logic/fix-retry-logic/{{.metadata.name}}'");
@@ -227,7 +221,7 @@ fn missing_template_fails_init() {
 fn invalid_template_fails_init_with_validation_error_event() {
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
     let mut template = valid_workflow_template_object("review-and-fix");
-    template.spec.tasks[1].depends_on = vec!["missing".to_string()];
+    template.spec.vessels[1].depends_on = vec!["missing".to_string()];
 
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
@@ -236,7 +230,7 @@ fn invalid_template_fails_init_with_validation_error_event() {
         outcome.events.as_slice(),
         [ConvoyEvent::TemplateInvalid { name, errors }]
             if name == "review-and-fix"
-                && matches!(errors.as_slice(), [ValidationError::UnknownDependency { task, missing }] if task == "review" && missing == "missing")
+                && matches!(errors.as_slice(), [ValidationError::UnknownDependency { vessel, missing }] if vessel == "review" && missing == "missing")
     ));
 }
 
@@ -274,13 +268,13 @@ fn fan_out_advances_all_newly_ready_tasks() {
     let spec = valid_convoy_spec();
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
-        tasks: vec![
-            flotilla_resources::SnapshotTask { name: "a".to_string(), depends_on: Vec::new(), processes: Vec::new() },
-            flotilla_resources::SnapshotTask { name: "b".to_string(), depends_on: Vec::new(), processes: Vec::new() },
-            flotilla_resources::SnapshotTask { name: "c".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+        vessels: vec![
+            flotilla_resources::VesselRequirement { name: "a".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement { name: "b".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement { name: "c".to_string(), depends_on: Vec::new(), crew: Vec::new() },
         ],
     });
-    status.tasks =
+    status.work =
         [("a".to_string(), pending_task_state()), ("b".to_string(), pending_task_state()), ("c".to_string(), pending_task_state())]
             .into_iter()
             .collect();
@@ -290,7 +284,7 @@ fn fan_out_advances_all_newly_ready_tasks() {
 
     assert_eq!(
         outcome.patch,
-        Some(controller_patches::advance_tasks_to_ready(
+        Some(controller_patches::advance_work_to_ready(
             [("a".to_string(), timestamp(20)), ("b".to_string(), timestamp(20)), ("c".to_string(), timestamp(20)),].into_iter().collect()
         ))
     );
@@ -300,29 +294,29 @@ fn fan_out_advances_all_newly_ready_tasks() {
 fn fan_in_waits_until_all_dependencies_complete() {
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
-        tasks: vec![
-            flotilla_resources::SnapshotTask { name: "implement".to_string(), depends_on: Vec::new(), processes: Vec::new() },
-            flotilla_resources::SnapshotTask { name: "verify".to_string(), depends_on: Vec::new(), processes: Vec::new() },
-            flotilla_resources::SnapshotTask {
+        vessels: vec![
+            flotilla_resources::VesselRequirement { name: "implement".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement { name: "verify".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement {
                 name: "review".to_string(),
                 depends_on: vec!["implement".to_string(), "verify".to_string()],
-                processes: Vec::new(),
+                crew: Vec::new(),
             },
         ],
     });
-    status.tasks.insert("verify".to_string(), pending_task_state());
-    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Completed;
-    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
-    status.tasks.get_mut("verify").expect("verify").phase = TaskPhase::Running;
-    status.tasks.get_mut("verify").expect("verify").started_at = Some(timestamp(9));
-    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Pending;
+    status.work.insert("verify".to_string(), pending_task_state());
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
+    status.work.get_mut("verify").expect("verify").phase = WorkPhase::Running;
+    status.work.get_mut("verify").expect("verify").started_at = Some(timestamp(9));
+    status.work.get_mut("review").expect("review").phase = WorkPhase::Pending;
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status.clone()));
 
     let first = reconcile(&convoy, None, timestamp(20));
     assert_eq!(first.patch, Some(controller_patches::roll_up_phase(ConvoyPhase::Active, Some(timestamp(20)), None)));
 
-    status.tasks.get_mut("verify").expect("verify").phase = TaskPhase::Completed;
-    status.tasks.get_mut("verify").expect("verify").finished_at = Some(timestamp(10));
+    status.work.get_mut("verify").expect("verify").phase = WorkPhase::Completed;
+    status.work.get_mut("verify").expect("verify").finished_at = Some(timestamp(10));
     status.phase = ConvoyPhase::Active;
 
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
@@ -330,7 +324,7 @@ fn fan_in_waits_until_all_dependencies_complete() {
 
     assert_eq!(
         second.patch,
-        Some(controller_patches::advance_tasks_to_ready([("review".to_string(), timestamp(21))].into_iter().collect()))
+        Some(controller_patches::advance_work_to_ready([("review".to_string(), timestamp(21))].into_iter().collect()))
     );
 }
 
@@ -338,10 +332,10 @@ fn fan_in_waits_until_all_dependencies_complete() {
 fn failed_task_triggers_fail_fast() {
     let mut status = bootstrapped_convoy_status();
     status.phase = ConvoyPhase::Active;
-    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Failed;
-    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
-    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Running;
-    status.tasks.get_mut("review").expect("review").started_at = Some(timestamp(11));
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Failed;
+    status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.work.get_mut("review").expect("review").phase = WorkPhase::Running;
+    status.work.get_mut("review").expect("review").started_at = Some(timestamp(11));
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
 
     let outcome = reconcile(&convoy, None, timestamp(30));
@@ -360,8 +354,8 @@ fn failed_task_triggers_fail_fast() {
 fn all_completed_rolls_up_to_completed() {
     let mut status = bootstrapped_convoy_status();
     status.phase = ConvoyPhase::Active;
-    for task in status.tasks.values_mut() {
-        task.phase = TaskPhase::Completed;
+    for task in status.work.values_mut() {
+        task.phase = WorkPhase::Completed;
         task.finished_at = Some(timestamp(12));
     }
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
@@ -376,8 +370,8 @@ fn terminal_completed_convoy_reconciles_to_noop() {
     let mut status = bootstrapped_convoy_status();
     status.phase = ConvoyPhase::Completed;
     status.finished_at = Some(timestamp(40));
-    for task in status.tasks.values_mut() {
-        task.phase = TaskPhase::Completed;
+    for task in status.work.values_mut() {
+        task.phase = WorkPhase::Completed;
         task.finished_at = Some(timestamp(12));
     }
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
@@ -393,10 +387,10 @@ fn terminal_failed_convoy_reconciles_to_noop() {
     let mut status = bootstrapped_convoy_status();
     status.phase = ConvoyPhase::Failed;
     status.finished_at = Some(timestamp(30));
-    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Failed;
-    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
-    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Cancelled;
-    status.tasks.get_mut("review").expect("review").finished_at = Some(timestamp(30));
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Failed;
+    status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.work.get_mut("review").expect("review").phase = WorkPhase::Cancelled;
+    status.work.get_mut("review").expect("review").finished_at = Some(timestamp(30));
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
 
     let outcome = reconcile(&convoy, None, timestamp(31));
@@ -423,13 +417,13 @@ fn advancing_ready_tasks_emits_task_phase_change_events() {
     let spec = valid_convoy_spec();
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
-        tasks: vec![
-            flotilla_resources::SnapshotTask { name: "a".to_string(), depends_on: Vec::new(), processes: Vec::new() },
-            flotilla_resources::SnapshotTask { name: "b".to_string(), depends_on: Vec::new(), processes: Vec::new() },
-            flotilla_resources::SnapshotTask { name: "c".to_string(), depends_on: Vec::new(), processes: Vec::new() },
+        vessels: vec![
+            flotilla_resources::VesselRequirement { name: "a".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement { name: "b".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement { name: "c".to_string(), depends_on: Vec::new(), crew: Vec::new() },
         ],
     });
-    status.tasks =
+    status.work =
         [("a".to_string(), pending_task_state()), ("b".to_string(), pending_task_state()), ("c".to_string(), pending_task_state())]
             .into_iter()
             .collect();
@@ -440,9 +434,9 @@ fn advancing_ready_tasks_emits_task_phase_change_events() {
     assert!(matches!(
         outcome.events.as_slice(),
         [
-            ConvoyEvent::TaskPhaseChanged { task: a, from: TaskPhase::Pending, to: TaskPhase::Ready },
-            ConvoyEvent::TaskPhaseChanged { task: b, from: TaskPhase::Pending, to: TaskPhase::Ready },
-            ConvoyEvent::TaskPhaseChanged { task: c, from: TaskPhase::Pending, to: TaskPhase::Ready },
+            ConvoyEvent::WorkPhaseChanged { work: a, from: WorkPhase::Pending, to: WorkPhase::Ready },
+            ConvoyEvent::WorkPhaseChanged { work: b, from: WorkPhase::Pending, to: WorkPhase::Ready },
+            ConvoyEvent::WorkPhaseChanged { work: c, from: WorkPhase::Pending, to: WorkPhase::Ready },
         ] if a == "a" && b == "b" && c == "c"
     ));
 }
@@ -451,10 +445,10 @@ fn advancing_ready_tasks_emits_task_phase_change_events() {
 fn fail_fast_emits_phase_and_task_phase_change_events() {
     let mut status = bootstrapped_convoy_status();
     status.phase = ConvoyPhase::Active;
-    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Failed;
-    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
-    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Running;
-    status.tasks.get_mut("review").expect("review").started_at = Some(timestamp(11));
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Failed;
+    status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.work.get_mut("review").expect("review").phase = WorkPhase::Running;
+    status.work.get_mut("review").expect("review").started_at = Some(timestamp(11));
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
 
     let outcome = reconcile(&convoy, None, timestamp(30));
@@ -463,18 +457,18 @@ fn fail_fast_emits_phase_and_task_phase_change_events() {
         outcome.events.as_slice(),
         [
             ConvoyEvent::PhaseChanged { from: ConvoyPhase::Active, to: ConvoyPhase::Failed },
-            ConvoyEvent::TaskPhaseChanged { task, from: TaskPhase::Running, to: TaskPhase::Cancelled },
-        ] if task == "review"
+            ConvoyEvent::WorkPhaseChanged { work, from: WorkPhase::Running, to: WorkPhase::Cancelled },
+        ] if work == "review"
     ));
 }
 
 #[test]
 fn roll_up_to_active_emits_phase_change_event() {
     let mut status = bootstrapped_convoy_status();
-    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Completed;
-    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
-    status.tasks.get_mut("review").expect("review").phase = TaskPhase::Running;
-    status.tasks.get_mut("review").expect("review").started_at = Some(timestamp(9));
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(8));
+    status.work.get_mut("review").expect("review").phase = WorkPhase::Running;
+    status.work.get_mut("review").expect("review").started_at = Some(timestamp(9));
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
 
     let outcome = reconcile(&convoy, None, timestamp(20));
@@ -500,15 +494,15 @@ fn workflow_ref_change_after_init_fails_defensively() {
 #[test]
 fn snapshot_state_allows_advancement_without_template() {
     let mut status = bootstrapped_convoy_status();
-    status.tasks.get_mut("implement").expect("implement").phase = TaskPhase::Completed;
-    status.tasks.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.work.get_mut("implement").expect("implement").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
 
     let outcome = reconcile(&convoy, None, timestamp(60));
 
     assert_eq!(
         outcome.patch,
-        Some(controller_patches::advance_tasks_to_ready([("review".to_string(), timestamp(60))].into_iter().collect()))
+        Some(controller_patches::advance_work_to_ready([("review".to_string(), timestamp(60))].into_iter().collect()))
     );
 }
 
@@ -522,7 +516,7 @@ fn bootstrap_preserves_agent_processes_for_runtime_resolution() {
     let Some(ConvoyStatusPatch::Bootstrap { workflow_snapshot, .. }) = outcome.patch else {
         panic!("agent workflow should bootstrap");
     };
-    let ProcessSource::Agent { selector, prompt } = &workflow_snapshot.tasks[0].processes[0].source else {
+    let CrewSource::Agent { selector, prompt } = &workflow_snapshot.vessels[0].crew[0].source else {
         panic!("agent source should survive in the workflow snapshot");
     };
     assert_eq!(selector.capability, "code");
@@ -530,10 +524,10 @@ fn bootstrap_preserves_agent_processes_for_runtime_resolution() {
 }
 
 #[tokio::test]
-async fn ready_task_emits_task_workspace_creation_actuation() {
+async fn ready_task_emits_vessel_creation_actuation() {
     let mut status = bootstrapped_tool_only_convoy_status();
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Ready;
-    status.tasks.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Ready;
+    status.work.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
@@ -547,20 +541,20 @@ async fn ready_task_emits_task_workspace_creation_actuation() {
     match outcome
         .actuations
         .iter()
-        .find(|actuation| matches!(actuation, Actuation::CreateTaskWorkspace { .. }))
+        .find(|actuation| matches!(actuation, Actuation::CreateVessel { .. }))
         .expect("task workspace actuation should be present")
     {
-        Actuation::CreateTaskWorkspace { meta, spec } => {
+        Actuation::CreateVessel { meta, spec } => {
             let canonical_repo = canonicalize_repo_url("git@github.com:flotilla-org/flotilla.git").expect("repo url should canonicalize");
             assert_eq!(meta.name, "convoy-a-implement");
             assert_eq!(meta.labels.get("flotilla.work/convoy").map(String::as_str), Some("convoy-a"));
-            assert_eq!(meta.labels.get("flotilla.work/task").map(String::as_str), Some("implement"));
+            assert_eq!(meta.labels.get("flotilla.work/vessel").map(String::as_str), Some("implement"));
             assert_eq!(meta.labels.get("flotilla.work/repo-key").map(String::as_str), Some(repo_key(&canonical_repo).as_str()));
             assert_eq!(meta.owner_references.len(), 1);
             assert_eq!(meta.owner_references[0].kind, "Convoy");
             assert_eq!(meta.owner_references[0].name, "convoy-a");
             assert_eq!(spec.convoy_ref, "convoy-a");
-            assert_eq!(spec.task, "implement");
+            assert_eq!(spec.vessel_name, "implement");
             assert_eq!(spec.placement_policy_ref, "laptop-docker");
         }
         other => panic!("expected task workspace actuation, got {other:?}"),
@@ -571,14 +565,14 @@ async fn ready_task_emits_task_workspace_creation_actuation() {
 #[tokio::test]
 async fn ready_task_with_ready_workspace_moves_to_launching() {
     let mut status = bootstrapped_tool_only_convoy_status();
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Ready;
-    status.tasks.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Ready;
+    status.work.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(
         &convoy,
         None,
-        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Ready, None)],
         Vec::new(),
         timestamp(20),
     )
@@ -586,8 +580,8 @@ async fn ready_task_with_ready_workspace_moves_to_launching() {
 
     assert!(matches!(
         outcome.patch,
-        Some(ConvoyStatusPatch::TaskLaunching { ref task, started_at, ref placement })
-            if task == "implement"
+        Some(ConvoyStatusPatch::WorkLaunching { ref work, started_at, ref placement })
+            if work == "implement"
                 && started_at == timestamp(20)
                 && placement.fields.get("environment_ref") == Some(&serde_json::Value::String("env-implement".to_string()))
                 && placement.fields.get("checkout_ref") == Some(&serde_json::Value::String("checkout-implement".to_string()))
@@ -597,34 +591,34 @@ async fn ready_task_with_ready_workspace_moves_to_launching() {
 #[tokio::test]
 async fn launching_task_with_ready_workspace_moves_to_running() {
     let mut status = bootstrapped_tool_only_convoy_status();
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Launching;
-    status.tasks.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Launching;
+    status.work.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(
         &convoy,
         None,
-        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Ready, None)],
         Vec::new(),
         timestamp(20),
     )
     .await;
 
-    assert!(matches!(outcome.patch, Some(ConvoyStatusPatch::TaskRunning { ref task }) if task == "implement"));
+    assert!(matches!(outcome.patch, Some(ConvoyStatusPatch::WorkRunning { ref work }) if work == "implement"));
 }
 
 #[tokio::test]
 async fn running_task_with_failed_workspace_marks_task_failed() {
     let mut status = bootstrapped_tool_only_convoy_status();
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(
         &convoy,
         None,
-        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Failed, Some("terminal session crashed"))],
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Failed, Some("terminal session crashed"))],
         Vec::new(),
         timestamp(21),
     )
@@ -632,16 +626,16 @@ async fn running_task_with_failed_workspace_marks_task_failed() {
 
     assert!(matches!(
         outcome.patch,
-        Some(ConvoyStatusPatch::MarkTaskFailed { ref task, finished_at, ref message })
-            if task == "implement" && finished_at == timestamp(21) && message == "terminal session crashed"
+        Some(ConvoyStatusPatch::MarkWorkFailed { ref work, finished_at, ref message })
+            if work == "implement" && finished_at == timestamp(21) && message == "terminal session crashed"
     ));
 }
 
 #[tokio::test]
 async fn active_convoy_creates_presentation_when_missing() {
     let mut status = bootstrapped_tool_only_convoy_status();
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
@@ -657,7 +651,7 @@ async fn active_convoy_creates_presentation_when_missing() {
             Actuation::CreatePresentation { meta, spec }
                 if meta.name == "convoy-a-implement"
                     && meta.labels.get(CONVOY_LABEL).map(String::as_str) == Some("convoy-a")
-                    && meta.labels.get(TASK_LABEL).map(String::as_str) == Some("implement")
+                    && meta.labels.get(VESSEL_LABEL).map(String::as_str) == Some("implement")
                     && meta.owner_references.len() == 1
                     && meta.owner_references[0].kind == "Convoy"
                     && meta.owner_references[0].name == "convoy-a"
@@ -666,7 +660,7 @@ async fn active_convoy_creates_presentation_when_missing() {
                     && spec.name == "implement"
                     && spec.process_selector == BTreeMap::from([
                         (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
-                        (TASK_LABEL.to_string(), "implement".to_string()),
+                        (VESSEL_LABEL.to_string(), "implement".to_string()),
                     ])
         )
     }));
@@ -677,8 +671,8 @@ async fn active_convoy_does_not_recreate_existing_presentation() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome =
@@ -692,8 +686,8 @@ async fn completed_convoy_emits_presentation_and_workspace_deletes() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    for task in status.tasks.values_mut() {
-        task.phase = TaskPhase::Completed;
+    for task in status.work.values_mut() {
+        task.phase = WorkPhase::Completed;
         task.finished_at = Some(timestamp(19));
     }
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
@@ -702,8 +696,8 @@ async fn completed_convoy_emits_presentation_and_workspace_deletes() {
         &convoy,
         None,
         vec![
-            task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None),
-            task_workspace_object("convoy-a", "review", TaskWorkspacePhase::Ready, None),
+            vessel_object("convoy-a", "implement", VesselPhase::Ready, None),
+            vessel_object("convoy-a", "review", VesselPhase::Ready, None),
         ],
         vec![presentation_object("convoy-a", "implement"), presentation_object("convoy-a", "review")],
         timestamp(20),
@@ -726,11 +720,8 @@ async fn completed_convoy_emits_presentation_and_workspace_deletes() {
     assert!(outcome
         .actuations
         .iter()
-        .any(|actuation| matches!(actuation, Actuation::DeleteTaskWorkspace { name } if name == "convoy-a-implement")));
-    assert!(outcome
-        .actuations
-        .iter()
-        .any(|actuation| matches!(actuation, Actuation::DeleteTaskWorkspace { name } if name == "convoy-a-review")));
+        .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-a-implement")));
+    assert!(outcome.actuations.iter().any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-a-review")));
 }
 
 #[tokio::test]
@@ -738,8 +729,8 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Completed;
     status.finished_at = Some(timestamp(20));
-    for task in status.tasks.values_mut() {
-        task.phase = TaskPhase::Completed;
+    for task in status.work.values_mut() {
+        task.phase = WorkPhase::Completed;
         task.finished_at = Some(timestamp(19));
     }
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
@@ -747,7 +738,7 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
     let outcome = reconcile_once_with_resources(
         &convoy,
         None,
-        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Ready, None)],
         vec![presentation_object("convoy-a", "implement"), presentation_object("convoy-a", "review")],
         timestamp(21),
     )
@@ -765,7 +756,7 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
     assert!(outcome
         .actuations
         .iter()
-        .any(|actuation| matches!(actuation, Actuation::DeleteTaskWorkspace { name } if name == "convoy-a-implement")));
+        .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-a-implement")));
 }
 
 #[tokio::test]
@@ -773,8 +764,8 @@ async fn terminal_completed_convoy_without_observed_presentation_does_not_emit_s
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Completed;
     status.finished_at = Some(timestamp(20));
-    for task in status.tasks.values_mut() {
-        task.phase = TaskPhase::Completed;
+    for task in status.work.values_mut() {
+        task.phase = WorkPhase::Completed;
         task.finished_at = Some(timestamp(19));
     }
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
@@ -782,7 +773,7 @@ async fn terminal_completed_convoy_without_observed_presentation_does_not_emit_s
     let outcome = reconcile_once_with_resources(
         &convoy,
         None,
-        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Ready, None)],
         Vec::new(),
         timestamp(21),
     )
@@ -793,7 +784,7 @@ async fn terminal_completed_convoy_without_observed_presentation_does_not_emit_s
     assert!(outcome
         .actuations
         .iter()
-        .any(|actuation| matches!(actuation, Actuation::DeleteTaskWorkspace { name } if name == "convoy-a-implement")));
+        .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-a-implement")));
 }
 
 #[tokio::test]
@@ -801,9 +792,9 @@ async fn multi_task_convoy_creates_presentations_only_for_active_tasks() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
-    // `review` intentionally stays in Pending — covers the `TaskPhase::Pending => {}` arm.
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    // `review` intentionally stays in Pending — covers the `WorkPhase::Pending => {}` arm.
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
@@ -828,10 +819,10 @@ async fn ready_and_running_tasks_both_create_presentations_when_missing() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Running;
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
-    status.tasks.get_mut("review").expect("review task").phase = TaskPhase::Ready;
-    status.tasks.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("review").expect("review task").phase = WorkPhase::Ready;
+    status.work.get_mut("review").expect("review task").ready_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
@@ -853,15 +844,15 @@ async fn launching_task_creates_presentation_when_missing() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Launching;
-    status.tasks.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
-    status.tasks.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Launching;
+    status.work.get_mut("implement").expect("implement task").ready_at = Some(timestamp(12));
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(
         &convoy,
         None,
-        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Ready, None)],
         Vec::new(),
         timestamp(20),
     )
@@ -872,7 +863,7 @@ async fn launching_task_creates_presentation_when_missing() {
         Actuation::CreatePresentation { meta, spec }
             if meta.name == "convoy-a-implement"
                 && spec.name == "implement"
-                && spec.process_selector.get(TASK_LABEL).map(String::as_str) == Some("implement")
+                && spec.process_selector.get(VESSEL_LABEL).map(String::as_str) == Some("implement")
     )));
 }
 
@@ -881,16 +872,16 @@ async fn one_task_completed_deletes_only_that_presentation() {
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
-    status.tasks.get_mut("implement").expect("implement task").phase = TaskPhase::Completed;
-    status.tasks.get_mut("implement").expect("implement task").finished_at = Some(timestamp(19));
-    status.tasks.get_mut("review").expect("review task").phase = TaskPhase::Running;
-    status.tasks.get_mut("review").expect("review task").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Completed;
+    status.work.get_mut("implement").expect("implement task").finished_at = Some(timestamp(19));
+    status.work.get_mut("review").expect("review task").phase = WorkPhase::Running;
+    status.work.get_mut("review").expect("review task").started_at = Some(timestamp(18));
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(
         &convoy,
         None,
-        vec![task_workspace_object("convoy-a", "implement", TaskWorkspacePhase::Ready, None)],
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Ready, None)],
         vec![presentation_object("convoy-a", "implement"), presentation_object("convoy-a", "review")],
         timestamp(20),
     )

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -345,7 +345,7 @@ fn failed_task_triggers_fail_fast() {
         Some(controller_patches::fail_convoy(
             [("review".to_string(), timestamp(30))].into_iter().collect(),
             timestamp(30),
-            Some("task failure detected".to_string())
+            Some("work failure detected".to_string())
         ))
     );
 }

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -88,7 +88,7 @@ fn advance_work_to_ready_updates_only_selected_tasks() {
         work: BTreeMap::from([
             ("implement".to_string(), pending_task()),
             ("review".to_string(), WorkState {
-                phase: WorkPhase::Completed,
+                phase: WorkPhase::Complete,
                 ready_at: Some(ts(5)),
                 started_at: Some(ts(6)),
                 finished_at: Some(ts(7)),
@@ -108,7 +108,7 @@ fn advance_work_to_ready_updates_only_selected_tasks() {
 
     assert_eq!(status.work["implement"].phase, WorkPhase::Ready);
     assert_eq!(status.work["implement"].ready_at, Some(ts(10)));
-    assert_eq!(status.work["review"].phase, WorkPhase::Completed);
+    assert_eq!(status.work["review"].phase, WorkPhase::Complete);
     assert_eq!(status.message.as_deref(), Some("keep"));
 }
 
@@ -156,7 +156,7 @@ fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
 #[test]
 fn roll_up_phase_only_touches_convoy_level_fields() {
     let review = WorkState {
-        phase: WorkPhase::Completed,
+        phase: WorkPhase::Complete,
         ready_at: Some(ts(10)),
         started_at: Some(ts(11)),
         finished_at: Some(ts(12)),
@@ -207,7 +207,7 @@ fn external_completion_marks_task_complete_without_touching_convoy_phase() {
     patch.apply(&mut status);
 
     assert_eq!(status.phase, ConvoyPhase::Active);
-    assert_eq!(status.work["review"].phase, WorkPhase::Completed);
+    assert_eq!(status.work["review"].phase, WorkPhase::Complete);
     assert_eq!(status.work["review"].finished_at, Some(ts(50)));
     assert_eq!(status.work["review"].message.as_deref(), Some("done"));
 }

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 
 use chrono::{TimeZone, Utc};
 use flotilla_resources::{
-    controller_patches, ConvoyPhase, ConvoyStatus, ConvoyStatusPatch, ProcessDefinition, ProcessSource, Selector, SnapshotTask,
-    StatusPatch, TaskPhase, TaskState, WorkflowSnapshot,
+    controller_patches, ConvoyPhase, ConvoyStatus, ConvoyStatusPatch, CrewSource, CrewSpec, Selector, StatusPatch, VesselRequirement,
+    WorkPhase, WorkState, WorkflowSnapshot,
 };
 
 fn ts(seconds: i64) -> chrono::DateTime<Utc> {
@@ -12,32 +12,32 @@ fn ts(seconds: i64) -> chrono::DateTime<Utc> {
 
 fn sample_snapshot() -> WorkflowSnapshot {
     WorkflowSnapshot {
-        tasks: vec![
-            SnapshotTask {
+        vessels: vec![
+            VesselRequirement {
                 name: "implement".to_string(),
                 depends_on: Vec::new(),
-                processes: vec![
-                    ProcessDefinition {
+                crew: vec![
+                    CrewSpec {
                         role: "coder".to_string(),
-                        source: ProcessSource::Agent {
+                        source: CrewSource::Agent {
                             selector: Selector { capability: "code".to_string() },
                             prompt: Some("Implement {{inputs.feature}}".to_string()),
                         },
                         labels: BTreeMap::new(),
                     },
-                    ProcessDefinition {
+                    CrewSpec {
                         role: "build".to_string(),
-                        source: ProcessSource::Tool { command: "cargo test".to_string() },
+                        source: CrewSource::Tool { command: "cargo test".to_string() },
                         labels: BTreeMap::new(),
                     },
                 ],
             },
-            SnapshotTask {
+            VesselRequirement {
                 name: "review".to_string(),
                 depends_on: vec!["implement".to_string()],
-                processes: vec![ProcessDefinition {
+                crew: vec![CrewSpec {
                     role: "reviewer".to_string(),
-                    source: ProcessSource::Agent {
+                    source: CrewSource::Agent {
                         selector: Selector { capability: "code-review".to_string() },
                         prompt: Some("Review {{inputs.feature}}".to_string()),
                     },
@@ -48,8 +48,8 @@ fn sample_snapshot() -> WorkflowSnapshot {
     }
 }
 
-fn pending_task() -> TaskState {
-    TaskState { phase: TaskPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None }
+fn pending_task() -> WorkState {
+    WorkState { phase: WorkPhase::Pending, ready_at: None, started_at: None, finished_at: None, message: None, placement: None }
 }
 
 #[test]
@@ -77,18 +77,18 @@ fn bootstrap_sets_snapshot_and_initial_task_map() {
         status.observed_workflows.as_ref().expect("observed workflows"),
         &BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])
     );
-    assert_eq!(status.tasks, tasks);
+    assert_eq!(status.work, tasks);
 }
 
 #[test]
-fn advance_tasks_to_ready_updates_only_selected_tasks() {
+fn advance_work_to_ready_updates_only_selected_tasks() {
     let mut status = ConvoyStatus {
         phase: ConvoyPhase::Pending,
         workflow_snapshot: Some(sample_snapshot()),
-        tasks: BTreeMap::from([
+        work: BTreeMap::from([
             ("implement".to_string(), pending_task()),
-            ("review".to_string(), TaskState {
-                phase: TaskPhase::Completed,
+            ("review".to_string(), WorkState {
+                phase: WorkPhase::Completed,
                 ready_at: Some(ts(5)),
                 started_at: Some(ts(6)),
                 finished_at: Some(ts(7)),
@@ -103,12 +103,12 @@ fn advance_tasks_to_ready_updates_only_selected_tasks() {
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
     };
 
-    let patch = controller_patches::advance_tasks_to_ready(BTreeMap::from([("implement".to_string(), ts(10))]));
+    let patch = controller_patches::advance_work_to_ready(BTreeMap::from([("implement".to_string(), ts(10))]));
     patch.apply(&mut status);
 
-    assert_eq!(status.tasks["implement"].phase, TaskPhase::Ready);
-    assert_eq!(status.tasks["implement"].ready_at, Some(ts(10)));
-    assert_eq!(status.tasks["review"].phase, TaskPhase::Completed);
+    assert_eq!(status.work["implement"].phase, WorkPhase::Ready);
+    assert_eq!(status.work["implement"].ready_at, Some(ts(10)));
+    assert_eq!(status.work["review"].phase, WorkPhase::Completed);
     assert_eq!(status.message.as_deref(), Some("keep"));
 }
 
@@ -117,17 +117,17 @@ fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
     let mut status = ConvoyStatus {
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
-        tasks: BTreeMap::from([
-            ("implement".to_string(), TaskState {
-                phase: TaskPhase::Failed,
+        work: BTreeMap::from([
+            ("implement".to_string(), WorkState {
+                phase: WorkPhase::Failed,
                 ready_at: Some(ts(10)),
                 started_at: Some(ts(11)),
                 finished_at: Some(ts(12)),
                 message: Some("boom".to_string()),
                 placement: None,
             }),
-            ("review".to_string(), TaskState {
-                phase: TaskPhase::Running,
+            ("review".to_string(), WorkState {
+                phase: WorkPhase::Running,
                 ready_at: Some(ts(20)),
                 started_at: Some(ts(21)),
                 finished_at: None,
@@ -148,15 +148,15 @@ fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
     assert_eq!(status.phase, ConvoyPhase::Failed);
     assert_eq!(status.finished_at, Some(ts(30)));
     assert_eq!(status.message.as_deref(), Some("task failed"));
-    assert_eq!(status.tasks["implement"].phase, TaskPhase::Failed);
-    assert_eq!(status.tasks["review"].phase, TaskPhase::Cancelled);
-    assert_eq!(status.tasks["review"].finished_at, Some(ts(30)));
+    assert_eq!(status.work["implement"].phase, WorkPhase::Failed);
+    assert_eq!(status.work["review"].phase, WorkPhase::Cancelled);
+    assert_eq!(status.work["review"].finished_at, Some(ts(30)));
 }
 
 #[test]
 fn roll_up_phase_only_touches_convoy_level_fields() {
-    let review = TaskState {
-        phase: TaskPhase::Completed,
+    let review = WorkState {
+        phase: WorkPhase::Completed,
         ready_at: Some(ts(10)),
         started_at: Some(ts(11)),
         finished_at: Some(ts(12)),
@@ -166,7 +166,7 @@ fn roll_up_phase_only_touches_convoy_level_fields() {
     let mut status = ConvoyStatus {
         phase: ConvoyPhase::Pending,
         workflow_snapshot: Some(sample_snapshot()),
-        tasks: BTreeMap::from([("review".to_string(), review.clone())]),
+        work: BTreeMap::from([("review".to_string(), review.clone())]),
         message: Some("keep".to_string()),
         started_at: None,
         finished_at: None,
@@ -180,7 +180,7 @@ fn roll_up_phase_only_touches_convoy_level_fields() {
     assert_eq!(status.phase, ConvoyPhase::Completed);
     assert_eq!(status.finished_at, Some(ts(40)));
     assert_eq!(status.message.as_deref(), Some("keep"));
-    assert_eq!(status.tasks["review"], review);
+    assert_eq!(status.work["review"], review);
 }
 
 #[test]
@@ -188,8 +188,8 @@ fn external_completion_marks_task_complete_without_touching_convoy_phase() {
     let mut status = ConvoyStatus {
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
-        tasks: BTreeMap::from([("review".to_string(), TaskState {
-            phase: TaskPhase::Running,
+        work: BTreeMap::from([("review".to_string(), WorkState {
+            phase: WorkPhase::Running,
             ready_at: Some(ts(10)),
             started_at: Some(ts(11)),
             finished_at: None,
@@ -203,13 +203,13 @@ fn external_completion_marks_task_complete_without_touching_convoy_phase() {
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
     };
 
-    let patch = ConvoyStatusPatch::MarkTaskCompleted { task: "review".to_string(), finished_at: ts(50), message: Some("done".to_string()) };
+    let patch = ConvoyStatusPatch::MarkWorkCompleted { work: "review".to_string(), finished_at: ts(50), message: Some("done".to_string()) };
     patch.apply(&mut status);
 
     assert_eq!(status.phase, ConvoyPhase::Active);
-    assert_eq!(status.tasks["review"].phase, TaskPhase::Completed);
-    assert_eq!(status.tasks["review"].finished_at, Some(ts(50)));
-    assert_eq!(status.tasks["review"].message.as_deref(), Some("done"));
+    assert_eq!(status.work["review"].phase, WorkPhase::Completed);
+    assert_eq!(status.work["review"].finished_at, Some(ts(50)));
+    assert_eq!(status.work["review"].message.as_deref(), Some("done"));
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn convoy_lifecycle_timestamps_are_set_once_per_transition() {
     let mut status = ConvoyStatus {
         phase: ConvoyPhase::Pending,
         workflow_snapshot: Some(sample_snapshot()),
-        tasks: BTreeMap::from([("implement".to_string(), pending_task())]),
+        work: BTreeMap::from([("implement".to_string(), pending_task())]),
         message: None,
         started_at: None,
         finished_at: None,
@@ -225,30 +225,30 @@ fn convoy_lifecycle_timestamps_are_set_once_per_transition() {
         observed_workflows: Some(BTreeMap::new()),
     };
 
-    ConvoyStatusPatch::AdvanceTasksToReady { ready: BTreeMap::from([("implement".to_string(), ts(10))]) }.apply(&mut status);
-    ConvoyStatusPatch::AdvanceTasksToReady { ready: BTreeMap::from([("implement".to_string(), ts(11))]) }.apply(&mut status);
-    assert_eq!(status.tasks["implement"].ready_at, Some(ts(10)));
+    ConvoyStatusPatch::AdvanceWorkToReady { ready: BTreeMap::from([("implement".to_string(), ts(10))]) }.apply(&mut status);
+    ConvoyStatusPatch::AdvanceWorkToReady { ready: BTreeMap::from([("implement".to_string(), ts(11))]) }.apply(&mut status);
+    assert_eq!(status.work["implement"].ready_at, Some(ts(10)));
 
-    ConvoyStatusPatch::TaskLaunching {
-        task: "implement".to_string(),
+    ConvoyStatusPatch::WorkLaunching {
+        work: "implement".to_string(),
         started_at: ts(20),
         placement: flotilla_resources::PlacementStatus::default(),
     }
     .apply(&mut status);
-    ConvoyStatusPatch::TaskLaunching {
-        task: "implement".to_string(),
+    ConvoyStatusPatch::WorkLaunching {
+        work: "implement".to_string(),
         started_at: ts(21),
         placement: flotilla_resources::PlacementStatus::default(),
     }
     .apply(&mut status);
-    assert_eq!(status.tasks["implement"].started_at, Some(ts(20)));
+    assert_eq!(status.work["implement"].started_at, Some(ts(20)));
 
-    ConvoyStatusPatch::MarkTaskCompleted { task: "implement".to_string(), finished_at: ts(30), message: Some("done".to_string()) }
+    ConvoyStatusPatch::MarkWorkCompleted { work: "implement".to_string(), finished_at: ts(30), message: Some("done".to_string()) }
         .apply(&mut status);
-    ConvoyStatusPatch::MarkTaskCompleted { task: "implement".to_string(), finished_at: ts(31), message: Some("still done".to_string()) }
+    ConvoyStatusPatch::MarkWorkCompleted { work: "implement".to_string(), finished_at: ts(31), message: Some("still done".to_string()) }
         .apply(&mut status);
-    assert_eq!(status.tasks["implement"].finished_at, Some(ts(30)));
-    assert_eq!(status.tasks["implement"].message.as_deref(), Some("still done"));
+    assert_eq!(status.work["implement"].finished_at, Some(ts(30)));
+    assert_eq!(status.work["implement"].message.as_deref(), Some("still done"));
 
     ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Active, started_at: Some(ts(40)), finished_at: None }.apply(&mut status);
     ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Active, started_at: Some(ts(41)), finished_at: None }.apply(&mut status);

--- a/crates/flotilla-resources/tests/http_wire.rs
+++ b/crates/flotilla-resources/tests/http_wire.rs
@@ -241,7 +241,7 @@ async fn filtered_list_encodes_exact_match_label_selector() {
     let resolver = backend.using::<Convoy>("flotilla");
     let selector = BTreeMap::from([
         ("flotilla.work/convoy".to_string(), "convoy-a".to_string()),
-        ("flotilla.work/task".to_string(), "implement".to_string()),
+        ("flotilla.work/vessel".to_string(), "implement".to_string()),
     ]);
 
     let listed = resolver.list_matching_labels(&selector).await.expect("filtered list should succeed");
@@ -249,7 +249,7 @@ async fn filtered_list_encodes_exact_match_label_selector() {
     assert!(listed.items.is_empty());
     let request = request_rx.await.expect("captured request");
     assert!(
-        request.contains("/apis/flotilla.work/v1/namespaces/flotilla/convoys?labelSelector=flotilla.work%2Fconvoy%3Dconvoy-a%2Cflotilla.work%2Ftask%3Dimplement"),
+        request.contains("/apis/flotilla.work/v1/namespaces/flotilla/convoys?labelSelector=flotilla.work%2Fconvoy%3Dconvoy-a%2Cflotilla.work%2Fvessel%3Dimplement"),
         "unexpected request: {request}"
     );
 }

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -147,7 +147,7 @@ async fn list_matching_labels_returns_only_exact_matches() {
 
     let mut alpha_meta = convoy_meta("alpha");
     alpha_meta.labels.insert("flotilla.work/convoy".to_string(), "convoy-a".to_string());
-    alpha_meta.labels.insert("flotilla.work/task".to_string(), "implement".to_string());
+    alpha_meta.labels.insert("flotilla.work/vessel".to_string(), "implement".to_string());
     resolver.create(&alpha_meta, &convoy_spec("template-a")).await.expect("alpha create should succeed");
 
     let mut beta_meta = convoy_meta("beta");
@@ -156,12 +156,12 @@ async fn list_matching_labels_returns_only_exact_matches() {
 
     let mut gamma_meta = convoy_meta("gamma");
     gamma_meta.labels.insert("flotilla.work/convoy".to_string(), "convoy-b".to_string());
-    gamma_meta.labels.insert("flotilla.work/task".to_string(), "implement".to_string());
+    gamma_meta.labels.insert("flotilla.work/vessel".to_string(), "implement".to_string());
     resolver.create(&gamma_meta, &convoy_spec("template-c")).await.expect("gamma create should succeed");
 
     let selector = BTreeMap::from([
         ("flotilla.work/convoy".to_string(), "convoy-a".to_string()),
-        ("flotilla.work/task".to_string(), "implement".to_string()),
+        ("flotilla.work/vessel".to_string(), "implement".to_string()),
     ]);
 
     let listed = resolver.list_matching_labels(&selector).await.expect("filtered list should succeed");

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -125,16 +125,16 @@ async fn convoy_controller_roundtrip_and_cel_validation() -> Result<(), Box<dyn 
     apply_status_patch(
         &convoys,
         &created.metadata.name,
-        &external_patches::mark_task_completed("implement".to_string(), chrono::Utc::now(), Some("implemented".to_string())),
+        &external_patches::mark_work_completed("implement".to_string(), chrono::Utc::now(), Some("implemented".to_string())),
     )
     .await?;
     let ready_review = reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;
-    assert!(matches!(ready_review, Some(flotilla_resources::ConvoyStatusPatch::AdvanceTasksToReady { .. })));
+    assert!(matches!(ready_review, Some(flotilla_resources::ConvoyStatusPatch::AdvanceWorkToReady { .. })));
 
     apply_status_patch(
         &convoys,
         &created.metadata.name,
-        &external_patches::mark_task_completed("review".to_string(), chrono::Utc::now(), Some("reviewed".to_string())),
+        &external_patches::mark_work_completed("review".to_string(), chrono::Utc::now(), Some("reviewed".to_string())),
     )
     .await?;
     let completed = reconcile_once(&convoys, &templates, &created.metadata.name, chrono::Utc::now()).await?;

--- a/crates/flotilla-resources/tests/provisioning_http_wire.rs
+++ b/crates/flotilla-resources/tests/provisioning_http_wire.rs
@@ -57,12 +57,7 @@ fn response(status: &str, body: &str) -> String {
 }
 
 fn owner_reference(name: &str) -> OwnerReference {
-    OwnerReference {
-        api_version: "flotilla.work/v1".to_string(),
-        kind: "TaskWorkspace".to_string(),
-        name: name.to_string(),
-        controller: true,
-    }
+    OwnerReference { api_version: "flotilla.work/v1".to_string(), kind: "Vessel".to_string(), name: name.to_string(), controller: true }
 }
 
 #[tokio::test]
@@ -81,7 +76,7 @@ async fn http_list_decodes_owner_references() {
                 "annotations": { "note": "test" },
                 "ownerReferences": [{
                     "apiVersion": "flotilla.work/v1",
-                    "kind": "TaskWorkspace",
+                    "kind": "Vessel",
                     "name": "alpha-implement",
                     "controller": true
                 }],
@@ -125,7 +120,7 @@ async fn http_create_serializes_owner_references() {
             "annotations": { "note": "test" },
             "ownerReferences": [{
                 "apiVersion": "flotilla.work/v1",
-                "kind": "TaskWorkspace",
+                "kind": "Vessel",
                 "name": "alpha-implement",
                 "controller": true
             }],
@@ -154,7 +149,9 @@ async fn http_create_serializes_owner_references() {
     let request = request_rx.await.expect("captured request");
 
     assert!(request.starts_with("POST /apis/flotilla.work/v1/namespaces/flotilla/convoys HTTP/1.1"));
-    assert!(request.contains("\"ownerReferences\":[{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"TaskWorkspace\",\"name\":\"alpha-implement\",\"controller\":true}]"));
+    assert!(request.contains(
+        "\"ownerReferences\":[{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Vessel\",\"name\":\"alpha-implement\",\"controller\":true}]"
+    ));
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -5,22 +5,24 @@ use common::{owner_reference, resource_meta};
 use flotilla_resources::{
     Checkout, CheckoutSpec, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentMount,
     EnvironmentMountMode, EnvironmentSpec, FreshCloneCheckoutSpec, Host, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, InMemoryBackend, PlacementPolicy, PlacementPolicySpec, ResourceBackend, Selector, TaskWorkspace,
-    TaskWorkspacePhase, TaskWorkspaceSpec, TaskWorkspaceStatus, TerminalBrief, TerminalCrewContext, TerminalSession, TerminalSessionSource,
-    TerminalSessionSpec,
+    HostDirectPlacementPolicySpec, InMemoryBackend, PlacementPolicy, PlacementPolicySpec, ResourceBackend, Selector, TerminalBrief,
+    TerminalCrewContext, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselPhase, VesselSpec, VesselStatus,
 };
 
 fn placement_meta(name: &str) -> flotilla_resources::InputMeta {
     resource_meta().name(name).call()
 }
 
-fn task_workspace_meta(name: &str) -> flotilla_resources::InputMeta {
+fn vessel_meta(name: &str) -> flotilla_resources::InputMeta {
     resource_meta()
         .name(name)
         .labels(
-            [("flotilla.work/convoy".to_string(), "fix-bug-123".to_string()), ("flotilla.work/task".to_string(), "implement".to_string())]
-                .into_iter()
-                .collect(),
+            [
+                ("flotilla.work/convoy".to_string(), "fix-bug-123".to_string()),
+                ("flotilla.work/vessel".to_string(), "implement".to_string()),
+            ]
+            .into_iter()
+            .collect(),
         )
         .owner_references(vec![owner_reference("fix-bug-123", "Convoy")])
         .finalizers(vec!["flotilla.work/example".to_string()])
@@ -32,7 +34,7 @@ fn docker_environment_meta(name: &str) -> flotilla_resources::InputMeta {
     resource_meta()
         .name(name)
         .labels([("flotilla.work/host".to_string(), "01HXYZ".to_string())].into_iter().collect())
-        .owner_references(vec![owner_reference("convoy-fix-bug-123-implement", "TaskWorkspace")])
+        .owner_references(vec![owner_reference("convoy-fix-bug-123-implement", "Vessel")])
         .finalizers(vec!["flotilla.work/environment-teardown".to_string()])
         .call()
 }
@@ -58,18 +60,18 @@ async fn placement_policy_roundtrips_without_status() {
 }
 
 #[tokio::test]
-async fn task_workspace_metadata_and_status_roundtrip() {
-    let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<TaskWorkspace>("flotilla");
-    let spec = TaskWorkspaceSpec {
+async fn vessel_metadata_and_status_roundtrip() {
+    let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<Vessel>("flotilla");
+    let spec = VesselSpec {
         convoy_ref: "fix-bug-123".to_string(),
-        task: "implement".to_string(),
+        vessel_name: "implement".to_string(),
         placement_policy_ref: "docker-on-01HXYZ".to_string(),
         adopted_checkout_ref: None,
     };
-    let created = resolver.create(&task_workspace_meta("convoy-fix-bug-123-implement"), &spec).await.expect("create should succeed");
+    let created = resolver.create(&vessel_meta("convoy-fix-bug-123-implement"), &spec).await.expect("create should succeed");
     let updated = resolver
-        .update_status("convoy-fix-bug-123-implement", &created.metadata.resource_version, &TaskWorkspaceStatus {
-            phase: TaskWorkspacePhase::Ready,
+        .update_status("convoy-fix-bug-123-implement", &created.metadata.resource_version, &VesselStatus {
+            phase: VesselPhase::Ready,
             message: None,
             observed_policy_ref: Some("docker-on-01HXYZ".to_string()),
             observed_policy_version: Some("12".to_string()),
@@ -142,7 +144,7 @@ async fn agent_terminal_session_preserves_structured_launch_and_canonical_brief(
                 path: ".flotilla/briefs/coder.md".into(),
                 content: "You are coder in convoy demo.\n\nImplement the change.".into(),
             },
-            context: TerminalCrewContext { namespace: "flotilla".into(), convoy: "demo".into(), vessel: "demo-implement".into() },
+            context: TerminalCrewContext { namespace: "flotilla".into(), convoy: "demo".into(), vessel_ref: "demo-implement".into() },
             message: None,
         },
         cwd: "/workspace".into(),

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -2,8 +2,8 @@ use chrono::{TimeZone, Utc};
 use flotilla_resources::{
     CheckoutPhase, CheckoutStatus, CheckoutStatusPatch, ClonePhase, CloneStatus, CloneStatusPatch, EnvironmentPhase, EnvironmentStatus,
     EnvironmentStatusPatch, HostStatus, HostStatusPatch, InnerCommandStatus, PresentationPhase, PresentationStatus,
-    PresentationStatusPatch, StatusPatch, TaskWorkspacePhase, TaskWorkspaceStatus, TaskWorkspaceStatusPatch, TerminalSessionPhase,
-    TerminalSessionStatus, TerminalSessionStatusPatch,
+    PresentationStatusPatch, StatusPatch, TerminalSessionPhase, TerminalSessionStatus, TerminalSessionStatusPatch, VesselPhase,
+    VesselStatus, VesselStatusPatch,
 };
 
 #[test]
@@ -131,21 +131,21 @@ fn terminal_session_failure_is_distinct_from_a_stopped_crew_member_and_can_resta
 }
 
 #[test]
-fn task_workspace_status_patch_marks_provisioning_ready_and_failed() {
-    let mut status = TaskWorkspaceStatus::default();
+fn vessel_status_patch_marks_provisioning_ready_and_failed() {
+    let mut status = VesselStatus::default();
     let started_at = Utc.timestamp_opt(10, 0).single().expect("timestamp");
     let ready_at = Utc.timestamp_opt(20, 0).single().expect("timestamp");
 
-    TaskWorkspaceStatusPatch::MarkProvisioning {
+    VesselStatusPatch::MarkProvisioning {
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
         observed_policy_version: "12".to_string(),
         started_at,
     }
     .apply(&mut status);
-    assert_eq!(status.phase, TaskWorkspacePhase::Provisioning);
+    assert_eq!(status.phase, VesselPhase::Provisioning);
     assert_eq!(status.observed_policy_ref.as_deref(), Some("docker-on-01HXYZ"));
 
-    TaskWorkspaceStatusPatch::MarkProvisioning {
+    VesselStatusPatch::MarkProvisioning {
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
         observed_policy_version: "13".to_string(),
         started_at: Utc.timestamp_opt(11, 0).single().expect("timestamp"),
@@ -153,17 +153,17 @@ fn task_workspace_status_patch_marks_provisioning_ready_and_failed() {
     .apply(&mut status);
     assert_eq!(status.started_at, Some(started_at), "reconcile must not restamp an in-progress transition");
 
-    TaskWorkspaceStatusPatch::MarkReady {
+    VesselStatusPatch::MarkReady {
         environment_ref: Some("env-a".to_string()),
         checkout_ref: Some("checkout-a".to_string()),
         terminal_session_refs: vec!["term-a".to_string(), "term-b".to_string()],
         ready_at,
     }
     .apply(&mut status);
-    assert_eq!(status.phase, TaskWorkspacePhase::Ready);
+    assert_eq!(status.phase, VesselPhase::Ready);
     assert_eq!(status.terminal_session_refs.len(), 2);
 
-    TaskWorkspaceStatusPatch::MarkReady {
+    VesselStatusPatch::MarkReady {
         environment_ref: Some("env-a".to_string()),
         checkout_ref: Some("checkout-a".to_string()),
         terminal_session_refs: vec!["term-a".to_string(), "term-b".to_string()],
@@ -172,8 +172,8 @@ fn task_workspace_status_patch_marks_provisioning_ready_and_failed() {
     .apply(&mut status);
     assert_eq!(status.ready_at, Some(ready_at), "reconcile must not restamp an established Ready transition");
 
-    TaskWorkspaceStatusPatch::MarkFailed { message: "clone failed".to_string() }.apply(&mut status);
-    assert_eq!(status.phase, TaskWorkspacePhase::Failed);
+    VesselStatusPatch::MarkFailed { message: "clone failed".to_string() }.apply(&mut status);
+    assert_eq!(status.phase, VesselPhase::Failed);
     assert_eq!(status.message.as_deref(), Some("clone failed"));
 }
 

--- a/crates/flotilla-resources/tests/workflow_template_validation.rs
+++ b/crates/flotilla-resources/tests/workflow_template_validation.rs
@@ -21,9 +21,9 @@ fn assert_has_error(errors: &[ValidationError], expected: &ValidationError) {
 fn parse_rejects_process_without_selector_or_command() {
     let yaml = r#"
 inputs: []
-tasks:
+vessels:
   - name: implement
-    processes:
+    crew:
       - role: coder
 "#;
 
@@ -36,9 +36,9 @@ tasks:
 fn parse_rejects_process_with_selector_and_command() {
     let yaml = r#"
 inputs: []
-tasks:
+vessels:
   - name: implement
-    processes:
+    crew:
       - role: coder
         selector:
           capability: code
@@ -54,9 +54,9 @@ tasks:
 fn parse_rejects_prompt_on_tool_process() {
     let yaml = r#"
 inputs: []
-tasks:
+vessels:
   - name: implement
-    processes:
+    crew:
       - role: coder
         command: cargo test
         prompt: should-not-be-here
@@ -70,7 +70,7 @@ tasks:
 #[test]
 fn validate_rejects_duplicate_task_names() {
     let mut spec = valid_workflow_template_spec();
-    spec.tasks.push(spec.tasks[0].clone());
+    spec.vessels.push(spec.vessels[0].clone());
 
     let errors = validate(&spec).expect_err("validation should fail");
     assert_has_error(&errors, &ValidationError::DuplicateTaskName { name: "implement".to_string() });
@@ -88,8 +88,8 @@ fn validate_rejects_duplicate_input_names() {
 #[test]
 fn validate_rejects_duplicate_role_names_within_task() {
     let mut spec = valid_workflow_template_spec();
-    let duplicate_process = spec.tasks[0].processes[0].clone();
-    spec.tasks[0].processes.push(duplicate_process);
+    let duplicate_process = spec.vessels[0].crew[0].clone();
+    spec.vessels[0].crew.push(duplicate_process);
 
     let errors = validate(&spec).expect_err("validation should fail");
     assert_has_error(&errors, &ValidationError::DuplicateRoleInTask { task: "implement".to_string(), role: "coder".to_string() });
@@ -98,16 +98,16 @@ fn validate_rejects_duplicate_role_names_within_task() {
 #[test]
 fn validate_rejects_unknown_dependencies() {
     let mut spec = valid_workflow_template_spec();
-    spec.tasks[1].depends_on = vec!["missing".to_string()];
+    spec.vessels[1].depends_on = vec!["missing".to_string()];
 
     let errors = validate(&spec).expect_err("validation should fail");
-    assert_has_error(&errors, &ValidationError::UnknownDependency { task: "review".to_string(), missing: "missing".to_string() });
+    assert_has_error(&errors, &ValidationError::UnknownDependency { vessel: "review".to_string(), missing: "missing".to_string() });
 }
 
 #[test]
 fn validate_rejects_cycles() {
     let mut spec = valid_workflow_template_spec();
-    spec.tasks[0].depends_on = vec!["review".to_string()];
+    spec.vessels[0].depends_on = vec!["review".to_string()];
 
     let errors = validate(&spec).expect_err("validation should fail");
     assert_has_error(&errors, &ValidationError::DependencyCycle {
@@ -118,8 +118,8 @@ fn validate_rejects_cycles() {
 #[test]
 fn validate_rejects_unknown_input_references() {
     let mut spec = valid_workflow_template_spec();
-    if let Some(prompt) = match &mut spec.tasks[0].processes[0].source {
-        flotilla_resources::ProcessSource::Agent { prompt, .. } => prompt,
+    if let Some(prompt) = match &mut spec.vessels[0].crew[0].source {
+        flotilla_resources::CrewSource::Agent { prompt, .. } => prompt,
         _ => unreachable!("first process should be an agent"),
     } {
         *prompt = "Implement {{inputs.missing}}".to_string();
@@ -127,7 +127,7 @@ fn validate_rejects_unknown_input_references() {
 
     let errors = validate(&spec).expect_err("validation should fail");
     assert_has_error(&errors, &ValidationError::UnknownInputReference {
-        location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+        location: InterpolationLocation { vessel: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
         name: "missing".to_string(),
     });
 }
@@ -135,8 +135,8 @@ fn validate_rejects_unknown_input_references() {
 #[test]
 fn validate_rejects_unknown_workflow_fields() {
     let mut spec = valid_workflow_template_spec();
-    if let Some(prompt) = match &mut spec.tasks[0].processes[0].source {
-        flotilla_resources::ProcessSource::Agent { prompt, .. } => prompt,
+    if let Some(prompt) = match &mut spec.vessels[0].crew[0].source {
+        flotilla_resources::CrewSource::Agent { prompt, .. } => prompt,
         _ => unreachable!("first process should be an agent"),
     } {
         *prompt = "Implement {{workflow.uid}}".to_string();
@@ -144,7 +144,7 @@ fn validate_rejects_unknown_workflow_fields() {
 
     let errors = validate(&spec).expect_err("validation should fail");
     assert_has_error(&errors, &ValidationError::UnknownWorkflowField {
-        location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+        location: InterpolationLocation { vessel: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
         name: "uid".to_string(),
     });
 }
@@ -152,8 +152,8 @@ fn validate_rejects_unknown_workflow_fields() {
 #[test]
 fn validate_rejects_malformed_owned_interpolations() {
     let mut spec = valid_workflow_template_spec();
-    if let Some(prompt) = match &mut spec.tasks[0].processes[0].source {
-        flotilla_resources::ProcessSource::Agent { prompt, .. } => prompt,
+    if let Some(prompt) = match &mut spec.vessels[0].crew[0].source {
+        flotilla_resources::CrewSource::Agent { prompt, .. } => prompt,
         _ => unreachable!("first process should be an agent"),
     } {
         *prompt = "Implement {{inputs.branch }} then {{workflow.name.extra}}".to_string();
@@ -161,11 +161,11 @@ fn validate_rejects_malformed_owned_interpolations() {
 
     let errors = validate(&spec).expect_err("validation should fail");
     assert_has_error(&errors, &ValidationError::MalformedInterpolation {
-        location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+        location: InterpolationLocation { vessel: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
         text: "inputs.branch ".to_string(),
     });
     assert_has_error(&errors, &ValidationError::MalformedInterpolation {
-        location: InterpolationLocation { task: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
+        location: InterpolationLocation { vessel: "implement".to_string(), role: "coder".to_string(), field: InterpolationField::Prompt },
         text: "workflow.name.extra".to_string(),
     });
 }
@@ -175,9 +175,9 @@ fn validate_allows_foreign_interpolations() {
     let spec = parse_spec(
         r#"
 inputs: []
-tasks:
+vessels:
   - name: implement
-    processes:
+    crew:
       - role: build
         command: "kubectl get pod -o go-template='{{.metadata.name}}'"
 "#,
@@ -189,11 +189,11 @@ tasks:
 #[test]
 fn validate_rejects_reserved_process_label_keys() {
     let mut spec = valid_workflow_template_spec();
-    spec.tasks[0].processes[0].labels.insert("flotilla.work/convoy".to_string(), "manual".to_string());
+    spec.vessels[0].crew[0].labels.insert("flotilla.work/convoy".to_string(), "manual".to_string());
 
     let errors = validate(&spec).expect_err("reserved labels should fail validation");
     assert_has_error(&errors, &ValidationError::ReservedLabelKey {
-        task: "implement".to_string(),
+        vessel: "implement".to_string(),
         role: "coder".to_string(),
         key: "flotilla.work/convoy".to_string(),
     });
@@ -204,9 +204,9 @@ fn validate_allows_non_reserved_process_label_keys() {
     let spec = parse_spec(
         r#"
 inputs: []
-tasks:
+vessels:
   - name: implement
-    processes:
+    crew:
       - role: build
         command: cargo test
         labels:

--- a/crates/flotilla-resources/tests/workflow_template_validation.rs
+++ b/crates/flotilla-resources/tests/workflow_template_validation.rs
@@ -68,12 +68,12 @@ vessels:
 }
 
 #[test]
-fn validate_rejects_duplicate_task_names() {
+fn validate_rejects_duplicate_vessel_names() {
     let mut spec = valid_workflow_template_spec();
     spec.vessels.push(spec.vessels[0].clone());
 
     let errors = validate(&spec).expect_err("validation should fail");
-    assert_has_error(&errors, &ValidationError::DuplicateTaskName { name: "implement".to_string() });
+    assert_has_error(&errors, &ValidationError::DuplicateVesselName { name: "implement".to_string() });
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn validate_rejects_duplicate_role_names_within_task() {
     spec.vessels[0].crew.push(duplicate_process);
 
     let errors = validate(&spec).expect_err("validation should fail");
-    assert_has_error(&errors, &ValidationError::DuplicateRoleInTask { task: "implement".to_string(), role: "coder".to_string() });
+    assert_has_error(&errors, &ValidationError::DuplicateRoleInVessel { vessel: "implement".to_string(), role: "coder".to_string() });
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -41,28 +41,28 @@ impl App {
         match action {
             Action::SelectNext if self.ui.is_convoys => match self.convoys_focus() {
                 super::ConvoysFocus::List => self.convoys_tab_select_delta(1),
-                super::ConvoysFocus::Tasks => self.convoy_tasks_select_delta("flotilla", 1),
+                super::ConvoysFocus::Tasks => self.convoy_vessels_select_delta("flotilla", 1),
             },
             Action::SelectPrev if self.ui.is_convoys => match self.convoys_focus() {
                 super::ConvoysFocus::List => self.convoys_tab_select_delta(-1),
-                super::ConvoysFocus::Tasks => self.convoy_tasks_select_delta("flotilla", -1),
+                super::ConvoysFocus::Tasks => self.convoy_vessels_select_delta("flotilla", -1),
             },
             // On the Convoys list, Confirm (enter / l / right) drills into the task tree.
             // In the task tree, Confirm is currently a no-op (task-attach lands in PR 3).
             Action::Confirm if self.ui.is_convoys => {
                 if matches!(self.convoys_focus(), super::ConvoysFocus::List) {
-                    self.enter_convoy_tasks_focus("flotilla");
+                    self.enter_convoy_vessels_focus("flotilla");
                 }
             }
             // In the task tree, Dismiss (esc / left) returns to the convoy list.
             // On the convoy list, Dismiss is a no-op (don't act on the hidden repo page).
             Action::Dismiss if self.ui.is_convoys => {
                 if matches!(self.convoys_focus(), super::ConvoysFocus::Tasks) {
-                    self.exit_convoy_tasks_focus();
+                    self.exit_convoy_vessels_focus();
                 }
             }
-            Action::CompleteConvoyLeg if self.ui.is_convoys => self.open_complete_convoy_leg_palette(),
-            Action::AttachConvoyLeg if self.ui.is_convoys => self.attach_selected_convoy_task(),
+            Action::CompleteConvoyWork if self.ui.is_convoys => self.open_complete_convoy_work_palette(),
+            Action::AttachConvoyVessel if self.ui.is_convoys => self.attach_selected_convoy_vessel(),
             Action::Confirm if !self.ui.is_config => self.action_enter(),
             Action::OpenActionMenu if !self.ui.is_config => self.open_action_menu(),
             Action::OpenFilePicker if !self.ui.is_config => self.open_file_picker_from_active_repo_parent(),
@@ -405,18 +405,18 @@ impl App {
         }
     }
 
-    /// Open the command palette pre-filled with `convoy <id> leg <leg> complete `.
-    /// No-op when no convoy or leg is selected. Convoy ids and leg names are
+    /// Open the command palette pre-filled with `convoy <id> work <vessel> complete `.
+    /// No-op when no convoy or vessel is selected. Convoy ids and vessel names are
     /// arbitrary strings (no validation), so they are routed through the
     /// palette's quoting helper to round-trip whitespace and special characters.
-    pub(super) fn open_complete_convoy_leg_palette(&mut self) {
+    pub(super) fn open_complete_convoy_work_palette(&mut self) {
         let Some(convoy) = self.selected_convoy_summary("flotilla") else { return };
         let Some(task) = self.convoys_ui.selected_task.as_ref() else { return };
         let selected_task = task.clone();
         let completion_target =
-            convoy.tasks.iter().find(|candidate| candidate.name == *task).and_then(|task| task.completion_target.clone());
+            convoy.vessels.iter().find(|candidate| candidate.name == *task).and_then(|task| task.completion_target.clone());
         let Some(completion_target) = completion_target else {
-            self.set_status_message(Some(format!("completion unavailable for leg '{selected_task}'")));
+            self.set_status_message(Some(format!("completion unavailable for vessel '{selected_task}'")));
             return;
         };
         let target_node_id = match self.panel_target_node(&completion_target.host) {
@@ -427,21 +427,21 @@ impl App {
             }
         };
         let prefill = format!(
-            "convoy {} leg {} complete ",
+            "convoy {} work {} complete ",
             crate::palette::quote_palette_token(&completion_target.convoy),
-            crate::palette::quote_palette_token(&completion_target.leg),
+            crate::palette::quote_palette_token(&completion_target.vessel),
         );
         let widget = crate::widgets::command_palette::CommandPaletteWidget::with_prefill_on_node(prefill, target_node_id);
         self.screen.modal_stack.push(Box::new(widget));
     }
 
     /// Dispatch `SelectWorkspace` for the selected task's workspace, or show a transient status when none exists yet.
-    pub(super) fn attach_selected_convoy_task(&mut self) {
+    pub(super) fn attach_selected_convoy_vessel(&mut self) {
         let Some(task) = self.convoys_ui.selected_task.clone() else { return };
         // Single-namespace MVP: all convoys live in "flotilla" (see convoys_tab_select_delta).
         let target = self
             .selected_convoy_summary("flotilla")
-            .and_then(|convoy| convoy.tasks.iter().find(|t| t.name == task))
+            .and_then(|convoy| convoy.vessels.iter().find(|t| t.name == task))
             .map(|task| (task.workspace_ref.clone(), task.host.clone()));
         match target {
             Some((Some(ws_ref), host)) => {

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -455,7 +455,7 @@ impl App {
                 };
                 self.proto_commands.push(cmd);
             }
-            _ => self.set_status_message(Some(format!("no workspace yet for task '{task}'"))),
+            _ => self.set_status_message(Some(format!("no workspace yet for vessel '{task}'"))),
         }
     }
 

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -15,7 +15,7 @@ impl App {
     ///
     /// Called when the base layer widget (Normal mode_id) is on top, so that
     /// config mode gets Overview bindings, convoys mode gets Convoys bindings
-    /// (or ConvoyTasks when the user has drilled into the task tree), and
+    /// (or ConvoyVessels when the user has drilled into the vessel tree), and
     /// normal mode gets Normal bindings.
     fn resolve_action(&self, key: KeyEvent) -> Option<Action> {
         let mode = if self.ui.is_config {
@@ -23,7 +23,7 @@ impl App {
         } else if self.ui.is_convoys {
             let inner = match self.convoys_focus() {
                 super::ConvoysFocus::List => BindingModeId::Convoys,
-                super::ConvoysFocus::Tasks => BindingModeId::ConvoyTasks,
+                super::ConvoysFocus::Vessels => BindingModeId::ConvoyVessels,
             };
             KeyBindingMode::Composed(vec![BindingModeId::TabPage, inner])
         } else {
@@ -41,23 +41,23 @@ impl App {
         match action {
             Action::SelectNext if self.ui.is_convoys => match self.convoys_focus() {
                 super::ConvoysFocus::List => self.convoys_tab_select_delta(1),
-                super::ConvoysFocus::Tasks => self.convoy_vessels_select_delta("flotilla", 1),
+                super::ConvoysFocus::Vessels => self.convoy_vessels_select_delta("flotilla", 1),
             },
             Action::SelectPrev if self.ui.is_convoys => match self.convoys_focus() {
                 super::ConvoysFocus::List => self.convoys_tab_select_delta(-1),
-                super::ConvoysFocus::Tasks => self.convoy_vessels_select_delta("flotilla", -1),
+                super::ConvoysFocus::Vessels => self.convoy_vessels_select_delta("flotilla", -1),
             },
-            // On the Convoys list, Confirm (enter / l / right) drills into the task tree.
-            // In the task tree, Confirm is currently a no-op (task-attach lands in PR 3).
+            // On the Convoys list, Confirm (enter / l / right) drills into the vessel tree.
+            // In the vessel tree, Confirm is currently a no-op (task-attach lands in PR 3).
             Action::Confirm if self.ui.is_convoys => {
                 if matches!(self.convoys_focus(), super::ConvoysFocus::List) {
                     self.enter_convoy_vessels_focus("flotilla");
                 }
             }
-            // In the task tree, Dismiss (esc / left) returns to the convoy list.
+            // In the vessel tree, Dismiss (esc / left) returns to the convoy list.
             // On the convoy list, Dismiss is a no-op (don't act on the hidden repo page).
             Action::Dismiss if self.ui.is_convoys => {
-                if matches!(self.convoys_focus(), super::ConvoysFocus::Tasks) {
+                if matches!(self.convoys_focus(), super::ConvoysFocus::Vessels) {
                     self.exit_convoy_vessels_focus();
                 }
             }

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -411,12 +411,12 @@ impl App {
     /// palette's quoting helper to round-trip whitespace and special characters.
     pub(super) fn open_complete_convoy_work_palette(&mut self) {
         let Some(convoy) = self.selected_convoy_summary("flotilla") else { return };
-        let Some(task) = self.convoys_ui.selected_task.as_ref() else { return };
-        let selected_task = task.clone();
+        let Some(task) = self.convoys_ui.selected_vessel.as_ref() else { return };
+        let selected_vessel = task.clone();
         let completion_target =
             convoy.vessels.iter().find(|candidate| candidate.name == *task).and_then(|task| task.completion_target.clone());
         let Some(completion_target) = completion_target else {
-            self.set_status_message(Some(format!("completion unavailable for vessel '{selected_task}'")));
+            self.set_status_message(Some(format!("completion unavailable for vessel '{selected_vessel}'")));
             return;
         };
         let target_node_id = match self.panel_target_node(&completion_target.host) {
@@ -437,7 +437,7 @@ impl App {
 
     /// Dispatch `SelectWorkspace` for the selected task's workspace, or show a transient status when none exists yet.
     pub(super) fn attach_selected_convoy_vessel(&mut self) {
-        let Some(task) = self.convoys_ui.selected_task.clone() else { return };
+        let Some(task) = self.convoys_ui.selected_vessel.clone() else { return };
         // Single-namespace MVP: all convoys live in "flotilla" (see convoys_tab_select_delta).
         let target = self
             .selected_convoy_summary("flotilla")

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -285,8 +285,8 @@ pub enum ConvoysFocus {
 #[derive(Default)]
 pub struct ConvoysUiState {
     pub selected: Option<crate::convoy_model::ConvoyId>,
-    /// Name of the selected task within `selected`. Cleared when the convoy
-    /// selection changes; clamped against the convoy's task list on every
+    /// Name of the selected vessel within `selected`. Cleared when the convoy
+    /// selection changes; clamped against the convoy's vessel list on every
     /// snapshot/delta apply.
     pub selected_vessel: Option<String>,
     pub focus: ConvoysFocus,
@@ -1607,7 +1607,7 @@ impl App {
         &self.convoys_ui.filter
     }
 
-    /// Returns the selected task name within the selected convoy, if any.
+    /// Returns the selected vessel name within the selected convoy, if any.
     pub fn selected_convoy_task(&self) -> Option<&str> {
         self.convoys_ui.selected_vessel.as_deref()
     }
@@ -1624,17 +1624,17 @@ impl App {
     /// - Replaces a dangling selection (removed convoy) with the first available convoy.
     /// - Sets the first convoy as the default when no selection is set yet.
     /// - Resets task focus state when the selected convoy changes.
-    /// - Clamps `selected_vessel` against the selected convoy's current task list.
+    /// - Clamps `selected_vessel` against the selected convoy's current vessel list.
     fn refresh_convoy_selection(&mut self, namespace: &str) {
         let prior_selected = self.convoys_ui.selected.clone();
         let Some(model) = self.namespaces.get(namespace) else {
             self.convoys_ui.selected = None;
-            self.reset_convoy_task_state();
+            self.reset_convoy_vessel_state();
             return;
         };
         if model.convoys.is_empty() {
             self.convoys_ui.selected = None;
-            self.reset_convoy_task_state();
+            self.reset_convoy_vessel_state();
             return;
         }
         let still_valid = self.convoys_ui.selected.as_ref().is_some_and(|id| model.convoys.contains_key(id));
@@ -1642,12 +1642,12 @@ impl App {
             self.convoys_ui.selected = Some(model.convoys.keys().next().cloned().expect("non-empty checked above"));
         }
         if self.convoys_ui.selected != prior_selected {
-            self.reset_convoy_task_state();
+            self.reset_convoy_vessel_state();
         }
         self.clamp_selected_vessel(namespace);
     }
 
-    fn reset_convoy_task_state(&mut self) {
+    fn reset_convoy_vessel_state(&mut self) {
         self.convoys_ui.selected_vessel = None;
         self.convoys_ui.focus = ConvoysFocus::List;
     }
@@ -1683,7 +1683,7 @@ impl App {
         self.convoys_ui.focus = ConvoysFocus::Vessels;
     }
 
-    /// Return focus to the convoy list. Keeps `selected_vessel` so re-entering Tasks
+    /// Return focus to the convoy list. Keeps `selected_vessel` so re-entering Vessels
     /// resumes at the same row.
     pub fn exit_convoy_vessels_focus(&mut self) {
         self.convoys_ui.focus = ConvoysFocus::List;
@@ -1715,14 +1715,14 @@ impl App {
         let ids: Vec<crate::convoy_model::ConvoyId> = self.visible_convoys("flotilla").map(|c| c.id.clone()).collect();
         if ids.is_empty() {
             self.convoys_ui.selected = None;
-            self.reset_convoy_task_state();
+            self.reset_convoy_vessel_state();
             return;
         }
         let current_idx = self.convoys_ui.selected.as_ref().and_then(|id| ids.iter().position(|candidate| candidate == id)).unwrap_or(0);
         let new_idx = (current_idx as isize + delta).clamp(0, (ids.len() - 1) as isize) as usize;
         self.convoys_ui.selected = Some(ids[new_idx].clone());
         if self.convoys_ui.selected != prior_selected {
-            self.reset_convoy_task_state();
+            self.reset_convoy_vessel_state();
         }
     }
 
@@ -1751,7 +1751,7 @@ impl App {
             self.convoys_ui.selected = visible_ids.into_iter().next();
         }
         if self.convoys_ui.selected != prior_selected {
-            self.reset_convoy_task_state();
+            self.reset_convoy_vessel_state();
         }
         self.clamp_selected_vessel(namespace);
     }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -369,32 +369,34 @@ fn panel_row_to_convoy(row: &PanelRow) -> Option<crate::convoy_model::ConvoySumm
         return None;
     }
     let name = panel_string(&row.values, "name")?;
-    let tasks = row
+    let vessels = row
         .children
         .iter()
         .filter_map(|child| {
             let name = panel_string(&child.values, "name")?;
-            let vessel_target = child.intents.iter().find_map(|intent| match &intent.target {
-                IntentTarget::Vessel { attach_ref, host } => Some((attach_ref.clone(), host.clone())),
-                IntentTarget::Leg { .. } => None,
+            let attach_target = child.intents.iter().find_map(|intent| match &intent.target {
+                IntentTarget::Vessel { attach_ref: Some(attach_ref), host, .. } if intent.intent_id == "attach" => {
+                    Some((attach_ref.clone(), host.clone()))
+                }
+                IntentTarget::Vessel { .. } => None,
             });
             let completion_target = child.intents.iter().find_map(|intent| match &intent.target {
-                IntentTarget::Leg { convoy, leg, host, .. } if intent.intent_id == "complete-leg" => {
-                    Some(crate::convoy_model::LegCompletionTarget { convoy: convoy.clone(), leg: leg.clone(), host: host.clone() })
+                IntentTarget::Vessel { convoy, vessel, host, .. } if intent.intent_id == "complete-work" => {
+                    Some(crate::convoy_model::WorkCompletionTarget { convoy: convoy.clone(), vessel: vessel.clone(), host: host.clone() })
                 }
-                IntentTarget::Leg { .. } | IntentTarget::Vessel { .. } => None,
+                IntentTarget::Vessel { .. } => None,
             });
-            let workspace_ref = vessel_target.as_ref().map(|(attach_ref, _)| attach_ref.clone());
-            let intent_host = vessel_target.map(|(_, host)| host);
-            Some(crate::convoy_model::TaskSummary {
+            let workspace_ref = attach_target.as_ref().map(|(attach_ref, _)| attach_ref.clone());
+            let intent_host = attach_target.map(|(_, host)| host);
+            Some(crate::convoy_model::VesselSummary {
                 name: name.to_string(),
                 depends_on: child
                     .depends_on
                     .iter()
-                    .filter_map(|reference| reference.subresource.as_deref()?.strip_prefix("legs/").map(str::to_string))
+                    .filter_map(|reference| reference.subresource.as_deref()?.strip_prefix("vessels/").map(str::to_string))
                     .collect(),
                 phase: task_phase(panel_string(&child.values, "phase")?),
-                processes: panel_crew(&child.values),
+                crew: panel_crew(&child.values),
                 host: intent_host.or_else(|| panel_host(&child.values, "host")).or_else(|| child.resource.host.clone()),
                 checkout: panel_checkout(&child.values, "checkout"),
                 workspace_ref,
@@ -414,7 +416,7 @@ fn panel_row_to_convoy(row: &PanelRow) -> Option<crate::convoy_model::ConvoySumm
         phase: convoy_phase(panel_string(&row.values, "phase")?),
         message: panel_string(&row.values, "message").map(str::to_string),
         repo_hint: panel_string(&row.values, "repo").map(|repo| flotilla_protocol::RepoKey(repo.to_string())),
-        tasks,
+        vessels,
         started_at: panel_timestamp(&row.values, "started_at"),
         finished_at: panel_timestamp(&row.values, "finished_at"),
         observed_workflow_ref: panel_string(&row.values, "observed_workflow_ref").map(str::to_string),
@@ -460,15 +462,15 @@ fn panel_crew(values: &BTreeMap<String, PanelValue>) -> Vec<crate::convoy_model:
         .collect()
 }
 
-fn task_phase(phase: &str) -> crate::convoy_model::TaskPhase {
+fn task_phase(phase: &str) -> crate::convoy_model::WorkPhase {
     match phase {
-        "ready" => crate::convoy_model::TaskPhase::Ready,
-        "launching" => crate::convoy_model::TaskPhase::Launching,
-        "running" => crate::convoy_model::TaskPhase::Running,
-        "completed" => crate::convoy_model::TaskPhase::Completed,
-        "failed" => crate::convoy_model::TaskPhase::Failed,
-        "cancelled" => crate::convoy_model::TaskPhase::Cancelled,
-        _ => crate::convoy_model::TaskPhase::Pending,
+        "ready" => crate::convoy_model::WorkPhase::Ready,
+        "launching" => crate::convoy_model::WorkPhase::Launching,
+        "running" => crate::convoy_model::WorkPhase::Running,
+        "completed" => crate::convoy_model::WorkPhase::Completed,
+        "failed" => crate::convoy_model::WorkPhase::Failed,
+        "cancelled" => crate::convoy_model::WorkPhase::Cancelled,
+        _ => crate::convoy_model::WorkPhase::Pending,
     }
 }
 
@@ -1656,7 +1658,7 @@ impl App {
     /// limbo until the user pressed `j`/`k`.
     fn clamp_selected_task(&mut self, namespace: &str) {
         let Some(task) = self.convoys_ui.selected_task.clone() else { return };
-        let still_valid = self.selected_convoy_summary(namespace).is_some_and(|c| c.tasks.iter().any(|t| t.name == task));
+        let still_valid = self.selected_convoy_summary(namespace).is_some_and(|c| c.vessels.iter().any(|t| t.name == task));
         if !still_valid {
             self.convoys_ui.selected_task = None;
             self.convoys_ui.focus = ConvoysFocus::List;
@@ -1669,33 +1671,33 @@ impl App {
     }
 
     /// Switch focus to the task tree, defaulting to the first task if none selected.
-    /// No-op when no convoy is selected or the convoy has no legs.
-    pub fn enter_convoy_tasks_focus(&mut self, namespace: &str) {
+    /// No-op when no convoy is selected or the convoy has no vessels.
+    pub fn enter_convoy_vessels_focus(&mut self, namespace: &str) {
         let Some(convoy) = self.selected_convoy_summary(namespace) else { return };
-        if convoy.tasks.is_empty() {
+        if convoy.vessels.is_empty() {
             return;
         }
         if self.convoys_ui.selected_task.is_none() {
-            self.convoys_ui.selected_task = Some(convoy.tasks[0].name.clone());
+            self.convoys_ui.selected_task = Some(convoy.vessels[0].name.clone());
         }
         self.convoys_ui.focus = ConvoysFocus::Tasks;
     }
 
     /// Return focus to the convoy list. Keeps `selected_task` so re-entering Tasks
     /// resumes at the same row.
-    pub fn exit_convoy_tasks_focus(&mut self) {
+    pub fn exit_convoy_vessels_focus(&mut self) {
         self.convoys_ui.focus = ConvoysFocus::List;
     }
 
     /// Move task selection within the selected convoy by `delta` (positive = down).
-    /// Clamps at both ends. No-op when no legs are visible.
-    pub fn convoy_tasks_select_delta(&mut self, namespace: &str, delta: isize) {
+    /// Clamps at both ends. No-op when no vessels are visible.
+    pub fn convoy_vessels_select_delta(&mut self, namespace: &str, delta: isize) {
         let Some(convoy) = self.selected_convoy_summary(namespace) else { return };
-        if convoy.tasks.is_empty() {
+        if convoy.vessels.is_empty() {
             self.convoys_ui.selected_task = None;
             return;
         }
-        let names: Vec<String> = convoy.tasks.iter().map(|t| t.name.clone()).collect();
+        let names: Vec<String> = convoy.vessels.iter().map(|t| t.name.clone()).collect();
         let current_idx = self.convoys_ui.selected_task.as_ref().and_then(|n| names.iter().position(|m| m == n)).unwrap_or(0);
         let new_idx = (current_idx as isize + delta).clamp(0, (names.len() - 1) as isize) as usize;
         self.convoys_ui.selected_task = Some(names[new_idx].clone());

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -272,13 +272,13 @@ pub struct NamespaceModel {
 }
 
 /// Which pane has focus on the Convoys tab — the convoy list (left) or the
-/// task tree (right). `j/k` semantics depend on this: in `List` they move
-/// between convoys; in `Tasks` they move between tasks of the selected convoy.
+/// vessel tree (right). `j/k` semantics depend on this: in `List` they move
+/// between convoys; in `Vessels` they move between vessels of the selected convoy.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConvoysFocus {
     #[default]
     List,
-    Tasks,
+    Vessels,
 }
 
 /// UI state for the Convoys tab.
@@ -1670,7 +1670,7 @@ impl App {
         self.namespaces.get(namespace)?.convoys.get(id)
     }
 
-    /// Switch focus to the task tree, defaulting to the first task if none selected.
+    /// Switch focus to the vessel tree, defaulting to the first task if none selected.
     /// No-op when no convoy is selected or the convoy has no vessels.
     pub fn enter_convoy_vessels_focus(&mut self, namespace: &str) {
         let Some(convoy) = self.selected_convoy_summary(namespace) else { return };
@@ -1680,7 +1680,7 @@ impl App {
         if self.convoys_ui.selected_task.is_none() {
             self.convoys_ui.selected_task = Some(convoy.vessels[0].name.clone());
         }
-        self.convoys_ui.focus = ConvoysFocus::Tasks;
+        self.convoys_ui.focus = ConvoysFocus::Vessels;
     }
 
     /// Return focus to the convoy list. Keeps `selected_task` so re-entering Tasks

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -288,7 +288,7 @@ pub struct ConvoysUiState {
     /// Name of the selected task within `selected`. Cleared when the convoy
     /// selection changes; clamped against the convoy's task list on every
     /// snapshot/delta apply.
-    pub selected_task: Option<String>,
+    pub selected_vessel: Option<String>,
     pub focus: ConvoysFocus,
     pub filter: String,
 }
@@ -395,7 +395,7 @@ fn panel_row_to_convoy(row: &PanelRow) -> Option<crate::convoy_model::ConvoySumm
                     .iter()
                     .filter_map(|reference| reference.subresource.as_deref()?.strip_prefix("vessels/").map(str::to_string))
                     .collect(),
-                phase: task_phase(panel_string(&child.values, "phase")?),
+                phase: work_phase(panel_string(&child.values, "phase")?),
                 crew: panel_crew(&child.values),
                 host: intent_host.or_else(|| panel_host(&child.values, "host")).or_else(|| child.resource.host.clone()),
                 checkout: panel_checkout(&child.values, "checkout"),
@@ -462,12 +462,12 @@ fn panel_crew(values: &BTreeMap<String, PanelValue>) -> Vec<crate::convoy_model:
         .collect()
 }
 
-fn task_phase(phase: &str) -> crate::convoy_model::WorkPhase {
+fn work_phase(phase: &str) -> crate::convoy_model::WorkPhase {
     match phase {
         "ready" => crate::convoy_model::WorkPhase::Ready,
         "launching" => crate::convoy_model::WorkPhase::Launching,
         "running" => crate::convoy_model::WorkPhase::Running,
-        "completed" => crate::convoy_model::WorkPhase::Completed,
+        "complete" => crate::convoy_model::WorkPhase::Complete,
         "failed" => crate::convoy_model::WorkPhase::Failed,
         "cancelled" => crate::convoy_model::WorkPhase::Cancelled,
         _ => crate::convoy_model::WorkPhase::Pending,
@@ -1609,7 +1609,7 @@ impl App {
 
     /// Returns the selected task name within the selected convoy, if any.
     pub fn selected_convoy_task(&self) -> Option<&str> {
-        self.convoys_ui.selected_task.as_deref()
+        self.convoys_ui.selected_vessel.as_deref()
     }
 
     /// Returns the current focus pane for the Convoys tab.
@@ -1624,7 +1624,7 @@ impl App {
     /// - Replaces a dangling selection (removed convoy) with the first available convoy.
     /// - Sets the first convoy as the default when no selection is set yet.
     /// - Resets task focus state when the selected convoy changes.
-    /// - Clamps `selected_task` against the selected convoy's current task list.
+    /// - Clamps `selected_vessel` against the selected convoy's current task list.
     fn refresh_convoy_selection(&mut self, namespace: &str) {
         let prior_selected = self.convoys_ui.selected.clone();
         let Some(model) = self.namespaces.get(namespace) else {
@@ -1644,23 +1644,23 @@ impl App {
         if self.convoys_ui.selected != prior_selected {
             self.reset_convoy_task_state();
         }
-        self.clamp_selected_task(namespace);
+        self.clamp_selected_vessel(namespace);
     }
 
     fn reset_convoy_task_state(&mut self) {
-        self.convoys_ui.selected_task = None;
+        self.convoys_ui.selected_vessel = None;
         self.convoys_ui.focus = ConvoysFocus::List;
     }
 
-    /// If `selected_task` no longer matches a task in the selected convoy,
+    /// If `selected_vessel` no longer matches a task in the selected convoy,
     /// reset it (`None`) and snap focus back to the convoy list. Otherwise the
     /// task pane would render with bold borders but no selected row — visual
     /// limbo until the user pressed `j`/`k`.
-    fn clamp_selected_task(&mut self, namespace: &str) {
-        let Some(task) = self.convoys_ui.selected_task.clone() else { return };
+    fn clamp_selected_vessel(&mut self, namespace: &str) {
+        let Some(task) = self.convoys_ui.selected_vessel.clone() else { return };
         let still_valid = self.selected_convoy_summary(namespace).is_some_and(|c| c.vessels.iter().any(|t| t.name == task));
         if !still_valid {
-            self.convoys_ui.selected_task = None;
+            self.convoys_ui.selected_vessel = None;
             self.convoys_ui.focus = ConvoysFocus::List;
         }
     }
@@ -1677,13 +1677,13 @@ impl App {
         if convoy.vessels.is_empty() {
             return;
         }
-        if self.convoys_ui.selected_task.is_none() {
-            self.convoys_ui.selected_task = Some(convoy.vessels[0].name.clone());
+        if self.convoys_ui.selected_vessel.is_none() {
+            self.convoys_ui.selected_vessel = Some(convoy.vessels[0].name.clone());
         }
         self.convoys_ui.focus = ConvoysFocus::Vessels;
     }
 
-    /// Return focus to the convoy list. Keeps `selected_task` so re-entering Tasks
+    /// Return focus to the convoy list. Keeps `selected_vessel` so re-entering Tasks
     /// resumes at the same row.
     pub fn exit_convoy_vessels_focus(&mut self) {
         self.convoys_ui.focus = ConvoysFocus::List;
@@ -1694,13 +1694,13 @@ impl App {
     pub fn convoy_vessels_select_delta(&mut self, namespace: &str, delta: isize) {
         let Some(convoy) = self.selected_convoy_summary(namespace) else { return };
         if convoy.vessels.is_empty() {
-            self.convoys_ui.selected_task = None;
+            self.convoys_ui.selected_vessel = None;
             return;
         }
         let names: Vec<String> = convoy.vessels.iter().map(|t| t.name.clone()).collect();
-        let current_idx = self.convoys_ui.selected_task.as_ref().and_then(|n| names.iter().position(|m| m == n)).unwrap_or(0);
+        let current_idx = self.convoys_ui.selected_vessel.as_ref().and_then(|n| names.iter().position(|m| m == n)).unwrap_or(0);
         let new_idx = (current_idx as isize + delta).clamp(0, (names.len() - 1) as isize) as usize;
-        self.convoys_ui.selected_task = Some(names[new_idx].clone());
+        self.convoys_ui.selected_vessel = Some(names[new_idx].clone());
     }
 
     /// Move the convoy selection by `delta` positions (positive = down, negative = up).
@@ -1753,7 +1753,7 @@ impl App {
         if self.convoys_ui.selected != prior_selected {
             self.reset_convoy_task_state();
         }
-        self.clamp_selected_task(namespace);
+        self.clamp_selected_vessel(namespace);
     }
 
     pub(super) fn open_file_picker_from_active_repo_parent(&mut self) {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2192,7 +2192,7 @@ fn x_in_tasks_focus_opens_palette_with_complete_prefill() {
 }
 
 #[test]
-fn x_prefill_quotes_task_names_with_whitespace() {
+fn x_prefill_quotes_vessel_names_with_whitespace() {
     let mut app = stub_app();
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("fix-bug-123", &["fix my bug"])]))));
     app.ui.is_convoys = true;

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1324,7 +1324,7 @@ fn legacy_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_pro
                             crate::convoy_model::WorkPhase::Ready => "ready",
                             crate::convoy_model::WorkPhase::Launching => "launching",
                             crate::convoy_model::WorkPhase::Running => "running",
-                            crate::convoy_model::WorkPhase::Completed => "completed",
+                            crate::convoy_model::WorkPhase::Complete => "complete",
                             crate::convoy_model::WorkPhase::Failed => "failed",
                             crate::convoy_model::WorkPhase::Cancelled => "cancelled",
                         }
@@ -1556,7 +1556,7 @@ fn screen_renders_convoys_page_on_convoys_tab() {
     let mut terminal = Terminal::new(backend).expect("terminal");
 
     let convoys_selected = app.convoys_ui.selected.clone();
-    let convoys_selected_task = app.convoys_ui.selected_task.clone();
+    let convoys_selected_vessel = app.convoys_ui.selected_vessel.clone();
     let convoys_focus = app.convoys_ui.focus;
     let convoy_filter = app.convoys_ui.filter.clone();
     terminal
@@ -1572,7 +1572,7 @@ fn screen_renders_convoys_page_on_convoys_tab() {
                 in_flight: &app.in_flight,
                 namespaces: &app.namespaces,
                 convoys_selected,
-                convoys_selected_task: convoys_selected_task.as_deref(),
+                convoys_selected_vessel: convoys_selected_vessel.as_deref(),
                 convoys_focus,
                 convoy_filter: &convoy_filter,
                 convoys,
@@ -2041,7 +2041,7 @@ fn switching_convoys_resets_task_state_and_focus() {
 }
 
 #[test]
-fn delta_removing_selected_task_clamps_to_none_and_drops_focus() {
+fn delta_removing_selected_vessel_clamps_to_none_and_drops_focus() {
     let mut app = stub_app();
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
@@ -2060,7 +2060,7 @@ fn delta_removing_selected_task_clamps_to_none_and_drops_focus() {
         removed: vec![],
     })));
 
-    assert_eq!(app.selected_convoy_task(), None, "selected_task is reset when it disappears from the convoy");
+    assert_eq!(app.selected_convoy_task(), None, "selected_vessel is reset when it disappears from the convoy");
     assert_eq!(
         app.convoys_focus(),
         crate::app::ConvoysFocus::List,
@@ -2069,7 +2069,7 @@ fn delta_removing_selected_task_clamps_to_none_and_drops_focus() {
 }
 
 #[test]
-fn exit_tasks_focus_keeps_selected_task() {
+fn exit_tasks_focus_keeps_selected_vessel() {
     let mut app = stub_app();
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
@@ -2079,7 +2079,7 @@ fn exit_tasks_focus_keeps_selected_task() {
     app.exit_convoy_vessels_focus();
 
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
-    assert_eq!(app.selected_convoy_task(), Some("t2"), "selected_task survives exit so re-entering picks up the same row");
+    assert_eq!(app.selected_convoy_task(), Some("t2"), "selected_vessel survives exit so re-entering picks up the same row");
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1303,16 +1303,16 @@ fn legacy_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_pro
 
     let resource = ResourceRef::new("flotilla.work/v1", "Convoy", &convoy.namespace, &convoy.name);
     let children = convoy
-        .tasks
+        .vessels
         .into_iter()
         .map(|task| {
             let host = task.host.clone().unwrap_or_else(HostName::local);
             let mut intents = Vec::new();
             if let Some(workspace_ref) = task.workspace_ref.clone() {
-                intents.push(RowIntent::vessel("attach", workspace_ref, host.clone()));
+                intents.push(RowIntent::vessel("attach", &convoy.namespace, &convoy.name, &task.name, host.clone(), Some(workspace_ref)));
             }
             if let Some(target) = task.completion_target.clone() {
-                intents.push(RowIntent::leg("complete-leg", &convoy.namespace, target.convoy, target.leg, target.host));
+                intents.push(RowIntent::vessel("complete-work", &convoy.namespace, target.convoy, target.vessel, target.host, None));
             }
             let mut values = BTreeMap::from([
                 ("name".to_string(), PanelValue::String(task.name.clone())),
@@ -1320,13 +1320,13 @@ fn legacy_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_pro
                     "phase".to_string(),
                     PanelValue::String(
                         match task.phase {
-                            crate::convoy_model::TaskPhase::Pending => "pending",
-                            crate::convoy_model::TaskPhase::Ready => "ready",
-                            crate::convoy_model::TaskPhase::Launching => "launching",
-                            crate::convoy_model::TaskPhase::Running => "running",
-                            crate::convoy_model::TaskPhase::Completed => "completed",
-                            crate::convoy_model::TaskPhase::Failed => "failed",
-                            crate::convoy_model::TaskPhase::Cancelled => "cancelled",
+                            crate::convoy_model::WorkPhase::Pending => "pending",
+                            crate::convoy_model::WorkPhase::Ready => "ready",
+                            crate::convoy_model::WorkPhase::Launching => "launching",
+                            crate::convoy_model::WorkPhase::Running => "running",
+                            crate::convoy_model::WorkPhase::Completed => "completed",
+                            crate::convoy_model::WorkPhase::Failed => "failed",
+                            crate::convoy_model::WorkPhase::Cancelled => "cancelled",
                         }
                         .to_string(),
                     ),
@@ -1334,7 +1334,7 @@ fn legacy_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_pro
                 (
                     "crew".to_string(),
                     PanelValue::List(
-                        task.processes
+                        task.crew
                             .into_iter()
                             .map(|process| {
                                 PanelValue::Map(BTreeMap::from([
@@ -1361,11 +1361,11 @@ fn legacy_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_pro
                 values.insert("message".to_string(), PanelValue::String(message));
             }
             PanelRow {
-                resource: resource.subresource(format!("legs/{}", task.name)),
+                resource: resource.subresource(format!("vessels/{}", task.name)),
                 values,
                 intents,
                 children: vec![],
-                depends_on: task.depends_on.iter().map(|name| resource.subresource(format!("legs/{name}"))).collect(),
+                depends_on: task.depends_on.iter().map(|name| resource.subresource(format!("vessels/{name}"))).collect(),
             }
         })
         .collect();
@@ -1445,7 +1445,7 @@ fn test_convoy(
         phase,
         message: None,
         repo_hint: None,
-        tasks: vec![],
+        vessels: vec![],
         started_at: None,
         finished_at: None,
         observed_workflow_ref: None,
@@ -1722,7 +1722,7 @@ fn convoy_filter_narrows_visible_convoys() {
             phase: ConvoyPhase::Active,
             message: None,
             repo_hint: None,
-            tasks: vec![],
+            vessels: vec![],
             started_at: None,
             finished_at: None,
             observed_workflow_ref: None,
@@ -1768,7 +1768,7 @@ fn convoy_filter_matches_repo_hint() {
         phase: ConvoyPhase::Active,
         message: None,
         repo_hint: Some(RepoKey("flotilla-org/flotilla".into())),
-        tasks: vec![],
+        vessels: vec![],
         started_at: None,
         finished_at: None,
         observed_workflow_ref: None,
@@ -1782,7 +1782,7 @@ fn convoy_filter_matches_repo_hint() {
         phase: ConvoyPhase::Active,
         message: None,
         repo_hint: None,
-        tasks: vec![],
+        vessels: vec![],
         started_at: None,
         finished_at: None,
         observed_workflow_ref: None,
@@ -1841,7 +1841,7 @@ fn select_next_stays_within_filtered_set() {
             phase: ConvoyPhase::Active,
             message: None,
             repo_hint: None,
-            tasks: vec![],
+            vessels: vec![],
             started_at: None,
             finished_at: None,
             observed_workflow_ref: None,
@@ -1952,19 +1952,19 @@ fn move_tab_is_ignored_on_convoys_tab() {
 
 fn convoy_with_tasks(name: &str, tasks: &[&str]) -> crate::convoy_model::ConvoySummary {
     let mut c = test_convoy("flotilla", name, crate::convoy_model::ConvoyPhase::Active, false);
-    c.tasks = tasks
+    c.vessels = tasks
         .iter()
-        .map(|t| crate::convoy_model::TaskSummary {
+        .map(|t| crate::convoy_model::VesselSummary {
             name: (*t).into(),
             depends_on: vec![],
-            phase: crate::convoy_model::TaskPhase::Pending,
-            processes: vec![],
+            phase: crate::convoy_model::WorkPhase::Pending,
+            crew: vec![],
             host: None,
             checkout: None,
             workspace_ref: None,
-            completion_target: Some(crate::convoy_model::LegCompletionTarget {
+            completion_target: Some(crate::convoy_model::WorkCompletionTarget {
                 convoy: name.to_string(),
-                leg: (*t).to_string(),
+                vessel: (*t).to_string(),
                 host: HostName::local(),
             }),
             ready_at: None,
@@ -1989,7 +1989,7 @@ fn enter_tasks_focus_default_selects_first_task() {
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
     assert_eq!(app.selected_convoy_task(), None);
 
-    app.enter_convoy_tasks_focus("flotilla");
+    app.enter_convoy_vessels_focus("flotilla");
 
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
     assert_eq!(app.selected_convoy_task(), Some("t1"));
@@ -2001,24 +2001,24 @@ fn enter_tasks_focus_noop_on_empty_tasks() {
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &[])]))));
     app.ui.is_convoys = true;
 
-    app.enter_convoy_tasks_focus("flotilla");
+    app.enter_convoy_vessels_focus("flotilla");
 
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List, "focus should stay on List when convoy has no tasks");
     assert_eq!(app.selected_convoy_task(), None);
 }
 
 #[test]
-fn convoy_tasks_select_delta_clamps_within_tasks() {
+fn convoy_vessels_select_delta_clamps_within_tasks() {
     let mut app = stub_app();
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2", "t3"])]))));
     app.ui.is_convoys = true;
-    app.enter_convoy_tasks_focus("flotilla");
+    app.enter_convoy_vessels_focus("flotilla");
 
-    app.convoy_tasks_select_delta("flotilla", 1);
+    app.convoy_vessels_select_delta("flotilla", 1);
     assert_eq!(app.selected_convoy_task(), Some("t2"));
-    app.convoy_tasks_select_delta("flotilla", 5);
+    app.convoy_vessels_select_delta("flotilla", 5);
     assert_eq!(app.selected_convoy_task(), Some("t3"), "clamps at last task");
-    app.convoy_tasks_select_delta("flotilla", -10);
+    app.convoy_vessels_select_delta("flotilla", -10);
     assert_eq!(app.selected_convoy_task(), Some("t1"), "clamps at first task");
 }
 
@@ -2030,7 +2030,7 @@ fn switching_convoys_resets_task_state_and_focus() {
         convoy_with_tasks("beta", &["b1"]),
     ]))));
     app.ui.is_convoys = true;
-    app.enter_convoy_tasks_focus("flotilla");
+    app.enter_convoy_vessels_focus("flotilla");
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
 
     app.convoys_tab_select_delta(1);
@@ -2045,8 +2045,8 @@ fn delta_removing_selected_task_clamps_to_none_and_drops_focus() {
     let mut app = stub_app();
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
-    app.enter_convoy_tasks_focus("flotilla");
-    app.convoy_tasks_select_delta("flotilla", 1);
+    app.enter_convoy_vessels_focus("flotilla");
+    app.convoy_vessels_select_delta("flotilla", 1);
     assert_eq!(app.selected_convoy_task(), Some("t2"));
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
 
@@ -2073,10 +2073,10 @@ fn exit_tasks_focus_keeps_selected_task() {
     let mut app = stub_app();
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
-    app.enter_convoy_tasks_focus("flotilla");
-    app.convoy_tasks_select_delta("flotilla", 1);
+    app.enter_convoy_vessels_focus("flotilla");
+    app.convoy_vessels_select_delta("flotilla", 1);
 
-    app.exit_convoy_tasks_focus();
+    app.exit_convoy_vessels_focus();
 
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
     assert_eq!(app.selected_convoy_task(), Some("t2"), "selected_task survives exit so re-entering picks up the same row");
@@ -2188,7 +2188,7 @@ fn x_in_tasks_focus_opens_palette_with_complete_prefill() {
         .as_any()
         .downcast_ref::<crate::widgets::command_palette::CommandPaletteWidget>()
         .expect("top modal is CommandPaletteWidget");
-    assert_eq!(palette.input_value(), "convoy fix-bug-123 leg review complete ");
+    assert_eq!(palette.input_value(), "convoy fix-bug-123 work review complete ");
 }
 
 #[test]
@@ -2208,7 +2208,7 @@ fn x_prefill_quotes_task_names_with_whitespace() {
         .as_any()
         .downcast_ref::<crate::widgets::command_palette::CommandPaletteWidget>()
         .expect("top modal is CommandPaletteWidget");
-    assert_eq!(palette.input_value(), "convoy fix-bug-123 leg \"fix my bug\" complete ");
+    assert_eq!(palette.input_value(), "convoy fix-bug-123 work \"fix my bug\" complete ");
 }
 
 #[test]
@@ -2222,12 +2222,12 @@ fn x_then_enter_dispatches_convoy_task_complete() {
 
     let cmd = app.proto_commands.take_next().expect("expected a command after Enter on palette");
     match &cmd.0.action {
-        flotilla_protocol::CommandAction::ConvoyLegComplete { convoy, leg, message } => {
+        flotilla_protocol::CommandAction::ConvoyWorkComplete { convoy, work, message } => {
             assert_eq!(convoy, "fix-bug-123");
-            assert_eq!(leg, "implement");
+            assert_eq!(work, "implement");
             assert_eq!(*message, None);
         }
-        other => panic!("expected ConvoyLegComplete, got {other:?}"),
+        other => panic!("expected ConvoyWorkComplete, got {other:?}"),
     }
 }
 
@@ -2236,7 +2236,7 @@ fn x_then_enter_routes_remote_convoy_task_complete_to_its_host() {
     let mut app = stub_app();
     insert_peer_host(&mut app.model, "feta", PeerStatus::Connected);
     let mut convoy = convoy_with_tasks("remote-convoy", &["implement"]);
-    convoy.tasks[0].completion_target.as_mut().expect("completion target").host = HostName::new("feta");
+    convoy.vessels[0].completion_target.as_mut().expect("completion target").host = HostName::new("feta");
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
@@ -2250,10 +2250,10 @@ fn x_then_enter_routes_remote_convoy_task_complete_to_its_host() {
 #[test]
 fn x_uses_complete_intent_target_instead_of_display_fields() {
     let mut app = stub_app();
-    let mut convoy = convoy_with_tasks("display-convoy", &["display-leg"]);
-    convoy.tasks[0].completion_target = Some(crate::convoy_model::LegCompletionTarget {
+    let mut convoy = convoy_with_tasks("display-convoy", &["display-vessel"]);
+    convoy.vessels[0].completion_target = Some(crate::convoy_model::WorkCompletionTarget {
         convoy: "target-convoy".into(),
-        leg: "target-leg".into(),
+        vessel: "target-vessel".into(),
         host: HostName::local(),
     });
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
@@ -2269,14 +2269,14 @@ fn x_uses_complete_intent_target_instead_of_display_fields() {
         .as_any()
         .downcast_ref::<crate::widgets::command_palette::CommandPaletteWidget>()
         .expect("top modal is CommandPaletteWidget");
-    assert_eq!(palette.input_value(), "convoy target-convoy leg target-leg complete ");
+    assert_eq!(palette.input_value(), "convoy target-convoy work target-vessel complete ");
 }
 
 #[test]
 fn x_rejects_complete_intent_for_unknown_remote_host() {
     let mut app = stub_app();
     let mut convoy = convoy_with_tasks("remote-convoy", &["implement"]);
-    convoy.tasks[0].completion_target.as_mut().expect("completion target").host = HostName::new("missing-host");
+    convoy.vessels[0].completion_target.as_mut().expect("completion target").host = HostName::new("missing-host");
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
@@ -2290,33 +2290,33 @@ fn x_rejects_complete_intent_for_unknown_remote_host() {
 fn x_is_unavailable_without_complete_intent() {
     let mut app = stub_app();
     let mut convoy = convoy_with_tasks("alpha", &["implement"]);
-    convoy.tasks[0].completion_target = None;
+    convoy.vessels[0].completion_target = None;
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
     app.handle_key(key(KeyCode::Char('x')));
 
     assert!(!app.screen.has_modal());
-    assert_eq!(app.model.status_message.as_deref(), Some("completion unavailable for leg 'implement'"));
+    assert_eq!(app.model.status_message.as_deref(), Some("completion unavailable for vessel 'implement'"));
 }
 
 // -- Convoy task attach (`a`) --
 
-fn convoy_with_task_workspace_refs(name: &str, tasks: &[(&str, Option<&str>)]) -> crate::convoy_model::ConvoySummary {
+fn convoy_with_vessel_refs(name: &str, tasks: &[(&str, Option<&str>)]) -> crate::convoy_model::ConvoySummary {
     let mut c = test_convoy("flotilla", name, crate::convoy_model::ConvoyPhase::Active, false);
-    c.tasks = tasks
+    c.vessels = tasks
         .iter()
-        .map(|(t, ws)| crate::convoy_model::TaskSummary {
+        .map(|(t, ws)| crate::convoy_model::VesselSummary {
             name: (*t).into(),
             depends_on: vec![],
-            phase: crate::convoy_model::TaskPhase::Running,
-            processes: vec![],
+            phase: crate::convoy_model::WorkPhase::Running,
+            crew: vec![],
             host: None,
             checkout: None,
             workspace_ref: ws.map(str::to_string),
-            completion_target: Some(crate::convoy_model::LegCompletionTarget {
+            completion_target: Some(crate::convoy_model::WorkCompletionTarget {
                 convoy: name.to_string(),
-                leg: (*t).to_string(),
+                vessel: (*t).to_string(),
                 host: HostName::local(),
             }),
             ready_at: None,
@@ -2331,7 +2331,7 @@ fn convoy_with_task_workspace_refs(name: &str, tasks: &[(&str, Option<&str>)]) -
 #[test]
 fn a_on_task_with_workspace_ref_dispatches_select_workspace() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_task_workspace_refs("alpha", &[(
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessel_refs("alpha", &[(
         "implement",
         Some("ws://task-a-implement"),
     )])]))));
@@ -2355,8 +2355,8 @@ fn a_on_task_with_workspace_ref_dispatches_select_workspace() {
 fn a_on_remote_task_routes_select_workspace_to_its_host() {
     let mut app = stub_app();
     insert_peer_host(&mut app.model, "feta", PeerStatus::Connected);
-    let mut convoy = convoy_with_task_workspace_refs("alpha", &[("implement", Some("ws://remote"))]);
-    convoy.tasks[0].host = Some(HostName::new("feta"));
+    let mut convoy = convoy_with_vessel_refs("alpha", &[("implement", Some("ws://remote"))]);
+    convoy.vessels[0].host = Some(HostName::new("feta"));
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
@@ -2369,8 +2369,8 @@ fn a_on_remote_task_routes_select_workspace_to_its_host() {
 #[test]
 fn a_on_unknown_remote_task_does_not_fall_back_to_local_execution() {
     let mut app = stub_app();
-    let mut convoy = convoy_with_task_workspace_refs("alpha", &[("implement", Some("ws://remote"))]);
-    convoy.tasks[0].host = Some(HostName::new("missing-host"));
+    let mut convoy = convoy_with_vessel_refs("alpha", &[("implement", Some("ws://remote"))]);
+    convoy.vessels[0].host = Some(HostName::new("missing-host"));
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
@@ -2383,10 +2383,7 @@ fn a_on_unknown_remote_task_does_not_fall_back_to_local_execution() {
 #[test]
 fn a_on_task_without_workspace_ref_sets_status_message() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_task_workspace_refs("alpha", &[(
-        "implement",
-        None,
-    )])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessel_refs("alpha", &[("implement", None)])]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
     assert_eq!(app.selected_convoy_task(), Some("implement"));
@@ -2402,7 +2399,7 @@ fn a_on_task_without_workspace_ref_sets_status_message() {
 #[test]
 fn a_on_two_task_convoy_dispatches_correct_ws_ref_per_selection() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_task_workspace_refs("alpha", &[
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessel_refs("alpha", &[
         ("implement", Some("ws://impl")),
         ("review", Some("ws://rev")),
     ])]))));

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1991,7 +1991,7 @@ fn enter_tasks_focus_default_selects_first_task() {
 
     app.enter_convoy_vessels_focus("flotilla");
 
-    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
     assert_eq!(app.selected_convoy_task(), Some("t1"));
 }
 
@@ -2031,7 +2031,7 @@ fn switching_convoys_resets_task_state_and_focus() {
     ]))));
     app.ui.is_convoys = true;
     app.enter_convoy_vessels_focus("flotilla");
-    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
 
     app.convoys_tab_select_delta(1);
 
@@ -2048,7 +2048,7 @@ fn delta_removing_selected_task_clamps_to_none_and_drops_focus() {
     app.enter_convoy_vessels_focus("flotilla");
     app.convoy_vessels_select_delta("flotilla", 1);
     assert_eq!(app.selected_convoy_task(), Some("t2"));
-    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
 
     // Remove t2 via delta.
     let mut shrunk = convoy_with_tasks("alpha", &["t1"]);
@@ -2090,7 +2090,7 @@ fn l_drills_in_then_esc_returns_to_list_focus() {
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
 
     app.handle_key(key(KeyCode::Char('l')));
-    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
     assert_eq!(app.selected_convoy_task(), Some("t1"));
 
     app.handle_key(key(KeyCode::Esc));
@@ -2104,7 +2104,7 @@ fn h_returns_from_tasks_to_list_focus() {
     app.ui.is_convoys = true;
 
     app.handle_key(key(KeyCode::Char('l')));
-    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
 
     app.handle_key(key(KeyCode::Char('h')));
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
@@ -2117,7 +2117,7 @@ fn enter_also_drills_into_tasks_focus() {
     app.ui.is_convoys = true;
 
     app.handle_key(key(KeyCode::Enter));
-    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
 }
 
 #[test]
@@ -2127,7 +2127,7 @@ fn right_and_left_arrows_navigate_focus() {
     app.ui.is_convoys = true;
 
     app.handle_key(key(KeyCode::Right));
-    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Tasks);
+    assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
 
     app.handle_key(key(KeyCode::Left));
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1950,7 +1950,7 @@ fn move_tab_is_ignored_on_convoys_tab() {
 
 // -- Convoy task selection state --
 
-fn convoy_with_tasks(name: &str, tasks: &[&str]) -> crate::convoy_model::ConvoySummary {
+fn convoy_with_vessels(name: &str, tasks: &[&str]) -> crate::convoy_model::ConvoySummary {
     let mut c = test_convoy("flotilla", name, crate::convoy_model::ConvoyPhase::Active, false);
     c.vessels = tasks
         .iter()
@@ -1983,7 +1983,7 @@ fn snapshot_with(convoys: Vec<crate::convoy_model::ConvoySummary>) -> crate::con
 #[test]
 fn enter_tasks_focus_default_selects_first_task() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
 
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
@@ -1998,7 +1998,7 @@ fn enter_tasks_focus_default_selects_first_task() {
 #[test]
 fn enter_tasks_focus_noop_on_empty_tasks() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &[])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &[])]))));
     app.ui.is_convoys = true;
 
     app.enter_convoy_vessels_focus("flotilla");
@@ -2010,7 +2010,7 @@ fn enter_tasks_focus_noop_on_empty_tasks() {
 #[test]
 fn convoy_vessels_select_delta_clamps_within_tasks() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2", "t3"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1", "t2", "t3"])]))));
     app.ui.is_convoys = true;
     app.enter_convoy_vessels_focus("flotilla");
 
@@ -2026,8 +2026,8 @@ fn convoy_vessels_select_delta_clamps_within_tasks() {
 fn switching_convoys_resets_task_state_and_focus() {
     let mut app = stub_app();
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![
-        convoy_with_tasks("alpha", &["a1"]),
-        convoy_with_tasks("beta", &["b1"]),
+        convoy_with_vessels("alpha", &["a1"]),
+        convoy_with_vessels("beta", &["b1"]),
     ]))));
     app.ui.is_convoys = true;
     app.enter_convoy_vessels_focus("flotilla");
@@ -2043,7 +2043,7 @@ fn switching_convoys_resets_task_state_and_focus() {
 #[test]
 fn delta_removing_selected_vessel_clamps_to_none_and_drops_focus() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
     app.enter_convoy_vessels_focus("flotilla");
     app.convoy_vessels_select_delta("flotilla", 1);
@@ -2051,7 +2051,7 @@ fn delta_removing_selected_vessel_clamps_to_none_and_drops_focus() {
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::Vessels);
 
     // Remove t2 via delta.
-    let mut shrunk = convoy_with_tasks("alpha", &["t1"]);
+    let mut shrunk = convoy_with_vessels("alpha", &["t1"]);
     shrunk.id = crate::convoy_model::ConvoyId::new("flotilla", "alpha");
     app.handle_daemon_event(panel_delta_event(Box::new(crate::convoy_model::ConvoyFixtureDelta {
         seq: 2,
@@ -2071,7 +2071,7 @@ fn delta_removing_selected_vessel_clamps_to_none_and_drops_focus() {
 #[test]
 fn exit_tasks_focus_keeps_selected_vessel() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
     app.enter_convoy_vessels_focus("flotilla");
     app.convoy_vessels_select_delta("flotilla", 1);
@@ -2085,7 +2085,7 @@ fn exit_tasks_focus_keeps_selected_vessel() {
 #[test]
 fn l_drills_in_then_esc_returns_to_list_focus() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1", "t2"])]))));
     app.ui.is_convoys = true;
     assert_eq!(app.convoys_focus(), crate::app::ConvoysFocus::List);
 
@@ -2100,7 +2100,7 @@ fn l_drills_in_then_esc_returns_to_list_focus() {
 #[test]
 fn h_returns_from_tasks_to_list_focus() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1"])]))));
     app.ui.is_convoys = true;
 
     app.handle_key(key(KeyCode::Char('l')));
@@ -2113,7 +2113,7 @@ fn h_returns_from_tasks_to_list_focus() {
 #[test]
 fn enter_also_drills_into_tasks_focus() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1"])]))));
     app.ui.is_convoys = true;
 
     app.handle_key(key(KeyCode::Enter));
@@ -2123,7 +2123,7 @@ fn enter_also_drills_into_tasks_focus() {
 #[test]
 fn right_and_left_arrows_navigate_focus() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1"])]))));
     app.ui.is_convoys = true;
 
     app.handle_key(key(KeyCode::Right));
@@ -2136,7 +2136,7 @@ fn right_and_left_arrows_navigate_focus() {
 #[test]
 fn arrow_keys_route_task_navigation_when_tasks_focused() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2", "t3"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1", "t2", "t3"])]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Right));
 
@@ -2149,7 +2149,7 @@ fn arrow_keys_route_task_navigation_when_tasks_focused() {
 #[test]
 fn jk_routes_to_task_navigation_when_tasks_focused() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("alpha", &["t1", "t2", "t3"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("alpha", &["t1", "t2", "t3"])]))));
     app.ui.is_convoys = true;
 
     app.handle_key(key(KeyCode::Char('l')));
@@ -2168,7 +2168,7 @@ fn jk_routes_to_task_navigation_when_tasks_focused() {
 #[test]
 fn x_in_tasks_focus_opens_palette_with_complete_prefill() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("fix-bug-123", &[
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("fix-bug-123", &[
         "implement",
         "review",
     ])]))));
@@ -2194,7 +2194,7 @@ fn x_in_tasks_focus_opens_palette_with_complete_prefill() {
 #[test]
 fn x_prefill_quotes_vessel_names_with_whitespace() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("fix-bug-123", &["fix my bug"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("fix-bug-123", &["fix my bug"])]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
     assert_eq!(app.selected_convoy_task(), Some("fix my bug"));
@@ -2214,7 +2214,7 @@ fn x_prefill_quotes_vessel_names_with_whitespace() {
 #[test]
 fn x_then_enter_dispatches_convoy_task_complete() {
     let mut app = stub_app();
-    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_tasks("fix-bug-123", &["implement"])]))));
+    app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy_with_vessels("fix-bug-123", &["implement"])]))));
     app.ui.is_convoys = true;
     app.handle_key(key(KeyCode::Char('l')));
     app.handle_key(key(KeyCode::Char('x')));
@@ -2235,7 +2235,7 @@ fn x_then_enter_dispatches_convoy_task_complete() {
 fn x_then_enter_routes_remote_convoy_task_complete_to_its_host() {
     let mut app = stub_app();
     insert_peer_host(&mut app.model, "feta", PeerStatus::Connected);
-    let mut convoy = convoy_with_tasks("remote-convoy", &["implement"]);
+    let mut convoy = convoy_with_vessels("remote-convoy", &["implement"]);
     convoy.vessels[0].completion_target.as_mut().expect("completion target").host = HostName::new("feta");
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;
@@ -2250,7 +2250,7 @@ fn x_then_enter_routes_remote_convoy_task_complete_to_its_host() {
 #[test]
 fn x_uses_complete_intent_target_instead_of_display_fields() {
     let mut app = stub_app();
-    let mut convoy = convoy_with_tasks("display-convoy", &["display-vessel"]);
+    let mut convoy = convoy_with_vessels("display-convoy", &["display-vessel"]);
     convoy.vessels[0].completion_target = Some(crate::convoy_model::WorkCompletionTarget {
         convoy: "target-convoy".into(),
         vessel: "target-vessel".into(),
@@ -2275,7 +2275,7 @@ fn x_uses_complete_intent_target_instead_of_display_fields() {
 #[test]
 fn x_rejects_complete_intent_for_unknown_remote_host() {
     let mut app = stub_app();
-    let mut convoy = convoy_with_tasks("remote-convoy", &["implement"]);
+    let mut convoy = convoy_with_vessels("remote-convoy", &["implement"]);
     convoy.vessels[0].completion_target.as_mut().expect("completion target").host = HostName::new("missing-host");
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;
@@ -2289,7 +2289,7 @@ fn x_rejects_complete_intent_for_unknown_remote_host() {
 #[test]
 fn x_is_unavailable_without_complete_intent() {
     let mut app = stub_app();
-    let mut convoy = convoy_with_tasks("alpha", &["implement"]);
+    let mut convoy = convoy_with_vessels("alpha", &["implement"]);
     convoy.vessels[0].completion_target = None;
     app.handle_daemon_event(panel_snapshot_event(Box::new(snapshot_with(vec![convoy]))));
     app.ui.is_convoys = true;

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -29,7 +29,7 @@ pub enum BindingModeId {
     Convoys,
     /// Inner focus on the Convoys tab — the task tree on the right pane.
     /// Composed with `TabPage`. `j/k` navigate tasks; `esc` returns to the
-    /// convoy list; `x` opens the palette pre-filled to complete the leg.
+    /// convoy list; `x` opens the palette pre-filled to complete the work.
     ConvoyTasks,
     Help,
     ActionMenu,
@@ -156,8 +156,8 @@ pub static BINDINGS: &[Binding] = &[
     b(BindingModeId::ConvoyTasks, "h", Action::Dismiss),
     b(BindingModeId::ConvoyTasks, "left", Action::Dismiss),
     hk(BindingModeId::ConvoyTasks, "esc", "ESC", Action::Dismiss, "List"),
-    h(BindingModeId::ConvoyTasks, "x", Action::CompleteConvoyLeg, "Complete"),
-    h(BindingModeId::ConvoyTasks, "a", Action::AttachConvoyLeg, "Attach"),
+    h(BindingModeId::ConvoyTasks, "x", Action::CompleteConvoyWork, "Complete"),
+    h(BindingModeId::ConvoyTasks, "a", Action::AttachConvoyVessel, "Attach"),
     h(BindingModeId::ConvoyTasks, "r", Action::Refresh, "Refresh"),
     // ── Overview (replaces old Config) ──
     h(BindingModeId::Overview, "j", Action::SelectNext, "Down"),

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -27,10 +27,10 @@ pub enum BindingModeId {
     /// confirm dialog.
     TabPage,
     Convoys,
-    /// Inner focus on the Convoys tab — the task tree on the right pane.
-    /// Composed with `TabPage`. `j/k` navigate tasks; `esc` returns to the
+    /// Inner focus on the Convoys tab — the vessel tree on the right pane.
+    /// Composed with `TabPage`. `j/k` navigate vessels; `esc` returns to the
     /// convoy list; `x` opens the palette pre-filled to complete the work.
-    ConvoyTasks,
+    ConvoyVessels,
     Help,
     ActionMenu,
     DeleteConfirm,
@@ -144,21 +144,21 @@ pub static BINDINGS: &[Binding] = &[
     b(BindingModeId::Normal, "p", Action::Dispatch(Intent::OpenChangeRequest)),
     // ── Convoys (outer focus: convoy list) ──
     // j/k/up/down come from Shared (SelectNext/SelectPrev). enter comes from Shared (Confirm).
-    // l and right are vim-style and arrow-style synonyms for "drill into the task tree" — the
+    // l and right are vim-style and arrow-style synonyms for "drill into the vessel tree" — the
     // app dispatches Confirm on the Convoys list to enter task focus.
     h(BindingModeId::Convoys, "l", Action::Confirm, "Tasks"),
     b(BindingModeId::Convoys, "right", Action::Confirm),
     // [, ], q come from TabPage (composed). Keep r here: refresh semantics are tab-specific.
     h(BindingModeId::Convoys, "r", Action::Refresh, "Refresh"),
-    // ── ConvoyTasks (inner focus: task tree) ──
+    // ── ConvoyVessels (inner focus: vessel tree) ──
     // j/k/up/down come from Shared. h/left/esc mirror the vim and arrow navigation used to
-    // enter the task tree; the app dispatches Dismiss in Tasks focus to return to the list.
-    b(BindingModeId::ConvoyTasks, "h", Action::Dismiss),
-    b(BindingModeId::ConvoyTasks, "left", Action::Dismiss),
-    hk(BindingModeId::ConvoyTasks, "esc", "ESC", Action::Dismiss, "List"),
-    h(BindingModeId::ConvoyTasks, "x", Action::CompleteConvoyWork, "Complete"),
-    h(BindingModeId::ConvoyTasks, "a", Action::AttachConvoyVessel, "Attach"),
-    h(BindingModeId::ConvoyTasks, "r", Action::Refresh, "Refresh"),
+    // enter the vessel tree; the app dispatches Dismiss in Vessels focus to return to the list.
+    b(BindingModeId::ConvoyVessels, "h", Action::Dismiss),
+    b(BindingModeId::ConvoyVessels, "left", Action::Dismiss),
+    hk(BindingModeId::ConvoyVessels, "esc", "ESC", Action::Dismiss, "List"),
+    h(BindingModeId::ConvoyVessels, "x", Action::CompleteConvoyWork, "Complete"),
+    h(BindingModeId::ConvoyVessels, "a", Action::AttachConvoyVessel, "Attach"),
+    h(BindingModeId::ConvoyVessels, "r", Action::Refresh, "Refresh"),
     // ── Overview (replaces old Config) ──
     h(BindingModeId::Overview, "j", Action::SelectNext, "Down"),
     h(BindingModeId::Overview, "k", Action::SelectPrev, "Up"),

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -317,7 +317,7 @@ fn format_crew_list_human(response: &CrewListResponse) -> String {
             Cell::new(member.stance.as_deref().unwrap_or("-")),
         ]);
     }
-    format!("Convoy: {}  Vessel: {}  Leg: {}\n{}\n", response.convoy, response.vessel, response.leg, table)
+    format!("Convoy: {}  Vessel: {} ({})\n{}\n", response.convoy, response.vessel, response.vessel_ref, table)
 }
 
 /// Extract a short display name from a repo path (last path component).

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -553,8 +553,8 @@ mod command_result_human {
     fn crew_list_shows_defined_and_runtime_state() {
         let result = CommandValue::CrewList(Box::new(CrewListResponse {
             convoy: "convoy-a".into(),
-            vessel: "convoy-a-implement".into(),
-            leg: "implement".into(),
+            vessel_ref: "convoy-a-implement".into(),
+            vessel: "implement".into(),
             members: vec![
                 CrewListMember {
                     role: "coder".into(),

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -65,7 +65,7 @@ pub enum WorkPhase {
     Ready,
     Launching,
     Running,
-    Completed,
+    Complete,
     Failed,
     Cancelled,
 }

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -60,7 +60,7 @@ impl ConvoyPhase {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskPhase {
+pub enum WorkPhase {
     Pending,
     Ready,
     Launching,
@@ -79,22 +79,22 @@ pub struct ProcessSummary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LegCompletionTarget {
+pub struct WorkCompletionTarget {
     pub convoy: String,
-    pub leg: String,
+    pub vessel: String,
     pub host: HostName,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
-pub struct TaskSummary {
+pub struct VesselSummary {
     pub name: String,
     pub depends_on: Vec<String>,
-    pub phase: TaskPhase,
-    pub processes: Vec<ProcessSummary>,
+    pub phase: WorkPhase,
+    pub crew: Vec<ProcessSummary>,
     pub host: Option<HostName>,
     pub checkout: Option<CheckoutRef>,
     pub workspace_ref: Option<String>,
-    pub completion_target: Option<LegCompletionTarget>,
+    pub completion_target: Option<WorkCompletionTarget>,
     pub ready_at: Option<Timestamp>,
     pub started_at: Option<Timestamp>,
     pub finished_at: Option<Timestamp>,
@@ -110,7 +110,7 @@ pub struct ConvoySummary {
     pub phase: ConvoyPhase,
     pub message: Option<String>,
     pub repo_hint: Option<RepoKey>,
-    pub tasks: Vec<TaskSummary>,
+    pub vessels: Vec<VesselSummary>,
     pub started_at: Option<Timestamp>,
     pub finished_at: Option<Timestamp>,
     pub observed_workflow_ref: Option<String>,

--- a/crates/flotilla-tui/src/keymap.rs
+++ b/crates/flotilla-tui/src/keymap.rs
@@ -282,7 +282,7 @@ impl Keymap {
             (&config.help, BindingModeId::Help),
             (&config.config, BindingModeId::Overview),
             (&config.convoys, BindingModeId::Convoys),
-            (&config.convoy_vessels, BindingModeId::ConvoyTasks),
+            (&config.convoy_vessels, BindingModeId::ConvoyVessels),
             (&config.action_menu, BindingModeId::ActionMenu),
             (&config.delete_confirm, BindingModeId::DeleteConfirm),
             (&config.close_confirm, BindingModeId::CloseConfirm),

--- a/crates/flotilla-tui/src/keymap.rs
+++ b/crates/flotilla-tui/src/keymap.rs
@@ -44,9 +44,9 @@ pub enum Action {
     OpenContextualPalette,
     FillSelected,
     /// Open the command palette pre-filled to complete the selected convoy task.
-    CompleteConvoyLeg,
+    CompleteConvoyWork,
     /// Attach the active workspace manager to the selected convoy task's workspace.
-    AttachConvoyLeg,
+    AttachConvoyVessel,
     Dispatch(Intent),
 }
 
@@ -113,8 +113,8 @@ impl Action {
             "open_command_palette" => Action::OpenCommandPalette,
             "open_contextual_palette" => Action::OpenContextualPalette,
             "fill_selected" => Action::FillSelected,
-            "complete_convoy_leg" => Action::CompleteConvoyLeg,
-            "attach_convoy_leg" => Action::AttachConvoyLeg,
+            "complete_convoy_work" => Action::CompleteConvoyWork,
+            "attach_convoy_vessel" => Action::AttachConvoyVessel,
             // Intent-wrapping actions
             "switch_to_workspace" => Action::Dispatch(Intent::SwitchToWorkspace),
             "create_workspace" => Action::Dispatch(Intent::CreateWorkspace),
@@ -163,8 +163,8 @@ impl Action {
             Action::OpenCommandPalette => "open_command_palette",
             Action::OpenContextualPalette => "open_contextual_palette",
             Action::FillSelected => "fill_selected",
-            Action::CompleteConvoyLeg => "complete_convoy_leg",
-            Action::AttachConvoyLeg => "attach_convoy_leg",
+            Action::CompleteConvoyWork => "complete_convoy_work",
+            Action::AttachConvoyVessel => "attach_convoy_vessel",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "switch_to_workspace",
                 Intent::CreateWorkspace => "create_workspace",
@@ -210,8 +210,8 @@ impl Action {
             Action::OpenCommandPalette => "Open command palette",
             Action::OpenContextualPalette => "Open contextual palette (pre-filled)",
             Action::FillSelected => "Fill selected item",
-            Action::CompleteConvoyLeg => "Complete convoy leg",
-            Action::AttachConvoyLeg => "Attach to leg workspace",
+            Action::CompleteConvoyWork => "Complete work",
+            Action::AttachConvoyVessel => "Attach to vessel workspace",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "Switch to workspace",
                 Intent::CreateWorkspace => "Create workspace",
@@ -282,7 +282,7 @@ impl Keymap {
             (&config.help, BindingModeId::Help),
             (&config.config, BindingModeId::Overview),
             (&config.convoys, BindingModeId::Convoys),
-            (&config.convoy_tasks, BindingModeId::ConvoyTasks),
+            (&config.convoy_vessels, BindingModeId::ConvoyTasks),
             (&config.action_menu, BindingModeId::ActionMenu),
             (&config.delete_confirm, BindingModeId::DeleteConfirm),
             (&config.close_confirm, BindingModeId::CloseConfirm),

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -281,11 +281,11 @@ pub fn palette_completions(
         return verb_completions(&noun_name, "");
     }
 
-    // `convoy <id> leg <Tab>` and `convoy <id> leg <partial>`: complete with
+    // `convoy <id> work <Tab>` and `convoy <id> work <partial>`: complete with
     // task names from the named convoy. The clap tree treats the task subject as
     // a free-form positional and would otherwise return nothing. Past the task
     // subject we fall through to the clap walker for verbs (`complete` etc.).
-    if noun_name == "convoy" && tokens.len() >= 3 && tokens[2] == "leg" {
+    if noun_name == "convoy" && tokens.len() >= 3 && tokens[2] == "work" {
         // tokens[1] is the raw whitespace-split token: convoy ids that contain
         // whitespace (and would have been double-quoted by `quote_palette_token`)
         // won't look up correctly here, since `palette_completions` uses
@@ -316,14 +316,14 @@ pub fn palette_completions(
     vec![]
 }
 
-/// Task-name completions for `convoy <id> leg <Tab>` / partial.
+/// Vessel-name completions for `convoy <id> work <Tab>` / partial.
 fn convoy_leg_completions(convoy_id: &str, partial: &str, namespaces: &crate::app::NamespaceMap) -> Vec<PaletteCompletion> {
     // Single-namespace MVP: search the "flotilla" namespace.
     let lower = partial.to_lowercase();
     let Some(model) = namespaces.get("flotilla") else { return vec![] };
     let Some(convoy) = model.convoys.values().find(|convoy| convoy.name == convoy_id) else { return vec![] };
     convoy
-        .tasks
+        .vessels
         .iter()
         .filter(|t| lower.is_empty() || t.name.to_lowercase().starts_with(&lower))
         .map(|t| PaletteCompletion { value: t.name.clone(), description: format!("{:?}", t.phase), key_hint: None })
@@ -796,7 +796,7 @@ mod tests {
     use crate::app::test_builders::repo_info;
 
     fn namespaces_with_convoy(name: &str, tasks: &[&str]) -> crate::app::NamespaceMap {
-        use crate::convoy_model::{ConvoyId, ConvoyPhase, ConvoySummary, TaskPhase, TaskSummary};
+        use crate::convoy_model::{ConvoyId, ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase};
         let convoy = ConvoySummary {
             id: ConvoyId::new("flotilla", name),
             namespace: "flotilla".into(),
@@ -805,13 +805,13 @@ mod tests {
             phase: ConvoyPhase::Active,
             message: None,
             repo_hint: None,
-            tasks: tasks
+            vessels: tasks
                 .iter()
-                .map(|t| TaskSummary {
+                .map(|t| VesselSummary {
                     name: (*t).into(),
                     depends_on: vec![],
-                    phase: TaskPhase::Pending,
-                    processes: vec![],
+                    phase: WorkPhase::Pending,
+                    crew: vec![],
                     host: None,
                     checkout: None,
                     workspace_ref: None,
@@ -1112,7 +1112,7 @@ mod tests {
     fn convoy_task_names_listed_after_task_keyword() {
         let model = empty_model();
         let namespaces = namespaces_with_convoy("fix-bug-123", &["implement", "review"]);
-        let completions = palette_completions("convoy fix-bug-123 leg ", &model, &namespaces, true);
+        let completions = palette_completions("convoy fix-bug-123 work ", &model, &namespaces, true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"implement"), "expected 'implement' in {values:?}");
         assert!(values.contains(&"review"), "expected 'review' in {values:?}");
@@ -1122,7 +1122,7 @@ mod tests {
     fn convoy_task_names_filter_by_partial() {
         let model = empty_model();
         let namespaces = namespaces_with_convoy("fix-bug-123", &["implement", "review"]);
-        let completions = palette_completions("convoy fix-bug-123 leg imp", &model, &namespaces, true);
+        let completions = palette_completions("convoy fix-bug-123 work imp", &model, &namespaces, true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert_eq!(values, vec!["implement"]);
     }
@@ -1131,7 +1131,7 @@ mod tests {
     fn convoy_task_complete_verb_completes_after_task_subject() {
         let model = empty_model();
         let namespaces = namespaces_with_convoy("fix-bug-123", &["implement"]);
-        let completions = palette_completions("convoy fix-bug-123 leg implement ", &model, &namespaces, true);
+        let completions = palette_completions("convoy fix-bug-123 work implement ", &model, &namespaces, true);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"complete"), "expected 'complete' verb in {values:?}");
     }

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -282,9 +282,9 @@ pub fn palette_completions(
     }
 
     // `convoy <id> work <Tab>` and `convoy <id> work <partial>`: complete with
-    // task names from the named convoy. The clap tree treats the task subject as
-    // a free-form positional and would otherwise return nothing. Past the task
-    // subject we fall through to the clap walker for verbs (`complete` etc.).
+    // vessel names from the named convoy. The clap tree treats the vessel subject
+    // as a free-form positional and would otherwise return nothing. Past the
+    // vessel subject we fall through to the clap walker for verbs (`complete` etc.).
     if noun_name == "convoy" && tokens.len() >= 3 && tokens[2] == "work" {
         // tokens[1] is the raw whitespace-split token: convoy ids that contain
         // whitespace (and would have been double-quoted by `quote_palette_token`)
@@ -295,10 +295,10 @@ pub fn palette_completions(
         // command itself dispatches correctly even when completions don't fire.
         let convoy_id = tokens[1];
         if tokens.len() == 3 && trailing_space {
-            return convoy_leg_completions(convoy_id, "", namespaces);
+            return convoy_vessel_completions(convoy_id, "", namespaces);
         }
         if tokens.len() == 4 && !trailing_space {
-            return convoy_leg_completions(convoy_id, tokens[3], namespaces);
+            return convoy_vessel_completions(convoy_id, tokens[3], namespaces);
         }
     }
 
@@ -317,7 +317,7 @@ pub fn palette_completions(
 }
 
 /// Vessel-name completions for `convoy <id> work <Tab>` / partial.
-fn convoy_leg_completions(convoy_id: &str, partial: &str, namespaces: &crate::app::NamespaceMap) -> Vec<PaletteCompletion> {
+fn convoy_vessel_completions(convoy_id: &str, partial: &str, namespaces: &crate::app::NamespaceMap) -> Vec<PaletteCompletion> {
     // Single-namespace MVP: search the "flotilla" namespace.
     let lower = partial.to_lowercase();
     let Some(model) = namespaces.get("flotilla") else { return vec![] };
@@ -795,7 +795,7 @@ mod tests {
 
     use crate::app::test_builders::repo_info;
 
-    fn namespaces_with_convoy(name: &str, tasks: &[&str]) -> crate::app::NamespaceMap {
+    fn namespaces_with_convoy(name: &str, vessels: &[&str]) -> crate::app::NamespaceMap {
         use crate::convoy_model::{ConvoyId, ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase};
         let convoy = ConvoySummary {
             id: ConvoyId::new("flotilla", name),
@@ -805,7 +805,7 @@ mod tests {
             phase: ConvoyPhase::Active,
             message: None,
             repo_hint: None,
-            vessels: tasks
+            vessels: vessels
                 .iter()
                 .map(|t| VesselSummary {
                     name: (*t).into(),
@@ -1109,7 +1109,7 @@ mod tests {
     }
 
     #[test]
-    fn convoy_task_names_listed_after_task_keyword() {
+    fn convoy_vessel_names_listed_after_work_keyword() {
         let model = empty_model();
         let namespaces = namespaces_with_convoy("fix-bug-123", &["implement", "review"]);
         let completions = palette_completions("convoy fix-bug-123 work ", &model, &namespaces, true);
@@ -1119,7 +1119,7 @@ mod tests {
     }
 
     #[test]
-    fn convoy_task_names_filter_by_partial() {
+    fn convoy_vessel_names_filter_by_partial() {
         let model = empty_model();
         let namespaces = namespaces_with_convoy("fix-bug-123", &["implement", "review"]);
         let completions = palette_completions("convoy fix-bug-123 work imp", &model, &namespaces, true);
@@ -1128,7 +1128,7 @@ mod tests {
     }
 
     #[test]
-    fn convoy_task_complete_verb_completes_after_task_subject() {
+    fn convoy_work_complete_verb_completes_after_vessel_subject() {
         let model = empty_model();
         let namespaces = namespaces_with_convoy("fix-bug-123", &["implement"]);
         let completions = palette_completions("convoy fix-bug-123 work implement ", &model, &namespaces, true);

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -148,7 +148,7 @@ fn render_frame(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Resul
     terminal.draw(|f| {
         let area = f.area();
         let convoys_selected = app.convoys_ui.selected.clone();
-        let convoys_selected_task = app.convoys_ui.selected_task.as_deref();
+        let convoys_selected_vessel = app.convoys_ui.selected_vessel.as_deref();
         let convoys_focus = app.convoys_ui.focus;
         let convoy_filter = app.convoys_ui.filter.as_str();
         // Single-namespace MVP: all convoys live in "flotilla". Multi-namespace
@@ -166,7 +166,7 @@ fn render_frame(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Resul
             in_flight: &app.in_flight,
             namespaces: &app.namespaces,
             convoys_selected,
-            convoys_selected_task,
+            convoys_selected_vessel,
             convoys_focus,
             convoy_filter,
             convoys,

--- a/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
@@ -57,12 +57,11 @@ impl<'a> ConvoyDetail<'a> {
 
         let items: Vec<TreeItem<String>> = self
             .convoy
-            .tasks
+            .vessels
             .iter()
             .map(|t| {
                 let g = task_glyph(t.phase);
-                let label =
-                    Line::from(vec![Span::styled(g.symbol, g.style), Span::raw(format!(" {} ({} proc)", t.name, t.processes.len()))]);
+                let label = Line::from(vec![Span::styled(g.symbol, g.style), Span::raw(format!(" {} ({} proc)", t.name, t.crew.len()))]);
                 TreeItem::new_leaf(t.name.clone(), label)
             })
             .collect();
@@ -84,7 +83,7 @@ mod tests {
     use ratatui::{backend::TestBackend, Terminal};
 
     use super::*;
-    use crate::convoy_model::{ConvoyId, ConvoyPhase, ConvoySummary, ProcessSummary, TaskPhase, TaskSummary};
+    use crate::convoy_model::{ConvoyId, ConvoyPhase, ConvoySummary, ProcessSummary, VesselSummary, WorkPhase};
 
     fn multi_task_convoy() -> ConvoySummary {
         ConvoySummary {
@@ -95,12 +94,12 @@ mod tests {
             phase: ConvoyPhase::Active,
             message: None,
             repo_hint: None,
-            tasks: vec![
-                TaskSummary {
+            vessels: vec![
+                VesselSummary {
                     name: "implement".into(),
                     depends_on: vec![],
-                    phase: TaskPhase::Running,
-                    processes: vec![ProcessSummary { role: "coder".into(), command_preview: "claude".into() }],
+                    phase: WorkPhase::Running,
+                    crew: vec![ProcessSummary { role: "coder".into(), command_preview: "claude".into() }],
                     host: None,
                     checkout: None,
                     workspace_ref: None,
@@ -110,11 +109,11 @@ mod tests {
                     finished_at: None,
                     message: None,
                 },
-                TaskSummary {
+                VesselSummary {
                     name: "review".into(),
                     depends_on: vec!["implement".into()],
-                    phase: TaskPhase::Pending,
-                    processes: vec![ProcessSummary { role: "reviewer".into(), command_preview: "claude".into() }],
+                    phase: WorkPhase::Pending,
+                    crew: vec![ProcessSummary { role: "reviewer".into(), command_preview: "claude".into() }],
                     host: None,
                     checkout: None,
                     workspace_ref: None,
@@ -165,7 +164,7 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(60, 10)).unwrap();
         let mut convoy = multi_task_convoy();
         convoy.initializing = true;
-        convoy.tasks.clear();
+        convoy.vessels.clear();
         terminal
             .draw(|f| {
                 ConvoyDetail { convoy: &convoy, selected_task: None, focused: false }.render(f, f.area());
@@ -181,7 +180,7 @@ mod tests {
         convoy.phase = ConvoyPhase::Failed;
         convoy.message = Some("missing input 'topic'".into());
         convoy.initializing = true;
-        convoy.tasks.clear();
+        convoy.vessels.clear();
 
         terminal
             .draw(|f| {

--- a/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
@@ -9,12 +9,12 @@ use ratatui::{
 };
 use tui_tree_widget::{Tree, TreeItem, TreeState};
 
-use super::glyphs::{convoy_glyph, task_glyph};
+use super::glyphs::{convoy_glyph, work_glyph};
 use crate::convoy_model::ConvoySummary;
 
 pub struct ConvoyDetail<'a> {
     pub convoy: &'a ConvoySummary,
-    pub selected_task: Option<&'a str>,
+    pub selected_vessel: Option<&'a str>,
     pub focused: bool,
 }
 
@@ -60,17 +60,17 @@ impl<'a> ConvoyDetail<'a> {
             .vessels
             .iter()
             .map(|t| {
-                let g = task_glyph(t.phase);
+                let g = work_glyph(t.phase);
                 let label = Line::from(vec![Span::styled(g.symbol, g.style), Span::raw(format!(" {} ({} proc)", t.name, t.crew.len()))]);
                 TreeItem::new_leaf(t.name.clone(), label)
             })
             .collect();
 
-        // TreeState is built from `selected_task` on every render. Selection lives
+        // TreeState is built from `selected_vessel` on every render. Selection lives
         // in `ConvoysUiState` (the source of truth); expansion isn't needed because
         // tasks render as flat leaves today. Lift TreeState if we get nested tasks.
         let mut state = TreeState::default();
-        if let Some(name) = self.selected_task {
+        if let Some(name) = self.selected_vessel {
             state.select(vec![name.to_string()]);
         }
         let tree = Tree::new(&items).expect("unique task names").highlight_style(Style::default().add_modifier(Modifier::REVERSED));
@@ -137,19 +137,19 @@ mod tests {
         let convoy = multi_task_convoy();
         terminal
             .draw(|f| {
-                ConvoyDetail { convoy: &convoy, selected_task: None, focused: false }.render(f, f.area());
+                ConvoyDetail { convoy: &convoy, selected_vessel: None, focused: false }.render(f, f.area());
             })
             .unwrap();
         insta::assert_snapshot!(terminal.backend());
     }
 
     #[test]
-    fn convoy_detail_with_selected_task_renders() {
+    fn convoy_detail_with_selected_vessel_renders() {
         let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
         let convoy = multi_task_convoy();
         terminal
             .draw(|f| {
-                ConvoyDetail { convoy: &convoy, selected_task: Some("review"), focused: true }.render(f, f.area());
+                ConvoyDetail { convoy: &convoy, selected_vessel: Some("review"), focused: true }.render(f, f.area());
             })
             .unwrap();
         let rendered: String = terminal.backend().buffer().content().iter().map(|c| c.symbol()).collect();
@@ -167,7 +167,7 @@ mod tests {
         convoy.vessels.clear();
         terminal
             .draw(|f| {
-                ConvoyDetail { convoy: &convoy, selected_task: None, focused: false }.render(f, f.area());
+                ConvoyDetail { convoy: &convoy, selected_vessel: None, focused: false }.render(f, f.area());
             })
             .unwrap();
         insta::assert_snapshot!(terminal.backend());
@@ -184,7 +184,7 @@ mod tests {
 
         terminal
             .draw(|f| {
-                ConvoyDetail { convoy: &convoy, selected_task: None, focused: false }.render(f, f.area());
+                ConvoyDetail { convoy: &convoy, selected_vessel: None, focused: false }.render(f, f.area());
             })
             .expect("render convoy detail");
 

--- a/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/detail.rs
@@ -34,7 +34,7 @@ impl<'a> ConvoyDetail<'a> {
         .block(Block::default().borders(Borders::ALL).border_style(border_style));
         f.render_widget(header, chunks[0]);
 
-        // Body: task tree OR initializing placeholder
+        // Body: vessel tree OR initializing placeholder
         let body_block = Block::default().borders(Borders::ALL).border_style(border_style).title(" Tasks ");
         let body_area = chunks[1];
         let body_inner = body_block.inner(body_area);

--- a/crates/flotilla-tui/src/widgets/convoys_page/glyphs.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/glyphs.rs
@@ -19,13 +19,13 @@ pub fn convoy_glyph(phase: ConvoyPhase) -> Glyph {
     }
 }
 
-pub fn task_glyph(phase: WorkPhase) -> Glyph {
+pub fn work_glyph(phase: WorkPhase) -> Glyph {
     match phase {
         WorkPhase::Pending => Glyph { symbol: "○", style: Style::default().add_modifier(Modifier::DIM) },
         WorkPhase::Ready => Glyph { symbol: "◐", style: Style::default().fg(Color::Yellow) },
         WorkPhase::Launching => Glyph { symbol: "◑", style: Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD) },
         WorkPhase::Running => Glyph { symbol: "●", style: Style::default().fg(Color::Green) },
-        WorkPhase::Completed => Glyph { symbol: "✓", style: Style::default().fg(Color::Green).add_modifier(Modifier::BOLD) },
+        WorkPhase::Complete => Glyph { symbol: "✓", style: Style::default().fg(Color::Green).add_modifier(Modifier::BOLD) },
         WorkPhase::Failed => Glyph { symbol: "✗", style: Style::default().fg(Color::Red) },
         WorkPhase::Cancelled => Glyph { symbol: "⊘", style: Style::default().fg(Color::Red).add_modifier(Modifier::DIM) },
     }

--- a/crates/flotilla-tui/src/widgets/convoys_page/glyphs.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/glyphs.rs
@@ -1,8 +1,8 @@
-//! Status glyphs + colour mapping for convoy / leg phases.
+//! Status glyphs + colour mapping for convoy / work phases.
 
 use ratatui::style::{Color, Modifier, Style};
 
-use crate::convoy_model::{ConvoyPhase, TaskPhase};
+use crate::convoy_model::{ConvoyPhase, WorkPhase};
 
 pub struct Glyph {
     pub symbol: &'static str,
@@ -19,14 +19,14 @@ pub fn convoy_glyph(phase: ConvoyPhase) -> Glyph {
     }
 }
 
-pub fn task_glyph(phase: TaskPhase) -> Glyph {
+pub fn task_glyph(phase: WorkPhase) -> Glyph {
     match phase {
-        TaskPhase::Pending => Glyph { symbol: "○", style: Style::default().add_modifier(Modifier::DIM) },
-        TaskPhase::Ready => Glyph { symbol: "◐", style: Style::default().fg(Color::Yellow) },
-        TaskPhase::Launching => Glyph { symbol: "◑", style: Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD) },
-        TaskPhase::Running => Glyph { symbol: "●", style: Style::default().fg(Color::Green) },
-        TaskPhase::Completed => Glyph { symbol: "✓", style: Style::default().fg(Color::Green).add_modifier(Modifier::BOLD) },
-        TaskPhase::Failed => Glyph { symbol: "✗", style: Style::default().fg(Color::Red) },
-        TaskPhase::Cancelled => Glyph { symbol: "⊘", style: Style::default().fg(Color::Red).add_modifier(Modifier::DIM) },
+        WorkPhase::Pending => Glyph { symbol: "○", style: Style::default().add_modifier(Modifier::DIM) },
+        WorkPhase::Ready => Glyph { symbol: "◐", style: Style::default().fg(Color::Yellow) },
+        WorkPhase::Launching => Glyph { symbol: "◑", style: Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD) },
+        WorkPhase::Running => Glyph { symbol: "●", style: Style::default().fg(Color::Green) },
+        WorkPhase::Completed => Glyph { symbol: "✓", style: Style::default().fg(Color::Green).add_modifier(Modifier::BOLD) },
+        WorkPhase::Failed => Glyph { symbol: "✗", style: Style::default().fg(Color::Red) },
+        WorkPhase::Cancelled => Glyph { symbol: "⊘", style: Style::default().fg(Color::Red).add_modifier(Modifier::DIM) },
     }
 }

--- a/crates/flotilla-tui/src/widgets/convoys_page/list.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/list.rs
@@ -58,7 +58,7 @@ mod tests {
             phase,
             message: None,
             repo_hint: None,
-            tasks: vec![],
+            vessels: vec![],
             started_at: None,
             finished_at: None,
             observed_workflow_ref: None,

--- a/crates/flotilla-tui/src/widgets/convoys_page/mod.rs
+++ b/crates/flotilla-tui/src/widgets/convoys_page/mod.rs
@@ -21,7 +21,7 @@ use crate::convoy_model::{ConvoyId, ConvoySummary};
 pub struct ConvoysPage<'a> {
     pub convoys: Vec<&'a ConvoySummary>,
     pub selected: Option<&'a ConvoyId>,
-    pub selected_task: Option<&'a str>,
+    pub selected_vessel: Option<&'a str>,
     pub focus: crate::app::ConvoysFocus,
     pub filter: &'a str,
 }
@@ -43,7 +43,7 @@ impl<'a> ConvoysPage<'a> {
         ConvoyList { convoys: self.convoys.as_slice(), selected: self.selected, focused: list_focused }.render(f, chunks[0]);
         if let Some(id) = self.selected {
             if let Some(convoy) = self.convoys.iter().find(|c| &c.id == id) {
-                ConvoyDetail { convoy, selected_task: self.selected_task, focused: !list_focused }.render(f, chunks[1]);
+                ConvoyDetail { convoy, selected_vessel: self.selected_vessel, focused: !list_focused }.render(f, chunks[1]);
             }
         }
     }

--- a/crates/flotilla-tui/src/widgets/mod.rs
+++ b/crates/flotilla-tui/src/widgets/mod.rs
@@ -132,7 +132,7 @@ pub struct RenderContext<'a> {
     /// Currently selected convoy id for the Convoys tab.
     pub convoys_selected: Option<crate::convoy_model::ConvoyId>,
     /// Currently selected task name within the selected convoy, if any.
-    pub convoys_selected_task: Option<&'a str>,
+    pub convoys_selected_vessel: Option<&'a str>,
     /// Which pane (list / tasks) currently has focus on the Convoys tab.
     pub convoys_focus: crate::app::ConvoysFocus,
     /// Active filter string for the Convoys tab.

--- a/crates/flotilla-tui/src/widgets/overview_page.rs
+++ b/crates/flotilla-tui/src/widgets/overview_page.rs
@@ -145,7 +145,7 @@ mod tests {
                     in_flight: &in_flight,
                     namespaces: &empty_namespaces,
                     convoys_selected: None,
-                    convoys_selected_task: None,
+                    convoys_selected_vessel: None,
                     convoys_focus: crate::app::ConvoysFocus::List,
                     convoy_filter: "",
                     convoys: vec![],

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -328,7 +328,7 @@ impl InteractiveWidget for Screen {
             ConvoysPage {
                 convoys: ctx.convoys.clone(),
                 selected,
-                selected_task: ctx.convoys_selected_task,
+                selected_vessel: ctx.convoys_selected_vessel,
                 focus: ctx.convoys_focus,
                 filter: ctx.convoy_filter,
             }

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -16,8 +16,8 @@ use flotilla_core::{
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::HostName;
 use flotilla_resources::{
-    apply_status_patch, controller_patches, Convoy, ConvoyPhase, ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend, SnapshotTask,
-    TaskPhase, TaskState, WorkflowSnapshot,
+    apply_status_patch, controller_patches, Convoy, ConvoyPhase, ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend,
+    VesselRequirement, WorkPhase, WorkState, WorkflowSnapshot,
 };
 use flotilla_tui::{app::App, theme::Theme};
 
@@ -164,20 +164,20 @@ async fn x_then_enter_completes_leg_via_palette() {
         app.handle_daemon_event(event);
     }
 
-    // Create a convoy and bootstrap its status so it has a leg ready for completion.
+    // Create a convoy and bootstrap its status so it has work ready for completion.
     let convoys = backend.using::<Convoy>("flotilla");
     convoys.create(&convoy_meta("fix-bug-123"), &convoy_spec("review-and-fix")).await.expect("create convoy");
 
     let mut tasks = BTreeMap::new();
-    tasks.insert("implement".to_string(), TaskState {
-        phase: TaskPhase::Pending,
+    tasks.insert("implement".to_string(), WorkState {
+        phase: WorkPhase::Pending,
         ready_at: None,
         started_at: None,
         finished_at: None,
         message: None,
         placement: None,
     });
-    let snapshot = WorkflowSnapshot { tasks: vec![SnapshotTask { name: "implement".into(), depends_on: vec![], processes: vec![] }] };
+    let snapshot = WorkflowSnapshot { vessels: vec![VesselRequirement { name: "implement".into(), depends_on: vec![], crew: vec![] }] };
     apply_status_patch(
         &convoys,
         "fix-bug-123",
@@ -199,7 +199,7 @@ async fn x_then_enter_completes_leg_via_palette() {
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         drain(&mut app, &mut daemon_rx);
-        if app.convoys("flotilla").iter().any(|convoy| !convoy.tasks.is_empty()) {
+        if app.convoys("flotilla").iter().any(|convoy| !convoy.vessels.is_empty()) {
             break;
         }
         if Instant::now() >= deadline {
@@ -219,9 +219,9 @@ async fn x_then_enter_completes_leg_via_palette() {
         KeyEvent::new(KeyCode::Enter, KeyModifiers::empty())
     }
 
-    app.handle_key(key('l')); // drill into leg focus
+    app.handle_key(key('l')); // drill into vessel focus
     app.handle_key(key('x')); // open palette pre-filled
-    app.handle_key(enter()); // confirm — dispatch ConvoyLegComplete
+    app.handle_key(enter()); // confirm — dispatch ConvoyWorkComplete
 
     // Dispatch the queued command through the daemon.
     let mut took_one = false;
@@ -236,8 +236,8 @@ async fn x_then_enter_completes_leg_via_palette() {
     loop {
         drain(&mut app, &mut daemon_rx);
         if let Some(c) = app.convoys("flotilla").first() {
-            if let Some(t) = c.tasks.iter().find(|t| t.name == "implement") {
-                if t.phase == flotilla_tui::convoy_model::TaskPhase::Completed {
+            if let Some(t) = c.vessels.iter().find(|t| t.name == "implement") {
+                if t.phase == flotilla_tui::convoy_model::WorkPhase::Completed {
                     break;
                 }
             }

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -124,7 +124,7 @@ async fn tui_shows_convoys_from_daemon() {
 }
 
 #[tokio::test]
-async fn x_then_enter_completes_leg_via_palette() {
+async fn x_then_enter_completes_work_via_palette() {
     use std::collections::BTreeMap;
 
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -237,7 +237,7 @@ async fn x_then_enter_completes_leg_via_palette() {
         drain(&mut app, &mut daemon_rx);
         if let Some(c) = app.convoys("flotilla").first() {
             if let Some(t) = c.vessels.iter().find(|t| t.name == "implement") {
-                if t.phase == flotilla_tui::convoy_model::WorkPhase::Completed {
+                if t.phase == flotilla_tui::convoy_model::WorkPhase::Complete {
                     break;
                 }
             }

--- a/crates/flotilla-tui/tests/support/high_fidelity.rs
+++ b/crates/flotilla-tui/tests/support/high_fidelity.rs
@@ -354,7 +354,7 @@ impl HighFidelityHarness {
         let mut terminal = Terminal::new(backend).expect("create test terminal");
         let theme = self.app.theme.clone();
         let convoys_selected = self.app.convoys_ui.selected.clone();
-        let convoys_selected_task = self.app.convoys_ui.selected_task.clone();
+        let convoys_selected_vessel = self.app.convoys_ui.selected_vessel.clone();
         let convoys_focus = self.app.convoys_ui.focus;
         let convoy_filter_str = self.app.convoys_ui.filter.clone();
         terminal
@@ -370,7 +370,7 @@ impl HighFidelityHarness {
                     in_flight: &self.app.in_flight,
                     namespaces: &self.app.namespaces,
                     convoys_selected,
-                    convoys_selected_task: convoys_selected_task.as_deref(),
+                    convoys_selected_vessel: convoys_selected_vessel.as_deref(),
                     convoys_focus,
                     convoy_filter: &convoy_filter_str,
                     convoys,

--- a/crates/flotilla-tui/tests/support/mod.rs
+++ b/crates/flotilla-tui/tests/support/mod.rs
@@ -187,7 +187,7 @@ impl TestHarness {
                     in_flight: &self.in_flight,
                     namespaces: &empty_namespaces,
                     convoys_selected: None,
-                    convoys_selected_task: None,
+                    convoys_selected_vessel: None,
                     convoys_focus: flotilla_tui::app::ConvoysFocus::List,
                     convoy_filter: "",
                     convoys: vec![],

--- a/docs/adr/0007-requirements-first-placement.md
+++ b/docs/adr/0007-requirements-first-placement.md
@@ -27,11 +27,17 @@ Recipes are a strict subset: a fully-pinned requirement.
   a hand-authored request with pins). The old AttachableSet-era
   `ProvisioningTarget` picker collapses into pins; env-reuse (`=env_id`)
   becomes an affinity requirement.
-- **Fan-out**: one requirement may materialise several Vessels
-  (`forall: platform in …`). The platform matrix belongs on the **Project**
-  (what this island targets), keeping templates fleet-portable and runs
-  reproducible; fleet-derived ranges ("everywhere we can, min N") are a
-  designed-for later resolver expression.
+- **Fan-out** *(amended 2026-07-11, #680 grill)*: **one requirement ↔ one
+  Vessel (at a time) is an invariant** — the requirement is the unit of
+  placement resolution, **not** the fan-out unit. Fan-out is *authored*: an
+  orchestrating agent calling commands, or an embedded script (possibly
+  staged/graph-building), emits several concrete requirements with unique
+  names (`test[linux-x86]`, `test[darwin-arm64]`). Any future declarative
+  expansion construct is a real new type, never a field on
+  `VesselRequirement` that consumers must statefully ignore. The platform
+  matrix still belongs on the **Project** (what this island targets), keeping
+  templates fleet-portable and runs reproducible; fleet-derived ranges
+  ("everywhere we can, min N") are a designed-for later resolver expression.
 - **Requirements describe the Hull**; crew-side selectors
   (`capability: code` → concrete agent) are a separate axis resolved the same
   requirements-first way (v1: simple lookup).

--- a/docs/adr/0008-agentic-first-orchestration.md
+++ b/docs/adr/0008-agentic-first-orchestration.md
@@ -24,8 +24,12 @@ dynamic practice**, not designed ahead of it.
   producing. This pulls a **Python and/or TypeScript client SDK** forward
   (sooner rather than later), tracking the CLI surface closely. Simple
   workflow programs stay simply analysable; some will be very dynamic.
-- **Inter-leg data flow stays deliberately unformalised** (prompts + git)
-  until patterns recur.
+- **Inter-crew data flow stays deliberately unformalised** (prompts + git)
+  until patterns recur. *(Note 2026-07-11, #680 grill: when it does formalise,
+  the shape is per-workflow explicitness about what a crew passes on and
+  receives — filesystem state via vcs push/pull or mutagen-style sync,
+  artifacts in object storage — never a blanket implicit sync rule; workflows
+  may legitimately call for experimentally isolated branches.)*
 
 ## Open: durable execution
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1005,7 +1005,8 @@ mod tests {
 
     #[test]
     fn cli_parses_convoy_noun() {
-        let cli = Cli::try_parse_from(["flotilla", "convoy", "convoy-a", "leg", "implement", "complete"]).expect("convoy cli should parse");
+        let cli =
+            Cli::try_parse_from(["flotilla", "convoy", "convoy-a", "work", "implement", "complete"]).expect("convoy cli should parse");
         assert!(matches!(cli.command, Some(SubCommand::Convoy(_))));
     }
 


### PR DESCRIPTION
Closes #680.

## What changed

Mechanical vocabulary repair per the #680 grill rulings — no behaviour changes.

| Before | After |
|---|---|
| `TaskWorkspace` resource (+ CRD, `taskworkspaces` plural) | `Vessel` (`vessels`) |
| `TaskDefinition` + `SnapshotTask` (byte-identical duplicates) | **one** `VesselRequirement { name, depends_on, crew }` |
| `ProcessDefinition` / `ProcessSource` | `CrewSpec` / `CrewSource` |
| `ConvoyStatus.tasks: BTreeMap<_, TaskState>` / `TaskPhase` | `work: BTreeMap<vessel_name, WorkState>` / `WorkPhase` — the work *aboard* a vessel; vessels never "complete" |
| `ConvoyStatusPatch` task variants | `WorkLaunching` / `WorkRunning` / `MarkWork*` / `AdvanceWorkToReady`, field `work` |
| `TASK_LABEL` / `TASK_WORKSPACE_LABEL` / ordinals | `flotilla.work/vessel` (within-convoy name) / `flotilla.work/vessel_ref` (resource name) / `vessel_ordinal` + `crew_ordinal` |
| `IntentTarget::Vessel {attach_ref}` + `IntentTarget::Leg {..}` (one entity split in two) | one `IntentTarget::Vessel { namespace, convoy, vessel, host, attach_ref: Option }` |
| `IntentKind::CompleteLeg`, `ConvoyLegComplete`, CLI `convoy X leg Y complete` | `CompleteWork`, `ConvoyWorkComplete`, `convoy X work Y complete` |
| `WorkflowSnapshot.tasks` / template `tasks:` + `processes:` (wire + YAML + CRDs) | `vessels:` + `crew:` |
| #675 residue: `TerminalSessionIdentity{vessel,leg}`, `--vessel` crew flag | `{vessel_ref, vessel}` (ref = resource name, vessel = within-convoy name), `--vessel-ref` |
| Panel subresource `legs/<name>`; TUI `TaskSummary`/`LegCompletionTarget`/actions/palette | `vessels/<name>`; `VesselSummary`/`WorkCompletionTarget`/`complete_convoy_work`/`convoy <id> work <vessel> complete` |

Also: ADR 0007 amended (1 requirement ↔ 1 vessel invariant; fan-out is authored, never a field), ADR 0008 note (crew data-flow formalisation direction), CONTEXT.md avoid-list updated, `PROTOCOL_VERSION` 6 → 7 (wire field renames; no-compat phase).

## Naming convention established

The string `implement` is the **vessel** (within-convoy name = requirement name = work key; `VESSEL_LABEL`); `myconvoy-implement` is the **vessel_ref** (resource name; `VESSEL_REF_LABEL`). Async/tokio "task" usage is untouched.

## Notes for review

- **Pre-existing oddity, not changed**: `FleetListRow.vessel` is populated with `session.spec.env_ref` (`in_process.rs` fleet listing) — looks like a mislabel that predates this PR; left as-is to keep this slice mechanical.
- No TUI snapshot files changed (palette snapshots don't enumerate convoy subcommands).
- `grep -riE '\bleg\b|\blegs\b' crates src --include='*.rs'` (excluding `legacy`) returns zero; all task-era type names return zero.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (all green; the two crew-CLI tests and http_wire selector test updated for the renamed flags/labels)
- `cargo dylint --all -- --all-targets` (pre-existing advisory path-length warnings only)
