### PR TITLE
fix: delete dead repo root resolver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Key bindings are configurable via TOML. Defaults: `j/k` navigate, `Enter` execut
 
 Stored in `~/.config/flotilla/`:
 - `repos/*.toml` — one per tracked repo (`path = "..."`, plus per-provider config: `change_request`, `issue_tracker`, `cloud_agent`, `ai_utility`, `workspace_manager`, `terminal_pool`, `vcs.git`)
-- `tab-order.json` — array of repo paths
+- `open-views.toml` — ordered TUI-owned View addresses and label overrides
 - `keybindings.toml` — user key binding overrides
 
 Workspace templates: `.flotilla/workspace.yaml` in repo root.

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, OnceLock},
+    sync::{Mutex, OnceLock},
 };
 
 use flotilla_protocol::NodeId;
@@ -403,10 +403,6 @@ impl ConfigStore {
         self.base.join("repos")
     }
 
-    fn tab_order_file(&self) -> DaemonHostPath {
-        self.base.join("tab-order.json")
-    }
-
     /// Load all persisted repo paths from config dir, sorted alphabetically by path.
     pub fn load_repos(&self) -> Vec<ExecutionEnvironmentPath> {
         let dir = self.repos_dir();
@@ -452,15 +448,6 @@ impl ConfigStore {
         let key = repo_file_key(path.as_path());
         let file = dir.join(format!("{key}.toml"));
         let _ = std::fs::remove_file(file.as_path());
-    }
-
-    /// Load the legacy tab order. Read-only: the file is no longer written —
-    /// it survives only to order repo registration and to seed
-    /// `open-views.toml` for configs created before the View model (ADR 0013).
-    pub fn load_tab_order(&self) -> Option<Vec<ExecutionEnvironmentPath>> {
-        let content = std::fs::read_to_string(self.tab_order_file().as_path()).ok()?;
-        let paths: Vec<String> = serde_json::from_str(&content).ok()?;
-        Some(paths.into_iter().map(|s| ExecutionEnvironmentPath::new(PathBuf::from(s))).collect())
     }
 
     fn open_views_file(&self) -> DaemonHostPath {
@@ -578,65 +565,6 @@ impl ConfigStore {
         }
         ResolvedCheckoutConfig { strategy: global.vcs.git.checkout_strategy.clone(), path: global.vcs.git.checkout_path.clone() }
     }
-}
-
-/// Collect repo roots: persisted (in legacy saved tab order, when present)
-/// first, then CLI args, then auto-detect from cwd. Persists any new repos.
-/// Tab order is a Surface concern (`open-views.toml`, ADR 0013) — nothing
-/// here writes it.
-pub async fn resolve_repo_roots(cli_roots: &[PathBuf], config: &ConfigStore) -> Vec<ExecutionEnvironmentPath> {
-    use crate::providers::{
-        vcs::{git::GitVcs, Vcs},
-        ProcessCommandRunner,
-    };
-
-    let mut repo_roots: Vec<ExecutionEnvironmentPath> = Vec::new();
-
-    // 1. Persisted repos in saved tab order
-    let persisted = config.load_repos();
-    let tab_order = config.load_tab_order();
-    if let Some(order) = tab_order {
-        for path in &order {
-            if persisted.contains(path) && !repo_roots.contains(path) {
-                repo_roots.push(path.clone());
-            }
-        }
-        // Any persisted repos not in the order file go at the end
-        for path in &persisted {
-            if !repo_roots.contains(path) {
-                repo_roots.push(path.clone());
-            }
-        }
-    } else {
-        repo_roots.extend(persisted);
-    }
-
-    // 2. CLI args (appended after persisted)
-    for root in cli_roots {
-        let canonical = ExecutionEnvironmentPath::new(std::fs::canonicalize(root).unwrap_or_else(|_| root.clone()));
-        if !repo_roots.contains(&canonical) {
-            repo_roots.push(canonical);
-        }
-    }
-
-    // 3. Auto-detect from cwd — resolve to main repo root (not worktree)
-    let cwd = std::env::current_dir().ok();
-    if let Some(ref cwd) = cwd {
-        let git = GitVcs::new(Arc::new(ProcessCommandRunner));
-        let ee_cwd = ExecutionEnvironmentPath::new(cwd);
-        if let Some(repo_root) = git.resolve_repo_root(&ee_cwd).await {
-            if !repo_roots.contains(&repo_root) {
-                repo_roots.push(repo_root);
-            }
-        }
-    }
-
-    // Persist any new repos
-    for path in &repo_roots {
-        config.save_repo(path);
-    }
-
-    repo_roots
 }
 
 #[cfg(test)]

--- a/crates/flotilla-core/src/config/tests.rs
+++ b/crates/flotilla-core/src/config/tests.rs
@@ -126,24 +126,6 @@ fn load_repos_returns_empty_when_dir_missing() {
 }
 
 #[test]
-fn legacy_tab_order_loads_and_tolerates_parse_failures() {
-    let dir = tempdir().unwrap();
-    let base = dir.path();
-    let store = ConfigStore::with_base(base);
-
-    assert!(store.load_tab_order().is_none());
-
-    std::fs::write(base.join("tab-order.json"), r#"["/a", "/b"]"#).expect("write tab-order fixture");
-    assert_eq!(store.load_tab_order(), Some(vec![ee("/a"), ee("/b")]));
-
-    std::fs::write(base.join("tab-order.json"), "not json {{{").expect("write tab-order fixture");
-    assert!(store.load_tab_order().is_none());
-
-    std::fs::write(base.join("tab-order.json"), r#"{"k":"v"}"#).expect("write tab-order fixture");
-    assert!(store.load_tab_order().is_none());
-}
-
-#[test]
 fn open_views_roundtrip_and_parse_failures() {
     let dir = tempdir().unwrap();
     let base = dir.path();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 Stored in `~/.config/flotilla/`:
 
 - `repos/*.toml` — one file per tracked repo, containing `path = "..."`
-- `tab-order.json` — array of repo paths controlling tab order
+- `open-views.toml` — the ordered set of Views opened by the TUI
 
 Repos are added interactively from within flotilla using the `a` key.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,17 @@ use std::{path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use color_eyre::Result;
-use flotilla_core::{agents, config::ConfigStore, daemon::DaemonHandle, path_context::DaemonHostPath, path_policy::PathPolicy};
+use flotilla_core::{
+    agents,
+    config::ConfigStore,
+    daemon::DaemonHandle,
+    path_context::{DaemonHostPath, ExecutionEnvironmentPath},
+    path_policy::PathPolicy,
+    providers::{
+        vcs::{git::GitVcs, Vcs},
+        ProcessCommandRunner,
+    },
+};
 use flotilla_protocol::{
     commands::CommandValue, output::OutputFormat, AgentHookEvent, AttachableId, Command, CommandAction, EnvironmentId, HostName,
     RepoSelector,
@@ -283,6 +293,28 @@ fn exit_cli_parse_error(error: clap::Error) -> ! {
     std::process::exit(exit_code)
 }
 
+fn select_startup_repo_roots(cli_roots: &[PathBuf], cwd_repo_root: Option<PathBuf>) -> Vec<PathBuf> {
+    if cli_roots.is_empty() {
+        cwd_repo_root.into_iter().collect()
+    } else {
+        cli_roots.iter().map(|root| std::fs::canonicalize(root).unwrap_or_else(|_| root.clone())).collect()
+    }
+}
+
+async fn startup_repo_roots(cli_roots: &[PathBuf]) -> Vec<PathBuf> {
+    let cwd_repo_root = if cli_roots.is_empty() {
+        let cwd = std::env::current_dir().ok().map(ExecutionEnvironmentPath::new);
+        let vcs = GitVcs::new(Arc::new(ProcessCommandRunner));
+        match cwd {
+            Some(cwd) => vcs.resolve_repo_root(&cwd).await.map(ExecutionEnvironmentPath::into_path_buf),
+            None => None,
+        }
+    } else {
+        None
+    };
+    select_startup_repo_roots(cli_roots, cwd_repo_root)
+}
+
 /// Run the TUI. With `scoped_view`, run in scoped mode: exactly that View,
 /// no tab shell, no open-view persistence.
 async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) -> Result<()> {
@@ -299,7 +331,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     #[cfg(unix)]
     flotilla_tui::terminal::install_sigterm_handler();
 
-    let cli_repo_roots = cli.repo_root.clone();
+    let startup_repo_roots = startup_repo_roots(&cli.repo_root).await;
     let cli_theme = cli.theme.clone();
 
     // Spawn daemon init on a separate task so it runs concurrently with the splash
@@ -333,18 +365,17 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
         }
     };
 
-    for root in &cli_repo_roots {
-        let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+    for root in startup_repo_roots {
         if let Err(e) = daemon
             .execute(flotilla_protocol::Command {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: flotilla_protocol::CommandAction::TrackRepoPath { path: canonical.clone() },
+                action: flotilla_protocol::CommandAction::TrackRepoPath { path: root.clone() },
             })
             .await
         {
-            info!(repo = %canonical.display(), err = %e, "failed to add repo");
+            info!(repo = %root.display(), err = %e, "failed to add repo");
         }
     }
 
@@ -1033,12 +1064,32 @@ fn uninstall_claude_code_hooks(path: &std::path::Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use clap::Parser;
     use flotilla_protocol::{
         qualified_path::HostId, EnvironmentId, HostListEntry, HostName, NodeId, NodeInfo, PeerConnectionState, ProvisioningTarget,
     };
 
-    use super::{provisioning_target_for_environment, run_replica_snapshot, select_host_target, Cli, SubCommand};
+    use super::{
+        provisioning_target_for_environment, run_replica_snapshot, select_host_target, select_startup_repo_roots, Cli, SubCommand,
+    };
+
+    #[test]
+    fn explicit_repo_roots_take_precedence_over_cwd_detection() {
+        let explicit = vec![PathBuf::from("/repos/one"), PathBuf::from("/repos/two")];
+
+        let roots = select_startup_repo_roots(&explicit, Some(PathBuf::from("/repos/current")));
+
+        assert_eq!(roots, explicit);
+    }
+
+    #[test]
+    fn cwd_repo_is_used_when_no_explicit_root_is_given() {
+        let roots = select_startup_repo_roots(&[], Some(PathBuf::from("/repos/current")));
+
+        assert_eq!(roots, vec![PathBuf::from("/repos/current")]);
+    }
 
     #[test]
     fn cli_parses_topology_subcommand() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,14 @@ fn select_startup_repo_roots(cli_roots: &[PathBuf], cwd_repo_root: Option<PathBu
     if cli_roots.is_empty() {
         cwd_repo_root.into_iter().collect()
     } else {
-        cli_roots.iter().map(|root| std::fs::canonicalize(root).unwrap_or_else(|_| root.clone())).collect()
+        let mut roots = Vec::with_capacity(cli_roots.len());
+        for root in cli_roots {
+            let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+            if !roots.contains(&canonical) {
+                roots.push(canonical);
+            }
+        }
+        roots
     }
 }
 
@@ -1082,6 +1089,15 @@ mod tests {
         let roots = select_startup_repo_roots(&explicit, Some(PathBuf::from("/repos/current")));
 
         assert_eq!(roots, explicit);
+    }
+
+    #[test]
+    fn explicit_repo_roots_are_deduplicated_in_argument_order() {
+        let explicit = vec![PathBuf::from("/repos/one"), PathBuf::from("/repos/two"), PathBuf::from("/repos/one")];
+
+        let roots = select_startup_repo_roots(&explicit, None);
+
+        assert_eq!(roots, vec![PathBuf::from("/repos/one"), PathBuf::from("/repos/two")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove the dead `resolve_repo_roots` path and legacy `tab-order.json` loader
- preserve no-argument current-repository discovery in the live startup `TrackRepoPath` path
- make explicit CLI repository roots intentionally take precedence over cwd discovery
- update active configuration docs to name `open-views.toml`

## Root cause

Embedded-mode removal left repository-root resolution disconnected from startup. The legacy tab-order loader also no longer seeded any live view state, so both paths had become dead while the useful current-working-directory fallback had been lost.

When explicit roots are supplied, startup tracks exactly those roots. Cwd discovery is only a no-argument fallback, avoiding an unexpected extra repository alongside an explicit selection.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (GitHub Actions)
- focused startup repository selection tests
- `cargo test -p flotilla-core --locked config::tests`

All GitHub Actions checks pass. The workspace suite also passed locally before the final rebase; a post-rebase daemon timeout under concurrent local Rust build load did not reproduce in CI.

Closes #707