### PR TITLE
aggregator: include project_ref on convoy panel rows

### DIFF
--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -312,6 +312,7 @@ impl Aggregator {
         insert_optional_timestamp(&mut values, "started_at", status.and_then(|status| status.started_at));
         insert_optional_timestamp(&mut values, "finished_at", status.and_then(|status| status.finished_at));
         insert_optional_string(&mut values, "observed_workflow_ref", status.and_then(|status| status.observed_workflow_ref.clone()));
+        insert_optional_string(&mut values, "project_ref", convoy.spec.project_ref.clone());
         if let Some(repo) = convoy.metadata.labels.get(flotilla_resources::REPO_LABEL) {
             values.insert("repo".to_string(), PanelValue::String(repo.clone()));
         }
@@ -439,6 +440,7 @@ mod tests {
             values: BTreeMap::from([
                 ("name".to_string(), PanelValue::String(name.to_string())),
                 ("phase".to_string(), PanelValue::String("active".to_string())),
+                ("project_ref".to_string(), PanelValue::String("my-project".to_string())),
             ]),
             intents: vec![],
             children: vec![],
@@ -474,6 +476,20 @@ mod tests {
 
         let snapshot = state.snapshot().await;
         assert!(snapshot.tab.panels[0].rows.iter().any(|row| row.values.get("name").and_then(PanelValue::as_str) == Some("new")));
+    }
+
+    #[tokio::test]
+    async fn replica_cache_preserves_project_ref() {
+        let state = AggregatorProjectionState::new();
+        let (tx, mut rx) = broadcast::channel(8);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
+
+        aggregator.apply_replica_cache(vec![remote_snapshot("feta", "generation-1", "remote-convoy")]).await;
+        assert!(matches!(rx.recv().await.expect("initial event"), DaemonEvent::PanelSnapshot(_)));
+
+        let snapshot = state.snapshot().await;
+        let row = snapshot.tab.panels[0].rows.first().expect("replica convoy row");
+        assert_eq!(row.values.get("project_ref").and_then(PanelValue::as_str), Some("my-project"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -72,7 +72,9 @@ async fn aggregator_emits_panel_events() {
     // Create a Convoy resource — the Aggregator should pick it up via the watch
     // stream and emit a PanelSnapshot for the default convoy tab.
     let convoys = backend.using::<flotilla_resources::Convoy>("flotilla");
-    convoys.create(&convoy_meta("test-convoy-1"), &convoy_spec("my-workflow")).await.expect("create convoy");
+    let mut spec = convoy_spec("my-workflow");
+    spec.project_ref = Some("my-project".to_string());
+    convoys.create(&convoy_meta("test-convoy-1"), &spec).await.expect("create convoy");
 
     // Wait for the convoy panel snapshot.
     let found = tokio::time::timeout(Duration::from_secs(5), async {
@@ -92,6 +94,7 @@ async fn aggregator_emits_panel_events() {
     let rows = &found.tab.panels[0].rows;
     assert_eq!(rows.len(), 1, "expected exactly one convoy in the snapshot");
     assert_eq!(rows[0].values.get("name").and_then(PanelValue::as_str), Some("test-convoy-1"));
+    assert_eq!(rows[0].values.get("project_ref").and_then(PanelValue::as_str), Some("my-project"));
 }
 
 /// Verifies the causal chain:


### PR DESCRIPTION
## Summary

- include optional `ConvoySpec.project_ref` in aggregated convoy panel row values
- verify local daemon panel events expose the project reference
- verify fleet replica merging preserves the project reference

## Why

The manifest connector needs to construct its project → convoy → vessel GroupPath from `project_ref` when available. Convoy rows previously exposed only the repository fallback, so downstream consumers could not recover the explicit project grouping.

## Impact

Convoy panel consumers can now distinguish explicit project membership while existing convoys without `project_ref` keep their current row shape.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `TMPDIR="$PWD/.codex-tmp" cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #682