### PR TITLE
fix: reduce per-project refresh scan multiplication

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -56,7 +56,10 @@ use crate::{
     model::{provider_names_from_registry, repo_name, RepoModel},
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        discovery::{discover_providers, run_host_detectors, DiscoveryResult, DiscoveryRuntime, EnvironmentAssertion, EnvironmentBag},
+        discovery::{
+            discover_providers_with_host_scoped, run_host_detectors, DiscoveryResult, DiscoveryRuntime, EnvironmentAssertion,
+            EnvironmentBag,
+        },
         ssh_runner::SshCommandRunner,
         ChannelLabel, CommandRunner,
     },
@@ -569,7 +572,21 @@ async fn discover_repo_for_environment(
     let remote_env = StaticEnvVars::from_bag(&host_bag);
     let env: &dyn crate::providers::discovery::EnvVars = if environment_id == local_environment_id { &*discovery.env } else { &remote_env };
 
-    Ok(discover_providers(&host_bag, &ee_path, &discovery.repo_detectors, &discovery.factories, config, runner, env).await)
+    let host_scoped = discovery
+        .host_scoped_providers
+        .discover_for_environment(environment_id, &host_bag, &discovery.factories, config, &ee_path, Arc::clone(&runner))
+        .await;
+    Ok(discover_providers_with_host_scoped(
+        &host_bag,
+        &ee_path,
+        &discovery.repo_detectors,
+        &discovery.factories,
+        config,
+        runner,
+        env,
+        &host_scoped,
+    )
+    .await)
 }
 
 fn normalize_local_provider_hosts(

--- a/crates/flotilla-core/src/model.rs
+++ b/crates/flotilla-core/src/model.rs
@@ -15,7 +15,7 @@ use crate::{
         registry::{ProviderRegistry, ProviderSet},
         types::RepoCriteria,
     },
-    refresh::RepoRefreshHandle,
+    refresh::{RefreshSchedule, RepoRefreshHandle},
 };
 pub fn labels_from_registry(registry: &ProviderRegistry) -> RepoLabels {
     fn labels<T: ?Sized>(set: &ProviderSet<T>) -> CategoryLabels {
@@ -95,7 +95,8 @@ impl RepoModel {
         let labels = labels_from_registry(&registry);
         let registry = Arc::new(registry);
         let criteria = RepoCriteria { repo_slug };
-        let refresh_handle = RepoRefreshHandle::spawn(
+        let refresh_schedule = RefreshSchedule::for_repo(&repo_root, Duration::from_secs(10), Duration::from_secs(60));
+        let refresh_handle = RepoRefreshHandle::spawn_with_schedule(
             repo_root,
             registry.clone(),
             criteria,
@@ -103,7 +104,7 @@ impl RepoModel {
             host_id,
             attachable_store,
             agent_state_store,
-            Duration::from_secs(10),
+            refresh_schedule,
         );
         Self { registry, data: DataStore::default(), labels, refresh_handle, environment_id }
     }

--- a/crates/flotilla-core/src/providers/coding_agent/claude.rs
+++ b/crates/flotilla-core/src/providers/coding_agent/claude.rs
@@ -4,7 +4,6 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc, LazyLock, Mutex,
     },
-    time::Instant,
 };
 
 use async_trait::async_trait;
@@ -12,13 +11,14 @@ use reqwest;
 use serde::Deserialize;
 use tracing::{debug, info, warn};
 
-use crate::providers::{http_execute, run, types::*, CommandRunner, HttpClient};
+use crate::providers::{http_execute, run, scan_cache::SharedScan, types::*, CommandRunner, HttpClient};
 
 pub struct ClaudeCodingAgent {
     provider_name: String,
     runner: Arc<dyn CommandRunner>,
     http: Arc<dyn HttpClient>,
-    sessions_cache: Mutex<SessionsCache>,
+    sessions: SharedScan<Vec<WebSession>>,
+    known_session_ids: Mutex<std::collections::HashSet<String>>,
     auth_warned: AtomicBool,
 }
 
@@ -28,13 +28,28 @@ impl ClaudeCodingAgent {
             provider_name,
             runner,
             http,
-            sessions_cache: Mutex::new(SessionsCache {
-                sessions: Vec::new(),
-                fetched_at: None,
-                known_ids: std::collections::HashSet::new(),
-            }),
+            sessions: SharedScan::new(std::time::Duration::from_secs(SESSIONS_CACHE_TTL_SECS)),
+            known_session_ids: Mutex::new(std::collections::HashSet::new()),
             auth_warned: AtomicBool::new(false),
         }
+    }
+
+    fn log_session_changes(&self, fetched: &[WebSession]) {
+        let mut known_ids = self.known_session_ids.lock().expect("Claude known session IDs lock poisoned");
+        let new_ids: std::collections::HashSet<String> = fetched.iter().map(|session| session.id.clone()).collect();
+        if !known_ids.is_empty() {
+            for session in fetched {
+                if !known_ids.contains(&session.id) {
+                    info!(provider = "claude", title = %session.title, id = %session.id, "session appeared");
+                }
+            }
+            for old_id in &*known_ids {
+                if !new_ids.contains(old_id) {
+                    info!(provider = "claude", id = %old_id, "session gone");
+                }
+            }
+        }
+        *known_ids = new_ids;
     }
 }
 
@@ -114,15 +129,7 @@ impl WebSession {
     }
 }
 
-// ---------- sessions cache ----------
-
-struct SessionsCache {
-    sessions: Vec<WebSession>,
-    fetched_at: Option<Instant>,
-    known_ids: std::collections::HashSet<String>,
-}
-
-const SESSIONS_CACHE_TTL_SECS: u64 = 30;
+const SESSIONS_CACHE_TTL_SECS: u64 = 60;
 const CLAUDE_API_BASE_URL: &str = "https://api.anthropic.com";
 
 fn sessions_url_for(base_url: &str) -> String {
@@ -252,47 +259,15 @@ impl ClaudeCodingAgent {
 #[async_trait]
 impl super::CloudAgentService for ClaudeCodingAgent {
     async fn list_sessions(&self, criteria: &RepoCriteria) -> Result<Vec<(String, CloudAgentSession)>, String> {
-        // Check instance cache
-        let cached = {
-            let cache = self.sessions_cache.lock().unwrap();
-            if let Some(fetched_at) = cache.fetched_at {
-                if fetched_at.elapsed().as_secs() < SESSIONS_CACHE_TTL_SECS {
-                    Some(cache.sessions.clone())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        let sessions = if let Some(sessions) = cached {
-            debug!(provider = "claude", "Claude sessions: cache hit");
-            sessions
-        } else {
-            let fetched = self.fetch_sessions(CLAUDE_API_BASE_URL).await?;
-            debug!(provider = "claude", count = fetched.len(), "Claude sessions: fetched from API");
-
-            // Diff against known IDs and log additions/removals at INFO
-            let mut cache = self.sessions_cache.lock().unwrap();
-            let new_ids: std::collections::HashSet<String> = fetched.iter().map(|s| s.id.clone()).collect();
-            if !cache.known_ids.is_empty() {
-                for s in &fetched {
-                    if !cache.known_ids.contains(&s.id) {
-                        info!(provider = "claude", title = %s.title, id = %s.id, "session appeared");
-                    }
-                }
-                for old_id in &cache.known_ids {
-                    if !new_ids.contains(old_id) {
-                        info!(provider = "claude", id = %old_id, "session gone");
-                    }
-                }
-            }
-            cache.known_ids = new_ids;
-            cache.sessions = fetched.clone();
-            cache.fetched_at = Some(Instant::now());
-            fetched
-        };
+        let sessions = self
+            .sessions
+            .get_or_scan(|| async {
+                let fetched = self.fetch_sessions(CLAUDE_API_BASE_URL).await?;
+                debug!(provider = "claude", count = fetched.len(), "Claude sessions: fetched from API");
+                self.log_session_changes(&fetched);
+                Ok(fetched)
+            })
+            .await?;
 
         // No remote slug means no cloud sessions can match this repo
         let Some(ref slug) = criteria.repo_slug else {
@@ -338,7 +313,11 @@ impl super::CloudAgentService for ClaudeCodingAgent {
     }
 
     async fn archive_session(&self, session_id: &str) -> Result<(), String> {
-        self.archive_session_inner(session_id, CLAUDE_API_BASE_URL).await
+        let result = self.archive_session_inner(session_id, CLAUDE_API_BASE_URL).await;
+        if result.is_ok() {
+            self.sessions.invalidate();
+        }
+        result
     }
 
     async fn attach_command(&self, session_id: &str) -> Result<String, String> {
@@ -348,7 +327,10 @@ impl super::CloudAgentService for ClaudeCodingAgent {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     use tokio::sync::Mutex as AsyncMutex;
 
@@ -385,6 +367,45 @@ mod tests {
 
     fn make_agent(runner: Arc<dyn CommandRunner>, http: Arc<dyn crate::providers::HttpClient>) -> ClaudeCodingAgent {
         ClaudeCodingAgent::new("claude".into(), runner, http)
+    }
+
+    struct CountingSessionsHttp {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl crate::providers::HttpClient for CountingSessionsHttp {
+        async fn execute(
+            &self,
+            _request: reqwest::Request,
+            _label: &crate::providers::ChannelLabel,
+        ) -> Result<http::Response<bytes::Bytes>, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            Ok(http::Response::builder()
+                .status(200)
+                .body(bytes::Bytes::from_static(
+                    br#"{"data":[{"id":"one","title":"One","session_status":"running","updated_at":"2026-03-01T00:00:00Z","session_context":{"outcomes":[]}}]}"#,
+                ))
+                .expect("session response"))
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_repo_projections_share_one_account_wide_session_fetch() {
+        let _test_lock = TEST_LOCK.lock().await;
+        reset_auth_state();
+        let runner = mock_runner(vec![Ok(token_json("shared", now_epoch_secs() + 3600))]);
+        let http = Arc::new(CountingSessionsHttp { calls: AtomicUsize::new(0) });
+        let agent = make_agent(runner, http.clone());
+
+        let repo_a = RepoCriteria { repo_slug: Some("owner/a".into()) };
+        let repo_b = RepoCriteria { repo_slug: Some("owner/b".into()) };
+        let (first, second) = tokio::join!(agent.list_sessions(&repo_a), agent.list_sessions(&repo_b));
+
+        first.expect("first repo projection");
+        second.expect("second repo projection");
+        assert_eq!(http.calls.load(Ordering::SeqCst), 1, "account-wide fetch should be shared before filtering by repo");
     }
 
     #[tokio::test]
@@ -477,46 +498,42 @@ mod tests {
         let session = replay::test_session(empty_fixture.to_str().unwrap(), replay::Masks::new());
         let http = replay::test_http_client(&session);
         let agent = make_agent(runner, http);
-        {
-            let mut cache = agent.sessions_cache.lock().unwrap();
-            cache.sessions = vec![
-                WebSession {
-                    id: "one".into(),
-                    title: "One".into(),
-                    session_status: "running".into(),
-                    created_at: String::new(),
-                    updated_at: "2026-03-05T00:00:00Z".into(),
-                    session_context: SessionContext {
-                        model: "sonnet".into(),
-                        outcomes: vec![SessionOutcome {
-                            git_info: Some(SessionGitInfo { branches: vec!["refs/heads/feat-a".into()], repo: Some("owner/repo".into()) }),
-                        }],
-                    },
+        agent.sessions.seed(vec![
+            WebSession {
+                id: "one".into(),
+                title: "One".into(),
+                session_status: "running".into(),
+                created_at: String::new(),
+                updated_at: "2026-03-05T00:00:00Z".into(),
+                session_context: SessionContext {
+                    model: "sonnet".into(),
+                    outcomes: vec![SessionOutcome {
+                        git_info: Some(SessionGitInfo { branches: vec!["refs/heads/feat-a".into()], repo: Some("owner/repo".into()) }),
+                    }],
                 },
-                WebSession {
-                    id: "two".into(),
-                    title: "Two".into(),
-                    session_status: "something-else".into(),
-                    created_at: String::new(),
-                    updated_at: "2026-03-04T00:00:00Z".into(),
-                    session_context: SessionContext { model: String::new(), outcomes: vec![SessionOutcome { git_info: None }] },
+            },
+            WebSession {
+                id: "two".into(),
+                title: "Two".into(),
+                session_status: "something-else".into(),
+                created_at: String::new(),
+                updated_at: "2026-03-04T00:00:00Z".into(),
+                session_context: SessionContext { model: String::new(), outcomes: vec![SessionOutcome { git_info: None }] },
+            },
+            WebSession {
+                id: "skip".into(),
+                title: "Skip".into(),
+                session_status: "running".into(),
+                created_at: String::new(),
+                updated_at: "2026-03-03T00:00:00Z".into(),
+                session_context: SessionContext {
+                    model: "opus".into(),
+                    outcomes: vec![SessionOutcome {
+                        git_info: Some(SessionGitInfo { branches: vec!["refs/heads/feat-b".into()], repo: Some("other/repo".into()) }),
+                    }],
                 },
-                WebSession {
-                    id: "skip".into(),
-                    title: "Skip".into(),
-                    session_status: "running".into(),
-                    created_at: String::new(),
-                    updated_at: "2026-03-03T00:00:00Z".into(),
-                    session_context: SessionContext {
-                        model: "opus".into(),
-                        outcomes: vec![SessionOutcome {
-                            git_info: Some(SessionGitInfo { branches: vec!["refs/heads/feat-b".into()], repo: Some("other/repo".into()) }),
-                        }],
-                    },
-                },
-            ];
-            cache.fetched_at = Some(Instant::now());
-        }
+            },
+        ]);
 
         let sessions = agent.list_sessions(&RepoCriteria { repo_slug: Some("owner/repo".into()) }).await.expect("list sessions");
 

--- a/crates/flotilla-core/src/providers/coding_agent/cursor.rs
+++ b/crates/flotilla-core/src/providers/coding_agent/cursor.rs
@@ -1,24 +1,30 @@
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 use async_trait::async_trait;
 use serde::Deserialize;
 use tracing::warn;
 
-use crate::providers::{http_execute, types::*, HttpClient};
+use crate::providers::{http_execute, scan_cache::SharedScan, types::*, HttpClient};
+
+const AGENTS_CACHE_TTL: Duration = Duration::from_secs(60);
 
 pub struct CursorCodingAgent {
     provider_name: String,
     api_key: String,
     http: Arc<dyn HttpClient>,
+    agents_cache: SharedScan<Vec<CursorAgent>>,
     auth_warned: AtomicBool,
 }
 
 impl CursorCodingAgent {
     pub fn new(provider_name: String, api_key: String, http: Arc<dyn HttpClient>) -> Self {
-        Self { provider_name, api_key, http, auth_warned: AtomicBool::new(false) }
+        Self { provider_name, api_key, http, agents_cache: SharedScan::new(AGENTS_CACHE_TTL), auth_warned: AtomicBool::new(false) }
     }
 
     async fn fetch_agents(&self) -> Result<Vec<CursorAgent>, String> {
@@ -159,7 +165,7 @@ fn repo_slug_from_cursor_repository(repository: &str) -> Option<String> {
 #[async_trait]
 impl super::CloudAgentService for CursorCodingAgent {
     async fn list_sessions(&self, criteria: &RepoCriteria) -> Result<Vec<(String, CloudAgentSession)>, String> {
-        let agents = match self.fetch_agents().await {
+        let agents = match self.agents_cache.get_or_scan(|| self.fetch_agents()).await {
             Ok(agents) => agents,
             Err(e) if e.contains("authentication") => {
                 if !self.auth_warned.swap(true, Ordering::Relaxed) {
@@ -211,6 +217,8 @@ impl super::CloudAgentService for CursorCodingAgent {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
     use crate::providers::coding_agent::CloudAgentService;
 
@@ -298,6 +306,42 @@ mod tests {
     fn cursor_service() -> CursorCodingAgent {
         let http: Arc<dyn crate::providers::HttpClient> = Arc::new(MockHttpClient);
         CursorCodingAgent::new("cursor".into(), "test-key".into(), http)
+    }
+
+    struct CountingCursorHttp {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::HttpClient for CountingCursorHttp {
+        async fn execute(
+            &self,
+            _request: reqwest::Request,
+            _label: &crate::providers::ChannelLabel,
+        ) -> Result<http::Response<bytes::Bytes>, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            Ok(http::Response::builder()
+                .status(200)
+                .body(bytes::Bytes::from_static(
+                    br#"{"agents":[{"id":"one","name":"One","status":"RUNNING","source":{"repository":"owner/a"},"target":{"branchName":"main"}}]}"#,
+                ))
+                .expect("Cursor response"))
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_repo_projections_share_one_account_wide_agent_fetch() {
+        let http = Arc::new(CountingCursorHttp { calls: AtomicUsize::new(0) });
+        let agent = CursorCodingAgent::new("cursor".into(), "test-key".into(), http.clone());
+        let repo_a = RepoCriteria { repo_slug: Some("owner/a".into()) };
+        let repo_b = RepoCriteria { repo_slug: Some("owner/b".into()) };
+
+        let (first, second) = tokio::join!(agent.list_sessions(&repo_a), agent.list_sessions(&repo_b));
+
+        assert_eq!(first.expect("first repo projection").len(), 1);
+        assert!(second.expect("second repo projection").is_empty());
+        assert_eq!(http.calls.load(Ordering::SeqCst), 1, "account-wide fetch should be shared before filtering by repo");
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -13,12 +13,16 @@ pub mod factories;
 pub mod test_support;
 
 use std::{
+    collections::HashMap,
     path::PathBuf,
-    sync::{Arc, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
+    time::Duration,
 };
 
 use async_trait::async_trait;
+use flotilla_protocol::EnvironmentId;
 use futures::stream;
+use tokio::sync::OnceCell as AsyncOnceCell;
 
 use crate::{
     agent_adapter::AgentAdapterRegistry,
@@ -32,6 +36,7 @@ use crate::{
         issue_tracker::IssueProvider,
         presentation::PresentationManager,
         registry::{ProviderRegistry, ProviderSet},
+        scan_cache::{SharedPresentationManager, SharedTerminalPool},
         terminal::TerminalPool,
         vcs::{CheckoutManager, Vcs},
         CommandRunner,
@@ -533,6 +538,112 @@ pub struct DiscoveryRuntime {
     pub repo_detectors: Vec<Box<dyn RepoDetector>>,
     pub factories: FactoryRegistry,
     pub(crate) attachable_store: OnceLock<SharedAttachableStore>,
+    pub(crate) host_scoped_providers: HostScopedProviderCache,
+}
+
+const HOST_SCAN_CACHE_TTL: Duration = Duration::from_secs(10);
+
+#[derive(Default)]
+pub(crate) struct HostScopedProviderCache {
+    environments: Mutex<HashMap<EnvironmentId, Arc<AsyncOnceCell<HostScopedDiscovery>>>>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct HostScopedProviders {
+    cloud_agents: Vec<(ProviderDescriptor, Arc<dyn CloudAgentService>)>,
+    presentation_managers: Vec<(ProviderDescriptor, Arc<dyn PresentationManager>)>,
+    terminal_pools: Vec<(ProviderDescriptor, Arc<dyn TerminalPool>)>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct HostScopedDiscovery {
+    providers: HostScopedProviders,
+    unmet: Vec<(String, UnmetRequirement)>,
+}
+
+impl HostScopedDiscovery {
+    fn install(&self, registry: &mut ProviderRegistry, unmet: &mut Vec<(String, UnmetRequirement)>) {
+        for (descriptor, provider) in &self.providers.cloud_agents {
+            registry.cloud_agents.insert(descriptor.implementation.clone(), descriptor.clone(), Arc::clone(provider));
+        }
+        for (descriptor, provider) in &self.providers.presentation_managers {
+            registry.presentation_managers.insert(descriptor.implementation.clone(), descriptor.clone(), Arc::clone(provider));
+        }
+        for (descriptor, provider) in &self.providers.terminal_pools {
+            registry.terminal_pools.insert(descriptor.implementation.clone(), descriptor.clone(), Arc::clone(provider));
+        }
+        unmet.extend(self.unmet.iter().cloned());
+    }
+}
+
+async fn probe_host_category<T: ?Sized + Send + Sync + 'static>(
+    factories: &[Box<dyn Factory<Descriptor = ProviderDescriptor, Output = T>>],
+    host_bag: &EnvironmentBag,
+    config: &ConfigStore,
+    probe_root: &ExecutionEnvironmentPath,
+    runner: &Arc<dyn CommandRunner>,
+    wrap: impl Fn(Arc<T>) -> Arc<T>,
+) -> (Vec<(ProviderDescriptor, Arc<T>)>, Vec<(String, UnmetRequirement)>) {
+    let mut providers = Vec::new();
+    let mut unmet = Vec::new();
+    for factory in factories {
+        let descriptor = factory.descriptor();
+        if providers.iter().any(|(existing, _): &(ProviderDescriptor, Arc<T>)| existing.implementation == descriptor.implementation) {
+            continue;
+        }
+        match factory.probe(host_bag, config, probe_root, Arc::clone(runner)).await {
+            Ok(provider) => providers.push((descriptor, wrap(provider))),
+            Err(requirements) => {
+                unmet.extend(requirements.into_iter().map(|requirement| (descriptor.implementation.clone(), requirement)));
+            }
+        }
+    }
+    (providers, unmet)
+}
+
+impl HostScopedProviderCache {
+    /// Probe host-scoped categories once per environment and retain the provider
+    /// instances for every repository discovered there. All factories in these
+    /// categories are audited to depend only on the host bag, process config,
+    /// and environment runner; none consumes repository detector state or root.
+    pub(crate) async fn discover_for_environment(
+        &self,
+        environment_id: &EnvironmentId,
+        host_bag: &EnvironmentBag,
+        factories: &FactoryRegistry,
+        config: &ConfigStore,
+        probe_root: &ExecutionEnvironmentPath,
+        runner: Arc<dyn CommandRunner>,
+    ) -> HostScopedDiscovery {
+        let cell = self
+            .environments
+            .lock()
+            .expect("host-scoped provider cache lock poisoned")
+            .entry(environment_id.clone())
+            .or_insert_with(|| Arc::new(AsyncOnceCell::new()))
+            .clone();
+
+        cell.get_or_init(|| async {
+            let (cloud_agents, mut unmet) =
+                probe_host_category(&factories.cloud_agents, host_bag, config, probe_root, &runner, |provider| provider).await;
+            let (presentation_managers, presentation_unmet) =
+                probe_host_category(&factories.presentation_managers, host_bag, config, probe_root, &runner, |provider| {
+                    Arc::new(SharedPresentationManager::new(provider, HOST_SCAN_CACHE_TTL))
+                })
+                .await;
+            unmet.extend(presentation_unmet);
+            let (terminal_pools, terminal_unmet) =
+                probe_host_category(&factories.terminal_pools, host_bag, config, probe_root, &runner, |provider| {
+                    Arc::new(SharedTerminalPool::new(provider, HOST_SCAN_CACHE_TTL))
+                })
+                .await;
+            unmet.extend(terminal_unmet);
+
+            HostScopedDiscovery { providers: HostScopedProviders { cloud_agents, presentation_managers, terminal_pools }, unmet }
+        })
+        .await
+        .clone()
+    }
 }
 
 impl DiscoveryRuntime {
@@ -545,6 +656,7 @@ impl DiscoveryRuntime {
             repo_detectors: detectors::default_repo_detectors(),
             factories,
             attachable_store: OnceLock::new(),
+            host_scoped_providers: HostScopedProviderCache::default(),
         }
     }
 
@@ -588,6 +700,34 @@ pub async fn discover_providers(
     config: &ConfigStore,
     runner: Arc<dyn CommandRunner>,
     env: &dyn EnvVars,
+) -> DiscoveryResult {
+    discover_providers_inner(host_bag, repo_root, repo_detectors, factories, config, runner, env, None).await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn discover_providers_with_host_scoped(
+    host_bag: &EnvironmentBag,
+    repo_root: &ExecutionEnvironmentPath,
+    repo_detectors: &[Box<dyn RepoDetector>],
+    factories: &FactoryRegistry,
+    config: &ConfigStore,
+    runner: Arc<dyn CommandRunner>,
+    env: &dyn EnvVars,
+    host_scoped: &HostScopedDiscovery,
+) -> DiscoveryResult {
+    discover_providers_inner(host_bag, repo_root, repo_detectors, factories, config, runner, env, Some(host_scoped)).await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn discover_providers_inner(
+    host_bag: &EnvironmentBag,
+    repo_root: &ExecutionEnvironmentPath,
+    repo_detectors: &[Box<dyn RepoDetector>],
+    factories: &FactoryRegistry,
+    config: &ConfigStore,
+    runner: Arc<dyn CommandRunner>,
+    env: &dyn EnvVars,
+    host_scoped: Option<&HostScopedDiscovery>,
 ) -> DiscoveryResult {
     let runner_ref = &*runner;
     // Phase 1: run repo detectors
@@ -638,22 +778,26 @@ pub async fn discover_providers(
         registry.issue_trackers.insert(desc.implementation.clone(), desc, provider);
     })
     .await;
-    probe_all(&factories.cloud_agents, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
-        registry.cloud_agents.insert(desc.implementation.clone(), desc, provider);
-    })
-    .await;
+    if host_scoped.is_none() {
+        probe_all(&factories.cloud_agents, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
+            registry.cloud_agents.insert(desc.implementation.clone(), desc, provider);
+        })
+        .await;
+    }
     probe_all(&factories.ai_utilities, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
         registry.ai_utilities.insert(desc.implementation.clone(), desc, provider);
     })
     .await;
-    probe_all(&factories.presentation_managers, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
-        registry.presentation_managers.insert(desc.implementation.clone(), desc, provider);
-    })
-    .await;
-    probe_all(&factories.terminal_pools, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
-        registry.terminal_pools.insert(desc.implementation.clone(), desc, provider);
-    })
-    .await;
+    if host_scoped.is_none() {
+        probe_all(&factories.presentation_managers, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
+            registry.presentation_managers.insert(desc.implementation.clone(), desc, provider);
+        })
+        .await;
+        probe_all(&factories.terminal_pools, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
+            registry.terminal_pools.insert(desc.implementation.clone(), desc, provider);
+        })
+        .await;
+    }
     probe_all(&factories.environment_providers, &combined, config, repo_root, &runner, &mut unmet, |desc, provider| {
         registry.environment_providers.insert(desc.implementation.clone(), desc, provider);
     })
@@ -671,6 +815,10 @@ pub async fn discover_providers(
                 unmet.extend(reqs.into_iter().map(|r| (desc.implementation.clone(), r)));
             }
         }
+    }
+
+    if let Some(host_scoped) = host_scoped {
+        host_scoped.install(&mut registry, &mut unmet);
     }
 
     // Apply provider preferences from config, tracking unresolved preferences.

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -269,6 +269,7 @@ fn minimal_discovery_runtime(follower: bool, runner: std::sync::Arc<dyn CommandR
         repo_detectors: super::detectors::default_repo_detectors(),
         factories,
         attachable_store: OnceLock::new(),
+        host_scoped_providers: Default::default(),
     }
 }
 // ---------------------------------------------------------------------------
@@ -1202,6 +1203,7 @@ pub fn fake_discovery_with_provider_set(providers: FakeDiscoveryProviders) -> Di
             issue_query_services: issue_query_service_factories,
         },
         attachable_store,
+        host_scoped_providers: Default::default(),
     }
 }
 

--- a/crates/flotilla-core/src/providers/discovery/tests.rs
+++ b/crates/flotilla-core/src/providers/discovery/tests.rs
@@ -252,3 +252,123 @@ fn service_descriptor_fields() {
 fn service_category_slug() {
     assert_eq!(ServiceCategory::IssueQuery.slug(), "issue_query");
 }
+
+struct CountingPresentationManager(Arc<std::sync::atomic::AtomicUsize>);
+
+#[async_trait]
+impl PresentationManager for CountingPresentationManager {
+    async fn list_workspaces(&self) -> Result<Vec<(String, crate::providers::types::Workspace)>, String> {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(vec![])
+    }
+
+    async fn create_workspace(
+        &self,
+        _config: &crate::providers::types::WorkspaceAttachRequest,
+    ) -> Result<(String, crate::providers::types::Workspace), String> {
+        unreachable!("not used by this test")
+    }
+
+    async fn select_workspace(&self, _ws_ref: &str) -> Result<(), String> {
+        unreachable!("not used by this test")
+    }
+
+    async fn delete_workspace(&self, _ws_ref: &str) -> Result<(), String> {
+        unreachable!("not used by this test")
+    }
+
+    fn binding_scope_prefix(&self) -> String {
+        String::new()
+    }
+}
+
+struct CountingPresentationFactory {
+    probes: Arc<std::sync::atomic::AtomicUsize>,
+    scans: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[async_trait]
+impl Factory for CountingPresentationFactory {
+    type Descriptor = ProviderDescriptor;
+    type Output = dyn PresentationManager;
+
+    fn descriptor(&self) -> ProviderDescriptor {
+        ProviderDescriptor::named(ProviderCategory::WorkspaceManager, "test")
+    }
+
+    async fn probe(
+        &self,
+        _env: &EnvironmentBag,
+        _config: &ConfigStore,
+        _repo_root: &ExecutionEnvironmentPath,
+        _runner: Arc<dyn CommandRunner>,
+    ) -> Result<Arc<dyn PresentationManager>, Vec<UnmetRequirement>> {
+        self.probes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(Arc::new(CountingPresentationManager(Arc::clone(&self.scans))))
+    }
+}
+
+fn factories_with_presentation(factory: CountingPresentationFactory) -> FactoryRegistry {
+    FactoryRegistry {
+        vcs: vec![],
+        checkout_managers: vec![],
+        change_requests: vec![],
+        issue_trackers: vec![],
+        cloud_agents: vec![],
+        ai_utilities: vec![],
+        presentation_managers: vec![Box::new(factory)],
+        terminal_pools: vec![],
+        environment_providers: vec![],
+        issue_query_services: vec![],
+    }
+}
+
+#[tokio::test]
+async fn host_scoped_provider_cache_probes_once_and_reuses_scans_within_an_environment() {
+    let cache = HostScopedProviderCache::default();
+    let probes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let scans = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let factories = factories_with_presentation(CountingPresentationFactory { probes: Arc::clone(&probes), scans: Arc::clone(&scans) });
+    let config_dir = tempfile::tempdir().expect("config dir");
+    let config = ConfigStore::with_base(config_dir.path());
+    let runner: Arc<dyn CommandRunner> = Arc::new(test_support::DiscoveryMockRunner::builder().build());
+    let host_bag = EnvironmentBag::new();
+    let environment_a = EnvironmentId::new("a");
+    let environment_b = EnvironmentId::new("b");
+
+    let first = cache
+        .discover_for_environment(
+            &environment_a,
+            &host_bag,
+            &factories,
+            &config,
+            &ExecutionEnvironmentPath::new("/first"),
+            Arc::clone(&runner),
+        )
+        .await;
+    let second = cache
+        .discover_for_environment(
+            &environment_a,
+            &host_bag,
+            &factories,
+            &config,
+            &ExecutionEnvironmentPath::new("/second"),
+            Arc::clone(&runner),
+        )
+        .await;
+    assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 1, "the second repo must not probe host providers again");
+
+    let first_manager = &first.providers.presentation_managers[0].1;
+    let second_manager = &second.providers.presentation_managers[0].1;
+    let (first_result, second_result) = tokio::join!(first_manager.list_workspaces(), second_manager.list_workspaces());
+    first_result.expect("first environment scan");
+    second_result.expect("shared environment scan");
+    assert_eq!(scans.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+    let distinct_environment = cache
+        .discover_for_environment(&environment_b, &host_bag, &factories, &config, &ExecutionEnvironmentPath::new("/third"), runner)
+        .await;
+    distinct_environment.providers.presentation_managers[0].1.list_workspaces().await.expect("distinct environment scan");
+    assert_eq!(probes.load(std::sync::atomic::Ordering::SeqCst), 2);
+    assert_eq!(scans.load(std::sync::atomic::Ordering::SeqCst), 2);
+}

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -9,6 +9,7 @@ pub mod issue_query;
 pub mod issue_tracker;
 pub mod presentation;
 pub mod registry;
+pub(crate) mod scan_cache;
 pub mod ssh_runner;
 pub mod terminal;
 pub mod types;

--- a/crates/flotilla-core/src/providers/scan_cache.rs
+++ b/crates/flotilla-core/src/providers/scan_cache.rs
@@ -1,0 +1,255 @@
+use std::{
+    future::Future,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use tokio::{sync::Mutex as AsyncMutex, time::Instant};
+
+use crate::{
+    path_context::ExecutionEnvironmentPath,
+    providers::{
+        presentation::PresentationManager,
+        terminal::{TerminalEnvVars, TerminalPool, TerminalSession},
+        types::{Workspace, WorkspaceAttachRequest},
+    },
+};
+
+pub(crate) struct SharedScan<T> {
+    ttl: Duration,
+    result: Mutex<Option<CachedScan<T>>>,
+    scan_lock: AsyncMutex<()>,
+}
+
+struct CachedScan<T> {
+    scanned_at: Instant,
+    result: Result<T, String>,
+}
+
+impl<T: Clone> SharedScan<T> {
+    pub(crate) fn new(ttl: Duration) -> Self {
+        Self { ttl, result: Mutex::new(None), scan_lock: AsyncMutex::new(()) }
+    }
+
+    pub(crate) async fn get_or_scan<F, Fut>(&self, scan: F) -> Result<T, String>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T, String>>,
+    {
+        if let Some(result) = self.fresh_result() {
+            return result;
+        }
+
+        let _guard = self.scan_lock.lock().await;
+        if let Some(result) = self.fresh_result() {
+            return result;
+        }
+
+        let result = scan().await;
+        *self.result.lock().expect("shared scan result lock poisoned") =
+            Some(CachedScan { scanned_at: Instant::now(), result: result.clone() });
+        result
+    }
+
+    pub(crate) fn invalidate(&self) {
+        *self.result.lock().expect("shared scan result lock poisoned") = None;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn seed(&self, value: T) {
+        *self.result.lock().expect("shared scan result lock poisoned") = Some(CachedScan { scanned_at: Instant::now(), result: Ok(value) });
+    }
+
+    fn fresh_result(&self) -> Option<Result<T, String>> {
+        self.result
+            .lock()
+            .expect("shared scan result lock poisoned")
+            .as_ref()
+            .filter(|cached| cached.scanned_at.elapsed() < self.ttl)
+            .map(|cached| cached.result.clone())
+    }
+}
+
+pub(crate) struct SharedPresentationManager {
+    inner: Arc<dyn PresentationManager>,
+    workspaces: SharedScan<Vec<(String, Workspace)>>,
+}
+
+impl SharedPresentationManager {
+    pub(crate) fn new(inner: Arc<dyn PresentationManager>, ttl: Duration) -> Self {
+        Self { inner, workspaces: SharedScan::new(ttl) }
+    }
+}
+
+#[async_trait]
+impl PresentationManager for SharedPresentationManager {
+    async fn list_workspaces(&self) -> Result<Vec<(String, Workspace)>, String> {
+        self.workspaces.get_or_scan(|| self.inner.list_workspaces()).await
+    }
+
+    async fn create_workspace(&self, config: &WorkspaceAttachRequest) -> Result<(String, Workspace), String> {
+        let result = self.inner.create_workspace(config).await;
+        if result.is_ok() {
+            self.workspaces.invalidate();
+        }
+        result
+    }
+
+    async fn select_workspace(&self, ws_ref: &str) -> Result<(), String> {
+        self.inner.select_workspace(ws_ref).await
+    }
+
+    async fn delete_workspace(&self, ws_ref: &str) -> Result<(), String> {
+        let result = self.inner.delete_workspace(ws_ref).await;
+        if result.is_ok() {
+            self.workspaces.invalidate();
+        }
+        result
+    }
+
+    fn binding_scope_prefix(&self) -> String {
+        self.inner.binding_scope_prefix()
+    }
+}
+
+pub(crate) struct SharedTerminalPool {
+    inner: Arc<dyn TerminalPool>,
+    sessions: SharedScan<Vec<TerminalSession>>,
+}
+
+impl SharedTerminalPool {
+    pub(crate) fn new(inner: Arc<dyn TerminalPool>, ttl: Duration) -> Self {
+        Self { inner, sessions: SharedScan::new(ttl) }
+    }
+}
+
+#[async_trait]
+impl TerminalPool for SharedTerminalPool {
+    fn tracks_session_liveness(&self) -> bool {
+        self.inner.tracks_session_liveness()
+    }
+
+    async fn list_sessions(&self) -> Result<Vec<TerminalSession>, String> {
+        self.sessions.get_or_scan(|| self.inner.list_sessions()).await
+    }
+
+    async fn ensure_session(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+    ) -> Result<(), String> {
+        let result = self.inner.ensure_session(session_name, command, cwd, env_vars).await;
+        if result.is_ok() {
+            self.sessions.invalidate();
+        }
+        result
+    }
+
+    fn attach_args(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+    ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
+        self.inner.attach_args(session_name, command, cwd, env_vars)
+    }
+
+    async fn attach_command(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+    ) -> Result<String, String> {
+        self.inner.attach_command(session_name, command, cwd, env_vars).await
+    }
+
+    async fn kill_session(&self, session_name: &str) -> Result<(), String> {
+        let result = self.inner.kill_session(session_name).await;
+        if result.is_ok() {
+            self.sessions.invalidate();
+        }
+        result
+    }
+
+    async fn deliver(&self, session_name: &str, text: &str, submit: bool) -> Result<(), String> {
+        self.inner.deliver(session_name, text, submit).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::sync::Mutex;
+
+    use super::*;
+
+    struct CountingPresentationManager {
+        calls: AtomicUsize,
+        workspaces: Mutex<Vec<(String, Workspace)>>,
+    }
+
+    impl CountingPresentationManager {
+        fn new() -> Self {
+            Self { calls: AtomicUsize::new(0), workspaces: Mutex::new(vec![]) }
+        }
+    }
+
+    #[async_trait]
+    impl PresentationManager for CountingPresentationManager {
+        async fn list_workspaces(&self) -> Result<Vec<(String, Workspace)>, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            Ok(self.workspaces.lock().await.clone())
+        }
+
+        async fn create_workspace(&self, config: &WorkspaceAttachRequest) -> Result<(String, Workspace), String> {
+            let workspace = Workspace { name: config.name.clone(), correlation_keys: vec![], attachable_set_id: None };
+            let entry = (format!("workspace:{}", config.name), workspace);
+            self.workspaces.lock().await.push(entry.clone());
+            Ok(entry)
+        }
+
+        async fn select_workspace(&self, _ws_ref: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn delete_workspace(&self, ws_ref: &str) -> Result<(), String> {
+            self.workspaces.lock().await.retain(|(candidate, _)| candidate != ws_ref);
+            Ok(())
+        }
+
+        fn binding_scope_prefix(&self) -> String {
+            String::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_workspace_reads_share_one_scan_and_mutations_invalidate_it() {
+        let inner = Arc::new(CountingPresentationManager::new());
+        let manager = SharedPresentationManager::new(inner.clone(), Duration::from_secs(10));
+
+        let (first, second) = tokio::join!(manager.list_workspaces(), manager.list_workspaces());
+        assert!(first.expect("first workspace scan").is_empty());
+        assert!(second.expect("second workspace scan").is_empty());
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1, "concurrent readers should share the underlying scan");
+
+        let request = WorkspaceAttachRequest {
+            name: "new".into(),
+            working_directory: ExecutionEnvironmentPath::new("/repo"),
+            attach_commands: vec![],
+            template_yaml: None,
+            template_vars: Default::default(),
+        };
+        manager.create_workspace(&request).await.expect("create workspace");
+        let workspaces = manager.list_workspaces().await.expect("scan after mutation");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 2, "a successful mutation should invalidate the shared result");
+    }
+}

--- a/crates/flotilla-core/src/providers/scan_cache.rs
+++ b/crates/flotilla-core/src/providers/scan_cache.rs
@@ -18,8 +18,13 @@ use crate::{
 
 pub(crate) struct SharedScan<T> {
     ttl: Duration,
-    result: Mutex<Option<CachedScan<T>>>,
+    state: Mutex<ScanState<T>>,
     scan_lock: AsyncMutex<()>,
+}
+
+struct ScanState<T> {
+    generation: u64,
+    result: Option<CachedScan<T>>,
 }
 
 struct CachedScan<T> {
@@ -29,7 +34,7 @@ struct CachedScan<T> {
 
 impl<T: Clone> SharedScan<T> {
     pub(crate) fn new(ttl: Duration) -> Self {
-        Self { ttl, result: Mutex::new(None), scan_lock: AsyncMutex::new(()) }
+        Self { ttl, state: Mutex::new(ScanState { generation: 0, result: None }), scan_lock: AsyncMutex::new(()) }
     }
 
     pub(crate) async fn get_or_scan<F, Fut>(&self, scan: F) -> Result<T, String>
@@ -46,25 +51,31 @@ impl<T: Clone> SharedScan<T> {
             return Ok(result);
         }
 
+        let generation = self.state.lock().expect("shared scan state lock poisoned").generation;
         let result = scan().await?;
-        *self.result.lock().expect("shared scan result lock poisoned") =
-            Some(CachedScan { scanned_at: Instant::now(), result: result.clone() });
+        let mut state = self.state.lock().expect("shared scan state lock poisoned");
+        if state.generation == generation {
+            state.result = Some(CachedScan { scanned_at: Instant::now(), result: result.clone() });
+        }
         Ok(result)
     }
 
     pub(crate) fn invalidate(&self) {
-        *self.result.lock().expect("shared scan result lock poisoned") = None;
+        let mut state = self.state.lock().expect("shared scan state lock poisoned");
+        state.generation = state.generation.wrapping_add(1);
+        state.result = None;
     }
 
     #[cfg(test)]
     pub(crate) fn seed(&self, value: T) {
-        *self.result.lock().expect("shared scan result lock poisoned") = Some(CachedScan { scanned_at: Instant::now(), result: value });
+        self.state.lock().expect("shared scan state lock poisoned").result = Some(CachedScan { scanned_at: Instant::now(), result: value });
     }
 
     fn fresh_result(&self) -> Option<T> {
-        self.result
+        self.state
             .lock()
-            .expect("shared scan result lock poisoned")
+            .expect("shared scan state lock poisoned")
+            .result
             .as_ref()
             .filter(|cached| cached.scanned_at.elapsed() < self.ttl)
             .map(|cached| cached.result.clone())
@@ -210,6 +221,32 @@ mod tests {
         assert_eq!(first, Err("transient failure".to_string()));
         assert_eq!(second, Ok(42));
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn invalidation_during_a_scan_prevents_the_stale_result_from_being_cached() {
+        let scan = Arc::new(SharedScan::new(Duration::from_secs(10)));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let in_flight = {
+            let scan = Arc::clone(&scan);
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            tokio::spawn(async move {
+                scan.get_or_scan(|| async move {
+                    started.notify_one();
+                    release.notified().await;
+                    Ok(1)
+                })
+                .await
+            })
+        };
+
+        started.notified().await;
+        scan.invalidate();
+        release.notify_one();
+        assert_eq!(in_flight.await.expect("scan task"), Ok(1));
+        assert_eq!(scan.get_or_scan(|| async { Ok(2) }).await, Ok(2));
     }
 
     struct CountingPresentationManager {

--- a/crates/flotilla-core/src/providers/scan_cache.rs
+++ b/crates/flotilla-core/src/providers/scan_cache.rs
@@ -24,7 +24,7 @@ pub(crate) struct SharedScan<T> {
 
 struct CachedScan<T> {
     scanned_at: Instant,
-    result: Result<T, String>,
+    result: T,
 }
 
 impl<T: Clone> SharedScan<T> {
@@ -38,18 +38,18 @@ impl<T: Clone> SharedScan<T> {
         Fut: Future<Output = Result<T, String>>,
     {
         if let Some(result) = self.fresh_result() {
-            return result;
+            return Ok(result);
         }
 
         let _guard = self.scan_lock.lock().await;
         if let Some(result) = self.fresh_result() {
-            return result;
+            return Ok(result);
         }
 
-        let result = scan().await;
+        let result = scan().await?;
         *self.result.lock().expect("shared scan result lock poisoned") =
             Some(CachedScan { scanned_at: Instant::now(), result: result.clone() });
-        result
+        Ok(result)
     }
 
     pub(crate) fn invalidate(&self) {
@@ -58,10 +58,10 @@ impl<T: Clone> SharedScan<T> {
 
     #[cfg(test)]
     pub(crate) fn seed(&self, value: T) {
-        *self.result.lock().expect("shared scan result lock poisoned") = Some(CachedScan { scanned_at: Instant::now(), result: Ok(value) });
+        *self.result.lock().expect("shared scan result lock poisoned") = Some(CachedScan { scanned_at: Instant::now(), result: value });
     }
 
-    fn fresh_result(&self) -> Option<Result<T, String>> {
+    fn fresh_result(&self) -> Option<T> {
         self.result
             .lock()
             .expect("shared scan result lock poisoned")
@@ -188,6 +188,29 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::*;
+
+    #[tokio::test]
+    async fn failed_scans_are_retried_instead_of_cached() {
+        let scan = SharedScan::new(Duration::from_secs(10));
+        let calls = AtomicUsize::new(0);
+
+        let first = scan
+            .get_or_scan(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<usize, _>("transient failure".to_string())
+            })
+            .await;
+        let second = scan
+            .get_or_scan(|| async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(42)
+            })
+            .await;
+
+        assert_eq!(first, Err("transient failure".to_string()));
+        assert_eq!(second, Ok(42));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
 
     struct CountingPresentationManager {
         calls: AtomicUsize,

--- a/crates/flotilla-core/src/providers/vcs/fixtures/git_create_remote_branch.yaml
+++ b/crates/flotilla-core/src/providers/vcs/fixtures/git_create_remote_branch.yaml
@@ -1,134 +1,124 @@
-# Fixture for creating a worktree that tracks a remote-only branch.
-# The branch feature/remote-only exists on origin but not locally.
-# The worktree should end up on the remote branch's commit, not main.
-interactions:
-# 1. Check if local branch exists — it doesn't
-- channel: command
-  cmd: git
-  args:
-  - show-ref
-  - '--verify'
-  - '--quiet'
-  - refs/heads/feature/remote-only
-  cwd: '{repo}'
-  stdout: null
-  stderr: ''
-  exit_code: 1
-# 2. Detect default branch (always runs)
-- channel: command
-  cmd: git
-  args:
-  - symbolic-ref
-  - refs/remotes/origin/HEAD
-  - '--short'
-  cwd: '{repo}'
-  stdout: "origin/main\n"
-  stderr: null
-  exit_code: 0
-# 3. Check if remote tracking branch exists — it does
-- channel: command
-  cmd: git
-  args:
-  - show-ref
-  - '--verify'
-  - '--quiet'
-  - refs/remotes/origin/feature/remote-only
-  cwd: '{repo}'
-  stdout: null
-  stderr: ''
-  exit_code: 0
-# 4. Fetch the remote branch to get latest
-- channel: command
-  cmd: git
-  args:
-  - fetch
-  - origin
-  - feature/remote-only
-  cwd: '{repo}'
-  stdout: ''
-  stderr: null
-  exit_code: 0
-# 5. Create worktree tracking the remote branch
-- channel: command
-  cmd: git
-  args:
-  - worktree
-  - add
-  - -b
-  - feature/remote-only
-  - '{repo}.feature-remote-only'
-  - origin/feature/remote-only
-  cwd: '{repo}'
-  stdout: ''
-  stderr: null
-  exit_code: 0
-# 6. Enrichment — trunk ahead/behind (1 commit ahead of main)
-- channel: command
-  label: trunk-ab
-  cmd: git
-  args:
-  - rev-list
-  - '--left-right'
-  - '--count'
-  - HEAD...main
-  cwd: '{repo}.feature-remote-only'
-  stdout: "1\t0\n"
-  stderr: null
-  exit_code: 0
-# 7. Enrichment — remote ahead/behind (in sync with origin)
-- channel: command
-  label: remote-ab
-  cmd: git
-  args:
-  - rev-list
-  - '--left-right'
-  - '--count'
-  - HEAD...origin/feature/remote-only
-  cwd: '{repo}.feature-remote-only'
-  stdout: "0\t0\n"
-  stderr: null
-  exit_code: 0
-# 8. Enrichment — working tree status (clean)
-- channel: command
-  cmd: git
-  args:
-  - status
-  - '--porcelain'
-  cwd: '{repo}.feature-remote-only'
-  stdout: ''
-  stderr: null
-  exit_code: 0
-# 9. Enrichment — last commit
-- channel: command
-  cmd: git
-  args:
-  - log
-  - '-1'
-  - "--format=%h\t%s"
-  cwd: '{repo}.feature-remote-only'
-  stdout: "abc1234\tremote-only work\n"
-  stderr: null
-  exit_code: 0
-# 10. Enrichment — issue links (none)
-- channel: command
-  cmd: git
-  args:
-  - config
-  - '--get-regexp'
-  - branch\.feature/remote-only\.flotilla\.issues\.
-  cwd: '{repo}.feature-remote-only'
-  stdout: null
-  stderr: ''
-  exit_code: 1
-# 11. Verification — confirm HEAD commit message
-- channel: command
-  label: verify-commit
-  cmd: git
-  args:
-  - log
-  - '-1'
-  - '--format=%s'
-  cwd: '{repo}.feature-remote-only'
-  stdout: "remote-only work\n"
-  stderr: null
-  exit_code: 0
+rounds:
+- interactions:
+  - channel: command
+    cmd: git
+    args:
+    - config
+    - '--get-regexp'
+    - ^branch\..*\.flotilla\.issues\.
+    cwd: '{repo}'
+    stderr: ''
+    exit_code: 1
+  - channel: command
+    cmd: git
+    args:
+    - fetch
+    - origin
+    - feature/remote-only
+    cwd: '{repo}'
+    stdout: ''
+    exit_code: 0
+  - channel: command
+    cmd: git
+    args:
+    - log
+    - '-1'
+    - "--format=%h\t%s"
+    cwd: '{repo}.feature-remote-only'
+    stdout: "8d63943\tremote-only work\n"
+    exit_code: 0
+  - channel: command
+    cmd: git
+    args:
+    - show-ref
+    - '--verify'
+    - '--quiet'
+    - refs/heads/feature/remote-only
+    cwd: '{repo}'
+    stderr: ''
+    exit_code: 1
+  - channel: command
+    cmd: git
+    args:
+    - show-ref
+    - '--verify'
+    - '--quiet'
+    - refs/heads/main
+    cwd: '{repo}'
+    stdout: ''
+    exit_code: 0
+  - channel: command
+    cmd: git
+    args:
+    - show-ref
+    - '--verify'
+    - '--quiet'
+    - refs/remotes/origin/feature/remote-only
+    cwd: '{repo}'
+    stdout: ''
+    exit_code: 0
+  - channel: command
+    cmd: git
+    args:
+    - status
+    - '--porcelain'
+    cwd: '{repo}.feature-remote-only'
+    stdout: ''
+    exit_code: 0
+  - channel: command
+    cmd: git
+    args:
+    - symbolic-ref
+    - refs/remotes/origin/HEAD
+    - '--short'
+    cwd: '{repo}'
+    stderr: |
+      fatal: ref refs/remotes/origin/HEAD is not a symbolic ref
+    exit_code: 1
+  - channel: command
+    cmd: git
+    args:
+    - worktree
+    - add
+    - '-b'
+    - feature/remote-only
+    - '{repo}.feature-remote-only'
+    - origin/feature/remote-only
+    cwd: '{repo}'
+    stdout: |
+      branch 'feature/remote-only' set up to track 'origin/feature/remote-only'.
+      HEAD is now at 8d63943 remote-only work
+    exit_code: 0
+  - channel: command
+    label: remote-ab
+    cmd: git
+    args:
+    - rev-list
+    - '--left-right'
+    - '--count'
+    - HEAD...origin/feature/remote-only
+    cwd: '{repo}.feature-remote-only'
+    stdout: "0\t0\n"
+    exit_code: 0
+  - channel: command
+    label: trunk-ab
+    cmd: git
+    args:
+    - rev-list
+    - '--left-right'
+    - '--count'
+    - HEAD...main
+    cwd: '{repo}.feature-remote-only'
+    stdout: "1\t0\n"
+    exit_code: 0
+  - channel: command
+    label: verify-commit
+    cmd: git
+    args:
+    - log
+    - '-1'
+    - '--format=%s'
+    cwd: '{repo}.feature-remote-only'
+    stdout: |
+      remote-only work
+    exit_code: 0

--- a/crates/flotilla-core/src/providers/vcs/fixtures/wt_list.yaml
+++ b/crates/flotilla-core/src/providers/vcs/fixtures/wt_list.yaml
@@ -1,104 +1,93 @@
-interactions:
-- channel: command
-  cmd: wt
-  args:
-  - list
-  - '--format=json'
-  cwd: '{repo}'
-  stdout: |
-    [
-      {
-        "branch": "main",
-        "path": "{repo}",
-        "kind": "worktree",
-        "commit": {
-          "sha": "e0eeb7d842fd739ad99b040d72d04aa11bfcc675",
-          "short_sha": "e0eeb7d",
-          "message": "Initial commit",
-          "timestamp": 1773058918
-        },
-        "working_tree": {
-          "staged": false,
-          "modified": false,
-          "untracked": false,
-          "renamed": false,
-          "deleted": false,
-          "diff": {
-            "added": 0,
-            "deleted": 0
-          }
-        },
-        "main_state": "is_main",
-        "remote": {
-          "name": "origin",
+rounds:
+- interactions:
+  - channel: command
+    cmd: git
+    args:
+    - config
+    - '--get-regexp'
+    - ^branch\..*\.flotilla\.issues\.
+    cwd: '{repo}'
+    stderr: ''
+    exit_code: 1
+  - channel: command
+    cmd: wt
+    args:
+    - list
+    - '--format=json'
+    cwd: '{repo}'
+    stdout: |
+      [
+        {
           "branch": "main",
-          "ahead": 0,
-          "behind": 0
+          "path": "{repo}",
+          "kind": "worktree",
+          "commit": {
+            "sha": "4c44c16c9e0cb9f65178c3293262421cee536d74",
+            "short_sha": "4c44c16",
+            "message": "Initial commit",
+            "timestamp": 1783964124
+          },
+          "working_tree": {
+            "staged": false,
+            "modified": false,
+            "untracked": false,
+            "renamed": false,
+            "deleted": false,
+            "diff": {
+              "added": 0,
+              "deleted": 0
+            }
+          },
+          "main_state": "is_main",
+          "remote": {
+            "name": "origin",
+            "branch": "main",
+            "ahead": 0,
+            "behind": 0
+          },
+          "worktree": {
+            "detached": false
+          },
+          "is_main": true,
+          "is_current": true,
+          "is_previous": true,
+          "statusline": "main  \u001b[2m^\u001b[22m\u001b[2m|\u001b[22m",
+          "symbols": "^|"
         },
-        "worktree": {
-          "detached": false
-        },
-        "is_main": true,
-        "is_current": true,
-        "is_previous": true,
-        "statusline": "main  \u001b[2m^\u001b[22m\u001b[2m|\u001b[22m",
-        "symbols": "^|"
-      },
-      {
-        "branch": "feature/foo",
-        "path": "{repo}.feature-foo",
-        "kind": "worktree",
-        "commit": {
-          "sha": "e0eeb7d842fd739ad99b040d72d04aa11bfcc675",
-          "short_sha": "e0eeb7d",
-          "message": "Initial commit",
-          "timestamp": 1773058918
-        },
-        "working_tree": {
-          "staged": true,
-          "modified": true,
-          "untracked": true,
-          "renamed": false,
-          "deleted": false,
-          "diff": {
-            "added": 2,
-            "deleted": 1
-          }
-        },
-        "main_state": "same_commit",
-        "main": {
-          "ahead": 0,
-          "behind": 0
-        },
-        "worktree": {
-          "detached": false
-        },
-        "is_main": false,
-        "is_current": false,
-        "is_previous": false,
-        "statusline": "feature/foo  \u001b[36m+\u001b[39m\u001b[36m!\u001b[39m\u001b[36m?\u001b[39m\u001b[2m–\u001b[22m  @\u001b[32m+2\u001b[0m \u001b[31m-1\u001b[0m",
-        "symbols": "+!?–"
-      }
-    ]
-  stderr: null
-  exit_code: 0
-- channel: command
-  cmd: git
-  args:
-  - config
-  - '--get-regexp'
-  - branch\.main\.flotilla\.issues\.
-  cwd: '{repo}'
-  stdout: null
-  stderr: ''
-  exit_code: 1
-- channel: command
-  cmd: git
-  args:
-  - config
-  - '--get-regexp'
-  - branch\.feature/foo\.flotilla\.issues\.
-  cwd: '{repo}'
-  stdout: null
-  stderr: ''
-  exit_code: 1
+        {
+          "branch": "feature/foo",
+          "path": "{repo}.feature-foo",
+          "kind": "worktree",
+          "commit": {
+            "sha": "4c44c16c9e0cb9f65178c3293262421cee536d74",
+            "short_sha": "4c44c16",
+            "message": "Initial commit",
+            "timestamp": 1783964124
+          },
+          "working_tree": {
+            "staged": true,
+            "modified": true,
+            "untracked": true,
+            "renamed": false,
+            "deleted": false,
+            "diff": {
+              "added": 2,
+              "deleted": 1
+            }
+          },
+          "main_state": "same_commit",
+          "main": {
+            "ahead": 0,
+            "behind": 0
+          },
+          "worktree": {
+            "detached": false
+          },
+          "is_main": false,
+          "is_current": false,
+          "is_previous": false,
+          "statusline": "feature/foo  \u001b[36m+\u001b[39m\u001b[36m!\u001b[39m\u001b[36m?\u001b[39m\u001b[2m–\u001b[22m  @\u001b[32m+2\u001b[0m \u001b[31m-1\u001b[0m",
+          "symbols": "+!?–"
+        }
+      ]
+    exit_code: 0

--- a/crates/flotilla-core/src/providers/vcs/git_worktree.rs
+++ b/crates/flotilla-core/src/providers/vcs/git_worktree.rs
@@ -126,6 +126,7 @@ impl GitCheckoutManager {
         branch: &str,
         is_main: bool,
         default_branch: &str,
+        issue_links: Vec<AssociationKey>,
     ) -> (ExecutionEnvironmentPath, Checkout) {
         let host_path = flotilla_protocol::HostPath::new(flotilla_protocol::HostName::local(), path.as_path());
         let correlation_keys = vec![CorrelationKey::Branch(branch.to_string()), CorrelationKey::CheckoutPath(host_path.into())];
@@ -134,7 +135,7 @@ impl GitCheckoutManager {
         let remote_ref = format!("HEAD...origin/{branch}");
         let raw = path.as_path();
 
-        let (trunk_ab, remote_ab, wt_status, commit, issue_links) = tokio::join!(
+        let (trunk_ab, remote_ab, wt_status, commit) = tokio::join!(
             async {
                 if !is_main {
                     run!(self.runner, "git", &["rev-list", "--left-right", "--count", &trunk_ref], raw, TaskId("trunk-ab"))
@@ -157,7 +158,6 @@ impl GitCheckoutManager {
                     Some(CommitInfo { short_sha: sha.to_string(), message: msg.to_string() })
                 })
             },
-            async { super::read_branch_issue_links(raw, branch, &*self.runner).await },
         );
 
         (path.clone(), Checkout {
@@ -195,15 +195,15 @@ impl super::CheckoutManager for GitCheckoutManager {
         let ee_entries: Vec<(ExecutionEnvironmentPath, String)> =
             entries.into_iter().map(|(path, branch)| (ExecutionEnvironmentPath::new(path), branch)).collect();
 
-        let futures: Vec<_> = ee_entries
-            .iter()
-            .enumerate()
-            .map(|(i, (path, branch))| {
-                // The first worktree in porcelain output is always the main worktree
-                let is_main = i == 0;
-                self.enrich_checkout(path, branch, is_main, &default_branch)
-            })
-            .collect();
+        let branches: Vec<_> = ee_entries.iter().map(|(_, branch)| branch.clone()).collect();
+        let mut issue_links = super::read_branch_issue_links_batch(root, &branches, &*self.runner).await;
+        let mut futures = Vec::with_capacity(ee_entries.len());
+        for (index, (path, branch)) in ee_entries.iter().enumerate() {
+            // The first worktree in porcelain output is always the main worktree.
+            let is_main = index == 0;
+            let links = issue_links.remove(branch).unwrap_or_default();
+            futures.push(self.enrich_checkout(path, branch, is_main, &default_branch, links));
+        }
         Ok(futures::future::join_all(futures).await)
     }
 
@@ -260,8 +260,9 @@ impl super::CheckoutManager for GitCheckoutManager {
                 run!(self.runner, "git", &["worktree", "add", "-b", branch, wt_str, &start_point], root,)?;
             }
         }
-        // A newly created worktree is never the main worktree
-        Ok(self.enrich_checkout(&wt_path, branch, false, &default_branch).await)
+        // A newly created worktree is never the main worktree.
+        let issue_links = super::read_branch_issue_links(root, branch, &*self.runner).await;
+        Ok(self.enrich_checkout(&wt_path, branch, false, &default_branch, issue_links).await)
     }
 
     async fn remove_checkout(&self, repo_root: &ExecutionEnvironmentPath, branch: &str) -> Result<(), String> {

--- a/crates/flotilla-core/src/providers/vcs/mod.rs
+++ b/crates/flotilla-core/src/providers/vcs/mod.rs
@@ -262,6 +262,20 @@ mod tests {
         assert!(keys.is_empty());
     }
 
+    #[tokio::test]
+    async fn batch_issue_links_do_not_cross_match_branch_prefixes() {
+        let runner =
+            MockRunner::new(vec![Ok(
+                concat!("branch.main.flotilla.issues.github 1\n", "branch.main-2.flotilla.issues.github 2\n",).to_string()
+            )]);
+        let branches = vec!["main".to_string(), "main-2".to_string()];
+
+        let links = read_branch_issue_links_batch(Path::new("/repo"), &branches, &runner).await;
+
+        assert_eq!(links["main"], vec![AssociationKey::IssueRef("github".into(), "1".into())]);
+        assert_eq!(links["main-2"], vec![AssociationKey::IssueRef("github".into(), "2".into())]);
+    }
+
     #[test]
     fn parse_ahead_behind_normal() {
         let ab = parse_ahead_behind("3\t5\n").expect("should parse");

--- a/crates/flotilla-core/src/providers/vcs/mod.rs
+++ b/crates/flotilla-core/src/providers/vcs/mod.rs
@@ -4,7 +4,7 @@ pub mod git_worktree;
 pub mod provisioning;
 pub mod wt;
 
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use async_trait::async_trait;
 use flotilla_protocol::CheckoutIntent;
@@ -130,12 +130,39 @@ pub fn parse_issue_config_output(output: &str) -> Vec<AssociationKey> {
 /// Read issue links from git config for a specific branch.
 /// Returns empty vec if no links or on error (non-fatal).
 pub(crate) async fn read_branch_issue_links(repo_root: &Path, branch: &str, runner: &dyn CommandRunner) -> Vec<AssociationKey> {
-    let pattern = format!("branch\\.{}\\.flotilla\\.issues\\.", regex_escape_branch(branch));
-    let result = run!(runner, "git", &["config", "--get-regexp", &pattern], repo_root);
-    match result {
-        Ok(output) => parse_issue_config_output(&output),
-        Err(_) => Vec::new(),
+    let branches = [branch.to_string()];
+    read_branch_issue_links_batch(repo_root, &branches, runner).await.remove(branch).unwrap_or_default()
+}
+
+/// Read issue links for every supplied branch with one repository-wide git config query.
+/// Returns an empty map if there are no links or the best-effort query fails.
+pub(crate) async fn read_branch_issue_links_batch(
+    repo_root: &Path,
+    branches: &[String],
+    runner: &dyn CommandRunner,
+) -> HashMap<String, Vec<AssociationKey>> {
+    let pattern = r"^branch\..*\.flotilla\.issues\.";
+    let Ok(output) = run!(runner, "git", &["config", "--get-regexp", pattern], repo_root) else {
+        return HashMap::new();
+    };
+
+    let mut links: HashMap<String, Vec<AssociationKey>> = HashMap::new();
+    for line in output.lines() {
+        let Some((config_key, value)) = line.trim().split_once(' ') else {
+            continue;
+        };
+        for branch in branches {
+            let prefix = format!("branch.{branch}.flotilla.issues.");
+            let Some(provider) = config_key.strip_prefix(&prefix) else {
+                continue;
+            };
+            for id in value.split(',').map(str::trim).filter(|id| !id.is_empty()) {
+                links.entry(branch.clone()).or_default().push(AssociationKey::IssueRef(provider.to_string(), id.to_string()));
+            }
+            break;
+        }
     }
+    links
 }
 
 /// Write issue links to git config for a specific branch.
@@ -202,21 +229,6 @@ pub(crate) async fn validate_checkout_target_in_git_dir(
     validate_checkout_target_with_prefix(cwd, &["--git-dir", git_dir], branch, intent, runner).await
 }
 
-/// Escape special regex characters in branch names for git config --get-regexp.
-fn regex_escape_branch(branch: &str) -> String {
-    let mut escaped = String::with_capacity(branch.len());
-    for c in branch.chars() {
-        match c {
-            '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '\\' | '|' | '^' | '$' => {
-                escaped.push('\\');
-                escaped.push(c);
-            }
-            _ => escaped.push(c),
-        }
-    }
-    escaped
-}
-
 #[cfg(test)]
 mod tests {
     use flotilla_protocol::CheckoutIntent;
@@ -248,12 +260,6 @@ mod tests {
     fn parse_issue_links_empty() {
         let keys = parse_issue_config_output("");
         assert!(keys.is_empty());
-    }
-
-    #[test]
-    fn regex_escape_branch_with_dots() {
-        assert_eq!(regex_escape_branch("feat.x"), "feat\\.x");
-        assert_eq!(regex_escape_branch("simple"), "simple");
     }
 
     #[test]

--- a/crates/flotilla-core/src/providers/vcs/wt.rs
+++ b/crates/flotilla-core/src/providers/vcs/wt.rs
@@ -120,11 +120,11 @@ impl super::CheckoutManager for WtCheckoutManager {
         let worktrees: Vec<WtWorktree> = serde_json::from_str(json).map_err(|e| e.to_string())?;
         let mut checkouts: Vec<(ExecutionEnvironmentPath, Checkout)> = worktrees.into_iter().map(|wt| wt.into_checkout()).collect();
 
-        // Enrich with issue links from git config
-        let futures: Vec<_> = checkouts.iter().map(|(_, co)| super::read_branch_issue_links(root, &co.branch, &*self.runner)).collect();
-        let all_links = futures::future::join_all(futures).await;
-        for ((_, co), links) in checkouts.iter_mut().zip(all_links) {
-            co.association_keys = links;
+        // Enrich with issue links from one repository-wide git config query.
+        let branches: Vec<_> = checkouts.iter().map(|(_, checkout)| checkout.branch.clone()).collect();
+        let mut issue_links = super::read_branch_issue_links_batch(root, &branches, &*self.runner).await;
+        for (_, checkout) in &mut checkouts {
+            checkout.association_keys = issue_links.remove(&checkout.branch).unwrap_or_default();
         }
 
         Ok(checkouts)
@@ -184,8 +184,31 @@ mod tests {
     use super::*;
     use crate::providers::{
         replay,
+        testing::MockRunner,
         vcs::{checkout_test_support::git, CheckoutManager},
     };
+
+    #[tokio::test]
+    async fn list_checkouts_reads_all_branch_issue_links_with_one_git_config_call() {
+        let worktrees = serde_json::json!([
+            {"branch": "main", "path": "/repo", "is_main": true},
+            {"branch": "feature/foo", "path": "/repo.feature-foo"}
+        ])
+        .to_string();
+        let issue_links =
+            concat!("branch.main.flotilla.issues.github 1\n", "branch.feature/foo.flotilla.issues.linear ENG-2\n").to_string();
+        let runner = Arc::new(MockRunner::new(vec![Ok(worktrees), Ok(issue_links)]));
+        let manager = WtCheckoutManager::new(runner.clone());
+
+        let checkouts = manager.list_checkouts(&ExecutionEnvironmentPath::new("/repo")).await.expect("list checkouts with issue links");
+
+        assert_eq!(checkouts[0].1.association_keys, vec![AssociationKey::IssueRef("github".into(), "1".into())]);
+        assert_eq!(checkouts[1].1.association_keys, vec![AssociationKey::IssueRef("linear".into(), "ENG-2".into())]);
+        assert_eq!(runner.calls(), vec![
+            ("wt".into(), vec!["list".into(), "--format=json".into()]),
+            ("git".into(), vec!["config".into(), "--get-regexp".into(), r"^branch\..*\.flotilla\.issues\.".into(),]),
+        ]);
+    }
 
     // ── Setup helpers (only called in record mode) ──
 

--- a/crates/flotilla-core/src/refresh.rs
+++ b/crates/flotilla-core/src/refresh.rs
@@ -1,6 +1,7 @@
 use std::{
-    collections::HashMap,
+    collections::{hash_map::DefaultHasher, HashMap},
     future::Future,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -13,6 +14,7 @@ use flotilla_protocol::{
 use tokio::{
     sync::{watch, Notify},
     task::JoinHandle,
+    time::Instant,
 };
 
 use crate::{
@@ -51,6 +53,76 @@ pub struct RepoRefreshHandle {
     _task_handle: JoinHandle<()>,
 }
 
+#[derive(Clone, Copy)]
+struct RefreshCadence {
+    interval: Duration,
+    offset: Duration,
+}
+
+#[derive(Clone, Copy)]
+enum RefreshKind {
+    Full,
+    Fast,
+    Slow,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct RefreshSchedule {
+    startup_offset: Duration,
+    fast: RefreshCadence,
+    slow: RefreshCadence,
+}
+
+impl RefreshSchedule {
+    pub(crate) fn for_repo(repo_root: &Path, fast_interval: Duration, slow_interval: Duration) -> Self {
+        let mut hasher = DefaultHasher::new();
+        repo_root.hash(&mut hasher);
+        let hash = hasher.finish();
+        Self {
+            startup_offset: stagger_offset(hash.rotate_left(41), Duration::from_secs(1)),
+            fast: RefreshCadence { interval: fast_interval, offset: stagger_offset(hash, fast_interval) },
+            slow: RefreshCadence { interval: slow_interval, offset: stagger_offset(hash.rotate_left(17), slow_interval) },
+        }
+    }
+
+    #[cfg(test)]
+    fn without_stagger(fast_interval: Duration, slow_interval: Duration) -> Self {
+        Self {
+            startup_offset: Duration::ZERO,
+            fast: RefreshCadence { interval: fast_interval, offset: Duration::ZERO },
+            slow: RefreshCadence { interval: slow_interval, offset: Duration::ZERO },
+        }
+    }
+}
+
+impl From<Duration> for RefreshSchedule {
+    fn from(interval: Duration) -> Self {
+        Self::without_stagger_for_interval(interval)
+    }
+}
+
+impl RefreshSchedule {
+    fn without_stagger_for_interval(interval: Duration) -> Self {
+        Self {
+            startup_offset: Duration::ZERO,
+            fast: RefreshCadence { interval, offset: Duration::ZERO },
+            slow: RefreshCadence { interval, offset: Duration::ZERO },
+        }
+    }
+}
+
+fn stagger_offset(hash: u64, interval: Duration) -> Duration {
+    let interval_nanos = interval.as_nanos();
+    if interval_nanos == 0 {
+        return Duration::ZERO;
+    }
+    Duration::from_nanos((u128::from(hash) % interval_nanos) as u64)
+}
+
+fn first_tick(cadence: RefreshCadence) -> Instant {
+    Instant::now() + cadence.interval + cadence.offset
+}
+
 pub(crate) fn normalize_checkout_publication(path: QualifiedPath, host_id: Option<&HostId>, _host_name: &HostName) -> QualifiedPath {
     match host_id {
         Some(host_id) => QualifiedPath::host(host_id.clone(), path.path),
@@ -87,23 +159,73 @@ impl RepoRefreshHandle {
         agent_state_store: crate::agents::SharedAgentStateStore,
         interval: Duration,
     ) -> Self {
+        Self::spawn_with_schedule(
+            repo_root,
+            registry,
+            criteria,
+            environment_id,
+            host_id,
+            attachable_store,
+            agent_state_store,
+            interval.into(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn spawn_with_schedule(
+        repo_root: PathBuf,
+        registry: Arc<ProviderRegistry>,
+        criteria: RepoCriteria,
+        environment_id: Option<EnvironmentId>,
+        host_id: Option<HostId>,
+        attachable_store: SharedAttachableStore,
+        agent_state_store: crate::agents::SharedAgentStateStore,
+        schedule: RefreshSchedule,
+    ) -> Self {
         let (snapshot_tx, snapshot_rx) = watch::channel(Arc::new(RefreshSnapshot::default()));
         let refresh_trigger = Arc::new(Notify::new());
         let trigger = refresh_trigger.clone();
 
         let task_handle = tokio::spawn(async move {
-            let mut timer = tokio::time::interval(interval);
-            timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                tokio::select! {
-                    _ = timer.tick() => {}
-                    _ = trigger.notified() => {}
-                }
+            if !schedule.startup_offset.is_zero() {
+                tokio::time::sleep(schedule.startup_offset).await;
+            }
+            let mut provider_data = ProviderData::default();
+            let mut fast_errors = Vec::new();
+            let mut slow_errors = Vec::new();
+            let initial = run_refresh_cycle(
+                RefreshKind::Full,
+                &mut provider_data,
+                &mut fast_errors,
+                &mut slow_errors,
+                &repo_root,
+                &registry,
+                &criteria,
+                environment_id.as_ref(),
+                host_id.as_ref(),
+                &attachable_store,
+                &agent_state_store,
+            )
+            .await;
+            if snapshot_tx.send(initial).is_err() {
+                return;
+            }
 
-                // Fetch all provider data
-                let mut provider_data = ProviderData::default();
-                let errors = refresh_providers(
+            let mut fast_timer = tokio::time::interval_at(first_tick(schedule.fast), schedule.fast.interval);
+            fast_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut slow_timer = tokio::time::interval_at(first_tick(schedule.slow), schedule.slow.interval);
+            slow_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                let kind = tokio::select! {
+                    _ = fast_timer.tick() => RefreshKind::Fast,
+                    _ = slow_timer.tick() => RefreshKind::Slow,
+                    _ = trigger.notified() => RefreshKind::Full,
+                };
+                let snapshot = run_refresh_cycle(
+                    kind,
                     &mut provider_data,
+                    &mut fast_errors,
+                    &mut slow_errors,
                     &repo_root,
                     &registry,
                     &criteria,
@@ -113,13 +235,6 @@ impl RepoRefreshHandle {
                     &agent_state_store,
                 )
                 .await;
-                let provider_health = compute_provider_health(&registry, &errors);
-
-                // Correlate
-                let providers = Arc::new(provider_data);
-                let (work_items, correlation_groups) = data::correlate(&providers);
-
-                let snapshot = Arc::new(RefreshSnapshot { providers, work_items, correlation_groups, errors, provider_health });
 
                 // Publish — receivers will see has_changed().
                 // Break if receiver is dropped (handle dropped without Drop running).
@@ -149,6 +264,34 @@ impl RepoRefreshHandle {
     pub fn trigger_refresh(&self) {
         self.refresh_trigger.notify_one();
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_refresh_cycle(
+    kind: RefreshKind,
+    provider_data: &mut ProviderData,
+    fast_errors: &mut Vec<RefreshError>,
+    slow_errors: &mut Vec<RefreshError>,
+    repo_root: &Path,
+    registry: &ProviderRegistry,
+    criteria: &RepoCriteria,
+    environment_id: Option<&EnvironmentId>,
+    host_id: Option<&HostId>,
+    attachable_store: &SharedAttachableStore,
+    agent_state_store: &crate::agents::SharedAgentStateStore,
+) -> Arc<RefreshSnapshot> {
+    if matches!(kind, RefreshKind::Full | RefreshKind::Fast) {
+        *fast_errors =
+            refresh_fast_providers(provider_data, repo_root, registry, environment_id, host_id, attachable_store, agent_state_store).await;
+    }
+    if matches!(kind, RefreshKind::Full | RefreshKind::Slow) {
+        *slow_errors = refresh_slow_providers(provider_data, repo_root, registry, criteria, host_id).await;
+    }
+    let errors: Vec<_> = fast_errors.iter().chain(slow_errors.iter()).cloned().collect();
+    let provider_health = compute_provider_health(registry, &errors);
+    let providers = Arc::new(provider_data.clone());
+    let (work_items, correlation_groups) = data::correlate(&providers);
+    Arc::new(RefreshSnapshot { providers, work_items, correlation_groups, errors, provider_health })
 }
 
 impl Drop for RepoRefreshHandle {
@@ -195,12 +338,34 @@ fn insert_category_health<I>(
 }
 
 /// Fetch all provider data into the given ProviderData struct.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 async fn refresh_providers(
     pd: &mut ProviderData,
     repo_root: &Path,
     registry: &ProviderRegistry,
     criteria: &RepoCriteria,
+    environment_id: Option<&EnvironmentId>,
+    host_id: Option<&HostId>,
+    attachable_store: &SharedAttachableStore,
+    agent_state_store: &crate::agents::SharedAgentStateStore,
+) -> Vec<RefreshError> {
+    let mut errors = refresh_fast_providers(pd, repo_root, registry, environment_id, host_id, attachable_store, agent_state_store).await;
+    errors.extend(refresh_slow_providers(pd, repo_root, registry, criteria, host_id).await);
+    errors
+}
+
+fn collect_errors(errors: &mut Vec<RefreshError>, category: &'static str, provider_errors: Vec<(String, String)>) {
+    for (provider, message) in provider_errors {
+        errors.push(RefreshError { category, provider, message });
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn refresh_fast_providers(
+    pd: &mut ProviderData,
+    repo_root: &Path,
+    registry: &ProviderRegistry,
     environment_id: Option<&EnvironmentId>,
     host_id: Option<&HostId>,
     attachable_store: &SharedAttachableStore,
@@ -220,22 +385,6 @@ async fn refresh_providers(
             (vec![], vec![])
         }
     };
-
-    let cr_fut = collect_named_results(
-        registry.change_requests.iter().map(|(desc, cr)| (desc.display_name.clone(), cr.list_change_requests(repo_root, 20))).collect(),
-    );
-
-    let sessions_fut = collect_named_results(
-        registry.cloud_agents.iter().map(|(desc, ca)| (desc.display_name.clone(), ca.list_sessions(criteria))).collect(),
-    );
-
-    let branches_fut = collect_named_results(
-        registry.vcs.iter().map(|(desc, vcs)| (desc.display_name.clone(), vcs.list_remote_branches(&ee_root))).collect(),
-    );
-
-    let merged_fut = collect_named_results(
-        registry.change_requests.iter().map(|(desc, cr)| (desc.display_name.clone(), cr.list_merged_branch_names(repo_root, 50))).collect(),
-    );
 
     let ws_fut = async {
         if let Some((desc, ws_mgr)) = registry.presentation_managers.preferred_with_desc() {
@@ -264,21 +413,7 @@ async fn refresh_providers(
         }
     };
 
-    let (
-        (checkouts, checkout_errors),
-        (crs, cr_errors),
-        (sessions, session_errors),
-        (branches, branch_errors),
-        (merged, merged_errors),
-        (workspaces, ws_errors),
-        tp_errors,
-    ) = tokio::join!(checkouts_fut, cr_fut, sessions_fut, branches_fut, merged_fut, ws_fut, tp_fut);
-
-    fn collect_errors(errors: &mut Vec<RefreshError>, category: &'static str, provider_errors: Vec<(String, String)>) {
-        for (provider, message) in provider_errors {
-            errors.push(RefreshError { category, provider, message });
-        }
-    }
+    let ((checkouts, checkout_errors), (workspaces, ws_errors), tp_errors) = tokio::join!(checkouts_fut, ws_fut, tp_fut);
 
     let local_host = HostName::local();
     pd.checkouts = checkouts
@@ -295,7 +430,46 @@ async fn refresh_providers(
         .collect();
     collect_errors(&mut errors, "checkouts", checkout_errors);
 
-    pd.change_requests = crs.into_iter().collect();
+    pd.workspaces = workspaces.into_iter().collect();
+    for workspace in pd.workspaces.values_mut() {
+        workspace.correlation_keys = normalize_checkout_correlation_keys(workspace.correlation_keys.clone(), host_id, &local_host);
+    }
+    collect_errors(&mut errors, "workspaces", ws_errors);
+
+    collect_errors(&mut errors, "terminals", tp_errors);
+
+    project_attachable_data(pd, registry, attachable_store);
+    project_agent_data(pd, agent_state_store);
+
+    errors
+}
+
+async fn refresh_slow_providers(
+    pd: &mut ProviderData,
+    repo_root: &Path,
+    registry: &ProviderRegistry,
+    criteria: &RepoCriteria,
+    host_id: Option<&HostId>,
+) -> Vec<RefreshError> {
+    let mut errors = Vec::new();
+    let ee_root = ExecutionEnvironmentPath::new(repo_root);
+    let cr_fut = collect_named_results(
+        registry.change_requests.iter().map(|(desc, cr)| (desc.display_name.clone(), cr.list_change_requests(repo_root, 20))).collect(),
+    );
+    let sessions_fut = collect_named_results(
+        registry.cloud_agents.iter().map(|(desc, agent)| (desc.display_name.clone(), agent.list_sessions(criteria))).collect(),
+    );
+    let branches_fut = collect_named_results(
+        registry.vcs.iter().map(|(desc, vcs)| (desc.display_name.clone(), vcs.list_remote_branches(&ee_root))).collect(),
+    );
+    let merged_fut = collect_named_results(
+        registry.change_requests.iter().map(|(desc, cr)| (desc.display_name.clone(), cr.list_merged_branch_names(repo_root, 50))).collect(),
+    );
+    let ((change_requests, cr_errors), (sessions, session_errors), (branches, branch_errors), (merged, merged_errors)) =
+        tokio::join!(cr_fut, sessions_fut, branches_fut, merged_fut);
+
+    let local_host = HostName::local();
+    pd.change_requests = change_requests.into_iter().collect();
     for change_request in pd.change_requests.values_mut() {
         change_request.correlation_keys =
             normalize_checkout_correlation_keys(change_request.correlation_keys.clone(), host_id, &local_host);
@@ -308,28 +482,15 @@ async fn refresh_providers(
     }
     collect_errors(&mut errors, "sessions", session_errors);
 
-    pd.workspaces = workspaces.into_iter().collect();
-    for workspace in pd.workspaces.values_mut() {
-        workspace.correlation_keys = normalize_checkout_correlation_keys(workspace.correlation_keys.clone(), host_id, &local_host);
+    use flotilla_protocol::delta::{Branch, BranchStatus};
+    pd.branches.clear();
+    collect_errors(&mut errors, "branches", branch_errors);
+    collect_errors(&mut errors, "merged", merged_errors);
+    for name in branches {
+        pd.branches.insert(name, Branch { status: BranchStatus::Remote });
     }
-    collect_errors(&mut errors, "workspaces", ws_errors);
-
-    collect_errors(&mut errors, "terminals", tp_errors);
-
-    project_attachable_data(pd, registry, attachable_store);
-    project_agent_data(pd, agent_state_store);
-    {
-        use flotilla_protocol::delta::{Branch, BranchStatus};
-        let remote = branches;
-        collect_errors(&mut errors, "branches", branch_errors);
-        let merged_names = merged;
-        collect_errors(&mut errors, "merged", merged_errors);
-        for name in remote {
-            pd.branches.insert(name, Branch { status: BranchStatus::Remote });
-        }
-        for name in merged_names {
-            pd.branches.insert(name, Branch { status: BranchStatus::Merged });
-        }
+    for name in merged {
+        pd.branches.insert(name, Branch { status: BranchStatus::Merged });
     }
 
     errors

--- a/crates/flotilla-core/src/refresh.rs
+++ b/crates/flotilla-core/src/refresh.rs
@@ -191,6 +191,11 @@ impl RepoRefreshHandle {
             if !schedule.startup_offset.is_zero() {
                 tokio::time::sleep(schedule.startup_offset).await;
             }
+            // A manual trigger received during the startup stagger is already
+            // satisfied by the initial full refresh. Consume its permit before
+            // scanning so a mutation-triggered refresh that arrives while the
+            // scan is in flight remains pending for the loop below.
+            let _ = trigger.notified().now_or_never();
             let mut provider_data = ProviderData::default();
             let mut fast_errors = Vec::new();
             let mut slow_errors = Vec::new();
@@ -211,10 +216,6 @@ impl RepoRefreshHandle {
             if snapshot_tx.send(initial).is_err() {
                 return;
             }
-            // A manual trigger received during the startup stagger is already
-            // satisfied by the initial full refresh. Consume its permit so it
-            // does not immediately duplicate the same provider work.
-            let _ = trigger.notified().now_or_never();
 
             let mut fast_timer = tokio::time::interval_at(first_tick(schedule.fast), schedule.fast.interval);
             fast_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/crates/flotilla-core/src/refresh.rs
+++ b/crates/flotilla-core/src/refresh.rs
@@ -531,6 +531,7 @@ fn project_attachable_data(pd: &mut ProviderData, registry: &ProviderRegistry, a
         tracing::warn!("attachable store lock poisoned while projecting provider data");
         return;
     };
+    pd.managed_terminals.clear();
 
     if let Some(provider_name) = workspace_provider.as_deref() {
         for (ws_ref, workspace) in &mut pd.workspaces {
@@ -612,6 +613,7 @@ fn project_agent_data(pd: &mut ProviderData, agent_state_store: &crate::agents::
         tracing::warn!("agent state store lock poisoned while projecting agent data");
         return;
     };
+    pd.agents.clear();
     for (attachable_id, entry) in store.list_agents() {
         // Only include agents whose terminal's attachable set belongs to this repo.
         // Find the set that contains this attachable_id.

--- a/crates/flotilla-core/src/refresh.rs
+++ b/crates/flotilla-core/src/refresh.rs
@@ -280,18 +280,47 @@ async fn run_refresh_cycle(
     attachable_store: &SharedAttachableStore,
     agent_state_store: &crate::agents::SharedAgentStateStore,
 ) -> Arc<RefreshSnapshot> {
-    if matches!(kind, RefreshKind::Full | RefreshKind::Fast) {
-        *fast_errors =
-            refresh_fast_providers(provider_data, repo_root, registry, environment_id, host_id, attachable_store, agent_state_store).await;
-    }
-    if matches!(kind, RefreshKind::Full | RefreshKind::Slow) {
-        *slow_errors = refresh_slow_providers(provider_data, repo_root, registry, criteria, host_id).await;
+    match kind {
+        RefreshKind::Full => {
+            let mut fast_data = provider_data.clone();
+            let mut slow_data = provider_data.clone();
+            let (new_fast_errors, new_slow_errors) = tokio::join!(
+                refresh_fast_providers(&mut fast_data, repo_root, registry, environment_id, host_id, attachable_store, agent_state_store,),
+                refresh_slow_providers(&mut slow_data, repo_root, registry, criteria, host_id),
+            );
+            install_fast_provider_data(provider_data, fast_data);
+            install_slow_provider_data(provider_data, slow_data);
+            *fast_errors = new_fast_errors;
+            *slow_errors = new_slow_errors;
+        }
+        RefreshKind::Fast => {
+            *fast_errors =
+                refresh_fast_providers(provider_data, repo_root, registry, environment_id, host_id, attachable_store, agent_state_store)
+                    .await;
+        }
+        RefreshKind::Slow => {
+            *slow_errors = refresh_slow_providers(provider_data, repo_root, registry, criteria, host_id).await;
+        }
     }
     let errors: Vec<_> = fast_errors.iter().chain(slow_errors.iter()).cloned().collect();
     let provider_health = compute_provider_health(registry, &errors);
     let providers = Arc::new(provider_data.clone());
     let (work_items, correlation_groups) = data::correlate(&providers);
     Arc::new(RefreshSnapshot { providers, work_items, correlation_groups, errors, provider_health })
+}
+
+fn install_fast_provider_data(target: &mut ProviderData, source: ProviderData) {
+    target.checkouts = source.checkouts;
+    target.workspaces = source.workspaces;
+    target.managed_terminals = source.managed_terminals;
+    target.attachable_sets = source.attachable_sets;
+    target.agents = source.agents;
+}
+
+fn install_slow_provider_data(target: &mut ProviderData, source: ProviderData) {
+    target.change_requests = source.change_requests;
+    target.sessions = source.sessions;
+    target.branches = source.branches;
 }
 
 impl Drop for RepoRefreshHandle {

--- a/crates/flotilla-core/src/refresh.rs
+++ b/crates/flotilla-core/src/refresh.rs
@@ -11,6 +11,7 @@ use flotilla_protocol::{
     qualified_path::{HostId, PathQualifier, QualifiedPath},
     CorrelationKey, EnvironmentId, HostName,
 };
+use futures::FutureExt;
 use tokio::{
     sync::{watch, Notify},
     task::JoinHandle,
@@ -210,6 +211,10 @@ impl RepoRefreshHandle {
             if snapshot_tx.send(initial).is_err() {
                 return;
             }
+            // A manual trigger received during the startup stagger is already
+            // satisfied by the initial full refresh. Consume its permit so it
+            // does not immediately duplicate the same provider work.
+            let _ = trigger.notified().now_or_never();
 
             let mut fast_timer = tokio::time::interval_at(first_tick(schedule.fast), schedule.fast.interval);
             fast_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);

--- a/crates/flotilla-core/src/refresh/tests.rs
+++ b/crates/flotilla-core/src/refresh/tests.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashSet, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashSet,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use async_trait::async_trait;
 use flotilla_protocol::{
@@ -296,6 +303,162 @@ async fn wait_for_snapshot(rx: &mut tokio::sync::watch::Receiver<Arc<RefreshSnap
         .expect("timed out waiting for snapshot")
         .expect("snapshot channel closed");
     rx.borrow().clone()
+}
+
+struct CountingCloudAgent(AtomicUsize);
+
+#[async_trait]
+impl CloudAgentService for CountingCloudAgent {
+    async fn list_sessions(&self, _criteria: &RepoCriteria) -> Result<Vec<(String, CloudAgentSession)>, String> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![])
+    }
+
+    async fn archive_session(&self, _session_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn attach_command(&self, _session_id: &str) -> Result<String, String> {
+        Ok(String::new())
+    }
+}
+
+struct CountingWorkspaceManager(AtomicUsize);
+
+#[async_trait]
+impl PresentationManager for CountingWorkspaceManager {
+    async fn list_workspaces(&self) -> Result<Vec<(String, Workspace)>, String> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![])
+    }
+
+    async fn create_workspace(&self, _config: &WorkspaceAttachRequest) -> Result<(String, Workspace), String> {
+        Err("not implemented".into())
+    }
+
+    async fn select_workspace(&self, _ws_ref: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn delete_workspace(&self, _ws_ref: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn binding_scope_prefix(&self) -> String {
+        String::new()
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn periodic_refresh_uses_fast_and_slow_provider_cadences() {
+    let cloud_agent = Arc::new(CountingCloudAgent(AtomicUsize::new(0)));
+    let workspace_manager = Arc::new(CountingWorkspaceManager(AtomicUsize::new(0)));
+    let mut registry = ProviderRegistry::new();
+    registry.cloud_agents.insert("cloud", desc("Cloud"), cloud_agent.clone());
+    registry.presentation_managers.insert("workspace", desc("Workspace"), workspace_manager.clone());
+
+    let handle = RepoRefreshHandle::spawn_with_schedule(
+        repo_root(),
+        Arc::new(registry),
+        criteria(),
+        None,
+        None,
+        test_attachable_store(),
+        test_agent_state_store(),
+        RefreshSchedule::without_stagger(Duration::from_secs(10), Duration::from_secs(60)),
+    );
+    let mut rx = handle.snapshot_rx.clone();
+    rx.changed().await.expect("initial full refresh");
+    assert_eq!(workspace_manager.0.load(Ordering::SeqCst), 1);
+    assert_eq!(cloud_agent.0.load(Ordering::SeqCst), 1);
+
+    tokio::time::advance(Duration::from_secs(10)).await;
+    rx.changed().await.expect("fast refresh");
+    assert_eq!(workspace_manager.0.load(Ordering::SeqCst), 2);
+    assert_eq!(cloud_agent.0.load(Ordering::SeqCst), 1, "cloud agents should wait for the slow cadence");
+
+    handle.trigger_refresh();
+    rx.changed().await.expect("manual full refresh");
+    assert_eq!(workspace_manager.0.load(Ordering::SeqCst), 3);
+    assert_eq!(cloud_agent.0.load(Ordering::SeqCst), 2, "manual refresh should include slow providers");
+}
+
+#[tokio::test(start_paused = true)]
+async fn staggered_schedule_delays_the_initial_full_refresh() {
+    let workspace_manager = Arc::new(CountingWorkspaceManager(AtomicUsize::new(0)));
+    let mut registry = ProviderRegistry::new();
+    registry.presentation_managers.insert("workspace", desc("Workspace"), workspace_manager.clone());
+    let schedule = RefreshSchedule {
+        startup_offset: Duration::from_secs(3),
+        fast: RefreshCadence { interval: Duration::from_secs(10), offset: Duration::from_secs(3) },
+        slow: RefreshCadence { interval: Duration::from_secs(60), offset: Duration::from_secs(20) },
+    };
+
+    let handle = RepoRefreshHandle::spawn_with_schedule(
+        repo_root(),
+        Arc::new(registry),
+        criteria(),
+        None,
+        None,
+        test_attachable_store(),
+        test_agent_state_store(),
+        schedule,
+    );
+    let mut rx = handle.snapshot_rx.clone();
+    tokio::task::yield_now().await;
+    assert!(!rx.has_changed().expect("refresh sender alive"));
+
+    tokio::time::advance(Duration::from_secs(2)).await;
+    tokio::task::yield_now().await;
+    assert!(!rx.has_changed().expect("refresh sender alive"));
+
+    tokio::time::advance(Duration::from_secs(1)).await;
+    rx.changed().await.expect("staggered initial refresh");
+    assert_eq!(workspace_manager.0.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn repo_refresh_schedules_have_stable_distinct_offsets() {
+    let fast = Duration::from_secs(10);
+    let slow = Duration::from_secs(60);
+    let first = RefreshSchedule::for_repo(Path::new("/repos/first"), fast, slow);
+    let first_again = RefreshSchedule::for_repo(Path::new("/repos/first"), fast, slow);
+    let second = RefreshSchedule::for_repo(Path::new("/repos/second"), fast, slow);
+
+    assert_eq!(first.fast.offset, first_again.fast.offset);
+    assert_eq!(first.slow.offset, first_again.slow.offset);
+    assert_eq!(first.startup_offset, first_again.startup_offset);
+    assert_ne!(first.fast.offset, second.fast.offset);
+    assert_ne!(first.slow.offset, second.slow.offset);
+    assert_ne!(first.startup_offset, second.startup_offset);
+    assert!(first.startup_offset < Duration::from_secs(1));
+    assert!(first.fast.offset < fast);
+    assert!(first.slow.offset < slow);
+}
+
+#[tokio::test(start_paused = true)]
+async fn fast_refresh_preserves_slow_provider_errors_and_health() {
+    let mut registry = ProviderRegistry::new();
+    registry.cloud_agents.insert("cloud", desc("Cloud"), Arc::new(MockCloudAgent::failing("offline")));
+    let handle = RepoRefreshHandle::spawn_with_schedule(
+        repo_root(),
+        Arc::new(registry),
+        criteria(),
+        None,
+        None,
+        test_attachable_store(),
+        test_agent_state_store(),
+        RefreshSchedule::without_stagger(Duration::from_secs(10), Duration::from_secs(60)),
+    );
+    let mut rx = handle.snapshot_rx.clone();
+    rx.changed().await.expect("initial full refresh");
+
+    tokio::time::advance(Duration::from_secs(10)).await;
+    rx.changed().await.expect("fast refresh");
+    let snapshot = rx.borrow().clone();
+
+    assert!(snapshot.errors.iter().any(|error| error.category == "sessions" && error.message == "offline"));
+    assert_eq!(snapshot.provider_health.get(&("cloud_agent", "Cloud".into())), Some(&false));
 }
 
 #[test]

--- a/crates/flotilla-core/src/refresh/tests.rs
+++ b/crates/flotilla-core/src/refresh/tests.rs
@@ -698,13 +698,13 @@ fn project_attachable_data_populates_sets_and_ids() {
     let store_dir = tempfile::tempdir().expect("tempdir");
     let attachable_store =
         crate::attachable::shared_file_backed_attachable_store(&crate::path_context::DaemonHostPath::new(store_dir.path()));
-    let set_id = {
+    let (set_id, attachable_id) = {
         let mut store = attachable_store.lock().expect("lock store");
         let set_id = store.ensure_terminal_set(
             Some(flotilla_protocol::HostName::local()),
             Some(flotilla_protocol::HostPath::new(flotilla_protocol::HostName::local(), PathBuf::from("/tmp/wt-feat")).into()),
         );
-        let _attachable_id = store.ensure_terminal_attachable(
+        let attachable_id = store.ensure_terminal_attachable(
             &set_id,
             "terminal_pool",
             "shpool",
@@ -721,7 +721,7 @@ fn project_attachable_data_populates_sets_and_ids() {
             object_id: set_id.to_string(),
             external_ref: "ws-1".into(),
         });
-        set_id
+        (set_id, attachable_id)
     };
 
     let mut pd = ProviderData::default();
@@ -746,7 +746,54 @@ fn project_attachable_data_populates_sets_and_ids() {
 
     assert_eq!(pd.attachable_sets.len(), 1);
     assert!(pd.attachable_sets.contains_key(&set_id));
+    assert!(pd.managed_terminals.contains_key(&attachable_id));
     assert_eq!(pd.workspaces.get("ws-1").and_then(|ws| ws.attachable_set_id.as_ref()), Some(&set_id));
+
+    attachable_store.lock().expect("lock store").remove_set(&set_id);
+    project_attachable_data(&mut pd, &registry, &attachable_store);
+    assert!(pd.managed_terminals.is_empty(), "removed terminals must not survive the next projection");
+}
+
+#[test]
+fn project_agent_data_removes_agents_missing_from_the_store() {
+    let attachable_store = test_attachable_store();
+    let agent_store = test_agent_state_store();
+    let host = flotilla_protocol::HostName::local();
+    let checkout = flotilla_protocol::HostPath::new(host.clone(), "/repo/wt-feat");
+    let (set_id, attachable_id) = {
+        let mut store = attachable_store.lock().expect("lock attachable store");
+        let set_id = store.ensure_terminal_set(Some(host), Some(checkout.clone().into()));
+        let attachable_id = store.ensure_terminal_attachable(
+            &set_id,
+            "terminal_pool",
+            "test",
+            "agent",
+            crate::attachable::TerminalPurpose { checkout: "feat".into(), role: "agent".into(), index: 0 },
+            "claude",
+            ExecutionEnvironmentPath::new("/repo/wt-feat"),
+            flotilla_protocol::TerminalStatus::Running,
+        );
+        (set_id, attachable_id)
+    };
+    agent_store.lock().expect("lock agent store").upsert(attachable_id.clone(), crate::agents::AgentEntry {
+        harness: flotilla_protocol::AgentHarness::ClaudeCode,
+        status: flotilla_protocol::AgentStatus::Active,
+        model: None,
+        session_title: None,
+        session_id: None,
+        last_event_epoch_secs: 0,
+    });
+    let mut pd = ProviderData::default();
+    pd.checkouts.insert(checkout.into(), TestCheckout::new("feat").build());
+
+    project_attachable_data(&mut pd, &ProviderRegistry::new(), &attachable_store);
+    project_agent_data(&mut pd, &agent_store);
+    assert!(pd.attachable_sets.contains_key(&set_id));
+    assert!(pd.agents.contains_key(attachable_id.as_str()));
+
+    agent_store.lock().expect("lock agent store").remove(&attachable_id);
+    project_agent_data(&mut pd, &agent_store);
+    assert!(pd.agents.is_empty(), "removed agents must not survive the next projection");
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/refresh/tests.rs
+++ b/crates/flotilla-core/src/refresh/tests.rs
@@ -349,6 +349,81 @@ impl PresentationManager for CountingWorkspaceManager {
     }
 }
 
+struct BarrierCheckoutManager(Arc<tokio::sync::Barrier>);
+
+#[async_trait]
+impl CheckoutManager for BarrierCheckoutManager {
+    async fn validate_target(
+        &self,
+        _repo_root: &ExecutionEnvironmentPath,
+        _branch: &str,
+        _intent: flotilla_protocol::CheckoutIntent,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn list_checkouts(&self, _repo_root: &ExecutionEnvironmentPath) -> Result<Vec<(ExecutionEnvironmentPath, Checkout)>, String> {
+        self.0.wait().await;
+        Ok(vec![])
+    }
+
+    async fn create_checkout(
+        &self,
+        _repo_root: &ExecutionEnvironmentPath,
+        _branch: &str,
+        _create_branch: bool,
+    ) -> Result<(ExecutionEnvironmentPath, Checkout), String> {
+        Err("not implemented".to_string())
+    }
+
+    async fn remove_checkout(&self, _repo_root: &ExecutionEnvironmentPath, _branch: &str) -> Result<(), String> {
+        Err("not implemented".to_string())
+    }
+}
+
+struct BarrierCloudAgent(Arc<tokio::sync::Barrier>);
+
+#[async_trait]
+impl CloudAgentService for BarrierCloudAgent {
+    async fn list_sessions(&self, _criteria: &RepoCriteria) -> Result<Vec<(String, CloudAgentSession)>, String> {
+        self.0.wait().await;
+        Ok(vec![])
+    }
+
+    async fn archive_session(&self, _session_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn attach_command(&self, _session_id: &str) -> Result<String, String> {
+        Ok(String::new())
+    }
+}
+
+#[tokio::test]
+async fn full_refresh_runs_fast_and_slow_tiers_concurrently() {
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let mut registry = ProviderRegistry::new();
+    registry.checkout_managers.insert("checkout", desc("Checkout"), Arc::new(BarrierCheckoutManager(Arc::clone(&barrier))));
+    registry.cloud_agents.insert("cloud", desc("Cloud"), Arc::new(BarrierCloudAgent(Arc::clone(&barrier))));
+
+    let handle = RepoRefreshHandle::spawn(
+        repo_root(),
+        Arc::new(registry),
+        criteria(),
+        None,
+        None,
+        test_attachable_store(),
+        test_agent_state_store(),
+        Duration::from_secs(60),
+    );
+    let mut rx = handle.snapshot_rx.clone();
+
+    tokio::time::timeout(Duration::from_secs(2), barrier.wait())
+        .await
+        .expect("fast and slow providers should both start before either finishes");
+    wait_for_snapshot(&mut rx).await;
+}
+
 #[tokio::test(start_paused = true)]
 async fn periodic_refresh_uses_fast_and_slow_provider_cadences() {
     let cloud_agent = Arc::new(CountingCloudAgent(AtomicUsize::new(0)));

--- a/crates/flotilla-core/src/refresh/tests.rs
+++ b/crates/flotilla-core/src/refresh/tests.rs
@@ -349,6 +349,71 @@ impl PresentationManager for CountingWorkspaceManager {
     }
 }
 
+struct BlockingFirstWorkspaceManager {
+    calls: AtomicUsize,
+    started: tokio::sync::Notify,
+    release: tokio::sync::Notify,
+}
+
+#[async_trait]
+impl PresentationManager for BlockingFirstWorkspaceManager {
+    async fn list_workspaces(&self) -> Result<Vec<(String, Workspace)>, String> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            self.started.notify_one();
+            self.release.notified().await;
+        }
+        Ok(vec![])
+    }
+
+    async fn create_workspace(&self, _config: &WorkspaceAttachRequest) -> Result<(String, Workspace), String> {
+        Err("not implemented".into())
+    }
+
+    async fn select_workspace(&self, _ws_ref: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn delete_workspace(&self, _ws_ref: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn binding_scope_prefix(&self) -> String {
+        String::new()
+    }
+}
+
+#[tokio::test]
+async fn trigger_during_initial_scan_runs_a_follow_up_refresh() {
+    let manager = Arc::new(BlockingFirstWorkspaceManager {
+        calls: AtomicUsize::new(0),
+        started: tokio::sync::Notify::new(),
+        release: tokio::sync::Notify::new(),
+    });
+    let mut registry = ProviderRegistry::new();
+    registry.presentation_managers.insert("workspace", desc("Workspace"), manager.clone());
+    let _handle = RepoRefreshHandle::spawn(
+        repo_root(),
+        Arc::new(registry),
+        criteria(),
+        None,
+        None,
+        test_attachable_store(),
+        test_agent_state_store(),
+        Duration::from_secs(60),
+    );
+
+    manager.started.notified().await;
+    _handle.trigger_refresh();
+    manager.release.notify_one();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while manager.calls.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("trigger received during the initial scan should remain pending");
+}
+
 struct BarrierCheckoutManager(Arc<tokio::sync::Barrier>);
 
 #[async_trait]

--- a/crates/flotilla-core/src/refresh/tests.rs
+++ b/crates/flotilla-core/src/refresh/tests.rs
@@ -480,6 +480,7 @@ async fn staggered_schedule_delays_the_initial_full_refresh() {
         schedule,
     );
     let mut rx = handle.snapshot_rx.clone();
+    handle.trigger_refresh();
     tokio::task::yield_now().await;
     assert!(!rx.has_changed().expect("refresh sender alive"));
 
@@ -489,6 +490,7 @@ async fn staggered_schedule_delays_the_initial_full_refresh() {
 
     tokio::time::advance(Duration::from_secs(1)).await;
     rx.changed().await.expect("staggered initial refresh");
+    tokio::task::yield_now().await;
     assert_eq!(workspace_manager.0.load(Ordering::SeqCst), 1);
 }
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -2130,12 +2130,19 @@ async fn trigger_refresh_and_recv(
     repo: &Path,
     rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>,
 ) -> DaemonEvent {
+    let expected_identity = daemon.tracked_repo_identity_for_path(repo).await.expect("refreshed repo should be tracked");
     daemon.refresh(&RepoSelector::Path(repo.to_path_buf())).await.expect("refresh should succeed");
     loop {
         let event = recv_event(rx).await;
         match &event {
-            DaemonEvent::RepoSnapshot(snapshot) if snapshot.repo.as_deref() == Some(repo) => return event,
-            DaemonEvent::RepoDelta(delta) if delta.repo.as_deref() == Some(repo) => return event,
+            DaemonEvent::RepoSnapshot(snapshot)
+                if snapshot.repo.as_deref() == Some(repo) && snapshot.repo_identity == expected_identity =>
+            {
+                return event;
+            }
+            DaemonEvent::RepoDelta(delta) if delta.repo.as_deref() == Some(repo) && delta.repo_identity == expected_identity => {
+                return event
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

- cache host-scoped provider discovery and workspace/terminal scans per environment with TTL and single-flight semantics
- share Claude and Cursor account-wide session fetches across projects for at least one minute
- split refreshes into staggered 10-second local and 60-second network tiers while keeping manual refresh full
- batch worktree issue metadata into one repository-wide Git config query

## Why

Each tracked project independently repeated host-wide and account-wide provider work on synchronized refresh ticks. On macOS, the resulting bursts of short-lived `git`, `gh`, `zellij`, and `shpool` processes overwhelmed `syspolicyd` as the project count grew.

## Impact

Adding a project now adds project-specific observation work without multiplying identical host-wide scans. Stable per-project offsets spread startup and periodic work, while provider health and errors remain intact across the fast and slow refresh tiers.

## Checks

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- parallel Standards and Spec reviews: no remaining findings

Fixes #689
