### PR TITLE
aggregator: add free-floating sessions query

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -8,7 +8,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use flotilla_protocol::{
-    result_set::{ConvoyRow, QueryId, ResultSet, Rows},
+    result_set::{ConvoyRow, QueryId, ResultSet, Rows, SessionRow},
     HostName, ResourceRef,
 };
 use tokio::sync::{RwLock, RwLockWriteGuard};
@@ -26,6 +26,16 @@ impl QueryRow for ConvoyRow {
 
     fn into_rows(rows: Vec<Self>) -> Rows {
         Rows::Convoys(rows)
+    }
+}
+
+impl QueryRow for SessionRow {
+    fn resource(&self) -> &ResourceRef {
+        &self.resource
+    }
+
+    fn into_rows(rows: Vec<Self>) -> Rows {
+        Rows::Sessions(rows)
     }
 }
 
@@ -66,9 +76,40 @@ impl<R: QueryRow> QueryProjection<R> {
     }
 }
 
+impl<R: QueryRow + PartialEq> QueryProjection<R> {
+    /// Replace every replica host's contribution after a fleet refresh and
+    /// return the changed and removed rows when the result set advanced.
+    pub fn replace_replica_rows(&mut self, replacements: HashMap<HostName, HashMap<ResourceRef, R>>) -> Option<(Vec<R>, Vec<ResourceRef>)> {
+        let previous = std::mem::take(&mut self.replica_rows);
+        let changed = replacements
+            .iter()
+            .flat_map(|(host, rows)| {
+                let prior = previous.get(host);
+                rows.iter()
+                    .filter(move |(reference, row)| prior.and_then(|prior| prior.get(*reference)) != Some(*row))
+                    .map(|(_, row)| row.clone())
+            })
+            .collect::<Vec<_>>();
+        let removed = previous
+            .iter()
+            .flat_map(|(host, rows)| {
+                let replacement = replacements.get(host);
+                rows.keys().filter(move |reference| replacement.is_none_or(|replacement| !replacement.contains_key(*reference))).cloned()
+            })
+            .collect::<Vec<_>>();
+        self.replica_rows = replacements;
+        if changed.is_empty() && removed.is_empty() {
+            return None;
+        }
+        self.seq = self.seq.saturating_add(1);
+        Some((changed, removed))
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct AggregatorProjectionState {
     convoys: Arc<RwLock<QueryProjection<ConvoyRow>>>,
+    sessions: Arc<RwLock<QueryProjection<SessionRow>>>,
 }
 
 impl AggregatorProjectionState {
@@ -92,6 +133,22 @@ impl AggregatorProjectionState {
         self.convoys.read().await.local_result_set()
     }
 
+    pub async fn write_sessions(&self) -> RwLockWriteGuard<'_, QueryProjection<SessionRow>> {
+        self.sessions.write().await
+    }
+
+    pub async fn sessions_result_set(&self) -> ResultSet {
+        self.sessions.read().await.result_set()
+    }
+
+    pub async fn sessions_seq(&self) -> u64 {
+        self.sessions.read().await.seq
+    }
+
+    pub async fn local_sessions_result_set(&self) -> ResultSet {
+        self.sessions.read().await.local_result_set()
+    }
+
     /// This host's local result sets across all named queries, in the order
     /// of [`QueryId::ALL`].
     pub async fn local_result_sets(&self) -> Vec<ResultSet> {
@@ -99,6 +156,7 @@ impl AggregatorProjectionState {
         for query in QueryId::ALL {
             result_sets.push(match query {
                 QueryId::Convoys => self.local_result_set().await,
+                QueryId::Sessions => self.local_sessions_result_set().await,
             });
         }
         result_sets
@@ -108,6 +166,7 @@ impl AggregatorProjectionState {
     pub async fn result_set_for(&self, query: QueryId) -> ResultSet {
         match query {
             QueryId::Convoys => self.result_set().await,
+            QueryId::Sessions => self.sessions_result_set().await,
         }
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -304,7 +304,7 @@ fn append_crewless_convoy_rows(
 ) {
     let mut convoys_with_crew: HashSet<String> = rows.iter().map(|row| row.convoy.clone()).collect();
     for result_set in result_sets {
-        let Rows::Convoys(convoys) = &result_set.rows;
+        let Rows::Convoys(convoys) = &result_set.rows else { continue };
         for row in convoys {
             if row.resource.namespace != target_namespace {
                 continue;

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2666,12 +2666,24 @@ impl InProcessDaemon {
         }
 
         let namespace = self.provisioning_namespace().await;
-        let terminal_sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace);
-        let sessions = terminal_sessions.list().await.map_err(|err| err.to_string())?.items;
+        let durable_sessions =
+            self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace).list().await.map_err(|err| err.to_string())?.items;
+        let observed_sessions = self
+            .observed_resource_backend
+            .clone()
+            .using::<ResourceTerminalSession>(&namespace)
+            .list()
+            .await
+            .map_err(|err| err.to_string())?
+            .items;
+        let mut sessions_by_name = HashMap::new();
+        for session in durable_sessions.into_iter().chain(observed_sessions) {
+            sessions_by_name.insert(session.metadata.name.clone(), session);
+        }
         let mut exact = Vec::new();
         let mut prefix = Vec::new();
 
-        for session in sessions {
+        for session in sessions_by_name.into_values() {
             if session.status.as_ref().map(|status| status.phase) != Some(ResourceTerminalSessionPhase::Running) {
                 continue;
             }

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1,16 +1,16 @@
 //! Resource-store and fleet-replica Aggregator maintaining named-query result sets.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use flotilla_core::aggregator_projection::AggregatorProjectionState;
 use flotilla_protocol::{
-    result_set::{ConvoyPhase, ConvoyRow, CrewMemberSummary, QueryId, ResultDelta, Rows, VesselRow, WorkPhase},
+    result_set::{ConvoyPhase, ConvoyRow, CrewMemberSummary, QueryId, ResultDelta, Rows, SessionPhase, SessionRow, VesselRow, WorkPhase},
     DaemonEvent, FleetReplicaSnapshot, HostName, ResourceRef,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Presentation, Resource, ResourceError, ResourceList,
-    ResourceObject, TypedResolver, VesselRequirement, WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL,
-    VESSEL_LABEL,
+    api_version, terminal_session_attach_target, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Presentation,
+    Resource, ResourceError, ResourceList, ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement,
+    WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_LABEL, VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::broadcast;
@@ -18,28 +18,43 @@ use tokio::sync::broadcast;
 type PresentationKey = (String, String, String);
 
 #[derive(bon::Builder)]
+pub struct AggregatorResolvers {
+    durable_convoys: TypedResolver<Convoy>,
+    durable_presentations: TypedResolver<Presentation>,
+    durable_sessions: TypedResolver<TerminalSession>,
+    observed_convoys: TypedResolver<Convoy>,
+    observed_presentations: TypedResolver<Presentation>,
+    observed_sessions: TypedResolver<TerminalSession>,
+}
+
+#[derive(bon::Builder)]
 pub struct Aggregator {
     state: AggregatorProjectionState,
     local_host: HostName,
     presentation_workspaces: HashMap<PresentationKey, String>,
     bootstrapping: bool,
-    emitted_initial_snapshot: bool,
+    emitted_queries: HashSet<QueryId>,
     event_tx: broadcast::Sender<DaemonEvent>,
 }
 
 impl Aggregator {
     pub fn new(state: AggregatorProjectionState, local_host: HostName, event_tx: broadcast::Sender<DaemonEvent>) -> Self {
-        Self { state, local_host, presentation_workspaces: HashMap::new(), bootstrapping: false, emitted_initial_snapshot: false, event_tx }
+        Self { state, local_host, presentation_workspaces: HashMap::new(), bootstrapping: false, emitted_queries: HashSet::new(), event_tx }
     }
 
     pub async fn run(
         mut self,
-        durable_convoys: TypedResolver<Convoy>,
-        durable_presentations: TypedResolver<Presentation>,
-        observed_convoys: TypedResolver<Convoy>,
-        observed_presentations: TypedResolver<Presentation>,
+        resolvers: AggregatorResolvers,
         mut replica_rx: broadcast::Receiver<Vec<FleetReplicaSnapshot>>,
     ) -> Result<(), ResourceError> {
+        let AggregatorResolvers {
+            durable_convoys,
+            durable_presentations,
+            durable_sessions,
+            observed_convoys,
+            observed_presentations,
+            observed_sessions,
+        } = resolvers;
         self.bootstrapping = true;
         {
             let mut view = self.state.write().await;
@@ -48,13 +63,23 @@ impl Aggregator {
                 view.seq = view.seq.saturating_add(1);
             }
         }
+        {
+            let mut view = self.state.write_sessions().await;
+            if !view.local_rows.is_empty() {
+                view.local_rows.clear();
+                view.seq = view.seq.saturating_add(1);
+            }
+        }
         let mut durable_convoy_stream = self.list_and_watch_convoys(durable_convoys).await?;
         let mut durable_presentation_stream = self.list_and_watch_presentations(durable_presentations).await?;
+        let mut durable_session_stream = self.list_and_watch_sessions(durable_sessions).await?;
         let mut observed_convoy_stream = self.list_and_watch_convoys(observed_convoys).await?;
         let mut observed_presentation_stream = self.list_and_watch_presentations(observed_presentations).await?;
+        let mut observed_session_stream = self.list_and_watch_sessions(observed_sessions).await?;
         self.bootstrapping = false;
-        self.emitted_initial_snapshot = true;
+        self.emitted_queries.extend(QueryId::ALL.iter().copied());
         let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.result_set().await)));
+        let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.sessions_result_set().await)));
 
         loop {
             tokio::select! {
@@ -68,6 +93,11 @@ impl Aggregator {
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator durable presentation watch ended")),
                 },
+                event = durable_session_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_session_event(event).await,
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator durable terminal session watch ended")),
+                },
                 event = observed_convoy_stream.next() => match event {
                     Some(Ok(event)) => self.apply_convoy_event(event).await,
                     Some(Err(err)) => return Err(err),
@@ -77,6 +107,11 @@ impl Aggregator {
                     Some(Ok(event)) => self.apply_presentation_event(event).await,
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator observed presentation watch ended")),
+                },
+                event = observed_session_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_session_event(event).await,
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator observed terminal session watch ended")),
                 },
                 replica = replica_rx.recv() => match replica {
                     Ok(snapshots) => self.apply_replica_cache(snapshots).await,
@@ -111,6 +146,18 @@ impl Aggregator {
         let start = watch_start(&listed);
         for presentation in listed.items {
             self.apply_presentation_event(WatchEvent::Added(presentation)).await;
+        }
+        resolver.watch(start).await
+    }
+
+    async fn list_and_watch_sessions(
+        &mut self,
+        resolver: TypedResolver<TerminalSession>,
+    ) -> Result<flotilla_resources::WatchStream<TerminalSession>, ResourceError> {
+        let listed = resolver.list().await?;
+        let start = watch_start(&listed);
+        for session in listed.items {
+            self.apply_session_event(WatchEvent::Added(session)).await;
         }
         resolver.watch(start).await
     }
@@ -183,10 +230,10 @@ impl Aggregator {
                 if self.bootstrapping {
                     return;
                 }
-                if self.emitted_initial_snapshot {
+                if self.emitted_queries.contains(&QueryId::Convoys) {
                     self.emit_delta(vec![row], Vec::new()).await;
                 } else {
-                    self.emitted_initial_snapshot = true;
+                    self.emitted_queries.insert(QueryId::Convoys);
                     let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
                 }
             }
@@ -205,56 +252,100 @@ impl Aggregator {
         }
     }
 
-    pub async fn apply_replica_cache(&mut self, snapshots: Vec<FleetReplicaSnapshot>) {
-        let mut replacements = HashMap::new();
-        for snapshot in snapshots {
-            let host = snapshot.host;
-            let mut rows = HashMap::new();
-            if let Some(Rows::Convoys(convoys)) =
-                snapshot.result_sets.into_iter().find(|result_set| result_set.query() == QueryId::Convoys).map(|result_set| result_set.rows)
-            {
-                for mut row in convoys {
-                    set_row_host(&mut row, &host);
-                    rows.insert(row.resource.clone(), row);
+    pub async fn apply_session_event(&mut self, event: WatchEvent<TerminalSession>) {
+        match event {
+            WatchEvent::Added(session) | WatchEvent::Modified(session) => {
+                if let Some(row) = self.summarize_session(&session) {
+                    let reference = row.resource.clone();
+                    let result_set = {
+                        let mut view = self.state.write_sessions().await;
+                        view.local_rows.insert(reference, row.clone());
+                        view.seq = view.seq.saturating_add(1);
+                        view.result_set()
+                    };
+                    if self.bootstrapping {
+                        return;
+                    }
+                    if self.emitted_queries.contains(&QueryId::Sessions) {
+                        self.emit_session_delta(vec![row], Vec::new()).await;
+                    } else {
+                        self.emitted_queries.insert(QueryId::Sessions);
+                        let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
+                    }
+                } else {
+                    self.remove_local_session(&session).await;
                 }
             }
-            replacements.insert(host, rows);
+            WatchEvent::Deleted(session) => self.remove_local_session(&session).await,
         }
+    }
 
-        let (changed, removed, full_result_set) = {
-            let mut view = self.state.write().await;
-            let previous = std::mem::take(&mut view.replica_rows);
-            let changed = replacements
-                .iter()
-                .flat_map(|(host, rows)| {
-                    let prior = previous.get(host);
-                    rows.iter()
-                        .filter(move |(reference, row)| prior.and_then(|prior| prior.get(*reference)) != Some(*row))
-                        .map(|(_, row)| row.clone())
-                })
-                .collect::<Vec<_>>();
-            let removed = previous
-                .iter()
-                .flat_map(|(host, rows)| {
-                    let replacement = replacements.get(host);
-                    rows.keys()
-                        .filter(move |reference| replacement.is_none_or(|replacement| !replacement.contains_key(*reference)))
-                        .cloned()
-                })
-                .collect::<Vec<_>>();
-            view.replica_rows = replacements;
-            if changed.is_empty() && removed.is_empty() {
+    async fn remove_local_session(&self, session: &ResourceObject<TerminalSession>) {
+        let reference = self.session_ref(&session.metadata.namespace, &session.metadata.name);
+        let removed = {
+            let mut view = self.state.write_sessions().await;
+            if view.local_rows.remove(&reference).is_none() {
                 return;
             }
             view.seq = view.seq.saturating_add(1);
-            (changed, removed, view.result_set())
+            reference
         };
+        if !self.bootstrapping {
+            self.emit_session_delta(Vec::new(), vec![removed]).await;
+        }
+    }
 
-        if self.emitted_initial_snapshot {
-            self.emit_delta(changed, removed).await;
-        } else {
-            self.emitted_initial_snapshot = true;
-            let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(full_result_set)));
+    pub async fn apply_replica_cache(&mut self, snapshots: Vec<FleetReplicaSnapshot>) {
+        let mut convoy_replacements = HashMap::new();
+        let mut session_replacements = HashMap::new();
+        for snapshot in snapshots {
+            let host = snapshot.host;
+            let mut convoy_rows = HashMap::new();
+            let mut session_rows = HashMap::new();
+            for result_set in snapshot.result_sets {
+                match result_set.rows {
+                    Rows::Convoys(convoys) => {
+                        for mut row in convoys {
+                            set_convoy_row_host(&mut row, &host);
+                            convoy_rows.insert(row.resource.clone(), row);
+                        }
+                    }
+                    Rows::Sessions(sessions) => {
+                        for mut row in sessions {
+                            set_session_row_host(&mut row, &host);
+                            session_rows.insert(row.resource.clone(), row);
+                        }
+                    }
+                }
+            }
+            convoy_replacements.insert(host.clone(), convoy_rows);
+            session_replacements.insert(host, session_rows);
+        }
+
+        let convoy_change = {
+            let mut view = self.state.write().await;
+            view.replace_replica_rows(convoy_replacements)
+        };
+        if let Some((changed, removed)) = convoy_change {
+            if self.emitted_queries.contains(&QueryId::Convoys) {
+                self.emit_delta(changed, removed).await;
+            } else {
+                self.emitted_queries.insert(QueryId::Convoys);
+                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.result_set().await)));
+            }
+        }
+
+        let session_change = {
+            let mut view = self.state.write_sessions().await;
+            view.replace_replica_rows(session_replacements)
+        };
+        if let Some((changed, removed)) = session_change {
+            if self.emitted_queries.contains(&QueryId::Sessions) {
+                self.emit_session_delta(changed, removed).await;
+            } else {
+                self.emitted_queries.insert(QueryId::Sessions);
+                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.sessions_result_set().await)));
+            }
         }
     }
 
@@ -263,8 +354,39 @@ impl Aggregator {
         let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changed: Rows::Convoys(changed), removed })));
     }
 
+    async fn emit_session_delta(&self, changed: Vec<SessionRow>, removed: Vec<ResourceRef>) {
+        let seq = self.state.sessions_seq().await;
+        let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changed: Rows::Sessions(changed), removed })));
+    }
+
     fn convoy_ref(&self, namespace: &str, name: &str) -> ResourceRef {
         ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
+    }
+
+    fn session_ref(&self, namespace: &str, name: &str) -> ResourceRef {
+        ResourceRef::new(api_version(TerminalSession::API_PATHS), TerminalSession::API_PATHS.kind, namespace, name)
+            .on_host(self.local_host.clone())
+    }
+
+    fn summarize_session(&self, session: &ResourceObject<TerminalSession>) -> Option<SessionRow> {
+        if session.metadata.labels.contains_key(CONVOY_LABEL) {
+            return None;
+        }
+        let status = session.status.as_ref()?;
+        if status.phase != TerminalSessionPhase::Running {
+            return None;
+        }
+        let name = &session.metadata.name;
+        Some(
+            SessionRow::builder()
+                .resource(self.session_ref(&session.metadata.namespace, name))
+                .name(name)
+                .maybe_repo(session.metadata.labels.get(REPO_LABEL).map(|repo| flotilla_protocol::RepoKey(repo.clone())))
+                .host(self.local_host.clone())
+                .maybe_attach(terminal_session_attach_target(session).is_ok().then(|| name.clone()))
+                .phase(SessionPhase::Running)
+                .build(),
+        )
     }
 
     fn vessel_attach(&self, namespace: &str, convoy: &str, vessel: &str) -> Option<String> {
@@ -342,12 +464,17 @@ fn watch_start<T: Resource>(listed: &ResourceList<T>) -> WatchStart {
     }
 }
 
-fn set_row_host(row: &mut ConvoyRow, host: &HostName) {
+fn set_convoy_row_host(row: &mut ConvoyRow, host: &HostName) {
     row.resource.host = Some(host.clone());
     for vessel in &mut row.vessels {
         vessel.resource.host = Some(host.clone());
         vessel.host = host.clone();
     }
+}
+
+fn set_session_row_host(row: &mut SessionRow, host: &HostName) {
+    row.resource.host = Some(host.clone());
+    row.host = host.clone();
 }
 
 fn convoy_phase(phase: ResourceConvoyPhase) -> ConvoyPhase {
@@ -405,6 +532,24 @@ mod tests {
         }
     }
 
+    fn remote_session_snapshot(host: &str, generation: &str, name: &str) -> FleetReplicaSnapshot {
+        let host = HostName::new(host);
+        let session = ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", name);
+        let row = SessionRow::builder()
+            .resource(session)
+            .name(name)
+            .host(HostName::new("incorrect-source-host"))
+            .attach(name)
+            .phase(SessionPhase::Running)
+            .build();
+        FleetReplicaSnapshot {
+            host,
+            generation: Some(generation.to_string()),
+            rows: Vec::new(),
+            result_sets: vec![ResultSet { seq: 1, rows: Rows::Sessions(vec![row]) }],
+        }
+    }
+
     fn convoy_names(rows: &Rows) -> Vec<&str> {
         rows.as_convoys().expect("convoy rows").iter().map(|row| row.name.as_str()).collect()
     }
@@ -441,6 +586,23 @@ mod tests {
         let rows = result_set.rows.as_convoys().expect("convoy rows");
         let row = rows.first().expect("replica convoy row");
         assert_eq!(row.project_ref.as_deref(), Some("my-project"));
+    }
+
+    #[tokio::test]
+    async fn replica_cache_unions_sessions_and_stamps_origin_host() {
+        let state = AggregatorProjectionState::new();
+        let (tx, mut rx) = broadcast::channel(8);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
+
+        aggregator.apply_replica_cache(vec![remote_session_snapshot("feta", "generation-1", "terminal-yeoman")]).await;
+        let event = rx.recv().await.expect("sessions replica event");
+        assert!(matches!(event, DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Sessions));
+
+        let result_set = state.sessions_result_set().await;
+        let rows = result_set.rows.as_sessions().expect("session rows");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].resource.host, Some(HostName::new("feta")));
+        assert_eq!(rows[0].host, HostName::new("feta"));
     }
 
     #[tokio::test]
@@ -481,10 +643,14 @@ mod tests {
 
         let result = Aggregator::new(state.clone(), HostName::new("local"), event_tx)
             .run(
-                durable.clone().using::<Convoy>("flotilla"),
-                durable.using::<Presentation>("flotilla"),
-                observed.clone().using::<Convoy>("flotilla"),
-                observed.using::<Presentation>("flotilla"),
+                AggregatorResolvers::builder()
+                    .durable_convoys(durable.clone().using::<Convoy>("flotilla"))
+                    .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
+                    .durable_sessions(durable.using::<TerminalSession>("flotilla"))
+                    .observed_convoys(observed.clone().using::<Convoy>("flotilla"))
+                    .observed_presentations(observed.clone().using::<Presentation>("flotilla"))
+                    .observed_sessions(observed.using::<TerminalSession>("flotilla"))
+                    .build(),
                 replica_rx,
             )
             .await;

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -11,18 +11,20 @@ use flotilla_protocol::{
     DaemonEvent, FleetReplicaSnapshot, HostName, ResourceRef,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Presentation, Resource, ResourceError, ResourceList,
-    ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WatchEvent, WatchStart,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Environment, Presentation, Resource, ResourceError,
+    ResourceList, ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WatchEvent, WatchStart,
     WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_LABEL, VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::broadcast;
 
 type PresentationKey = (String, String, String);
+type SessionKey = (String, String);
 
 #[derive(bon::Builder)]
 pub struct AggregatorResolvers {
     durable_convoys: TypedResolver<Convoy>,
+    durable_environments: TypedResolver<Environment>,
     durable_presentations: TypedResolver<Presentation>,
     durable_sessions: TypedResolver<TerminalSession>,
     observed_convoys: TypedResolver<Convoy>,
@@ -35,6 +37,7 @@ pub struct Aggregator {
     state: AggregatorProjectionState,
     local_host: HostName,
     presentation_workspaces: HashMap<PresentationKey, String>,
+    terminal_sessions: HashMap<SessionKey, ResourceObject<TerminalSession>>,
     bootstrapping: bool,
     emitted_queries: HashSet<QueryId>,
     attach_resolver: Option<Arc<InProcessDaemon>>,
@@ -47,6 +50,7 @@ impl Aggregator {
             state,
             local_host,
             presentation_workspaces: HashMap::new(),
+            terminal_sessions: HashMap::new(),
             bootstrapping: false,
             emitted_queries: HashSet::new(),
             attach_resolver: None,
@@ -66,6 +70,7 @@ impl Aggregator {
     ) -> Result<(), ResourceError> {
         let AggregatorResolvers {
             durable_convoys,
+            durable_environments,
             durable_presentations,
             durable_sessions,
             observed_convoys,
@@ -88,6 +93,7 @@ impl Aggregator {
             }
         }
         let mut durable_convoy_stream = self.list_and_watch_convoys(durable_convoys).await?;
+        let mut durable_environment_stream = self.list_and_watch_environments(durable_environments).await?;
         let mut durable_presentation_stream = self.list_and_watch_presentations(durable_presentations).await?;
         let mut durable_session_stream = self.list_and_watch_sessions(durable_sessions).await?;
         let mut observed_convoy_stream = self.list_and_watch_convoys(observed_convoys).await?;
@@ -104,6 +110,11 @@ impl Aggregator {
                     Some(Ok(event)) => self.apply_convoy_event(event).await,
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator durable convoy watch ended")),
+                },
+                event = durable_environment_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_environment_event(event).await,
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator durable environment watch ended")),
                 },
                 event = durable_presentation_stream.next() => match event {
                     Some(Ok(event)) => self.apply_presentation_event(event).await,
@@ -165,6 +176,14 @@ impl Aggregator {
             self.apply_presentation_event(WatchEvent::Added(presentation)).await;
         }
         resolver.watch(start).await
+    }
+
+    async fn list_and_watch_environments(
+        &self,
+        resolver: TypedResolver<Environment>,
+    ) -> Result<flotilla_resources::WatchStream<Environment>, ResourceError> {
+        let listed = resolver.list().await?;
+        resolver.watch(watch_start(&listed)).await
     }
 
     async fn list_and_watch_sessions(
@@ -272,6 +291,7 @@ impl Aggregator {
     pub async fn apply_session_event(&mut self, event: WatchEvent<TerminalSession>) {
         match event {
             WatchEvent::Added(session) | WatchEvent::Modified(session) => {
+                self.terminal_sessions.insert((session.metadata.namespace.clone(), session.metadata.name.clone()), session.clone());
                 if let Some(row) = self.summarize_session(&session).await {
                     let reference = row.resource.clone();
                     let result_set = {
@@ -293,7 +313,27 @@ impl Aggregator {
                     self.remove_local_session(&session).await;
                 }
             }
-            WatchEvent::Deleted(session) => self.remove_local_session(&session).await,
+            WatchEvent::Deleted(session) => {
+                self.terminal_sessions.remove(&(session.metadata.namespace.clone(), session.metadata.name.clone()));
+                self.remove_local_session(&session).await;
+            }
+        }
+    }
+
+    async fn apply_environment_event(&mut self, event: WatchEvent<Environment>) {
+        let environment = match event {
+            WatchEvent::Added(environment) | WatchEvent::Modified(environment) | WatchEvent::Deleted(environment) => environment,
+        };
+        let namespace = &environment.metadata.namespace;
+        let name = &environment.metadata.name;
+        let affected = self
+            .terminal_sessions
+            .iter()
+            .filter(|((session_namespace, _), session)| session_namespace == namespace && session.spec.env_ref == *name)
+            .map(|(_, session)| session.clone())
+            .collect::<Vec<_>>();
+        for session in affected {
+            self.apply_session_event(WatchEvent::Modified(session)).await;
         }
     }
 
@@ -666,6 +706,7 @@ mod tests {
             .run(
                 AggregatorResolvers::builder()
                     .durable_convoys(durable.clone().using::<Convoy>("flotilla"))
+                    .durable_environments(durable.clone().using::<Environment>("flotilla"))
                     .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
                     .durable_sessions(durable.using::<TerminalSession>("flotilla"))
                     .observed_convoys(observed.clone().using::<Convoy>("flotilla"))

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1,16 +1,19 @@
 //! Resource-store and fleet-replica Aggregator maintaining named-query result sets.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
-use flotilla_core::aggregator_projection::AggregatorProjectionState;
+use flotilla_core::{aggregator_projection::AggregatorProjectionState, in_process::InProcessDaemon};
 use flotilla_protocol::{
     result_set::{ConvoyPhase, ConvoyRow, CrewMemberSummary, QueryId, ResultDelta, Rows, SessionPhase, SessionRow, VesselRow, WorkPhase},
     DaemonEvent, FleetReplicaSnapshot, HostName, ResourceRef,
 };
 use flotilla_resources::{
-    api_version, terminal_session_attach_target, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Presentation,
-    Resource, ResourceError, ResourceList, ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement,
-    WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_LABEL, VESSEL_LABEL,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Presentation, Resource, ResourceError, ResourceList,
+    ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WatchEvent, WatchStart,
+    WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_LABEL, VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::broadcast;
@@ -34,12 +37,26 @@ pub struct Aggregator {
     presentation_workspaces: HashMap<PresentationKey, String>,
     bootstrapping: bool,
     emitted_queries: HashSet<QueryId>,
+    attach_resolver: Option<Arc<InProcessDaemon>>,
     event_tx: broadcast::Sender<DaemonEvent>,
 }
 
 impl Aggregator {
     pub fn new(state: AggregatorProjectionState, local_host: HostName, event_tx: broadcast::Sender<DaemonEvent>) -> Self {
-        Self { state, local_host, presentation_workspaces: HashMap::new(), bootstrapping: false, emitted_queries: HashSet::new(), event_tx }
+        Self {
+            state,
+            local_host,
+            presentation_workspaces: HashMap::new(),
+            bootstrapping: false,
+            emitted_queries: HashSet::new(),
+            attach_resolver: None,
+            event_tx,
+        }
+    }
+
+    pub fn with_attach_resolver(mut self, daemon: Arc<InProcessDaemon>) -> Self {
+        self.attach_resolver = Some(daemon);
+        self
     }
 
     pub async fn run(
@@ -255,7 +272,7 @@ impl Aggregator {
     pub async fn apply_session_event(&mut self, event: WatchEvent<TerminalSession>) {
         match event {
             WatchEvent::Added(session) | WatchEvent::Modified(session) => {
-                if let Some(row) = self.summarize_session(&session) {
+                if let Some(row) = self.summarize_session(&session).await {
                     let reference = row.resource.clone();
                     let result_set = {
                         let mut view = self.state.write_sessions().await;
@@ -368,7 +385,7 @@ impl Aggregator {
             .on_host(self.local_host.clone())
     }
 
-    fn summarize_session(&self, session: &ResourceObject<TerminalSession>) -> Option<SessionRow> {
+    async fn summarize_session(&self, session: &ResourceObject<TerminalSession>) -> Option<SessionRow> {
         if session.metadata.labels.contains_key(CONVOY_LABEL) {
             return None;
         }
@@ -377,13 +394,17 @@ impl Aggregator {
             return None;
         }
         let name = &session.metadata.name;
+        let attach = match &self.attach_resolver {
+            Some(daemon) if daemon.resolve_attach_command_internal(name).await.is_ok() => Some(name.clone()),
+            _ => None,
+        };
         Some(
             SessionRow::builder()
                 .resource(self.session_ref(&session.metadata.namespace, name))
                 .name(name)
                 .maybe_repo(session.metadata.labels.get(REPO_LABEL).map(|repo| flotilla_protocol::RepoKey(repo.clone())))
                 .host(self.local_host.clone())
-                .maybe_attach(terminal_session_attach_target(session).is_ok().then(|| name.clone()))
+                .maybe_attach(attach)
                 .phase(SessionPhase::Running)
                 .build(),
         )

--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -1,5 +1,5 @@
 mod aggregator;
-pub use aggregator::Aggregator;
+pub use aggregator::{Aggregator, AggregatorResolvers};
 
 pub mod cli;
 pub mod peer;

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -757,6 +757,7 @@ fn spawn_aggregator_task(
                     .run(
                         AggregatorResolvers::builder()
                             .durable_convoys(durable.clone().using::<Convoy>(&namespace))
+                            .durable_environments(durable.clone().using::<Environment>(&namespace))
                             .durable_presentations(durable.using::<Presentation>(&namespace))
                             .durable_sessions(durable.using::<flotilla_resources::TerminalSession>(&namespace))
                             .observed_convoys(observed.clone().using::<Convoy>(&namespace))

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -750,7 +750,8 @@ fn spawn_aggregator_task(
             let namespace = namespace.clone();
             let state = state.clone();
             async move {
-                let mut aggregator = Aggregator::new(state, daemon.host_name().clone(), daemon.event_sender());
+                let mut aggregator =
+                    Aggregator::new(state, daemon.host_name().clone(), daemon.event_sender()).with_attach_resolver(Arc::clone(&daemon));
                 aggregator.apply_replica_cache(daemon.cached_fleet_replica_snapshots().await).await;
                 aggregator
                     .run(

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -41,7 +41,7 @@ use tracing::warn;
 
 use crate::{
     supervisor::{supervise, ControllerSupervision},
-    Aggregator,
+    Aggregator, AggregatorResolvers,
 };
 
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
@@ -754,10 +754,14 @@ fn spawn_aggregator_task(
                 aggregator.apply_replica_cache(daemon.cached_fleet_replica_snapshots().await).await;
                 aggregator
                     .run(
-                        durable.clone().using::<Convoy>(&namespace),
-                        durable.using::<Presentation>(&namespace),
-                        observed.clone().using::<Convoy>(&namespace),
-                        observed.using::<Presentation>(&namespace),
+                        AggregatorResolvers::builder()
+                            .durable_convoys(durable.clone().using::<Convoy>(&namespace))
+                            .durable_presentations(durable.using::<Presentation>(&namespace))
+                            .durable_sessions(durable.using::<flotilla_resources::TerminalSession>(&namespace))
+                            .observed_convoys(observed.clone().using::<Convoy>(&namespace))
+                            .observed_presentations(observed.using::<Presentation>(&namespace))
+                            .observed_sessions(observed.using::<flotilla_resources::TerminalSession>(&namespace))
+                            .build(),
                         daemon.subscribe_fleet_replicas(),
                     )
                     .await

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -6,7 +6,10 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use flotilla_core::{
-    config::ConfigStore, daemon::DaemonHandle, in_process::InProcessDaemon, providers::discovery::test_support::fake_discovery,
+    config::ConfigStore,
+    daemon::DaemonHandle,
+    in_process::InProcessDaemon,
+    providers::discovery::test_support::{fake_discovery, fake_discovery_with_provider_set, FakeDiscoveryProviders, FakeTerminalPool},
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{
@@ -14,8 +17,8 @@ use flotilla_protocol::{
     DaemonEvent, HostName, QueryCursor,
 };
 use flotilla_resources::{
-    ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend, TerminalSession, TerminalSessionPhase, TerminalSessionSource,
-    TerminalSessionSpec, TerminalSessionStatus, CONVOY_LABEL, REPO_LABEL,
+    ConvoySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ResourceBackend, TerminalSession,
+    TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, CONVOY_LABEL, REPO_LABEL,
 };
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -119,13 +122,23 @@ async fn running_convoyless_session_emits_attachable_session_row() {
     let daemon = InProcessDaemon::new_with_resource_backend(
         vec![],
         Arc::clone(&config),
-        fake_discovery(false),
+        fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(Arc::new(FakeTerminalPool::new()))),
         HostName::new("local"),
         backend.clone(),
     )
     .await;
     let mut rx = daemon.subscribe();
-    let sessions = backend.using::<TerminalSession>("flotilla");
+    let host_id = daemon.local_host_id().expect("local host id");
+    let environment_name = format!("host-direct-{host_id}");
+    backend
+        .using::<Environment>("flotilla")
+        .create(&InputMeta::builder().name(environment_name.clone()).build(), &EnvironmentSpec {
+            host_direct: Some(HostDirectEnvironmentSpec { host_ref: host_id.to_string(), repo_default_dir: "/tmp".to_string() }),
+            docker: None,
+        })
+        .await
+        .expect("create attach environment");
+    let sessions = daemon.observed_resource_backend().using::<TerminalSession>("flotilla");
     let convoy_session = sessions
         .create(
             &InputMeta::builder()
@@ -137,7 +150,7 @@ async fn running_convoyless_session_emits_attachable_session_row() {
                 role: "coder".to_string(),
                 source: TerminalSessionSource::Tool { command: "bash".to_string() },
                 cwd: "/repo".to_string(),
-                pool: "cleat".to_string(),
+                pool: "fake-terminals".to_string(),
             },
         )
         .await
@@ -150,6 +163,24 @@ async fn running_convoyless_session_emits_attachable_session_row() {
         })
         .await
         .expect("mark convoy terminal session running");
+    let unresolvable = sessions
+        .create(&InputMeta::builder().name("terminal-unresolvable".to_string()).build(), &TerminalSessionSpec {
+            env_ref: "missing-environment".to_string(),
+            role: "observer".to_string(),
+            source: TerminalSessionSource::Tool { command: "bash".to_string() },
+            cwd: "/repo".to_string(),
+            pool: "fake".to_string(),
+        })
+        .await
+        .expect("create unresolvable terminal session");
+    sessions
+        .update_status(&unresolvable.metadata.name, &unresolvable.metadata.resource_version, &TerminalSessionStatus {
+            phase: TerminalSessionPhase::Running,
+            session_id: Some("cleat-unresolvable".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("mark unresolvable terminal session running");
     let options = RuntimeOptions {
         namespace: "flotilla".to_string(),
         heartbeat_interval: Duration::from_secs(300),
@@ -166,11 +197,11 @@ async fn running_convoyless_session_emits_attachable_session_row() {
                 .labels(BTreeMap::from([(REPO_LABEL.to_string(), "flotilla-org/flotilla".to_string())]))
                 .build(),
             &TerminalSessionSpec {
-                env_ref: "host-direct-local".to_string(),
+                env_ref: environment_name,
                 role: "yeoman".to_string(),
                 source: TerminalSessionSource::Tool { command: "bash".to_string() },
                 cwd: "/repo".to_string(),
-                pool: "cleat".to_string(),
+                pool: "fake-terminals".to_string(),
             },
         )
         .await
@@ -207,12 +238,14 @@ async fn running_convoyless_session_emits_attachable_session_row() {
     .await
     .expect("timed out waiting for sessions result rows");
 
-    assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].name, "terminal-yeoman");
-    assert_eq!(rows[0].repo.as_ref().map(|repo| repo.0.as_str()), Some("flotilla-org/flotilla"));
-    assert_eq!(rows[0].host, HostName::new("local"));
-    assert_eq!(rows[0].attach.as_deref(), Some("terminal-yeoman"));
-    assert_eq!(rows[0].phase, flotilla_protocol::SessionPhase::Running);
+    let row = rows.iter().find(|row| row.name == "terminal-yeoman").expect("attachable session row");
+    assert_eq!(row.repo.as_ref().map(|repo| repo.0.as_str()), Some("flotilla-org/flotilla"));
+    assert_eq!(row.host, HostName::new("local"));
+    assert_eq!(row.attach.as_deref(), Some("terminal-yeoman"));
+    assert_eq!(row.phase, flotilla_protocol::SessionPhase::Running);
+    let unresolvable = rows.iter().find(|row| row.name == "terminal-unresolvable").expect("unresolvable session row");
+    assert_eq!(unresolvable.attach, None);
+    assert!(daemon.resolve_attach_command_internal("terminal-yeoman").await.is_ok());
 
     let replay =
         daemon.subscribe_queries(&[QueryCursor { query: QueryId::Sessions, since: None }]).await.expect("subscribe to sessions query");
@@ -223,8 +256,9 @@ async fn running_convoyless_session_emits_attachable_session_row() {
             _ => None,
         })
         .expect("sessions replay result set");
-    assert_eq!(replayed.len(), 1);
-    assert_eq!(replayed[0].name, "terminal-yeoman");
+    assert_eq!(replayed.len(), 2);
+    let unresolvable = replayed.iter().find(|row| row.name == "terminal-unresolvable").expect("unresolvable session row");
+    assert_eq!(unresolvable.attach, None);
 
     let replica = daemon.fleet_replica_snapshot_internal().await.expect("fleet replica snapshot");
     let local_sessions = replica
@@ -233,7 +267,7 @@ async fn running_convoyless_session_emits_attachable_session_row() {
         .find(|result_set| result_set.query() == QueryId::Sessions)
         .map(session_rows)
         .expect("local sessions result set");
-    assert_eq!(local_sessions.len(), 1);
+    assert_eq!(local_sessions.len(), 2);
 
     let running = sessions.get("terminal-yeoman").await.expect("running terminal session");
     sessions

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -130,12 +130,13 @@ async fn running_convoyless_session_emits_attachable_session_row() {
     let mut rx = daemon.subscribe();
     let host_id = daemon.local_host_id().expect("local host id");
     let environment_name = format!("host-direct-{host_id}");
-    backend
-        .using::<Environment>("flotilla")
-        .create(&InputMeta::builder().name(environment_name.clone()).build(), &EnvironmentSpec {
-            host_direct: Some(HostDirectEnvironmentSpec { host_ref: host_id.to_string(), repo_default_dir: "/tmp".to_string() }),
-            docker: None,
-        })
+    let environment_spec = EnvironmentSpec {
+        host_direct: Some(HostDirectEnvironmentSpec { host_ref: host_id.to_string(), repo_default_dir: "/tmp".to_string() }),
+        docker: None,
+    };
+    let environments = backend.using::<Environment>("flotilla");
+    environments
+        .create(&InputMeta::builder().name(environment_name.clone()).build(), &environment_spec)
         .await
         .expect("create attach environment");
     let sessions = daemon.observed_resource_backend().using::<TerminalSession>("flotilla");
@@ -197,7 +198,7 @@ async fn running_convoyless_session_emits_attachable_session_row() {
                 .labels(BTreeMap::from([(REPO_LABEL.to_string(), "flotilla-org/flotilla".to_string())]))
                 .build(),
             &TerminalSessionSpec {
-                env_ref: environment_name,
+                env_ref: environment_name.clone(),
                 role: "yeoman".to_string(),
                 source: TerminalSessionSource::Tool { command: "bash".to_string() },
                 cwd: "/repo".to_string(),
@@ -268,6 +269,57 @@ async fn running_convoyless_session_emits_attachable_session_row() {
         .map(session_rows)
         .expect("local sessions result set");
     assert_eq!(local_sessions.len(), 2);
+
+    environments.delete(&environment_name).await.expect("delete attach environment");
+    let unavailable = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions => {
+                    if let Some(row) = delta
+                        .changed
+                        .as_sessions()
+                        .expect("session rows")
+                        .iter()
+                        .find(|row| row.name == "terminal-yeoman" && row.attach.is_none())
+                    {
+                        return row.clone();
+                    }
+                }
+                Ok(_) => continue,
+                Err(err) => panic!("broadcast receive error: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for attach capability removal");
+    assert_eq!(unavailable.attach, None);
+
+    environments
+        .create(&InputMeta::builder().name(environment_name.clone()).build(), &environment_spec)
+        .await
+        .expect("recreate attach environment");
+    let available = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions => {
+                    if let Some(row) = delta
+                        .changed
+                        .as_sessions()
+                        .expect("session rows")
+                        .iter()
+                        .find(|row| row.name == "terminal-yeoman" && row.attach.as_deref() == Some("terminal-yeoman"))
+                    {
+                        return row.clone();
+                    }
+                }
+                Ok(_) => continue,
+                Err(err) => panic!("broadcast receive error: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for attach capability restoration");
+    assert_eq!(available.attach.as_deref(), Some("terminal-yeoman"));
 
     let running = sessions.get("terminal-yeoman").await.expect("running terminal session");
     sessions

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -10,10 +10,13 @@ use flotilla_core::{
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{
-    result_set::{ConvoyRow, QueryId, ResultSet},
+    result_set::{ConvoyRow, QueryId, ResultSet, SessionRow},
     DaemonEvent, HostName, QueryCursor,
 };
-use flotilla_resources::{ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend};
+use flotilla_resources::{
+    ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend, TerminalSession, TerminalSessionPhase, TerminalSessionSource,
+    TerminalSessionSpec, TerminalSessionStatus, CONVOY_LABEL, REPO_LABEL,
+};
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&dir).expect("create config dir");
@@ -46,6 +49,10 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
 
 fn convoy_rows(result_set: &ResultSet) -> &[ConvoyRow] {
     result_set.rows.as_convoys().expect("convoy rows")
+}
+
+fn session_rows(result_set: &ResultSet) -> &[SessionRow] {
+    result_set.rows.as_sessions().expect("session rows")
 }
 
 #[tokio::test]
@@ -102,6 +109,153 @@ async fn aggregator_emits_result_set_events() {
     assert_eq!(rows.len(), 1, "expected exactly one convoy in the result set");
     assert_eq!(rows[0].name, "test-convoy-1");
     assert_eq!(rows[0].project_ref.as_deref(), Some("my-project"));
+}
+
+#[tokio::test]
+async fn running_convoyless_session_emits_attachable_session_row() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    let mut rx = daemon.subscribe();
+    let sessions = backend.using::<TerminalSession>("flotilla");
+    let convoy_session = sessions
+        .create(
+            &InputMeta::builder()
+                .name("terminal-convoy-coder".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string())]))
+                .build(),
+            &TerminalSessionSpec {
+                env_ref: "host-direct-local".to_string(),
+                role: "coder".to_string(),
+                source: TerminalSessionSource::Tool { command: "bash".to_string() },
+                cwd: "/repo".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("create convoy terminal session");
+    sessions
+        .update_status(&convoy_session.metadata.name, &convoy_session.metadata.resource_version, &TerminalSessionStatus {
+            phase: TerminalSessionPhase::Running,
+            session_id: Some("cleat-convoy-coder".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("mark convoy terminal session running");
+    let options = RuntimeOptions {
+        namespace: "flotilla".to_string(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_secs(300),
+        start_controllers: false,
+        ..RuntimeOptions::default()
+    };
+    let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("runtime start");
+
+    let created = sessions
+        .create(
+            &InputMeta::builder()
+                .name("terminal-yeoman".to_string())
+                .labels(BTreeMap::from([(REPO_LABEL.to_string(), "flotilla-org/flotilla".to_string())]))
+                .build(),
+            &TerminalSessionSpec {
+                env_ref: "host-direct-local".to_string(),
+                role: "yeoman".to_string(),
+                source: TerminalSessionSource::Tool { command: "bash".to_string() },
+                cwd: "/repo".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("create terminal session");
+    sessions
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &TerminalSessionStatus {
+            phase: TerminalSessionPhase::Running,
+            session_id: Some("cleat-yeoman".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("mark terminal session running");
+
+    let rows = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Ok(DaemonEvent::ResultSet(result_set)) if result_set.query() == QueryId::Sessions => {
+                    let rows = session_rows(&result_set);
+                    if !rows.is_empty() {
+                        return rows.to_vec();
+                    }
+                }
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions => {
+                    let rows = delta.changed.as_sessions().expect("session rows");
+                    if !rows.is_empty() {
+                        return rows.to_vec();
+                    }
+                }
+                Ok(_) => continue,
+                Err(err) => panic!("broadcast receive error: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for sessions result rows");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].name, "terminal-yeoman");
+    assert_eq!(rows[0].repo.as_ref().map(|repo| repo.0.as_str()), Some("flotilla-org/flotilla"));
+    assert_eq!(rows[0].host, HostName::new("local"));
+    assert_eq!(rows[0].attach.as_deref(), Some("terminal-yeoman"));
+    assert_eq!(rows[0].phase, flotilla_protocol::SessionPhase::Running);
+
+    let replay =
+        daemon.subscribe_queries(&[QueryCursor { query: QueryId::Sessions, since: None }]).await.expect("subscribe to sessions query");
+    let replayed = replay
+        .iter()
+        .find_map(|event| match event {
+            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Sessions => Some(session_rows(result_set)),
+            _ => None,
+        })
+        .expect("sessions replay result set");
+    assert_eq!(replayed.len(), 1);
+    assert_eq!(replayed[0].name, "terminal-yeoman");
+
+    let replica = daemon.fleet_replica_snapshot_internal().await.expect("fleet replica snapshot");
+    let local_sessions = replica
+        .result_sets
+        .iter()
+        .find(|result_set| result_set.query() == QueryId::Sessions)
+        .map(session_rows)
+        .expect("local sessions result set");
+    assert_eq!(local_sessions.len(), 1);
+
+    let running = sessions.get("terminal-yeoman").await.expect("running terminal session");
+    sessions
+        .update_status(&running.metadata.name, &running.metadata.resource_version, &TerminalSessionStatus {
+            phase: TerminalSessionPhase::Stopped,
+            ..Default::default()
+        })
+        .await
+        .expect("stop terminal session");
+    let removed = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions && !delta.removed.is_empty() => return delta,
+                Ok(_) => continue,
+                Err(err) => panic!("broadcast receive error: {err}"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for stopped session removal");
+    assert_eq!(removed.removed.len(), 1);
+    assert_eq!(removed.removed[0].name, "terminal-yeoman");
 }
 
 /// Verifies the causal chain:

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -96,7 +96,9 @@ pub use query::{
     TopologyRoute, UnmetRequirementInfo,
 };
 pub use resource_ref::ResourceRef;
-pub use result_set::{ConvoyPhase, ConvoyRow, CrewMemberSummary, QueryId, ResultDelta, ResultSet, Rows, VesselRow, WorkPhase};
+pub use result_set::{
+    ConvoyPhase, ConvoyRow, CrewMemberSummary, QueryId, ResultDelta, ResultSet, Rows, SessionPhase, SessionRow, VesselRow, WorkPhase,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -111,7 +113,7 @@ pub use snapshot::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 8;
+pub const PROTOCOL_VERSION: u32 = 9;
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -113,7 +113,7 @@ pub use snapshot::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 9;
+pub const PROTOCOL_VERSION: u32 = 10;
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -590,15 +590,46 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
 }
 
 #[test]
+fn result_set_round_trips_free_floating_session_capabilities() {
+    use crate::{
+        resource_ref::ResourceRef,
+        result_set::{QueryId, ResultSet, Rows, SessionPhase, SessionRow},
+    };
+
+    let row = SessionRow::builder()
+        .resource(ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", "terminal-yeoman"))
+        .name("terminal-yeoman")
+        .repo(RepoKey("flotilla-org/flotilla".into()))
+        .host(HostName::new("local"))
+        .attach("terminal-yeoman")
+        .phase(SessionPhase::Running)
+        .build();
+    let event = DaemonEvent::ResultSet(Box::new(ResultSet { seq: 11, rows: Rows::Sessions(vec![row]) }));
+
+    let encoded = serde_json::to_string(&event).expect("serialize session result set");
+    let decoded: DaemonEvent = serde_json::from_str(&encoded).expect("deserialize session result set");
+    let DaemonEvent::ResultSet(result_set) = decoded else { panic!("expected ResultSet") };
+    assert_eq!(result_set.seq, 11);
+    assert_eq!(result_set.query(), QueryId::Sessions);
+    let rows = result_set.rows.as_sessions().expect("session rows");
+    assert_eq!(rows[0].name, "terminal-yeoman");
+    assert_eq!(rows[0].repo.as_ref().map(|repo| repo.0.as_str()), Some("flotilla-org/flotilla"));
+    assert_eq!(rows[0].host, HostName::new("local"));
+    assert_eq!(rows[0].attach.as_deref(), Some("terminal-yeoman"));
+    assert_eq!(rows[0].phase, SessionPhase::Running);
+}
+
+#[test]
 fn subscribe_queries_request_round_trips_cursors() {
     use crate::result_set::QueryId;
 
     let request = Request::SubscribeQueries {
-        queries: vec![QueryCursor { query: QueryId::Convoys, since: Some(41) }, QueryCursor { query: QueryId::Convoys, since: None }],
+        queries: vec![QueryCursor { query: QueryId::Convoys, since: Some(41) }, QueryCursor { query: QueryId::Sessions, since: None }],
     };
     let encoded = serde_json::to_string(&request).expect("serialize subscribe request");
     assert!(encoded.contains("\"subscribe_queries\""));
     assert!(encoded.contains("\"convoys\""));
+    assert!(encoded.contains("\"sessions\""));
     let decoded: Request = serde_json::from_str(&encoded).expect("deserialize subscribe request");
     assert_eq!(decoded, request);
 }

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -24,15 +24,19 @@ pub enum QueryId {
     /// All Convoys — durable ∪ observed, fleet-merged, joined with
     /// Presentation attach state. Rows are [`ConvoyRow`].
     Convoys,
+    /// Free-floating TerminalSessions with no Convoy association. Rows are
+    /// [`SessionRow`].
+    Sessions,
 }
 
 impl QueryId {
     /// Every query the Aggregator maintains.
-    pub const ALL: &'static [QueryId] = &[QueryId::Convoys];
+    pub const ALL: &'static [QueryId] = &[QueryId::Convoys, QueryId::Sessions];
 
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Convoys => "convoys",
+            Self::Sessions => "sessions",
         }
     }
 }
@@ -85,18 +89,21 @@ impl ResultDelta {
 #[serde(tag = "kind", content = "rows", rename_all = "snake_case")]
 pub enum Rows {
     Convoys(Vec<ConvoyRow>),
+    Sessions(Vec<SessionRow>),
 }
 
 impl Rows {
     pub fn query(&self) -> QueryId {
         match self {
             Self::Convoys(_) => QueryId::Convoys,
+            Self::Sessions(_) => QueryId::Sessions,
         }
     }
 
     pub fn len(&self) -> usize {
         match self {
             Self::Convoys(rows) => rows.len(),
+            Self::Sessions(rows) => rows.len(),
         }
     }
 
@@ -107,8 +114,62 @@ impl Rows {
     pub fn as_convoys(&self) -> Option<&[ConvoyRow]> {
         match self {
             Self::Convoys(rows) => Some(rows),
+            _ => None,
         }
     }
+
+    pub fn as_sessions(&self) -> Option<&[SessionRow]> {
+        match self {
+            Self::Sessions(rows) => Some(rows),
+            _ => None,
+        }
+    }
+}
+
+/// Lifecycle phase of a free-floating terminal session.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionPhase {
+    #[default]
+    Starting,
+    Running,
+    Stopped,
+    Failed,
+}
+
+impl SessionPhase {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl fmt::Display for SessionPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One row of the [`QueryId::Sessions`] result set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[builder(on(String, into))]
+pub struct SessionRow {
+    /// Row identity and merge key across hosts.
+    pub resource: ResourceRef,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<RepoKey>,
+    /// Host whose daemon can act on this session.
+    pub host: HostName,
+    /// Session reference accepted by `flotilla attach`. `Some` is a
+    /// capability fact: the daemon can currently resolve the attachment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attach: Option<String>,
+    pub phase: SessionPhase,
 }
 
 /// Convoy lifecycle phase as reported on query rows.


### PR DESCRIPTION
Closes #683.

## What changed

- add a typed `sessions` named query with `SessionRow` and independent query sequencing
- project running free-floating terminal and persistent-agent sessions while excluding convoy-owned sessions
- include session result sets in subscription replay, local fleet snapshots, and replica union
- advertise attach references only when the daemon can resolve them
- recompute attach capabilities when their environment changes
- bump the wire protocol version for the new query variant

## Why

The aggregator only exposed the convoy query after #684. Consumers preparing the free-floating vessel/session UI need a fleet-aware, subscribable result set for running sessions, including truthful attach capability and repository/host context.

## Impact

Clients can subscribe to `QueryId::Sessions` alongside convoys and receive typed full results and deltas. Fleet replicas carry and merge the same query. Sessions associated with convoys remain absent from this result set.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- independent standards and issue-spec review, with all findings resolved
