### PR TITLE
aggregator: make vessel completion capability reflect work state

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3153,6 +3153,9 @@ impl InProcessDaemon {
                     Some(status) if !status.work.contains_key(work) => {
                         flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} does not contain work {work}") }
                     }
+                    Some(status) if status.work.get(work).is_some_and(|state| state.phase.is_terminal()) => {
+                        flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} work {work} is already terminal") }
+                    }
                     Some(_) => {
                         match apply_resource_status_patch(
                             &convoys,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3150,14 +3150,12 @@ impl InProcessDaemon {
             let result = match convoys.get(convoy).await {
                 Ok(current) => match current.status.as_ref() {
                     None => flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} has no status") },
-                    Some(status) if !status.work.contains_key(work) => {
-                        flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} does not contain work {work}") }
-                    }
-                    Some(status) if status.work.get(work).is_some_and(|state| state.phase.is_terminal()) => {
-                        flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} work {work} is already terminal") }
-                    }
-                    Some(_) => {
-                        match apply_resource_status_patch(
+                    Some(status) => match status.work.get(work) {
+                        None => flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} does not contain work {work}") },
+                        Some(state) if state.phase.is_terminal() => {
+                            flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} work {work} is already terminal") }
+                        }
+                        Some(_) => match apply_resource_status_patch(
                             &convoys,
                             convoy,
                             &convoy_external_patches::force_work_completed(work.clone(), chrono::Utc::now(), message.clone()),
@@ -3166,8 +3164,8 @@ impl InProcessDaemon {
                         {
                             Ok(_) => flotilla_protocol::CommandValue::Ok,
                             Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
-                        }
-                    }
+                        },
+                    },
                 },
                 Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
             };

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -114,6 +114,23 @@ async fn wait_for_command_result(events: &mut tokio::sync::broadcast::Receiver<D
     .expect("timeout waiting for command result")
 }
 
+async fn force_complete_work(daemon: &InProcessDaemon, events: &mut tokio::sync::broadcast::Receiver<DaemonEvent>) -> CommandValue {
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyWorkForceComplete {
+                convoy: "convoy-a".to_string(),
+                work: "implement".to_string(),
+                message: Some("done".to_string()),
+            },
+        })
+        .await
+        .expect("execute should return a command id");
+    wait_for_command_result(events, command_id).await
+}
+
 async fn new_attach_test_daemon(config_base: &Path) -> Arc<InProcessDaemon> {
     new_attach_test_daemon_with_pool(config_base).await.0
 }
@@ -2208,37 +2225,24 @@ async fn convoy_completion_command_updates_convoy_task_status() {
         .expect("convoy status update should succeed");
 
     let mut events = daemon.subscribe();
-    let command_id = daemon
-        .execute(Command {
-            node_id: None,
-            provisioning_target: None,
-            context_repo: None,
-            action: CommandAction::ConvoyWorkForceComplete {
-                convoy: "convoy-a".to_string(),
-                work: "implement".to_string(),
-                message: Some("done".to_string()),
-            },
-        })
-        .await
-        .expect("execute should return a command id");
-
-    let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
-        loop {
-            match events.recv().await {
-                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
-                Ok(_) => {}
-                Err(err) => panic!("unexpected event error: {err}"),
-            }
-        }
-    })
-    .await
-    .expect("timeout waiting for command result");
+    let result = force_complete_work(&daemon, &mut events).await;
 
     assert_eq!(result, CommandValue::Ok);
     let convoy = convoys.get("convoy-a").await.expect("convoy get should succeed");
     let status = convoy.status.expect("convoy status should exist");
     assert_eq!(status.work["implement"].phase, WorkPhase::Complete);
     assert_eq!(status.work["implement"].message.as_deref(), Some("done"));
+
+    for phase in [WorkPhase::Complete, WorkPhase::Failed, WorkPhase::Cancelled] {
+        let current = convoys.get("convoy-a").await.expect("convoy get should succeed");
+        let mut status = current.status.expect("convoy status should exist");
+        status.work.get_mut("implement").expect("implement work").phase = phase;
+        convoys.update_status("convoy-a", &current.metadata.resource_version, &status).await.expect("convoy status update should succeed");
+
+        assert_eq!(force_complete_work(&daemon, &mut events).await, CommandValue::Error {
+            message: "convoy convoy-a work implement is already terminal".to_string()
+        });
+    }
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -284,7 +284,7 @@ impl Aggregator {
                     .vessels
                     .iter()
                     .map(|definition| {
-                        self.summarize_vessel(&resource, definition, status.and_then(|status| status.work.get(&definition.name)))
+                        self.summarize_vessel(&resource, definition, phase, status.and_then(|status| status.work.get(&definition.name)))
                     })
                     .collect()
             })
@@ -305,7 +305,13 @@ impl Aggregator {
             .build()
     }
 
-    fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {
+    fn summarize_vessel(
+        &self,
+        convoy_ref: &ResourceRef,
+        definition: &VesselRequirement,
+        convoy_phase: ResourceConvoyPhase,
+        state: Option<&WorkState>,
+    ) -> VesselRow {
         let crew = definition
             .crew
             .iter()
@@ -329,6 +335,7 @@ impl Aggregator {
             .depends_on(definition.depends_on.clone())
             .host(self.local_host.clone())
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
+            .complete_work(!convoy_phase_is_terminal(convoy_phase) && state.is_some_and(|state| !work_phase_is_terminal(state.phase)))
             .build()
     }
 }
@@ -380,10 +387,17 @@ fn work_phase(phase: ResourceWorkPhase) -> WorkPhase {
     }
 }
 
+fn work_phase_is_terminal(phase: ResourceWorkPhase) -> bool {
+    matches!(phase, ResourceWorkPhase::Complete | ResourceWorkPhase::Failed | ResourceWorkPhase::Cancelled)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::Utc;
     use flotilla_protocol::result_set::ResultSet;
-    use flotilla_resources::{InMemoryBackend, ResourceBackend};
+    use flotilla_resources::{ConvoySpec, InMemoryBackend, ObjectMeta, ResourceBackend, WorkCompletionAuthority, WorkflowSnapshot};
 
     use super::*;
 
@@ -407,6 +421,93 @@ mod tests {
 
     fn convoy_names(rows: &Rows) -> Vec<&str> {
         rows.as_convoys().expect("convoy rows").iter().map(|row| row.name.as_str()).collect()
+    }
+
+    fn convoy_with_work(convoy_phase: ResourceConvoyPhase, work_phase: Option<ResourceWorkPhase>) -> ResourceObject<Convoy> {
+        let definition = VesselRequirement::builder().name("implement".to_string()).crew(Vec::new()).build();
+        let work = work_phase
+            .map(|phase| {
+                ("implement".to_string(), WorkState {
+                    phase,
+                    completion_authority: WorkCompletionAuthority::CrewRollup,
+                    ready_at: None,
+                    started_at: None,
+                    finished_at: None,
+                    message: None,
+                    placement: None,
+                })
+            })
+            .into_iter()
+            .collect();
+        ResourceObject {
+            metadata: ObjectMeta {
+                name: "convoy-a".to_string(),
+                namespace: "flotilla".to_string(),
+                resource_version: "1".to_string(),
+                labels: BTreeMap::new(),
+                annotations: BTreeMap::new(),
+                owner_references: Vec::new(),
+                finalizers: Vec::new(),
+                deletion_timestamp: None,
+                creation_timestamp: Utc::now(),
+            },
+            spec: ConvoySpec {
+                workflow_ref: "scratch".to_string(),
+                inputs: BTreeMap::new(),
+                placement_policy: None,
+                repository: None,
+                r#ref: None,
+                project_ref: None,
+                adopted_checkout_ref: None,
+            },
+            status: Some(ConvoyStatus {
+                phase: convoy_phase,
+                workflow_snapshot: Some(WorkflowSnapshot { vessels: vec![definition] }),
+                work,
+                ..Default::default()
+            }),
+        }
+    }
+
+    async fn emitted_vessel(convoy: ResourceObject<Convoy>) -> VesselRow {
+        let state = AggregatorProjectionState::new();
+        let (tx, mut rx) = broadcast::channel(1);
+        let mut aggregator = Aggregator::new(state, HostName::new("local"), tx);
+
+        aggregator.apply_convoy_event(WatchEvent::Added(convoy)).await;
+
+        let DaemonEvent::ResultSet(result_set) = rx.recv().await.expect("initial result set") else {
+            panic!("expected result set");
+        };
+        result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row").vessels.first().expect("vessel row").clone()
+    }
+
+    #[tokio::test]
+    async fn terminal_work_is_not_completable() {
+        for phase in [ResourceWorkPhase::Complete, ResourceWorkPhase::Failed, ResourceWorkPhase::Cancelled] {
+            let vessel = emitted_vessel(convoy_with_work(ResourceConvoyPhase::Active, Some(phase))).await;
+
+            assert!(!vessel.complete_work, "{phase:?} work must not expose the completion override");
+        }
+    }
+
+    #[tokio::test]
+    async fn work_missing_from_status_is_not_completable() {
+        let vessel = emitted_vessel(convoy_with_work(ResourceConvoyPhase::Active, None)).await;
+
+        assert!(!vessel.complete_work);
+    }
+
+    #[tokio::test]
+    async fn only_active_convoy_work_exposes_the_completion_override() {
+        let active = emitted_vessel(convoy_with_work(ResourceConvoyPhase::Active, Some(ResourceWorkPhase::Running))).await;
+        assert!(active.complete_work);
+
+        for phase in [ResourceConvoyPhase::Completed, ResourceConvoyPhase::Failed, ResourceConvoyPhase::Cancelled] {
+            let vessel = emitted_vessel(convoy_with_work(phase, Some(ResourceWorkPhase::Running))).await;
+
+            assert!(!vessel.complete_work, "{phase:?} convoy must not expose the completion override");
+        }
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -284,7 +284,7 @@ impl Aggregator {
                     .vessels
                     .iter()
                     .map(|definition| {
-                        self.summarize_vessel(&resource, definition, phase, status.and_then(|status| status.work.get(&definition.name)))
+                        self.summarize_vessel(&resource, definition, status.and_then(|status| status.work.get(&definition.name)))
                     })
                     .collect()
             })
@@ -305,13 +305,7 @@ impl Aggregator {
             .build()
     }
 
-    fn summarize_vessel(
-        &self,
-        convoy_ref: &ResourceRef,
-        definition: &VesselRequirement,
-        convoy_phase: ResourceConvoyPhase,
-        state: Option<&WorkState>,
-    ) -> VesselRow {
+    fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {
         let crew = definition
             .crew
             .iter()
@@ -335,7 +329,7 @@ impl Aggregator {
             .depends_on(definition.depends_on.clone())
             .host(self.local_host.clone())
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
-            .complete_work(!convoy_phase_is_terminal(convoy_phase) && state.is_some_and(|state| !work_phase_is_terminal(state.phase)))
+            .complete_work(state.is_some_and(|state| !state.phase.is_terminal()))
             .build()
     }
 }
@@ -387,10 +381,6 @@ fn work_phase(phase: ResourceWorkPhase) -> WorkPhase {
     }
 }
 
-fn work_phase_is_terminal(phase: ResourceWorkPhase) -> bool {
-    matches!(phase, ResourceWorkPhase::Complete | ResourceWorkPhase::Failed | ResourceWorkPhase::Cancelled)
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -423,6 +413,7 @@ mod tests {
         rows.as_convoys().expect("convoy rows").iter().map(|row| row.name.as_str()).collect()
     }
 
+    #[bon::builder]
     fn convoy_with_work(convoy_phase: ResourceConvoyPhase, work_phase: Option<ResourceWorkPhase>) -> ResourceObject<Convoy> {
         let definition = VesselRequirement::builder().name("implement".to_string()).crew(Vec::new()).build();
         let work = work_phase
@@ -479,13 +470,15 @@ mod tests {
         let DaemonEvent::ResultSet(result_set) = rx.recv().await.expect("initial result set") else {
             panic!("expected result set");
         };
-        result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row").vessels.first().expect("vessel row").clone()
+        let rows = result_set.rows.as_convoys().expect("convoy rows");
+        let convoy = rows.first().expect("convoy row");
+        convoy.vessels.first().expect("vessel row").clone()
     }
 
     #[tokio::test]
     async fn terminal_work_is_not_completable() {
         for phase in [ResourceWorkPhase::Complete, ResourceWorkPhase::Failed, ResourceWorkPhase::Cancelled] {
-            let vessel = emitted_vessel(convoy_with_work(ResourceConvoyPhase::Active, Some(phase))).await;
+            let vessel = emitted_vessel(convoy_with_work().convoy_phase(ResourceConvoyPhase::Active).work_phase(phase).call()).await;
 
             assert!(!vessel.complete_work, "{phase:?} work must not expose the completion override");
         }
@@ -493,20 +486,17 @@ mod tests {
 
     #[tokio::test]
     async fn work_missing_from_status_is_not_completable() {
-        let vessel = emitted_vessel(convoy_with_work(ResourceConvoyPhase::Active, None)).await;
+        let vessel = emitted_vessel(convoy_with_work().convoy_phase(ResourceConvoyPhase::Active).call()).await;
 
         assert!(!vessel.complete_work);
     }
 
     #[tokio::test]
-    async fn only_active_convoy_work_exposes_the_completion_override() {
-        let active = emitted_vessel(convoy_with_work(ResourceConvoyPhase::Active, Some(ResourceWorkPhase::Running))).await;
-        assert!(active.complete_work);
+    async fn non_terminal_work_is_completable() {
+        for phase in [ResourceWorkPhase::Pending, ResourceWorkPhase::Ready, ResourceWorkPhase::Launching, ResourceWorkPhase::Running] {
+            let vessel = emitted_vessel(convoy_with_work().convoy_phase(ResourceConvoyPhase::Active).work_phase(phase).call()).await;
 
-        for phase in [ResourceConvoyPhase::Completed, ResourceConvoyPhase::Failed, ResourceConvoyPhase::Cancelled] {
-            let vessel = emitted_vessel(convoy_with_work(phase, Some(ResourceWorkPhase::Running))).await;
-
-            assert!(!vessel.complete_work, "{phase:?} convoy must not expose the completion override");
+            assert!(vessel.complete_work, "{phase:?} work must expose the completion override");
         }
     }
 

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -570,6 +570,7 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
         .crew(vec![CrewMemberSummary { role: "coder".into(), command_preview: "fix the bug".into() }])
         .host(HostName::new("local"))
         .attach("ws-1".to_string())
+        .complete_work(true)
         .build();
     let review = VesselRow::builder()
         .resource(review_ref)
@@ -596,7 +597,8 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
     assert_eq!(rows[0].vessels[1].depends_on, vec![rows[0].vessels[0].name.clone()]);
     assert!(rows[0].vessels[0].attach.is_some(), "presentation join surfaces as attach capability");
     assert!(rows[0].vessels[1].attach.is_none());
-    assert!(rows[0].vessels[1].complete_work);
+    assert!(rows[0].vessels[0].complete_work);
+    assert!(!rows[0].vessels[1].complete_work, "capabilities default closed");
     assert_eq!(StreamKey::Query { query: QueryId::Convoys }, StreamKey::Query { query: result_set.query() });
 }
 

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -237,7 +237,7 @@ pub struct VesselRow {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attach: Option<String>,
     /// Capability fact: the daemon will accept completing this vessel's work.
-    #[builder(default = true)]
+    #[builder(default)]
     pub complete_work: bool,
 }
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -114,6 +114,12 @@ pub enum WorkPhase {
     Cancelled,
 }
 
+impl WorkPhase {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Complete | Self::Failed | Self::Cancelled)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum WorkCompletionAuthority {
     #[default]


### PR DESCRIPTION
## Summary

- derive `VesselRow.complete_work` from the presence of non-terminal vessel work
- reject forced completion when work is already complete, failed, or cancelled
- share terminal-phase semantics between aggregation and command validation

## Why

`complete_work` was always emitted as `true` because the builder default was never overridden. That made the result-set capability disagree with real vessel state, and the command path also accepted already-terminal work.

After #681, crew completion remains reconciler-owned while this field describes the human override surface. Non-terminal work advertises the override; absent or terminal work does not.

## Impact

Consumers can rely on `complete_work` when deciding whether to expose the human completion override. Direct CLI attempts to complete terminal work now return a clear error instead of succeeding as a no-op or rewriting terminal state.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- two-axis standards/spec review against issue #694 and the merged #681 completion-authority model

Closes #694