### PR TITLE
refactor: rename sessions query to independents

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -8,7 +8,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use flotilla_protocol::{
-    result_set::{ConvoyRow, QueryId, ResultSet, Rows, SessionRow},
+    result_set::{ConvoyRow, IndependentRow, QueryId, ResultSet, Rows},
     HostName, ResourceRef,
 };
 use tokio::sync::{RwLock, RwLockWriteGuard};
@@ -29,13 +29,13 @@ impl QueryRow for ConvoyRow {
     }
 }
 
-impl QueryRow for SessionRow {
+impl QueryRow for IndependentRow {
     fn resource(&self) -> &ResourceRef {
         &self.resource
     }
 
     fn into_rows(rows: Vec<Self>) -> Rows {
-        Rows::Sessions(rows)
+        Rows::Independents(rows)
     }
 }
 
@@ -109,7 +109,7 @@ impl<R: QueryRow + PartialEq> QueryProjection<R> {
 #[derive(Debug, Default, Clone)]
 pub struct AggregatorProjectionState {
     convoys: Arc<RwLock<QueryProjection<ConvoyRow>>>,
-    sessions: Arc<RwLock<QueryProjection<SessionRow>>>,
+    independents: Arc<RwLock<QueryProjection<IndependentRow>>>,
 }
 
 impl AggregatorProjectionState {
@@ -133,20 +133,20 @@ impl AggregatorProjectionState {
         self.convoys.read().await.local_result_set()
     }
 
-    pub async fn write_sessions(&self) -> RwLockWriteGuard<'_, QueryProjection<SessionRow>> {
-        self.sessions.write().await
+    pub async fn write_independents(&self) -> RwLockWriteGuard<'_, QueryProjection<IndependentRow>> {
+        self.independents.write().await
     }
 
-    pub async fn sessions_result_set(&self) -> ResultSet {
-        self.sessions.read().await.result_set()
+    pub async fn independents_result_set(&self) -> ResultSet {
+        self.independents.read().await.result_set()
     }
 
-    pub async fn sessions_seq(&self) -> u64 {
-        self.sessions.read().await.seq
+    pub async fn independents_seq(&self) -> u64 {
+        self.independents.read().await.seq
     }
 
-    pub async fn local_sessions_result_set(&self) -> ResultSet {
-        self.sessions.read().await.local_result_set()
+    pub async fn local_independents_result_set(&self) -> ResultSet {
+        self.independents.read().await.local_result_set()
     }
 
     /// This host's local result sets across all named queries, in the order
@@ -156,7 +156,7 @@ impl AggregatorProjectionState {
         for query in QueryId::ALL {
             result_sets.push(match query {
                 QueryId::Convoys => self.local_result_set().await,
-                QueryId::Sessions => self.local_sessions_result_set().await,
+                QueryId::Independents => self.local_independents_result_set().await,
             });
         }
         result_sets
@@ -166,7 +166,7 @@ impl AggregatorProjectionState {
     pub async fn result_set_for(&self, query: QueryId) -> ResultSet {
         match query {
             QueryId::Convoys => self.result_set().await,
-            QueryId::Sessions => self.sessions_result_set().await,
+            QueryId::Independents => self.independents_result_set().await,
         }
     }
 }

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -8,7 +8,9 @@ use std::{
 use async_trait::async_trait;
 use flotilla_core::{aggregator_projection::AggregatorProjectionState, in_process::InProcessDaemon};
 use flotilla_protocol::{
-    result_set::{ConvoyPhase, ConvoyRow, CrewMemberSummary, QueryId, ResultDelta, Rows, SessionPhase, SessionRow, VesselRow, WorkPhase},
+    result_set::{
+        ConvoyPhase, ConvoyRow, CrewMemberSummary, IndependentRow, QueryId, ResultDelta, Rows, SessionPhase, VesselRow, WorkPhase,
+    },
     DaemonEvent, FleetReplicaSnapshot, HostName, ResourceRef,
 };
 use flotilla_resources::{
@@ -176,7 +178,7 @@ impl Aggregator {
             }
         }
         {
-            let mut view = self.state.write_sessions().await;
+            let mut view = self.state.write_independents().await;
             if !view.local_rows.is_empty() {
                 view.local_rows.clear();
                 view.seq = view.seq.saturating_add(1);
@@ -192,7 +194,7 @@ impl Aggregator {
         self.bootstrapping = false;
         self.emitted_queries.extend(QueryId::ALL.iter().copied());
         let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.result_set().await)));
-        let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.sessions_result_set().await)));
+        let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.independents_result_set().await)));
 
         loop {
             tokio::select! {
@@ -353,7 +355,7 @@ impl Aggregator {
     ) -> Result<WatchStream<Environment>, ResourceError> {
         let listed = resolver.list().await?;
         let watch = resolver.watch(watch_start(&listed)).await?;
-        self.rebuild_session_projection().await;
+        self.rebuild_independents_projection().await;
         Ok(watch)
     }
 
@@ -482,7 +484,7 @@ impl Aggregator {
         let replacement =
             sessions.into_iter().map(|session| ((session.metadata.namespace.clone(), session.metadata.name.clone()), session)).collect();
         self.sessions_by_source.insert(source, replacement);
-        self.rebuild_session_projection().await;
+        self.rebuild_independents_projection().await;
     }
 
     async fn apply_session_event_from(&mut self, source: LocalSource, event: WatchEvent<TerminalSession>) {
@@ -500,14 +502,14 @@ impl Aggregator {
                     .remove(&(session.metadata.namespace.clone(), session.metadata.name.clone()));
             }
         }
-        self.rebuild_session_projection().await;
+        self.rebuild_independents_projection().await;
     }
 
     async fn apply_environment_event(&mut self, _event: WatchEvent<Environment>) {
-        self.rebuild_session_projection().await;
+        self.rebuild_independents_projection().await;
     }
 
-    async fn rebuild_session_projection(&mut self) {
+    async fn rebuild_independents_projection(&mut self) {
         let mut effective_sessions = HashMap::new();
         for source in LOCAL_SOURCE_PRECEDENCE {
             let Some(sessions) = self.sessions_by_source.get(&source) else { continue };
@@ -520,7 +522,7 @@ impl Aggregator {
                 let references = self
                     .terminal_sessions
                     .values()
-                    .filter(|session| is_projected_session(session))
+                    .filter(|session| is_independent_session(session))
                     .map(|session| session.metadata.name.clone())
                     .collect::<Vec<_>>();
                 daemon.resolvable_attach_references(&references).await.unwrap_or_default()
@@ -530,13 +532,13 @@ impl Aggregator {
 
         let mut replacement = HashMap::new();
         for session in self.terminal_sessions.values() {
-            if let Some(row) = self.summarize_session(session, &attachable_references) {
+            if let Some(row) = self.summarize_independent(session, &attachable_references) {
                 replacement.insert(row.resource.clone(), row);
             }
         }
 
         let (changed, removed, result_set) = {
-            let mut view = self.state.write_sessions().await;
+            let mut view = self.state.write_independents().await;
             let changed = replacement
                 .iter()
                 .filter(|(reference, row)| view.local_rows.get(*reference) != Some(*row))
@@ -554,21 +556,21 @@ impl Aggregator {
         if self.bootstrapping {
             return;
         }
-        if self.emitted_queries.contains(&QueryId::Sessions) {
-            self.emit_session_delta(changed, removed).await;
+        if self.emitted_queries.contains(&QueryId::Independents) {
+            self.emit_independent_delta(changed, removed).await;
         } else {
-            self.emitted_queries.insert(QueryId::Sessions);
+            self.emitted_queries.insert(QueryId::Independents);
             let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
         }
     }
 
     pub async fn apply_replica_cache(&mut self, snapshots: Vec<FleetReplicaSnapshot>) {
         let mut convoy_replacements = HashMap::new();
-        let mut session_replacements = HashMap::new();
+        let mut independent_replacements = HashMap::new();
         for snapshot in snapshots {
             let host = snapshot.host;
             let mut convoy_rows = HashMap::new();
-            let mut session_rows = HashMap::new();
+            let mut independent_rows = HashMap::new();
             for result_set in snapshot.result_sets {
                 match result_set.rows {
                     Rows::Convoys(convoys) => {
@@ -577,16 +579,16 @@ impl Aggregator {
                             convoy_rows.insert(row.resource.clone(), row);
                         }
                     }
-                    Rows::Sessions(sessions) => {
-                        for mut row in sessions {
-                            set_session_row_host(&mut row, &host);
-                            session_rows.insert(row.resource.clone(), row);
+                    Rows::Independents(independents) => {
+                        for mut row in independents {
+                            set_independent_row_host(&mut row, &host);
+                            independent_rows.insert(row.resource.clone(), row);
                         }
                     }
                 }
             }
             convoy_replacements.insert(host.clone(), convoy_rows);
-            session_replacements.insert(host, session_rows);
+            independent_replacements.insert(host, independent_rows);
         }
 
         let convoy_change = {
@@ -602,16 +604,16 @@ impl Aggregator {
             }
         }
 
-        let session_change = {
-            let mut view = self.state.write_sessions().await;
-            view.replace_replica_rows(session_replacements)
+        let independent_change = {
+            let mut view = self.state.write_independents().await;
+            view.replace_replica_rows(independent_replacements)
         };
-        if let Some((changed, removed)) = session_change {
-            if self.emitted_queries.contains(&QueryId::Sessions) {
-                self.emit_session_delta(changed, removed).await;
+        if let Some((changed, removed)) = independent_change {
+            if self.emitted_queries.contains(&QueryId::Independents) {
+                self.emit_independent_delta(changed, removed).await;
             } else {
-                self.emitted_queries.insert(QueryId::Sessions);
-                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.sessions_result_set().await)));
+                self.emitted_queries.insert(QueryId::Independents);
+                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.independents_result_set().await)));
             }
         }
     }
@@ -621,9 +623,9 @@ impl Aggregator {
         let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changed: Rows::Convoys(changed), removed })));
     }
 
-    async fn emit_session_delta(&self, changed: Vec<SessionRow>, removed: Vec<ResourceRef>) {
-        let seq = self.state.sessions_seq().await;
-        let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changed: Rows::Sessions(changed), removed })));
+    async fn emit_independent_delta(&self, changed: Vec<IndependentRow>, removed: Vec<ResourceRef>) {
+        let seq = self.state.independents_seq().await;
+        let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changed: Rows::Independents(changed), removed })));
     }
 
     fn convoy_ref(&self, namespace: &str, name: &str) -> ResourceRef {
@@ -640,14 +642,18 @@ impl Aggregator {
             .on_host(self.local_host.clone())
     }
 
-    fn summarize_session(&self, session: &ResourceObject<TerminalSession>, attachable_references: &HashSet<String>) -> Option<SessionRow> {
-        if !is_projected_session(session) {
+    fn summarize_independent(
+        &self,
+        session: &ResourceObject<TerminalSession>,
+        attachable_references: &HashSet<String>,
+    ) -> Option<IndependentRow> {
+        if !is_independent_session(session) {
             return None;
         }
         let name = &session.metadata.name;
         let attach = attachable_references.contains(name).then(|| name.clone());
         Some(
-            SessionRow::builder()
+            IndependentRow::builder()
                 .resource(self.session_ref(&session.metadata.namespace, name))
                 .name(name)
                 .maybe_repo(session.metadata.labels.get(REPO_LABEL).map(|repo| flotilla_protocol::RepoKey(repo.clone())))
@@ -741,7 +747,7 @@ fn presentation_key(presentation: &ResourceObject<Presentation>) -> Option<Prese
     ))
 }
 
-fn is_projected_session(session: &ResourceObject<TerminalSession>) -> bool {
+fn is_independent_session(session: &ResourceObject<TerminalSession>) -> bool {
     !session.metadata.labels.contains_key(CONVOY_LABEL)
         && session.status.as_ref().map(|status| status.phase) == Some(TerminalSessionPhase::Running)
 }
@@ -754,7 +760,7 @@ fn set_convoy_row_host(row: &mut ConvoyRow, host: &HostName) {
     }
 }
 
-fn set_session_row_host(row: &mut SessionRow, host: &HostName) {
+fn set_independent_row_host(row: &mut IndependentRow, host: &HostName) {
     row.resource.host = Some(host.clone());
     row.host = host.clone();
 }
@@ -991,7 +997,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn session_projection_resolves_attach_capabilities_once_per_rebuild() {
+    async fn independents_projection_resolves_attach_capabilities_once_per_rebuild() {
         let state = AggregatorProjectionState::new();
         let (event_tx, _) = broadcast::channel(4);
         let resolver = Arc::new(CountingAttachResolver { calls: AtomicUsize::new(0) });
@@ -1002,8 +1008,8 @@ mod tests {
             .await;
 
         assert_eq!(resolver.calls.load(Ordering::SeqCst), 1);
-        let result_set = state.sessions_result_set().await;
-        let rows = result_set.rows.as_sessions().expect("session rows");
+        let result_set = state.independents_result_set().await;
+        let rows = result_set.rows.as_independents().expect("session rows");
         assert_eq!(rows.len(), 2);
         assert!(rows.iter().all(|row| row.attach.as_deref() == Some(row.name.as_str())));
     }
@@ -1026,10 +1032,10 @@ mod tests {
         }
     }
 
-    fn remote_session_snapshot(host: &str, generation: &str, name: &str) -> FleetReplicaSnapshot {
+    fn remote_independent_snapshot(host: &str, generation: &str, name: &str) -> FleetReplicaSnapshot {
         let host = HostName::new(host);
         let session = ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", name);
-        let row = SessionRow::builder()
+        let row = IndependentRow::builder()
             .resource(session)
             .name(name)
             .host(HostName::new("incorrect-source-host"))
@@ -1040,7 +1046,7 @@ mod tests {
             host,
             generation: Some(generation.to_string()),
             rows: Vec::new(),
-            result_sets: vec![ResultSet { seq: 1, rows: Rows::Sessions(vec![row]) }],
+            result_sets: vec![ResultSet { seq: 1, rows: Rows::Independents(vec![row]) }],
         }
     }
 
@@ -1166,17 +1172,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replica_cache_unions_sessions_and_stamps_origin_host() {
+    async fn replica_cache_unions_independents_and_stamps_origin_host() {
         let state = AggregatorProjectionState::new();
         let (tx, mut rx) = broadcast::channel(8);
         let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
 
-        aggregator.apply_replica_cache(vec![remote_session_snapshot("feta", "generation-1", "terminal-yeoman")]).await;
-        let event = rx.recv().await.expect("sessions replica event");
-        assert!(matches!(event, DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Sessions));
+        aggregator.apply_replica_cache(vec![remote_independent_snapshot("feta", "generation-1", "terminal-yeoman")]).await;
+        let event = rx.recv().await.expect("independents replica event");
+        assert!(matches!(event, DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Independents));
 
-        let result_set = state.sessions_result_set().await;
-        let rows = result_set.rows.as_sessions().expect("session rows");
+        let result_set = state.independents_result_set().await;
+        let rows = result_set.rows.as_independents().expect("independent rows");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].resource.host, Some(HostName::new("feta")));
         assert_eq!(rows[0].host, HostName::new("feta"));
@@ -1322,15 +1328,15 @@ mod tests {
             Aggregator::new(run_state, HostName::new("local"), event_tx).run_with_sources(sources, replica_rx).await
         });
 
-        let initial = recv_query_event(&mut event_rx, QueryId::Sessions, "initial sessions result set timeout").await;
-        let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial sessions result set") };
-        assert_eq!(initial.rows.as_sessions().expect("session rows")[0].name, "deleted-while-watch-expired");
+        let initial = recv_query_event(&mut event_rx, QueryId::Independents, "initial independents result set timeout").await;
+        let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial independents result set") };
+        assert_eq!(initial.rows.as_independents().expect("independent rows")[0].name, "deleted-while-watch-expired");
 
-        let removal = recv_query_event(&mut event_rx, QueryId::Sessions, "sessions relist delta timeout").await;
-        let DaemonEvent::ResultDelta(removal) = removal else { panic!("expected sessions relist delta") };
+        let removal = recv_query_event(&mut event_rx, QueryId::Independents, "independents relist delta timeout").await;
+        let DaemonEvent::ResultDelta(removal) = removal else { panic!("expected independents relist delta") };
         assert_eq!(removal.removed.len(), 1);
         assert_eq!(removal.removed[0].name, "deleted-while-watch-expired");
-        assert!(state.sessions_result_set().await.rows.is_empty());
+        assert!(state.independents_result_set().await.rows.is_empty());
         assert_eq!(durable_sessions.list_calls.load(Ordering::SeqCst), 2);
         assert_eq!(durable_sessions.watch_calls.load(Ordering::SeqCst), 2);
         assert!(!task.is_finished(), "aggregator should remain alive after session relist");

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -13,12 +13,14 @@ use flotilla_core::{
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{
-    result_set::{ConvoyRow, QueryId, ResultSet, SessionRow},
+    result_set::{ConvoyRow, IndependentRow, QueryId, ResultSet},
     DaemonEvent, HostName, QueryCursor,
 };
 use flotilla_resources::{
-    ConvoySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ResourceBackend, TerminalSession,
-    TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, CONVOY_LABEL, REPO_LABEL,
+    Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, Environment, EnvironmentSpec, HostDirectEnvironmentSpec,
+    InMemoryBackend, InputMeta, ResourceBackend, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, VesselRequirement, WorkPhase as ResourceWorkPhase, WorkState, WorkflowSnapshot, CONVOY_LABEL, REPO_LABEL,
+    VESSEL_LABEL,
 };
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -54,8 +56,8 @@ fn convoy_rows(result_set: &ResultSet) -> &[ConvoyRow] {
     result_set.rows.as_convoys().expect("convoy rows")
 }
 
-fn session_rows(result_set: &ResultSet) -> &[SessionRow] {
-    result_set.rows.as_sessions().expect("session rows")
+fn independent_rows(result_set: &ResultSet) -> &[IndependentRow] {
+    result_set.rows.as_independents().expect("independent rows")
 }
 
 #[tokio::test]
@@ -115,7 +117,7 @@ async fn aggregator_emits_result_set_events() {
 }
 
 #[tokio::test]
-async fn running_convoyless_session_emits_attachable_session_row() {
+async fn running_convoyless_session_emits_attachable_independent_row() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let config = test_config(tmp.path().join("config"));
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
@@ -144,7 +146,10 @@ async fn running_convoyless_session_emits_attachable_session_row() {
         .create(
             &InputMeta::builder()
                 .name("terminal-convoy-coder".to_string())
-                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string())]))
+                .labels(BTreeMap::from([
+                    (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+                    (VESSEL_LABEL.to_string(), "coder".to_string()),
+                ]))
                 .build(),
             &TerminalSessionSpec {
                 env_ref: "host-direct-local".to_string(),
@@ -164,6 +169,19 @@ async fn running_convoyless_session_emits_attachable_session_row() {
         })
         .await
         .expect("mark convoy terminal session running");
+    let convoys = backend.using::<Convoy>("flotilla");
+    let convoy = convoys.create(&convoy_meta("convoy-a"), &convoy_spec("scratch")).await.expect("create convoy for bound terminal session");
+    convoys
+        .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
+            phase: ResourceConvoyPhase::Active,
+            workflow_snapshot: Some(WorkflowSnapshot {
+                vessels: vec![VesselRequirement::builder().name("coder".to_string()).crew(Vec::new()).build()],
+            }),
+            work: BTreeMap::from([("coder".to_string(), WorkState::builder().phase(ResourceWorkPhase::Running).build())]),
+            ..Default::default()
+        })
+        .await
+        .expect("mark convoy vessel running");
     let unresolvable = sessions
         .create(&InputMeta::builder().name("terminal-unresolvable".to_string()).build(), &TerminalSessionSpec {
             env_ref: "missing-environment".to_string(),
@@ -219,14 +237,14 @@ async fn running_convoyless_session_emits_attachable_session_row() {
     let rows = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Ok(DaemonEvent::ResultSet(result_set)) if result_set.query() == QueryId::Sessions => {
-                    let rows = session_rows(&result_set);
+                Ok(DaemonEvent::ResultSet(result_set)) if result_set.query() == QueryId::Independents => {
+                    let rows = independent_rows(&result_set);
                     if !rows.is_empty() {
                         return rows.to_vec();
                     }
                 }
-                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions => {
-                    let rows = delta.changed.as_sessions().expect("session rows");
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Independents => {
+                    let rows = delta.changed.as_independents().expect("independent rows");
                     if !rows.is_empty() {
                         return rows.to_vec();
                     }
@@ -237,7 +255,23 @@ async fn running_convoyless_session_emits_attachable_session_row() {
         }
     })
     .await
-    .expect("timed out waiting for sessions result rows");
+    .expect("timed out waiting for independents result rows");
+
+    assert!(
+        rows.iter().all(|row| row.name != "terminal-convoy-coder"),
+        "convoy-bound terminal sessions surface on vessel rows, never in independents",
+    );
+    let convoy_replay =
+        daemon.subscribe_queries(&[QueryCursor { query: QueryId::Convoys, since: None }]).await.expect("subscribe to convoys query");
+    let convoy_rows = convoy_replay
+        .iter()
+        .find_map(|event| match event {
+            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys => Some(convoy_rows(result_set)),
+            _ => None,
+        })
+        .expect("convoys replay result set");
+    let convoy = convoy_rows.iter().find(|row| row.name == "convoy-a").expect("convoy row for bound terminal session");
+    assert!(convoy.vessels.iter().any(|vessel| vessel.name == "coder"), "convoy-bound terminal session surfaces on its vessel row");
 
     let row = rows.iter().find(|row| row.name == "terminal-yeoman").expect("attachable session row");
     assert_eq!(row.repo.as_ref().map(|repo| repo.0.as_str()), Some("flotilla-org/flotilla"));
@@ -248,37 +282,39 @@ async fn running_convoyless_session_emits_attachable_session_row() {
     assert_eq!(unresolvable.attach, None);
     assert!(daemon.resolve_attach_command_internal("terminal-yeoman").await.is_ok());
 
-    let replay =
-        daemon.subscribe_queries(&[QueryCursor { query: QueryId::Sessions, since: None }]).await.expect("subscribe to sessions query");
+    let replay = daemon
+        .subscribe_queries(&[QueryCursor { query: QueryId::Independents, since: None }])
+        .await
+        .expect("subscribe to independents query");
     let replayed = replay
         .iter()
         .find_map(|event| match event {
-            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Sessions => Some(session_rows(result_set)),
+            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Independents => Some(independent_rows(result_set)),
             _ => None,
         })
-        .expect("sessions replay result set");
+        .expect("independents replay result set");
     assert_eq!(replayed.len(), 2);
     let unresolvable = replayed.iter().find(|row| row.name == "terminal-unresolvable").expect("unresolvable session row");
     assert_eq!(unresolvable.attach, None);
 
     let replica = daemon.fleet_replica_snapshot_internal().await.expect("fleet replica snapshot");
-    let local_sessions = replica
+    let local_independents = replica
         .result_sets
         .iter()
-        .find(|result_set| result_set.query() == QueryId::Sessions)
-        .map(session_rows)
-        .expect("local sessions result set");
-    assert_eq!(local_sessions.len(), 2);
+        .find(|result_set| result_set.query() == QueryId::Independents)
+        .map(independent_rows)
+        .expect("local independents result set");
+    assert_eq!(local_independents.len(), 2);
 
     environments.delete(&environment_name).await.expect("delete attach environment");
     let unavailable = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions => {
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Independents => {
                     if let Some(row) = delta
                         .changed
-                        .as_sessions()
-                        .expect("session rows")
+                        .as_independents()
+                        .expect("independent rows")
                         .iter()
                         .find(|row| row.name == "terminal-yeoman" && row.attach.is_none())
                     {
@@ -301,11 +337,11 @@ async fn running_convoyless_session_emits_attachable_session_row() {
     let available = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions => {
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Independents => {
                     if let Some(row) = delta
                         .changed
-                        .as_sessions()
-                        .expect("session rows")
+                        .as_independents()
+                        .expect("independent rows")
                         .iter()
                         .find(|row| row.name == "terminal-yeoman" && row.attach.as_deref() == Some("terminal-yeoman"))
                     {
@@ -332,7 +368,7 @@ async fn running_convoyless_session_emits_attachable_session_row() {
     let removed = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Sessions && !delta.removed.is_empty() => return delta,
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Independents && !delta.removed.is_empty() => return delta,
                 Ok(_) => continue,
                 Err(err) => panic!("broadcast receive error: {err}"),
             }

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -1,7 +1,7 @@
 //! The catalog projection: query result-set rows in, metadata patches out.
 //!
 //! Pure functions — no I/O, no clock. The connector loop feeds it the
-//! fleet-merged `convoys` and `sessions` rows and sends what comes back.
+//! fleet-merged `convoys` and `independents` rows and sends what comes back.
 //!
 //! Truthfulness rules (design §7 on flotilla-org/flotilla#667):
 //! - every path is published honestly; the PM's resolver decides
@@ -13,7 +13,7 @@
 
 use std::collections::BTreeMap;
 
-use flotilla_protocol::result_set::{ConvoyPhase, ConvoyRow, SessionPhase, SessionRow, VesselRow, WorkPhase};
+use flotilla_protocol::result_set::{ConvoyPhase, ConvoyRow, IndependentRow, SessionPhase, VesselRow, WorkPhase};
 
 use crate::{
     keys::{
@@ -28,7 +28,7 @@ use crate::{
 /// The rows the catalog is projected from.
 pub struct CatalogInput<'a> {
     pub convoys: &'a [ConvoyRow],
-    pub sessions: &'a [SessionRow],
+    pub independents: &'a [IndependentRow],
 }
 
 /// A normalized badge: the frozen `status.state` vocabulary plus whether
@@ -162,8 +162,8 @@ pub fn project_catalog(input: &CatalogInput<'_>, mint: &dyn RecipeMint) -> Catal
     for convoy in input.convoys {
         project_convoy(&mut catalog, convoy, mint);
     }
-    for session in input.sessions {
-        project_session(&mut catalog, session, mint);
+    for independent in input.independents {
+        project_independent(&mut catalog, independent, mint);
     }
     catalog
 }
@@ -289,9 +289,9 @@ fn project_vessel(
     catalog.assert_facts(MetadataTarget::Group(path), facts, ordinal);
 }
 
-fn project_session(catalog: &mut Catalog, session: &SessionRow, mint: &dyn RecipeMint) {
-    let namespace = &session.resource.namespace;
-    let project = project_segment(None, session.repo.as_ref().map(|repo| repo.0.as_str()));
+fn project_independent(catalog: &mut Catalog, independent: &IndependentRow, mint: &dyn RecipeMint) {
+    let namespace = &independent.resource.namespace;
+    let project = project_segment(None, independent.repo.as_ref().map(|repo| repo.0.as_str()));
     let mut path = Vec::new();
     if let Some(segment) = &project {
         assert_project_group(catalog, segment);
@@ -302,18 +302,18 @@ fn project_session(catalog: &mut Catalog, session: &SessionRow, mint: &dyn Recip
     // ordering semantics are gap §9.6 for the Leg-1 freeze).
     let ordinal = project.is_none().then_some(ARCHIPELAGO_ORDINAL);
 
-    path.push(GroupSegment::text(SEGMENT_VESSEL, session.name.clone()));
+    path.push(GroupSegment::text(SEGMENT_VESSEL, independent.name.clone()));
     let group_path = GroupPath(path);
-    let badge = session_badge(session.phase);
+    let badge = session_badge(independent.phase);
     let mut facts = vec![
         (KEY_STATUS_STATE, MetadataValue::text(badge.state.as_str())),
-        (KEY_VESSEL_HOST, MetadataValue::text(session.host.to_string())),
-        (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:sessions/{namespace}/{}", session.name))),
+        (KEY_VESSEL_HOST, MetadataValue::text(independent.host.to_string())),
+        (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:independents/{namespace}/{}", independent.name))),
     ];
     if badge.attention {
         facts.push((KEY_STATUS_ATTENTION, MetadataValue::Bool(true)));
     }
-    if let Some(recipe) = session.attach.as_deref().and_then(|attach_ref| mint.attach(attach_ref)) {
+    if let Some(recipe) = independent.attach.as_deref().and_then(|attach_ref| mint.attach(attach_ref)) {
         facts.push((KEY_MATERIALIZE_TARGET, MetadataValue::text("pane")));
         facts.push((KEY_MATERIALIZE_RECIPE, MetadataValue::text(recipe.command())));
     }
@@ -322,7 +322,7 @@ fn project_session(catalog: &mut Catalog, session: &SessionRow, mint: &dyn Recip
     // The identity half of the pane → identity → group join: `flotilla
     // attach` stamps this identity on the pane; the scope fact published
     // here resolves the pane into its group.
-    let identity_value = format!("{}/{namespace}/{}", session.host, session.name);
+    let identity_value = format!("{}/{namespace}/{}", independent.host, independent.name);
     catalog.assert_facts(
         MetadataTarget::Identity(MetadataIdentity { key: KEY_SESSION.to_owned(), value: MetadataValue::text(identity_value) }),
         vec![(KEY_SCOPE, group_path.to_scope_value()), (KEY_STATUS_STATE, MetadataValue::text(badge.state.as_str()))],

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -27,8 +27,8 @@ fn vessel(convoy: &ResourceRef, name: &str, phase: WorkPhase, attach: Option<&st
 }
 
 #[bon::builder]
-fn session(namespace: &str, name: &str, phase: SessionPhase, repo: Option<&str>, attach: Option<&str>) -> SessionRow {
-    SessionRow::builder()
+fn independent(namespace: &str, name: &str, phase: SessionPhase, repo: Option<&str>, attach: Option<&str>) -> IndependentRow {
+    IndependentRow::builder()
         .resource(session_ref(namespace, name))
         .name(name)
         .maybe_repo(repo.map(|repo| RepoKey(repo.to_owned())))
@@ -82,7 +82,7 @@ fn convoy_with_project_ref_projects_the_full_spine() {
             vessel().convoy(&reference).name("review").phase(WorkPhase::Complete).call(),
         ])
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], sessions: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     // project_ref wins over the repo as the project segment value.
@@ -129,7 +129,7 @@ fn failed_convoy_surfaces_attention_and_message() {
         .message("vessel checkout failed: disk full")
         .repo(RepoKey("flotilla-org/flotilla".to_owned()))
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], sessions: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     let project_segment = GroupSegment::text(SEGMENT_PROJECT, "flotilla-org/flotilla");
@@ -149,7 +149,7 @@ fn initializing_convoy_reads_waiting_whatever_its_phase() {
         .phase(ConvoyPhase::Active)
         .initializing(true)
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], sessions: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     let convoy_patch = find(&patches, &group(vec![GroupSegment::text(SEGMENT_CONVOY, "dev/warming-up")]));
@@ -167,7 +167,7 @@ fn ready_vessel_waits_with_attention() {
         .phase(ConvoyPhase::Active)
         .vessels(vec![vessel().convoy(&reference).name("implement").phase(WorkPhase::Ready).call()])
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], sessions: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     let implement =
@@ -177,15 +177,15 @@ fn ready_vessel_waits_with_attention() {
 }
 
 #[test]
-fn session_with_repo_groups_under_project_and_publishes_identity() {
-    let session = session()
+fn independent_with_repo_groups_under_project_and_publishes_identity() {
+    let independent = independent()
         .namespace("dev")
         .name("terminal-scratch")
         .phase(SessionPhase::Running)
         .repo("flotilla-org/flotilla")
         .attach("terminal-scratch")
         .call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], sessions: &[session] }, &mint());
+    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
     let project_segment = GroupSegment::text(SEGMENT_PROJECT, "flotilla-org/flotilla");
@@ -194,8 +194,8 @@ fn session_with_repo_groups_under_project_and_publishes_identity() {
     assert_eq!(text(group_patch, KEY_STATUS_STATE), "active");
     assert_eq!(text(group_patch, KEY_MATERIALIZE_TARGET), "pane");
     assert_eq!(text(group_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach terminal-scratch");
-    assert_eq!(text(group_patch, KEY_FACTORY_ID), "flotilla:sessions/dev/terminal-scratch");
-    assert_eq!(group_patch.set[KEY_STATUS_STATE].ordinal, None, "project-parented sessions are not archipelago-ordered");
+    assert_eq!(text(group_patch, KEY_FACTORY_ID), "flotilla:independents/dev/terminal-scratch");
+    assert_eq!(group_patch.set[KEY_STATUS_STATE].ordinal, None, "project-parented independents are not archipelago-ordered");
 
     let project = find(&patches, &group(vec![project_segment.clone()]));
     assert_eq!(text(project, KEY_PROJECT_NAME), "flotilla", "repo fallback labels the project with the short name");
@@ -212,9 +212,9 @@ fn session_with_repo_groups_under_project_and_publishes_identity() {
 }
 
 #[test]
-fn session_without_repo_is_archipelago_ordered_first() {
-    let session = session().namespace("dev").name("yeoman").phase(SessionPhase::Running).attach("yeoman").call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], sessions: &[session] }, &mint());
+fn independent_without_repo_is_archipelago_ordered_first() {
+    let independent = independent().namespace("dev").name("yeoman").phase(SessionPhase::Running).attach("yeoman").call();
+    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
     let group_patch = find(&patches, &group(vec![GroupSegment::text(SEGMENT_VESSEL, "yeoman")]));
@@ -227,9 +227,9 @@ fn session_without_repo_is_archipelago_ordered_first() {
 }
 
 #[test]
-fn session_without_attach_lists_without_recipe() {
-    let session = session().namespace("dev").name("wedged").phase(SessionPhase::Failed).repo("flotilla-org/flotilla").call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], sessions: &[session] }, &mint());
+fn independent_without_attach_lists_without_recipe() {
+    let independent = independent().namespace("dev").name("wedged").phase(SessionPhase::Failed).repo("flotilla-org/flotilla").call();
+    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
     let group_patch = find(
@@ -251,12 +251,12 @@ fn diff_sets_changes_and_unsets_disappearances() {
         .phase(ConvoyPhase::Failed)
         .message("boom")
         .build();
-    let old_session = session().namespace("dev").name("scratch").phase(SessionPhase::Running).attach("scratch").call();
-    let previous = project_catalog(&CatalogInput { convoys: &[failed], sessions: &[old_session] }, &mint());
+    let old_independent = independent().namespace("dev").name("scratch").phase(SessionPhase::Running).attach("scratch").call();
+    let previous = project_catalog(&CatalogInput { convoys: &[failed], independents: &[old_independent] }, &mint());
 
     let recovered =
         ConvoyRow::builder().resource(reference).name("auth").workflow_ref("implement-review").phase(ConvoyPhase::Active).build();
-    let current = project_catalog(&CatalogInput { convoys: &[recovered], sessions: &[] }, &mint());
+    let current = project_catalog(&CatalogInput { convoys: &[recovered], independents: &[] }, &mint());
 
     let patches = current.diff_patches(&previous);
 
@@ -268,11 +268,11 @@ fn diff_sets_changes_and_unsets_disappearances() {
     assert!(convoy_patch.unset.contains(&KEY_STATUS_ATTENTION.to_owned()));
     assert!(convoy_patch.unset.contains(&KEY_CONVOY_MESSAGE.to_owned()));
 
-    // The vanished session is explicitly unset on both its targets.
-    let session_group = find(&patches, &group(vec![GroupSegment::text(SEGMENT_VESSEL, "scratch")]));
-    assert!(session_group.set.is_empty());
-    assert!(session_group.unset.contains(&KEY_STATUS_STATE.to_owned()));
-    assert!(session_group.unset.contains(&KEY_MATERIALIZE_RECIPE.to_owned()));
+    // The vanished independent is explicitly unset on both its targets.
+    let independent_group = find(&patches, &group(vec![GroupSegment::text(SEGMENT_VESSEL, "scratch")]));
+    assert!(independent_group.set.is_empty());
+    assert!(independent_group.unset.contains(&KEY_STATUS_STATE.to_owned()));
+    assert!(independent_group.unset.contains(&KEY_MATERIALIZE_RECIPE.to_owned()));
     let identity_patch = find(&patches, &session_identity("feta/dev/scratch"));
     assert!(identity_patch.set.is_empty());
     assert!(identity_patch.unset.contains(&KEY_SCOPE.to_owned()));
@@ -282,11 +282,11 @@ fn diff_sets_changes_and_unsets_disappearances() {
 
 #[test]
 fn reassert_covers_every_target() {
-    let session =
-        session().namespace("dev").name("scratch").phase(SessionPhase::Running).repo("flotilla-org/flotilla").attach("scratch").call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], sessions: &[session] }, &mint());
+    let independent =
+        independent().namespace("dev").name("scratch").phase(SessionPhase::Running).repo("flotilla-org/flotilla").attach("scratch").call();
+    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
-    assert_eq!(patches.len(), 3, "project group + session group + session identity");
+    assert_eq!(patches.len(), 3, "project group + independent group + independent identity");
     assert!(patches.iter().all(|patch| patch.unset.is_empty()));
     assert!(patches.iter().all(|patch| patch.source_id == SOURCE_CONNECTOR));
 }
@@ -302,7 +302,7 @@ fn shared_spine_helpers_match_the_catalog_targets() {
         .repo(RepoKey("flotilla-org/flotilla".to_owned()))
         .vessels(vec![vessel().convoy(&reference).name("implement").phase(WorkPhase::Running).call()])
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], sessions: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     // The actuator's tab stamp builds its scope with these helpers; they

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -99,7 +99,7 @@ pub use query::{
 };
 pub use resource_ref::ResourceRef;
 pub use result_set::{
-    ConvoyPhase, ConvoyRow, CrewMemberSummary, QueryId, ResultDelta, ResultSet, Rows, SessionPhase, SessionRow, VesselRow, WorkPhase,
+    ConvoyPhase, ConvoyRow, CrewMemberSummary, IndependentRow, QueryId, ResultDelta, ResultSet, Rows, SessionPhase, VesselRow, WorkPhase,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -603,13 +603,13 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
 }
 
 #[test]
-fn result_set_round_trips_free_floating_session_capabilities() {
+fn result_set_round_trips_independent_capabilities() {
     use crate::{
         resource_ref::ResourceRef,
-        result_set::{QueryId, ResultSet, Rows, SessionPhase, SessionRow},
+        result_set::{IndependentRow, QueryId, ResultSet, Rows, SessionPhase},
     };
 
-    let row = SessionRow::builder()
+    let row = IndependentRow::builder()
         .resource(ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", "terminal-yeoman"))
         .name("terminal-yeoman")
         .repo(RepoKey("flotilla-org/flotilla".into()))
@@ -617,14 +617,14 @@ fn result_set_round_trips_free_floating_session_capabilities() {
         .attach("terminal-yeoman")
         .phase(SessionPhase::Running)
         .build();
-    let event = DaemonEvent::ResultSet(Box::new(ResultSet { seq: 11, rows: Rows::Sessions(vec![row]) }));
+    let event = DaemonEvent::ResultSet(Box::new(ResultSet { seq: 11, rows: Rows::Independents(vec![row]) }));
 
-    let encoded = serde_json::to_string(&event).expect("serialize session result set");
-    let decoded: DaemonEvent = serde_json::from_str(&encoded).expect("deserialize session result set");
+    let encoded = serde_json::to_string(&event).expect("serialize independents result set");
+    let decoded: DaemonEvent = serde_json::from_str(&encoded).expect("deserialize independents result set");
     let DaemonEvent::ResultSet(result_set) = decoded else { panic!("expected ResultSet") };
     assert_eq!(result_set.seq, 11);
-    assert_eq!(result_set.query(), QueryId::Sessions);
-    let rows = result_set.rows.as_sessions().expect("session rows");
+    assert_eq!(result_set.query(), QueryId::Independents);
+    let rows = result_set.rows.as_independents().expect("independent rows");
     assert_eq!(rows[0].name, "terminal-yeoman");
     assert_eq!(rows[0].repo.as_ref().map(|repo| repo.0.as_str()), Some("flotilla-org/flotilla"));
     assert_eq!(rows[0].host, HostName::new("local"));
@@ -637,12 +637,12 @@ fn subscribe_queries_request_round_trips_cursors() {
     use crate::result_set::QueryId;
 
     let request = Request::SubscribeQueries {
-        queries: vec![QueryCursor { query: QueryId::Convoys, since: Some(41) }, QueryCursor { query: QueryId::Sessions, since: None }],
+        queries: vec![QueryCursor { query: QueryId::Convoys, since: Some(41) }, QueryCursor { query: QueryId::Independents, since: None }],
     };
     let encoded = serde_json::to_string(&request).expect("serialize subscribe request");
     assert!(encoded.contains("\"subscribe_queries\""));
     assert!(encoded.contains("\"convoys\""));
-    assert!(encoded.contains("\"sessions\""));
+    assert!(encoded.contains("\"independents\""));
     let decoded: Request = serde_json::from_str(&encoded).expect("deserialize subscribe request");
     assert_eq!(decoded, request);
 }

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -24,19 +24,19 @@ pub enum QueryId {
     /// All Convoys — durable ∪ observed, fleet-merged, joined with
     /// Presentation attach state. Rows are [`ConvoyRow`].
     Convoys,
-    /// Free-floating TerminalSessions with no Convoy association. Rows are
-    /// [`SessionRow`].
-    Sessions,
+    /// TerminalSessions with no Convoy association. Rows are
+    /// [`IndependentRow`].
+    Independents,
 }
 
 impl QueryId {
     /// Every query the Aggregator maintains.
-    pub const ALL: &'static [QueryId] = &[QueryId::Convoys, QueryId::Sessions];
+    pub const ALL: &'static [QueryId] = &[QueryId::Convoys, QueryId::Independents];
 
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Convoys => "convoys",
-            Self::Sessions => "sessions",
+            Self::Independents => "independents",
         }
     }
 }
@@ -89,21 +89,21 @@ impl ResultDelta {
 #[serde(tag = "kind", content = "rows", rename_all = "snake_case")]
 pub enum Rows {
     Convoys(Vec<ConvoyRow>),
-    Sessions(Vec<SessionRow>),
+    Independents(Vec<IndependentRow>),
 }
 
 impl Rows {
     pub fn query(&self) -> QueryId {
         match self {
             Self::Convoys(_) => QueryId::Convoys,
-            Self::Sessions(_) => QueryId::Sessions,
+            Self::Independents(_) => QueryId::Independents,
         }
     }
 
     pub fn len(&self) -> usize {
         match self {
             Self::Convoys(rows) => rows.len(),
-            Self::Sessions(rows) => rows.len(),
+            Self::Independents(rows) => rows.len(),
         }
     }
 
@@ -118,15 +118,15 @@ impl Rows {
         }
     }
 
-    pub fn as_sessions(&self) -> Option<&[SessionRow]> {
+    pub fn as_independents(&self) -> Option<&[IndependentRow]> {
         match self {
-            Self::Sessions(rows) => Some(rows),
+            Self::Independents(rows) => Some(rows),
             _ => None,
         }
     }
 }
 
-/// Lifecycle phase of a free-floating terminal session.
+/// Lifecycle phase of an independent terminal session.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionPhase {
@@ -154,10 +154,10 @@ impl fmt::Display for SessionPhase {
     }
 }
 
-/// One row of the [`QueryId::Sessions`] result set.
+/// One row of the [`QueryId::Independents`] result set.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 #[builder(on(String, into))]
-pub struct SessionRow {
+pub struct IndependentRow {
     /// Row identity and merge key across hosts.
     pub resource: ResourceRef,
     pub name: String,

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -29,7 +29,7 @@ use flotilla_manifest::{
     wire::MetadataPatch,
 };
 use flotilla_protocol::{
-    result_set::{ConvoyRow, ResultDelta, ResultSet, Rows, SessionRow},
+    result_set::{ConvoyRow, IndependentRow, ResultDelta, ResultSet, Rows},
     DaemonEvent, QueryCursor, QueryId, ResourceRef,
 };
 use tokio::sync::broadcast::error::RecvError;
@@ -74,7 +74,7 @@ pub enum Applied {
 #[derive(Default)]
 pub struct ConnectorState {
     convoys: HashMap<ResourceRef, ConvoyRow>,
-    sessions: HashMap<ResourceRef, SessionRow>,
+    independents: HashMap<ResourceRef, IndependentRow>,
     seqs: HashMap<QueryId, u64>,
     catalog: Catalog,
 }
@@ -95,7 +95,7 @@ impl ConnectorState {
         }
         match &set.rows {
             Rows::Convoys(rows) => self.convoys = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect(),
-            Rows::Sessions(rows) => self.sessions = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect(),
+            Rows::Independents(rows) => self.independents = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect(),
         }
         self.seqs.insert(query, set.seq);
         Applied::Updated
@@ -118,9 +118,9 @@ impl ConnectorState {
                     self.convoys.insert(row.resource.clone(), row.clone());
                 }
             }
-            Rows::Sessions(rows) => {
+            Rows::Independents(rows) => {
                 for row in rows {
-                    self.sessions.insert(row.resource.clone(), row.clone());
+                    self.independents.insert(row.resource.clone(), row.clone());
                 }
             }
         }
@@ -129,8 +129,8 @@ impl ConnectorState {
                 QueryId::Convoys => {
                     self.convoys.remove(removed);
                 }
-                QueryId::Sessions => {
-                    self.sessions.remove(removed);
+                QueryId::Independents => {
+                    self.independents.remove(removed);
                 }
             }
         }
@@ -142,8 +142,8 @@ impl ConnectorState {
     /// move the PM from the previously published catalog to the new one.
     pub fn rebuild(&mut self, mint: &dyn RecipeMint) -> Vec<MetadataPatch> {
         let convoys: Vec<ConvoyRow> = self.convoys.values().cloned().collect();
-        let sessions: Vec<SessionRow> = self.sessions.values().cloned().collect();
-        let next = project_catalog(&CatalogInput { convoys: &convoys, sessions: &sessions }, mint);
+        let independents: Vec<IndependentRow> = self.independents.values().cloned().collect();
+        let next = project_catalog(&CatalogInput { convoys: &convoys, independents: &independents }, mint);
         let patches = next.diff_patches(&self.catalog);
         self.catalog = next;
         patches

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -16,8 +16,8 @@ use tokio::sync::broadcast;
 
 use super::*;
 
-fn session_row(name: &str, phase: SessionPhase) -> SessionRow {
-    SessionRow::builder()
+fn independent_row(name: &str, phase: SessionPhase) -> IndependentRow {
+    IndependentRow::builder()
         .resource(ResourceRef::new("flotilla/v1", "TerminalSession", "dev", name).on_host(HostName::new("feta")))
         .name(name)
         .host(HostName::new("feta"))
@@ -26,12 +26,12 @@ fn session_row(name: &str, phase: SessionPhase) -> SessionRow {
         .build()
 }
 
-fn sessions_set(seq: u64, rows: Vec<SessionRow>) -> DaemonEvent {
-    DaemonEvent::ResultSet(Box::new(ResultSet { seq, rows: Rows::Sessions(rows) }))
+fn independents_set(seq: u64, rows: Vec<IndependentRow>) -> DaemonEvent {
+    DaemonEvent::ResultSet(Box::new(ResultSet { seq, rows: Rows::Independents(rows) }))
 }
 
-fn sessions_delta(seq: u64, changed: Vec<SessionRow>, removed: Vec<ResourceRef>) -> DaemonEvent {
-    DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changed: Rows::Sessions(changed), removed }))
+fn independents_delta(seq: u64, changed: Vec<IndependentRow>, removed: Vec<ResourceRef>) -> DaemonEvent {
+    DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changed: Rows::Independents(changed), removed }))
 }
 
 fn convoys_set(seq: u64) -> DaemonEvent {
@@ -42,7 +42,7 @@ fn mint() -> AttachOnlyRecipes {
     AttachOnlyRecipes::new("flotilla")
 }
 
-fn session_group(name: &str) -> MetadataTarget {
+fn independent_group(name: &str) -> MetadataTarget {
     MetadataTarget::Group(GroupPath(vec![GroupSegment::text(SEGMENT_VESSEL, name)]))
 }
 
@@ -53,34 +53,34 @@ fn session_identity(value: &str) -> MetadataTarget {
 #[test]
 fn state_applies_full_set_then_contiguous_deltas() {
     let mut state = ConnectorState::default();
-    assert_eq!(state.apply_event(&sessions_set(3, vec![session_row("scratch", SessionPhase::Running)])), Applied::Updated);
-    assert_eq!(state.apply_event(&sessions_delta(4, vec![session_row("yeoman", SessionPhase::Running)], vec![])), Applied::Updated);
-    assert_eq!(state.sessions.len(), 2);
+    assert_eq!(state.apply_event(&independents_set(3, vec![independent_row("scratch", SessionPhase::Running)])), Applied::Updated);
+    assert_eq!(state.apply_event(&independents_delta(4, vec![independent_row("yeoman", SessionPhase::Running)], vec![])), Applied::Updated);
+    assert_eq!(state.independents.len(), 2);
 
     // Duplicates and stale full sets are ignored.
-    assert_eq!(state.apply_event(&sessions_delta(4, vec![], vec![])), Applied::Ignored);
-    assert_eq!(state.apply_event(&sessions_set(2, vec![])), Applied::Ignored);
-    assert_eq!(state.sessions.len(), 2);
+    assert_eq!(state.apply_event(&independents_delta(4, vec![], vec![])), Applied::Ignored);
+    assert_eq!(state.apply_event(&independents_set(2, vec![])), Applied::Ignored);
+    assert_eq!(state.independents.len(), 2);
 
     // Removal deltas drop rows.
-    let removed = session_row("yeoman", SessionPhase::Running).resource;
-    assert_eq!(state.apply_event(&sessions_delta(5, vec![], vec![removed])), Applied::Updated);
-    assert_eq!(state.sessions.len(), 1);
+    let removed = independent_row("yeoman", SessionPhase::Running).resource;
+    assert_eq!(state.apply_event(&independents_delta(5, vec![], vec![removed])), Applied::Updated);
+    assert_eq!(state.independents.len(), 1);
 }
 
 #[test]
 fn gaps_and_unseeded_deltas_request_resubscription() {
     let mut state = ConnectorState::default();
     // A delta before any full set is a gap: there is nothing to apply onto.
-    assert_eq!(state.apply_event(&sessions_delta(1, vec![], vec![])), Applied::Gap(QueryId::Sessions));
+    assert_eq!(state.apply_event(&independents_delta(1, vec![], vec![])), Applied::Gap(QueryId::Independents));
 
-    assert_eq!(state.apply_event(&sessions_set(1, vec![])), Applied::Updated);
-    assert_eq!(state.apply_event(&sessions_delta(3, vec![], vec![])), Applied::Gap(QueryId::Sessions));
+    assert_eq!(state.apply_event(&independents_set(1, vec![])), Applied::Updated);
+    assert_eq!(state.apply_event(&independents_delta(3, vec![], vec![])), Applied::Gap(QueryId::Independents));
 
     // Cursors resume from what was actually applied.
     let cursors = state.cursors();
-    let sessions = cursors.iter().find(|cursor| cursor.query == QueryId::Sessions).expect("sessions cursor");
-    assert_eq!(sessions.since, Some(1));
+    let independents = cursors.iter().find(|cursor| cursor.query == QueryId::Independents).expect("independents cursor");
+    assert_eq!(independents.since, Some(1));
     let convoys = cursors.iter().find(|cursor| cursor.query == QueryId::Convoys).expect("convoys cursor");
     assert_eq!(convoys.since, None, "never-seen queries subscribe from scratch");
 }
@@ -88,18 +88,19 @@ fn gaps_and_unseeded_deltas_request_resubscription() {
 #[test]
 fn rebuild_publishes_diffs_not_repeats() {
     let mut state = ConnectorState::default();
-    state.apply_event(&sessions_set(1, vec![session_row("scratch", SessionPhase::Running)]));
+    state.apply_event(&independents_set(1, vec![independent_row("scratch", SessionPhase::Running)]));
 
     let first = state.rebuild(&mint());
-    assert!(first.iter().any(|patch| patch.target == session_group("scratch")));
+    assert!(first.iter().any(|patch| patch.target == independent_group("scratch")));
     assert!(first.iter().any(|patch| patch.target == session_identity("feta/dev/scratch")));
 
     assert!(state.rebuild(&mint()).is_empty(), "unchanged rows publish nothing");
 
-    let removed = session_row("scratch", SessionPhase::Running).resource;
-    state.apply_event(&sessions_delta(2, vec![], vec![removed]));
+    let removed = independent_row("scratch", SessionPhase::Running).resource;
+    state.apply_event(&independents_delta(2, vec![], vec![removed]));
     let after_removal = state.rebuild(&mint());
-    let group_patch = after_removal.iter().find(|patch| patch.target == session_group("scratch")).expect("unset patch for removed session");
+    let group_patch =
+        after_removal.iter().find(|patch| patch.target == independent_group("scratch")).expect("unset patch for removed independent");
     assert!(group_patch.set.is_empty());
     assert!(group_patch.unset.contains(&KEY_STATUS_STATE.to_owned()));
 }
@@ -195,7 +196,8 @@ async fn wait_until(mut condition: impl FnMut() -> bool) {
 
 #[tokio::test]
 async fn connector_publishes_bootstrap_deltas_gap_recovery_and_reasserts() {
-    let daemon = Arc::new(MockDaemon::new(vec![convoys_set(1), sessions_set(1, vec![session_row("scratch", SessionPhase::Running)])]));
+    let daemon =
+        Arc::new(MockDaemon::new(vec![convoys_set(1), independents_set(1, vec![independent_row("scratch", SessionPhase::Running)])]));
     let sink = Arc::new(RecordingSink::new());
     let handle = tokio::spawn(run_connector(
         daemon.clone() as Arc<dyn DaemonHandle>,
@@ -204,17 +206,17 @@ async fn connector_publishes_bootstrap_deltas_gap_recovery_and_reasserts() {
         Duration::from_millis(50),
     ));
 
-    // Bootstrap: the session's group and identity facts are published.
+    // Bootstrap: the independent's group and identity facts are published.
     wait_until(|| {
         let patches = sink.recorded();
-        patches.iter().any(|patch| patch.target == session_group("scratch"))
+        patches.iter().any(|patch| patch.target == independent_group("scratch"))
             && patches.iter().any(|patch| patch.target == session_identity("feta/dev/scratch"))
     })
     .await;
 
     // A contiguous delta publishes the change.
-    daemon.tx.send(sessions_delta(2, vec![session_row("yeoman", SessionPhase::Running)], vec![])).expect("send delta");
-    wait_until(|| sink.recorded().iter().any(|patch| patch.target == session_group("yeoman"))).await;
+    daemon.tx.send(independents_delta(2, vec![independent_row("yeoman", SessionPhase::Running)], vec![])).expect("send delta");
+    wait_until(|| sink.recorded().iter().any(|patch| patch.target == independent_group("yeoman"))).await;
 
     // The reassert tick republishes the full catalog.
     let seen = sink.recorded().len();
@@ -223,7 +225,7 @@ async fn connector_publishes_bootstrap_deltas_gap_recovery_and_reasserts() {
     // A gapped delta triggers resubscription (the mock replies with its
     // bootstrap sets again).
     let calls_before = daemon.subscribe_calls.load(Ordering::SeqCst);
-    daemon.tx.send(sessions_delta(9, vec![], vec![])).expect("send gapped delta");
+    daemon.tx.send(independents_delta(9, vec![], vec![])).expect("send gapped delta");
     wait_until(|| daemon.subscribe_calls.load(Ordering::SeqCst) > calls_before).await;
 
     handle.abort();


### PR DESCRIPTION
## What

- rename the control-plane `Sessions` query surface to `Independents`, including protocol rows, projections, federation, manifest input, and PM connector state
- change the query wire spelling and manifest factory namespace from `sessions` to `independents`
- preserve resource-layer `TerminalSession` and lifecycle `SessionPhase` terminology
- cover the classification invariant that convoy-bound terminal sessions appear through convoy vessel rows and never through independents

## Why

Issue #731 establishes **Independent** as the canonical query/view noun for running terminal sessions that are not attached to a convoy. This removes the overloaded `Sessions` query vocabulary while leaving the underlying resource model intact.

## Impact

This intentionally makes the query protocol spelling a breaking change with no compatibility shim. Consumers must subscribe to `independents` and decode `IndependentRow` values.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- standards and spec reviews passed after strengthening the convoy classification integration test

Closes #731