### PR TITLE
docs: ADR 0014 curated scoped queries + ADR 0015 intent completion

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,6 +149,31 @@ cache layer, fetched per external-service+repo (not per host), and the
 **Aggregator** links them to resources for views.
 _Avoid_: Resource (they are not), entity.
 
+**Demand-backed Query**:
+An **Aggregator** query family materialized only while subscribed, fetched
+from an external system of record (issues, change requests), staleness-stamped
+(`as_of`), windowed with fetch-more, discarded on unsubscribe. Contrast
+**store-backed** queries (convoys, independents, checkouts): incrementally
+maintained over the resource store, always warm and complete. Same wire
+contract for both.
+_Avoid_: Cache sync, mirror, replication (nothing persists).
+
+**Completion**:
+The admission-time stage of a create verb that fills what the caller's
+*intent* left blank (branch + convoy names, workflow default) before the spec
+persists — the store never holds a half-spec. Meta-agents are upstream
+completers proposing fuller specs; admission remains the backstop.
+_Avoid_: Defaulting webhook, enrichment, the governor's job.
+
+**Independent**:
+A terminal session with no **Convoy** association — sailing alone, per the
+convoy-era term. Adopted attachables, persistent agents, loose work sessions.
+Appears in the `independents` query and nowhere else; joining a Convoy removes
+it there (convoy-bound sessions surface on vessel rows instead), so nothing is
+ever double-listed.
+_Avoid_: Session (maximally overloaded — cloud agents, cleat, tmux, zellij all
+claim it), free-floating session, loose session.
+
 **External Result**:
 An artifact a **Convoy** produces in an external service — a PR, a CMS article, a
 YouTube video. Producing one is an action with an external result that Flotilla

--- a/docs/adr/0014-curated-scoped-queries-demand-backed-materialization.md
+++ b/docs/adr/0014-curated-scoped-queries-demand-backed-materialization.md
@@ -1,0 +1,118 @@
+# Curated scoped queries; demand-backed materialization
+
+**Status:** Accepted
+**Date:** 2026-07-14
+**Relates to:** ADR 0011 (named-query result sets — this ADR grows `QueryId`
+into parameterized families and adds a second materialization class), ADR 0012
+(tables — this ADR **amends** its generic-tier section), ADR 0006 (resources
+vs reference data — this ADR supplies reference data's query mechanism),
+issue #666 (v1 table slice, rewritten against this ADR), issue #633 (M1
+dogfood — the user stories this was derived from).
+
+Pre-implementation review of #666 surfaced that the generic `Resources{kind}`
+tier silently required an untyped raw-JSON list/watch API on the resource
+backend and turned `QueryId` from a finite enum into an open family — pulling
+against ADR 0011's typed-rows decision. Re-deriving the view layer
+scenario-first from the M1 user stories (add a project; see a project's
+activity including issues; start a convoy from an issue; drive it all from a
+Presentation Manager) showed the generality was not load-bearing: every story
+needs a *specific, typed* query. Separately, the issues story forced a second
+look at what the Aggregator materializes: repos have thousands of issues and
+flotilla must not become a shadow issue tracker.
+
+## Every query family is curated and typed
+
+The v1 view layer is built exclusively from **curated typed query families**:
+`convoys{scope}`, `independents{scope}`, `checkouts{scope}`,
+`issues{scope}`. Rows stay typed structs per ADR 0011; adding a family is a
+`Rows` variant, a row type, and a registry entry. The mechanisms (subscription,
+deltas, registry, generated actions) are generic; the code per kind is
+specific. There is no untyped list/watch on the resource backend and no
+raw-JSON row type.
+
+**The generic `Resources{kind}` tier of ADR 0012 is repositioned as a
+possible future tier, not part of v1.** If it is ever built, its
+representation is **columnar** (a schema plus parallel column arrays —
+structure-of-arrays), not variant rows: a generic consumer renders columns
+positionally and never destructures per-kind row enums. Nothing in v1 may
+presuppose it.
+
+## `QueryId` is a family plus owned scope parameters
+
+`QueryId` grows from a finite `Copy` enum to family + owned parameters, where
+the parameters are **scope**: a project reference or repo key. A project
+scope expands to its constituent repos inside the Aggregator — consumers
+never learn a project's composition. Scope rides the View address per ADR
+0013's `?key=value` channel. Global (unscoped) forms remain for fleet-wide
+tables. Subscription cost scales with what is on screen.
+
+## Two materialization classes, one wire contract
+
+- **Store-backed** queries (`convoys`, `independents`, `checkouts`):
+  incrementally maintained over the resource store; always warm, always
+  complete, flotilla-authoritative.
+- **Demand-backed** queries (`issues`, later `change_requests`): materialized
+  by the Aggregator **only while subscribed**, fetched from the external
+  system of record, discarded on unsubscribe. Nothing persists.
+
+Both classes speak the same `ResultSet`/`ResultDelta`/seq contract, so
+consumers cannot tell them apart except through set metadata: demand-backed
+sets carry `as_of` (staleness is honest by construction) and `has_more`.
+
+A demand-backed materialization is a **window** (first page, updated-desc),
+kept fresh while subscribed via the provider's incremental-sync verbs.
+**Fetch-more is an intent on the result set** — the materializer appends the
+next page as ordinary deltas; paging state lives server-side and consumers
+never stitch pages. Beyond the window you search (a separate ephemeral scoped
+query), not scroll.
+
+The Plane-A provider implementations (`IssueProvider`: paged list, search,
+fetch-by-id, changed-since with ETag handling) are **reused as the fetch
+layer** under the demand-backed materializer. What Plane A's deletion
+condemns is the consumption pipeline (correlation → WorkItem → Snapshot),
+not these adapters.
+
+## Issues are never replicated
+
+The forge is the system of record. Flotilla holds exactly two forms of issue
+data: **references-on-work** — a repo key + issue number on a convoy/branch
+plus a small display snapshot (title, state, `as_of`) so boards render
+offline, bounded by active work — and the transient demand-backed windows
+above. Triage/board intelligence ("what should I or the governor pick up
+next") is add-on-program territory consuming these queries, never core
+features. Growing issue mutation/comment/label features in core is the
+reimplementing-the-tracker failure mode this section exists to forbid.
+
+## `independents`, not `sessions`
+
+The free-floating-sessions query is renamed **`independents`** (rows
+`IndependentRow`), after the convoy-era term for ships sailing outside any
+convoy. "Session" is maximally overloaded (cloud agents, cleat, tmux, zellij)
+and was already attracting misuse. The underlying resource kind remains
+`TerminalSession` — at the resource layer the word is literally correct. The
+exclusion rule stands: a session appears under its convoy's vessel rows *or*
+in `independents`, never both.
+
+## Scope keys are mortal
+
+Scopes are made of repo identity, so repo identity becomes a real referent:
+**Repository is a resource** (convergent-facts class per the #688 model),
+natural-keyed by normalized canonical remote, with `host:path` fallback for
+remote-less repos. Remotes move as ordinary project lifecycle (transfers,
+renames, forge migrations), so the model commits to **`moved` pointers
+(old key → new key) and referent repair**; no referent shape anywhere may
+assume repo keys are immortal. The repair mechanism is built when first
+needed; the commitment is binding now.
+
+## Consequences
+
+- Codex's pre-#666 hidden dependencies on an untyped backend API dissolve;
+  the `QueryId` change shrinks to owned params on curated families.
+- Each new listable kind costs a deliberate design moment (row type, columns,
+  actions). That is a feature: every table someone sees was designed.
+- `Sessions` → `Independents` is a mechanical rename sweep (no compat).
+- Demand-backed metadata (`as_of`, `has_more`) is a protocol addition;
+  store-backed sets simply omit it.
+- The fleet-staleness column #666's acceptance mentions is satisfied
+  per-class: demand-backed rows via `as_of`; store-backed rows via the
+  federation/replica-cache staleness landed with #632.

--- a/docs/adr/0015-intent-completion-at-admission.md
+++ b/docs/adr/0015-intent-completion-at-admission.md
@@ -1,0 +1,91 @@
+# Intent completion at admission
+
+**Status:** Accepted
+**Date:** 2026-07-14
+**Relates to:** ADR 0008 (agentic-first orchestration — meta-agents become
+upstream completers, never prerequisites), ADR 0010 (crew provisioning — the
+Brief this ADR fills), ADR 0014 (the issue references whose snapshots feed
+the Brief), issue #633 (M1 story: start a convoy from an issue with a single
+contained crew agent).
+
+Starting a convoy from an issue requires *something* to turn sparse human
+intent ("this issue, go") into a full-fledged `ConvoySpec`: a branch name, a
+convoy name, a workflow choice, a Brief. Plane A answers this with an
+`AiUtility` call (haiku) generating branch names from the TUI's input flow.
+The eventual best incumbent is the governor — it will hold project context.
+But making the governor the *owner* of completion would couple starting work
+to a meta-agent that does not exist yet. Completion is therefore a **seam**,
+not an agent's job.
+
+## Completion is an admission-time, daemon-side stage of the create verb
+
+Callers submit **intent**: an issue reference, optionally a workflow choice,
+optionally free text — with any spec fields left blank. Before the
+`ConvoySpec` persists, the convoy's home daemon completes it: branch name and
+convoy name (generated **together** by one call so they cohere), checkout
+path (derived from branch), workflow (the Project's `default_workflow_ref`
+when unspecified). **The resource store never holds a half-spec**; nothing
+downstream — reconcilers, queries, tables — ever sees one. This is the k8s
+defaulting/mutating-admission pattern.
+
+Every caller — TUI issue-row action, bare CLI, future governor — hits the
+same verb and gets consistent completion. The verb is **flag-complete and
+non-interactively drivable by construction** (recorded M1 constraint): a
+caller that supplies every field gets no completion; that caller is exactly
+what a governor will be.
+
+## Completers
+
+The M1 name completer reuses the Plane-A `AiUtility` provider (haiku via the
+Anthropic API), called from the admission stage instead of the TUI branch
+flow, with a **deterministic fallback** when keyless or offline: slugified
+issue title, truncated, suffixed with the issue number
+(`fix-attachable-set-leak-719`). Creating work must never fail on a naming
+nicety.
+
+Meta-agents (governor, bosun) arrive later as **upstream completers**: they
+submit intent with more fields pre-filled (naming conventions observed,
+workflow chosen, crew provisioning proposed — hooks, skills, system prompt,
+tokens, proxies). A human-approval gate between a proposed spec and admission
+is a **policy knob on this same pipeline**, not a new mechanism. Admission
+defaulting remains the backstop for whatever any caller leaves blank.
+
+## Only branches and convoys are named at admission
+
+Vessel names are workflow-template-defined roles (`implement`, `review`) —
+positional, not christened. **Hulls carry the persistent names**: the hull is
+the physical ship; crews rotate, voyages end, the ship keeps her name. A hull
+is christened once at allocation (the same naming facility, second call
+site), stable across reuse, convoys, and crews — it is what a metaphor
+visualization keys a ship model/variant on, and what lets a human recognize
+"the same environment as yesterday." A vessel's display identity composes as
+*hull name + role*. (Hull is portfolio-defined; the christening convention
+belongs in the project-map glossary too.)
+
+## The Brief embeds an issue snapshot
+
+The crew Brief for issue-initiated work is: a generated preamble (convoy,
+branch, repo, role, completion verbs) + the **issue snapshot** — title, body,
+labels as-of launch, stamped `as_of`, with the full reference alongside — +
+the human's free-text slot (later also the governor's instruction slot).
+
+Snapshot-primary, walked from the scenarios that force it: a **contained**
+crew may have no `gh`, no credentials, no network — a bare reference would
+make its first act an impossible fetch; the Brief is the durable
+script-as-executed and issue bodies mutate, so only a snapshot is an honest
+record; the reference keeps live refresh possible for stances that allow it.
+This matters more as stances lock down (e.g. crews that can push a branch —
+possibly only to a mirror — but not open PRs: forge capability is part of
+the Stance posture, realized walls-first through which credentials hull-prep
+installs).
+
+## Consequences
+
+- The governor becomes adoptable incrementally: same verb, richer caller.
+  Nothing built for the human path needs undoing.
+- Admission needs the Anthropic key reachable from the convoy's home daemon —
+  matching where Plane A already makes this call, and homes follow the work.
+- Name generation adds one LLM round-trip to create; the deterministic
+  fallback bounds the failure mode.
+- Brief snapshots duplicate issue text into vessel workspaces by design;
+  that is the record, not a cache to invalidate.


### PR DESCRIPTION
Records the 2026-07-14 grill re-deriving #666 scenario-first from the M1 user stories (add project → see activity incl. issues → start convoy from issue → drive it from a PM), triggered by the pre-implementation review that surfaced #666's hidden untyped-backend dependencies.

**ADR 0014 — Curated scoped queries; demand-backed materialization** (amends ADR 0012's generic tier)
- v1 view layer = curated typed query families only (`convoys{scope}`, `independents{scope}`, `checkouts{scope}`, `issues{scope}`); generic `Resources{kind}` repositioned as future, columnar (SoA) if ever built
- `QueryId` = family + owned scope params; project scope expands inside the Aggregator
- Store-backed vs demand-backed materialization classes, one wire contract; demand-backed = subscription-lifetime windows with `as_of`/`has_more`, fetch-more as intent, Plane-A provider impls reused as the fetch layer
- Issues never replicated: references-on-work + snapshots only; boards/triage are add-on programs
- `sessions` query → `independents` (convoy-era term); resource kind stays `TerminalSession`
- Repository becomes a resource (convergent-facts, natural-keyed); repo keys are mortal — `moved` pointers + referent repair committed

**ADR 0015 — Intent completion at admission**
- Create verbs take partial *intent*; the home daemon completes it (AiUtility reuse + deterministic fallback) before the spec persists — store never holds half-specs
- Governor/bosun arrive later as upstream completers; human approval is a policy gate on the same pipeline; verb is flag-complete by construction
- Brief embeds an `as_of`-stamped issue snapshot (contained crews may have no forge access; Briefs are the script-as-executed)
- Hulls are christened (persistent names at allocation); vessel roles stay template-defined

Also adds CONTEXT.md glossary entries: **Demand-backed Query**, **Completion**, **Independent**.

Follow-up issues and the #666 rewrite land after this merges.