### PR TITLE
fix: refresh TUI issue listings

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -586,6 +586,7 @@ fn handle_event(
             }
         }
         DaemonEvent::RepoTracked(_)
+        | DaemonEvent::RepoRefreshCompleted { .. }
         | DaemonEvent::CommandStarted { .. }
         | DaemonEvent::CommandFinished { .. }
         | DaemonEvent::CommandStepUpdate { .. }
@@ -665,6 +666,7 @@ async fn recover_from_gap(
                                 }
                             }
                             DaemonEvent::RepoTracked(_)
+                            | DaemonEvent::RepoRefreshCompleted { .. }
                             | DaemonEvent::RepoUntracked { .. }
                             | DaemonEvent::CommandStarted { .. }
                             | DaemonEvent::CommandFinished { .. }
@@ -766,6 +768,7 @@ impl DaemonHandle for SocketDaemon {
                     DaemonEvent::PanelSnapshot(snap) => (StreamKey::Panel { tab: snap.tab.id.clone() }, snap.seq),
                     DaemonEvent::PanelDelta(delta) => (StreamKey::Panel { tab: delta.tab_id.clone() }, delta.seq),
                     DaemonEvent::RepoTracked(_)
+                    | DaemonEvent::RepoRefreshCompleted { .. }
                     | DaemonEvent::RepoUntracked { .. }
                     | DaemonEvent::CommandStarted { .. }
                     | DaemonEvent::CommandFinished { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1225,6 +1225,21 @@ impl InProcessDaemon {
         .await
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub async fn trigger_root_refresh_for_test(&self, repo_path: &Path) -> Result<(), String> {
+        let identity =
+            self.tracked_repo_identity_for_path(repo_path).await.ok_or_else(|| format!("repo not tracked: {}", repo_path.display()))?;
+        let repos = self.repos.read().await;
+        let state = repos.get(&identity).ok_or_else(|| format!("repo not tracked: {}", repo_path.display()))?;
+        let root = state
+            .roots
+            .iter()
+            .find(|root| root.path == repo_path)
+            .ok_or_else(|| format!("repo root not tracked: {}", repo_path.display()))?;
+        root.model.refresh_handle.trigger_refresh();
+        Ok(())
+    }
+
     /// Returns the current connection status for a peer host.
     pub async fn peer_connection_status(&self, node_id: &NodeId) -> PeerConnectionState {
         self.host_registry.peer_connection_status(node_id).await
@@ -1558,19 +1573,21 @@ impl InProcessDaemon {
                 .iter_mut()
                 .filter_map(|(identity, state)| {
                     let mut any_changed = false;
+                    let mut preferred_changed = false;
                     let mut snapshots = Vec::new();
-                    for root in &mut state.roots {
+                    for (root_index, root) in state.roots.iter_mut().enumerate() {
                         let handle = &mut root.model.refresh_handle;
                         if handle.snapshot_rx.has_changed().unwrap_or(false) {
                             let _ = handle.snapshot_rx.borrow_and_update();
                             any_changed = true;
+                            preferred_changed |= root_index == 0;
                         }
                         snapshots.push(handle.snapshot_rx.borrow().clone());
                     }
                     if !any_changed {
                         return None;
                     }
-                    Some((identity.clone(), snapshots))
+                    Some((identity.clone(), snapshots, preferred_changed))
                 })
                 .collect()
         };
@@ -1585,7 +1602,7 @@ impl InProcessDaemon {
 
         // Correlate and build proto snapshots outside any lock
         let mut updates = Vec::new();
-        for (identity, snapshots) in changed {
+        for (identity, snapshots, preferred_changed) in changed {
             let environment_id = {
                 let repos = self.repos.read().await;
                 repos.get(&identity).and_then(|state| state.preferred_environment_id().cloned())
@@ -1623,11 +1640,11 @@ impl InProcessDaemon {
             let (work_items, correlation_groups) = crate::data::correlate(&providers);
 
             let re_snapshot = RefreshSnapshot { providers, work_items, correlation_groups, errors, provider_health };
-            updates.push((identity, last_local_providers, re_snapshot));
+            updates.push((identity, last_local_providers, re_snapshot, preferred_changed));
         }
 
         let namespace = self.provisioning_namespace().await;
-        for (identity, local_providers, snapshot) in &updates {
+        for (identity, local_providers, snapshot, _) in &updates {
             if snapshot.errors.iter().any(|error| error.category == "checkouts") {
                 warn!(repo = %identity.path, "skipping observed checkout reconciliation after checkout discovery failed");
                 continue;
@@ -1641,7 +1658,7 @@ impl InProcessDaemon {
 
         // Apply updates under write lock and broadcast
         let mut repos = self.repos.write().await;
-        for (identity, last_local_providers, re_snapshot) in updates {
+        for (identity, last_local_providers, re_snapshot, preferred_changed) in updates {
             let Some(state) = repos.get_mut(&identity) else {
                 continue;
             };
@@ -1693,6 +1710,12 @@ impl InProcessDaemon {
 
             let event = choose_event(proto_snapshot, delta_entry);
             let _ = self.event_tx.send(event);
+            if preferred_changed {
+                let _ = self.event_tx.send(DaemonEvent::RepoRefreshCompleted {
+                    repo_identity: state.identity().clone(),
+                    repo: Some(state.preferred_path().to_path_buf()),
+                });
+            }
         }
 
         drop(repos);

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1888,7 +1888,14 @@ async fn trigger_refresh_and_recv(
     rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>,
 ) -> DaemonEvent {
     daemon.refresh(&RepoSelector::Path(repo.to_path_buf())).await.expect("refresh should succeed");
-    recv_event(rx).await
+    loop {
+        let event = recv_event(rx).await;
+        match &event {
+            DaemonEvent::RepoSnapshot(snapshot) if snapshot.repo.as_deref() == Some(repo) => return event,
+            DaemonEvent::RepoDelta(delta) if delta.repo.as_deref() == Some(repo) => return event,
+            _ => {}
+        }
+    }
 }
 
 #[tokio::test]
@@ -1909,6 +1916,14 @@ async fn daemon_broadcasts_snapshots() {
         }
         other => panic!("expected RepoSnapshot or RepoDelta, got {:?}", other),
     }
+
+    assert!(
+        matches!(
+            recv_event(&mut rx).await,
+            DaemonEvent::RepoRefreshCompleted { repo: Some(completed_repo), .. } if completed_repo == repo
+        ),
+        "repo data event should be followed by its refresh completion marker"
+    );
 }
 
 #[tokio::test]
@@ -2988,6 +3003,53 @@ async fn duplicate_local_roots_share_identity_but_remain_tracked() {
     assert_eq!(repos[0].path.as_deref(), Some(repo_b.as_path()), "remaining root should become the preferred path");
     assert!(daemon.tracked_repo_identity_for_path(&repo_a).await.is_none());
     assert_eq!(daemon.tracked_repo_identity_for_path(&repo_b).await, Some(identity_b));
+}
+
+#[tokio::test]
+async fn only_preferred_root_refresh_emits_completion_for_shared_identity() {
+    let (_temp, repo_a, repo_b, daemon) = daemon_for_duplicate_fake_repos().await;
+    let identity = daemon.tracked_repo_identity_for_path(&repo_a).await.expect("shared repo identity");
+    let mut events = daemon.subscribe();
+
+    daemon.trigger_root_refresh_for_test(&repo_a).await.expect("settle preferred root");
+    loop {
+        if matches!(
+            recv_event(&mut events).await,
+            DaemonEvent::RepoRefreshCompleted { repo_identity, .. } if repo_identity == identity
+        ) {
+            break;
+        }
+    }
+    while events.try_recv().is_ok() {}
+
+    daemon.trigger_root_refresh_for_test(&repo_b).await.expect("refresh non-preferred root");
+    loop {
+        match recv_event(&mut events).await {
+            DaemonEvent::RepoSnapshot(snapshot) if snapshot.repo_identity == identity => break,
+            DaemonEvent::RepoDelta(delta) if delta.repo_identity == identity => break,
+            _ => {}
+        }
+    }
+    while let Ok(event) = events.try_recv() {
+        assert!(
+            !matches!(event, DaemonEvent::RepoRefreshCompleted { .. }),
+            "non-preferred root refresh should not emit a logical repo completion: {event:?}"
+        );
+    }
+
+    daemon.trigger_root_refresh_for_test(&repo_a).await.expect("refresh preferred root");
+    loop {
+        match recv_event(&mut events).await {
+            DaemonEvent::RepoSnapshot(snapshot) if snapshot.repo_identity == identity => break,
+            DaemonEvent::RepoDelta(delta) if delta.repo_identity == identity => break,
+            _ => {}
+        }
+    }
+    assert!(matches!(
+        recv_event(&mut events).await,
+        DaemonEvent::RepoRefreshCompleted { repo_identity, repo: Some(path) }
+            if repo_identity == identity && path == repo_a
+    ));
 }
 
 // TODO(task-9): Migrate to fake VCS — this test depends on real git for two reasons:

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -225,6 +225,15 @@ pub enum DaemonEvent {
     /// Incremental delta — sent when only a subset of data changed.
     #[serde(rename = "repo_delta")]
     RepoDelta(Box<RepoDelta>),
+    /// A local provider refresh cycle completed for a repo. This is distinct
+    /// from snapshot/delta publication, which can also be caused by replay or
+    /// peer-overlay changes.
+    #[serde(rename = "repo_refresh_completed")]
+    RepoRefreshCompleted {
+        repo_identity: RepoIdentity,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        repo: Option<std::path::PathBuf>,
+    },
     #[serde(rename = "repo_tracked")]
     RepoTracked(Box<RepoInfo>),
     #[serde(rename = "repo_untracked")]

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -267,6 +267,17 @@ fn error_response_builds_with_error_message() {
 }
 
 #[test]
+fn repo_refresh_completed_event_roundtrip() {
+    let event = DaemonEvent::RepoRefreshCompleted {
+        repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/my-repo".into() },
+        repo: Some(PathBuf::from("/tmp/my-repo")),
+    };
+    let json = serde_json::to_value(&event).expect("serialize");
+    assert_eq!(json["kind"], "repo_refresh_completed");
+    test_helpers::assert_json_roundtrip(&event);
+}
+
+#[test]
 fn daemon_event_command_started_roundtrip() {
     let event = DaemonEvent::CommandStarted {
         command_id: 42,

--- a/crates/flotilla-tui/src/app/issue_view.rs
+++ b/crates/flotilla-tui/src/app/issue_view.rs
@@ -11,6 +11,36 @@ use flotilla_protocol::{
 
 use crate::widgets::section_table::IssueRow;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PendingIssueFetch {
+    Page(u32),
+    PageThenRefresh(u32),
+    RefreshFirstPage,
+    RefreshFirstPageAgain,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IssueRefreshRequest {
+    Started,
+    Deferred,
+    Ignored,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IssueFetchCompletion {
+    Ignored,
+    Applied,
+    AppliedAndRefresh,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IssueFetchFailure {
+    Ignored,
+    Initial,
+    Existing,
+    ExistingAndRefresh,
+}
+
 /// State for a single paginated query — tracks accumulated items and next page.
 pub struct IssuePagingState {
     pub params: IssueQuery,
@@ -18,21 +48,111 @@ pub struct IssuePagingState {
     pub next_page: u32,
     pub total: Option<u32>,
     pub has_more: bool,
-    pub fetch_pending: bool,
+    pub pending_fetch: Option<PendingIssueFetch>,
 }
 
 impl IssuePagingState {
     pub fn new(params: IssueQuery) -> Self {
-        Self { params, items: Vec::new(), next_page: 1, total: None, has_more: true, fetch_pending: false }
+        Self { params, items: Vec::new(), next_page: 1, total: None, has_more: true, pending_fetch: None }
     }
 
-    /// Append a fetched page of results and update pagination metadata.
-    pub fn append_page(&mut self, page: IssueResultPage) {
+    fn append_page(&mut self, page: IssueResultPage) {
         self.total = page.total;
         self.has_more = page.has_more;
-        self.fetch_pending = false;
         self.next_page += 1;
         self.items.extend(page.items);
+    }
+
+    fn replace_first_page(&mut self, page: IssueResultPage) {
+        self.items = page.items;
+        self.total = page.total;
+        self.has_more = page.has_more;
+        self.next_page = 2;
+    }
+
+    pub fn fetch_pending(&self) -> bool {
+        self.pending_fetch.is_some()
+    }
+
+    pub fn begin_page_fetch(&mut self, page: u32) -> bool {
+        if self.fetch_pending() || self.next_page != page {
+            return false;
+        }
+        self.pending_fetch = Some(PendingIssueFetch::Page(page));
+        true
+    }
+
+    pub fn request_refresh(&mut self) -> IssueRefreshRequest {
+        if self.next_page == 1 {
+            return IssueRefreshRequest::Ignored;
+        }
+        match self.pending_fetch {
+            None => {
+                self.pending_fetch = Some(PendingIssueFetch::RefreshFirstPage);
+                IssueRefreshRequest::Started
+            }
+            Some(PendingIssueFetch::Page(page)) => {
+                self.pending_fetch = Some(PendingIssueFetch::PageThenRefresh(page));
+                IssueRefreshRequest::Deferred
+            }
+            Some(PendingIssueFetch::RefreshFirstPage) => {
+                self.pending_fetch = Some(PendingIssueFetch::RefreshFirstPageAgain);
+                IssueRefreshRequest::Deferred
+            }
+            Some(PendingIssueFetch::PageThenRefresh(_) | PendingIssueFetch::RefreshFirstPageAgain) => IssueRefreshRequest::Deferred,
+        }
+    }
+
+    pub fn complete_fetch(&mut self, requested_page: u32, page: IssueResultPage) -> IssueFetchCompletion {
+        match self.pending_fetch {
+            Some(PendingIssueFetch::Page(page_number)) if page_number == requested_page => {
+                self.append_page(page);
+                self.pending_fetch = None;
+                IssueFetchCompletion::Applied
+            }
+            Some(PendingIssueFetch::PageThenRefresh(page_number)) if page_number == requested_page => {
+                self.append_page(page);
+                self.pending_fetch = Some(PendingIssueFetch::RefreshFirstPage);
+                IssueFetchCompletion::AppliedAndRefresh
+            }
+            Some(PendingIssueFetch::RefreshFirstPage) if requested_page == 1 => {
+                self.replace_first_page(page);
+                self.pending_fetch = None;
+                IssueFetchCompletion::Applied
+            }
+            Some(PendingIssueFetch::RefreshFirstPageAgain) if requested_page == 1 => {
+                self.replace_first_page(page);
+                self.pending_fetch = Some(PendingIssueFetch::RefreshFirstPage);
+                IssueFetchCompletion::AppliedAndRefresh
+            }
+            _ => IssueFetchCompletion::Ignored,
+        }
+    }
+
+    pub fn fail_fetch(&mut self, requested_page: u32) -> IssueFetchFailure {
+        match self.pending_fetch {
+            Some(PendingIssueFetch::Page(page_number)) if page_number == requested_page => {
+                self.pending_fetch = None;
+                if requested_page == 1 && self.items.is_empty() {
+                    IssueFetchFailure::Initial
+                } else {
+                    IssueFetchFailure::Existing
+                }
+            }
+            Some(PendingIssueFetch::PageThenRefresh(page_number)) if page_number == requested_page => {
+                self.pending_fetch = Some(PendingIssueFetch::RefreshFirstPage);
+                IssueFetchFailure::ExistingAndRefresh
+            }
+            Some(PendingIssueFetch::RefreshFirstPage) if requested_page == 1 => {
+                self.pending_fetch = None;
+                IssueFetchFailure::Existing
+            }
+            Some(PendingIssueFetch::RefreshFirstPageAgain) if requested_page == 1 => {
+                self.pending_fetch = Some(PendingIssueFetch::RefreshFirstPage);
+                IssueFetchFailure::ExistingAndRefresh
+            }
+            _ => IssueFetchFailure::Ignored,
+        }
     }
 
     /// Convert the paging state's issue items into native `IssueRow` values
@@ -68,6 +188,60 @@ impl IssueViewState {
         } else {
             self.default.as_mut()
         }
+    }
+
+    fn matching_mut(&mut self, params: &IssueQuery) -> Option<&mut IssuePagingState> {
+        if params.search.is_some() {
+            if self.search_query != params.search {
+                return None;
+            }
+            self.search.as_mut()
+        } else {
+            self.default.as_mut()
+        }
+    }
+
+    pub fn begin_page_fetch(&mut self, params: &IssueQuery, page: u32) -> bool {
+        let target = if params.search.is_some() {
+            if self.search_query != params.search {
+                return false;
+            }
+            &mut self.search
+        } else {
+            &mut self.default
+        };
+        if target.is_none() {
+            if page != 1 {
+                return false;
+            }
+            *target = Some(IssuePagingState::new(params.clone()));
+        }
+        let Some(state) = target.as_mut() else { return false };
+        state.params == *params && state.begin_page_fetch(page)
+    }
+
+    pub fn request_refresh(&mut self, params: &IssueQuery) -> IssueRefreshRequest {
+        let Some(state) = self.matching_mut(params) else { return IssueRefreshRequest::Ignored };
+        if state.params != *params {
+            return IssueRefreshRequest::Ignored;
+        }
+        state.request_refresh()
+    }
+
+    pub fn complete_fetch(&mut self, params: &IssueQuery, requested_page: u32, page: IssueResultPage) -> IssueFetchCompletion {
+        let Some(state) = self.matching_mut(params) else { return IssueFetchCompletion::Ignored };
+        if state.params != *params {
+            return IssueFetchCompletion::Ignored;
+        }
+        state.complete_fetch(requested_page, page)
+    }
+
+    pub fn fail_fetch(&mut self, params: &IssueQuery, requested_page: u32) -> IssueFetchFailure {
+        let Some(state) = self.matching_mut(params) else { return IssueFetchFailure::Ignored };
+        if state.params != *params {
+            return IssueFetchFailure::Ignored;
+        }
+        state.fail_fetch(requested_page)
     }
 
     /// Convert the active listing's items into native `IssueRow` values for display.
@@ -116,7 +290,7 @@ mod tests {
             next_page: 2,
             total: Some(1),
             has_more: false,
-            fetch_pending: false,
+            pending_fetch: None,
         });
         let active = state.active().expect("should have active");
         assert_eq!(active.items.len(), 1);
@@ -132,7 +306,7 @@ mod tests {
             next_page: 2,
             total: Some(1),
             has_more: false,
-            fetch_pending: false,
+            pending_fetch: None,
         });
         state.search = Some(IssuePagingState {
             params: IssueQuery { search: Some("search".into()) },
@@ -140,7 +314,7 @@ mod tests {
             next_page: 2,
             total: Some(1),
             has_more: false,
-            fetch_pending: false,
+            pending_fetch: None,
         });
         let active = state.active().expect("should have active");
         assert!(active.params.search.is_some());
@@ -155,17 +329,18 @@ mod tests {
             next_page: 2,
             total: None,
             has_more: true,
-            fetch_pending: true,
+            pending_fetch: Some(PendingIssueFetch::Page(2)),
         };
-        paging.append_page(IssueResultPage {
+        let completion = paging.complete_fetch(2, IssueResultPage {
             items: vec![test_issue("2", "Second"), test_issue("3", "Third")],
             total: Some(10),
             has_more: true,
         });
+        assert_eq!(completion, IssueFetchCompletion::Applied);
         assert_eq!(paging.items.len(), 3);
         assert_eq!(paging.total, Some(10));
         assert!(paging.has_more);
-        assert!(!paging.fetch_pending);
+        assert!(!paging.fetch_pending());
         assert_eq!(paging.next_page, 3);
     }
 
@@ -177,7 +352,7 @@ mod tests {
             next_page: 1,
             total: Some(2),
             has_more: false,
-            fetch_pending: false,
+            pending_fetch: None,
         };
         let rows = paging.to_issue_rows();
         assert_eq!(rows.len(), 2);
@@ -206,7 +381,7 @@ mod tests {
             next_page: 1,
             total: None,
             has_more: false,
-            fetch_pending: false,
+            pending_fetch: None,
         });
         state.search = Some(IssuePagingState {
             params: IssueQuery { search: Some("test".into()) },
@@ -214,7 +389,7 @@ mod tests {
             next_page: 1,
             total: None,
             has_more: true,
-            fetch_pending: false,
+            pending_fetch: None,
         });
         let active = state.active_mut().expect("should have active");
         assert!(active.params.search.is_some());

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -192,7 +192,7 @@ impl App {
         let Some(page) = self.screen.repo_pages.get(&repo_identity) else { return };
         let Some(view) = self.issue_views.get(&repo_identity) else { return };
         let Some(active) = view.active() else { return };
-        if !active.has_more || active.fetch_pending {
+        if !active.has_more || active.fetch_pending() {
             return;
         }
         let issue_count = active.items.len();

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -1739,7 +1739,7 @@ fn set_search_query_resets_search_paging_state() {
         next_page: 2,
         total: Some(10),
         has_more: true,
-        fetch_pending: false,
+        pending_fetch: None,
     });
     app.issue_views.insert(repo.clone(), view);
 
@@ -1757,7 +1757,7 @@ fn set_search_query_resets_search_paging_state() {
 fn stale_search_results_discarded_by_drain() {
     use flotilla_protocol::issue_query::{IssueQuery, IssueResultPage};
 
-    use crate::app::issue_view::{IssuePagingState, IssueQueryUpdate, IssueViewState};
+    use crate::app::issue_view::{IssuePagingState, IssueQueryUpdate, IssueViewState, PendingIssueFetch};
 
     let mut app = stub_app();
     let repo = app.model.repo_order[0].clone();
@@ -1771,7 +1771,7 @@ fn stale_search_results_discarded_by_drain() {
         next_page: 1,
         total: None,
         has_more: true,
-        fetch_pending: true,
+        pending_fetch: Some(PendingIssueFetch::Page(1)),
     });
     app.issue_views.insert(repo.clone(), view);
 

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -783,76 +783,50 @@ impl App {
     }
 
     pub(crate) fn drain_background_updates(&mut self) {
-        use issue_view::IssueQueryUpdate;
+        use issue_view::{IssueFetchCompletion, IssueFetchFailure, IssueQueryUpdate};
 
         while let Ok(update) = self.issue_update_rx.try_recv() {
             match update {
                 IssueQueryUpdate::PageFetched { repo, params, requested_page, page } => {
                     let Some(view) = self.issue_views.get_mut(&repo) else { continue };
-                    let target = if params.search.is_some() {
-                        // Discard results from a stale search — the user may
-                        // have started a new search or cleared while this was
-                        // in flight.
-                        if view.search_query != params.search {
-                            continue;
+                    match view.complete_fetch(&params, requested_page, page) {
+                        IssueFetchCompletion::Ignored => continue,
+                        IssueFetchCompletion::Applied => {}
+                        IssueFetchCompletion::AppliedAndRefresh => {
+                            self.spawn_query_page(repo.clone(), params, 1, 50);
                         }
-                        view.search.as_mut()
-                    } else {
-                        view.default.as_mut()
-                    };
-                    let Some(state) = target else { continue };
-                    if state.params != params || state.next_page != requested_page || !state.fetch_pending {
-                        continue;
                     }
-                    state.append_page(page);
                     self.push_issue_items_to_repo_data(&repo);
                 }
                 IssueQueryUpdate::QueryFailed { repo, params, requested_page, message } => {
                     tracing::warn!(%message, requested_page, is_search = params.search.is_some(), "issue query failed");
-                    let mut restore_default_rows = false;
-                    let mut remove_default_state = false;
-                    let mut clear_search_ui = false;
-                    if let Some(view) = self.issue_views.get_mut(&repo) {
-                        let target = if params.search.is_some() {
-                            if view.search_query != params.search {
-                                continue;
-                            }
-                            view.search.as_mut()
-                        } else {
-                            view.default.as_mut()
-                        };
-                        let Some(state) = target else { continue };
-                        if state.params != params || state.next_page != requested_page || !state.fetch_pending {
-                            continue;
-                        }
-                        if requested_page == 1 && state.items.is_empty() {
-                            if params.search.is_some() {
-                                view.search = None;
-                                view.search_query = None;
-                                restore_default_rows = true;
-                                clear_search_ui = true;
-                            } else {
-                                remove_default_state = true;
-                            }
-                        } else {
-                            state.fetch_pending = false;
-                        }
-                    } else {
+                    let Some(view) = self.issue_views.get_mut(&repo) else { continue };
+                    let failure = view.fail_fetch(&params, requested_page);
+                    if failure == IssueFetchFailure::Ignored {
                         continue;
                     }
+
+                    let initial_failure = failure == IssueFetchFailure::Initial;
+                    let refresh_after_failure = failure == IssueFetchFailure::ExistingAndRefresh;
                     self.set_status_message(Some(message));
-                    if remove_default_state {
+
+                    if initial_failure && params.search.is_some() {
+                        if let Some(view) = self.issue_views.get_mut(&repo) {
+                            view.search = None;
+                            view.search_query = None;
+                        }
+                        if let Some(page) = self.screen.repo_pages.get_mut(&repo) {
+                            page.active_search_query = None;
+                        }
+                        self.push_issue_items_to_repo_data(&repo);
+                    } else if initial_failure {
                         if let Some(view) = self.issue_views.get_mut(&repo) {
                             view.default = None;
                         }
                     }
-                    if clear_search_ui {
-                        if let Some(page) = self.screen.repo_pages.get_mut(&repo) {
-                            page.active_search_query = None;
-                        }
-                    }
-                    if restore_default_rows {
-                        self.push_issue_items_to_repo_data(&repo);
+
+                    if refresh_after_failure {
+                        self.spawn_query_page(repo, params, 1, 50);
                     }
                 }
             }
@@ -861,28 +835,12 @@ impl App {
 
     fn begin_issue_page_fetch(&mut self, repo: &RepoIdentity, params: &flotilla_protocol::issue_query::IssueQuery, page: u32) -> bool {
         let view = self.issue_views.entry(repo.clone()).or_default();
-        let target = if params.search.is_some() {
-            if view.search_query != params.search {
-                return false;
-            }
-            &mut view.search
-        } else {
-            &mut view.default
-        };
+        view.begin_page_fetch(params, page)
+    }
 
-        if target.is_none() {
-            if page != 1 {
-                return false;
-            }
-            *target = Some(issue_view::IssuePagingState::new(params.clone()));
-        }
-
-        let Some(state) = target.as_mut() else { return false };
-        if state.params != *params || state.fetch_pending || state.next_page != page {
-            return false;
-        }
-        state.fetch_pending = true;
-        true
+    fn begin_issue_refresh(&mut self, repo: &RepoIdentity, params: &flotilla_protocol::issue_query::IssueQuery) -> bool {
+        let Some(view) = self.issue_views.get_mut(repo) else { return false };
+        view.request_refresh(params) == issue_view::IssueRefreshRequest::Started
     }
 
     /// Spawn a background task to query one page of issue results.
@@ -947,6 +905,33 @@ impl App {
             return;
         }
         self.spawn_query_page(repo_identity.clone(), params, 1, 50);
+    }
+
+    /// Refresh settled issue listings while preserving their current rows until
+    /// replacement page-one results arrive. An initial fetch already in flight
+    /// is left alone.
+    fn refresh_issue_views(&mut self, repo_identity: &RepoIdentity) {
+        if self.model.repos.get(repo_identity).is_some_and(|r| r.path.starts_with("<remote>")) {
+            return;
+        }
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+
+        self.maybe_fetch_default_issues(repo_identity);
+        let params: Vec<_> = self
+            .issue_views
+            .get(repo_identity)
+            .into_iter()
+            .flat_map(|view| [view.default.as_ref(), view.search.as_ref()])
+            .flatten()
+            .map(|state| state.params.clone())
+            .collect();
+        for params in params {
+            if self.begin_issue_refresh(repo_identity, &params) {
+                self.spawn_query_page(repo_identity.clone(), params, 1, 50);
+            }
+        }
     }
 
     /// Push issue rows from `IssueViewState` into the `Shared<RepoData>` for
@@ -1198,6 +1183,7 @@ impl App {
         match event {
             DaemonEvent::RepoSnapshot(snap) => self.apply_snapshot(*snap),
             DaemonEvent::RepoDelta(delta) => self.apply_delta(*delta),
+            DaemonEvent::RepoRefreshCompleted { repo_identity, .. } => self.refresh_issue_views(&repo_identity),
             DaemonEvent::RepoTracked(info) => self.handle_repo_added(*info),
             DaemonEvent::RepoUntracked { repo_identity, .. } => self.handle_repo_removed(&repo_identity),
             DaemonEvent::CommandStarted { command_id, node_id, repo_identity, repo, description, .. } => {
@@ -1411,7 +1397,6 @@ impl App {
         // Log and display errors (clears status when errors resolve)
         self.set_status_message(format_error_status(&snap.errors, &path));
 
-        // On first snapshot for a repo, fetch default issues.
         self.maybe_fetch_default_issues(&repo_identity);
     }
 

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -14,12 +14,12 @@ use flotilla_core::{
 use flotilla_protocol::{
     provider_data::Issue,
     qualified_path::{HostId, QualifiedPath},
-    Change, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostSummary, ImageId, NodeId, NodeInfo, ProvisioningTarget, RepoSelector,
-    WorkItemIdentity,
+    Change, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostSummary, ImageId, NodeId, NodeInfo, ProvisioningTarget, RepoIdentity,
+    RepoSelector, WorkItemIdentity,
 };
 use tempfile::tempdir;
 use test_support::*;
-use tokio::sync::{Mutex as TokioMutex, Notify};
+use tokio::sync::{watch, Mutex as TokioMutex, Semaphore};
 
 use super::*;
 
@@ -64,33 +64,33 @@ fn insert_peer_host(model: &mut TuiModel, name: &str, status: PeerStatus) {
 #[derive(Clone)]
 struct QueryStep {
     expected_page: u32,
-    gate: Option<Arc<Notify>>,
+    gate: Option<Arc<Semaphore>>,
     result: IssueResultPage,
 }
 
 struct ScriptedIssueQueryService {
     steps: TokioMutex<VecDeque<QueryStep>>,
-    requests: TokioMutex<Vec<u32>>,
+    requests: watch::Sender<Vec<u32>>,
 }
 
 impl ScriptedIssueQueryService {
     fn new(steps: Vec<QueryStep>) -> Self {
-        Self { steps: TokioMutex::new(steps.into()), requests: TokioMutex::new(Vec::new()) }
+        Self { steps: TokioMutex::new(steps.into()), requests: watch::channel(Vec::new()).0 }
     }
 
-    async fn requests(&self) -> Vec<u32> {
-        self.requests.lock().await.clone()
+    fn requests(&self) -> Vec<u32> {
+        self.requests.borrow().clone()
     }
 }
 
 #[async_trait]
 impl IssueQueryService for ScriptedIssueQueryService {
     async fn query(&self, _repo: &Path, _params: &IssueQuery, page: u32, _count: usize) -> Result<IssueResultPage, String> {
-        self.requests.lock().await.push(page);
+        self.requests.send_modify(|requests| requests.push(page));
         let step = self.steps.lock().await.pop_front().expect("unexpected issue query");
         assert_eq!(step.expected_page, page, "unexpected page requested");
         if let Some(gate) = step.gate {
-            gate.notified().await;
+            gate.acquire().await.expect("query gate should remain open").forget();
         }
         Ok(step.result)
     }
@@ -139,6 +139,50 @@ async fn app_with_issue_query_service(service: Arc<dyn IssueQueryService>) -> (t
     let repos = daemon_handle.list_repos().await.expect("list repos");
     let app = App::new(daemon_handle, repos, Arc::new(ConfigStore::with_base(temp.path().join("tui-config"))), Theme::classic());
     (temp, repo, daemon, app)
+}
+
+async fn drain_until_requests(app: &mut App, service: &ScriptedIssueQueryService, expected: &[u32]) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            app.drain_background_updates();
+            let requests = service.requests();
+            assert!(expected.starts_with(&requests), "unexpected issue query sequence: {requests:?}");
+            if requests == expected {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for issue queries");
+}
+
+async fn drain_until_first_issue(app: &mut App, repo: &RepoIdentity, expected_id: &str) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            app.drain_background_updates();
+            if app.repo_data[repo].read().issue_rows.first().is_some_and(|row| row.id == expected_id) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for issue rows");
+}
+
+async fn drain_until_issue_count(app: &mut App, repo: &RepoIdentity, expected_count: usize) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            app.drain_background_updates();
+            if app.issue_views.get(repo).and_then(|view| view.default.as_ref()).is_some_and(|state| state.items.len() == expected_count) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for issue count");
 }
 
 // -- CommandQueue --
@@ -291,7 +335,7 @@ fn apply_snapshot_updates_provider_data() {
 
 #[tokio::test]
 async fn repeated_snapshots_do_not_queue_duplicate_initial_issue_pages() {
-    let page_one_gate = Arc::new(Notify::new());
+    let page_one_gate = Arc::new(Semaphore::new(0));
     let service = Arc::new(ScriptedIssueQueryService::new(vec![
         QueryStep { expected_page: 1, gate: Some(Arc::clone(&page_one_gate)), result: issue_page(1..=50, true) },
         QueryStep { expected_page: 1, gate: Some(Arc::clone(&page_one_gate)), result: issue_page(1..=50, true) },
@@ -300,16 +344,105 @@ async fn repeated_snapshots_do_not_queue_duplicate_initial_issue_pages() {
 
     let snapshot = daemon.get_state(&RepoSelector::Path(repo.clone())).await.expect("repo snapshot");
     app.handle_daemon_event(DaemonEvent::RepoSnapshot(Box::new(snapshot.clone())));
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    drain_until_requests(&mut app, &service, &[1]).await;
 
     app.handle_daemon_event(DaemonEvent::RepoSnapshot(Box::new(snapshot)));
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    assert_eq!(service.requests(), vec![1], "initial issue fetch should stay in-flight instead of queueing a duplicate page 1");
 
-    assert_eq!(service.requests().await, vec![1], "initial issue fetch should stay in-flight instead of queueing a duplicate page 1");
+    page_one_gate.add_permits(1);
+    let repo_identity = app.model.active_repo_identity().clone();
+    drain_until_first_issue(&mut app, &repo_identity, "1").await;
+}
 
-    page_one_gate.notify_waiters();
-    tokio::time::sleep(Duration::from_millis(10)).await;
-    app.drain_background_updates();
+#[tokio::test]
+async fn manual_refresh_replaces_default_issue_page_when_fresh_results_arrive() {
+    let refreshed_page_gate = Arc::new(Semaphore::new(0));
+    let service = Arc::new(ScriptedIssueQueryService::new(vec![
+        QueryStep { expected_page: 1, gate: None, result: issue_page(1..=1, false) },
+        QueryStep { expected_page: 1, gate: Some(Arc::clone(&refreshed_page_gate)), result: issue_page(2..=2, false) },
+    ]));
+    let (_temp, repo, daemon, mut app) = app_with_issue_query_service(service.clone()).await;
+
+    let snapshot = daemon.get_state(&RepoSelector::Path(repo.clone())).await.expect("repo snapshot");
+    app.handle_daemon_event(DaemonEvent::RepoSnapshot(Box::new(snapshot)));
+
+    let repo_identity = app.model.active_repo_identity().clone();
+    drain_until_first_issue(&mut app, &repo_identity, "1").await;
+
+    let mut daemon_events = daemon.subscribe();
+    app.handle_key(key(KeyCode::Char('r')));
+    let (command, pending_ctx) = app.proto_commands.take_next().expect("refresh command");
+    executor::dispatch(command, &mut app, pending_ctx).await;
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let event = daemon_events.recv().await.expect("daemon event");
+            let refresh_completed = matches!(event, DaemonEvent::RepoRefreshCompleted { .. });
+            app.handle_daemon_event(event);
+            if refresh_completed {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("refreshed repo data");
+    drain_until_requests(&mut app, &service, &[1, 1]).await;
+
+    assert_eq!(service.requests(), vec![1, 1], "manual refresh should refetch the first issue page");
+    assert_eq!(app.repo_data[&repo_identity].read().issue_rows[0].id, "1", "old issue rows should remain visible while refreshing");
+
+    refreshed_page_gate.add_permits(1);
+    drain_until_first_issue(&mut app, &repo_identity, "2").await;
+}
+
+#[tokio::test]
+async fn periodic_refresh_completion_replaces_default_issue_page() {
+    let service = Arc::new(ScriptedIssueQueryService::new(vec![
+        QueryStep { expected_page: 1, gate: None, result: issue_page(1..=1, false) },
+        QueryStep { expected_page: 1, gate: None, result: issue_page(2..=2, false) },
+    ]));
+    let (_temp, repo, daemon, mut app) = app_with_issue_query_service(service.clone()).await;
+
+    let snapshot = daemon.get_state(&RepoSelector::Path(repo.clone())).await.expect("repo snapshot");
+    app.handle_daemon_event(DaemonEvent::RepoSnapshot(Box::new(snapshot)));
+
+    let repo_identity = app.model.active_repo_identity().clone();
+    drain_until_first_issue(&mut app, &repo_identity, "1").await;
+    app.handle_daemon_event(DaemonEvent::RepoRefreshCompleted { repo_identity: repo_identity.clone(), repo: Some(repo) });
+    drain_until_first_issue(&mut app, &repo_identity, "2").await;
+
+    assert_eq!(service.requests(), vec![1, 1]);
+}
+
+#[tokio::test]
+async fn refresh_during_issue_pagination_runs_after_the_page_completes() {
+    let page_two_gate = Arc::new(Semaphore::new(0));
+    let service = Arc::new(ScriptedIssueQueryService::new(vec![
+        QueryStep { expected_page: 1, gate: None, result: issue_page(1..=50, true) },
+        QueryStep { expected_page: 2, gate: Some(Arc::clone(&page_two_gate)), result: issue_page(51..=60, false) },
+        QueryStep { expected_page: 1, gate: None, result: issue_page(101..=101, false) },
+    ]));
+    let (_temp, repo, daemon, mut app) = app_with_issue_query_service(service.clone()).await;
+
+    let snapshot = daemon.get_state(&RepoSelector::Path(repo.clone())).await.expect("repo snapshot");
+    app.handle_daemon_event(DaemonEvent::RepoSnapshot(Box::new(snapshot)));
+
+    let repo_identity = app.model.active_repo_identity().clone();
+    drain_until_issue_count(&mut app, &repo_identity, 50).await;
+    let page = app.screen.repo_pages.get_mut(&repo_identity).expect("repo page");
+    page.reconcile_if_changed();
+    page.table.select_flat_index(44);
+    app.handle_key(key(KeyCode::Char('j')));
+    drain_until_requests(&mut app, &service, &[1, 2]).await;
+
+    app.handle_daemon_event(DaemonEvent::RepoRefreshCompleted { repo_identity: repo_identity.clone(), repo: Some(repo) });
+    assert_eq!(service.requests(), vec![1, 2], "refresh should wait for the in-flight page");
+
+    page_two_gate.add_permits(1);
+    drain_until_requests(&mut app, &service, &[1, 2, 1]).await;
+    drain_until_first_issue(&mut app, &repo_identity, "101").await;
+
+    assert_eq!(service.requests(), vec![1, 2, 1], "deferred refresh should run after pagination");
 }
 
 #[tokio::test]
@@ -322,22 +455,21 @@ async fn infinite_scroll_appends_the_next_issue_page_without_duplicates() {
 
     let snapshot = daemon.get_state(&RepoSelector::Path(repo)).await.expect("repo snapshot");
     app.handle_daemon_event(DaemonEvent::RepoSnapshot(Box::new(snapshot)));
-    tokio::time::sleep(Duration::from_millis(10)).await;
-    app.drain_background_updates();
 
     let repo_identity = app.model.active_repo_identity().clone();
+    drain_until_issue_count(&mut app, &repo_identity, 50).await;
     let page = app.screen.repo_pages.get_mut(&repo_identity).expect("repo page");
     page.reconcile_if_changed();
     page.table.select_flat_index(44);
 
     app.handle_key(key(KeyCode::Char('j')));
-    tokio::time::sleep(Duration::from_millis(10)).await;
-    app.drain_background_updates();
+    drain_until_requests(&mut app, &service, &[1, 2]).await;
+    drain_until_issue_count(&mut app, &repo_identity, 60).await;
 
     let default = app.issue_views.get(&repo_identity).and_then(|view| view.default.as_ref()).expect("default issue view");
     let ids: Vec<&str> = default.items.iter().map(|(id, _)| id.as_str()).collect();
     let unique_ids: std::collections::HashSet<&str> = ids.iter().copied().collect();
-    assert_eq!(service.requests().await, vec![1, 2], "scrolling near the bottom should request exactly one next page");
+    assert_eq!(service.requests(), vec![1, 2], "scrolling near the bottom should request exactly one next page");
     assert_eq!(ids.len(), 60, "the first two pages should be appended together");
     assert_eq!(unique_ids.len(), 60, "issue paging should not duplicate items");
     assert_eq!(ids.first().copied(), Some("1"));
@@ -362,7 +494,7 @@ fn first_page_search_failure_clears_active_search_state() {
         next_page: 1,
         total: None,
         has_more: true,
-        fetch_pending: true,
+        pending_fetch: Some(issue_view::PendingIssueFetch::Page(1)),
     });
 
     app.issue_update_tx

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -411,6 +411,9 @@ pub(crate) fn format_event_human(event: &flotilla_protocol::DaemonEvent) -> Stri
                 delta.changes.len()
             )
         }
+        DaemonEvent::RepoRefreshCompleted { repo_identity, repo } => {
+            format!("[refresh]  {}: completed", repo_label(repo.as_deref(), repo_identity))
+        }
         DaemonEvent::RepoTracked(info) => {
             format!("[repo]     {}: tracked", info.name)
         }
@@ -481,6 +484,7 @@ fn event_stream_seq(event: &DaemonEvent) -> Option<(StreamKey, u64)> {
         DaemonEvent::PanelSnapshot(snapshot) => Some((StreamKey::Panel { tab: snapshot.tab.id.clone() }, snapshot.seq)),
         DaemonEvent::PanelDelta(delta) => Some((StreamKey::Panel { tab: delta.tab_id.clone() }, delta.seq)),
         DaemonEvent::RepoTracked(_)
+        | DaemonEvent::RepoRefreshCompleted { .. }
         | DaemonEvent::RepoUntracked { .. }
         | DaemonEvent::CommandStarted { .. }
         | DaemonEvent::CommandFinished { .. }

--- a/crates/flotilla-tui/tests/support/high_fidelity.rs
+++ b/crates/flotilla-tui/tests/support/high_fidelity.rs
@@ -319,6 +319,9 @@ impl HighFidelityHarness {
             DaemonEvent::PeerStatusChanged { node_id, status } => format!("peer_status node_id={node_id} status={status:?}"),
             DaemonEvent::RepoSnapshot(snap) => format!("repo_snapshot repo={} seq={}", fmt_optional_path(snap.repo.as_deref()), snap.seq),
             DaemonEvent::RepoDelta(delta) => format!("repo_delta repo={} seq={}", fmt_optional_path(delta.repo.as_deref()), delta.seq),
+            DaemonEvent::RepoRefreshCompleted { repo, .. } => {
+                format!("repo_refresh_completed repo={}", fmt_optional_path(repo.as_deref()))
+            }
             DaemonEvent::RepoTracked(info) => format!("repo_tracked {}", fmt_optional_path(info.path.as_deref())),
             DaemonEvent::RepoUntracked { path, .. } => format!("repo_untracked {}", fmt_optional_path(path.as_deref())),
             DaemonEvent::HostRemoved { environment_id, .. } => format!("host_removed {environment_id}"),
@@ -434,6 +437,9 @@ fn record_recent_event(recent: &mut Vec<String>, source: &str, event: &DaemonEve
         }
         DaemonEvent::RepoDelta(delta) => {
             format!("{source}: repo_delta repo={} seq={}", fmt_optional_path(delta.repo.as_deref()), delta.seq)
+        }
+        DaemonEvent::RepoRefreshCompleted { repo, .. } => {
+            format!("{source}: repo_refresh_completed repo={}", fmt_optional_path(repo.as_deref()))
         }
         DaemonEvent::RepoTracked(info) => format!("{source}: repo_tracked {}", fmt_optional_path(info.path.as_deref())),
         DaemonEvent::RepoUntracked { path, .. } => format!("{source}: repo_untracked {}", fmt_optional_path(path.as_deref())),


### PR DESCRIPTION
## Summary

- emit a precise repo-refresh completion event after the preferred local root finishes refreshing
- re-query settled default and active-search issue listings when that event arrives
- preserve visible issue rows during refresh and defer refreshes behind in-flight pagination
- avoid duplicate refresh queries for logical repos with multiple tracked roots

## Root cause

Issue listings became stateless queries, but the TUI retained fetch-once paging state. Repo refreshes updated snapshot-backed provider data without requesting fresh issue query results, leaving the Issues section stale.

## User impact

Pressing `r` and periodic provider refreshes now update issue listings without blanking the current rows. Refreshes that race with infinite scrolling are queued and applied afterward.

Closes #690.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- independent standards and issue-spec reviews
