### PR TITLE
fix: never mistake an incompatible daemon for a stale socket in connect_or_spawn

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -320,6 +320,13 @@ pub async fn connect_or_spawn(
     // handshake failure means a daemon is listening but is incompatible or
     // malformed; surface that error instead of treating the socket as stale
     // and silently spawning a second daemon over the live process.
+    //
+    // Deliberately no retry at this probe, unlike the two probes below: those
+    // sit in windows where a *just-spawned* daemon is expected and an error is
+    // probably a startup race, while a steady-state daemon that fails a
+    // 5s-bounded handshake is a condition the caller should hear about
+    // immediately — this is the interactive path, and retries would only
+    // delay an error the user has to act on anyway.
     if let Some(daemon) = connect_existing_stateful(socket_path).await? {
         return Ok(daemon);
     }
@@ -405,7 +412,9 @@ pub async fn connect_or_spawn(
         spawn_daemon(config_dir, config_dir_override, socket_override)?;
     }
 
-    // Poll for connection with a 10s deadline. Handshake errors here are
+    // Poll for connection with a 10s deadline (soft: the deadline is checked
+    // between probes, and a probe can block up to HELLO_HANDSHAKE_TIMEOUT, so
+    // the true worst-case is deadline + handshake timeout). Handshake errors here are
     // retried rather than propagated: the daemon on this socket was spawned by
     // us moments ago, so an error is far more likely a startup race (accepted
     // before the serve loop is up) than a genuine incompatibility. The last

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -316,8 +316,11 @@ pub async fn connect_or_spawn(
     config_dir_override: Option<&Path>,
     socket_override: Option<&Path>,
 ) -> Result<Arc<SocketDaemon>, String> {
-    // Try to connect to existing daemon
-    if let Ok(daemon) = SocketDaemon::connect(socket_path).await {
+    // An existing socket must complete the stateful Hello handshake. A
+    // handshake failure means a daemon is listening but is incompatible or
+    // malformed; surface that error instead of treating the socket as stale
+    // and silently spawning a second daemon over the live process.
+    if let Some(daemon) = connect_existing_stateful(socket_path).await? {
         return Ok(daemon);
     }
 
@@ -339,7 +342,7 @@ pub async fn connect_or_spawn(
             }
             Ok(None) => {
                 // Another process spawned the daemon — retry connect.
-                if let Ok(daemon) = SocketDaemon::connect(socket_path).await {
+                if let Some(daemon) = connect_existing_stateful(socket_path).await? {
                     return Ok(daemon);
                 }
                 // Their daemon didn't come up — retry lock acquisition rather than
@@ -362,7 +365,7 @@ pub async fn connect_or_spawn(
                     }
                     Ok(None) => {
                         // Someone else spawned while we waited — one last connect attempt.
-                        if let Ok(daemon) = SocketDaemon::connect(socket_path).await {
+                        if let Some(daemon) = connect_existing_stateful(socket_path).await? {
                             return Ok(daemon);
                         }
                         return Err("daemon spawn failed: all lock attempts exhausted and connect still failing".into());
@@ -390,13 +393,27 @@ pub async fn connect_or_spawn(
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
         tokio::time::sleep(Duration::from_millis(50)).await;
-        if let Ok(daemon) = SocketDaemon::connect(socket_path).await {
+        if let Some(daemon) = connect_existing_stateful(socket_path).await? {
             return Ok(daemon);
         }
         if tokio::time::Instant::now() >= deadline {
             return Err("timed out waiting for daemon to start (10s)".into());
         }
     }
+}
+
+/// Connect to an existing socket and require the client Hello handshake.
+///
+/// `Ok(None)` means no daemon accepted the Unix-socket connection, so the
+/// caller may use the spawn path. Once connected, handshake failures are
+/// returned verbatim: a live but incompatible daemon must not be mistaken for
+/// a stale socket.
+async fn connect_existing_stateful(socket_path: &Path) -> Result<Option<Arc<SocketDaemon>>, String> {
+    let session = match connect_unix_message_session(socket_path).await {
+        Ok(session) => session,
+        Err(_) => return Ok(None),
+    };
+    SocketDaemon::from_session_stateful(session).await.map(Some)
 }
 
 /// Send a request on the wire and wait for the response.

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -341,15 +341,31 @@ pub async fn connect_or_spawn(
                 break;
             }
             Ok(None) => {
-                // Another process spawned the daemon — retry connect.
-                if let Some(daemon) = connect_existing_stateful(socket_path).await? {
-                    return Ok(daemon);
-                }
+                // Another process spawned the daemon — retry connect. A
+                // handshake error here is most likely a race with that
+                // process's daemon still starting up, so it spends a retry
+                // attempt rather than aborting; but it must never fall
+                // through to the spawn path, which would delete the socket of
+                // a live (if unwell or incompatible) daemon.
+                let last_probe_error = match connect_existing_stateful(socket_path).await {
+                    Ok(Some(daemon)) => return Ok(daemon),
+                    Ok(None) => None,
+                    Err(e) => {
+                        warn!(attempt = attempt + 1, error = %e, "handshake with peer-spawned daemon failed");
+                        Some(e)
+                    }
+                };
                 // Their daemon didn't come up — retry lock acquisition rather than
                 // falling through to spawn without mutual exclusion.
                 if attempt + 1 < MAX_LOCK_RETRIES {
                     warn!(attempt = attempt + 1, "connect after lock wait failed, retrying lock");
                     continue;
+                }
+                // Retries exhausted. Only spawn if the last probe found no
+                // listener at all; a live daemon that kept failing the
+                // handshake is a reportable condition, not a stale socket.
+                if let Some(e) = last_probe_error {
+                    return Err(format!("a daemon is listening but the handshake kept failing across {MAX_LOCK_RETRIES} lock-wait attempts; last error: {e}"));
                 }
                 // Exhausted retries — acquire lock ourselves before spawning
                 // so we never spawn without mutual exclusion.

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -404,6 +404,22 @@ pub async fn connect_or_spawn(
         }
     }
 
+    // Final probe under the exclusively-held spawn lock. A daemon may have
+    // appeared (or kept failing the handshake) while we contended for the
+    // lock — in particular, a `continue` after a handshake error re-enters
+    // lock acquisition, which the releasing winner has left uncontended, so
+    // winning the lock says nothing about the socket being free. The lock
+    // makes this check race-free: nothing else may spawn while we hold it.
+    match connect_existing_stateful(socket_path).await {
+        Ok(Some(daemon)) => return Ok(daemon),
+        Ok(None) => {}
+        Err(e) => {
+            return Err(format!(
+                "won the spawn lock, but a live daemon is on the socket and failing the handshake — not spawning over it: {e}"
+            ));
+        }
+    }
+
     {
         // Clean up stale socket
         let _ = std::fs::remove_file(socket_path);

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -389,31 +389,54 @@ pub async fn connect_or_spawn(
         spawn_daemon(config_dir, config_dir_override, socket_override)?;
     }
 
-    // Poll for connection with a 10s deadline.
+    // Poll for connection with a 10s deadline. Handshake errors here are
+    // retried rather than propagated: the daemon on this socket was spawned by
+    // us moments ago, so an error is far more likely a startup race (accepted
+    // before the serve loop is up) than a genuine incompatibility. The last
+    // error is surfaced if the deadline expires without a successful handshake.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut last_handshake_error: Option<String> = None;
     loop {
         tokio::time::sleep(Duration::from_millis(50)).await;
-        if let Some(daemon) = connect_existing_stateful(socket_path).await? {
-            return Ok(daemon);
+        match connect_existing_stateful(socket_path).await {
+            Ok(Some(daemon)) => return Ok(daemon),
+            Ok(None) => {}
+            Err(e) => last_handshake_error = Some(e),
         }
         if tokio::time::Instant::now() >= deadline {
-            return Err("timed out waiting for daemon to start (10s)".into());
+            return Err(match last_handshake_error {
+                Some(e) => format!("daemon spawned but handshake kept failing until the 10s deadline; last error: {e}"),
+                None => "timed out waiting for daemon to start (10s)".into(),
+            });
         }
     }
 }
+
+/// Deadline for a listening daemon to complete the Hello handshake. Generous
+/// for a local Unix socket; only a wedged or badly stalled daemon exceeds it.
+const HELLO_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Connect to an existing socket and require the client Hello handshake.
 ///
 /// `Ok(None)` means no daemon accepted the Unix-socket connection, so the
 /// caller may use the spawn path. Once connected, handshake failures are
 /// returned verbatim: a live but incompatible daemon must not be mistaken for
-/// a stale socket.
+/// a stale socket. The handshake is bounded — a daemon that accepts the
+/// connection but never replies is reported as an error rather than hanging
+/// the caller (or, worse, being treated as absent and spawned over).
 async fn connect_existing_stateful(socket_path: &Path) -> Result<Option<Arc<SocketDaemon>>, String> {
     let session = match connect_unix_message_session(socket_path).await {
         Ok(session) => session,
         Err(_) => return Ok(None),
     };
-    SocketDaemon::from_session_stateful(session).await.map(Some)
+    match tokio::time::timeout(HELLO_HANDSHAKE_TIMEOUT, SocketDaemon::from_session_stateful(session)).await {
+        Ok(result) => result.map(Some),
+        Err(_) => Err(format!(
+            "daemon at {} accepted the connection but did not complete the Hello handshake within {}s — it may be wedged; check or restart it",
+            socket_path.display(),
+            HELLO_HANDSHAKE_TIMEOUT.as_secs()
+        )),
+    }
 }
 
 /// Send a request on the wire and wait for the response.

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -114,6 +114,36 @@ async fn read_request(session: &MessageSession) -> (u64, Request) {
 }
 
 #[tokio::test]
+async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("daemon.sock");
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!(
+                "skipping connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning: unix socket bind not permitted: {err}"
+            );
+            return;
+        }
+        Err(err) => panic!("bind listener: {err}"),
+    };
+
+    // Accept the connection and hold it open without ever sending a Hello —
+    // a wedged daemon from the caller's point of view.
+    let server_task = tokio::spawn(async move {
+        let (_stream, _) = listener.accept().await.expect("accept client");
+        std::future::pending::<()>().await;
+    });
+
+    let error = match connect_or_spawn(&socket_path, dir.path(), None, Some(&socket_path)).await {
+        Ok(_) => panic!("a wedged daemon must surface an error, not hang or be replaced"),
+        Err(error) => error,
+    };
+    assert!(error.contains("did not complete the Hello handshake"), "unexpected error: {error}");
+    server_task.abort();
+}
+
+#[tokio::test]
 async fn client_hello_rejects_daemon_protocol_version_mismatch() {
     let (client, server) = message_session_pair();
     let server_task = tokio::spawn(async move {

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -114,6 +114,82 @@ async fn read_request(session: &MessageSession) -> (u64, Request) {
 }
 
 #[tokio::test]
+async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_contention() {
+    // The two-process fleet-upgrade race: process B wins the spawn lock,
+    // brings up an incompatible daemon, and releases the lock; process A —
+    // which was blocked on B's lock — must report B's daemon rather than
+    // deleting its socket and spawning over it. The test plays B: it holds
+    // the spawn lock, binds a stale-version listener only after A's first
+    // probe has found nothing, then releases the lock.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("daemon.sock");
+    let lock_path = std::path::PathBuf::from(format!("{}.lock", socket_path.display()));
+
+    let lock_file = match acquire_spawn_lock(&lock_path) {
+        Ok(Some(file)) => file,
+        Ok(None) => panic!("fresh lock should be won outright"),
+        Err(err) if err.contains("Operation not permitted") || err.contains("not supported") => {
+            eprintln!(
+                "skipping connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_contention: flock not available: {err}"
+            );
+            return;
+        }
+        Err(err) => panic!("acquire spawn lock: {err}"),
+    };
+
+    let client_socket = socket_path.clone();
+    let client_dir = dir.path().to_path_buf();
+    let client_task = tokio::spawn(async move { connect_or_spawn(&client_socket, &client_dir, None, Some(&client_socket)).await });
+
+    // Give A time to run its first probe (nothing listening) and block on the lock.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!("skipping connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_contention: unix socket bind not permitted: {err}");
+            client_task.abort();
+            return;
+        }
+        Err(err) => panic!("bind listener: {err}"),
+    };
+    let server_task = tokio::spawn(async move {
+        // B's daemon answers every probe with a stale-version Hello.
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(accepted) => accepted,
+                Err(_) => return,
+            };
+            let session = unix_message_session(stream);
+            let _ = session.read().await;
+            let _ = session
+                .write(Message::Hello {
+                    protocol_version: PROTOCOL_VERSION - 1,
+                    node_id: NodeId::new("stale-daemon"),
+                    display_name: "stale daemon".into(),
+                    session_id: uuid::Uuid::new_v4(),
+                    connection_role: Some(ConnectionRole::Client),
+                })
+                .await;
+        }
+    });
+
+    // B releases the spawn lock; A unblocks, probes the stale daemon, and
+    // must ultimately error — never remove the socket and spawn.
+    drop(lock_file);
+
+    let result = client_task.await.expect("join client task");
+    server_task.abort();
+
+    let error = match result {
+        Ok(_) => panic!("an incompatible daemon that appeared during lock contention must be reported, not connected to or replaced"),
+        Err(error) => error,
+    };
+    assert!(error.contains("protocol version mismatch"), "unexpected error: {error}");
+    assert!(socket_path.exists(), "the live daemon's socket must not be deleted (spawn path must not be reached)");
+}
+
+#[tokio::test]
 async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning() {
     let dir = tempfile::tempdir().expect("tempdir");
     let socket_path = dir.path().join("daemon.sock");

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -5,7 +5,7 @@ use flotilla_protocol::{
     result_set::{QueryId, ResultDelta, ResultSet, Rows},
     EnvironmentId, NodeId, NodeInfo, RepoDelta, RepoIdentity, RepoSnapshot,
 };
-use flotilla_transport::message::{message_session_pair, MessageSession};
+use flotilla_transport::message::{message_session_pair, unix_message_session, MessageSession};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     net::UnixListener,
@@ -111,6 +111,68 @@ async fn read_request(session: &MessageSession) -> (u64, Request) {
         Some(Message::Request { id, request }) => (id, request),
         other => panic!("expected request, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn client_hello_rejects_daemon_protocol_version_mismatch() {
+    let (client, server) = message_session_pair();
+    let server_task = tokio::spawn(async move {
+        let hello = server.read().await.expect("read client hello").expect("client hello");
+        assert!(matches!(hello, Message::Hello { protocol_version: PROTOCOL_VERSION, .. }));
+        server
+            .write(Message::Hello {
+                protocol_version: PROTOCOL_VERSION - 1,
+                node_id: NodeId::new("stale-daemon"),
+                display_name: "stale daemon".into(),
+                session_id: uuid::Uuid::new_v4(),
+                connection_role: Some(ConnectionRole::Client),
+            })
+            .await
+            .expect("write stale daemon hello");
+    });
+
+    let error = do_client_hello(&client).await.expect_err("protocol mismatch should reject the daemon");
+    assert!(error.contains("protocol version mismatch"), "unexpected error: {error}");
+    assert!(error.contains(&(PROTOCOL_VERSION - 1).to_string()), "error should report the daemon version: {error}");
+    server_task.await.expect("join server task");
+}
+
+#[tokio::test]
+async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("daemon.sock");
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!("skipping connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch: unix socket bind not permitted: {err}");
+            return;
+        }
+        Err(err) => panic!("bind listener: {err}"),
+    };
+
+    let server_task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept client");
+        let session = unix_message_session(stream);
+        session
+            .write(Message::Hello {
+                protocol_version: PROTOCOL_VERSION - 1,
+                node_id: NodeId::new("stale-daemon"),
+                display_name: "stale daemon".into(),
+                session_id: uuid::Uuid::new_v4(),
+                connection_role: Some(ConnectionRole::Client),
+            })
+            .await
+            .expect("write stale daemon hello");
+    });
+
+    let result = connect_or_spawn(&socket_path, dir.path(), None, Some(&socket_path)).await;
+    server_task.await.expect("join server task");
+
+    let error = match result {
+        Ok(_) => panic!("an existing incompatible daemon should be rejected instead of reused or replaced"),
+        Err(error) => error,
+    };
+    assert!(error.contains("protocol version mismatch"), "unexpected error: {error}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Ports the surviving half of an uncommitted pre-#692 draft found in the main checkout during the fleet upgrade (preserved on `handshake-hardening-draft-wip`). The other half — client-side version check in `do_client_hello` and the server replying with its Hello before closing on mismatch — already landed with #692; this PR carries only what main lacks.

## The gap

`connect_or_spawn` probed for an existing daemon with plain `SocketDaemon::connect`, which performs **no Hello handshake at all** — and treated *any* connect failure as "no daemon here", falling through to the spawn path. Consequences with protocol v8's handshake enforcement:

- a client that can't handshake with a **live but version-mismatched daemon** would delete the socket out from under it and **spawn a second daemon** on the same state dir;
- the mismatch diagnostic ("daemon has vN, client has vM — restart the daemon") that #692 added could never surface through the `connect_or_spawn` path, because the stateless probe doesn't exchange versions.

Exactly the window a fleet upgrade opens — found while doing one.

## Change

- New `connect_existing_stateful`: connection-refused ⇒ `Ok(None)` (spawn path allowed); connection accepted ⇒ the stateful Hello **must** succeed, and any handshake failure (version mismatch, malformed reply) is returned verbatim instead of being treated as a stale socket.
- All four probe sites in `connect_or_spawn` (initial, post-lock-wait, last-chance, post-spawn poll) go through it.
- Tests: `do_client_hello` rejects a stale-version daemon with a diagnostic naming both versions; `connect_or_spawn` against a live mismatched listener errors instead of reusing or replacing it.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (56 suites)