### PR TITLE
aggregator: avoid repeated session scans for attach capabilities

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -282,6 +282,68 @@ fn fleet_row_attach_reference_label(row: &FleetListRow) -> String {
     }
 }
 
+enum AttachTarget {
+    Local(Box<flotilla_resources::ResourceObject<ResourceTerminalSession>>),
+    Replica { host: HostName },
+}
+
+impl AttachTarget {
+    async fn resolve(&self, daemon: &InProcessDaemon, reference: &str) -> Result<String, String> {
+        match self {
+            Self::Local(session) => daemon.attach_command_for_session(reference, session).await,
+            Self::Replica { host } => daemon.recursive_attach_command_for_remote(host, reference).await,
+        }
+    }
+}
+
+struct AttachCandidate {
+    label: String,
+    references: Vec<String>,
+    target: AttachTarget,
+}
+
+struct AttachCandidateIndex {
+    candidates: Vec<AttachCandidate>,
+    exact: HashMap<String, Vec<usize>>,
+}
+
+impl AttachCandidateIndex {
+    fn new(candidates: Vec<AttachCandidate>) -> Self {
+        let mut exact: HashMap<String, Vec<usize>> = HashMap::new();
+        for (index, candidate) in candidates.iter().enumerate() {
+            for reference in &candidate.references {
+                exact.entry(reference.clone()).or_default().push(index);
+            }
+        }
+        Self { candidates, exact }
+    }
+
+    async fn resolve(&self, daemon: &InProcessDaemon, reference: &str) -> Result<String, String> {
+        if reference.trim().is_empty() {
+            return Err("attach reference is required".to_string());
+        }
+
+        let matches = self.exact.get(reference).cloned().unwrap_or_else(|| {
+            self.candidates
+                .iter()
+                .enumerate()
+                .filter(|(_, candidate)| candidate.references.iter().any(|candidate| candidate.starts_with(reference)))
+                .map(|(index, _)| index)
+                .collect()
+        });
+        match matches.as_slice() {
+            [] => Err(format!("no attach target matching '{reference}'")),
+            [index] => self.candidates[*index].target.resolve(daemon, reference).await,
+            _ => {
+                let mut labels: Vec<_> = matches.iter().map(|index| self.candidates[*index].label.clone()).collect();
+                labels.sort();
+                labels.dedup();
+                Err(format!("attach reference '{reference}' is ambiguous: {}", labels.join(", ")))
+            }
+        }
+    }
+}
+
 fn session_status_label(phase: Option<ResourceTerminalSessionPhase>) -> String {
     match phase {
         Some(ResourceTerminalSessionPhase::Starting) | None => "starting".to_string(),
@@ -2810,21 +2872,25 @@ impl InProcessDaemon {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }
+        let index = self.attach_candidate_index().await?;
+        index.resolve(self, reference).await
+    }
 
-        enum AttachMatch {
-            Local(Box<flotilla_resources::ResourceObject<ResourceTerminalSession>>),
-            Replica { host: HostName },
+    pub async fn resolvable_attach_references_internal(&self, references: &[String]) -> Result<HashSet<String>, String> {
+        if references.is_empty() {
+            return Ok(HashSet::new());
         }
-
-        impl AttachMatch {
-            async fn resolve(self, daemon: &InProcessDaemon, reference: &str) -> Result<String, String> {
-                match self {
-                    Self::Local(session) => daemon.attach_command_for_session(reference, &session).await,
-                    Self::Replica { host } => daemon.recursive_attach_command_for_remote(&host, reference).await,
-                }
+        let index = self.attach_candidate_index().await?;
+        let mut resolved = HashSet::new();
+        for reference in references {
+            if index.resolve(self, reference).await.is_ok() {
+                resolved.insert(reference.clone());
             }
         }
+        Ok(resolved)
+    }
 
+    async fn attach_candidate_index(&self) -> Result<AttachCandidateIndex, String> {
         let namespace = self.provisioning_namespace().await;
         let durable_sessions =
             self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace).list().await.map_err(|err| err.to_string())?.items;
@@ -2840,20 +2906,16 @@ impl InProcessDaemon {
         for session in durable_sessions.into_iter().chain(observed_sessions) {
             sessions_by_name.insert(session.metadata.name.clone(), session);
         }
-        let mut exact = Vec::new();
-        let mut prefix = Vec::new();
-
+        let mut candidates = Vec::new();
         for session in sessions_by_name.into_values() {
             if session.status.as_ref().map(|status| status.phase) != Some(ResourceTerminalSessionPhase::Running) {
                 continue;
             }
-            let refs = attach_reference_keys(&session.metadata.name, &session.metadata.labels);
-            let label = attach_reference_label(&session.metadata.name, &session.metadata.labels);
-            if refs.iter().any(|candidate| candidate == reference) {
-                exact.push((label, AttachMatch::Local(Box::new(session))));
-            } else if refs.iter().any(|candidate| candidate.starts_with(reference)) {
-                prefix.push((label, AttachMatch::Local(Box::new(session))));
-            }
+            candidates.push(AttachCandidate {
+                label: attach_reference_label(&session.metadata.name, &session.metadata.labels),
+                references: attach_reference_keys(&session.metadata.name, &session.metadata.labels),
+                target: AttachTarget::Local(Box::new(session)),
+            });
         }
 
         let configured_replica_hosts: HashSet<HostName> = self
@@ -2868,33 +2930,16 @@ impl InProcessDaemon {
                     if row.crew_state != "running" {
                         continue;
                     }
-                    let refs = fleet_row_attach_reference_keys(row);
-                    let label = fleet_row_attach_reference_label(row);
-                    let target = AttachMatch::Replica { host: row.host.clone() };
-                    if refs.iter().any(|candidate| candidate == reference) {
-                        exact.push((label, target));
-                    } else if refs.iter().any(|candidate| candidate.starts_with(reference)) {
-                        prefix.push((label, target));
-                    }
+                    candidates.push(AttachCandidate {
+                        label: fleet_row_attach_reference_label(row),
+                        references: fleet_row_attach_reference_keys(row),
+                        target: AttachTarget::Replica { host: row.host.clone() },
+                    });
                 }
             }
         }
         drop(cache);
-
-        let mut matches = if exact.is_empty() { prefix } else { exact };
-        match matches.len() {
-            0 => Err(format!("no attach target matching '{reference}'")),
-            1 => {
-                let (_label, target) = matches.remove(0);
-                target.resolve(self, reference).await
-            }
-            _ => {
-                let mut labels: Vec<_> = matches.into_iter().map(|(label, _)| label).collect();
-                labels.sort();
-                labels.dedup();
-                Err(format!("attach reference '{reference}' is ambiguous: {}", labels.join(", ")))
-            }
-        }
+        Ok(AttachCandidateIndex::new(candidates))
     }
 
     async fn attach_command_for_session(

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -327,7 +327,7 @@ impl AttachCandidateIndex {
             self.candidates
                 .iter()
                 .enumerate()
-                .filter(|(_, candidate)| candidate.references.iter().any(|candidate| candidate.starts_with(reference)))
+                .filter(|(_, candidate)| candidate.references.iter().any(|candidate_reference| candidate_reference.starts_with(reference)))
                 .map(|(index, _)| index)
                 .collect()
         });
@@ -2869,6 +2869,7 @@ impl InProcessDaemon {
     }
 
     pub async fn resolve_attach_command_internal(&self, reference: &str) -> Result<String, String> {
+        // Preserve validation precedence without paying to build the candidate index.
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, OnceLock},
 };
@@ -1414,6 +1414,31 @@ async fn attach_query_prefers_exact_reference_over_prefix_matches() {
         .expect("attach query should execute");
 
     assert_eq!(result, CommandValue::AttachCommandResolved { command: "attach session-exact".to_string() });
+}
+
+#[tokio::test]
+async fn batch_attach_capabilities_return_only_resolvable_references() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
+        .await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-convoy-b-review-reviewer", "session-b", "convoy-b", "review", "reviewer")
+        .await;
+
+    let references =
+        vec!["terminal-convoy-a-implement-coder".to_string(), "terminal-convoy-b-review-reviewer".to_string(), "missing".to_string()];
+    let resolved =
+        daemon.resolvable_attach_references_internal(&references).await.expect("batch attach capability resolution should succeed");
+
+    assert_eq!(
+        resolved,
+        HashSet::from(["terminal-convoy-a-implement-coder".to_string(), "terminal-convoy-b-review-reviewer".to_string(),])
+    );
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -69,6 +69,18 @@ impl<T: Resource> AggregatorWatchSource<T> for TypedResolver<T> {
     }
 }
 
+#[async_trait]
+pub(crate) trait AttachCapabilityResolver: Send + Sync {
+    async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String>;
+}
+
+#[async_trait]
+impl AttachCapabilityResolver for InProcessDaemon {
+    async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String> {
+        self.resolvable_attach_references_internal(references).await
+    }
+}
+
 #[derive(bon::Builder)]
 pub struct Aggregator {
     state: AggregatorProjectionState,
@@ -83,7 +95,8 @@ pub struct Aggregator {
     terminal_sessions: HashMap<SessionKey, ResourceObject<TerminalSession>>,
     bootstrapping: bool,
     emitted_queries: HashSet<QueryId>,
-    attach_resolver: Option<Arc<InProcessDaemon>>,
+    #[builder(skip)]
+    attach_resolver: Option<Arc<dyn AttachCapabilityResolver>>,
     event_tx: broadcast::Sender<DaemonEvent>,
 }
 
@@ -106,8 +119,11 @@ impl Aggregator {
         }
     }
 
-    pub fn with_attach_resolver(mut self, daemon: Arc<InProcessDaemon>) -> Self {
-        self.attach_resolver = Some(daemon);
+    pub(crate) fn with_attach_resolver<R>(mut self, resolver: Arc<R>) -> Self
+    where
+        R: AttachCapabilityResolver + 'static,
+    {
+        self.attach_resolver = Some(resolver);
         self
     }
 
@@ -484,9 +500,22 @@ impl Aggregator {
         }
         self.terminal_sessions = effective_sessions;
 
+        let attachable_references = match &self.attach_resolver {
+            Some(daemon) => {
+                let references = self
+                    .terminal_sessions
+                    .values()
+                    .filter(|session| is_projected_session(session))
+                    .map(|session| session.metadata.name.clone())
+                    .collect::<Vec<_>>();
+                daemon.resolvable_attach_references(&references).await.unwrap_or_default()
+            }
+            None => HashSet::new(),
+        };
+
         let mut replacement = HashMap::new();
         for session in self.terminal_sessions.values() {
-            if let Some(row) = self.summarize_session(session).await {
+            if let Some(row) = self.summarize_session(session, &attachable_references) {
                 replacement.insert(row.resource.clone(), row);
             }
         }
@@ -596,19 +625,12 @@ impl Aggregator {
             .on_host(self.local_host.clone())
     }
 
-    async fn summarize_session(&self, session: &ResourceObject<TerminalSession>) -> Option<SessionRow> {
-        if session.metadata.labels.contains_key(CONVOY_LABEL) {
-            return None;
-        }
-        let status = session.status.as_ref()?;
-        if status.phase != TerminalSessionPhase::Running {
+    fn summarize_session(&self, session: &ResourceObject<TerminalSession>, attachable_references: &HashSet<String>) -> Option<SessionRow> {
+        if !is_projected_session(session) {
             return None;
         }
         let name = &session.metadata.name;
-        let attach = match &self.attach_resolver {
-            Some(daemon) if daemon.resolve_attach_command_internal(name).await.is_ok() => Some(name.clone()),
-            _ => None,
-        };
+        let attach = attachable_references.contains(name).then(|| name.clone());
         Some(
             SessionRow::builder()
                 .resource(self.session_ref(&session.metadata.namespace, name))
@@ -704,6 +726,11 @@ fn presentation_key(presentation: &ResourceObject<Presentation>) -> Option<Prese
     ))
 }
 
+fn is_projected_session(session: &ResourceObject<TerminalSession>) -> bool {
+    !session.metadata.labels.contains_key(CONVOY_LABEL)
+        && session.status.as_ref().map(|status| status.phase) == Some(TerminalSessionPhase::Running)
+}
+
 fn set_convoy_row_host(row: &mut ConvoyRow, host: &HostName) {
     row.resource.host = Some(host.clone());
     for vessel in &mut row.vessels {
@@ -797,6 +824,18 @@ mod tests {
         async fn watch(&self, _start: WatchStart) -> Result<WatchStream<T>, ResourceError> {
             self.watch_calls.fetch_add(1, Ordering::SeqCst);
             self.watches.lock().await.pop_front().ok_or_else(|| ResourceError::other("scripted watch exhausted"))?
+        }
+    }
+
+    struct CountingAttachResolver {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl AttachCapabilityResolver for CountingAttachResolver {
+        async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(references.iter().cloned().collect())
         }
     }
 
@@ -934,6 +973,24 @@ mod tests {
             })
             .await
             .expect("set scripted terminal session status")
+    }
+
+    #[tokio::test]
+    async fn session_projection_resolves_attach_capabilities_once_per_rebuild() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(4);
+        let resolver = Arc::new(CountingAttachResolver { calls: AtomicUsize::new(0) });
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx).with_attach_resolver(Arc::clone(&resolver));
+
+        aggregator
+            .replace_session_source(LocalSource::Durable, vec![session_object("session-a").await, session_object("session-b").await])
+            .await;
+
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 1);
+        let result_set = state.sessions_result_set().await;
+        let rows = result_set.rows.as_sessions().expect("session rows");
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|row| row.attach.as_deref() == Some(row.name.as_str())));
     }
 
     fn remote_snapshot(host: &str, generation: &str, name: &str) -> FleetReplicaSnapshot {


### PR DESCRIPTION
## What changed

- build a reusable attach-candidate index from durable and observed terminal sessions
- resolve all projected session attach capabilities through one batch call per aggregator rebuild
- preserve exact and prefix matching, ambiguity handling, replica routing, and early blank-reference validation
- add coverage proving multiple projected rows use a single batch resolver invocation

## Why

`Aggregator::summarize_session` previously resolved each session independently. Every resolution listed both session stores and scanned all candidates, making a projection rebuild O(n²).

The batch API lists each store once and reuses the resulting index across all projected session references.

## Impact

Running session rows continue to expose `attach: Some` when resolvable, while projection cost now scales with a single store scan per rebuild.

Closes #700.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- parallel Standards and issue-spec reviews, with all findings addressed