### PR TITLE
fix: move sqlite resource I/O off Tokio threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +716,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1354,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "tokio-rusqlite",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1657,15 +1655,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1686,11 +1675,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2227,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3450,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
@@ -4207,6 +4196,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rusqlite"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302563ae4a2127f3d2c105f4f2f0bd7cae3609371755600ebc148e0ccd8510d6"
+dependencies = [
+ "crossbeam-channel",
+ "rusqlite",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/flotilla-daemon/Cargo.toml
+++ b/crates/flotilla-daemon/Cargo.toml
@@ -31,7 +31,7 @@ visibility = "0.1.1"
 
 [dev-dependencies]
 indexmap = { workspace = true }
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 tempfile = "3"
 flotilla-core = { path = "../flotilla-core", features = ["test-support"] }
 flotilla-daemon = { path = ".", features = ["test-support"] }

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -99,12 +99,17 @@ fn build_peer_manager(daemon: &Arc<InProcessDaemon>, config: &ConfigStore) -> Re
     Ok(Arc::new(Mutex::new(peer_manager)))
 }
 
-fn build_embedded_resource_backend(config: &ConfigStore) -> Result<ResourceBackend, String> {
+async fn build_embedded_resource_backend(config: &ConfigStore) -> Result<ResourceBackend, String> {
     let path = config.state_dir().as_path().join("resources.sqlite");
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| format!("create embedded resource store directory {}: {err}", parent.display()))?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|err| format!("create embedded resource store directory {}: {err}", parent.display()))?;
     }
-    SqliteBackend::open(&path).map(ResourceBackend::Sqlite).map_err(|err| format!("open embedded resource store {}: {err}", path.display()))
+    SqliteBackend::open_async(&path)
+        .await
+        .map(ResourceBackend::Sqlite)
+        .map_err(|err| format!("open embedded resource store {}: {err}", path.display()))
 }
 
 pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &ConfigStore) -> Result<tokio::task::JoinHandle<()>, String> {
@@ -187,7 +192,7 @@ impl DaemonServer {
     ) -> Result<Self, String> {
         let daemon_config = config.load_daemon_config()?;
         let host_name = daemon_config.host_name.map(HostName::new).unwrap_or_else(HostName::local);
-        let resource_backend = build_embedded_resource_backend(&config)?;
+        let resource_backend = build_embedded_resource_backend(&config).await?;
         let daemon =
             InProcessDaemon::new_with_resource_backend(repo_paths, Arc::clone(&config), discovery, host_name.clone(), resource_backend)
                 .await;

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -21,7 +21,8 @@ base64 = "0.22"
 bytes = "1"
 tracing = "0.1"
 sha2 = "0.10"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
+tokio-rusqlite = "0.7"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -7,9 +7,10 @@ use std::{
 
 use chrono::Utc;
 use futures::{stream, StreamExt};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection as RusqliteConnection, OptionalExtension};
 use serde_json::Value;
 use tokio::sync::mpsc;
+use tokio_rusqlite::Connection;
 
 use crate::{
     error::ResourceError,
@@ -24,10 +25,9 @@ type WatchersByStore = HashMap<StoreKey, Vec<WatchSender>>;
 
 #[derive(Debug, Clone)]
 pub struct SqliteBackend {
-    // rusqlite is synchronous. The embedded daemon currently serializes SQLite
-    // access behind one mutex; move this behind spawn_blocking or tokio-rusqlite
-    // if controller contention shows up in practice.
-    connection: Arc<Mutex<Connection>>,
+    connection: Connection,
+    // Mutations notify and watches register from the connection thread so a
+    // committed event cannot land between replay and live delivery.
     watchers: Arc<Mutex<WatchersByStore>>,
     event_retention: EventRetention,
 }
@@ -70,8 +70,14 @@ impl SqliteBackend {
     }
 
     pub fn open_with_event_retention(path: impl AsRef<Path>, event_retention: EventRetention) -> Result<Self, ResourceError> {
-        let connection = Connection::open(path).map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
+        let connection =
+            RusqliteConnection::open(path).map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
         Self::from_connection(connection, event_retention)
+    }
+
+    pub async fn open_async(path: impl AsRef<Path>) -> Result<Self, ResourceError> {
+        let connection = Connection::open(path).await.map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
+        Self::from_async_connection(connection, EventRetention::default()).await
     }
 
     pub fn open_in_memory() -> Result<Self, ResourceError> {
@@ -79,11 +85,25 @@ impl SqliteBackend {
     }
 
     pub fn open_in_memory_with_event_retention(event_retention: EventRetention) -> Result<Self, ResourceError> {
-        let connection = Connection::open_in_memory().map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
+        let connection =
+            RusqliteConnection::open_in_memory().map_err(|err| ResourceError::other(format!("open sqlite resource store: {err}")))?;
         Self::from_connection(connection, event_retention)
     }
 
-    fn from_connection(mut connection: Connection, event_retention: EventRetention) -> Result<Self, ResourceError> {
+    fn from_connection(mut connection: RusqliteConnection, event_retention: EventRetention) -> Result<Self, ResourceError> {
+        Self::initialize_connection(&mut connection, event_retention)?;
+        Ok(Self { connection: connection.into(), watchers: Arc::new(Mutex::new(HashMap::new())), event_retention })
+    }
+
+    async fn from_async_connection(connection: Connection, event_retention: EventRetention) -> Result<Self, ResourceError> {
+        connection
+            .call(move |connection| Self::initialize_connection(connection, event_retention))
+            .await
+            .map_err(Self::map_connection_error)?;
+        Ok(Self { connection, watchers: Arc::new(Mutex::new(HashMap::new())), event_retention })
+    }
+
+    fn initialize_connection(connection: &mut RusqliteConnection, event_retention: EventRetention) -> Result<(), ResourceError> {
         connection
             .busy_timeout(Duration::from_secs(5))
             .map_err(|err| ResourceError::other(format!("configure sqlite resource store busy timeout: {err}")))?;
@@ -135,7 +155,7 @@ impl SqliteBackend {
                 "#,
             )
             .map_err(|err| ResourceError::other(format!("initialize sqlite resource store: {err}")))?;
-        let startup_diagnostics = Self::diagnostics_from_connection(&connection, event_retention)?;
+        let startup_diagnostics = Self::diagnostics_from_connection(connection, event_retention)?;
         if !startup_diagnostics.warnings.is_empty() {
             tracing::warn!(
                 event_count = startup_diagnostics.event_count,
@@ -146,29 +166,40 @@ impl SqliteBackend {
                 "resource event log tripwire triggered on startup; compacting",
             );
         }
-        Self::compact_existing_events(&mut connection, event_retention)?;
-        Ok(Self { connection: Arc::new(Mutex::new(connection)), watchers: Arc::new(Mutex::new(HashMap::new())), event_retention })
+        Self::compact_existing_events(connection, event_retention)?;
+        Ok(())
     }
 
     fn store_key<T: Resource>(namespace: &str) -> StoreKey {
         (T::API_PATHS.group.to_string(), T::API_PATHS.version.to_string(), T::API_PATHS.kind.to_string(), namespace.to_string())
     }
 
-    fn lock_connection(&self) -> Result<MutexGuard<'_, Connection>, ResourceError> {
-        self.connection.lock().map_err(|_| ResourceError::other("sqlite resource store lock poisoned"))
+    fn lock_watchers(watchers: &Mutex<WatchersByStore>) -> Result<MutexGuard<'_, WatchersByStore>, ResourceError> {
+        watchers.lock().map_err(|_| ResourceError::other("sqlite resource watch lock poisoned"))
     }
 
-    fn lock_watchers(&self) -> Result<MutexGuard<'_, WatchersByStore>, ResourceError> {
-        self.watchers.lock().map_err(|_| ResourceError::other("sqlite resource watch lock poisoned"))
+    async fn call<R, F>(&self, operation: F) -> Result<R, ResourceError>
+    where
+        R: Send + 'static,
+        F: FnOnce(&mut RusqliteConnection) -> Result<R, ResourceError> + Send + 'static,
+    {
+        self.connection.call(operation).await.map_err(Self::map_connection_error)
+    }
+
+    fn map_connection_error(error: tokio_rusqlite::Error<ResourceError>) -> ResourceError {
+        match error {
+            tokio_rusqlite::Error::Error(error) => error,
+            other => ResourceError::other(format!("sqlite connection thread failed: {other}")),
+        }
     }
 
     pub(crate) async fn diagnostics(&self) -> Result<ResourceStoreDiagnostics, ResourceError> {
-        let connection = self.lock_connection()?;
-        Self::diagnostics_from_connection(&connection, self.event_retention)
+        let event_retention = self.event_retention;
+        self.call(move |connection| Self::diagnostics_from_connection(connection, event_retention)).await
     }
 
     fn diagnostics_from_connection(
-        connection: &Connection,
+        connection: &RusqliteConnection,
         event_retention: EventRetention,
     ) -> Result<ResourceStoreDiagnostics, ResourceError> {
         let object_count = connection
@@ -214,7 +245,7 @@ impl SqliteBackend {
         ResourceError::other(format!("{action}: {err}"))
     }
 
-    fn current_version(conn: &Connection, key: &StoreKey) -> Result<u64, ResourceError> {
+    fn current_version(conn: &RusqliteConnection, key: &StoreKey) -> Result<u64, ResourceError> {
         let version = conn
             .query_row(
                 "SELECT next_version FROM resource_sequences WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4",
@@ -300,7 +331,7 @@ impl SqliteBackend {
         Ok(())
     }
 
-    fn compact_existing_events(connection: &mut Connection, event_retention: EventRetention) -> Result<(), ResourceError> {
+    fn compact_existing_events(connection: &mut RusqliteConnection, event_retention: EventRetention) -> Result<(), ResourceError> {
         let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource event startup compaction"))?;
         let stores = {
             let mut statement = tx
@@ -317,8 +348,8 @@ impl SqliteBackend {
         tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource event startup compaction"))
     }
 
-    fn notify_watchers(&self, key: &StoreKey, event: StoredEvent) {
-        if let Ok(mut watchers) = self.lock_watchers() {
+    fn notify_watchers(watchers: &Mutex<WatchersByStore>, key: &StoreKey, event: StoredEvent) {
+        if let Ok(mut watchers) = Self::lock_watchers(watchers) {
             if let Some(entries) = watchers.get_mut(key) {
                 entries.retain(|watcher| watcher.send(event.clone()).is_ok());
             }
@@ -327,45 +358,51 @@ impl SqliteBackend {
 
     pub(crate) async fn get_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceObject<T>, ResourceError> {
         let key = Self::store_key::<T>(namespace);
-        let conn = self.lock_connection()?;
-        let body: String = conn
-            .query_row(
-                r#"
-                SELECT body_json FROM resource_objects
-                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
-                "#,
-                params![key.0, key.1, key.2, key.3, name],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|err| Self::map_sqlite(err, "read sqlite resource object"))?
-            .ok_or_else(|| ResourceError::not_found(name))?;
-        let value = serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
-        Self::decode_object::<T>(value)
+        let name = name.to_string();
+        self.call(move |connection| {
+            let body: String = connection
+                .query_row(
+                    r#"
+                    SELECT body_json FROM resource_objects
+                    WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                    "#,
+                    params![key.0, key.1, key.2, key.3, name],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|err| Self::map_sqlite(err, "read sqlite resource object"))?
+                .ok_or_else(|| ResourceError::not_found(&name))?;
+            let value = serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
+            Self::decode_object::<T>(value)
+        })
+        .await
     }
 
     pub(crate) async fn list_typed<T: Resource>(&self, namespace: &str) -> Result<ResourceList<T>, ResourceError> {
         let key = Self::store_key::<T>(namespace);
-        let conn = self.lock_connection()?;
-        let mut statement = conn
-            .prepare(
-                r#"
-                SELECT body_json FROM resource_objects
-                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4
-                ORDER BY name
-                "#,
-            )
-            .map_err(|err| Self::map_sqlite(err, "prepare sqlite resource list"))?;
-        let rows = statement
-            .query_map(params![key.0, key.1, key.2, key.3], |row| row.get::<_, String>(0))
-            .map_err(|err| Self::map_sqlite(err, "query sqlite resource list"))?;
-        let mut items = Vec::new();
-        for row in rows {
-            let body = row.map_err(|err| Self::map_sqlite(err, "read sqlite resource list row"))?;
-            let value = serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
-            items.push(Self::decode_object::<T>(value)?);
-        }
-        Ok(ResourceList { items, resource_version: Self::current_version(&conn, &key)?.to_string(), generation: None })
+        self.call(move |connection| {
+            let mut statement = connection
+                .prepare(
+                    r#"
+                    SELECT body_json FROM resource_objects
+                    WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4
+                    ORDER BY name
+                    "#,
+                )
+                .map_err(|err| Self::map_sqlite(err, "prepare sqlite resource list"))?;
+            let rows = statement
+                .query_map(params![key.0, key.1, key.2, key.3], |row| row.get::<_, String>(0))
+                .map_err(|err| Self::map_sqlite(err, "query sqlite resource list"))?;
+            let mut items = Vec::new();
+            for row in rows {
+                let body = row.map_err(|err| Self::map_sqlite(err, "read sqlite resource list row"))?;
+                let value =
+                    serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode stored object JSON: {err}")))?;
+                items.push(Self::decode_object::<T>(value)?);
+            }
+            Ok(ResourceList { items, resource_version: Self::current_version(connection, &key)?.to_string(), generation: None })
+        })
+        .await
     }
 
     pub(crate) async fn list_typed_matching_labels<T: Resource>(
@@ -393,54 +430,61 @@ impl SqliteBackend {
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
         let key = Self::store_key::<T>(namespace);
-        let mut conn = self.lock_connection()?;
-        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource create"))?;
-        let exists = tx
-            .query_row(
-                r#"
-                SELECT 1 FROM resource_objects
-                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
-                "#,
-                params![key.0, key.1, key.2, key.3, meta.name],
-                |_| Ok(()),
-            )
-            .optional()
-            .map_err(|err| Self::map_sqlite(err, "check sqlite resource create conflict"))?
-            .is_some();
-        if exists {
-            return Err(ResourceError::conflict(&meta.name, "resource already exists"));
-        }
+        let namespace = namespace.to_string();
+        let meta = meta.clone();
+        let spec = spec.clone();
+        let watchers = Arc::clone(&self.watchers);
+        let event_retention = self.event_retention;
+        self.call(move |connection| {
+            let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource create"))?;
+            let exists = tx
+                .query_row(
+                    r#"
+                    SELECT 1 FROM resource_objects
+                    WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                    "#,
+                    params![key.0, key.1, key.2, key.3, meta.name],
+                    |_| Ok(()),
+                )
+                .optional()
+                .map_err(|err| Self::map_sqlite(err, "check sqlite resource create conflict"))?
+                .is_some();
+            if exists {
+                return Err(ResourceError::conflict(&meta.name, "resource already exists"));
+            }
 
-        let version = Self::allocate_version(&tx, &key)?;
-        let object = ResourceObject::<T> {
-            metadata: ObjectMeta {
-                name: meta.name.clone(),
-                namespace: namespace.to_string(),
-                resource_version: version.to_string(),
-                labels: meta.labels.clone(),
-                annotations: meta.annotations.clone(),
-                owner_references: meta.owner_references.clone(),
-                finalizers: meta.finalizers.clone(),
-                deletion_timestamp: meta.deletion_timestamp,
-                creation_timestamp: Utc::now(),
-            },
-            spec: Self::clone_through_serde(spec)?,
-            status: None,
-        };
-        let encoded = Self::encode_object(&object)?;
-        let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
-        tx.execute(
-            r#"
-            INSERT INTO resource_objects (group_name, version, kind, namespace, name, resource_version, body_json)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-            "#,
-            params![key.0, key.1, key.2, key.3, meta.name, version, body_json],
-        )
-        .map_err(|err| Self::map_sqlite(err, "insert sqlite resource object"))?;
-        Self::insert_event(&tx, &key, version, StoredEventKind::Added, &body_json, self.event_retention)?;
-        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource create"))?;
-        self.notify_watchers(&key, StoredEvent { kind: StoredEventKind::Added, object: encoded });
-        Ok(object)
+            let version = Self::allocate_version(&tx, &key)?;
+            let object = ResourceObject::<T> {
+                metadata: ObjectMeta {
+                    name: meta.name.clone(),
+                    namespace,
+                    resource_version: version.to_string(),
+                    labels: meta.labels.clone(),
+                    annotations: meta.annotations.clone(),
+                    owner_references: meta.owner_references.clone(),
+                    finalizers: meta.finalizers.clone(),
+                    deletion_timestamp: meta.deletion_timestamp,
+                    creation_timestamp: Utc::now(),
+                },
+                spec: Self::clone_through_serde(&spec)?,
+                status: None,
+            };
+            let encoded = Self::encode_object(&object)?;
+            let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+            tx.execute(
+                r#"
+                INSERT INTO resource_objects (group_name, version, kind, namespace, name, resource_version, body_json)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                "#,
+                params![key.0, key.1, key.2, key.3, meta.name, version, body_json],
+            )
+            .map_err(|err| Self::map_sqlite(err, "insert sqlite resource object"))?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Added, &body_json, event_retention)?;
+            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource create"))?;
+            Self::notify_watchers(&watchers, &key, StoredEvent { kind: StoredEventKind::Added, object: encoded });
+            Ok(object)
+        })
+        .await
     }
 
     pub(crate) async fn update_typed<T: Resource>(
@@ -451,46 +495,53 @@ impl SqliteBackend {
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
         let key = Self::store_key::<T>(namespace);
-        let mut conn = self.lock_connection()?;
-        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource update"))?;
-        let existing = Self::select_existing::<T>(&tx, &key, &meta.name)?;
-        let mut object = existing.ok_or_else(|| ResourceError::not_found(&meta.name))?;
-        if object.metadata.resource_version != resource_version {
-            return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
-        }
-        if object.matches_update(meta, spec)? {
-            return Ok(object);
-        }
+        let meta = meta.clone();
+        let resource_version = resource_version.to_string();
+        let spec = spec.clone();
+        let watchers = Arc::clone(&self.watchers);
+        let event_retention = self.event_retention;
+        self.call(move |connection| {
+            let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource update"))?;
+            let existing = Self::select_existing::<T>(&tx, &key, &meta.name)?;
+            let mut object = existing.ok_or_else(|| ResourceError::not_found(&meta.name))?;
+            if object.metadata.resource_version != resource_version {
+                return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
+            }
+            if object.matches_update(&meta, &spec)? {
+                return Ok(object);
+            }
 
-        let version = Self::allocate_version(&tx, &key)?;
-        object.metadata.resource_version = version.to_string();
-        object.metadata.labels = meta.labels.clone();
-        object.metadata.annotations = meta.annotations.clone();
-        object.metadata.owner_references = meta.owner_references.clone();
-        object.metadata.finalizers = meta.finalizers.clone();
-        object.metadata.deletion_timestamp = meta.deletion_timestamp;
-        object.spec = Self::clone_through_serde(spec)?;
+            let version = Self::allocate_version(&tx, &key)?;
+            object.metadata.resource_version = version.to_string();
+            object.metadata.labels = meta.labels.clone();
+            object.metadata.annotations = meta.annotations.clone();
+            object.metadata.owner_references = meta.owner_references.clone();
+            object.metadata.finalizers = meta.finalizers.clone();
+            object.metadata.deletion_timestamp = meta.deletion_timestamp;
+            object.spec = Self::clone_through_serde(&spec)?;
 
-        let encoded = Self::encode_object(&object)?;
-        let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
-        let event_kind = if object.metadata.deletion_timestamp.is_some() && object.metadata.finalizers.is_empty() {
-            tx.execute(
-                r#"
-                DELETE FROM resource_objects
-                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
-                "#,
-                params![key.0, key.1, key.2, key.3, meta.name],
-            )
-            .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
-            StoredEventKind::Deleted
-        } else {
-            Self::upsert_object(&tx, &key, &meta.name, version, &body_json)?;
-            StoredEventKind::Modified
-        };
-        Self::insert_event(&tx, &key, version, event_kind, &body_json, self.event_retention)?;
-        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource update"))?;
-        self.notify_watchers(&key, StoredEvent { kind: event_kind, object: encoded });
-        Ok(object)
+            let encoded = Self::encode_object(&object)?;
+            let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+            let event_kind = if object.metadata.deletion_timestamp.is_some() && object.metadata.finalizers.is_empty() {
+                tx.execute(
+                    r#"
+                    DELETE FROM resource_objects
+                    WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                    "#,
+                    params![key.0, key.1, key.2, key.3, meta.name],
+                )
+                .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
+                StoredEventKind::Deleted
+            } else {
+                Self::upsert_object(&tx, &key, &meta.name, version, &body_json)?;
+                StoredEventKind::Modified
+            };
+            Self::insert_event(&tx, &key, version, event_kind, &body_json, event_retention)?;
+            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource update"))?;
+            Self::notify_watchers(&watchers, &key, StoredEvent { kind: event_kind, object: encoded });
+            Ok(object)
+        })
+        .await
     }
 
     pub(crate) async fn update_status_typed<T: Resource>(
@@ -501,66 +552,80 @@ impl SqliteBackend {
         status: &T::Status,
     ) -> Result<ResourceObject<T>, ResourceError> {
         let key = Self::store_key::<T>(namespace);
-        let mut conn = self.lock_connection()?;
-        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource status update"))?;
-        let existing = Self::select_existing::<T>(&tx, &key, name)?;
-        let mut object = existing.ok_or_else(|| ResourceError::not_found(name))?;
-        if object.metadata.resource_version != resource_version {
-            return Err(ResourceError::conflict(name, "stale resourceVersion"));
-        }
-        if object.matches_status(status)? {
-            return Ok(object);
-        }
+        let name = name.to_string();
+        let resource_version = resource_version.to_string();
+        let status = status.clone();
+        let watchers = Arc::clone(&self.watchers);
+        let event_retention = self.event_retention;
+        self.call(move |connection| {
+            let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource status update"))?;
+            let existing = Self::select_existing::<T>(&tx, &key, &name)?;
+            let mut object = existing.ok_or_else(|| ResourceError::not_found(&name))?;
+            if object.metadata.resource_version != resource_version {
+                return Err(ResourceError::conflict(&name, "stale resourceVersion"));
+            }
+            if object.matches_status(&status)? {
+                return Ok(object);
+            }
 
-        let version = Self::allocate_version(&tx, &key)?;
-        object.metadata.resource_version = version.to_string();
-        object.status = Some(Self::clone_through_serde(status)?);
+            let version = Self::allocate_version(&tx, &key)?;
+            object.metadata.resource_version = version.to_string();
+            object.status = Some(Self::clone_through_serde(&status)?);
 
-        let encoded = Self::encode_object(&object)?;
-        let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
-        Self::upsert_object(&tx, &key, name, version, &body_json)?;
-        Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, self.event_retention)?;
-        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource status update"))?;
-        self.notify_watchers(&key, StoredEvent { kind: StoredEventKind::Modified, object: encoded });
-        Ok(object)
+            let encoded = Self::encode_object(&object)?;
+            let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+            Self::upsert_object(&tx, &key, &name, version, &body_json)?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, event_retention)?;
+            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource status update"))?;
+            Self::notify_watchers(&watchers, &key, StoredEvent { kind: StoredEventKind::Modified, object: encoded });
+            Ok(object)
+        })
+        .await
     }
 
     pub(crate) async fn delete_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<(), ResourceError> {
         let key = Self::store_key::<T>(namespace);
-        let mut conn = self.lock_connection()?;
-        let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource delete"))?;
-        let existing = Self::select_existing::<T>(&tx, &key, name)?;
-        let mut object = existing.ok_or_else(|| ResourceError::not_found(name))?;
-        if object.metadata.is_pending_finalization() {
-            return Ok(());
-        }
-        let version = Self::allocate_version(&tx, &key)?;
-        object.metadata.resource_version = version.to_string();
+        let name = name.to_string();
+        let watchers = Arc::clone(&self.watchers);
+        let event_retention = self.event_retention;
+        self.call(move |connection| {
+            let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource delete"))?;
+            let existing = Self::select_existing::<T>(&tx, &key, &name)?;
+            let mut object = existing.ok_or_else(|| ResourceError::not_found(&name))?;
+            if object.metadata.is_pending_finalization() {
+                return Ok(());
+            }
+            let version = Self::allocate_version(&tx, &key)?;
+            object.metadata.resource_version = version.to_string();
 
-        let (event_kind, encoded) = if !object.metadata.finalizers.is_empty() && object.metadata.deletion_timestamp.is_none() {
-            object.metadata.deletion_timestamp = Some(Utc::now());
-            let encoded = Self::encode_object(&object)?;
-            let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
-            Self::upsert_object(&tx, &key, name, version, &body_json)?;
-            Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, self.event_retention)?;
-            (StoredEventKind::Modified, encoded)
-        } else {
-            let encoded = Self::encode_object(&object)?;
-            let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
-            tx.execute(
-                r#"
-                DELETE FROM resource_objects
-                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
-                "#,
-                params![key.0, key.1, key.2, key.3, name],
-            )
-            .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
-            Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json, self.event_retention)?;
-            (StoredEventKind::Deleted, encoded)
-        };
-        tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource delete"))?;
-        self.notify_watchers(&key, StoredEvent { kind: event_kind, object: encoded });
-        Ok(())
+            let (event_kind, encoded) = if !object.metadata.finalizers.is_empty() && object.metadata.deletion_timestamp.is_none() {
+                object.metadata.deletion_timestamp = Some(Utc::now());
+                let encoded = Self::encode_object(&object)?;
+                let body_json =
+                    serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+                Self::upsert_object(&tx, &key, &name, version, &body_json)?;
+                Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, event_retention)?;
+                (StoredEventKind::Modified, encoded)
+            } else {
+                let encoded = Self::encode_object(&object)?;
+                let body_json =
+                    serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
+                tx.execute(
+                    r#"
+                    DELETE FROM resource_objects
+                    WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                    "#,
+                    params![key.0, key.1, key.2, key.3, name],
+                )
+                .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
+                Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json, event_retention)?;
+                (StoredEventKind::Deleted, encoded)
+            };
+            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource delete"))?;
+            Self::notify_watchers(&watchers, &key, StoredEvent { kind: event_kind, object: encoded });
+            Ok(())
+        })
+        .await
     }
 
     pub(crate) async fn watch_typed<T: Resource>(&self, namespace: &str, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {
@@ -575,15 +640,17 @@ impl SqliteBackend {
             }
         };
         let (sender, receiver) = mpsc::unbounded_channel();
-        let replay = {
-            let conn = self.lock_connection()?;
-            let replay = match replay_from {
-                Some(version) => Self::replay_events(&conn, &key, version)?,
-                None => Vec::new(),
-            };
-            self.lock_watchers()?.entry(key.clone()).or_default().push(sender);
-            replay
-        };
+        let watchers = Arc::clone(&self.watchers);
+        let replay = self
+            .call(move |connection| {
+                let replay = match replay_from {
+                    Some(version) => Self::replay_events(connection, &key, version)?,
+                    None => Vec::new(),
+                };
+                Self::lock_watchers(&watchers)?.entry(key).or_default().push(sender);
+                Ok(replay)
+            })
+            .await?;
 
         let replay_stream = stream::iter(replay.into_iter().map(Self::decode_event::<T>));
         let live_stream = stream::unfold(receiver, |mut receiver| async {
@@ -635,7 +702,7 @@ impl SqliteBackend {
         Ok(())
     }
 
-    fn replay_events(conn: &Connection, key: &StoreKey, replay_from: u64) -> Result<Vec<StoredEvent>, ResourceError> {
+    fn replay_events(conn: &RusqliteConnection, key: &StoreKey, replay_from: u64) -> Result<Vec<StoredEvent>, ResourceError> {
         let compacted_through = conn
             .query_row(
                 r#"

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::{sync::mpsc as std_mpsc, thread, time::Instant};
+
 use chrono::Utc;
 use common::{
     contract::{
@@ -16,17 +18,48 @@ use common::{
 use flotilla_controllers::reconcilers::VesselReconciler;
 use flotilla_resources::{
     controller::{Actuation, ControllerLoop, Reconciler},
-    Convoy, ConvoyPhase, ConvoyReconciler, EventRetention, ResourceBackend, ResourceError, SqliteBackend, TerminalSession,
-    TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec, WatchEvent, WatchStart, WorkPhase, WorkflowTemplate, CONVOY_LABEL,
-    VESSEL_REF_LABEL,
+    ApiPaths, Convoy, ConvoyPhase, ConvoyReconciler, EventRetention, NoStatusPatch, Resource, ResourceBackend, ResourceError,
+    SqliteBackend, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec, WatchEvent, WatchStart, WorkPhase,
+    WorkflowTemplate, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 use futures::StreamExt;
 use rstest::rstest;
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use tempfile::tempdir;
 use tokio::time::{timeout, Duration};
 
 fn backend() -> ResourceBackend {
     ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend should open"))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SlowResource;
+
+#[derive(Debug, Clone, Deserialize)]
+struct SlowSpec {
+    value: String,
+    #[serde(skip)]
+    serialization_delay: Duration,
+}
+
+impl Serialize for SlowSpec {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        thread::sleep(self.serialization_delay);
+        let mut state = serializer.serialize_struct("SlowSpec", 1)?;
+        state.serialize_field("value", &self.value)?;
+        state.end()
+    }
+}
+
+impl Resource for SlowResource {
+    type Spec = SlowSpec;
+    type Status = ();
+    type StatusPatch = NoStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.test", version: "v1", plural: "slowresources", kind: "SlowResource" };
 }
 
 #[rstest]
@@ -159,6 +192,88 @@ async fn objects_and_resource_versions_survive_restart() {
         .await
         .expect("update should succeed after restart");
     assert_eq!(updated.metadata.resource_version, "2");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn delayed_sqlite_open_does_not_stall_tokio_executor() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+
+    let blocker_path = path.clone();
+    let (locked_tx, locked_rx) = std_mpsc::channel();
+    let blocker = thread::spawn(move || {
+        let connection = rusqlite::Connection::open(blocker_path).expect("blocking connection should open");
+        connection.execute_batch("CREATE TABLE startup_lock (value INTEGER); BEGIN EXCLUSIVE").expect("exclusive transaction should begin");
+        locked_tx.send(()).expect("lock acquisition should be reported");
+        thread::sleep(Duration::from_millis(400));
+        connection.execute_batch("ROLLBACK").expect("exclusive transaction should roll back");
+    });
+    locked_rx.recv().expect("blocking transaction should start");
+
+    let started = Instant::now();
+    let heartbeat = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        started.elapsed()
+    });
+    SqliteBackend::open_async(&path).await.expect("sqlite backend should open after lock release");
+
+    let heartbeat_delay = heartbeat.await.expect("heartbeat should complete");
+    assert!(heartbeat_delay < Duration::from_millis(150), "Tokio heartbeat was delayed by {heartbeat_delay:?}");
+    blocker.join().expect("blocking connection thread should finish");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn slow_sqlite_crud_does_not_stall_tokio_executor() {
+    let resolver = backend().using::<SlowResource>("flotilla");
+    let started = Instant::now();
+    let heartbeat = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        started.elapsed()
+    });
+
+    resolver
+        .create(&resource_meta().name("alpha").call(), &SlowSpec {
+            value: "alpha".to_string(),
+            serialization_delay: Duration::from_millis(200),
+        })
+        .await
+        .expect("slow create should succeed");
+
+    let heartbeat_delay = heartbeat.await.expect("heartbeat should complete");
+    assert!(heartbeat_delay < Duration::from_millis(150), "Tokio heartbeat was delayed by {heartbeat_delay:?}");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn concurrent_create_and_watch_delivers_the_committed_version_once() {
+    let resolver = backend().using::<SlowResource>("flotilla");
+    let create_resolver = resolver.clone();
+    let create = tokio::spawn(async move {
+        create_resolver
+            .create(&resource_meta().name("alpha").call(), &SlowSpec {
+                value: "alpha".to_string(),
+                serialization_delay: Duration::from_millis(200),
+            })
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    let watch_resolver = resolver.clone();
+    let watch = tokio::spawn(async move { watch_resolver.watch(WatchStart::FromVersion("0".to_string())).await });
+    tokio::task::yield_now().await;
+    thread::sleep(Duration::from_millis(450));
+
+    create.await.expect("create task should complete").expect("create should succeed");
+    let mut watch = watch.await.expect("watch task should complete").expect("watch should start");
+    let event = timeout(Duration::from_secs(1), watch.next())
+        .await
+        .expect("watch should replay the create")
+        .expect("watch should remain open")
+        .expect("event should decode");
+    assert!(matches!(event, WatchEvent::Added(object) if object.metadata.name == "alpha"));
+    assert!(
+        timeout(Duration::from_millis(50), watch.next()).await.is_err(),
+        "the committed version must not be emitted by both replay and live notification"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- hand synchronous SQLite work to a dedicated `tokio-rusqlite` connection thread
- initialize the embedded resource database asynchronously during daemon startup
- preserve replay/live watch ordering by serializing watcher registration and mutation notification with database operations
- add regressions for executor responsiveness and exactly-once watch delivery

## Why

The SQLite resource backend performed synchronous `rusqlite` calls while inside async `ResourceBackend` methods. Under lock contention or heavier controller activity, those calls could block Tokio executor threads. Moving the connection behind `tokio-rusqlite` keeps the existing backend contract while isolating database I/O from the executor.

## Impact

The public `ResourceBackend` behavior remains unchanged. Existing synchronous construction helpers remain available, while production daemon startup uses the new asynchronous open path. Resource mutations, event replay, and live watch registration remain serialized to avoid duplicate or missed watch events.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `RUSTC_WRAPPER= TMPDIR="$PWD/.codex-tmp" cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTC_WRAPPER= TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked`

Closes #619
