### PR TITLE
fix: keep attachable set identity stable

### DIFF
--- a/crates/flotilla-core/src/attachable/store.rs
+++ b/crates/flotilla-core/src/attachable/store.rs
@@ -357,12 +357,25 @@ impl AttachableStoreState {
     }
 
     fn remove_member_link(&mut self, set_id: &AttachableSetId, attachable_id: &AttachableId) -> bool {
-        if let Some(set) = self.registry.sets.get_mut(set_id) {
+        let changed = if let Some(set) = self.registry.sets.get_mut(set_id) {
             let original_len = set.members.len();
             set.members.retain(|member| member != attachable_id);
-            return set.members.len() != original_len;
+            set.members.len() != original_len
+        } else {
+            false
+        };
+        if changed {
+            let is_empty = self.registry.sets.get(set_id).is_some_and(|set| set.members.is_empty());
+            let is_bound = self
+                .registry
+                .bindings
+                .iter()
+                .any(|binding| binding.object_kind == BindingObjectKind::AttachableSet && binding.object_id == set_id.as_str());
+            if is_empty && !is_bound {
+                self.registry.sets.shift_remove(set_id);
+            }
         }
-        false
+        changed
     }
 
     fn remove_set(&mut self, id: &AttachableSetId) -> Option<RemovedSetInfo> {

--- a/crates/flotilla-core/src/attachable/store/tests.rs
+++ b/crates/flotilla-core/src/attachable/store/tests.rs
@@ -146,6 +146,48 @@ fn contract_moving_last_attachable_prunes_unbound_source_set(store: &mut impl At
     assert_eq!(store.registry().sets.get(&target_set_id).map(|set| set.members.as_slice()), Some([attachable_id].as_slice()));
 }
 
+fn contract_moving_last_attachable_preserves_bound_source_set(store: &mut impl AttachableStoreApi) {
+    let host = HostName::new("desktop");
+    let source_set_id = store.ensure_terminal_set(Some(host.clone()), Some(HostPath::new(host.clone(), "/repo/source").into()));
+    let target_set_id = store.ensure_terminal_set(Some(host.clone()), Some(HostPath::new(host, "/repo/target").into()));
+    let attachable_id = store.ensure_terminal_attachable(
+        &source_set_id,
+        "terminal_pool",
+        "shpool",
+        "session-1",
+        TerminalPurpose { checkout: "source".into(), role: "main".into(), index: 0 },
+        "claude",
+        ExecutionEnvironmentPath::new("/repo/source"),
+        TerminalStatus::Running,
+    );
+    store.replace_binding(ProviderBinding {
+        provider_category: "workspace_manager".into(),
+        provider_name: "cmux".into(),
+        object_kind: BindingObjectKind::AttachableSet,
+        object_id: source_set_id.to_string(),
+        external_ref: "workspace:1".into(),
+    });
+
+    let moved_id = store.ensure_terminal_attachable(
+        &target_set_id,
+        "terminal_pool",
+        "shpool",
+        "session-1",
+        TerminalPurpose { checkout: "target".into(), role: "main".into(), index: 0 },
+        "claude",
+        ExecutionEnvironmentPath::new("/repo/target"),
+        TerminalStatus::Running,
+    );
+
+    assert_eq!(moved_id, attachable_id);
+    assert_eq!(store.registry().sets.get(&source_set_id).map(|set| set.members.as_slice()), Some([].as_slice()));
+    assert_eq!(
+        store.lookup_binding("workspace_manager", "cmux", BindingObjectKind::AttachableSet, "workspace:1"),
+        Some(source_set_id.as_str())
+    );
+    assert_eq!(store.registry().sets.get(&target_set_id).map(|set| set.members.as_slice()), Some([attachable_id].as_slice()));
+}
+
 fn contract_replacing_binding_is_deterministic(store: &mut impl AttachableStoreApi) {
     store.replace_binding(ProviderBinding {
         provider_category: "workspace_manager".into(),
@@ -325,6 +367,18 @@ fn file_backed_contract_moving_last_attachable_prunes_unbound_source_set() {
 #[test]
 fn in_memory_contract_moving_last_attachable_prunes_unbound_source_set() {
     contract_moving_last_attachable_prunes_unbound_source_set(&mut InMemoryAttachableStore::new());
+}
+
+#[test]
+fn file_backed_contract_moving_last_attachable_preserves_bound_source_set() {
+    contract_moving_last_attachable_preserves_bound_source_set(&mut AttachableStore::with_base(&temp_base(
+        &tempfile::tempdir().expect("tempdir"),
+    )));
+}
+
+#[test]
+fn in_memory_contract_moving_last_attachable_preserves_bound_source_set() {
+    contract_moving_last_attachable_preserves_bound_source_set(&mut InMemoryAttachableStore::new());
 }
 
 #[test]

--- a/crates/flotilla-core/src/attachable/store/tests.rs
+++ b/crates/flotilla-core/src/attachable/store/tests.rs
@@ -115,6 +115,37 @@ fn contract_ensure_terminal_attachable_uses_binding_as_primary_identity(store: &
     );
 }
 
+fn contract_moving_last_attachable_prunes_unbound_source_set(store: &mut impl AttachableStoreApi) {
+    let host = HostName::new("desktop");
+    let source_set_id = store.ensure_terminal_set(Some(host.clone()), Some(HostPath::new(host.clone(), "/repo/source").into()));
+    let target_set_id = store.ensure_terminal_set(Some(host.clone()), Some(HostPath::new(host, "/repo/target").into()));
+    let attachable_id = store.ensure_terminal_attachable(
+        &source_set_id,
+        "terminal_pool",
+        "shpool",
+        "session-1",
+        TerminalPurpose { checkout: "source".into(), role: "main".into(), index: 0 },
+        "claude",
+        ExecutionEnvironmentPath::new("/repo/source"),
+        TerminalStatus::Running,
+    );
+
+    let moved_id = store.ensure_terminal_attachable(
+        &target_set_id,
+        "terminal_pool",
+        "shpool",
+        "session-1",
+        TerminalPurpose { checkout: "target".into(), role: "main".into(), index: 0 },
+        "claude",
+        ExecutionEnvironmentPath::new("/repo/target"),
+        TerminalStatus::Running,
+    );
+
+    assert_eq!(moved_id, attachable_id);
+    assert!(!store.registry().sets.contains_key(&source_set_id), "unbound source set should be removed when its last member moves");
+    assert_eq!(store.registry().sets.get(&target_set_id).map(|set| set.members.as_slice()), Some([attachable_id].as_slice()));
+}
+
 fn contract_replacing_binding_is_deterministic(store: &mut impl AttachableStoreApi) {
     store.replace_binding(ProviderBinding {
         provider_category: "workspace_manager".into(),
@@ -282,6 +313,18 @@ fn file_backed_contract_ensure_terminal_attachable_uses_binding_as_primary_ident
 #[test]
 fn in_memory_contract_ensure_terminal_attachable_uses_binding_as_primary_identity() {
     contract_ensure_terminal_attachable_uses_binding_as_primary_identity(&mut InMemoryAttachableStore::new());
+}
+
+#[test]
+fn file_backed_contract_moving_last_attachable_prunes_unbound_source_set() {
+    contract_moving_last_attachable_prunes_unbound_source_set(&mut AttachableStore::with_base(&temp_base(
+        &tempfile::tempdir().expect("tempdir"),
+    )));
+}
+
+#[test]
+fn in_memory_contract_moving_last_attachable_prunes_unbound_source_set() {
+    contract_moving_last_attachable_prunes_unbound_source_set(&mut InMemoryAttachableStore::new());
 }
 
 #[test]

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -51,6 +51,14 @@ fn display_host_for_checkout_path(providers_data: &ProviderData, checkout_path: 
     })
 }
 
+fn known_local_checkout_key<'a>(
+    providers_data: &'a ProviderData,
+    checkout_path: &Path,
+    local_host: &HostName,
+) -> Option<&'a QualifiedPath> {
+    providers_data.checkouts.keys().find(|key| key.path == checkout_path && checkout_is_local_owned(key, local_host))
+}
+
 fn workspace_label_for_host(
     label: &str,
     target_node_id: &NodeId,
@@ -763,7 +771,10 @@ impl StepResolver for ExecutorStepResolver {
                     &self.local_host,
                     tm.as_ref(),
                 );
-                service.create_workspace_for_teleport(&path, branch.as_deref(), &cmd).await?;
+                let checkout_key = known_local_checkout_key(self.providers_data.as_ref(), &path, &self.local_host)
+                    .cloned()
+                    .unwrap_or_else(|| QualifiedPath::host(self.environment_manager.local_host_id().clone(), path.clone()));
+                service.create_workspace_for_teleport(&path, &checkout_key, branch.as_deref(), &cmd).await?;
                 Ok(StepOutcome::Completed)
             }
             StepAction::ArchiveSession { session_id } => {
@@ -828,11 +839,11 @@ impl StepResolver for ExecutorStepResolver {
                 let workspace_config =
                     workspace_config(self.repo.root.as_path(), &label, checkout_path.as_path(), "claude", self.config_base.as_path());
                 let template_yaml = workspace_config.template_yaml.clone();
-                let prepared_commands = if let Some(ref tm) = tm {
+                let prepared_commands = if let (Some(tm), Some(set_id)) = (tm.as_ref(), attachable_set_id.as_ref()) {
                     let terminal_preparation = TerminalPreparationService::new(tm, self.daemon_socket_path.as_ref().map(|p| p.as_path()));
                     let workspace_config = workspace_config.clone();
                     terminal_preparation
-                        .prepare_terminal_commands(&branch, checkout_path.as_path(), &[], move || workspace_config.clone())
+                        .prepare_terminal_commands(set_id, &branch, checkout_path.as_path(), &[], move || workspace_config.clone())
                         .await?
                 } else {
                     let workspace_config = workspace_config.clone();
@@ -974,11 +985,11 @@ impl StepResolver for ExecutorStepResolver {
                         Some(&checkout_key),
                         None,
                     );
-                    let commands = if let Some(ref tm) = tm {
+                    let commands = if let (Some(tm), Some(set_id)) = (tm.as_ref(), attachable_set_id.as_ref()) {
                         let terminal_preparation =
                             TerminalPreparationService::new(tm, self.daemon_socket_path.as_ref().map(|p| p.as_path()));
                         terminal_preparation
-                            .prepare_terminal_commands(&co.branch, checkout_path.as_path(), &requested_commands, || {
+                            .prepare_terminal_commands(set_id, &co.branch, checkout_path.as_path(), &requested_commands, || {
                                 workspace_config(
                                     self.repo.root.as_path(),
                                     &co.branch,

--- a/crates/flotilla-core/src/executor/session_actions.rs
+++ b/crates/flotilla-core/src/executor/session_actions.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, path::Path};
 
-use flotilla_protocol::{provider_data::Issue, CommandValue, HostName};
+use flotilla_protocol::{provider_data::Issue, qualified_path::QualifiedPath, CommandValue, HostName};
 use tracing::{info, warn};
 
-use super::WorkspaceOrchestrator;
+use super::{known_local_checkout_key, WorkspaceOrchestrator};
 use crate::{
     attachable::SharedAttachableStore,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
@@ -215,6 +215,7 @@ impl<'a> TeleportSessionActionService<'a> {
     pub(super) async fn create_workspace_for_teleport(
         &self,
         checkout_path: &Path,
+        checkout_key: &QualifiedPath,
         branch: Option<&str>,
         teleport_cmd: &str,
     ) -> Result<(), String> {
@@ -228,14 +229,12 @@ impl<'a> TeleportSessionActionService<'a> {
             self.terminal_manager,
         );
         let name = branch.unwrap_or("session");
-        workspace_orchestrator.create_workspace_for_teleport(checkout_path, name, teleport_cmd).await
+        workspace_orchestrator.create_workspace_for_teleport(checkout_path, Some(checkout_key), name, teleport_cmd).await
     }
 
     fn checkout_path_from_key(&self, checkout_key: Option<&ExecutionEnvironmentPath>) -> Option<ExecutionEnvironmentPath> {
-        checkout_key.and_then(|key| {
-            let host_key = flotilla_protocol::qualified_path::QualifiedPath::from_host_name(self.local_host, key.as_path().to_path_buf());
-            self.read_only.providers_data.checkouts.get(&host_key).map(|_| key.clone())
-        })
+        checkout_key
+            .and_then(|key| known_local_checkout_key(self.read_only.providers_data, key.as_path(), self.local_host).map(|_| key.clone()))
     }
 }
 

--- a/crates/flotilla-core/src/executor/terminals.rs
+++ b/crates/flotilla-core/src/executor/terminals.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use flotilla_protocol::{arg::Arg, HostName, HostPath, PreparedTerminalCommand, ResolvedPaneCommand};
+use flotilla_protocol::{arg::Arg, AttachableSetId, PreparedTerminalCommand, ResolvedPaneCommand};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -20,18 +20,9 @@ impl<'a> TerminalPreparationService<'a> {
         Self { terminal_manager, daemon_socket_path }
     }
 
-    pub(super) async fn resolve_workspace_commands(&self, config: &mut WorkspaceConfig) {
+    pub(super) async fn resolve_workspace_commands_in_set(&self, config: &mut WorkspaceConfig, set_id: &AttachableSetId) {
         let rendered = parse_workspace_template(config).render(&config.template_vars);
         info!(count = rendered.content.len(), "terminal manager: resolving content entries");
-        let host = HostName::local();
-        let checkout_path = HostPath::new(host.clone(), config.working_directory.clone().into_path_buf());
-        let set_id = match self.terminal_manager.allocate_set(host, checkout_path.into()) {
-            Ok(id) => id,
-            Err(err) => {
-                warn!(err = %err, "failed to allocate terminal set");
-                return;
-            }
-        };
         let socket_str = self.daemon_socket_path.map(|p| p.display().to_string());
         let mut resolved = Vec::new();
         for entry in &rendered.content {
@@ -80,15 +71,13 @@ impl<'a> TerminalPreparationService<'a> {
 
     pub(super) async fn prepare_terminal_commands(
         &self,
+        set_id: &AttachableSetId,
         branch: &str,
         checkout_path: &Path,
         requested_commands: &[PreparedTerminalCommand],
         workspace_config: impl FnOnce() -> WorkspaceConfig,
     ) -> Result<Vec<ResolvedPaneCommand>, String> {
         if !requested_commands.is_empty() {
-            let host = HostName::local();
-            let hp = HostPath::new(host.clone(), checkout_path.to_path_buf());
-            let set_id = self.terminal_manager.allocate_set(host, hp.into())?;
             let socket_str = self.daemon_socket_path.map(|p| p.display().to_string());
 
             let mut resolved = Vec::new();
@@ -135,7 +124,7 @@ impl<'a> TerminalPreparationService<'a> {
         }
 
         let mut config = workspace_config();
-        self.resolve_workspace_commands(&mut config).await;
+        self.resolve_workspace_commands_in_set(&mut config, set_id).await;
 
         let commands = if let Some(resolved) = config.resolved_commands { resolved } else { render_template_commands(&config) };
 

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -1005,12 +1005,15 @@ async fn teleport_session_creates_workspace_even_when_one_exists() {
 #[tokio::test]
 async fn teleport_session_persists_workspace_binding() {
     let workspace_manager = Arc::new(MockWorkspaceManager::succeeding());
+    let terminal_pool = Arc::new(MockTerminalPool { killed: tokio::sync::Mutex::new(vec![]) });
     let mut registry = empty_registry();
     registry.cloud_agents.insert("claude", desc("claude"), Arc::new(MockCloudAgent::succeeding()));
     registry.presentation_managers.insert("cmux", desc("cmux"), Arc::clone(&workspace_manager) as Arc<dyn PresentationManager>);
+    registry.terminal_pools.insert("shpool", desc("shpool"), terminal_pool);
     let mut data = empty_data();
     data.sessions.insert("sess-1".to_string(), TestSession::new("test session").with_session_ref("claude", "sess-1").build());
-    data.checkouts.insert(hp("/repo/wt-feat").into(), TestCheckout::new("feat").build());
+    let checkout_key = QualifiedPath::host(HostId::new("test-local-host-id"), "/repo/wt-feat");
+    data.checkouts.insert(checkout_key.clone(), TestCheckout::new("feat").build());
     let runner = runner_ok();
     let temp = tempfile::tempdir().expect("tempdir");
     let attachable_store = test_attachable_store(&DaemonHostPath::new(temp.path()));
@@ -1036,7 +1039,9 @@ async fn teleport_session_persists_workspace_binding() {
         .lookup_binding("workspace_manager", "cmux", BindingObjectKind::AttachableSet, "mock-ref")
         .expect("workspace binding should exist");
     let set = store.registry().sets.values().find(|set| set.id.as_str() == object_id).expect("set should exist");
-    assert_eq!(set.checkout, Some(HostPath::new(local_host(), PathBuf::from("/repo/wt-feat")).into()));
+    assert_eq!(store.registry().sets.len(), 1, "teleport should use one canonical attachable set");
+    assert_eq!(set.checkout, Some(checkout_key));
+    assert!(!set.members.is_empty(), "workspace binding should point to the set holding the terminal");
 }
 // -----------------------------------------------------------------------
 // Tests: SelectWorkspace
@@ -1843,23 +1848,35 @@ async fn teleport_session_uses_provider_specific_attach_command() {
 
 #[tokio::test]
 async fn teleport_session_with_branch_creates_checkout() {
+    let terminal_pool = Arc::new(MockTerminalPool { killed: tokio::sync::Mutex::new(vec![]) });
     let mut registry = empty_registry();
     registry.cloud_agents.insert("claude", desc("claude"), Arc::new(MockCloudAgent::succeeding()));
     registry.checkout_managers.insert("wt", desc("wt"), Arc::new(MockCheckoutManager::succeeding("feat", "/repo/wt-feat")));
     registry.presentation_managers.insert("cmux", desc("cmux"), Arc::new(MockWorkspaceManager::succeeding()));
+    registry.terminal_pools.insert("shpool", desc("shpool"), terminal_pool);
     let mut data = empty_data();
     data.sessions.insert("sess-1".to_string(), TestSession::new("test session").with_session_ref("claude", "sess-1").build());
     let runner = runner_ok();
+    let attachable_store = crate::attachable::shared_in_memory_attachable_store();
 
-    let result = run_build_plan_to_completion(
+    let result = run_build_plan_to_completion_with(
         CommandAction::TeleportSession { session_id: "sess-1".to_string(), branch: Some("feat".to_string()), checkout_key: None },
         registry,
         data,
         runner,
+        repo_root(),
+        config_base(),
+        attachable_store.clone(),
     )
     .await;
 
     assert_ok(result);
+    let store = attachable_store.lock().expect("attachable store lock");
+    assert_eq!(store.registry().sets.len(), 1, "fresh teleport checkout should use one canonical set");
+    let set = store.registry().sets.values().next().expect("canonical set");
+    assert_eq!(set.checkout, Some(QualifiedPath::host(HostId::new("test-local-host-id"), "/repo/wt-feat")));
+    assert!(!set.members.is_empty(), "canonical set should hold the terminal");
+    assert_eq!(store.lookup_binding("workspace_manager", "cmux", BindingObjectKind::AttachableSet, "mock-ref"), Some(set.id.as_str()));
 }
 
 #[tokio::test]
@@ -2393,10 +2410,12 @@ async fn checkout_plan_end_to_end_creates_workspace() {
     let mut registry = ProviderRegistry::new();
     registry.checkout_managers.insert("wt", desc("wt"), Arc::new(MockCheckoutManager::succeeding("feat-x", "/repo/wt-feat-x")));
     registry.presentation_managers.insert("cmux", desc("cmux"), Arc::clone(&ws_mgr) as Arc<dyn PresentationManager>);
+    registry.terminal_pools.insert("shpool", desc("shpool"), Arc::new(MockTerminalPool { killed: tokio::sync::Mutex::new(vec![]) }));
     let registry = Arc::new(registry);
     let runner: Arc<dyn CommandRunner> = Arc::new(MockRunner::new(vec![Err("missing".into()), Err("missing".into())]));
     let providers_data = Arc::new(empty_data());
-    let cb = config_base();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cb = DaemonHostPath::new(temp.path());
     let attachable = test_attachable_store(&cb);
     let lh = local_host();
     let repo = RepoExecutionContext { identity: repo_identity(), root: repo_root() };
@@ -2446,6 +2465,14 @@ async fn checkout_plan_end_to_end_creates_workspace() {
     let store = attachable.lock().expect("attachable store lock");
     let matching_sets = store.sets_for_checkout(&expected_checkout);
     assert_eq!(matching_sets.len(), 1, "new checkout should create one attachable set with its stable qualified path");
+    assert_eq!(store.registry().sets.len(), 1, "workspace terminals must not create a second set for the same checkout");
+    let set = store.registry().sets.get(&matching_sets[0]).expect("canonical attachable set");
+    assert!(!set.members.is_empty(), "workspace terminals should belong to the canonical attachable set");
+    assert_eq!(
+        store.lookup_binding("workspace_manager", "cmux", BindingObjectKind::AttachableSet, "mock-ref"),
+        Some(set.id.as_str()),
+        "workspace binding should point at the terminal-holding set"
+    );
 }
 
 #[tokio::test]
@@ -3092,7 +3119,8 @@ async fn resolve_workspace_commands_no_template_uses_default() {
     };
 
     let service = super::terminals::TerminalPreparationService::new(&tm, None);
-    service.resolve_workspace_commands(&mut config).await;
+    let set_id = tm.allocate_set(HostName::local(), HostPath::new(HostName::local(), "/repo/wt").into()).expect("allocate terminal set");
+    service.resolve_workspace_commands_in_set(&mut config, &set_id).await;
 
     // Default template has one "main" terminal entry
     assert!(config.resolved_commands.is_some());
@@ -3121,7 +3149,8 @@ content:
     };
 
     let service = super::terminals::TerminalPreparationService::new(&tm, None);
-    service.resolve_workspace_commands(&mut config).await;
+    let set_id = tm.allocate_set(HostName::local(), HostPath::new(HostName::local(), "/repo/wt").into()).expect("allocate terminal set");
+    service.resolve_workspace_commands_in_set(&mut config, &set_id).await;
 
     // All content entries were non-terminal, so resolved_commands stays None
     assert!(config.resolved_commands.is_none());
@@ -3132,6 +3161,7 @@ async fn prepare_terminal_commands_wraps_requested_commands_via_terminal_manager
     let mock_pool: Arc<dyn TerminalPool> = Arc::new(MockTerminalPool { killed: tokio::sync::Mutex::new(vec![]) });
     let store = crate::attachable::shared_in_memory_attachable_store();
     let tm = crate::terminal_manager::TerminalManager::new(mock_pool, store, HostName::local());
+    let set_id = tm.allocate_set(HostName::local(), HostPath::new(HostName::local(), "/repo/wt").into()).expect("allocate terminal set");
 
     let service = super::terminals::TerminalPreparationService::new(&tm, None);
     let requested = vec![PreparedTerminalCommand { role: "main".into(), command: "claude".into() }, PreparedTerminalCommand {
@@ -3140,7 +3170,7 @@ async fn prepare_terminal_commands_wraps_requested_commands_via_terminal_manager
     }];
 
     let result = service
-        .prepare_terminal_commands("feat", Path::new("/repo/wt"), &requested, || panic!("workspace config should not be built"))
+        .prepare_terminal_commands(&set_id, "feat", Path::new("/repo/wt"), &requested, || panic!("workspace config should not be built"))
         .await
         .expect("prepare requested terminal commands");
 
@@ -3167,7 +3197,8 @@ async fn resolve_workspace_commands_invalid_template_uses_default() {
     };
 
     let service = super::terminals::TerminalPreparationService::new(&tm, None);
-    service.resolve_workspace_commands(&mut config).await;
+    let set_id = tm.allocate_set(HostName::local(), HostPath::new(HostName::local(), "/repo/wt").into()).expect("allocate terminal set");
+    service.resolve_workspace_commands_in_set(&mut config, &set_id).await;
 
     let commands = config.resolved_commands.expect("invalid template should fall back to default template");
     assert_eq!(commands.len(), 1);

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -2492,7 +2492,8 @@ async fn checkout_plan_creates_workspace_for_preexisting_checkout() {
     let mut data = empty_data();
     data.checkouts.insert(hp("/repo/wt-feat-x").into(), TestCheckout::new("feat-x").build());
     let providers_data = Arc::new(data);
-    let cb = config_base();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cb = DaemonHostPath::new(temp.path());
     let attachable = test_attachable_store(&cb);
     let lh = local_host();
     let repo = RepoExecutionContext { identity: repo_identity(), root: repo_root() };
@@ -2555,7 +2556,8 @@ async fn checkout_plan_preserves_checkout_created_when_workspace_step_fails() {
     let registry = Arc::new(registry);
     let runner: Arc<dyn CommandRunner> = Arc::new(MockRunner::new(vec![Err("missing".into()), Err("missing".into())]));
     let providers_data = Arc::new(empty_data());
-    let cb = config_base();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let cb = DaemonHostPath::new(temp.path());
     let attachable = test_attachable_store(&cb);
     let lh = local_host();
     let repo = RepoExecutionContext { identity: repo_identity(), root: repo_root() };

--- a/crates/flotilla-core/src/executor/workspace.rs
+++ b/crates/flotilla-core/src/executor/workspace.rs
@@ -44,21 +44,32 @@ impl<'a> WorkspaceOrchestrator<'a> {
         Self { repo_root, registry, config_base, attachable_store, daemon_socket_path, local_host, terminal_manager }
     }
 
-    pub(super) async fn create_workspace_for_teleport(&self, checkout_path: &Path, label: &str, teleport_cmd: &str) -> Result<(), String> {
+    pub(super) async fn create_workspace_for_teleport(
+        &self,
+        checkout_path: &Path,
+        checkout_key: Option<&QualifiedPath>,
+        label: &str,
+        teleport_cmd: &str,
+    ) -> Result<(), String> {
         let Some((provider_name, ws_mgr)) = self.preferred_workspace_manager() else {
             return Ok(());
         };
 
+        let attachable_set_id = self.ensure_attachable_set_for_checkout(self.local_host, checkout_path, checkout_key, None);
         let mut config = workspace_config(self.repo_root, label, checkout_path, teleport_cmd, self.config_base);
-        if let Some(tm) = self.terminal_manager {
+        if let (Some(tm), Some(set_id)) = (self.terminal_manager, attachable_set_id.as_ref()) {
             let terminal_preparation = TerminalPreparationService::new(tm, self.daemon_socket_path);
-            terminal_preparation.resolve_workspace_commands(&mut config).await;
+            terminal_preparation.resolve_workspace_commands_in_set(&mut config, set_id).await;
         }
         let attach_request = workspace_attach_request_from_config(config);
 
         match ws_mgr.create_workspace(&attach_request).await {
             Ok((ws_ref, _workspace)) => {
-                self.persist_workspace_binding(provider_name, &ws_ref, self.local_host, checkout_path, None);
+                if let Some(set_id) = attachable_set_id.as_ref() {
+                    self.persist_workspace_binding_for_set(provider_name, &ws_ref, set_id, self.local_host, checkout_path, checkout_key);
+                } else {
+                    self.persist_workspace_binding(provider_name, &ws_ref, self.local_host, checkout_path, checkout_key);
+                }
                 Ok(())
             }
             Err(err) => Err(err),


### PR DESCRIPTION
## Summary

- thread the checkout's canonical attachable-set ID through terminal preparation instead of allocating a second hostname-qualified set
- preserve stable checkout identity for normal workspace creation and both existing/fresh teleport flows
- remove unbound attachable sets when their final member moves or is removed, while preserving intentionally empty bound sets
- add regressions covering checkout plans, teleport flows, and both attachable-store implementations

## Root cause

Workspace preparation created a stable HostId-qualified set for the checkout, but terminal preparation reconstructed the checkout from `HostName::local()` and re-ran set allocation. Because set deduplication uses the exact host/check-out/environment tuple, this produced a second set that held the live terminals while the checkout and workspace binding pointed at the first.

## Impact

Checkout rows, terminal sessions, and workspace bindings now share one attachable-set identity, restoring branch/issue-to-terminal correlation and preventing future empty source-set accumulation.

Existing stale registry files are not migrated, consistent with the repository's no-backward-compatibility policy.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #719