### PR TITLE
feat: daily-driver layout running the manifest connector

### DIFF
--- a/layouts/daily-driver.kdl
+++ b/layouts/daily-driver.kdl
@@ -1,0 +1,81 @@
+// Daily-driver layout: zellij + andamento + the flotilla manifest connector.
+//
+// This is the composed layout the PM-capability daily driver runs
+// (flotilla-org/flotilla#708). It is derived from andamento's own
+// layouts/andamento.kdl — which deliberately stays flotilla-free (the
+// git-watcher is the manifest architecture's independence proof) — plus one
+// pane running `flotilla pm connect`, the catalog half of the connector.
+//
+// Launch via scripts/run-daily-driver.sh, which sets the env vars used
+// below: ANDAMENTO_ROOT, FLOTILLA_BIN.
+
+plugins {
+    andamento-controller location="file:$ANDAMENTO_ROOT/target/wasm32-wasip1/release/andamento-controller.wasm" {
+        rail_structure "joined-cells"
+        rail_sizing "active-large"
+        rail_grouping "directory"
+        rail_segment_between_color "#282c34"
+        template_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
+        grouping_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
+    }
+    andamento-rail location="file:$ANDAMENTO_ROOT/target/wasm32-wasip1/release/andamento-rail.wasm" {
+        controller_plugin_url "andamento-controller"
+        config_plugin_url "andamento-config"
+        rail_placement "left"
+    }
+    andamento-config location="file:$ANDAMENTO_ROOT/target/wasm32-wasip1/release/andamento-config.wasm"
+}
+
+load_plugins {
+    andamento-controller
+}
+
+layout {
+    default_tab_template {
+        pane split_direction="vertical" {
+            pane size="23%" borderless=true {
+                plugin location="andamento-rail"
+            }
+            children
+        }
+        pane size=2 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+
+    new_tab_template {
+        pane split_direction="vertical" {
+            pane size="23%" borderless=true {
+                plugin location="andamento-rail"
+            }
+            pane
+        }
+        pane size=2 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+
+    tab name="main" {
+        pane split_direction="vertical" {
+            pane
+            pane split_direction="horizontal" {
+                pane size="40%" {
+                    plugin location="andamento-config" {
+                        close_on_hidden "false"
+                    }
+                }
+                pane command="$ANDAMENTO_ROOT/scripts/andamento-git-watcher.py" cwd="$ANDAMENTO_ROOT" {
+                    args "--interval" "5"
+                }
+                // The manifest metadata-patch connector: subscribes to the
+                // local daemon's named queries and publishes the catalog
+                // (projects/convoys/vessels, live + latent, badges) into
+                // andamento's metadata plane. Recipes it mints reference
+                // $FLOTILLA_BIN so activation works from fresh panes.
+                pane command="$FLOTILLA_BIN" {
+                    args "pm" "connect" "--flotilla-bin" "$FLOTILLA_BIN"
+                }
+            }
+        }
+    }
+}

--- a/scripts/run-daily-driver.sh
+++ b/scripts/run-daily-driver.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Launch the daily-driver zellij session: andamento rail + git-watcher +
+# the flotilla manifest connector (layouts/daily-driver.kdl, #708).
+#
+# Builds the andamento plugins, checks the flotilla dev binaries exist and
+# are properly signed (macOS 26.5.x syspolicyd mitigation, #689 — signing
+# itself stays a manual step), then execs zellij with the composed layout.
+set -euo pipefail
+
+FLOTILLA_ROOT=${FLOTILLA_ROOT:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"}
+export ANDAMENTO_ROOT=${ANDAMENTO_ROOT:-"$HOME/dev/andamento"}
+export FLOTILLA_BIN=${FLOTILLA_BIN:-"$FLOTILLA_ROOT/target/debug/flotilla"}
+ZELLIJ_BIN=${ZELLIJ_BIN:-"$HOME/dev/zellij/target/dev-opt/zellij"}
+
+if [[ ! -x "$FLOTILLA_BIN" ]]; then
+    echo "error: flotilla binary not found at $FLOTILLA_BIN — run cargo build first" >&2
+    exit 1
+fi
+
+# Warn (don't block) when the dev binaries look ad-hoc signed: per #689 the
+# per-exec assessment cost on macOS 26.5.x wants a real identity. Signing is
+# deliberately manual; see the dev-signing notes.
+for bin in "$FLOTILLA_BIN" "$(dirname "$FLOTILLA_BIN")/flotillad"; do
+    if [[ -x "$bin" ]] && ! codesign -dv "$bin" 2>&1 | grep -q "Authority="; then
+        echo "warning: $bin appears ad-hoc signed — re-sign it (see #689 dev-signing notes)" >&2
+    fi
+done
+
+cargo build --manifest-path "$ANDAMENTO_ROOT/Cargo.toml" --workspace --target wasm32-wasip1 --release
+
+exec "$ZELLIJ_BIN" --layout "$FLOTILLA_ROOT/layouts/daily-driver.kdl"

--- a/scripts/run-daily-driver.sh
+++ b/scripts/run-daily-driver.sh
@@ -20,11 +20,13 @@ fi
 # Warn (don't block) when the dev binaries look ad-hoc signed: per #689 the
 # per-exec assessment cost on macOS 26.5.x wants a real identity. Signing is
 # deliberately manual; see the dev-signing notes.
-for bin in "$FLOTILLA_BIN" "$(dirname "$FLOTILLA_BIN")/flotillad"; do
-    if [[ -x "$bin" ]] && ! codesign -dv "$bin" 2>&1 | grep -q "Authority="; then
-        echo "warning: $bin appears ad-hoc signed — re-sign it (see #689 dev-signing notes)" >&2
-    fi
-done
+if command -v codesign >/dev/null 2>&1; then
+    for bin in "$FLOTILLA_BIN" "$(dirname "$FLOTILLA_BIN")/flotillad"; do
+        if [[ -x "$bin" ]] && ! codesign -dv "$bin" 2>&1 | grep -q "Authority="; then
+            echo "warning: $bin appears ad-hoc signed — re-sign it (see #689 dev-signing notes)" >&2
+        fi
+    done
+fi
 
 cargo build --manifest-path "$ANDAMENTO_ROOT/Cargo.toml" --workspace --target wasm32-wasip1 --release
 


### PR DESCRIPTION
Adds `layouts/daily-driver.kdl` — andamento's daily layout composed with one extra pane running `flotilla pm connect --flotilla-bin $FLOTILLA_BIN` (the git-watcher's seat, per the #667 design) — and `scripts/run-daily-driver.sh` which builds the andamento plugins, warns when the dev binaries are ad-hoc signed (#689), and execs zellij with the layout.

Kept on the flotilla side deliberately: andamento's own `layouts/andamento.kdl` stays flotilla-free, preserving the git-watcher as the manifest independence proof.

This is the acceptance rig for #708's daily-driver checklist.