### PR TITLE
fix: require hello handshake for socket connections

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -98,22 +98,13 @@ pub struct SocketDaemon {
 impl SocketDaemon {
     /// Connect to a running daemon at the given Unix socket path.
     ///
-    /// Builds a session from the socket and then starts the shared client
-    /// reader/pending-request machinery on top of it.
+    /// Requires a bounded, stateful Hello handshake before starting the shared
+    /// client reader/pending-request machinery. This makes protocol-version
+    /// validation part of every real socket connection rather than an opt-in
+    /// call-site choice.
     pub async fn connect(socket_path: &Path) -> Result<Arc<Self>, String> {
         let session = connect_unix_message_session(socket_path).await?;
-        Self::from_session(session)
-    }
-
-    /// Connect to a running daemon with a stateful Hello handshake.
-    ///
-    /// Sends a `Hello` with `ConnectionRole::Client` and a fresh `session_id`,
-    /// waits for the server's Hello reply, then builds the normal client session.
-    /// The `session_id` enables cursor ownership for directed query responses.
-    pub async fn connect_stateful(socket_path: &Path) -> Result<Arc<Self>, String> {
-        let session = connect_unix_message_session(socket_path).await?;
-        do_client_hello(&session).await?;
-        Self::from_session(session)
+        from_session_stateful_bounded(socket_path, session).await
     }
 
     /// Build a client from an existing `MessageSession`, performing a Hello
@@ -470,8 +461,12 @@ async fn connect_existing_stateful(socket_path: &Path) -> Result<Option<Arc<Sock
         Ok(session) => session,
         Err(_) => return Ok(None),
     };
+    from_session_stateful_bounded(socket_path, session).await.map(Some)
+}
+
+async fn from_session_stateful_bounded(socket_path: &Path, session: MessageSession) -> Result<Arc<SocketDaemon>, String> {
     match tokio::time::timeout(HELLO_HANDSHAKE_TIMEOUT, SocketDaemon::from_session_stateful(session)).await {
-        Ok(result) => result.map(Some),
+        Ok(result) => result,
         Err(_) => Err(format!(
             "daemon at {} accepted the connection but did not complete the Hello handshake within {}s — it may be wedged; check or restart it",
             socket_path.display(),

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -6,10 +6,7 @@ use flotilla_protocol::{
     EnvironmentId, NodeId, NodeInfo, RepoDelta, RepoIdentity, RepoSnapshot,
 };
 use flotilla_transport::message::{message_session_pair, unix_message_session, MessageSession};
-use tokio::{
-    io::{AsyncBufReadExt, BufReader},
-    net::UnixListener,
-};
+use tokio::net::UnixListener;
 
 use super::*;
 
@@ -244,6 +241,47 @@ async fn client_hello_rejects_daemon_protocol_version_mismatch() {
 }
 
 #[tokio::test]
+async fn connect_rejects_daemon_protocol_version_mismatch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket_path = dir.path().join("daemon.sock");
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!("skipping connect_rejects_daemon_protocol_version_mismatch: unix socket bind not permitted: {err}");
+            return;
+        }
+        Err(err) => panic!("bind listener: {err}"),
+    };
+
+    let server_task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept client");
+        let session = unix_message_session(stream);
+        let hello = session.read().await.expect("read client hello").expect("client hello");
+        assert!(matches!(hello, Message::Hello { protocol_version: PROTOCOL_VERSION, .. }));
+        session
+            .write(Message::Hello {
+                protocol_version: PROTOCOL_VERSION - 1,
+                node_id: NodeId::new("stale-daemon"),
+                display_name: "stale daemon".into(),
+                session_id: uuid::Uuid::new_v4(),
+                connection_role: Some(ConnectionRole::Client),
+            })
+            .await
+            .expect("write stale daemon hello");
+    });
+
+    let error = match SocketDaemon::connect(&socket_path).await {
+        Ok(_) => {
+            server_task.abort();
+            panic!("public socket connections must reject an incompatible daemon");
+        }
+        Err(error) => error,
+    };
+    assert!(error.contains("protocol version mismatch"), "unexpected error: {error}");
+    server_task.await.expect("join server task");
+}
+
+#[tokio::test]
 async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
     let dir = tempfile::tempdir().expect("tempdir");
     let socket_path = dir.path().join("daemon.sock");
@@ -402,16 +440,28 @@ async fn dropping_socket_daemon_closes_connection_promptly() {
 
     let accept_task = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.expect("accept client");
-        stream
+        let session = unix_message_session(stream);
+        let hello = session.read().await.expect("read client hello").expect("client hello");
+        assert!(matches!(hello, Message::Hello { protocol_version: PROTOCOL_VERSION, .. }));
+        session
+            .write(Message::Hello {
+                protocol_version: PROTOCOL_VERSION,
+                node_id: NodeId::new("daemon"),
+                display_name: "daemon".into(),
+                session_id: uuid::Uuid::new_v4(),
+                connection_role: Some(ConnectionRole::Client),
+            })
+            .await
+            .expect("write daemon hello");
+        session
     });
 
     let daemon = SocketDaemon::connect(&socket_path).await.expect("connect socket daemon");
-    let server_stream = accept_task.await.expect("join accept task");
+    let server_session = accept_task.await.expect("join accept task");
 
     drop(daemon);
 
-    let mut server_lines = BufReader::new(server_stream).lines();
-    let eof = tokio::time::timeout(Duration::from_millis(100), server_lines.next_line())
+    let eof = tokio::time::timeout(Duration::from_millis(100), server_session.read())
         .await
         .expect("client drop should close connection promptly")
         .expect("read server EOF");


### PR DESCRIPTION
## Summary

- make `SocketDaemon::connect` perform the bounded stateful Hello handshake by default
- remove the opt-in `connect_stateful` socket constructor so production socket callers cannot bypass version validation
- update real-socket client tests to negotiate Hello and cover a stale daemon version directly

## Why

`status`, `watch`, and `replica-snapshot` all used the public socket constructor without exchanging protocol versions. Against an incompatible daemon they could therefore fail with confusing cross-version wire errors instead of the existing actionable version-mismatch diagnostic.

The public socket boundary now guarantees a compatible, responsive daemon before normal request handling begins, while retaining non-spawning behavior for these commands.

Closes #716.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-client --locked`
- `cargo test -p flotilla-daemon --locked --test socket_roundtrip`
- independent Standards and Spec review against #716