### PR TITLE
fix: remove observed Checkouts when a repo is untracked

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -875,6 +875,9 @@ pub struct InProcessDaemon {
     daemon_socket_path: RwLock<Option<PathBuf>>,
     resource_backend: ResourceBackend,
     observed_resource_backend: ResourceBackend,
+    /// Serializes observed Checkout publication with repository removal so a
+    /// refresh captured before untracking cannot recreate deleted resources.
+    observed_checkout_reconciliation: Mutex<()>,
     aggregator_projection_state: RwLock<AggregatorProjectionState>,
     /// Provisioning namespace used by daemon-side resource operations (e.g.
     /// looking up the Convoy whose task is being marked complete). Set by the
@@ -1013,6 +1016,7 @@ impl InProcessDaemon {
             daemon_socket_path: RwLock::new(None),
             resource_backend,
             observed_resource_backend: ResourceBackend::InMemory(InMemoryBackend::observed()),
+            observed_checkout_reconciliation: Mutex::new(()),
             aggregator_projection_state: RwLock::new(AggregatorProjectionState::new()),
             provisioning_namespace: RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
             fleet_replica_cache: RwLock::new(HashMap::new()),
@@ -1676,6 +1680,11 @@ impl InProcessDaemon {
                 warn!(repo = %identity.path, "skipping observed checkout reconciliation after checkout discovery failed");
                 continue;
             }
+            let _reconciliation = self.observed_checkout_reconciliation.lock().await;
+            let has_local_root = self.repos.read().await.get(identity).is_some_and(|state| !state.local_paths().is_empty());
+            if !has_local_root {
+                continue;
+            }
             if let Err(error) =
                 crate::observed_resources::reconcile_checkouts(&self.observed_resource_backend, &namespace, identity, local_providers).await
             {
@@ -2001,14 +2010,6 @@ impl InProcessDaemon {
     pub async fn add_repo(&self, path: &Path) -> Result<(PathBuf, Option<PathBuf>), String> {
         let (path, resolved_from) = self.normalize_repo_path(path).await;
 
-        // Check if already tracked (under read lock for fast path)
-        {
-            let identities = self.path_identities.read().await;
-            if identities.contains_key(&path) {
-                return Ok((path, resolved_from));
-            }
-        }
-
         // Create the model outside the lock (spawns provider detection and refresh)
         let DiscoveryResult { registry, repo_slug, host_repo_bag, repo_bag, unmet } = discover_repo_for_environment(
             &self.environment_manager,
@@ -2023,6 +2024,12 @@ impl InProcessDaemon {
             debug!(count = unmet.len(), ?unmet, "providers not activated: missing requirements");
         }
         let identity = repo_identity_from_bag_or_path(&path, &host_repo_bag);
+        if let Some(tracked_identity) = self.tracked_repo_identity_for_path(&path).await {
+            if tracked_identity == identity {
+                return Ok((path, resolved_from));
+            }
+            self.remove_repo(&path).await?;
+        }
         let slug = repo_slug.clone();
         let mut model = RepoModel::new(
             path.clone(),
@@ -2094,8 +2101,10 @@ impl InProcessDaemon {
     pub async fn remove_repo(&self, path: &Path) -> Result<(), String> {
         let path = path.to_path_buf();
         let repo_identity = self.tracked_repo_identity_for_path(&path).await.unwrap_or_else(|| fallback_repo_identity(&path));
+        let observed_reconciliation = self.observed_checkout_reconciliation.lock().await;
 
         let mut removed_identity = false;
+        let removed_final_local_root;
         let mut new_preferred_path = None;
         {
             let mut repos = self.repos.write().await;
@@ -2106,6 +2115,12 @@ impl InProcessDaemon {
             let previous_preferred = state.preferred_path().to_path_buf();
             if !state.remove_root(&path) {
                 return Err(format!("repo not tracked: {}", path.display()));
+            }
+            removed_final_local_root = state.local_paths().is_empty();
+            if !removed_final_local_root {
+                for root in state.roots.iter().filter(|root| root.is_local) {
+                    root.model.refresh_handle.trigger_refresh();
+                }
             }
             if state.roots.is_empty() {
                 repos.remove(&repo_identity);
@@ -2124,6 +2139,16 @@ impl InProcessDaemon {
             drop(pp);
             self.peer_overlay_versions.write().await.remove(&repo_identity);
         }
+
+        if removed_final_local_root {
+            let namespace = self.provisioning_namespace().await;
+            if let Err(error) =
+                crate::observed_resources::delete_observed_checkouts(&self.observed_resource_backend, &namespace, &repo_identity).await
+            {
+                warn!(repo = %repo_identity.path, %error, "failed to delete observed checkouts for untracked repo");
+            }
+        }
+        drop(observed_reconciliation);
 
         // Persist to config
         self.config.remove_repo(&ExecutionEnvironmentPath::new(&path));

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2028,7 +2028,14 @@ impl InProcessDaemon {
             if tracked_identity == identity {
                 return Ok((path, resolved_from));
             }
-            self.remove_repo(&path).await?;
+            if let Err(error) = self.remove_repo(&path).await {
+                // Another add_repo call may have removed or migrated this path
+                // after our identity lookup. Continue through the idempotent
+                // insertion path unless it is still tracked elsewhere.
+                if self.tracked_repo_identity_for_path(&path).await.is_some_and(|current| current != identity) {
+                    return Err(error);
+                }
+            }
         }
         let slug = repo_slug.clone();
         let mut model = RepoModel::new(

--- a/crates/flotilla-core/src/observed_resources.rs
+++ b/crates/flotilla-core/src/observed_resources.rs
@@ -19,14 +19,9 @@ pub async fn reconcile_checkouts(
     repo_identity: &RepoIdentity,
     providers: &ProviderData,
 ) -> Result<(), ResourceError> {
-    let canonical_repo = canonical_repo_url(repo_identity).map_err(ResourceError::invalid)?;
-    let repo_key = repo_key(&canonical_repo);
-    let repo_ref = descriptive_repo_slug(&canonical_repo);
+    let scope = observed_checkout_scope(repo_identity)?;
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
-    let selector = BTreeMap::from([
-        (AUTHORITY_LABEL.to_string(), LifecycleAuthority::Observed.as_label_value().to_string()),
-        (REPO_KEY_LABEL.to_string(), repo_key.clone()),
-    ]);
+    let selector = scope.selector();
     let mut existing: HashMap<_, _> = checkouts
         .list_matching_labels(&selector)
         .await?
@@ -36,12 +31,12 @@ pub async fn reconcile_checkouts(
         .collect();
 
     for (path, checkout) in &providers.checkouts {
-        let name = observed_checkout_name(&repo_key, path);
-        let meta = observed_checkout_meta(&name, &repo_key, &repo_ref);
+        let name = observed_checkout_name(&scope.repo_key, path);
+        let meta = observed_checkout_meta(&name, &scope.repo_key, &scope.repo_ref);
         let spec = ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
             r#ref: checkout.branch.clone(),
             path: path.path.to_string_lossy().into_owned(),
-            repo_ref: repo_ref.clone(),
+            repo_ref: scope.repo_ref.clone(),
             is_main: checkout.is_main,
         });
 
@@ -61,6 +56,45 @@ pub async fn reconcile_checkouts(
     }
 
     Ok(())
+}
+
+/// Delete the Checkout facts previously published for one local repository.
+///
+/// Adopted and managed Checkouts are outside this projection's lifecycle, so
+/// cleanup is restricted to resources carrying the observed authority label.
+pub async fn delete_observed_checkouts(
+    backend: &ResourceBackend,
+    namespace: &str,
+    repo_identity: &RepoIdentity,
+) -> Result<(), ResourceError> {
+    let scope = observed_checkout_scope(repo_identity)?;
+    let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
+    let selector = scope.selector();
+
+    for checkout in checkouts.list_matching_labels(&selector).await?.items {
+        checkouts.delete(&checkout.metadata.name).await?;
+    }
+
+    Ok(())
+}
+
+struct ObservedCheckoutScope {
+    repo_key: String,
+    repo_ref: String,
+}
+
+impl ObservedCheckoutScope {
+    fn selector(&self) -> BTreeMap<String, String> {
+        BTreeMap::from([
+            (AUTHORITY_LABEL.to_string(), LifecycleAuthority::Observed.as_label_value().to_string()),
+            (REPO_KEY_LABEL.to_string(), self.repo_key.clone()),
+        ])
+    }
+}
+
+fn observed_checkout_scope(repo_identity: &RepoIdentity) -> Result<ObservedCheckoutScope, ResourceError> {
+    let canonical_repo = canonical_repo_url(repo_identity).map_err(ResourceError::invalid)?;
+    Ok(ObservedCheckoutScope { repo_key: repo_key(&canonical_repo), repo_ref: descriptive_repo_slug(&canonical_repo) })
 }
 
 fn canonical_repo_url(identity: &RepoIdentity) -> Result<String, String> {

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1832,7 +1832,27 @@ async fn removing_one_of_multiple_local_roots_preserves_observed_checkouts() {
 
     daemon.remove_repo(&repo_a).await.expect("remove first local root");
 
-    assert_eq!(observed.list().await.expect("observed checkout list should succeed").items.len(), 2);
+    let surviving_checkout_path = repo_b.join("main").to_string_lossy().into_owned();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let remaining = observed.list().await.expect("observed checkout list should succeed");
+            if matches!(
+                remaining.items.as_slice(),
+                [checkout]
+                    if matches!(&checkout.spec, ResourceCheckoutSpec::Observed(spec) if spec.path == surviving_checkout_path)
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("surviving root's observed Checkout should remain");
+    let remaining = observed.list().await.expect("observed checkout list should succeed");
+    assert!(matches!(
+        &remaining.items[0].spec,
+        ResourceCheckoutSpec::Observed(spec) if spec.path == surviving_checkout_path
+    ));
 
     daemon.remove_repo(&repo_b).await.expect("remove final local root");
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -41,7 +41,7 @@ use flotilla_protocol::{
     TopologyRoute, WorkItemKind,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec,
+    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, TypedResolver,
     REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
@@ -49,6 +49,11 @@ use tokio::sync::Notify;
 struct FixedRemoteHostDetector {
     owner: &'static str,
     repo: &'static str,
+}
+
+struct MutableRemoteHostDetector {
+    owner: &'static str,
+    repo: Arc<std::sync::RwLock<String>>,
 }
 
 fn qpath(host: &HostName, path: impl Into<PathBuf>) -> QualifiedPath {
@@ -64,6 +69,19 @@ impl RepoDetector for FixedRemoteHostDetector {
         _env: &dyn flotilla_core::providers::discovery::EnvVars,
     ) -> Vec<EnvironmentAssertion> {
         vec![EnvironmentAssertion::remote_host(HostPlatform::GitHub, self.owner, self.repo, "origin")]
+    }
+}
+
+#[async_trait]
+impl RepoDetector for MutableRemoteHostDetector {
+    async fn detect(
+        &self,
+        _repo_root: &ExecutionEnvironmentPath,
+        _runner: &dyn flotilla_core::providers::CommandRunner,
+        _env: &dyn flotilla_core::providers::discovery::EnvVars,
+    ) -> Vec<EnvironmentAssertion> {
+        let repo = self.repo.read().expect("mutable remote detector should not be poisoned").clone();
+        vec![EnvironmentAssertion::remote_host(HostPlatform::GitHub, self.owner, repo, "origin")]
     }
 }
 
@@ -1737,6 +1755,211 @@ async fn repo_refresh_reconciles_observed_checkouts() {
 }
 
 #[tokio::test]
+async fn removing_final_local_root_deletes_observed_checkouts() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let state = FakeVcsState::builder(repo.clone()).branch("main", true).checkout("main").is_main(true).path(&repo).build().build();
+    let mut discovery = fake_vcs_discovery(state);
+    discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
+
+    let daemon =
+        InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let mut events = daemon.subscribe();
+
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+    assert_eq!(observed.list().await.expect("observed checkout list should succeed").items.len(), 1);
+
+    daemon.remove_repo(&repo).await.expect("remove final local root");
+
+    assert!(observed.list().await.expect("observed checkout list should succeed").items.is_empty());
+}
+
+#[tokio::test]
+async fn removing_final_local_root_preserves_adopted_checkouts() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let state = FakeVcsState::builder(repo.clone()).branch("main", true).checkout("main").is_main(true).path(&repo).build().build();
+    let mut discovery = fake_vcs_discovery(state);
+    discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
+
+    let daemon =
+        InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let mut events = daemon.subscribe();
+
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+    let published = observed.list().await.expect("observed checkout list should succeed");
+    let repo_key = published.items[0].metadata.labels.get(REPO_KEY_LABEL).expect("observed checkout should carry a repo key").clone();
+    observed
+        .create(
+            &InputMeta::builder()
+                .name("adopted-checkout".to_string())
+                .labels(std::collections::BTreeMap::from([
+                    (flotilla_resources::AUTHORITY_LABEL.to_string(), LifecycleAuthority::Adopted.as_label_value().to_string()),
+                    (REPO_KEY_LABEL.to_string(), repo_key),
+                ]))
+                .build(),
+            &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: "main".to_string(),
+                path: repo.to_string_lossy().into_owned(),
+                repo_ref: "github-com-owner-repo".to_string(),
+                is_main: true,
+            }),
+        )
+        .await
+        .expect("adopted checkout should be creatable");
+
+    daemon.remove_repo(&repo).await.expect("remove final local root");
+
+    let remaining = observed.list().await.expect("observed checkout list should succeed");
+    assert_eq!(remaining.items.len(), 1);
+    assert_eq!(remaining.items[0].metadata.name, "adopted-checkout");
+}
+
+#[tokio::test]
+async fn removing_one_of_multiple_local_roots_preserves_observed_checkouts() {
+    let (_temp, repo_a, repo_b, daemon) = daemon_for_duplicate_fake_repos().await;
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let mut events = daemon.subscribe();
+
+    let _ = trigger_refresh_and_recv(&daemon, &repo_a, &mut events).await;
+    wait_for_observed_checkout_count(&observed, 2).await;
+
+    daemon.remove_repo(&repo_a).await.expect("remove first local root");
+
+    assert_eq!(observed.list().await.expect("observed checkout list should succeed").items.len(), 2);
+
+    daemon.remove_repo(&repo_b).await.expect("remove final local root");
+
+    assert!(observed.list().await.expect("observed checkout list should succeed").items.is_empty());
+}
+
+#[tokio::test]
+async fn removing_final_local_root_deletes_observed_checkouts_when_virtual_root_remains() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo = temp.path().join("repo");
+    let virtual_repo = PathBuf::from("/remote/desktop/owner/repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let state = FakeVcsState::builder(repo.clone()).branch("main", true).checkout("main").is_main(true).path(&repo).build().build();
+    let mut discovery = fake_vcs_discovery(state);
+    discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
+
+    let daemon = InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    let identity = RepoIdentity { authority: "github.com".to_string(), path: "owner/repo".to_string() };
+    daemon.add_virtual_repo(identity.clone(), virtual_repo.clone(), vec![], 0).await.expect("add virtual root");
+    daemon.add_repo(&repo).await.expect("add local root");
+
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let mut events = daemon.subscribe();
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+    assert_eq!(observed.list().await.expect("observed checkout list should succeed").items.len(), 1);
+
+    daemon.remove_repo(&repo).await.expect("remove final local root");
+
+    assert!(observed.list().await.expect("observed checkout list should succeed").items.is_empty());
+    assert_eq!(daemon.tracked_repo_identity_for_path(&virtual_repo).await, Some(identity));
+}
+
+#[tokio::test]
+async fn repository_identity_change_removes_old_repo_key_observed_checkouts() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let state = FakeVcsState::builder(repo.clone()).branch("main", true).checkout("main").is_main(true).path(&repo).build().build();
+    let discovered_repo = Arc::new(std::sync::RwLock::new("old-repo".to_string()));
+    let mut discovery = fake_vcs_discovery(state);
+    discovery.repo_detectors.push(Box::new(MutableRemoteHostDetector { owner: "owner", repo: Arc::clone(&discovered_repo) }));
+
+    let daemon =
+        InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let mut events = daemon.subscribe();
+
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+    let old = observed.list().await.expect("observed checkout list should succeed");
+    assert_eq!(old.items.len(), 1);
+    assert_eq!(old.items[0].metadata.labels.get(REPO_LABEL).map(String::as_str), Some("github-com-owner-old-repo"));
+
+    *discovered_repo.write().expect("mutable remote detector should not be poisoned") = "new-repo".to_string();
+    daemon.add_repo(&repo).await.expect("refresh tracked path with new repository identity");
+    let _ = trigger_refresh_and_recv(&daemon, &repo, &mut events).await;
+
+    let current = observed.list().await.expect("observed checkout list should succeed");
+    assert_eq!(current.items.len(), 1);
+    assert_eq!(current.items[0].metadata.labels.get(REPO_LABEL).map(String::as_str), Some("github-com-owner-new-repo"));
+}
+
+#[tokio::test]
+async fn repository_identity_change_reconciles_old_identity_shared_by_another_root() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo_a = temp.path().join("repo-a");
+    let repo_b = temp.path().join("repo-b");
+    std::fs::create_dir_all(&repo_a).expect("create repo-a dir");
+    std::fs::create_dir_all(&repo_b).expect("create repo-b dir");
+
+    let state_a = FakeVcsState::builder(repo_a.clone()).branch("main", true).checkout("main").is_main(true).path(&repo_a).build().build();
+    let state_b = FakeVcsState::builder(repo_b.clone()).branch("main", true).checkout("main").is_main(true).path(&repo_b).build().build();
+    let discovered_repo = Arc::new(std::sync::RwLock::new("old-repo".to_string()));
+    let mut discovery = fake_discovery(false);
+    discovery.factories.vcs = vec![Box::new(FakeVcsFactory::new(state_a.clone())), Box::new(FakeVcsFactory::new(state_b.clone()))];
+    discovery.factories.checkout_managers =
+        vec![Box::new(FakeCheckoutManagerFactory::new(state_a)), Box::new(FakeCheckoutManagerFactory::new(state_b))];
+    discovery.repo_detectors.push(Box::new(MutableRemoteHostDetector { owner: "owner", repo: Arc::clone(&discovered_repo) }));
+
+    let daemon = InProcessDaemon::new(
+        vec![repo_a.clone(), repo_b.clone()],
+        test_config_store(temp.path().join("config")),
+        discovery,
+        HostName::local(),
+    )
+    .await;
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let mut events = daemon.subscribe();
+
+    let _ = trigger_refresh_and_recv(&daemon, &repo_a, &mut events).await;
+    wait_for_observed_checkout_count(&observed, 2).await;
+
+    *discovered_repo.write().expect("mutable remote detector should not be poisoned") = "new-repo".to_string();
+    daemon.add_repo(&repo_a).await.expect("migrate first root to new repository identity");
+    let _ = trigger_refresh_and_recv(&daemon, &repo_a, &mut events).await;
+
+    let repo_a_path = repo_a.to_string_lossy().into_owned();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let stale_old_identity_checkout =
+                observed.list().await.expect("observed checkout list should succeed").items.into_iter().any(|checkout| {
+                    checkout.metadata.labels.get(REPO_LABEL).map(String::as_str) == Some("github-com-owner-old-repo")
+                        && matches!(checkout.spec, ResourceCheckoutSpec::Observed(spec) if spec.path == repo_a_path)
+                });
+            if !stale_old_identity_checkout {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("migrated root's Checkout should be removed from the old identity");
+
+    let current = observed.list().await.expect("observed checkout list should succeed");
+    assert_eq!(current.items.len(), 2);
+    assert!(current.items.iter().any(|checkout| {
+        checkout.metadata.labels.get(REPO_LABEL).map(String::as_str) == Some("github-com-owner-old-repo")
+            && matches!(&checkout.spec, ResourceCheckoutSpec::Observed(spec) if spec.path == repo_b.to_string_lossy())
+    }));
+    assert!(current.items.iter().any(|checkout| {
+        checkout.metadata.labels.get(REPO_LABEL).map(String::as_str) == Some("github-com-owner-new-repo")
+            && matches!(&checkout.spec, ResourceCheckoutSpec::Observed(spec) if spec.path == repo_a.to_string_lossy())
+    }));
+}
+
+#[tokio::test]
 async fn static_ssh_repo_refresh_stamps_discovered_checkout_environment_id() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");
@@ -1896,6 +2119,19 @@ async fn trigger_refresh_and_recv(
             _ => {}
         }
     }
+}
+
+async fn wait_for_observed_checkout_count(observed: &TypedResolver<ResourceCheckout>, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if observed.list().await.expect("observed checkout list should succeed").items.len() == expected {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("observed checkout count should converge");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- remove a repository's observed Checkout resources when its final local root is untracked
- preserve adopted Checkouts and observed Checkouts still contributed by another local root sharing the identity
- migrate already-tracked paths when their discovered repository identity changes, reconciling both the old and new repo-key projections
- serialize observed Checkout reconciliation with removal so an in-flight refresh cannot recreate deleted resources

## Root cause

Observed Checkout cleanup only ran from the refresh reconciliation path. Once the final local root was removed, no later refresh existed to delete that repository's stale observed projection. Re-adding an already tracked path also returned before re-running discovery, so a changed remote identity could leave resources under the old repo key.

## Impact

Untracking is now reflected immediately in the ephemeral resource store. Lifecycle authority remains respected: only `LifecycleAuthority::Observed` Checkouts are deleted, while adopted resources remain intact.

Closes #677.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- two-axis standards/spec review, with all findings addressed
