### PR TITLE
fix: make finalizer deletion idempotent

### DIFF
--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -8,8 +8,8 @@ use flotilla_resources::{
     Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
     DockerPerTaskPlacementPolicySpec, Environment, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus, HostDirectEnvironmentSpec,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend,
-    TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec,
-    WorkflowSnapshot,
+    TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase,
+    WorkState, WorkflowSnapshot,
 };
 use tokio::{
     task::JoinHandle,
@@ -46,6 +46,18 @@ pub fn labeled_meta(name: &str, labels: impl IntoIterator<Item = (String, String
 pub fn vessel_meta(name: &str, repo_url: &str) -> InputMeta {
     let canonical_repo = canonicalize_repo_url(repo_url).expect("repo URL should canonicalize");
     controller_meta().name(name).labels([("flotilla.work/repo-key".to_string(), repo_key(&canonical_repo))].into_iter().collect()).call()
+}
+
+#[bon::builder]
+pub fn work_state(
+    phase: WorkPhase,
+    ready_at: Option<DateTime<Utc>>,
+    started_at: Option<DateTime<Utc>>,
+    finished_at: Option<DateTime<Utc>>,
+    message: Option<String>,
+    placement: Option<flotilla_resources::PlacementStatus>,
+) -> WorkState {
+    WorkState { phase, ready_at, started_at, finished_at, message, placement }
 }
 
 pub async fn create_convoy_with_single_task(

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -12,11 +12,12 @@ use flotilla_controllers::reconcilers::VesselReconciler;
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{Actuation, Reconciler},
-    Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
-    CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec,
-    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, LifecycleAuthority,
-    ObservedCheckoutSpec, PlacementPolicySpec, ResourceBackend, ResourceError, Selector, TerminalSession, TerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkflowSnapshot,
+    Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyPhase, ConvoyReconciler,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
+    DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec,
+    ResourceBackend, ResourceError, Selector, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
     CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
@@ -411,6 +412,93 @@ async fn run_finalizer_deletes_all_labeled_children() {
         backend.clone().using::<TerminalSession>(NAMESPACE).get("terminal-workspace-finalize-coder").await,
         Err(ResourceError::NotFound { .. })
     ));
+}
+
+#[tokio::test]
+async fn completed_convoy_does_not_repeat_vessel_delete_while_its_finalizer_is_pending() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+    let vessels = backend.clone().using::<Vessel>(NAMESPACE);
+    let terminals = backend.clone().using::<TerminalSession>(NAMESPACE);
+    let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-finalizer", "implement", REPO_URL, GIT_REF).await;
+
+    let mut status = convoy.status.expect("convoy status");
+    status.phase = ConvoyPhase::Completed;
+    status.observed_workflow_ref = Some("wf".to_string());
+    status.work.insert("implement".to_string(), WorkState {
+        phase: WorkPhase::Complete,
+        ready_at: None,
+        started_at: None,
+        finished_at: Some(Utc::now()),
+        message: Some("done".to_string()),
+        placement: None,
+    });
+    convoys
+        .update_status("convoy-finalizer", &convoy.metadata.resource_version, &status)
+        .await
+        .expect("convoy completion should be recorded");
+
+    let vessel =
+        create_workspace(&backend, NAMESPACE, "convoy-finalizer-implement", "convoy-finalizer", "implement", "policy-finalizer", REPO_URL)
+            .await;
+    let mut vessel_meta = InputMeta::from(&vessel.metadata);
+    vessel_meta.labels.insert(CONVOY_LABEL.to_string(), "convoy-finalizer".to_string());
+    vessel_meta.finalizers = vec!["flotilla.work/vessel-workspace-teardown".to_string()];
+    vessels
+        .update(&vessel_meta, &vessel.metadata.resource_version, &vessel.spec)
+        .await
+        .expect("vessel finalizer and convoy label should be recorded");
+    terminals
+        .create(
+            &labeled_meta("terminal-convoy-finalizer-implement-coder", [(
+                VESSEL_REF_LABEL.to_string(),
+                "convoy-finalizer-implement".to_string(),
+            )]),
+            &TerminalSessionSpec {
+                env_ref: "host-direct-01HXYZ".to_string(),
+                role: "coder".to_string(),
+                source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
+                cwd: "/workspace".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("terminal child should be created");
+
+    let convoy_reconciler =
+        ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(NAMESPACE)).with_vessels(vessels.clone());
+    let completed = convoys.get("convoy-finalizer").await.expect("completed convoy should exist");
+    let first_dependencies = convoy_reconciler.fetch_dependencies(&completed).await.expect("first dependencies should load");
+    let first_outcome = convoy_reconciler.reconcile(&completed, &first_dependencies, Utc::now());
+    assert!(first_outcome
+        .actuations
+        .iter()
+        .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-finalizer-implement")));
+
+    vessels.delete("convoy-finalizer-implement").await.expect("first convoy cleanup should mark the vessel for deletion");
+    let pending_vessel = vessels.get("convoy-finalizer-implement").await.expect("pending finalizer should retain the vessel");
+    assert!(pending_vessel.metadata.deletion_timestamp.is_some());
+
+    let second_dependencies = convoy_reconciler.fetch_dependencies(&completed).await.expect("second dependencies should load");
+    let second_outcome = convoy_reconciler.reconcile(&completed, &second_dependencies, Utc::now());
+    assert!(
+        !second_outcome
+            .actuations
+            .iter()
+            .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-finalizer-implement")),
+        "a vessel already awaiting finalization should not be deleted again"
+    );
+
+    let vessel_reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
+    vessel_reconciler.run_finalizer(&pending_vessel).await.expect("vessel finalizer should delete terminal children");
+    let clear_finalizer = InputMeta::from(&pending_vessel.metadata).without_finalizer("flotilla.work/vessel-workspace-teardown");
+    vessels
+        .update(&clear_finalizer, &pending_vessel.metadata.resource_version, &pending_vessel.spec)
+        .await
+        .expect("clearing the vessel finalizer should complete deletion");
+
+    assert!(matches!(vessels.get("convoy-finalizer-implement").await, Err(ResourceError::NotFound { .. })));
+    assert!(matches!(terminals.get("terminal-convoy-finalizer-implement-coder").await, Err(ResourceError::NotFound { .. })));
 }
 
 #[tokio::test]

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use common::{
     create_convoy_with_single_task, create_docker_worktree_policy, create_host_direct_policy, create_policy, create_ready_checkout,
     create_ready_clone, create_ready_docker_environment, create_ready_host_direct_environment, create_stopped_terminal, create_workspace,
-    labeled_meta, meta, vessel_meta, DockerWorktreePolicyFixture, ReadyCheckoutFixture, StoppedTerminalFixture,
+    labeled_meta, meta, vessel_meta, work_state, DockerWorktreePolicyFixture, ReadyCheckoutFixture, StoppedTerminalFixture,
 };
 use flotilla_controllers::reconcilers::VesselReconciler;
 use flotilla_resources::{
@@ -17,8 +17,8 @@ use flotilla_resources::{
     DockerPerTaskPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
     HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec,
     ResourceBackend, ResourceError, Selector, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
-    TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
-    CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
+    CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
@@ -425,14 +425,10 @@ async fn completed_convoy_does_not_repeat_vessel_delete_while_its_finalizer_is_p
     let mut status = convoy.status.expect("convoy status");
     status.phase = ConvoyPhase::Completed;
     status.observed_workflow_ref = Some("wf".to_string());
-    status.work.insert("implement".to_string(), WorkState {
-        phase: WorkPhase::Complete,
-        ready_at: None,
-        started_at: None,
-        finished_at: Some(Utc::now()),
-        message: Some("done".to_string()),
-        placement: None,
-    });
+    status.work.insert(
+        "implement".to_string(),
+        work_state().phase(WorkPhase::Complete).finished_at(Utc::now()).message("done".to_string()).call(),
+    );
     convoys
         .update_status("convoy-finalizer", &convoy.metadata.resource_version, &status)
         .await
@@ -448,25 +444,9 @@ async fn completed_convoy_does_not_repeat_vessel_delete_while_its_finalizer_is_p
         .update(&vessel_meta, &vessel.metadata.resource_version, &vessel.spec)
         .await
         .expect("vessel finalizer and convoy label should be recorded");
-    terminals
-        .create(
-            &labeled_meta("terminal-convoy-finalizer-implement-coder", [(
-                VESSEL_REF_LABEL.to_string(),
-                "convoy-finalizer-implement".to_string(),
-            )]),
-            &TerminalSessionSpec {
-                env_ref: "host-direct-01HXYZ".to_string(),
-                role: "coder".to_string(),
-                source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
-                cwd: "/workspace".to_string(),
-                pool: "cleat".to_string(),
-            },
-        )
-        .await
-        .expect("terminal child should be created");
+    create_labeled_terminal(&backend, NAMESPACE, "terminal-convoy-finalizer-implement-coder", "convoy-finalizer-implement").await;
 
-    let convoy_reconciler =
-        ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(NAMESPACE)).with_vessels(vessels.clone());
+    let convoy_reconciler = ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(NAMESPACE)).with_vessels(vessels.clone());
     let completed = convoys.get("convoy-finalizer").await.expect("completed convoy should exist");
     let first_dependencies = convoy_reconciler.fetch_dependencies(&completed).await.expect("first dependencies should load");
     let first_outcome = convoy_reconciler.reconcile(&completed, &first_dependencies, Utc::now());

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -231,6 +231,13 @@ pub struct ControllerLoop<R: Reconciler> {
 impl<R: Reconciler> ControllerLoop<R> {
     const WATCH_RESTART_BACKOFF: Duration = Duration::from_millis(100);
 
+    async fn write_tolerating_not_found<T>(write: impl Future<Output = Result<T, ResourceError>>) -> Result<(), ResourceError> {
+        match write.await {
+            Ok(_) | Err(ResourceError::NotFound { .. }) => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
     async fn apply_actuation(backend: &ResourceBackend, namespace: &str, actuation: Actuation) -> Result<(), ResourceError> {
         match actuation {
             Actuation::CreateEnvironment { meta, spec } => {
@@ -400,9 +407,7 @@ impl<R: Reconciler> ControllerLoop<R> {
                         && lifecycle_owned
                     {
                         let meta = InputMeta::from(&object.metadata).with_added_finalizer(finalizer_name);
-                        // A racing writer may win between get() and update(); rely on the resulting
-                        // watch event to requeue the object and retry finalizer attachment.
-                        primary.update(&meta, &object.metadata.resource_version, &object.spec).await?;
+                        Self::write_tolerating_not_found(primary.update(&meta, &object.metadata.resource_version, &object.spec)).await?;
                         continue;
                     }
                     if object.metadata.deletion_timestamp.is_some()
@@ -412,10 +417,7 @@ impl<R: Reconciler> ControllerLoop<R> {
                             reconciler.run_finalizer(&object).await?;
                         }
                         let meta = InputMeta::from(&object.metadata).without_finalizer(finalizer_name);
-                        match primary.update(&meta, &object.metadata.resource_version, &object.spec).await {
-                            Ok(_) | Err(ResourceError::NotFound { .. }) => {}
-                            Err(err) => return Err(err),
-                        }
+                        Self::write_tolerating_not_found(primary.update(&meta, &object.metadata.resource_version, &object.spec)).await?;
                         continue;
                     }
                 }
@@ -431,7 +433,7 @@ impl<R: Reconciler> ControllerLoop<R> {
                     Self::apply_actuation(&primary.backend, &primary.namespace, actuation).await?;
                 }
                 if let Some(patch) = outcome.patch {
-                    apply_status_patch(&primary, &name, &patch).await?;
+                    Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await?;
                 }
                 continue;
             }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -552,8 +552,9 @@ fn cleanup_actuations(
                 if presentations.contains_key(&resource_name) {
                     actuations.push(Actuation::DeletePresentation { name: resource_name.clone() });
                 }
-                if vessels.contains_key(&resource_name) {
+                if vessels.get(&resource_name).is_some_and(|vessel| vessel.metadata.deletion_timestamp.is_none()) {
                     actuations.push(Actuation::DeleteVessel { name: resource_name });
+                }
                 }
             }
             WorkPhase::Pending => {}

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -555,7 +555,6 @@ fn cleanup_actuations(
                 if vessels.get(&resource_name).is_some_and(|vessel| vessel.metadata.deletion_timestamp.is_none()) {
                     actuations.push(Actuation::DeleteVessel { name: resource_name });
                 }
-                }
             }
             WorkPhase::Pending => {}
         }

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -302,6 +302,9 @@ impl InMemoryBackend {
         self.with_store_mut::<T, _>(namespace, |store| {
             let existing = store.objects.get(name).cloned().ok_or_else(|| ResourceError::not_found(name))?;
             let mut object = Self::decode_object::<T>(existing)?;
+            if object.metadata.is_pending_finalization() {
+                return Ok(());
+            }
             let version = store.allocate_version();
             object.metadata.resource_version = version.to_string();
             if !object.metadata.finalizers.is_empty() && object.metadata.deletion_timestamp.is_none() {

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -121,6 +121,10 @@ impl ObjectMeta {
         self.labels.get(AUTHORITY_LABEL).map(|value| LifecycleAuthority::from_label_value(value)).transpose()
     }
 
+    pub fn is_pending_finalization(&self) -> bool {
+        !self.finalizers.is_empty() && self.deletion_timestamp.is_some()
+    }
+
     pub fn set_lifecycle_authority(&mut self, authority: LifecycleAuthority) {
         self.labels.insert(AUTHORITY_LABEL.to_string(), authority.as_label_value().to_string());
     }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -531,6 +531,9 @@ impl SqliteBackend {
         let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource delete"))?;
         let existing = Self::select_existing::<T>(&tx, &key, name)?;
         let mut object = existing.ok_or_else(|| ResourceError::not_found(name))?;
+        if object.metadata.is_pending_finalization() {
+            return Ok(());
+        }
         let version = Self::allocate_version(&tx, &key)?;
         object.metadata.resource_version = version.to_string();
 

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -194,6 +194,46 @@ pub async fn assert_delete_emits_event<F: ResourceContractFixture>() {
     assert_delete_emits_event_with_backend::<F>(in_memory_backend()).await;
 }
 
+pub async fn assert_repeated_delete_with_pending_finalizers_is_noop_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
+    let resolver = resolver::<F>(backend, "flotilla");
+    let finalizer = "flotilla.work/test-finalizer";
+    let mut meta = F::meta("alpha");
+    meta.finalizers = vec![finalizer.to_string()];
+    let created = resolver.create(&meta, &F::spec()).await.expect("create should succeed");
+    let mut watch = resolver.watch(WatchStart::FromVersion(created.metadata.resource_version.clone())).await.expect("watch should start");
+
+    resolver.delete("alpha").await.expect("first delete should mark the object for deletion");
+    let marked = timeout(Duration::from_secs(1), watch.next())
+        .await
+        .expect("first delete should emit an event")
+        .expect("watch should yield an item")
+        .expect("watch event should decode");
+    let WatchEvent::Modified(marked) = marked else { panic!("first delete should mark the object as modified") };
+    assert_eq!(marked.metadata.finalizers, vec![finalizer.to_string()]);
+    assert!(marked.metadata.deletion_timestamp.is_some(), "first delete should set the deletion timestamp");
+
+    resolver.delete("alpha").await.expect("repeated delete should be idempotent while finalizers are pending");
+    let still_marked = resolver.get("alpha").await.expect("pending finalizer should keep the object present");
+    assert_eq!(still_marked.metadata.resource_version, marked.metadata.resource_version);
+    assert_eq!(still_marked.metadata.finalizers, vec![finalizer.to_string()]);
+    assert!(still_marked.metadata.deletion_timestamp.is_some());
+    assert!(timeout(Duration::from_millis(100), watch.next()).await.is_err(), "repeated delete should not emit an event");
+
+    let cleared_meta = InputMeta::from(&marked.metadata).without_finalizer(finalizer);
+    let removed = resolver
+        .update(&cleared_meta, &marked.metadata.resource_version, &marked.spec)
+        .await
+        .expect("clearing the finalizer should succeed");
+    let deleted = timeout(Duration::from_secs(1), watch.next())
+        .await
+        .expect("clearing the finalizer should emit a deleted event")
+        .expect("watch should yield an item")
+        .expect("watch event should decode");
+    let WatchEvent::Deleted(deleted) = deleted else { panic!("clearing the finalizer should delete the object") };
+    assert_eq!(deleted.metadata.resource_version, removed.metadata.resource_version);
+    assert!(matches!(resolver.get("alpha").await, Err(ResourceError::NotFound { .. })));
+}
+
 pub async fn assert_watch_from_version_replays_with_backend<F: ResourceContractFixture>(backend: ResourceBackend) {
     let resolver = resolver::<F>(backend, "flotilla");
     resolver.create(&F::meta("alpha"), &F::spec()).await.expect("create should succeed");

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::Duration,
@@ -12,7 +12,7 @@ use common::{resource_meta, TestLoopHarness};
 use flotilla_resources::{
     controller::{Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler},
     ApiPaths, InMemoryBackend, InputMeta, LifecycleAuthority, NoStatusPatch, Presentation, PresentationSpec, Resource, ResourceBackend,
-    ResourceError, ResourceObject, TypedResolver, Vessel, VesselSpec,
+    ResourceError, ResourceObject, StatusPatch, TypedResolver, Vessel, VesselSpec,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{sync::mpsc, time::timeout};
@@ -114,12 +114,12 @@ impl Reconciler for FinalizingReconciler {
 }
 
 #[derive(Clone)]
-struct DeletingFinalizerReconciler {
+struct RacingFinalizerRemovalReconciler {
     finalized: Arc<Mutex<Vec<String>>>,
     primaries: TypedResolver<PrimaryResource>,
 }
 
-impl Reconciler for DeletingFinalizerReconciler {
+impl Reconciler for RacingFinalizerRemovalReconciler {
     type Resource = PrimaryResource;
     type Dependencies = ();
 
@@ -138,14 +138,131 @@ impl Reconciler for DeletingFinalizerReconciler {
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
         self.finalized.lock().expect("finalized lock").push(obj.metadata.name.clone());
-        match self.primaries.delete(&obj.metadata.name).await {
-            Ok(()) | Err(ResourceError::NotFound { .. }) => Ok(()),
+        let meta = InputMeta::from(&obj.metadata).without_finalizer("flotilla.work/test-finalizer");
+        match self.primaries.update(&meta, &obj.metadata.resource_version, &obj.spec).await {
+            Ok(_) | Err(ResourceError::NotFound { .. }) => Ok(()),
             Err(err) => Err(err),
         }
     }
 
     fn finalizer_name(&self) -> Option<&'static str> {
         Some("flotilla.work/test-finalizer")
+    }
+}
+
+fn delete_synchronously<T: Resource>(resolver: TypedResolver<T>, name: String) {
+    let handle = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().expect("runtime for synchronous delete");
+        runtime.block_on(async move {
+            resolver.delete(&name).await.expect("synchronous delete should succeed");
+        });
+    });
+    assert!(handle.join().is_ok(), "synchronous delete thread should not panic");
+}
+
+#[derive(Clone)]
+struct RacingAttachReconciler {
+    primaries: TypedResolver<PrimaryResource>,
+    target: String,
+    raced: Arc<AtomicBool>,
+}
+
+impl Reconciler for RacingAttachReconciler {
+    type Resource = PrimaryResource;
+    type Dependencies = ();
+
+    async fn fetch_dependencies(&self, _obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        Ok(())
+    }
+
+    fn reconcile(
+        &self,
+        _obj: &ResourceObject<Self::Resource>,
+        _deps: &Self::Dependencies,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> ReconcileOutcome<Self::Resource> {
+        ReconcileOutcome::new(None)
+    }
+
+    async fn run_finalizer(&self, _obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
+        Ok(())
+    }
+
+    fn finalizer_name(&self) -> Option<&'static str> {
+        if !self.raced.swap(true, Ordering::SeqCst) {
+            delete_synchronously(self.primaries.clone(), self.target.clone());
+        }
+        Some("flotilla.work/test-finalizer")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StatusfulResource;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct StatusfulSpec {
+    value: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct StatusfulStatus {
+    touched: bool,
+}
+
+enum TouchPatch {
+    Touch,
+}
+
+impl StatusPatch<StatusfulStatus> for TouchPatch {
+    fn apply(&self, status: &mut StatusfulStatus) {
+        match self {
+            Self::Touch => status.touched = true,
+        }
+    }
+}
+
+impl Resource for StatusfulResource {
+    type Spec = StatusfulSpec;
+    type Status = StatusfulStatus;
+    type StatusPatch = TouchPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "test-statusful", kind: "TestStatusful" };
+}
+
+#[derive(Clone)]
+struct RacingStatusPatchReconciler {
+    primaries: TypedResolver<StatusfulResource>,
+    target: String,
+    reconciled: Arc<Mutex<Vec<String>>>,
+}
+
+impl Reconciler for RacingStatusPatchReconciler {
+    type Resource = StatusfulResource;
+    type Dependencies = ();
+
+    async fn fetch_dependencies(&self, _obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        Ok(())
+    }
+
+    fn reconcile(
+        &self,
+        obj: &ResourceObject<Self::Resource>,
+        _deps: &Self::Dependencies,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> ReconcileOutcome<Self::Resource> {
+        self.reconciled.lock().expect("reconciled lock").push(obj.metadata.name.clone());
+        if obj.metadata.name == self.target {
+            delete_synchronously(self.primaries.clone(), obj.metadata.name.clone());
+        }
+        ReconcileOutcome::new(Some(TouchPatch::Touch))
+    }
+
+    async fn run_finalizer(&self, _obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
+        Ok(())
+    }
+
+    fn finalizer_name(&self) -> Option<&'static str> {
+        None
     }
 }
 
@@ -520,7 +637,7 @@ async fn controller_loop_survives_notfound_when_removing_finalizer() {
         ControllerLoop {
             primary: primaries.clone(),
             secondaries: Vec::new(),
-            reconciler: DeletingFinalizerReconciler { finalized: Arc::clone(&finalized), primaries: primaries.clone() },
+            reconciler: RacingFinalizerRemovalReconciler { finalized: Arc::clone(&finalized), primaries: primaries.clone() },
             resync_interval: Duration::from_secs(60),
             backend,
         }
@@ -552,6 +669,99 @@ async fn controller_loop_survives_notfound_when_removing_finalizer() {
     })
     .await
     .expect("controller loop should continue after finalizer removal NotFound");
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_loop_survives_notfound_when_attaching_finalizer() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    primaries.create(&primary_meta("alpha"), &PrimarySpec { value: "one".to_string() }).await.expect("primary create should succeed");
+
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries.clone(),
+            secondaries: Vec::new(),
+            reconciler: RacingAttachReconciler {
+                primaries: primaries.clone(),
+                target: "alpha".to_string(),
+                raced: Arc::new(AtomicBool::new(false)),
+            },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    harness
+        .wait_until(Duration::from_secs(1), || {
+            let primaries = primaries.clone();
+            async move { matches!(primaries.get("alpha").await, Err(ResourceError::NotFound { .. })) }
+        })
+        .await;
+
+    primaries.create(&primary_meta("beta"), &PrimarySpec { value: "two".to_string() }).await.expect("second primary create should succeed");
+    harness
+        .wait_until(Duration::from_secs(1), || {
+            let primaries = primaries.clone();
+            async move {
+                primaries
+                    .get("beta")
+                    .await
+                    .is_ok_and(|object| object.metadata.finalizers == vec!["flotilla.work/test-finalizer".to_string()])
+            }
+        })
+        .await;
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_loop_survives_notfound_when_patching_status() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let primaries = backend.clone().using::<StatusfulResource>("flotilla");
+    primaries.create(&primary_meta("alpha"), &StatusfulSpec { value: "one".to_string() }).await.expect("primary create should succeed");
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries.clone(),
+            secondaries: Vec::new(),
+            reconciler: RacingStatusPatchReconciler {
+                primaries: primaries.clone(),
+                target: "alpha".to_string(),
+                reconciled: Arc::clone(&reconciled),
+            },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    harness
+        .wait_until(Duration::from_secs(1), || {
+            let primaries = primaries.clone();
+            let reconciled = Arc::clone(&reconciled);
+            async move {
+                let alpha_reconciled = reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha");
+                alpha_reconciled && matches!(primaries.get("alpha").await, Err(ResourceError::NotFound { .. }))
+            }
+        })
+        .await;
+
+    primaries
+        .create(&primary_meta("beta"), &StatusfulSpec { value: "two".to_string() })
+        .await
+        .expect("second primary create should succeed");
+    harness
+        .wait_until(Duration::from_secs(1), || {
+            let reconciled = Arc::clone(&reconciled);
+            async move { reconciled.lock().expect("reconciled lock").iter().any(|name| name == "beta") }
+        })
+        .await;
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -6,14 +6,15 @@ use common::{
     contract::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip,
         assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
-        assert_metadata_roundtrip, assert_namespace_isolation, assert_stale_resource_version_conflicts,
-        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays, assert_watch_now_semantics,
+        assert_metadata_roundtrip, assert_namespace_isolation, assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
+        assert_stale_resource_version_conflicts, assert_store_diagnostics_report_retained_events_with_backend,
+        assert_watch_from_version_replays, assert_watch_now_semantics,
         assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
     },
     convoy_meta, convoy_spec,
 };
-use flotilla_resources::{Convoy, EventRetention, InMemoryBackend, InputMeta, ResourceBackend};
+use flotilla_resources::{Convoy, EventRetention, InMemoryBackend, ResourceBackend};
 use rstest::rstest;
 
 fn resolver(namespace: &str) -> flotilla_resources::TypedResolver<Convoy> {
@@ -122,23 +123,14 @@ async fn owner_references_roundtrip_through_in_memory_backend(#[case] _fixture: 
     assert_metadata_roundtrip::<ConvoyFixture>().await;
 }
 
+#[rstest]
+#[case(ConvoyFixture)]
 #[tokio::test]
-async fn delete_with_finalizers_marks_object_for_deletion_instead_of_removing_it() {
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    let resolver = backend.clone().using::<Convoy>("default");
-    resolver
-        .create(
-            &InputMeta::builder().name("alpha".to_string()).finalizers(vec!["flotilla.work/test-finalizer".to_string()]).build(),
-            &convoy_spec("template-a"),
-        )
-        .await
-        .expect("create should succeed");
-
-    resolver.delete("alpha").await.expect("delete should succeed");
-
-    let object = resolver.get("alpha").await.expect("object should remain until finalizers are removed");
-    assert_eq!(object.metadata.finalizers, vec!["flotilla.work/test-finalizer".to_string()]);
-    assert!(object.metadata.deletion_timestamp.is_some(), "delete should set deletion timestamp");
+async fn repeated_delete_is_noop_while_finalizers_are_pending(#[case] _fixture: ConvoyFixture) {
+    assert_repeated_delete_with_pending_finalizers_is_noop_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(
+        InMemoryBackend::default(),
+    ))
+    .await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use chrono::Utc;
 use common::{
     contract::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip_with_backend,
@@ -10,12 +11,14 @@ use common::{
         assert_watch_now_semantics_with_backend, assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
     },
-    convoy_meta, convoy_spec, TestLoopHarness,
+    convoy_meta, convoy_spec, convoy_status, pending_task_state, resource_meta, TestLoopHarness,
 };
-use flotilla_controllers::reconcilers::TaskWorkspaceReconciler;
+use flotilla_controllers::reconcilers::VesselReconciler;
 use flotilla_resources::{
-    controller::ControllerLoop, Convoy, EventRetention, InputMeta, ResourceBackend, ResourceError, SqliteBackend, TaskWorkspace,
-    TaskWorkspaceSpec, TerminalSession, TerminalSessionSource, TerminalSessionSpec, WatchEvent, WatchStart, TASK_WORKSPACE_LABEL,
+    controller::{Actuation, ControllerLoop, Reconciler},
+    Convoy, ConvoyPhase, ConvoyReconciler, EventRetention, ResourceBackend, ResourceError, SqliteBackend, TerminalSession,
+    TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec, WatchEvent, WatchStart, WorkPhase, WorkflowTemplate, CONVOY_LABEL,
+    VESSEL_REF_LABEL,
 };
 use futures::StreamExt;
 use rstest::rstest;
@@ -159,62 +162,100 @@ async fn objects_and_resource_versions_survive_restart() {
 }
 
 #[tokio::test]
-async fn pending_task_workspace_converges_after_sqlite_restart_and_repeated_delete() {
+async fn completed_convoy_cleanup_converges_after_sqlite_restart_with_pending_vessel_finalizer() {
     let dir = tempdir().expect("tempdir");
     let path = dir.path().join("resources.sqlite");
     let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should open"));
-    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    let vessels = backend.clone().using::<Vessel>("flotilla");
     let terminals = backend.clone().using::<TerminalSession>("flotilla");
-    workspaces
+
+    let convoy =
+        convoys.create(&convoy_meta("convoy-restart"), &convoy_spec("workflow-restart")).await.expect("convoy create should succeed");
+    let mut completed_status = convoy_status(ConvoyPhase::Completed);
+    completed_status.observed_workflow_ref = Some("workflow-restart".to_string());
+    let mut completed_work = pending_task_state();
+    completed_work.phase = WorkPhase::Complete;
+    completed_work.finished_at = Some(Utc::now());
+    completed_work.message = Some("done".to_string());
+    completed_status.work.insert("implement".to_string(), completed_work);
+    convoys
+        .update_status("convoy-restart", &convoy.metadata.resource_version, &completed_status)
+        .await
+        .expect("convoy completion should be recorded");
+
+    vessels
         .create(
-            &InputMeta::builder()
-                .name("convoy-restart-implement".to_string())
-                .finalizers(vec!["flotilla.work/task-workspace-teardown".to_string()])
-                .build(),
-            &TaskWorkspaceSpec {
-                convoy_ref: "convoy-restart".to_string(),
-                task: "implement".to_string(),
-                placement_policy_ref: "policy-restart".to_string(),
-                adopted_checkout_ref: None,
-            },
+            &resource_meta()
+                .name("convoy-restart-implement")
+                .labels([(CONVOY_LABEL.to_string(), "convoy-restart".to_string())].into_iter().collect())
+                .finalizers(vec!["flotilla.work/vessel-workspace-teardown".to_string()])
+                .call(),
+            &restart_vessel_spec(),
         )
         .await
-        .expect("workspace create should succeed");
+        .expect("vessel create should succeed");
     terminals
         .create(
-            &InputMeta::builder()
-                .name("terminal-convoy-restart-implement-coder".to_string())
-                .labels([(TASK_WORKSPACE_LABEL.to_string(), "convoy-restart-implement".to_string())].into_iter().collect())
-                .build(),
-            &TerminalSessionSpec {
-                env_ref: "host-direct-01HXYZ".to_string(),
-                role: "coder".to_string(),
-                source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
-                cwd: "/workspace".to_string(),
-                pool: "cleat".to_string(),
-            },
+            &resource_meta()
+                .name("terminal-convoy-restart-implement-coder")
+                .labels([(VESSEL_REF_LABEL.to_string(), "convoy-restart-implement".to_string())].into_iter().collect())
+                .call(),
+            &restart_terminal_session_spec(),
         )
         .await
         .expect("terminal child should be created");
-    workspaces.delete("convoy-restart-implement").await.expect("first delete should mark the workspace");
+
+    let convoy_reconciler = ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla")).with_vessels(vessels.clone());
+    let completed_convoy = convoys.get("convoy-restart").await.expect("completed convoy should exist");
+    let initial_dependencies =
+        convoy_reconciler.fetch_dependencies(&completed_convoy).await.expect("initial cleanup dependencies should load");
+    let initial_cleanup = convoy_reconciler.reconcile(&completed_convoy, &initial_dependencies, Utc::now());
+    assert!(initial_cleanup
+        .actuations
+        .iter()
+        .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-restart-implement")));
+
+    vessels.delete("convoy-restart-implement").await.expect("initial convoy cleanup should mark the vessel");
+    assert!(terminals.get("terminal-convoy-restart-implement-coder").await.is_ok(), "delayed finalizer should retain terminal child");
+
+    drop(convoy_reconciler);
     drop(terminals);
-    drop(workspaces);
+    drop(vessels);
+    drop(convoys);
     drop(backend);
 
     let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should reopen"));
-    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    let vessels = backend.clone().using::<Vessel>("flotilla");
     let terminals = backend.clone().using::<TerminalSession>("flotilla");
-    workspaces.delete("convoy-restart-implement").await.expect("restart cleanup should not hard-delete the pending workspace");
-    let pending = workspaces.get("convoy-restart-implement").await.expect("pending workspace should survive the repeated delete");
+    let convoy_reconciler = ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla")).with_vessels(vessels.clone());
+    let restarted_convoy = convoys.get("convoy-restart").await.expect("completed convoy should survive restart");
+    let restart_dependencies =
+        convoy_reconciler.fetch_dependencies(&restarted_convoy).await.expect("restart cleanup dependencies should load");
+    let restart_cleanup = convoy_reconciler.reconcile(&restarted_convoy, &restart_dependencies, Utc::now());
+    assert!(
+        !restart_cleanup
+            .actuations
+            .iter()
+            .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-restart-implement")),
+        "restart cleanup must leave a persisted pending vessel to its finalizer"
+    );
+
+    vessels
+        .delete("convoy-restart-implement")
+        .await
+        .expect("a repeated queued cleanup after restart should not hard-delete the pending vessel");
+    let pending = vessels.get("convoy-restart-implement").await.expect("pending vessel should survive the repeated delete");
     assert!(pending.metadata.deletion_timestamp.is_some());
-    assert_eq!(pending.metadata.finalizers, vec!["flotilla.work/task-workspace-teardown".to_string()]);
+    assert_eq!(pending.metadata.finalizers, vec!["flotilla.work/vessel-workspace-teardown".to_string()]);
 
     let mut harness = TestLoopHarness::new();
     harness.spawn(
         ControllerLoop {
-            primary: workspaces.clone(),
+            primary: vessels.clone(),
             secondaries: Vec::new(),
-            reconciler: TaskWorkspaceReconciler::new(backend.clone(), "flotilla"),
+            reconciler: VesselReconciler::new(backend.clone(), "flotilla"),
             resync_interval: Duration::from_secs(60),
             backend,
         }
@@ -222,15 +263,34 @@ async fn pending_task_workspace_converges_after_sqlite_restart_and_repeated_dele
     );
     harness
         .wait_until(Duration::from_secs(1), || {
-            let workspaces = workspaces.clone();
+            let vessels = vessels.clone();
             let terminals = terminals.clone();
             async move {
-                matches!(workspaces.get("convoy-restart-implement").await, Err(ResourceError::NotFound { .. }))
+                matches!(vessels.get("convoy-restart-implement").await, Err(ResourceError::NotFound { .. }))
                     && matches!(terminals.get("terminal-convoy-restart-implement-coder").await, Err(ResourceError::NotFound { .. }))
             }
         })
         .await;
     harness.shutdown().await;
+}
+
+fn restart_vessel_spec() -> VesselSpec {
+    VesselSpec {
+        convoy_ref: "convoy-restart".to_string(),
+        vessel_name: "implement".to_string(),
+        placement_policy_ref: "policy-restart".to_string(),
+        adopted_checkout_ref: None,
+    }
+}
+
+fn restart_terminal_session_spec() -> TerminalSessionSpec {
+    TerminalSessionSpec {
+        env_ref: "host-direct-01HXYZ".to_string(),
+        role: "coder".to_string(),
+        source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
+        cwd: "/workspace".to_string(),
+        pool: "cleat".to_string(),
+    }
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -5,14 +5,18 @@ use common::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip_with_backend,
         assert_delete_emits_event_with_backend, assert_identical_status_update_is_noop_with_backend,
         assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
-        assert_stale_resource_version_conflicts_with_backend, assert_store_diagnostics_report_retained_events_with_backend,
-        assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend,
-        assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
+        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_stale_resource_version_conflicts_with_backend,
+        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays_with_backend,
+        assert_watch_now_semantics_with_backend, assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
     },
-    convoy_meta, convoy_spec,
+    convoy_meta, convoy_spec, TestLoopHarness,
 };
-use flotilla_resources::{Convoy, EventRetention, ResourceBackend, SqliteBackend, WatchEvent, WatchStart};
+use flotilla_controllers::reconcilers::TaskWorkspaceReconciler;
+use flotilla_resources::{
+    controller::ControllerLoop, Convoy, EventRetention, InputMeta, ResourceBackend, ResourceError, SqliteBackend, TaskWorkspace,
+    TaskWorkspaceSpec, TerminalSession, TerminalSessionSource, TerminalSessionSpec, WatchEvent, WatchStart, TASK_WORKSPACE_LABEL,
+};
 use futures::StreamExt;
 use rstest::rstest;
 use tempfile::tempdir;
@@ -55,6 +59,13 @@ async fn identical_status_update_preserves_resource_version_and_emits_no_event(#
 #[tokio::test]
 async fn delete_emits_deleted_event(#[case] _fixture: ConvoyFixture) {
     assert_delete_emits_event_with_backend::<ConvoyFixture>(backend()).await;
+}
+
+#[rstest]
+#[case(ConvoyFixture)]
+#[tokio::test]
+async fn repeated_delete_is_noop_while_finalizers_are_pending(#[case] _fixture: ConvoyFixture) {
+    assert_repeated_delete_with_pending_finalizers_is_noop_with_backend::<ConvoyFixture>(backend()).await;
 }
 
 #[rstest]
@@ -145,6 +156,81 @@ async fn objects_and_resource_versions_survive_restart() {
         .await
         .expect("update should succeed after restart");
     assert_eq!(updated.metadata.resource_version, "2");
+}
+
+#[tokio::test]
+async fn pending_task_workspace_converges_after_sqlite_restart_and_repeated_delete() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should open"));
+    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let terminals = backend.clone().using::<TerminalSession>("flotilla");
+    workspaces
+        .create(
+            &InputMeta::builder()
+                .name("convoy-restart-implement".to_string())
+                .finalizers(vec!["flotilla.work/task-workspace-teardown".to_string()])
+                .build(),
+            &TaskWorkspaceSpec {
+                convoy_ref: "convoy-restart".to_string(),
+                task: "implement".to_string(),
+                placement_policy_ref: "policy-restart".to_string(),
+                adopted_checkout_ref: None,
+            },
+        )
+        .await
+        .expect("workspace create should succeed");
+    terminals
+        .create(
+            &InputMeta::builder()
+                .name("terminal-convoy-restart-implement-coder".to_string())
+                .labels([(TASK_WORKSPACE_LABEL.to_string(), "convoy-restart-implement".to_string())].into_iter().collect())
+                .build(),
+            &TerminalSessionSpec {
+                env_ref: "host-direct-01HXYZ".to_string(),
+                role: "coder".to_string(),
+                source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
+                cwd: "/workspace".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("terminal child should be created");
+    workspaces.delete("convoy-restart-implement").await.expect("first delete should mark the workspace");
+    drop(terminals);
+    drop(workspaces);
+    drop(backend);
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should reopen"));
+    let workspaces = backend.clone().using::<TaskWorkspace>("flotilla");
+    let terminals = backend.clone().using::<TerminalSession>("flotilla");
+    workspaces.delete("convoy-restart-implement").await.expect("restart cleanup should not hard-delete the pending workspace");
+    let pending = workspaces.get("convoy-restart-implement").await.expect("pending workspace should survive the repeated delete");
+    assert!(pending.metadata.deletion_timestamp.is_some());
+    assert_eq!(pending.metadata.finalizers, vec!["flotilla.work/task-workspace-teardown".to_string()]);
+
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: workspaces.clone(),
+            secondaries: Vec::new(),
+            reconciler: TaskWorkspaceReconciler::new(backend.clone(), "flotilla"),
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+    harness
+        .wait_until(Duration::from_secs(1), || {
+            let workspaces = workspaces.clone();
+            let terminals = terminals.clone();
+            async move {
+                matches!(workspaces.get("convoy-restart-implement").await, Err(ResourceError::NotFound { .. }))
+                    && matches!(terminals.get("terminal-convoy-restart-implement-coder").await, Err(ResourceError::NotFound { .. }))
+            }
+        })
+        .await;
+    harness.shutdown().await;
 }
 
 #[test]


### PR DESCRIPTION
Fixes #665
Fixes #662

## What changed

- Make repeated deletes of finalizer-pending resources a no-op in both in-memory and SQLite stores.
- Avoid scheduling another TaskWorkspace delete while that workspace is already pending finalization.
- Treat `NotFound` as idempotent success at all controller post-`get()` write sites.

## Why

A second cleanup delete could hard-delete a TaskWorkspace after its deletion timestamp was set but before its finalizer ran, stranding child TerminalSessions. Separately, a primary disappearing between a controller read and a write could stop the controller loop.

## Impact

Pending finalizers now retain control of teardown, including across a SQLite-backed restart; controllers continue processing later resources after these expected races.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
