### PR TITLE
fix: make forced work completion atomic

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -26,14 +26,15 @@ use flotilla_protocol::{
     StatusResponse, StreamKey, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute,
 };
 use flotilla_resources::{
-    apply_status_patch as apply_resource_status_patch, external_patches as convoy_external_patches, terminal_session_attach_target,
-    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CrewSource,
-    Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, Resource,
-    ResourceBackend, ResourceError, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
-    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
-    Vessel, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    apply_status_patch as apply_resource_status_patch, apply_status_patch_checked as apply_resource_status_patch_checked,
+    external_patches as convoy_external_patches, terminal_session_attach_target, Checkout as ResourceCheckout,
+    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus,
+    Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CrewSource, Environment as ResourceEnvironment,
+    InMemoryBackend, InputMeta, InputValue, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy,
+    Project, ProjectRepositorySpec, ProjectSpec, Resource, ResourceBackend, ResourceError, ResourceObject, TerminalBrief,
+    TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
+    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WorkflowTemplate,
+    WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -3192,26 +3193,25 @@ impl InProcessDaemon {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
             let namespace = self.provisioning_namespace().await;
             let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
-            let result = match convoys.get(convoy).await {
-                Ok(current) => match current.status.as_ref() {
-                    None => flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} has no status") },
-                    Some(status) => match status.work.get(work) {
-                        None => flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} does not contain work {work}") },
-                        Some(state) if state.phase.is_terminal() => {
-                            flotilla_protocol::CommandValue::Error { message: format!("convoy {convoy} work {work} is already terminal") }
-                        }
-                        Some(_) => match apply_resource_status_patch(
-                            &convoys,
-                            convoy,
-                            &convoy_external_patches::force_work_completed(work.clone(), chrono::Utc::now(), message.clone()),
-                        )
-                        .await
-                        {
-                            Ok(_) => flotilla_protocol::CommandValue::Ok,
-                            Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
-                        },
-                    },
+            let check_work_is_completable = |current: &ResourceObject<ResourceConvoy>| match current.status.as_ref() {
+                None => Err(ResourceError::other(format!("convoy {convoy} has no status"))),
+                Some(status) => match status.work.get(work) {
+                    None => Err(ResourceError::other(format!("convoy {convoy} does not contain work {work}"))),
+                    Some(state) if state.phase.is_terminal() => {
+                        Err(ResourceError::other(format!("convoy {convoy} work {work} is already terminal")))
+                    }
+                    Some(_) => Ok(()),
                 },
+            };
+            let result = match apply_resource_status_patch_checked(
+                &convoys,
+                convoy,
+                &convoy_external_patches::force_work_completed(work.clone(), chrono::Utc::now(), message.clone()),
+                check_work_is_completable,
+            )
+            .await
+            {
+                Ok(_) => flotilla_protocol::CommandValue::Ok,
                 Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
             };
             self.finish_context_free_command(id, empty_identity, result);

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -58,7 +58,7 @@ pub use resource::{
 };
 pub use retention::{EventRetention, ResourceStoreDiagnostics, ResourceStoreWarning};
 pub use sqlite::SqliteBackend;
-pub use status_patch::{apply_status_patch, NoStatusPatch, StatusPatch};
+pub use status_patch::{apply_status_patch, apply_status_patch_checked, NoStatusPatch, StatusPatch};
 pub use terminal_session::{
     terminal_session_attach_target, CrewSessionStatus, InnerCommandStatus, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession, TerminalSessionAttachTarget, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource,

--- a/crates/flotilla-resources/src/status_patch.rs
+++ b/crates/flotilla-resources/src/status_patch.rs
@@ -41,6 +41,33 @@ where
     .await
 }
 
+/// Applies a status patch only while `check` accepts each freshly fetched resource version.
+///
+/// The check runs before the initial write and again after every optimistic-concurrency conflict,
+/// keeping state-dependent validation in the same retry loop as the mutation it guards.
+pub async fn apply_status_patch_checked<T>(
+    resolver: &TypedResolver<T>,
+    name: &str,
+    patch: &T::StatusPatch,
+    check: impl Fn(&ResourceObject<T>) -> Result<(), ResourceError>,
+) -> Result<ResourceObject<T>, ResourceError>
+where
+    T: Resource,
+    T::Status: Default,
+{
+    apply_status_patch_inner(
+        name,
+        patch,
+        || async {
+            let current = resolver.get(name).await?;
+            check(&current)?;
+            Ok((current.metadata.resource_version, current.status))
+        },
+        |resource_version, new_status| async move { resolver.update_status(name, &resource_version, &new_status).await },
+    )
+    .await
+}
+
 async fn apply_status_patch_inner<S, P, R, G, GFut, U, UFut>(
     name: &str,
     patch: &P,

--- a/crates/flotilla-resources/tests/status_patch.rs
+++ b/crates/flotilla-resources/tests/status_patch.rs
@@ -97,6 +97,8 @@ async fn apply_status_patch_initializes_missing_status_from_default() {
     assert_eq!(updated.metadata.resource_version, "2");
 }
 
+// The patch blocks one runtime worker at a synchronous barrier while the second worker lands the
+// concurrent update that makes its resourceVersion stale.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn checked_status_patch_revalidates_after_conflict_before_retrying() {
     let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<CounterResource>("flotilla");

--- a/crates/flotilla-resources/tests/status_patch.rs
+++ b/crates/flotilla-resources/tests/status_patch.rs
@@ -1,5 +1,11 @@
-use flotilla_resources::{ApiPaths, InMemoryBackend, InputMeta, Resource, ResourceBackend, StatusPatch};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Barrier,
+};
+
+use flotilla_resources::{ApiPaths, InMemoryBackend, InputMeta, Resource, ResourceBackend, ResourceError, StatusPatch};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
 
 #[derive(Debug, Clone, Copy)]
 struct CounterResource;
@@ -17,6 +23,7 @@ struct CounterStatus {
 
 enum CounterPatch {
     Increment,
+    IncrementAfterConcurrentUpdate { update_started: Arc<Notify>, update_finished: Arc<Barrier>, update_triggered: Arc<AtomicBool> },
     SetNote(&'static str),
 }
 
@@ -32,6 +39,13 @@ impl StatusPatch<CounterStatus> for CounterPatch {
     fn apply(&self, status: &mut CounterStatus) {
         match self {
             Self::Increment => status.value += 1,
+            Self::IncrementAfterConcurrentUpdate { update_started, update_finished, update_triggered } => {
+                if !update_triggered.swap(true, Ordering::SeqCst) {
+                    update_started.notify_one();
+                    update_finished.wait();
+                }
+                status.value += 1;
+            }
             Self::SetNote(note) => status.note = Some((*note).to_string()),
         }
     }
@@ -81,4 +95,48 @@ async fn apply_status_patch_initializes_missing_status_from_default() {
     assert_eq!(created.status, None);
     assert_eq!(updated.status.expect("status"), CounterStatus { value: 0, note: Some("ready".to_string()) });
     assert_eq!(updated.metadata.resource_version, "2");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn checked_status_patch_revalidates_after_conflict_before_retrying() {
+    let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<CounterResource>("flotilla");
+    let created = resolver.create(&counter_meta("gamma"), &counter_spec("gamma")).await.expect("create should succeed");
+    resolver
+        .update_status("gamma", &created.metadata.resource_version, &CounterStatus { value: 1, note: None })
+        .await
+        .expect("seed status should succeed");
+
+    let update_started = Arc::new(Notify::new());
+    let update_finished = Arc::new(Barrier::new(2));
+    let update_triggered = Arc::new(AtomicBool::new(false));
+    let concurrent_update = {
+        let resolver = resolver.clone();
+        let update_started = Arc::clone(&update_started);
+        let update_finished = Arc::clone(&update_finished);
+        tokio::spawn(async move {
+            update_started.notified().await;
+            let current = resolver.get("gamma").await.expect("concurrent get should succeed");
+            resolver
+                .update_status("gamma", &current.metadata.resource_version, &CounterStatus { value: 1, note: Some("terminal".to_string()) })
+                .await
+                .expect("concurrent status update should succeed");
+            update_finished.wait();
+        })
+    };
+
+    let result = flotilla_resources::apply_status_patch_checked(
+        &resolver,
+        "gamma",
+        &CounterPatch::IncrementAfterConcurrentUpdate { update_started, update_finished, update_triggered },
+        |current| match current.status.as_ref() {
+            Some(status) if status.note.as_deref() == Some("terminal") => Err(ResourceError::other("counter is terminal")),
+            _ => Ok(()),
+        },
+    )
+    .await;
+    concurrent_update.await.expect("concurrent task should finish");
+
+    assert_eq!(result.expect_err("retry should reject the concurrent terminal state"), ResourceError::other("counter is terminal"));
+    let current = resolver.get("gamma").await.expect("final get should succeed");
+    assert_eq!(current.status.expect("status"), CounterStatus { value: 1, note: Some("terminal".to_string()) });
 }


### PR DESCRIPTION
## Summary

- add a checked status-patch helper that revalidates each freshly fetched resource version
- use it for forced convoy-work completion so optimistic-concurrency retries cannot overwrite terminal work
- preserve rejection of every terminal phase through the shared `WorkPhase::is_terminal()` rule
- add a deterministic in-memory conflict test covering the race

## Root cause

Forced completion validated a convoy once, then called the retrying status-patch helper. If reconciliation changed the work to `Failed` or `Cancelled` after validation, a conflict retry re-fetched that terminal status and blindly reapplied `ForceWorkCompleted`, overwriting it with `Complete`.

## Impact

The validation now runs inside the same resource-version retry loop as the mutation. A concurrent status change either makes the versioned write conflict and trigger revalidation, or the write succeeds against exactly the version that was validated.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- parallel standards and spec reviews against issue #704

Fixes #704