### PR TITLE
Disambiguate command subjects with @ addressing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
 name = "flotilla-commands"
 version = "0.1.0"
 dependencies = [
+ "bon",
  "clap",
  "flotilla-protocol",
  "tempfile",

--- a/crates/flotilla-commands/Cargo.toml
+++ b/crates/flotilla-commands/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 flotilla-protocol = { path = "../flotilla-protocol" }
+bon = { workspace = true }
 clap = { version = "4", features = ["derive", "string"] }
 
 [dev-dependencies]

--- a/crates/flotilla-commands/src/commands/checkout.rs
+++ b/crates/flotilla-commands/src/commands/checkout.rs
@@ -5,6 +5,7 @@ use flotilla_protocol::{CheckoutSelector, CheckoutTarget, Command, CommandAction
 
 use crate::{
     resolved::{HostResolution, RepoContext},
+    subject::{resolve_subject, write_subject},
     Resolved,
 };
 
@@ -13,7 +14,11 @@ use crate::{
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct CheckoutNoun {
     /// Branch name or checkout path
+    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
     pub subject: Option<String>,
+    /// Literal subject; use for external names beginning with `@`
+    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
+    pub explicit_subject: Option<String>,
 
     #[command(subcommand)]
     pub verb: Option<CheckoutVerb>,
@@ -41,7 +46,8 @@ pub enum CheckoutVerb {
 
 impl CheckoutNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        match (self.subject, self.verb) {
+        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        match (subject, self.verb) {
             (Some(_), Some(CheckoutVerb::Create { .. })) => {
                 Err("checkout create does not take a subject (repo comes from --repo or FLOTILLA_REPO)".into())
             }
@@ -89,9 +95,7 @@ impl CheckoutNoun {
 impl fmt::Display for CheckoutNoun {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "checkout")?;
-        if let Some(subject) = &self.subject {
-            write!(f, " {subject}")?;
-        }
+        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
         if let Some(verb) = &self.verb {
             match verb {
                 CheckoutVerb::Create { branch, fresh } => {
@@ -222,8 +226,24 @@ mod tests {
     }
 
     #[test]
+    fn marked_subject_disambiguates_branch_named_status() {
+        let resolved = parse(&["checkout", "@status", "status"]).resolve().expect("resolve marked checkout subject");
+        assert!(matches!(resolved, Resolved::NeedsContext { command: Command {
+            action: CommandAction::FetchCheckoutStatus { branch, .. }, ..
+        }, .. } if branch == "status"));
+    }
+
+    #[test]
+    fn explicit_subject_preserves_branch_beginning_with_marker() {
+        let resolved = parse(&["checkout", "--subject", "@topic", "status"]).resolve().expect("resolve explicit checkout subject");
+        assert!(matches!(resolved, Resolved::NeedsContext { command: Command {
+            action: CommandAction::FetchCheckoutStatus { branch, .. }, ..
+        }, .. } if branch == "@topic"));
+    }
+
+    #[test]
     fn checkout_remove_no_subject_errors() {
-        let noun = CheckoutNoun { subject: None, verb: Some(super::CheckoutVerb::Remove) };
+        let noun = CheckoutNoun { subject: None, explicit_subject: None, verb: Some(super::CheckoutVerb::Remove) };
         assert!(noun.resolve().is_err());
     }
 
@@ -245,6 +265,12 @@ mod tests {
     #[test]
     fn round_trip_status() {
         assert_round_trip::<CheckoutNoun>(&["checkout", "my-feature", "status"]);
+    }
+
+    #[test]
+    fn marked_and_explicit_subjects_round_trip() {
+        assert_round_trip::<CheckoutNoun>(&["checkout", "@status", "status"]);
+        assert_round_trip::<CheckoutNoun>(&["checkout", "--subject", "@topic", "status"]);
     }
 
     #[test]

--- a/crates/flotilla-commands/src/commands/checkout.rs
+++ b/crates/flotilla-commands/src/commands/checkout.rs
@@ -5,20 +5,15 @@ use flotilla_protocol::{CheckoutSelector, CheckoutTarget, Command, CommandAction
 
 use crate::{
     resolved::{HostResolution, RepoContext},
-    subject::{resolve_subject, write_subject},
-    Resolved,
+    Resolved, SubjectArgs,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Manage checkouts")]
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct CheckoutNoun {
-    /// Branch name or checkout path
-    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
-    pub subject: Option<String>,
-    /// Literal subject; use for external names beginning with `@`
-    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
-    pub explicit_subject: Option<String>,
+    #[command(flatten)]
+    pub subjects: SubjectArgs,
 
     #[command(subcommand)]
     pub verb: Option<CheckoutVerb>,
@@ -46,7 +41,7 @@ pub enum CheckoutVerb {
 
 impl CheckoutNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        let subject = self.subjects.resolve()?.map(|subject| subject.value);
         match (subject, self.verb) {
             (Some(_), Some(CheckoutVerb::Create { .. })) => {
                 Err("checkout create does not take a subject (repo comes from --repo or FLOTILLA_REPO)".into())
@@ -95,7 +90,7 @@ impl CheckoutNoun {
 impl fmt::Display for CheckoutNoun {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "checkout")?;
-        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
+        self.subjects.write(f)?;
         if let Some(verb) = &self.verb {
             match verb {
                 CheckoutVerb::Create { branch, fresh } => {
@@ -131,7 +126,7 @@ mod tests {
     use crate::{
         resolved::{HostResolution, RepoContext},
         test_utils::assert_round_trip,
-        Resolved,
+        Resolved, SubjectArgs,
     };
 
     fn parse(args: &[&str]) -> CheckoutNoun {
@@ -243,7 +238,7 @@ mod tests {
 
     #[test]
     fn checkout_remove_no_subject_errors() {
-        let noun = CheckoutNoun { subject: None, explicit_subject: None, verb: Some(super::CheckoutVerb::Remove) };
+        let noun = CheckoutNoun { subjects: SubjectArgs::default(), verb: Some(super::CheckoutVerb::Remove) };
         assert!(noun.resolve().is_err());
     }
 

--- a/crates/flotilla-commands/src/commands/crew.rs
+++ b/crates/flotilla-commands/src/commands/crew.rs
@@ -4,19 +4,15 @@ use flotilla_protocol::{Command, CommandAction, CrewCommandContext};
 use crate::{
     quote_value,
     resolved::{HostResolution, RepoContext},
-    subject::{resolve_subject, write_subject},
-    Resolved,
+    subject::SubjectInterpretation,
+    Resolved, SubjectArgs,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Parser)]
+#[derive(Debug, Clone, PartialEq, Eq, Parser, bon::Builder)]
 #[command(about = "Communicate with crew members")]
 pub struct CrewNoun {
-    /// Target crew role, or an unmarked crew command
-    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
-    pub subject: Option<String>,
-    /// Literal target subject; use for external names beginning with `@`
-    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
-    pub explicit_subject: Option<String>,
+    #[command(flatten)]
+    pub subjects: SubjectArgs,
     #[command(subcommand)]
     pub verb: Option<CrewVerb>,
     /// Explicit crew identity (normally read from FLOTILLA_CREW_ID)
@@ -54,17 +50,18 @@ impl CrewNoun {
             .maybe_vessel_ref(self.vessel_ref)
             .maybe_role(self.role)
             .build();
-        let subject = resolve_subject(self.subject, self.explicit_subject)?
-            .ok_or_else(|| "crew command requires a command or target subject".to_string())?;
-        let action = match (subject.value.as_str(), subject.forced, self.verb) {
-            ("list", false, None) if self.message.is_none() => CommandAction::QueryCrewList { context },
-            ("list", false, None) => return Err("`flotilla crew list` does not accept --message".to_string()),
-            ("complete", false, None) => CommandAction::CrewComplete { context, message: self.message },
-            ("fail", false, None) => CommandAction::CrewFail {
+        let subject = self.subjects.resolve()?.ok_or_else(|| "crew command requires a command or target subject".to_string())?;
+        let action = match (subject.value.as_str(), subject.interpretation, self.verb) {
+            ("list", SubjectInterpretation::Ordinary, None) if self.message.is_none() => CommandAction::QueryCrewList { context },
+            ("list", SubjectInterpretation::Ordinary, None) => {
+                return Err("`flotilla crew list` does not accept --message".to_string());
+            }
+            ("complete", SubjectInterpretation::Ordinary, None) => CommandAction::CrewComplete { context, message: self.message },
+            ("fail", SubjectInterpretation::Ordinary, None) => CommandAction::CrewFail {
                 context,
                 message: self.message.ok_or_else(|| "`flotilla crew fail` requires --message".to_string())?,
             },
-            (reserved @ ("list" | "complete" | "fail"), false, Some(_)) => {
+            (reserved @ ("list" | "complete" | "fail"), SubjectInterpretation::Ordinary, Some(_)) => {
                 return Err(format!("`{reserved}` is a crew command; use `@{reserved}` to address the crew role"));
             }
             (_, _, Some(CrewVerb::Handoff { message })) => CommandAction::CrewHandoff { context, target: subject.value, message },
@@ -85,7 +82,7 @@ impl CrewNoun {
 impl std::fmt::Display for CrewNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "crew")?;
-        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
+        self.subjects.write(f)?;
         for (flag, value) in [
             ("--crew-id", self.crew_id.as_ref()),
             ("--namespace", self.namespace.as_ref()),

--- a/crates/flotilla-commands/src/commands/crew.rs
+++ b/crates/flotilla-commands/src/commands/crew.rs
@@ -4,14 +4,19 @@ use flotilla_protocol::{Command, CommandAction, CrewCommandContext};
 use crate::{
     quote_value,
     resolved::{HostResolution, RepoContext},
+    subject::{resolve_subject, write_subject},
     Resolved,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Communicate with crew members")]
 pub struct CrewNoun {
-    /// Target crew role, or `list`
-    pub subject: String,
+    /// Target crew role, or an unmarked crew command
+    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
+    pub subject: Option<String>,
+    /// Literal target subject; use for external names beginning with `@`
+    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
+    pub explicit_subject: Option<String>,
     #[command(subcommand)]
     pub verb: Option<CrewVerb>,
     /// Explicit crew identity (normally read from FLOTILLA_CREW_ID)
@@ -49,17 +54,21 @@ impl CrewNoun {
             .maybe_vessel_ref(self.vessel_ref)
             .maybe_role(self.role)
             .build();
-        let action = match (self.subject.as_str(), self.verb) {
-            ("list", None) if self.message.is_none() => CommandAction::QueryCrewList { context },
-            ("list", None) => return Err("`flotilla crew list` does not accept --message".to_string()),
-            ("list", Some(_)) => return Err("`flotilla crew list` does not accept a verb".to_string()),
-            ("complete", None) => CommandAction::CrewComplete { context, message: self.message },
-            ("fail", None) => CommandAction::CrewFail {
+        let subject = resolve_subject(self.subject, self.explicit_subject)?
+            .ok_or_else(|| "crew command requires a command or target subject".to_string())?;
+        let action = match (subject.value.as_str(), subject.forced, self.verb) {
+            ("list", false, None) if self.message.is_none() => CommandAction::QueryCrewList { context },
+            ("list", false, None) => return Err("`flotilla crew list` does not accept --message".to_string()),
+            ("complete", false, None) => CommandAction::CrewComplete { context, message: self.message },
+            ("fail", false, None) => CommandAction::CrewFail {
                 context,
                 message: self.message.ok_or_else(|| "`flotilla crew fail` requires --message".to_string())?,
             },
-            (_, Some(CrewVerb::Handoff { message })) => CommandAction::CrewHandoff { context, target: self.subject, message },
-            (_, None) => return Err("crew target requires a verb (for example: handoff)".to_string()),
+            (reserved @ ("list" | "complete" | "fail"), false, Some(_)) => {
+                return Err(format!("`{reserved}` is a crew command; use `@{reserved}` to address the crew role"));
+            }
+            (_, _, Some(CrewVerb::Handoff { message })) => CommandAction::CrewHandoff { context, target: subject.value, message },
+            (_, _, None) => return Err("crew target requires a verb (for example: handoff)".to_string()),
         };
         Ok(Resolved::NeedsContext {
             command: Command { node_id: None, provisioning_target: None, context_repo: None, action },
@@ -75,7 +84,8 @@ impl CrewNoun {
 
 impl std::fmt::Display for CrewNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "crew {}", self.subject)?;
+        write!(f, "crew")?;
+        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
         for (flag, value) in [
             ("--crew-id", self.crew_id.as_ref()),
             ("--namespace", self.namespace.as_ref()),
@@ -129,6 +139,46 @@ mod tests {
             target: "reviewer".into(),
             message: "Review commit abc123".into(),
         });
+    }
+
+    #[test]
+    fn address_marker_disambiguates_reserved_role_names() {
+        for role in ["list", "complete", "fail"] {
+            let marked = format!("@{role}");
+            let noun = CrewNoun::try_parse_from(["crew", &marked, "handoff", "--message", "continue"]).expect("parse marked crew role");
+            assert_eq!(action(noun, Some("crew-123")), CommandAction::CrewHandoff {
+                context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
+                target: role.into(),
+                message: "continue".into(),
+            });
+        }
+    }
+
+    #[test]
+    fn unmarked_reserved_role_names_explain_the_address_marker() {
+        for role in ["list", "complete", "fail"] {
+            let noun = CrewNoun::try_parse_from(["crew", role, "handoff", "--message", "continue"]).expect("parse ambiguous crew role");
+            let error = noun.resolve_with_crew_id(Some("crew-123".into())).expect_err("unmarked reserved role should fail");
+            assert!(error.contains(&format!("@{role}")), "unexpected error: {error}");
+        }
+    }
+
+    #[test]
+    fn explicit_subject_preserves_literal_address_marker() {
+        let noun = CrewNoun::try_parse_from(["crew", "--subject", "@reviewer", "handoff", "--message", "continue"])
+            .expect("parse explicit crew subject");
+        assert_eq!(action(noun, Some("crew-123")), CommandAction::CrewHandoff {
+            context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
+            target: "@reviewer".into(),
+            message: "continue".into(),
+        });
+    }
+
+    #[test]
+    fn positional_and_explicit_subject_conflict() {
+        let error = CrewNoun::try_parse_from(["crew", "reviewer", "--subject", "other", "handoff", "--message", "continue"])
+            .expect_err("subjects should be mutually exclusive");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]
@@ -192,5 +242,11 @@ mod tests {
             "--message",
             "review-abc123",
         ]);
+    }
+
+    #[test]
+    fn marked_and_explicit_subjects_round_trip() {
+        assert_round_trip::<CrewNoun>(&["crew", "@list", "handoff", "--message", "review"]);
+        assert_round_trip::<CrewNoun>(&["crew", "--subject", "@reviewer", "handoff", "--message", "review"]);
     }
 }

--- a/crates/flotilla-commands/src/commands/crew.rs
+++ b/crates/flotilla-commands/src/commands/crew.rs
@@ -4,7 +4,7 @@ use flotilla_protocol::{Command, CommandAction, CrewCommandContext};
 use crate::{
     quote_value,
     resolved::{HostResolution, RepoContext},
-    subject::SubjectInterpretation,
+    subject::{is_crew_command_subject, SubjectInterpretation},
     Resolved, SubjectArgs,
 };
 
@@ -61,7 +61,7 @@ impl CrewNoun {
                 context,
                 message: self.message.ok_or_else(|| "`flotilla crew fail` requires --message".to_string())?,
             },
-            (reserved @ ("list" | "complete" | "fail"), SubjectInterpretation::Ordinary, Some(_)) => {
+            (reserved, SubjectInterpretation::Ordinary, Some(_)) if is_crew_command_subject(reserved) => {
                 return Err(format!("`{reserved}` is a crew command; use `@{reserved}` to address the crew role"));
             }
             (_, _, Some(CrewVerb::Handoff { message })) => CommandAction::CrewHandoff { context, target: subject.value, message },

--- a/crates/flotilla-commands/src/commands/environment.rs
+++ b/crates/flotilla-commands/src/commands/environment.rs
@@ -6,20 +6,15 @@ use flotilla_protocol::{Command, CommandAction, EnvironmentId, RepoSelector};
 use crate::{
     noun::NounCommand,
     resolved::{HostResolution, RepoContext},
-    subject::{resolve_subject, write_subject},
-    Resolved,
+    Resolved, SubjectArgs,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Manage environments", visible_alias = "env")]
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct EnvironmentNoun {
-    /// Canonical environment id
-    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
-    pub subject: Option<String>,
-    /// Literal subject; use for external names beginning with `@`
-    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
-    pub explicit_subject: Option<String>,
+    #[command(flatten)]
+    pub subjects: SubjectArgs,
 
     #[command(subcommand)]
     pub verb: Option<EnvironmentVerb>,
@@ -36,7 +31,7 @@ pub enum EnvironmentVerb {
 
 impl EnvironmentNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        let subject = self.subjects.resolve()?.map(|subject| subject.value);
         match (subject, self.verb) {
             (Some(subject), Some(EnvironmentVerb::Refresh { repo })) => {
                 let environment_id = EnvironmentId::parse(&subject)?;
@@ -72,7 +67,7 @@ impl EnvironmentNoun {
 impl fmt::Display for EnvironmentNoun {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "environment")?;
-        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
+        self.subjects.write(f)?;
         if let Some(verb) = &self.verb {
             match verb {
                 EnvironmentVerb::Refresh { repo } => {

--- a/crates/flotilla-commands/src/commands/environment.rs
+++ b/crates/flotilla-commands/src/commands/environment.rs
@@ -6,6 +6,7 @@ use flotilla_protocol::{Command, CommandAction, EnvironmentId, RepoSelector};
 use crate::{
     noun::NounCommand,
     resolved::{HostResolution, RepoContext},
+    subject::{resolve_subject, write_subject},
     Resolved,
 };
 
@@ -14,7 +15,11 @@ use crate::{
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct EnvironmentNoun {
     /// Canonical environment id
+    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
     pub subject: Option<String>,
+    /// Literal subject; use for external names beginning with `@`
+    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
+    pub explicit_subject: Option<String>,
 
     #[command(subcommand)]
     pub verb: Option<EnvironmentVerb>,
@@ -31,7 +36,8 @@ pub enum EnvironmentVerb {
 
 impl EnvironmentNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        match (self.subject, self.verb) {
+        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        match (subject, self.verb) {
             (Some(subject), Some(EnvironmentVerb::Refresh { repo })) => {
                 let environment_id = EnvironmentId::parse(&subject)?;
                 Ok(Resolved::NeedsContext {
@@ -49,8 +55,8 @@ impl EnvironmentNoun {
                 let environment_id = EnvironmentId::parse(&subject)?;
                 let cmd = clap::Command::new("environment-route").no_binary_name(true);
                 let cmd = <NounCommand as Subcommand>::augment_subcommands(cmd);
-                let matches = cmd.try_get_matches_from(&tokens).map_err(|e| e.to_string())?;
-                let noun = <NounCommand as clap::FromArgMatches>::from_arg_matches(&matches).map_err(|e| e.to_string())?;
+                let matches = cmd.try_get_matches_from(&tokens).map_err(crate::subject::format_parse_error)?;
+                let noun = <NounCommand as clap::FromArgMatches>::from_arg_matches(&matches).map_err(crate::subject::format_parse_error)?;
                 let mut resolved = noun.resolve()?;
                 resolved.set_explicit_environment(environment_id);
                 Ok(resolved)
@@ -66,9 +72,7 @@ impl EnvironmentNoun {
 impl fmt::Display for EnvironmentNoun {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "environment")?;
-        if let Some(subject) = &self.subject {
-            write!(f, " {subject}")?;
-        }
+        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
         if let Some(verb) = &self.verb {
             match verb {
                 EnvironmentVerb::Refresh { repo } => {
@@ -116,6 +120,22 @@ mod tests {
             repo: RepoContext::None,
             host: HostResolution::ExplicitEnvironment(EnvironmentId::host(HostId::new("alpha-env"))),
         });
+    }
+
+    #[test]
+    fn marked_subject_disambiguates_environment_named_refresh() {
+        let resolved = parse(&["environment", "@refresh", "refresh"]).resolve().expect("resolve marked environment subject");
+        assert!(matches!(resolved, Resolved::NeedsContext {
+            host: HostResolution::ExplicitEnvironment(EnvironmentId::Provisioned(id)), ..
+        } if id == "refresh"));
+    }
+
+    #[test]
+    fn explicit_subject_preserves_environment_beginning_with_marker() {
+        let resolved = parse(&["environment", "--subject", "@refresh", "refresh"]).resolve().expect("resolve explicit environment subject");
+        assert!(matches!(resolved, Resolved::NeedsContext {
+            host: HostResolution::ExplicitEnvironment(EnvironmentId::Provisioned(id)), ..
+        } if id == "@refresh"));
     }
 
     #[test]

--- a/crates/flotilla-commands/src/commands/host.rs
+++ b/crates/flotilla-commands/src/commands/host.rs
@@ -6,8 +6,7 @@ use flotilla_protocol::{Command, CommandAction, HostName, RepoSelector};
 use crate::{
     noun::NounCommand,
     resolved::{HostQueryKind, HostResolution, RepoContext},
-    subject::{resolve_subject, write_subject},
-    Refinable, Resolved,
+    Refinable, Resolved, SubjectArgs,
 };
 
 // ---------------------------------------------------------------------------
@@ -18,12 +17,8 @@ use crate::{
 #[command(about = "Manage and route to hosts")]
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct HostNounPartial {
-    /// Host name
-    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
-    pub subject: Option<String>,
-    /// Literal subject; use for external names beginning with `@`
-    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
-    pub explicit_subject: Option<String>,
+    #[command(flatten)]
+    pub subjects: SubjectArgs,
     #[command(subcommand)]
     pub verb: Option<HostVerbPartial>,
 }
@@ -70,7 +65,7 @@ impl Refinable for HostNounPartial {
     type Refined = HostNoun;
 
     fn refine(self) -> Result<HostNoun, String> {
-        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        let subject = self.subjects.resolve()?.map(|subject| subject.value);
         let verb = match self.verb {
             Some(HostVerbPartial::List) => HostVerb::List,
             Some(HostVerbPartial::Status) => HostVerb::Status,
@@ -145,7 +140,7 @@ impl HostNoun {
 impl fmt::Display for HostNounPartial {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "host")?;
-        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
+        self.subjects.write(f)?;
         if let Some(verb) = &self.verb {
             match verb {
                 HostVerbPartial::List => write!(f, " list")?,

--- a/crates/flotilla-commands/src/commands/host.rs
+++ b/crates/flotilla-commands/src/commands/host.rs
@@ -6,6 +6,7 @@ use flotilla_protocol::{Command, CommandAction, HostName, RepoSelector};
 use crate::{
     noun::NounCommand,
     resolved::{HostQueryKind, HostResolution, RepoContext},
+    subject::{resolve_subject, write_subject},
     Refinable, Resolved,
 };
 
@@ -13,17 +14,21 @@ use crate::{
 // Partial types (what clap parses into)
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Parser)]
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Manage and route to hosts")]
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct HostNounPartial {
     /// Host name
+    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
     pub subject: Option<String>,
+    /// Literal subject; use for external names beginning with `@`
+    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
+    pub explicit_subject: Option<String>,
     #[command(subcommand)]
     pub verb: Option<HostVerbPartial>,
 }
 
-#[derive(Debug, Clone, Subcommand)]
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum HostVerbPartial {
     /// List all known hosts
     List,
@@ -65,6 +70,7 @@ impl Refinable for HostNounPartial {
     type Refined = HostNoun;
 
     fn refine(self) -> Result<HostNoun, String> {
+        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
         let verb = match self.verb {
             Some(HostVerbPartial::List) => HostVerb::List,
             Some(HostVerbPartial::Status) => HostVerb::Status,
@@ -77,13 +83,13 @@ impl Refinable for HostNounPartial {
                 // start with the actual subcommand name, not a program name.
                 let cmd = clap::Command::new("host-route").no_binary_name(true);
                 let cmd = <NounCommand as Subcommand>::augment_subcommands(cmd);
-                let matches = cmd.try_get_matches_from(&tokens).map_err(|e| e.to_string())?;
-                let noun = <NounCommand as clap::FromArgMatches>::from_arg_matches(&matches).map_err(|e| e.to_string())?;
+                let matches = cmd.try_get_matches_from(&tokens).map_err(crate::subject::format_parse_error)?;
+                let noun = <NounCommand as clap::FromArgMatches>::from_arg_matches(&matches).map_err(crate::subject::format_parse_error)?;
                 HostVerb::Route(noun)
             }
             None => return Err("missing host command".into()),
         };
-        Ok(HostNoun { subject: self.subject, verb })
+        Ok(HostNoun { subject, verb })
     }
 }
 
@@ -139,9 +145,7 @@ impl HostNoun {
 impl fmt::Display for HostNounPartial {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "host")?;
-        if let Some(subject) = &self.subject {
-            write!(f, " {subject}")?;
-        }
+        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
         if let Some(verb) = &self.verb {
             match verb {
                 HostVerbPartial::List => write!(f, " list")?,
@@ -202,6 +206,37 @@ mod tests {
         assert_eq!(parse_and_resolve(&["host", "alpha", "status"]), Resolved::HostQuery {
             subject: HostName::new("alpha"),
             kind: HostQueryKind::Status
+        });
+    }
+
+    #[test]
+    fn marked_subject_disambiguates_host_named_status() {
+        assert_eq!(parse_and_resolve(&["host", "@status", "status"]), Resolved::HostQuery {
+            subject: HostName::new("status"),
+            kind: HostQueryKind::Status,
+        });
+    }
+
+    #[test]
+    fn explicit_subject_preserves_host_beginning_with_marker() {
+        assert_eq!(parse_and_resolve(&["host", "--subject", "@status", "status"]), Resolved::HostQuery {
+            subject: HostName::new("@status"),
+            kind: HostQueryKind::Status,
+        });
+    }
+
+    #[test]
+    fn marked_host_and_nested_repo_subjects_compose() {
+        let resolved = parse_and_resolve(&["host", "@checkout", "repo", "@refresh", "work"]);
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryRepoWork { repo: RepoSelector::Query("refresh".into()) },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Explicit(HostName::new("checkout")),
         });
     }
 
@@ -299,6 +334,12 @@ mod tests {
     fn host_display_status() {
         let partial = HostNounPartial::try_parse_from(["host", "alpha", "status"]).expect("should parse");
         assert_eq!(format!("{partial}"), "host alpha status");
+    }
+
+    #[test]
+    fn marked_and_explicit_subjects_round_trip() {
+        crate::test_utils::assert_round_trip::<HostNounPartial>(&["host", "@status", "status"]);
+        crate::test_utils::assert_round_trip::<HostNounPartial>(&["host", "--subject", "@status", "status"]);
     }
 
     #[test]

--- a/crates/flotilla-commands/src/commands/issue.rs
+++ b/crates/flotilla-commands/src/commands/issue.rs
@@ -3,6 +3,7 @@ use flotilla_protocol::{issue_query::IssueQuery, Command, CommandAction, RepoSel
 
 use crate::{
     resolved::{HostResolution, RepoContext},
+    subject::{resolve_subject, write_subject},
     Resolved,
 };
 
@@ -11,7 +12,11 @@ use crate::{
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct IssueNoun {
     /// Issue ID or comma-separated IDs (e.g. "1,5,7")
+    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
     pub subject: Option<String>,
+    /// Literal subject; use for external names beginning with `@`
+    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
+    pub explicit_subject: Option<String>,
 
     #[command(subcommand)]
     pub verb: Option<IssueVerb>,
@@ -29,7 +34,8 @@ pub enum IssueVerb {
 
 impl IssueNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        match (self.subject, self.verb) {
+        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        match (subject, self.verb) {
             (Some(subject), Some(IssueVerb::Open)) => Ok(Resolved::NeedsContext {
                 command: Command {
                     node_id: None,
@@ -79,9 +85,7 @@ impl IssueNoun {
 impl std::fmt::Display for IssueNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "issue")?;
-        if let Some(subject) = &self.subject {
-            write!(f, " {subject}")?;
-        }
+        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
         if let Some(verb) = &self.verb {
             match verb {
                 IssueVerb::Open => write!(f, " open")?,
@@ -130,6 +134,22 @@ mod tests {
     }
 
     #[test]
+    fn marked_subject_disambiguates_issue_named_open() {
+        let resolved = parse(&["issue", "@open", "open"]).resolve().expect("resolve marked issue subject");
+        assert!(matches!(resolved, Resolved::NeedsContext { command: Command {
+            action: CommandAction::OpenIssue { id }, ..
+        }, .. } if id == "open"));
+    }
+
+    #[test]
+    fn explicit_subject_preserves_issue_beginning_with_marker() {
+        let resolved = parse(&["issue", "--subject", "@open", "open"]).resolve().expect("resolve explicit issue subject");
+        assert!(matches!(resolved, Resolved::NeedsContext { command: Command {
+            action: CommandAction::OpenIssue { id }, ..
+        }, .. } if id == "@open"));
+    }
+
+    #[test]
     fn issue_suggest_branch_multiple() {
         let resolved = parse(&["issue", "1,5,7", "suggest-branch"]).resolve().unwrap();
         assert_eq!(resolved, Resolved::NeedsContext {
@@ -166,7 +186,7 @@ mod tests {
 
     #[test]
     fn issue_open_no_subject_errors() {
-        let noun = IssueNoun { subject: None, verb: Some(super::IssueVerb::Open) };
+        let noun = IssueNoun { subject: None, explicit_subject: None, verb: Some(super::IssueVerb::Open) };
         assert!(noun.resolve().is_err());
     }
 

--- a/crates/flotilla-commands/src/commands/issue.rs
+++ b/crates/flotilla-commands/src/commands/issue.rs
@@ -3,20 +3,15 @@ use flotilla_protocol::{issue_query::IssueQuery, Command, CommandAction, RepoSel
 
 use crate::{
     resolved::{HostResolution, RepoContext},
-    subject::{resolve_subject, write_subject},
-    Resolved,
+    Resolved, SubjectArgs,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Issues")]
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct IssueNoun {
-    /// Issue ID or comma-separated IDs (e.g. "1,5,7")
-    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
-    pub subject: Option<String>,
-    /// Literal subject; use for external names beginning with `@`
-    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
-    pub explicit_subject: Option<String>,
+    #[command(flatten)]
+    pub subjects: SubjectArgs,
 
     #[command(subcommand)]
     pub verb: Option<IssueVerb>,
@@ -34,7 +29,7 @@ pub enum IssueVerb {
 
 impl IssueNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        let subject = self.subjects.resolve()?.map(|subject| subject.value);
         match (subject, self.verb) {
             (Some(subject), Some(IssueVerb::Open)) => Ok(Resolved::NeedsContext {
                 command: Command {
@@ -85,7 +80,7 @@ impl IssueNoun {
 impl std::fmt::Display for IssueNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "issue")?;
-        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
+        self.subjects.write(f)?;
         if let Some(verb) = &self.verb {
             match verb {
                 IssueVerb::Open => write!(f, " open")?,
@@ -111,7 +106,7 @@ mod tests {
     use crate::{
         resolved::{HostResolution, RepoContext},
         test_utils::assert_round_trip,
-        Resolved,
+        Resolved, SubjectArgs,
     };
 
     fn parse(args: &[&str]) -> IssueNoun {
@@ -186,7 +181,7 @@ mod tests {
 
     #[test]
     fn issue_open_no_subject_errors() {
-        let noun = IssueNoun { subject: None, explicit_subject: None, verb: Some(super::IssueVerb::Open) };
+        let noun = IssueNoun { subjects: SubjectArgs::default(), verb: Some(super::IssueVerb::Open) };
         assert!(noun.resolve().is_err());
     }
 

--- a/crates/flotilla-commands/src/commands/repo.rs
+++ b/crates/flotilla-commands/src/commands/repo.rs
@@ -3,14 +3,21 @@ use std::{fmt, path::PathBuf};
 use clap::{Parser, Subcommand};
 use flotilla_protocol::{CheckoutTarget, Command, CommandAction, RepoSelector};
 
-use crate::Resolved;
+use crate::{
+    subject::{resolve_subject, write_subject},
+    Resolved,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Manage repositories")]
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct RepoNoun {
     /// Repository slug (e.g. owner/repo)
+    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
     pub subject: Option<String>,
+    /// Literal subject; use for external names beginning with `@`
+    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
+    pub explicit_subject: Option<String>,
 
     #[command(subcommand)]
     pub verb: Option<RepoVerb>,
@@ -40,7 +47,8 @@ pub enum RepoVerb {
 
 impl RepoNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        match (self.subject, self.verb) {
+        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        match (subject, self.verb) {
             (_, Some(RepoVerb::Add { path })) => Ok(Resolved::Ready(Command {
                 node_id: None,
                 provisioning_target: None,
@@ -108,9 +116,7 @@ impl RepoNoun {
 impl fmt::Display for RepoNoun {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "repo")?;
-        if let Some(subject) = &self.subject {
-            write!(f, " {subject}")?;
-        }
+        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
         if let Some(verb) = &self.verb {
             match verb {
                 RepoVerb::Add { path } => write!(f, " add {}", path.display())?,
@@ -247,6 +253,34 @@ mod tests {
     }
 
     #[test]
+    fn marked_subject_disambiguates_repo_named_refresh() {
+        let resolved = parse(&["repo", "@refresh", "providers"]).resolve().expect("resolve marked repo subject");
+        assert_eq!(
+            resolved,
+            Resolved::Ready(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryRepoProviders { repo: RepoSelector::Query("refresh".into()) },
+            })
+        );
+    }
+
+    #[test]
+    fn explicit_subject_preserves_repo_beginning_with_marker() {
+        let resolved = parse(&["repo", "--subject", "@refresh", "providers"]).resolve().expect("resolve explicit repo subject");
+        assert_eq!(
+            resolved,
+            Resolved::Ready(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryRepoProviders { repo: RepoSelector::Query("@refresh".into()) },
+            })
+        );
+    }
+
+    #[test]
     fn repo_query_work() {
         let resolved = parse(&["repo", "myslug", "work"]).resolve().unwrap();
         assert_eq!(
@@ -350,6 +384,12 @@ mod tests {
     #[test]
     fn round_trip_providers() {
         assert_round_trip::<RepoNoun>(&["repo", "myslug", "providers"]);
+    }
+
+    #[test]
+    fn marked_and_explicit_subjects_round_trip() {
+        assert_round_trip::<RepoNoun>(&["repo", "@refresh", "providers"]);
+        assert_round_trip::<RepoNoun>(&["repo", "--subject", "@refresh", "providers"]);
     }
 
     #[test]

--- a/crates/flotilla-commands/src/commands/repo.rs
+++ b/crates/flotilla-commands/src/commands/repo.rs
@@ -3,21 +3,14 @@ use std::{fmt, path::PathBuf};
 use clap::{Parser, Subcommand};
 use flotilla_protocol::{CheckoutTarget, Command, CommandAction, RepoSelector};
 
-use crate::{
-    subject::{resolve_subject, write_subject},
-    Resolved,
-};
+use crate::{Resolved, SubjectArgs};
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Manage repositories")]
 #[command(subcommand_precedence_over_arg = true, subcommand_negates_reqs = true)]
 pub struct RepoNoun {
-    /// Repository slug (e.g. owner/repo)
-    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
-    pub subject: Option<String>,
-    /// Literal subject; use for external names beginning with `@`
-    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
-    pub explicit_subject: Option<String>,
+    #[command(flatten)]
+    pub subjects: SubjectArgs,
 
     #[command(subcommand)]
     pub verb: Option<RepoVerb>,
@@ -47,7 +40,7 @@ pub enum RepoVerb {
 
 impl RepoNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        let subject = resolve_subject(self.subject, self.explicit_subject)?.map(|subject| subject.value);
+        let subject = self.subjects.resolve()?.map(|subject| subject.value);
         match (subject, self.verb) {
             (_, Some(RepoVerb::Add { path })) => Ok(Resolved::Ready(Command {
                 node_id: None,
@@ -116,7 +109,7 @@ impl RepoNoun {
 impl fmt::Display for RepoNoun {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "repo")?;
-        write_subject(f, self.subject.as_ref(), self.explicit_subject.as_ref())?;
+        self.subjects.write(f)?;
         if let Some(verb) = &self.verb {
             match verb {
                 RepoVerb::Add { path } => write!(f, " add {}", path.display())?,

--- a/crates/flotilla-commands/src/complete.rs
+++ b/crates/flotilla-commands/src/complete.rs
@@ -183,6 +183,24 @@ mod tests {
     }
 
     #[test]
+    fn marked_subject_completes_to_verbs() {
+        let input = "checkout @status ";
+        let completions = complete(&test_root(), input, input.len());
+        let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
+        assert!(values.contains(&"status"), "marked subject should complete to verbs, got: {values:?}");
+        assert!(values.contains(&"remove"));
+    }
+
+    #[test]
+    fn explicit_literal_subject_completes_to_verbs() {
+        let input = "checkout --subject @topic ";
+        let completions = complete(&test_root(), input, input.len());
+        let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
+        assert!(values.contains(&"status"), "explicit subject should complete to verbs, got: {values:?}");
+        assert!(values.contains(&"remove"));
+    }
+
+    #[test]
     fn host_with_subject_completes_to_verbs_and_nouns() {
         let completions = complete(&test_root(), "host feta ", 10);
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();

--- a/crates/flotilla-commands/src/lib.rs
+++ b/crates/flotilla-commands/src/lib.rs
@@ -12,4 +12,4 @@ pub use noun::NounCommand;
 pub use parse::{parse_host_command, parse_noun_command};
 pub use quote::quote_value;
 pub use resolved::{HostResolution, Refinable, RepoContext, Resolved};
-pub use subject::{address_subject_for_cli, subject_parse_hint};
+pub use subject::{address_subject_for_cli, subject_parse_hint, SubjectArgs, SubjectNoun};

--- a/crates/flotilla-commands/src/lib.rs
+++ b/crates/flotilla-commands/src/lib.rs
@@ -4,6 +4,7 @@ pub mod noun;
 pub mod parse;
 mod quote;
 pub mod resolved;
+mod subject;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
@@ -11,3 +12,4 @@ pub use noun::NounCommand;
 pub use parse::{parse_host_command, parse_noun_command};
 pub use quote::quote_value;
 pub use resolved::{HostResolution, Refinable, RepoContext, Resolved};
+pub use subject::{address_subject_for_cli, subject_parse_hint};

--- a/crates/flotilla-commands/src/parse.rs
+++ b/crates/flotilla-commands/src/parse.rs
@@ -4,16 +4,17 @@ use crate::{
     commands::host::HostNounPartial,
     noun::NounCommand,
     resolved::{Refinable, Resolved},
+    subject::format_parse_error,
 };
 
 pub fn parse_noun_command(tokens: &[&str]) -> Result<NounCommand, String> {
     let cmd = <NounCommand as Subcommand>::augment_subcommands(ClapCommand::new("flotilla").no_binary_name(true));
-    let matches = cmd.try_get_matches_from(tokens).map_err(|e| e.to_string())?;
+    let matches = cmd.try_get_matches_from(tokens).map_err(format_parse_error)?;
     <NounCommand as FromArgMatches>::from_arg_matches(&matches).map_err(|e| e.to_string())
 }
 
 pub fn parse_host_command(tokens: &[&str]) -> Result<Resolved, String> {
-    let partial = HostNounPartial::try_parse_from(tokens).map_err(|e| e.to_string())?;
+    let partial = HostNounPartial::try_parse_from(tokens).map_err(format_parse_error)?;
     partial.refine()?.resolve()
 }
 

--- a/crates/flotilla-commands/src/subject.rs
+++ b/crates/flotilla-commands/src/subject.rs
@@ -1,44 +1,101 @@
 use clap::{
     error::{ContextKind, ContextValue, ErrorKind},
-    CommandFactory, Subcommand,
+    Args, CommandFactory, Subcommand,
 };
 
 use crate::{commands::host::HostNounPartial, noun::NounCommand, quote_value};
 
 pub const ADDRESS_MARKER: char = '@';
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubjectNoun {
+    Checkout,
+    Crew,
+    Environment,
+    Host,
+    Issue,
+    Repo,
+}
+
+impl SubjectNoun {
+    pub fn from_command_name(name: &str) -> Option<Self> {
+        match name {
+            "checkout" => Some(Self::Checkout),
+            "crew" => Some(Self::Crew),
+            "environment" | "env" => Some(Self::Environment),
+            "host" => Some(Self::Host),
+            "issue" => Some(Self::Issue),
+            "repo" => Some(Self::Repo),
+            _ => None,
+        }
+    }
+
+    fn command_name(self) -> &'static str {
+        match self {
+            Self::Checkout => "checkout",
+            Self::Crew => "crew",
+            Self::Environment => "environment",
+            Self::Host => "host",
+            Self::Issue => "issue",
+            Self::Repo => "repo",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Args)]
+pub struct SubjectArgs {
+    /// Subject name; prefix with `@` when it matches a command
+    #[arg(value_name = "SUBJECT", conflicts_with = "explicit_subject")]
+    pub subject: Option<String>,
+    /// Literal subject; use for external names beginning with `@`
+    #[arg(long = "subject", value_name = "SUBJECT", conflicts_with = "subject")]
+    pub explicit_subject: Option<String>,
+}
+
+impl SubjectArgs {
+    pub fn positional(subject: String) -> Self {
+        Self { subject: Some(subject), explicit_subject: None }
+    }
+
+    pub(crate) fn resolve(self) -> Result<Option<ResolvedSubject>, String> {
+        match (self.subject, self.explicit_subject) {
+            (Some(_), Some(_)) => Err("subject may be supplied either positionally or with --subject, not both".to_string()),
+            (None, Some(value)) => Ok(Some(ResolvedSubject { value, interpretation: SubjectInterpretation::Forced })),
+            (Some(value), None) => {
+                if let Some(value) = value.strip_prefix(ADDRESS_MARKER) {
+                    if value.is_empty() {
+                        return Err("the @ address marker must be followed by a subject name".to_string());
+                    }
+                    Ok(Some(ResolvedSubject { value: value.to_string(), interpretation: SubjectInterpretation::Forced }))
+                } else {
+                    Ok(Some(ResolvedSubject { value, interpretation: SubjectInterpretation::Ordinary }))
+                }
+            }
+            (None, None) => Ok(None),
+        }
+    }
+
+    pub(crate) fn write(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(subject) = &self.subject {
+            write!(f, " {}", quote_value(subject))?;
+        }
+        if let Some(subject) = &self.explicit_subject {
+            write!(f, " --subject {}", quote_value(subject))?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SubjectInterpretation {
+    Ordinary,
+    Forced,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ResolvedSubject {
     pub value: String,
-    pub forced: bool,
-}
-
-pub(crate) fn resolve_subject(positional: Option<String>, explicit: Option<String>) -> Result<Option<ResolvedSubject>, String> {
-    match (positional, explicit) {
-        (Some(_), Some(_)) => Err("subject may be supplied either positionally or with --subject, not both".to_string()),
-        (None, Some(value)) => Ok(Some(ResolvedSubject { value, forced: true })),
-        (Some(value), None) => {
-            if let Some(value) = value.strip_prefix(ADDRESS_MARKER) {
-                if value.is_empty() {
-                    return Err("the @ address marker must be followed by a subject name".to_string());
-                }
-                Ok(Some(ResolvedSubject { value: value.to_string(), forced: true }))
-            } else {
-                Ok(Some(ResolvedSubject { value, forced: false }))
-            }
-        }
-        (None, None) => Ok(None),
-    }
-}
-
-pub(crate) fn write_subject(f: &mut std::fmt::Formatter<'_>, positional: Option<&String>, explicit: Option<&String>) -> std::fmt::Result {
-    if let Some(subject) = positional {
-        write!(f, " {}", quote_value(subject))?;
-    }
-    if let Some(subject) = explicit {
-        write!(f, " --subject {}", quote_value(subject))?;
-    }
-    Ok(())
+    pub interpretation: SubjectInterpretation,
 }
 
 /// Render a dynamic subject completion in a form that remains addressable.
@@ -46,7 +103,7 @@ pub(crate) fn write_subject(f: &mut std::fmt::Formatter<'_>, positional: Option<
 /// A leading `@` belongs to an opaque external identifier, so use the literal
 /// `--subject` form. Tokens colliding with verbs or routable nouns use the
 /// concise address marker.
-pub fn address_subject_for_cli(noun: &str, subject: &str) -> String {
+pub fn address_subject_for_cli(noun: SubjectNoun, subject: &str) -> String {
     if subject.starts_with(ADDRESS_MARKER) {
         return format!("--subject {}", quote_value(subject));
     }
@@ -80,12 +137,12 @@ pub(crate) fn format_parse_error(error: clap::Error) -> String {
     message
 }
 
-fn is_reserved_subject_token(noun: &str, subject: &str) -> bool {
-    if noun == "crew" && matches!(subject, "list" | "complete" | "fail") {
+fn is_reserved_subject_token(noun: SubjectNoun, subject: &str) -> bool {
+    if noun == SubjectNoun::Crew && matches!(subject, "list" | "complete" | "fail") {
         return true;
     }
 
-    if noun == "host" {
+    if noun == SubjectNoun::Host {
         let mut command = HostNounPartial::command();
         command.build();
         if command.find_subcommand(subject).is_some() {
@@ -95,6 +152,7 @@ fn is_reserved_subject_token(noun: &str, subject: &str) -> bool {
     }
 
     let root = <NounCommand as Subcommand>::augment_subcommands(clap::Command::new("subjects"));
+    let noun = noun.command_name();
     let Some(command) =
         root.get_subcommands().find(|command| command.get_name() == noun || command.get_all_aliases().any(|alias| alias == noun))
     else {
@@ -114,16 +172,16 @@ fn is_noun_token(subject: &str) -> bool {
 mod tests {
     use clap::Parser;
 
-    use super::{address_subject_for_cli, subject_parse_hint};
+    use super::{address_subject_for_cli, subject_parse_hint, SubjectNoun};
     use crate::commands::checkout::CheckoutNoun;
 
     #[test]
     fn address_form_is_only_added_when_needed() {
-        assert_eq!(address_subject_for_cli("checkout", "feature"), "feature");
-        assert_eq!(address_subject_for_cli("checkout", "status"), "@status");
-        assert_eq!(address_subject_for_cli("host", "repo"), "@repo");
-        assert_eq!(address_subject_for_cli("crew", "complete"), "@complete");
-        assert_eq!(address_subject_for_cli("checkout", "@topic"), "--subject @topic");
+        assert_eq!(address_subject_for_cli(SubjectNoun::Checkout, "feature"), "feature");
+        assert_eq!(address_subject_for_cli(SubjectNoun::Checkout, "status"), "@status");
+        assert_eq!(address_subject_for_cli(SubjectNoun::Host, "repo"), "@repo");
+        assert_eq!(address_subject_for_cli(SubjectNoun::Crew, "complete"), "@complete");
+        assert_eq!(address_subject_for_cli(SubjectNoun::Checkout, "@topic"), "--subject @topic");
     }
 
     #[test]

--- a/crates/flotilla-commands/src/subject.rs
+++ b/crates/flotilla-commands/src/subject.rs
@@ -1,0 +1,142 @@
+use clap::{
+    error::{ContextKind, ContextValue, ErrorKind},
+    CommandFactory, Subcommand,
+};
+
+use crate::{commands::host::HostNounPartial, noun::NounCommand, quote_value};
+
+pub const ADDRESS_MARKER: char = '@';
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedSubject {
+    pub value: String,
+    pub forced: bool,
+}
+
+pub(crate) fn resolve_subject(positional: Option<String>, explicit: Option<String>) -> Result<Option<ResolvedSubject>, String> {
+    match (positional, explicit) {
+        (Some(_), Some(_)) => Err("subject may be supplied either positionally or with --subject, not both".to_string()),
+        (None, Some(value)) => Ok(Some(ResolvedSubject { value, forced: true })),
+        (Some(value), None) => {
+            if let Some(value) = value.strip_prefix(ADDRESS_MARKER) {
+                if value.is_empty() {
+                    return Err("the @ address marker must be followed by a subject name".to_string());
+                }
+                Ok(Some(ResolvedSubject { value: value.to_string(), forced: true }))
+            } else {
+                Ok(Some(ResolvedSubject { value, forced: false }))
+            }
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+pub(crate) fn write_subject(f: &mut std::fmt::Formatter<'_>, positional: Option<&String>, explicit: Option<&String>) -> std::fmt::Result {
+    if let Some(subject) = positional {
+        write!(f, " {}", quote_value(subject))?;
+    }
+    if let Some(subject) = explicit {
+        write!(f, " --subject {}", quote_value(subject))?;
+    }
+    Ok(())
+}
+
+/// Render a dynamic subject completion in a form that remains addressable.
+///
+/// A leading `@` belongs to an opaque external identifier, so use the literal
+/// `--subject` form. Tokens colliding with verbs or routable nouns use the
+/// concise address marker.
+pub fn address_subject_for_cli(noun: &str, subject: &str) -> String {
+    if subject.starts_with(ADDRESS_MARKER) {
+        return format!("--subject {}", quote_value(subject));
+    }
+    if is_reserved_subject_token(noun, subject) {
+        format!("{ADDRESS_MARKER}{subject}")
+    } else {
+        subject.to_string()
+    }
+}
+
+pub fn subject_parse_hint(error: &clap::Error) -> Option<&'static str> {
+    if error.kind() != ErrorKind::UnknownArgument {
+        return None;
+    }
+    let Some(ContextValue::String(argument)) = error.get(ContextKind::InvalidArg) else {
+        return None;
+    };
+    if argument.starts_with('-') {
+        return None;
+    }
+    Some("If this value is a subject whose name matches a command, prefix it with `@`; use `--subject <literal>` for an external name beginning with `@`.")
+}
+
+pub(crate) fn format_parse_error(error: clap::Error) -> String {
+    let hint = subject_parse_hint(&error);
+    let mut message = error.to_string();
+    if let Some(hint) = hint {
+        message.push('\n');
+        message.push_str(hint);
+    }
+    message
+}
+
+fn is_reserved_subject_token(noun: &str, subject: &str) -> bool {
+    if noun == "crew" && matches!(subject, "list" | "complete" | "fail") {
+        return true;
+    }
+
+    if noun == "host" {
+        let mut command = HostNounPartial::command();
+        command.build();
+        if command.find_subcommand(subject).is_some() {
+            return true;
+        }
+        return is_noun_token(subject);
+    }
+
+    let root = <NounCommand as Subcommand>::augment_subcommands(clap::Command::new("subjects"));
+    let Some(command) =
+        root.get_subcommands().find(|command| command.get_name() == noun || command.get_all_aliases().any(|alias| alias == noun))
+    else {
+        return false;
+    };
+    command.find_subcommand(subject).is_some() || (command.is_allow_external_subcommands_set() && is_noun_token(subject))
+}
+
+fn is_noun_token(subject: &str) -> bool {
+    let root = <NounCommand as Subcommand>::augment_subcommands(clap::Command::new("subjects"));
+    let found =
+        root.get_subcommands().any(|command| command.get_name() == subject || command.get_all_aliases().any(|alias| alias == subject));
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{address_subject_for_cli, subject_parse_hint};
+    use crate::commands::checkout::CheckoutNoun;
+
+    #[test]
+    fn address_form_is_only_added_when_needed() {
+        assert_eq!(address_subject_for_cli("checkout", "feature"), "feature");
+        assert_eq!(address_subject_for_cli("checkout", "status"), "@status");
+        assert_eq!(address_subject_for_cli("host", "repo"), "@repo");
+        assert_eq!(address_subject_for_cli("crew", "complete"), "@complete");
+        assert_eq!(address_subject_for_cli("checkout", "@topic"), "--subject @topic");
+    }
+
+    #[test]
+    fn positional_collision_parse_errors_explain_the_address_marker() {
+        let error = CheckoutNoun::try_parse_from(["checkout", "status", "status"]).expect_err("ambiguous subject should fail");
+        let hint = subject_parse_hint(&error).expect("subject collision hint");
+        assert!(hint.contains("@"));
+        assert!(hint.contains("--subject"));
+    }
+
+    #[test]
+    fn unknown_flags_do_not_get_a_subject_hint() {
+        let error = CheckoutNoun::try_parse_from(["checkout", "--bogus"]).expect_err("unknown flag should fail");
+        assert!(subject_parse_hint(&error).is_none());
+    }
+}

--- a/crates/flotilla-commands/src/subject.rs
+++ b/crates/flotilla-commands/src/subject.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use clap::{
     error::{ContextKind, ContextValue, ErrorKind},
     Args, CommandFactory, Subcommand,
@@ -6,6 +8,7 @@ use clap::{
 use crate::{commands::host::HostNounPartial, noun::NounCommand, quote_value};
 
 pub const ADDRESS_MARKER: char = '@';
+const CREW_COMMAND_SUBJECTS: &[&str] = &["list", "complete", "fail"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubjectNoun {
@@ -138,31 +141,47 @@ pub(crate) fn format_parse_error(error: clap::Error) -> String {
 }
 
 fn is_reserved_subject_token(noun: SubjectNoun, subject: &str) -> bool {
-    if noun == SubjectNoun::Crew && matches!(subject, "list" | "complete" | "fail") {
+    if noun == SubjectNoun::Crew && is_crew_command_subject(subject) {
         return true;
     }
 
     if noun == SubjectNoun::Host {
-        let mut command = HostNounPartial::command();
-        command.build();
-        if command.find_subcommand(subject).is_some() {
-            return true;
-        }
-        return is_noun_token(subject);
+        return host_command_tree().find_subcommand(subject).is_some() || is_noun_token(subject_command_tree(), subject);
     }
 
-    let root = <NounCommand as Subcommand>::augment_subcommands(clap::Command::new("subjects"));
+    let root = subject_command_tree();
     let noun = noun.command_name();
     let Some(command) =
         root.get_subcommands().find(|command| command.get_name() == noun || command.get_all_aliases().any(|alias| alias == noun))
     else {
         return false;
     };
-    command.find_subcommand(subject).is_some() || (command.is_allow_external_subcommands_set() && is_noun_token(subject))
+    command.find_subcommand(subject).is_some() || (command.is_allow_external_subcommands_set() && is_noun_token(root, subject))
 }
 
-fn is_noun_token(subject: &str) -> bool {
-    let root = <NounCommand as Subcommand>::augment_subcommands(clap::Command::new("subjects"));
+pub(crate) fn is_crew_command_subject(subject: &str) -> bool {
+    CREW_COMMAND_SUBJECTS.contains(&subject)
+}
+
+fn subject_command_tree() -> &'static clap::Command {
+    static TREE: OnceLock<clap::Command> = OnceLock::new();
+    TREE.get_or_init(|| {
+        let mut command = <NounCommand as Subcommand>::augment_subcommands(clap::Command::new("subjects"));
+        command.build();
+        command
+    })
+}
+
+fn host_command_tree() -> &'static clap::Command {
+    static TREE: OnceLock<clap::Command> = OnceLock::new();
+    TREE.get_or_init(|| {
+        let mut command = HostNounPartial::command();
+        command.build();
+        command
+    })
+}
+
+fn is_noun_token(root: &clap::Command, subject: &str) -> bool {
     let found =
         root.get_subcommands().any(|command| command.get_name() == subject || command.get_all_aliases().any(|alias| alias == subject));
     found

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -62,6 +62,8 @@ pub struct Selector {
 pub enum ValidationError {
     DuplicateVesselName { name: String },
     DuplicateRoleInVessel { vessel: String, role: String },
+    ReservedAddressMarkerInVesselName { name: String },
+    ReservedAddressMarkerInCrewRole { vessel: String, role: String },
     ReservedLabelKey { vessel: String, role: String, key: String },
     UnknownDependency { vessel: String, missing: String },
     DependencyCycle { cycle: Vec<String> },
@@ -104,6 +106,12 @@ impl std::fmt::Display for ValidationError {
         match self {
             ValidationError::DuplicateVesselName { name } => write!(f, "duplicate vessel name `{name}`"),
             ValidationError::DuplicateRoleInVessel { vessel, role } => write!(f, "duplicate role `{role}` in vessel `{vessel}`"),
+            ValidationError::ReservedAddressMarkerInVesselName { name } => {
+                write!(f, "vessel name `{name}` may not begin with the reserved `@` address marker")
+            }
+            ValidationError::ReservedAddressMarkerInCrewRole { vessel, role } => {
+                write!(f, "crew role `{role}` on vessel `{vessel}` may not begin with the reserved `@` address marker")
+            }
             ValidationError::ReservedLabelKey { vessel, role, key } => {
                 write!(f, "reserved label key `{key}` on vessel `{vessel}` role `{role}`")
             }
@@ -161,6 +169,9 @@ fn collect_inputs(spec: &WorkflowTemplateSpec, errors: &mut Vec<ValidationError>
 fn collect_vessels<'a>(spec: &'a WorkflowTemplateSpec, errors: &mut Vec<ValidationError>) -> BTreeMap<String, &'a VesselRequirement> {
     let mut vessels_by_name = BTreeMap::new();
     for vessel in &spec.vessels {
+        if vessel.name.starts_with('@') {
+            push_error(errors, ValidationError::ReservedAddressMarkerInVesselName { name: vessel.name.clone() });
+        }
         if vessels_by_name.insert(vessel.name.clone(), vessel).is_some() {
             push_error(errors, ValidationError::DuplicateVesselName { name: vessel.name.clone() });
         }
@@ -182,6 +193,12 @@ fn validate_vessel(
     }
 
     for process in &vessel.crew {
+        if process.role.starts_with('@') {
+            push_error(errors, ValidationError::ReservedAddressMarkerInCrewRole {
+                vessel: vessel.name.clone(),
+                role: process.role.clone(),
+            });
+        }
         if !roles.insert(process.role.clone()) {
             push_error(errors, ValidationError::DuplicateRoleInVessel { vessel: vessel.name.clone(), role: process.role.clone() });
         }

--- a/crates/flotilla-resources/tests/workflow_template_validation.rs
+++ b/crates/flotilla-resources/tests/workflow_template_validation.rs
@@ -77,6 +77,24 @@ fn validate_rejects_duplicate_vessel_names() {
 }
 
 #[test]
+fn validate_rejects_address_marker_prefix_on_vessel_names() {
+    let mut spec = valid_workflow_template_spec();
+    spec.vessels[0].name = "@implement".to_string();
+
+    let errors = validate(&spec).expect_err("validation should fail");
+    assert!(errors.iter().any(|error| error.to_string().contains("vessel name `@implement`")), "unexpected errors: {errors:?}");
+}
+
+#[test]
+fn validate_rejects_address_marker_prefix_on_crew_roles() {
+    let mut spec = valid_workflow_template_spec();
+    spec.vessels[0].crew[0].role = "@coder".to_string();
+
+    let errors = validate(&spec).expect_err("validation should fail");
+    assert!(errors.iter().any(|error| error.to_string().contains("crew role `@coder`")), "unexpected errors: {errors:?}");
+}
+
+#[test]
 fn validate_rejects_duplicate_input_names() {
     let mut spec = valid_workflow_template_spec();
     spec.inputs.push(spec.inputs[0].clone());

--- a/crates/flotilla-tui/src/app/intent.rs
+++ b/crates/flotilla-tui/src/app/intent.rs
@@ -245,7 +245,7 @@ impl Intent {
             }
             Intent::OpenIssue => {
                 let id = item.issue_keys.first()?;
-                Some(NounCommand::Issue(IssueNoun { subject: Some(id.clone()), verb: Some(IssueVerb::Open) }))
+                Some(NounCommand::Issue(IssueNoun { subject: Some(id.clone()), explicit_subject: None, verb: Some(IssueVerb::Open) }))
             }
             Intent::ArchiveSession => {
                 let key = item.session_key.as_ref()?;
@@ -267,6 +267,7 @@ impl Intent {
                 let fresh = item.kind != WorkItemKind::RemoteBranch && item.kind != WorkItemKind::ChangeRequest;
                 Some(NounCommand::Checkout(CheckoutNoun {
                     subject: None,
+                    explicit_subject: None,
                     verb: Some(CheckoutVerb::Create { branch: branch.clone(), fresh }),
                 }))
             }
@@ -275,7 +276,7 @@ impl Intent {
                     return None;
                 }
                 let ids = item.issue_keys.join(",");
-                Some(NounCommand::Issue(IssueNoun { subject: Some(ids), verb: Some(IssueVerb::SuggestBranch) }))
+                Some(NounCommand::Issue(IssueNoun { subject: Some(ids), explicit_subject: None, verb: Some(IssueVerb::SuggestBranch) }))
             }
             // Non-convertible intents
             Intent::RemoveCheckout | Intent::CreateWorkspace | Intent::LinkIssuesToChangeRequest => None,

--- a/crates/flotilla-tui/src/app/intent.rs
+++ b/crates/flotilla-tui/src/app/intent.rs
@@ -6,7 +6,7 @@ use flotilla_commands::{
         issue::{IssueNoun, IssueVerb},
         workspace::{WorkspaceNoun, WorkspaceVerb},
     },
-    NounCommand,
+    NounCommand, SubjectArgs,
 };
 use flotilla_protocol::{CheckoutTarget, Command, CommandAction, NodeId, RepoLabels, WorkItem, WorkItemKind};
 
@@ -245,7 +245,7 @@ impl Intent {
             }
             Intent::OpenIssue => {
                 let id = item.issue_keys.first()?;
-                Some(NounCommand::Issue(IssueNoun { subject: Some(id.clone()), explicit_subject: None, verb: Some(IssueVerb::Open) }))
+                Some(NounCommand::Issue(IssueNoun { subjects: SubjectArgs::positional(id.clone()), verb: Some(IssueVerb::Open) }))
             }
             Intent::ArchiveSession => {
                 let key = item.session_key.as_ref()?;
@@ -266,8 +266,7 @@ impl Intent {
                 let branch = item.branch.as_ref()?;
                 let fresh = item.kind != WorkItemKind::RemoteBranch && item.kind != WorkItemKind::ChangeRequest;
                 Some(NounCommand::Checkout(CheckoutNoun {
-                    subject: None,
-                    explicit_subject: None,
+                    subjects: SubjectArgs::default(),
                     verb: Some(CheckoutVerb::Create { branch: branch.clone(), fresh }),
                 }))
             }
@@ -276,7 +275,7 @@ impl Intent {
                     return None;
                 }
                 let ids = item.issue_keys.join(",");
-                Some(NounCommand::Issue(IssueNoun { subject: Some(ids), explicit_subject: None, verb: Some(IssueVerb::SuggestBranch) }))
+                Some(NounCommand::Issue(IssueNoun { subjects: SubjectArgs::positional(ids), verb: Some(IssueVerb::SuggestBranch) }))
             }
             // Non-convertible intents
             Intent::RemoveCheckout | Intent::CreateWorkspace | Intent::LinkIssuesToChangeRequest => None,

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -414,7 +414,7 @@ fn resolve_noun_name(token: &str) -> Option<String> {
 
 /// Subject completions for a given noun, drawn from model data.
 fn subject_completions(noun: &str, partial: &str, model: &TuiModel, namespaces: &crate::app::NamespaceMap) -> Vec<PaletteCompletion> {
-    let lower = partial.to_lowercase();
+    let lower = partial.strip_prefix('@').unwrap_or(partial).to_lowercase();
     let items: Vec<(String, String)> = match noun {
         "convoy" => {
             // Single-namespace MVP: list convoys in "flotilla".
@@ -514,7 +514,11 @@ fn subject_completions(noun: &str, partial: &str, model: &TuiModel, namespaces: 
     items
         .into_iter()
         .filter(|(value, _)| lower.is_empty() || value.to_lowercase().starts_with(&lower))
-        .map(|(value, description)| PaletteCompletion { value, description, key_hint: None })
+        .map(|(value, description)| PaletteCompletion {
+            value: flotilla_commands::address_subject_for_cli(noun, &value),
+            description,
+            key_hint: None,
+        })
         .collect()
 }
 
@@ -905,6 +909,13 @@ mod tests {
             status: crate::app::PeerStatus::Connected,
             summary: stub_host_summary("brie"),
         });
+        model.hosts.insert(EnvironmentId::host(HostId::new("status-env")), crate::app::TuiHostState {
+            environment_id: EnvironmentId::host(HostId::new("status-env")),
+            host_name: HostName::new("status"),
+            is_local: false,
+            status: crate::app::PeerStatus::Connected,
+            summary: stub_host_summary("status"),
+        });
         model
     }
 
@@ -979,6 +990,8 @@ mod tests {
         let values: Vec<&str> = completions.iter().map(|c| c.value.as_str()).collect();
         assert!(values.contains(&"feta"), "expected 'feta' in {values:?}");
         assert!(values.contains(&"brie"), "expected 'brie' in {values:?}");
+        assert!(values.contains(&"@status"), "colliding host should use the address marker in {values:?}");
+        assert!(!values.contains(&"status"), "unmarked colliding host is not addressable: {values:?}");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -514,10 +514,10 @@ fn subject_completions(noun: &str, partial: &str, model: &TuiModel, namespaces: 
     items
         .into_iter()
         .filter(|(value, _)| lower.is_empty() || value.to_lowercase().starts_with(&lower))
-        .map(|(value, description)| PaletteCompletion {
-            value: flotilla_commands::address_subject_for_cli(noun, &value),
-            description,
-            key_hint: None,
+        .map(|(value, description)| {
+            let value = flotilla_commands::SubjectNoun::from_command_name(noun)
+                .map_or(value.clone(), |noun| flotilla_commands::address_subject_for_cli(noun, &value));
+            PaletteCompletion { value, description, key_hint: None }
         })
         .collect()
 }

--- a/crates/flotilla-tui/src/widgets/command_palette.rs
+++ b/crates/flotilla-tui/src/widgets/command_palette.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use crossterm::event::{KeyCode, KeyEvent};
-use flotilla_commands::{resolved::HostQueryKind, HostResolution, RepoContext, Resolved};
+use flotilla_commands::{address_subject_for_cli, resolved::HostQueryKind, HostResolution, RepoContext, Resolved, SubjectNoun};
 use flotilla_protocol::{Command, CommandAction, NodeId, ProvisioningTarget, RepoIdentity, RepoSelector, WorkItem};
 use ratatui::{
     layout::Rect,
@@ -27,14 +27,11 @@ pub fn palette_prefill(item: &WorkItem) -> Option<String> {
     }
     if let Some(branch) = &item.branch {
         if item.checkout_key().is_some() {
-            return Some(format!(
-                "checkout {} ",
-                flotilla_commands::address_subject_for_cli(flotilla_commands::SubjectNoun::Checkout, branch)
-            ));
+            return Some(format!("checkout {} ", address_subject_for_cli(SubjectNoun::Checkout, branch)));
         }
     }
     if let Some(issue_key) = item.issue_keys.first() {
-        return Some(format!("issue {} ", issue_key));
+        return Some(format!("issue {} ", address_subject_for_cli(SubjectNoun::Issue, issue_key)));
     }
     if let Some(session_key) = &item.session_key {
         return Some(format!("agent {} ", session_key));
@@ -995,6 +992,13 @@ mod tests {
         let mut item = bare_item();
         item.issue_keys = vec!["99".into()];
         assert_eq!(palette_prefill(&item), Some("issue 99 ".into()));
+    }
+
+    #[test]
+    fn prefill_addresses_issue_key_that_collides_with_a_verb() {
+        let mut item = bare_item();
+        item.issue_keys = vec!["open".into()];
+        assert_eq!(palette_prefill(&item), Some("issue @open ".into()));
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/command_palette.rs
+++ b/crates/flotilla-tui/src/widgets/command_palette.rs
@@ -27,7 +27,10 @@ pub fn palette_prefill(item: &WorkItem) -> Option<String> {
     }
     if let Some(branch) = &item.branch {
         if item.checkout_key().is_some() {
-            return Some(format!("checkout {} ", flotilla_commands::address_subject_for_cli("checkout", branch)));
+            return Some(format!(
+                "checkout {} ",
+                flotilla_commands::address_subject_for_cli(flotilla_commands::SubjectNoun::Checkout, branch)
+            ));
         }
     }
     if let Some(issue_key) = item.issue_keys.first() {

--- a/crates/flotilla-tui/src/widgets/command_palette.rs
+++ b/crates/flotilla-tui/src/widgets/command_palette.rs
@@ -27,7 +27,7 @@ pub fn palette_prefill(item: &WorkItem) -> Option<String> {
     }
     if let Some(branch) = &item.branch {
         if item.checkout_key().is_some() {
-            return Some(format!("checkout {} ", branch));
+            return Some(format!("checkout {} ", flotilla_commands::address_subject_for_cli("checkout", branch)));
         }
     }
     if let Some(issue_key) = item.issue_keys.first() {
@@ -967,6 +967,18 @@ mod tests {
     fn prefill_from_checkout_branch() {
         let item = checkout_item("feat/my-branch", "/tmp/repo", false);
         assert_eq!(palette_prefill(&item), Some("checkout feat/my-branch ".into()));
+    }
+
+    #[test]
+    fn prefill_addresses_checkout_branch_that_collides_with_a_verb() {
+        let item = checkout_item("status", "/tmp/repo", false);
+        assert_eq!(palette_prefill(&item), Some("checkout @status ".into()));
+    }
+
+    #[test]
+    fn prefill_uses_literal_subject_for_checkout_branch_beginning_with_marker() {
+        let item = checkout_item("@topic", "/tmp/repo", false);
+        assert_eq!(palette_prefill(&item), Some("checkout --subject @topic ".into()));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ impl Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let mut cli = Cli::parse();
+    let mut cli = Cli::try_parse().unwrap_or_else(|error| exit_cli_parse_error(error));
     let format = OutputFormat::from_json_flag(cli.json);
     let command = cli.command.take();
 
@@ -244,6 +244,18 @@ async fn main() -> Result<()> {
 
         None => run_tui(cli, None).await,
     }
+}
+
+fn exit_cli_parse_error(error: clap::Error) -> ! {
+    let hint = flotilla_commands::subject_parse_hint(&error);
+    let exit_code = error.exit_code();
+    if let Err(print_error) = error.print() {
+        eprintln!("failed to print command-line error: {print_error}");
+    }
+    if let Some(hint) = hint {
+        eprintln!("\n{hint}");
+    }
+    std::process::exit(exit_code)
 }
 
 /// Run the TUI. With `scoped_view`, run in scoped mode: exactly that View,
@@ -1045,6 +1057,14 @@ mod tests {
         let handoff = Cli::try_parse_from(["flotilla", "crew", "reviewer", "handoff", "--message", "Review commit abc123"])
             .expect("crew handoff should parse");
         assert!(matches!(handoff.command, Some(SubCommand::Crew(_))));
+
+        let marked = Cli::try_parse_from(["flotilla", "crew", "@list", "handoff", "--message", "Review commit abc123"])
+            .expect("marked crew role should parse");
+        assert!(matches!(marked.command, Some(SubCommand::Crew(_))));
+
+        let literal = Cli::try_parse_from(["flotilla", "crew", "--subject", "@reviewer", "handoff", "--message", "Review commit abc123"])
+            .expect("literal crew role should parse");
+        assert!(matches!(literal.command, Some(SubCommand::Crew(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve Flotilla's subject-before-verb grammar while allowing `@name` to force a positional subject
- add `--subject <literal>` for opaque external identifiers that legitimately begin with `@`
- apply the shared disambiguation to crew, host, repo, checkout, issue, and environment commands, including nested routing
- make completions and TUI palette prefills emit addressable subjects and explain the escape syntax in relevant parse errors
- reserve leading `@` in workflow vessel and crew-role names

## Root cause

Noun groups with both optional positional subjects and subjectless verbs rely on Clap's subcommand precedence. A subject whose text matches a verb or nested noun is therefore parsed as command grammar instead of data and becomes unaddressable.

## User impact

Ordinary commands remain unchanged. Colliding names can now be addressed explicitly, for example:

```text
flotilla crew @complete handoff --message "please continue"
flotilla checkout @status status
flotilla host @checkout repo @refresh work
```

External names beginning with `@` use the literal fallback:

```text
flotilla checkout --subject @topic status
```

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- independent standards and issue-spec review

Closes #697
