### PR TITLE
feat: add independents table

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -342,6 +342,7 @@ pub async fn build_plan(
         | CommandAction::QueryHostStatus { .. }
         | CommandAction::QueryHostProviders { .. }
         | CommandAction::Attach { .. }
+        | CommandAction::AttachTransient { .. }
         | CommandAction::QueryIssues { .. }
         | CommandAction::QueryIssueFetchByIds { .. }
         | CommandAction::QueryIssueOpenInBrowser { .. } => {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -272,6 +272,9 @@ fn attach_reference_label(session_name: &str, labels: &BTreeMap<String, String>)
 
 fn fleet_row_attach_reference_keys(row: &FleetListRow) -> Vec<String> {
     let mut refs = vec![row.convoy.clone(), row.vessel.clone(), row.crew.clone()];
+    if let Some(session) = &row.session {
+        refs.push(session.clone());
+    }
     if row.crew != "-" {
         refs.push(format!("{}/{}", row.convoy, row.crew));
         if let Some((_task, role)) = row.crew.rsplit_once('/') {
@@ -297,10 +300,10 @@ enum AttachTarget {
 }
 
 impl AttachTarget {
-    async fn resolve(&self, daemon: &InProcessDaemon, reference: &str) -> Result<ResolvedAttach, String> {
+    async fn resolve(&self, daemon: &InProcessDaemon, reference: &str, transient: bool) -> Result<ResolvedAttach, String> {
         match self {
             Self::Local(session) => {
-                let (command, host) = daemon.attach_command_for_session(reference, session).await?;
+                let (command, host) = daemon.attach_command_for_session(reference, session, transient).await?;
                 let labels = &session.metadata.labels;
                 let binding = AttachBinding::builder()
                     .host(host)
@@ -313,13 +316,13 @@ impl AttachTarget {
                 Ok(ResolvedAttach { command, binding: Some(binding) })
             }
             Self::Replica { row } => {
-                let command = daemon.recursive_attach_command_for_remote(&row.host, reference).await?;
+                let command = daemon.recursive_attach_command_for_remote(&row.host, reference, transient).await?;
                 // Replica rows carry crew as "vessel/role" (or a bare role)
                 // and the owning host's namespace + session name, so
                 // cross-host panes stamp the full join key.
                 let (vessel, role) = match row.crew.split_once('/') {
                     Some((vessel, role)) => (Some(vessel.to_owned()), Some(role.to_owned())),
-                    None => (None, Some(row.crew.clone()).filter(|role| !role.is_empty())),
+                    None => (None, Some(row.crew.clone()).filter(|role| !role.is_empty() && role != "-")),
                 };
                 let binding = AttachBinding::builder()
                     .host(row.host.clone())
@@ -338,6 +341,7 @@ impl AttachTarget {
 struct AttachCandidate {
     label: String,
     references: Vec<String>,
+    host: HostName,
     target: AttachTarget,
 }
 
@@ -357,12 +361,18 @@ impl AttachCandidateIndex {
         Self { candidates, exact }
     }
 
-    async fn resolve(&self, daemon: &InProcessDaemon, reference: &str) -> Result<ResolvedAttach, String> {
+    async fn resolve(
+        &self,
+        daemon: &InProcessDaemon,
+        reference: &str,
+        host: Option<&HostName>,
+        transient: bool,
+    ) -> Result<ResolvedAttach, String> {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }
 
-        let matches = self.exact.get(reference).cloned().unwrap_or_else(|| {
+        let mut matches = self.exact.get(reference).cloned().unwrap_or_else(|| {
             self.candidates
                 .iter()
                 .enumerate()
@@ -370,9 +380,15 @@ impl AttachCandidateIndex {
                 .map(|(index, _)| index)
                 .collect()
         });
+        if let Some(host) = host {
+            matches.retain(|index| &self.candidates[*index].host == host);
+        }
         match matches.as_slice() {
-            [] => Err(format!("no attach target matching '{reference}'")),
-            [index] => self.candidates[*index].target.resolve(daemon, reference).await,
+            [] => match host {
+                Some(host) => Err(format!("no attach target matching '{reference}' on host '{host}'")),
+                None => Err(format!("no attach target matching '{reference}'")),
+            },
+            [index] => self.candidates[*index].target.resolve(daemon, reference, transient).await,
             _ => {
                 let mut labels: Vec<_> = matches.iter().map(|index| self.candidates[*index].label.clone()).collect();
                 labels.sort();
@@ -2903,7 +2919,19 @@ impl InProcessDaemon {
             return Err("attach reference is required".to_string());
         }
         let index = self.attach_candidate_index().await?;
-        index.resolve(self, reference).await
+        index.resolve(self, reference, None, false).await
+    }
+
+    pub async fn resolve_transient_attach_command_internal(
+        &self,
+        reference: &str,
+        host: Option<&HostName>,
+    ) -> Result<ResolvedAttach, String> {
+        if reference.trim().is_empty() {
+            return Err("attach reference is required".to_string());
+        }
+        let index = self.attach_candidate_index().await?;
+        index.resolve(self, reference, host, true).await
     }
 
     pub async fn resolvable_attach_references_internal(&self, references: &[String]) -> Result<HashSet<String>, String> {
@@ -2913,7 +2941,7 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = HashSet::new();
         for reference in references {
-            if index.resolve(self, reference).await.is_ok() {
+            if index.resolve(self, reference, Some(&self.host_name), false).await.is_ok() {
                 resolved.insert(reference.clone());
             }
         }
@@ -2944,6 +2972,7 @@ impl InProcessDaemon {
             candidates.push(AttachCandidate {
                 label: attach_reference_label(&session.metadata.name, &session.metadata.labels),
                 references: attach_reference_keys(&session.metadata.name, &session.metadata.labels),
+                host: self.host_name.clone(),
                 target: AttachTarget::Local(Box::new(session)),
             });
         }
@@ -2956,15 +2985,55 @@ impl InProcessDaemon {
         let cache = self.fleet_replica_cache.read().await;
         for host in configured_replica_hosts {
             if let Some(entry) = cache.get(&host) {
+                let independent_references = entry
+                    .result_sets
+                    .iter()
+                    .filter_map(|result_set| result_set.rows.as_independents())
+                    .flatten()
+                    .filter_map(|row| row.attach.as_deref())
+                    .collect::<HashSet<_>>();
+                let mut indexed_sessions = HashSet::new();
                 for row in &entry.rows {
                     if row.crew_state != "running" {
                         continue;
                     }
+                    if let Some(session) = &row.session {
+                        if independent_references.contains(session.as_str()) {
+                            continue;
+                        }
+                        indexed_sessions.insert(session.clone());
+                    }
                     candidates.push(AttachCandidate {
                         label: fleet_row_attach_reference_label(row),
                         references: fleet_row_attach_reference_keys(row),
+                        host: row.host.clone(),
                         target: AttachTarget::Replica { row: Box::new(row.clone()) },
                     });
+                }
+                for result_set in &entry.result_sets {
+                    let Rows::Independents(rows) = &result_set.rows else { continue };
+                    for row in rows {
+                        let Some(reference) = &row.attach else { continue };
+                        if row.phase != flotilla_protocol::SessionPhase::Running || !indexed_sessions.insert(reference.clone()) {
+                            continue;
+                        }
+                        let fleet_row = FleetListRow::builder()
+                            .convoy("-")
+                            .vessel("-")
+                            .crew("-")
+                            .crew_state("running")
+                            .host(host.clone())
+                            .namespace(row.resource.namespace.clone())
+                            .session(reference.clone())
+                            .staleness(FleetStaleness::Local)
+                            .build();
+                        candidates.push(AttachCandidate {
+                            label: format!("{} ({host})", row.name),
+                            references: vec![reference.clone()],
+                            host: host.clone(),
+                            target: AttachTarget::Replica { row: Box::new(fleet_row) },
+                        });
+                    }
                 }
             }
         }
@@ -2978,6 +3047,7 @@ impl InProcessDaemon {
         &self,
         reference: &str,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
+        transient: bool,
     ) -> Result<(String, HostName), String> {
         let namespace = self.provisioning_namespace().await;
         let environments = self.resource_backend.clone().using::<ResourceEnvironment>(&namespace);
@@ -2994,7 +3064,7 @@ impl InProcessDaemon {
             .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
         let target_host = self.target_host_for_resource_ref(host_ref);
         if target_host != self.host_name {
-            let command = self.recursive_attach_command_for_remote(&target_host, reference).await?;
+            let command = self.recursive_attach_command_for_remote(&target_host, reference, transient).await?;
             return Ok((command, target_host));
         }
 
@@ -3002,18 +3072,26 @@ impl InProcessDaemon {
         Ok((command, self.host_name.clone()))
     }
 
-    async fn recursive_attach_command_for_remote(&self, target_host: &HostName, reference: &str) -> Result<String, String> {
+    async fn recursive_attach_command_for_remote(
+        &self,
+        target_host: &HostName,
+        reference: &str,
+        transient: bool,
+    ) -> Result<String, String> {
         let next_hop = self.host_registry.next_hop_host_for_target_host(target_host).await?.unwrap_or_else(|| target_host.clone());
         if next_hop == self.host_name {
             return Err(format!("unreachable next hop for host '{target_host}': route points back to local host"));
         }
 
         let resolver = ssh_resolver_from_config(self.config.base_path())?;
-        let command = vec![
-            flotilla_protocol::arg::Arg::Literal("flotilla".to_string()),
-            flotilla_protocol::arg::Arg::Literal("attach".to_string()),
-            flotilla_protocol::arg::Arg::Quoted(reference.to_string()),
-        ];
+        let mut command =
+            vec![flotilla_protocol::arg::Arg::Literal("flotilla".to_string()), flotilla_protocol::arg::Arg::Literal("attach".to_string())];
+        if transient {
+            command.push(flotilla_protocol::arg::Arg::Literal("--host".to_string()));
+            command.push(flotilla_protocol::arg::Arg::Quoted(target_host.to_string()));
+            command.push(flotilla_protocol::arg::Arg::Literal("--transient".to_string()));
+        }
+        command.push(flotilla_protocol::arg::Arg::Quoted(reference.to_string()));
         let args = resolver
             .one_hop_command_args(&next_hop, command)
             .map_err(|err| format!("unreachable next hop '{next_hop}' for host '{target_host}': {err}"))?;
@@ -3905,6 +3983,14 @@ impl DaemonHandle for InProcessDaemon {
                 }
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
             },
+            CommandAction::AttachTransient { reference, host } => {
+                match self.resolve_transient_attach_command_internal(reference, host.as_ref()).await {
+                    Ok(resolved) => {
+                        Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command: resolved.command, binding: resolved.binding })
+                    }
+                    Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
+                }
+            }
             CommandAction::QueryIssues { repo, params, page, count } => {
                 let repo_path = self.resolve_repo_selector(repo).await?;
                 let service = self.get_issue_query_service(&repo_path).await?;

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -7,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
-    result_set::{ConvoyPhase as WireConvoyPhase, ConvoyRow, QueryId, ResultSet, Rows},
+    result_set::{ConvoyPhase as WireConvoyPhase, ConvoyRow, IndependentRow, QueryId, ResultSet, Rows, SessionPhase},
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent,
     EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostSummary, ImageId, Issue, QueryCursor, RepoSelector, ResourceRef,
     SystemInfo, ToolInventory, TopologyRoute,
@@ -1285,6 +1285,94 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
     assert!(command.starts_with("ssh -t 'alice@feta.local' "), "bare role should resolve through the replica host: {command}");
     assert!(command.contains("flotilla attach"), "bare role should recursively invoke flotilla attach: {command}");
     assert!(command.contains("coder"), "command should preserve the original bare role reference: {command}");
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "terminal-remote-coder".to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command, .. } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "session name should resolve through the replica host: {command}");
+    assert!(command.contains("terminal-remote-coder"), "command should preserve the independent row's attach reference: {command}");
+}
+
+#[tokio::test]
+async fn transient_attach_selects_the_displayed_host_for_result_set_only_independents() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice")), ("gouda", "gouda.local", None)]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    for host in ["feta", "gouda"] {
+        let host_name = HostName::new(host);
+        let row = IndependentRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "TerminalSession", "dev", "terminal-scratch").on_host(host_name.clone()))
+            .name("terminal-scratch")
+            .host(host_name.clone())
+            .attach("terminal-scratch")
+            .phase(SessionPhase::Running)
+            .build();
+        let fleet_rows = (host == "feta")
+            .then(|| {
+                FleetListRow::builder()
+                    .convoy("-")
+                    .vessel("remote-environment")
+                    .crew("shell")
+                    .crew_state("running")
+                    .host(HostName::new("environment-host"))
+                    .namespace("dev")
+                    .session("terminal-scratch")
+                    .staleness(FleetStaleness::Local)
+                    .build()
+            })
+            .into_iter()
+            .collect();
+        daemon.fleet_replica_cache.write().await.insert(host_name, FleetReplicaCacheEntry {
+            rows: fleet_rows,
+            result_sets: vec![ResultSet { seq: 1, rows: Rows::Independents(vec![row]) }],
+            last_sync: Some(Utc::now()),
+            generation: Some(format!("gen-{host}")),
+            last_error: None,
+        });
+    }
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::AttachTransient { reference: "terminal-scratch".to_string(), host: Some(HostName::new("feta")) },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("transient attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command, binding } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    let binding = binding.expect("replica resolution carries a structured binding");
+    assert_eq!(binding.host, HostName::new("feta"));
+    assert_eq!(binding.session.as_deref(), Some("terminal-scratch"));
+    assert_eq!(binding.convoy, None);
+    assert_eq!(binding.role, None);
+    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "selected row should route through feta: {command}");
+    assert!(command.contains("--transient"), "recursive attach must preserve the no-stamp mode: {command}");
+    assert!(command.contains("--host"), "recursive attach must preserve the owning host: {command}");
+    assert!(!command.contains("gouda.local"), "same-named row on another host must not make selection ambiguous: {command}");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -359,12 +359,19 @@ async fn running_convoyless_session_emits_attachable_independent_row() {
 
     let running = sessions.get("terminal-yeoman").await.expect("running terminal session");
     sessions
-        .update_status(&running.metadata.name, &running.metadata.resource_version, &TerminalSessionStatus {
-            phase: TerminalSessionPhase::Stopped,
-            ..Default::default()
-        })
+        .update(
+            &InputMeta::builder()
+                .name(running.metadata.name.clone())
+                .labels(BTreeMap::from([
+                    (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+                    (VESSEL_LABEL.to_string(), "yeoman".to_string()),
+                ]))
+                .build(),
+            &running.metadata.resource_version,
+            &running.spec,
+        )
         .await
-        .expect("stop terminal session");
+        .expect("adopt terminal session into convoy");
     let removed = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
@@ -375,7 +382,7 @@ async fn running_convoyless_session_emits_attachable_independent_row() {
         }
     })
     .await
-    .expect("timed out waiting for stopped session removal");
+    .expect("timed out waiting for adopted session removal");
     assert_eq!(removed.removed.len(), 1);
     assert_eq!(removed.removed[0].name, "terminal-yeoman");
 }

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -108,6 +108,13 @@ pub enum CommandAction {
     Attach {
         reference: String,
     },
+    /// Resolve an attach for a temporary foreground excursion. Unlike the
+    /// human-facing CLI attach, recursive hops must not stamp PM metadata.
+    AttachTransient {
+        reference: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        host: Option<crate::HostName>,
+    },
     PrepareTerminalForCheckout {
         checkout_path: PathBuf,
         /// Role→command mappings from the requesting host's template.
@@ -271,6 +278,7 @@ impl CommandAction {
                 | CommandAction::QueryCrewList { .. }
                 | CommandAction::QueryFleetReplicaSnapshot {}
                 | CommandAction::Attach { .. }
+                | CommandAction::AttachTransient { .. }
                 | CommandAction::QueryIssues { .. }
                 | CommandAction::QueryIssueFetchByIds { .. }
                 | CommandAction::QueryIssueOpenInBrowser { .. }
@@ -285,6 +293,7 @@ impl Command {
             CommandAction::CreateWorkspaceFromPreparedTerminal { .. } => "Creating workspace...",
             CommandAction::SelectWorkspace { .. } => "Switching workspace...",
             CommandAction::Attach { .. } => "Resolving attach target...",
+            CommandAction::AttachTransient { .. } => "Resolving temporary attach target...",
             CommandAction::PrepareTerminalForCheckout { .. } => "Preparing terminal...",
             CommandAction::Checkout { target, .. } => match target {
                 CheckoutTarget::Branch(_) => "Checking out branch...",
@@ -560,6 +569,12 @@ mod tests {
                 provisioning_target: None,
                 context_repo: None,
                 action: CommandAction::Attach { reference: "convoy-a".into() },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::AttachTransient { reference: "terminal-scratch".into(), host: Some(crate::HostName::new("feta")) },
             },
             Command {
                 node_id: None,

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -115,7 +115,7 @@ pub use snapshot::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 11;
+pub const PROTOCOL_VERSION: u32 = 12;
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.

--- a/crates/flotilla-protocol/src/view_address.rs
+++ b/crates/flotilla-protocol/src/view_address.rs
@@ -30,6 +30,8 @@ pub enum ViewAddress {
     Overview,
     /// All convoys in one namespace.
     Convoys { namespace: String },
+    /// All terminal sessions that are not associated with a Convoy.
+    Independents,
     /// One convoy: its vessel DAG, phases, and intents.
     Convoy { namespace: String, name: String },
     /// One vessel: crew, work state, attach.
@@ -46,6 +48,7 @@ impl ViewAddress {
         match self {
             Self::Overview => "overview",
             Self::Convoys { .. } => "convoys",
+            Self::Independents => "independents",
             Self::Convoy { .. } => "convoy",
             Self::Vessel { .. } => "vessel",
             Self::Project { .. } => "project",
@@ -70,6 +73,7 @@ impl fmt::Display for ViewAddress {
         match self {
             Self::Overview => f.write_str("overview"),
             Self::Convoys { namespace } => write!(f, "convoys/{}", encode(namespace)),
+            Self::Independents => f.write_str("independents"),
             Self::Convoy { namespace, name } => write!(f, "convoy/{}/{}", encode(namespace), encode(name)),
             Self::Vessel { namespace, convoy, vessel } => {
                 write!(f, "vessel/{}/{}/{}", encode(namespace), encode(convoy), encode(vessel))
@@ -114,6 +118,10 @@ impl FromStr for ViewAddress {
             "convoys" => match segments[1..] {
                 [namespace] => Ok(Self::Convoys { namespace: decode(namespace)? }),
                 _ => Err(format!("convoys takes exactly one parameter (namespace): {s}")),
+            },
+            "independents" => match segments.len() {
+                1 => Ok(Self::Independents),
+                _ => Err(format!("independents takes no parameters: {s}")),
             },
             "convoy" => match segments[1..] {
                 [namespace, name] => Ok(Self::Convoy { namespace: decode(namespace)?, name: decode(name)? }),
@@ -173,6 +181,12 @@ mod tests {
         let addr = ViewAddress::Convoys { namespace: "flotilla".to_string() };
         assert_eq!(addr.to_string(), "convoys/flotilla");
         assert_eq!("convoys/flotilla".parse::<ViewAddress>().expect("parse"), addr);
+    }
+
+    #[test]
+    fn independents_round_trips() {
+        assert_eq!("independents".parse::<ViewAddress>().expect("parse"), ViewAddress::Independents);
+        assert_eq!(ViewAddress::Independents.to_string(), "independents");
     }
 
     #[test]
@@ -240,6 +254,7 @@ mod tests {
         assert!("overview/extra".parse::<ViewAddress>().is_err());
         assert!("convoys".parse::<ViewAddress>().is_err());
         assert!("convoys/a/b".parse::<ViewAddress>().is_err());
+        assert!("independents/extra".parse::<ViewAddress>().is_err());
         assert!("repo/github.com".parse::<ViewAddress>().is_err());
         assert!("".parse::<ViewAddress>().is_err());
         assert!("convoys//x".parse::<ViewAddress>().is_err());

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -19,6 +19,24 @@ use crate::widgets::{branch_input::BranchInputWidget, delete_confirm::DeleteConf
 pub async fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionContext>) {
     app.model.status_message = None;
 
+    // Pane attach is a synchronous query that resolves a command for the TUI
+    // process to run temporarily outside raw mode. It must not go through the
+    // ordinary command lifecycle (`execute` rejects query commands).
+    if matches!(&cmd.action, CommandAction::Attach { .. } | CommandAction::AttachTransient { .. }) {
+        match app.daemon.execute_query(cmd, app.session_id).await {
+            Ok(CommandValue::AttachCommandResolved { command, .. }) => {
+                app.pending_attach_command = Some(command);
+            }
+            Ok(CommandValue::Error { message }) | Err(message) => {
+                app.model.status_message = Some(message);
+            }
+            Ok(other) => {
+                app.model.status_message = Some(format!("unexpected attach response: {other:?}"));
+            }
+        }
+        return;
+    }
+
     // Route issue query commands through the background query path.
     if let CommandAction::QueryIssues { repo, params, page, count } = cmd.action {
         let repo_identity = match repo {
@@ -173,7 +191,27 @@ mod tests {
     };
 
     use super::*;
-    use crate::app::{test_support::stub_app, ui_state::BranchInputKind};
+    use crate::app::{
+        test_support::{stub_app, stub_app_with_query_result},
+        ui_state::BranchInputKind,
+    };
+
+    #[tokio::test]
+    async fn pane_attach_query_hands_the_resolved_command_to_the_event_loop() {
+        let mut app = stub_app_with_query_result(Ok(CommandValue::AttachCommandResolved {
+            command: "cleat attach terminal-scratch".to_string(),
+            binding: None,
+        }));
+        let command = app.command(CommandAction::AttachTransient {
+            reference: "terminal-scratch".to_string(),
+            host: Some(flotilla_protocol::HostName::new("kiwi")),
+        });
+
+        dispatch(command, &mut app, None).await;
+
+        assert_eq!(app.pending_attach_command.as_deref(), Some("cleat attach terminal-scratch"));
+        assert!(app.model.status_message.is_none());
+    }
 
     #[test]
     fn terminal_prepared_does_not_queue_follow_up_workspace_command() {

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -5,6 +5,7 @@ use super::{ui_state::PendingActionContext, App, BranchInputKind, Intent, OwnedS
 use crate::{
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
+    table_view::TableIntent,
     widgets::InteractiveWidget,
 };
 
@@ -366,16 +367,20 @@ impl App {
         }
     }
 
-    pub(super) fn execute_table_intent(&mut self, intent: crate::table_view::TableIntent) {
+    pub(super) fn execute_table_intent(&mut self, intent: TableIntent) {
         let (mut command, host) = match intent {
-            crate::table_view::TableIntent::AttachWorkspace { workspace_ref, host, repo_hint } => {
+            TableIntent::AttachWorkspace { workspace_ref, host, repo_hint } => {
                 let Some(repo_identity) = self.table_action_repo(repo_hint.as_ref()) else {
                     self.set_status_message(Some("Cannot attach workspace: the convoy does not identify a tracked repository".to_string()));
                     return;
                 };
                 (self.repo_command_for_identity(repo_identity, CommandAction::SelectWorkspace { ws_ref: workspace_ref }), host)
             }
-            crate::table_view::TableIntent::ForceCompleteWork { convoy, vessel, host } => {
+            TableIntent::AttachPane { reference, host } => {
+                self.proto_commands.push(self.command(CommandAction::AttachTransient { reference, host: Some(host) }));
+                return;
+            }
+            TableIntent::ForceCompleteWork { convoy, vessel, host } => {
                 (self.command(CommandAction::ConvoyWorkForceComplete { convoy, work: vessel, message: None }), host)
             }
         };

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -24,8 +24,8 @@ use flotilla_core::{
 };
 use flotilla_protocol::{
     Command, CommandAction, CommandValue, DaemonEvent, EnvironmentId, HostName, HostSummary, NodeId, PeerConnectionState, ProviderData,
-    ProviderError, ProvisioningTarget, RepoDelta, RepoIdentity, RepoInfo, RepoLabels, RepoSelector, RepoSnapshot, StepStatus, ViewAddress,
-    WorkItem, WorkItemIdentity,
+    ProviderError, ProvisioningTarget, RepoDelta, RepoIdentity, RepoInfo, RepoLabels, RepoSelector, RepoSnapshot, ResourceRef, StepStatus,
+    ViewAddress, WorkItem, WorkItemIdentity,
 };
 use indexmap::IndexMap;
 pub use intent::Intent;
@@ -276,7 +276,15 @@ pub type NamespaceMap = HashMap<String, NamespaceModel>;
 #[derive(Default)]
 pub struct NamespaceModel {
     pub convoys: IndexMap<crate::convoy_model::ConvoyId, crate::convoy_model::ConvoySummary>,
+    pub independents: IndexMap<ResourceRef, flotilla_protocol::IndependentRow>,
     pub last_seq: u64,
+}
+
+pub fn table_rows(namespaces: &NamespaceMap) -> crate::table_view::TableRows<'_> {
+    crate::table_view::TableRows {
+        convoys: namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect(),
+        independents: namespaces.values().flat_map(|namespace| namespace.independents.values()).collect(),
+    }
 }
 
 /// A command that has been dispatched to the daemon and is awaiting completion.
@@ -385,6 +393,9 @@ pub struct App {
     /// Set when the open-view set changed and the daemon subscription no
     /// longer matches it. The event loop re-subscribes and clears this.
     pub subscriptions_dirty: bool,
+    /// A resolved pane attach waiting for the event loop to leave raw mode,
+    /// run it as a child process, and then restore the TUI.
+    pub pending_attach_command: Option<String>,
 }
 
 impl App {
@@ -453,6 +464,7 @@ impl App {
             pending_repo_opens: Vec::new(),
             query_seqs: HashMap::new(),
             subscriptions_dirty: true,
+            pending_attach_command: None,
         }
     }
 
@@ -1198,31 +1210,58 @@ impl App {
             }
             DaemonEvent::ResultSet(result_set) => {
                 self.query_seqs.insert(result_set.query(), result_set.seq);
-                let Some(rows) = result_set.rows.as_convoys() else { return };
-                self.namespaces.clear();
-                for row in rows {
-                    let convoy = ConvoySummary::from(row);
-                    let namespace = convoy.namespace.clone();
-                    let entry = self.namespaces.entry(namespace.clone()).or_default();
-                    entry.convoys.insert(convoy.id.clone(), convoy);
-                    entry.last_seq = result_set.seq;
+                match &result_set.rows {
+                    flotilla_protocol::Rows::Convoys(rows) => {
+                        for namespace in self.namespaces.values_mut() {
+                            namespace.convoys.clear();
+                        }
+                        for row in rows {
+                            let convoy = ConvoySummary::from(row);
+                            let namespace = convoy.namespace.clone();
+                            let entry = self.namespaces.entry(namespace).or_default();
+                            entry.convoys.insert(convoy.id.clone(), convoy);
+                            entry.last_seq = result_set.seq;
+                        }
+                    }
+                    flotilla_protocol::Rows::Independents(rows) => {
+                        for namespace in self.namespaces.values_mut() {
+                            namespace.independents.clear();
+                        }
+                        for row in rows {
+                            let entry = self.namespaces.entry(row.resource.namespace.clone()).or_default();
+                            entry.independents.insert(row.resource.clone(), row.clone());
+                        }
+                    }
                 }
             }
             DaemonEvent::ResultDelta(delta) => {
                 self.query_seqs.insert(delta.query(), delta.seq);
-                let Some(changed) = delta.changed.as_convoys() else { return };
-                for row in changed {
-                    let convoy = ConvoySummary::from(row);
-                    let namespace = convoy.namespace.clone();
-                    let entry = self.namespaces.entry(namespace.clone()).or_default();
-                    entry.convoys.insert(convoy.id.clone(), convoy);
-                    entry.last_seq = delta.seq;
-                }
-                for removed in &delta.removed {
-                    let namespace = removed.namespace.clone();
-                    if let Some(entry) = self.namespaces.get_mut(&namespace) {
-                        entry.convoys.shift_remove(&ConvoyId::for_resource(removed));
-                        entry.last_seq = delta.seq;
+                match &delta.changed {
+                    flotilla_protocol::Rows::Convoys(changed) => {
+                        for row in changed {
+                            let convoy = ConvoySummary::from(row);
+                            let namespace = convoy.namespace.clone();
+                            let entry = self.namespaces.entry(namespace).or_default();
+                            entry.convoys.insert(convoy.id.clone(), convoy);
+                            entry.last_seq = delta.seq;
+                        }
+                        for removed in &delta.removed {
+                            if let Some(entry) = self.namespaces.get_mut(&removed.namespace) {
+                                entry.convoys.shift_remove(&ConvoyId::for_resource(removed));
+                                entry.last_seq = delta.seq;
+                            }
+                        }
+                    }
+                    flotilla_protocol::Rows::Independents(changed) => {
+                        for row in changed {
+                            let entry = self.namespaces.entry(row.resource.namespace.clone()).or_default();
+                            entry.independents.insert(row.resource.clone(), row.clone());
+                        }
+                        for removed in &delta.removed {
+                            if let Some(entry) = self.namespaces.get_mut(&removed.namespace) {
+                                entry.independents.shift_remove(removed);
+                            }
+                        }
                     }
                 }
             }

--- a/crates/flotilla-tui/src/app/test_support.rs
+++ b/crates/flotilla-tui/src/app/test_support.rs
@@ -3,16 +3,16 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex,
     },
 };
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use flotilla_core::{config::ConfigStore, daemon::DaemonHandle, data::SectionLabels};
 use flotilla_protocol::{
-    qualified_path::HostId, Change, Command, DaemonEvent, EnvironmentId, HostName, HostSummary, NodeId, NodeInfo, ProviderData,
-    ProviderError, ProvisioningTarget, RepoDelta, RepoInfo, RepoLabels, RepoSnapshot, StatusResponse, StreamKey, TopologyResponse,
-    WorkItem,
+    qualified_path::HostId, Change, Command, CommandValue, DaemonEvent, EnvironmentId, HostName, HostSummary, NodeId, NodeInfo,
+    ProviderData, ProviderError, ProvisioningTarget, RepoDelta, RepoInfo, RepoLabels, RepoSnapshot, StatusResponse, StreamKey,
+    TopologyResponse, WorkItem,
 };
 use tokio::sync::broadcast;
 use tui_input::Input;
@@ -24,6 +24,7 @@ use crate::{keymap::Keymap, widgets::WidgetContext};
 
 pub(crate) struct StubDaemon {
     tx: broadcast::Sender<DaemonEvent>,
+    query_result: Mutex<Option<Result<CommandValue, String>>>,
 }
 
 static STUB_APP_CONFIG_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -55,7 +56,13 @@ fn insert_stub_local_host(model: &mut TuiModel) {
 impl StubDaemon {
     pub(crate) fn new() -> Self {
         let (tx, _) = broadcast::channel(1);
-        Self { tx }
+        Self { tx, query_result: Mutex::new(None) }
+    }
+
+    pub(crate) fn with_query_result(result: Result<CommandValue, String>) -> Self {
+        let daemon = Self::new();
+        *daemon.query_result.lock().expect("query result lock") = Some(result);
+        daemon
     }
 }
 
@@ -78,7 +85,7 @@ impl DaemonHandle for StubDaemon {
     }
 
     async fn execute_query(&self, _command: Command, _session_id: uuid::Uuid) -> Result<flotilla_protocol::CommandValue, String> {
-        Err("stub".into())
+        self.query_result.lock().expect("query result lock").take().unwrap_or_else(|| Err("stub".into()))
     }
 
     async fn cancel(&self, _command_id: u64) -> Result<(), String> {
@@ -197,6 +204,14 @@ fn stub_app_with_repo_info(repo_info: RepoInfo) -> App {
 
 fn stub_app_with_repo_infos(repos_info: Vec<RepoInfo>) -> App {
     let daemon: Arc<dyn DaemonHandle> = Arc::new(StubDaemon::new());
+    stub_app_with_daemon(daemon, repos_info)
+}
+
+pub(crate) fn stub_app_with_query_result(result: Result<CommandValue, String>) -> App {
+    stub_app_with_daemon(Arc::new(StubDaemon::with_query_result(result)), vec![default_repo_info()])
+}
+
+fn stub_app_with_daemon(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>) -> App {
     let config_id = STUB_APP_CONFIG_COUNTER.fetch_add(1, Ordering::Relaxed);
     let config_base = std::env::temp_dir().join(format!("flotilla-test-{config_id}"));
     let _ = std::fs::remove_dir_all(&config_base);

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1575,6 +1575,36 @@ fn result_delta_event(delta: impl AsRef<crate::convoy_model::ConvoyFixtureDelta>
     }))
 }
 
+fn independent_row(name: &str, attach: Option<&str>) -> flotilla_protocol::IndependentRow {
+    flotilla_protocol::IndependentRow::builder()
+        .resource(flotilla_protocol::ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", name))
+        .name(name)
+        .repo(flotilla_protocol::RepoKey("flotilla-org/flotilla".to_string()))
+        .host(HostName::local())
+        .maybe_attach(attach.map(ToString::to_string))
+        .phase(flotilla_protocol::SessionPhase::Running)
+        .build()
+}
+
+fn independent_result_set(seq: u64, rows: Vec<flotilla_protocol::IndependentRow>) -> flotilla_protocol::DaemonEvent {
+    flotilla_protocol::DaemonEvent::ResultSet(Box::new(flotilla_protocol::ResultSet {
+        seq,
+        rows: flotilla_protocol::Rows::Independents(rows),
+    }))
+}
+
+fn independent_delta(
+    seq: u64,
+    changed: Vec<flotilla_protocol::IndependentRow>,
+    removed: Vec<flotilla_protocol::ResourceRef>,
+) -> flotilla_protocol::DaemonEvent {
+    flotilla_protocol::DaemonEvent::ResultDelta(Box::new(flotilla_protocol::ResultDelta {
+        seq,
+        changed: flotilla_protocol::Rows::Independents(changed),
+        removed,
+    }))
+}
+
 fn test_convoy(
     namespace: &str,
     name: &str,
@@ -1665,6 +1695,27 @@ fn app_applies_panel_delta() {
         removed: vec![convoy.id.clone()],
     })));
     assert!(app.namespaces["flotilla"].convoys.is_empty());
+}
+
+#[test]
+fn app_applies_independent_sets_and_removal_deltas_without_disturbing_convoys() {
+    let mut app = stub_app();
+    let convoy = test_convoy("flotilla", "x", crate::convoy_model::ConvoyPhase::Active, false);
+    app.handle_daemon_event(result_set_event(Box::new(crate::convoy_model::ConvoyFixtureSnapshot {
+        seq: 1,
+        namespace: "flotilla".into(),
+        convoys: vec![convoy],
+    })));
+    let independent = independent_row("terminal-scratch", Some("terminal-scratch"));
+    let reference = independent.resource.clone();
+
+    app.handle_daemon_event(independent_result_set(4, vec![independent]));
+
+    assert_eq!(app.namespaces["flotilla"].independents.len(), 1);
+    assert_eq!(app.namespaces["flotilla"].convoys.len(), 1, "query snapshots replace only their own family");
+    app.handle_daemon_event(independent_delta(5, vec![], vec![reference]));
+    assert!(app.namespaces["flotilla"].independents.is_empty());
+    assert_eq!(app.namespaces["flotilla"].convoys.len(), 1);
 }
 
 // -- Convoys tab rendering --
@@ -1758,12 +1809,12 @@ fn snapshot_with(convoys: Vec<crate::convoy_model::ConvoySummary>) -> crate::con
 fn selected_table_name(app: &App) -> Option<String> {
     let address = app.views.active_address()?;
     let name_column = match address {
-        ViewAddress::Convoys { .. } | ViewAddress::Project { .. } => 0,
+        ViewAddress::Convoys { .. } | ViewAddress::Independents | ViewAddress::Project { .. } => 0,
         ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. } => 1,
         ViewAddress::Overview | ViewAddress::Repo(_) => return None,
     };
-    let convoys = app.namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect::<Vec<_>>();
-    let view = crate::table_view::project(address, &convoys).ok()?;
+    let rows = crate::app::table_rows(&app.namespaces);
+    let view = crate::table_view::project(address, &rows).ok()?;
     app.views.active_table_state().selected_row(&view).map(|row| row.cells[name_column].text.clone())
 }
 
@@ -1830,6 +1881,25 @@ fn generated_vessel_actions_execute_attach_and_force_complete() {
             if convoy == "alpha" && work == "implement"
     ));
     assert_eq!(complete.context_repo, None, "force-complete remains a context-free command");
+}
+
+#[test]
+fn independent_view_subscribes_and_generates_a_pane_attach_query() {
+    let mut app = stub_app();
+    app.open_view(ViewAddress::Independents);
+    app.handle_daemon_event(independent_result_set(7, vec![independent_row("terminal-scratch", Some("terminal-scratch"))]));
+
+    assert!(app.query_cursors().iter().any(|cursor| cursor.query == flotilla_protocol::QueryId::Independents && cursor.since == Some(7)));
+
+    app.handle_key(key(KeyCode::Char('.')));
+    assert_eq!(selected_table_name(&app).as_deref(), Some("terminal-scratch"));
+    app.handle_key(key(KeyCode::Enter));
+    let command = app.proto_commands.take_next().expect("attach query").0;
+    assert!(matches!(
+        command.action,
+        CommandAction::AttachTransient { ref reference, host: Some(ref host) }
+            if reference == "terminal-scratch" && host == &HostName::local()
+    ));
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/view_kind.rs
+++ b/crates/flotilla-tui/src/app/view_kind.rs
@@ -17,6 +17,7 @@ pub(crate) fn query(address: &ViewAddress) -> Option<QueryId> {
         ViewAddress::Convoys { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. } | ViewAddress::Project { .. } => {
             Some(QueryId::Convoys)
         }
+        ViewAddress::Independents => Some(QueryId::Independents),
         ViewAddress::Overview | ViewAddress::Repo(_) => None,
     }
 }
@@ -46,7 +47,13 @@ pub(crate) fn compose_with_shell(scoped: bool, kind_modes: impl IntoIterator<Ite
 pub(crate) fn kind_modes(address: Option<&ViewAddress>) -> Vec<BindingModeId> {
     match address {
         Some(ViewAddress::Overview) => vec![BindingModeId::Overview],
-        Some(ViewAddress::Convoys { .. } | ViewAddress::Project { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. }) => {
+        Some(
+            ViewAddress::Convoys { .. }
+            | ViewAddress::Independents
+            | ViewAddress::Project { .. }
+            | ViewAddress::Convoy { .. }
+            | ViewAddress::Vessel { .. },
+        ) => {
             vec![BindingModeId::Convoys]
         }
         Some(ViewAddress::Repo(_)) => vec![BindingModeId::Normal],

--- a/crates/flotilla-tui/src/event.rs
+++ b/crates/flotilla-tui/src/event.rs
@@ -1,9 +1,12 @@
-use std::time::Duration;
+use std::{collections::VecDeque, time::Duration};
 
 use crossterm::event::{EventStream, KeyEventKind};
 use flotilla_protocol::DaemonEvent;
 use futures::{FutureExt, StreamExt};
-use tokio::sync::{broadcast, mpsc};
+use tokio::{
+    sync::{broadcast, mpsc},
+    task::JoinHandle,
+};
 
 #[derive(Clone, Debug)]
 pub enum Event {
@@ -16,12 +19,22 @@ pub enum Event {
 pub struct EventHandler {
     tx: mpsc::UnboundedSender<Event>,
     rx: mpsc::UnboundedReceiver<Event>,
+    retained: VecDeque<Event>,
+    tick_rate: Duration,
+    terminal_task: Option<JoinHandle<()>>,
 }
 
 impl EventHandler {
     pub fn new(tick_rate: Duration) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
-        let tx_clone = tx.clone();
+        let mut handler = Self { tx, rx, retained: VecDeque::new(), tick_rate, terminal_task: None };
+        handler.resume_terminal_input();
+        handler
+    }
+
+    fn spawn_terminal_task(&self) -> JoinHandle<()> {
+        let tx = self.tx.clone();
+        let tick_rate = self.tick_rate;
         tokio::spawn(async move {
             let mut reader = EventStream::new();
 
@@ -42,22 +55,43 @@ impl EventHandler {
                 let delay = interval.tick();
                 let event = reader.next().fuse();
                 tokio::select! {
-                    _ = delay => { let _ = tx_clone.send(Event::Tick); }
+                    _ = delay => { let _ = tx.send(Event::Tick); }
                     maybe = event => match maybe {
                         Some(Ok(crossterm::event::Event::Key(k)))
                             if k.kind == KeyEventKind::Press =>
                         {
-                            let _ = tx_clone.send(Event::Key(k));
+                            let _ = tx.send(Event::Key(k));
                         }
                         Some(Ok(crossterm::event::Event::Mouse(m))) => {
-                            let _ = tx_clone.send(Event::Mouse(m));
+                            let _ = tx.send(Event::Mouse(m));
                         }
                         _ => {}
                     }
                 }
             }
-        });
-        Self { tx, rx }
+        })
+    }
+
+    /// Stop polling the controlling terminal while a foreground child owns
+    /// it. Daemon events remain queued; stale terminal input and ticks do not.
+    pub async fn pause_terminal_input(&mut self) {
+        if let Some(task) = self.terminal_task.take() {
+            task.abort();
+            let _ = task.await;
+        }
+        while let Ok(event) = self.rx.try_recv() {
+            if matches!(event, Event::Daemon(_)) {
+                self.retained.push_back(event);
+            }
+        }
+    }
+
+    /// Resume terminal polling after the TUI has re-entered raw mode. The
+    /// task's startup drain discards keys left behind by the attached child.
+    pub fn resume_terminal_input(&mut self) {
+        if self.terminal_task.is_none() {
+            self.terminal_task = Some(self.spawn_terminal_task());
+        }
     }
 
     /// Forward daemon events into the unified event stream.
@@ -80,11 +114,22 @@ impl EventHandler {
     }
 
     pub async fn next(&mut self) -> Option<Event> {
-        self.rx.recv().await
+        match self.retained.pop_front() {
+            Some(event) => Some(event),
+            None => self.rx.recv().await,
+        }
     }
 
     /// Non-blocking: returns the next queued event if one is available.
     pub fn try_next(&mut self) -> Option<Event> {
-        self.rx.try_recv().ok()
+        self.retained.pop_front().or_else(|| self.rx.try_recv().ok())
+    }
+}
+
+impl Drop for EventHandler {
+    fn drop(&mut self) {
+        if let Some(task) = self.terminal_task.take() {
+            task.abort();
+        }
     }
 }

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -130,6 +130,15 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
         while let Some((cmd, pending_ctx)) = app.proto_commands.take_next() {
             app::executor::dispatch(cmd, &mut app, pending_ctx).await;
         }
+        if let Some(command) = app.pending_attach_command.take() {
+            events.pause_terminal_input().await;
+            let (next_terminal, result) = crate::terminal::run_temporary_attach(&command);
+            terminal = next_terminal;
+            events.resume_terminal_input();
+            if let Err(message) = result {
+                app.model.status_message = Some(message);
+            }
+        }
         app.drain_background_updates();
 
         // ── Re-sync query subscriptions after tab-set changes ──

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use flotilla_protocol::{HostName, RepoKey, ViewAddress};
+use flotilla_protocol::{HostName, IndependentRow, RepoKey, SessionPhase, ViewAddress};
 
 use crate::convoy_model::{ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase};
 
@@ -192,6 +192,7 @@ pub struct DetailField {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TableIntent {
     AttachWorkspace { workspace_ref: String, host: HostName, repo_hint: Option<RepoKey> },
+    AttachPane { reference: String, host: HostName },
     ForceCompleteWork { convoy: String, vessel: String, host: HostName },
 }
 
@@ -237,14 +238,35 @@ struct VesselProjection {
     vessel: VesselSummary,
 }
 
-pub fn project(address: &ViewAddress, convoys: &[&ConvoySummary]) -> Result<TableView, String> {
+/// Typed query rows currently available to the table registry. Surfaces build
+/// this once from their query caches; adding a query family grows this input
+/// without teaching the reusable widget about that family.
+#[derive(Default)]
+pub struct TableRows<'a> {
+    pub convoys: Vec<&'a ConvoySummary>,
+    pub independents: Vec<&'a IndependentRow>,
+}
+
+pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView, String> {
     match address {
         ViewAddress::Convoys { namespace } => {
-            let rows = convoys.iter().copied().filter(|convoy| &convoy.namespace == namespace).cloned();
+            let rows = data.convoys.iter().copied().filter(|convoy| &convoy.namespace == namespace).cloned();
             Ok(convoy_spec().project(format!("Convoys · {namespace}"), rows))
         }
+        ViewAddress::Independents => {
+            let mut rows = data.independents.clone();
+            rows.sort_by(|left, right| {
+                (&left.name, left.host.as_str(), &left.resource.namespace).cmp(&(
+                    &right.name,
+                    right.host.as_str(),
+                    &right.resource.namespace,
+                ))
+            });
+            Ok(independent_spec().project("Independents".to_string(), rows.into_iter().cloned()))
+        }
         ViewAddress::Project { namespace, name } => {
-            let rows = convoys
+            let rows = data
+                .convoys
                 .iter()
                 .copied()
                 .filter(|convoy| &convoy.namespace == namespace && convoy.project_ref.as_deref() == Some(name))
@@ -252,7 +274,7 @@ pub fn project(address: &ViewAddress, convoys: &[&ConvoySummary]) -> Result<Tabl
             Ok(convoy_spec().project(format!("Project · {name}"), rows))
         }
         ViewAddress::Convoy { namespace, name } => {
-            let convoy = find_convoy(convoys, namespace, name)?;
+            let convoy = find_convoy(&data.convoys, namespace, name)?;
             let rows = stable_topological_vessels(&convoy.vessels).into_iter().map(|vessel| VesselProjection {
                 namespace: namespace.clone(),
                 convoy: name.clone(),
@@ -262,7 +284,7 @@ pub fn project(address: &ViewAddress, convoys: &[&ConvoySummary]) -> Result<Tabl
             Ok(vessel_spec().project(format!("Convoy · {name}"), rows))
         }
         ViewAddress::Vessel { namespace, convoy, vessel } => {
-            let convoy_row = find_convoy(convoys, namespace, convoy)?;
+            let convoy_row = find_convoy(&data.convoys, namespace, convoy)?;
             let vessel_row = convoy_row
                 .vessels
                 .iter()
@@ -323,6 +345,14 @@ fn vessel_spec() -> TableSpec<VesselProjection> {
         columns: &VESSEL_COLUMNS,
         actions: &VESSEL_ACTIONS,
         row: RowSpec { id: vessel_id, drill: vessel_drill, describe: vessel_description },
+    }
+}
+
+fn independent_spec() -> TableSpec<IndependentRow> {
+    TableSpec {
+        columns: &INDEPENDENT_COLUMNS,
+        actions: &INDEPENDENT_ACTIONS,
+        row: RowSpec { id: independent_id, drill: |_| None, describe: independent_description },
     }
 }
 
@@ -405,6 +435,47 @@ static VESSEL_ACTIONS: [ActionSpec<VesselProjection>; 2] =
         key: 'x',
         resolve: force_complete_vessel,
     }];
+
+static INDEPENDENT_COLUMNS: [ColumnSpec<IndependentRow>; 5] = [
+    ColumnSpec {
+        id: "name",
+        label: "NAME",
+        width: WidthHint::Flexible { minimum: 14, weight: 2 },
+        alignment: Alignment::Left,
+        extract: |row| CellValue::plain(&row.name),
+    },
+    ColumnSpec {
+        id: "repo",
+        label: "REPO",
+        width: WidthHint::Flexible { minimum: 14, weight: 2 },
+        alignment: Alignment::Left,
+        extract: |row| CellValue::plain(row.repo.as_ref().map(|repo| repo.0.as_str()).unwrap_or("—")),
+    },
+    ColumnSpec {
+        id: "host",
+        label: "HOST",
+        width: WidthHint::Flexible { minimum: 8, weight: 1 },
+        alignment: Alignment::Left,
+        extract: |row| CellValue::plain(row.host.to_string()),
+    },
+    ColumnSpec { id: "phase", label: "PHASE", width: WidthHint::Fixed(9), alignment: Alignment::Left, extract: independent_phase },
+    ColumnSpec {
+        id: "attach",
+        label: "ATTACH",
+        width: WidthHint::Fixed(11),
+        alignment: Alignment::Left,
+        extract: |row| {
+            if row.attach.is_some() {
+                CellValue::toned("available", CellTone::Success)
+            } else {
+                CellValue::toned("unavailable", CellTone::Muted)
+            }
+        },
+    },
+];
+
+static INDEPENDENT_ACTIONS: [ActionSpec<IndependentRow>; 1] =
+    [ActionSpec { id: "attach", label: "Attach temporarily", key: 'a', resolve: attach_independent }];
 
 fn convoy_id(row: &ConvoySummary) -> RowId {
     RowId::new(row.id.as_str())
@@ -500,10 +571,45 @@ fn force_complete_vessel(row: &VesselProjection) -> Option<TableIntent> {
     Some(TableIntent::ForceCompleteWork { convoy: target.convoy.clone(), vessel: target.vessel.clone(), host: target.host.clone() })
 }
 
+fn independent_id(row: &IndependentRow) -> RowId {
+    RowId::new(format!("{}/{}/{}/{}@{}", row.resource.api_version, row.resource.kind, row.resource.namespace, row.resource.name, row.host))
+}
+
+fn independent_phase(row: &IndependentRow) -> CellValue {
+    let tone = match row.phase {
+        SessionPhase::Starting => CellTone::Warning,
+        SessionPhase::Running => CellTone::Success,
+        SessionPhase::Stopped => CellTone::Muted,
+        SessionPhase::Failed => CellTone::Error,
+    };
+    CellValue::toned(row.phase.to_string(), tone)
+}
+
+fn independent_description(row: &IndependentRow) -> Vec<DetailField> {
+    vec![
+        DetailField { label: "Namespace", value: row.resource.namespace.clone() },
+        DetailField { label: "Name", value: row.name.clone() },
+        DetailField { label: "Repository", value: row.repo.as_ref().map(|repo| repo.0.clone()).unwrap_or_else(|| "—".to_string()) },
+        DetailField { label: "Host", value: row.host.to_string() },
+        DetailField { label: "Phase", value: row.phase.to_string() },
+        DetailField { label: "Attach", value: if row.attach.is_some() { "available" } else { "unavailable" }.to_string() },
+    ]
+}
+
+fn attach_independent(row: &IndependentRow) -> Option<TableIntent> {
+    Some(TableIntent::AttachPane { reference: row.attach.clone()?, host: row.host.clone() })
+}
+
 #[cfg(test)]
 mod tests {
+    use flotilla_protocol::ResourceRef;
+
     use super::*;
     use crate::convoy_model::{ConvoyId, ProcessSummary, WorkCompletionTarget};
+
+    fn project_convoys(address: &str, convoys: &[&ConvoySummary]) -> Result<TableView, String> {
+        project(&address.parse().expect("valid address"), &TableRows { convoys: convoys.to_vec(), independents: vec![] })
+    }
 
     fn vessel(name: &str, depends_on: &[&str], phase: WorkPhase) -> VesselSummary {
         VesselSummary {
@@ -540,12 +646,23 @@ mod tests {
         }
     }
 
+    fn independent(name: &str, host: &str, attach: Option<&str>) -> IndependentRow {
+        IndependentRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "TerminalSession", "dev", name))
+            .name(name)
+            .repo(RepoKey("flotilla-org/flotilla".to_string()))
+            .host(HostName::new(host))
+            .maybe_attach(attach.map(ToString::to_string))
+            .phase(SessionPhase::Running)
+            .build()
+    }
+
     #[test]
     fn convoy_projection_exposes_honest_phase_message_and_drill_target() {
         let mut row = convoy(vec![vessel("implement", &[], WorkPhase::Running)]);
         row.phase = ConvoyPhase::Failed;
         row.message = Some("workspace launch failed: disk full".into());
-        let view = project(&"convoys/dev".parse().expect("valid address"), &[&row]).expect("project table");
+        let view = project_convoys("convoys/dev", &[&row]).expect("project table");
 
         assert_eq!(view.columns.iter().map(|column| column.id).collect::<Vec<_>>(), vec![
             "name", "workflow", "phase", "vessels", "scope", "message"
@@ -562,7 +679,7 @@ mod tests {
             vessel("docs", &[], WorkPhase::Ready),
             vessel("implement", &[], WorkPhase::Running),
         ]);
-        let view = project(&"convoy/dev/tables".parse().expect("valid address"), &[&row]).expect("project table");
+        let view = project_convoys("convoy/dev/tables", &[&row]).expect("project table");
 
         let names = view.rows.iter().map(|row| row.cells[1].text.as_str()).collect::<Vec<_>>();
         assert_eq!(names, vec!["docs", "implement", "review"]);
@@ -578,12 +695,10 @@ mod tests {
         elsewhere.name = "elsewhere".into();
         elsewhere.project_ref = Some("other".into());
 
-        let project_view =
-            project(&"project/dev/flotilla".parse().expect("valid address"), &[&in_project, &elsewhere]).expect("project table");
+        let project_view = project_convoys("project/dev/flotilla", &[&in_project, &elsewhere]).expect("project table");
         assert_eq!(project_view.rows.iter().map(|row| row.cells[0].text.as_str()).collect::<Vec<_>>(), vec!["tables"]);
 
-        let vessel =
-            project(&"vessel/dev/tables/review".parse().expect("valid address"), &[&in_project, &elsewhere]).expect("vessel table");
+        let vessel = project_convoys("vessel/dev/tables/review", &[&in_project, &elsewhere]).expect("vessel table");
         assert_eq!(vessel.rows.len(), 1);
         assert_eq!(vessel.rows[0].cells[1].text, "review");
     }
@@ -595,10 +710,28 @@ mod tests {
         actionable.completion_target =
             Some(WorkCompletionTarget { convoy: "tables".into(), vessel: "implement".into(), host: HostName::new("kiwi") });
         let row = convoy(vec![actionable, vessel("review", &["implement"], WorkPhase::Pending)]);
-        let view = project(&"convoy/dev/tables".parse().expect("valid address"), &[&row]).expect("project table");
+        let view = project_convoys("convoy/dev/tables", &[&row]).expect("project table");
 
         assert_eq!(view.rows[0].actions.iter().map(|action| action.id).collect::<Vec<_>>(), vec!["attach", "force_complete"]);
         assert!(view.rows[1].actions.is_empty(), "unavailable actions must not render");
+    }
+
+    #[test]
+    fn independent_projection_has_typed_columns_and_truthful_attach_action() {
+        let available = independent("scratch", "kiwi", Some("terminal-scratch"));
+        let unavailable = independent("wedged", "feta", None);
+        let view = project(&ViewAddress::Independents, &TableRows { convoys: vec![], independents: vec![&unavailable, &available] })
+            .expect("independents table");
+
+        assert_eq!(view.columns.iter().map(|column| column.id).collect::<Vec<_>>(), vec!["name", "repo", "host", "phase", "attach"]);
+        assert_eq!(view.rows.iter().map(|row| row.cells[0].text.as_str()).collect::<Vec<_>>(), vec!["scratch", "wedged"]);
+        assert_eq!(view.rows[0].cells[4], CellValue::toned("available", CellTone::Success));
+        assert_eq!(view.rows[0].actions[0].intent, TableIntent::AttachPane {
+            reference: "terminal-scratch".to_string(),
+            host: HostName::new("kiwi")
+        });
+        assert_eq!(view.rows[1].cells[4], CellValue::toned("unavailable", CellTone::Muted));
+        assert!(view.rows[1].actions.is_empty(), "an unavailable attach must not render as an action");
     }
 
     #[test]
@@ -608,13 +741,13 @@ mod tests {
         second.id = ConvoyId::new("dev", "other");
         second.name = "other".into();
         let address = "convoys/dev".parse().expect("valid address");
-        let view = project(&address, &[&first, &second]).expect("project table");
+        let view = project(&address, &TableRows { convoys: vec![&first, &second], independents: vec![] }).expect("project table");
         let mut state = TableState::default();
         state.reconcile(&view);
         state.select_delta(&view, 1);
         assert_eq!(state.selected_row(&view).map(|row| row.cells[0].text.as_str()), Some("other"));
 
-        let changed = project(&address, &[&first]).expect("project table");
+        let changed = project(&address, &TableRows { convoys: vec![&first], independents: vec![] }).expect("project table");
         state.reconcile(&changed);
         assert_eq!(state.selected_row(&changed).map(|row| row.cells[0].text.as_str()), Some("tables"));
     }
@@ -629,7 +762,7 @@ mod tests {
             rows.push(row);
         }
         let refs = rows.iter().collect::<Vec<_>>();
-        let view = project(&"convoys/dev".parse().expect("valid address"), &refs).expect("project table");
+        let view = project_convoys("convoys/dev", &refs).expect("project table");
         let mut state = TableState::default();
         state.reconcile(&view);
         state.select_delta(&view, 3);
@@ -649,7 +782,7 @@ mod tests {
         let mut active = convoy(vec![]);
         active.id = ConvoyId::new("dev", "other");
         active.name = "other".into();
-        let view = project(&"convoys/dev".parse().expect("valid address"), &[&failed, &active]).expect("project table").filtered("DISK");
+        let view = project_convoys("convoys/dev", &[&failed, &active]).expect("project table").filtered("DISK");
 
         assert_eq!(view.rows.len(), 1);
         assert_eq!(view.rows[0].cells[0].text, "tables");

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -11,6 +11,41 @@ pub fn restore_terminal() {
     ratatui::restore();
 }
 
+fn reinitialize_terminal() -> ratatui::DefaultTerminal {
+    use crossterm::event::EnableMouseCapture;
+
+    let terminal = ratatui::init();
+    if let Err(error) = execute!(stdout(), EnableMouseCapture) {
+        tracing::warn!(%error, "failed to re-enable mouse capture");
+    }
+    terminal
+}
+
+/// Temporarily leave the TUI to inspect a terminal session, then restore it.
+///
+/// This deliberately does not stamp Presentation Manager metadata: the pane
+/// remains owned by its existing project/archipelago context while the attach
+/// is only a transient foreground excursion.
+pub fn run_temporary_attach(command: &str) -> (ratatui::DefaultTerminal, Result<(), String>) {
+    restore_terminal();
+    let result = std::process::Command::new("sh")
+        .arg("-lc")
+        .arg(command)
+        .status()
+        .map_err(|error| format!("could not start attach command: {error}"))
+        .and_then(|status| {
+            if status.success() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "attach command exited with status {}",
+                    status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
+                ))
+            }
+        });
+    (reinitialize_terminal(), result)
+}
+
 /// Install a panic hook that restores the terminal before printing the panic.
 ///
 /// Must be called after `ratatui::init()`. Wraps whatever hook is currently
@@ -49,8 +84,6 @@ pub fn install_sigterm_handler() {
 /// their existing terminal binding with this value.
 #[cfg(unix)]
 pub fn suspend_and_resume() -> ratatui::DefaultTerminal {
-    use crossterm::{event::EnableMouseCapture, execute};
-
     restore_terminal();
     // SAFETY: kill(0, SIGTSTP) sends the signal to the entire process group.
     // The process suspends at this point and resumes on SIGCONT.
@@ -59,9 +92,5 @@ pub fn suspend_and_resume() -> ratatui::DefaultTerminal {
         tracing::warn!(err = %std::io::Error::last_os_error(), "SIGTSTP delivery failed");
     }
     // Resumed — re-initialise terminal
-    let terminal = ratatui::init();
-    if let Err(e) = execute!(stdout(), EnableMouseCapture) {
-        tracing::warn!(err = %e, "failed to re-enable mouse capture after resume");
-    }
-    terminal
+    reinitialize_terminal()
 }

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -118,7 +118,11 @@ impl Screen {
         match &view.target {
             ViewTarget::View(ViewAddress::Overview) => ActivePage::Overview,
             ViewTarget::View(
-                ViewAddress::Convoys { .. } | ViewAddress::Project { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. },
+                ViewAddress::Convoys { .. }
+                | ViewAddress::Independents
+                | ViewAddress::Project { .. }
+                | ViewAddress::Convoy { .. }
+                | ViewAddress::Vessel { .. },
             ) => ActivePage::Table,
             ViewTarget::View(ViewAddress::Repo(identity)) => {
                 if repos.contains_key(identity) {
@@ -366,8 +370,8 @@ impl InteractiveWidget for Screen {
             ActivePage::Table => {
                 let address = ctx.views.active_address().cloned().expect("table page has a parsed address");
                 let filter = ctx.views.active_table_state().filter.clone();
-                let convoys = ctx.namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect::<Vec<_>>();
-                match crate::table_view::project(&address, &convoys).map(|view| view.filtered(&filter)) {
+                let rows = crate::app::table_rows(ctx.namespaces);
+                match crate::table_view::project(&address, &rows).map(|view| view.filtered(&filter)) {
                     Ok(view) => {
                         let breadcrumbs =
                             ctx.views.active().breadcrumb_addresses().into_iter().map(ToString::to_string).collect::<Vec<_>>();

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -31,8 +31,8 @@ impl TableWidget {
     fn projected(ctx: &WidgetContext<'_>) -> Result<TableView, String> {
         let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
         let filter = ctx.views.active_table_state().filter.clone();
-        let convoys = ctx.namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect::<Vec<_>>();
-        table_view::project(address, &convoys).map(|view| view.filtered(&filter))
+        let rows = crate::app::table_rows(ctx.namespaces);
+        table_view::project(address, &rows).map(|view| view.filtered(&filter))
     }
 
     fn click_row(&self, mouse: MouseEvent, row_count: usize) -> Option<usize> {
@@ -237,8 +237,8 @@ impl InteractiveWidget for TableWidget {
         // the shared widget contract for direct embedding and test harnesses.
         let Some(address) = ctx.views.active_address().cloned() else { return };
         let filter = ctx.views.active_table_state().filter.clone();
-        let convoys = ctx.namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect::<Vec<_>>();
-        let Ok(view) = table_view::project(&address, &convoys).map(|view| view.filtered(&filter)) else { return };
+        let rows = crate::app::table_rows(ctx.namespaces);
+        let Ok(view) = table_view::project(&address, &rows).map(|view| view.filtered(&filter)) else { return };
         let breadcrumbs = ctx.views.active().breadcrumb_addresses().into_iter().map(ToString::to_string).collect::<Vec<_>>();
         self.render_table(frame, area, ctx.theme, &view, ctx.views.active_table_state_mut(), &breadcrumbs);
     }
@@ -335,7 +335,8 @@ mod tests {
             ),
         ];
         let rows = convoys.iter().collect::<Vec<_>>();
-        table_view::project(&"convoys/dev".parse().expect("valid address"), &rows).expect("project snapshot table")
+        table_view::project(&"convoys/dev".parse().expect("valid address"), &table_view::TableRows { convoys: rows, independents: vec![] })
+            .expect("project snapshot table")
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/tabs.rs
+++ b/crates/flotilla-tui/src/widgets/tabs.rs
@@ -71,6 +71,7 @@ fn default_label(view: &OpenView, model: &TuiModel, level: usize) -> String {
         ViewTarget::View(ViewAddress::Overview) => " ⚓ flotilla ".to_string(),
         ViewTarget::View(ViewAddress::Convoys { namespace }) if namespace == "flotilla" && level == 0 => " 🚢 convoys ".to_string(),
         ViewTarget::View(ViewAddress::Convoys { namespace }) => format!(" 🚢 {namespace} "),
+        ViewTarget::View(ViewAddress::Independents) => " ⛵ independents ".to_string(),
         ViewTarget::View(ViewAddress::Convoy { namespace, name }) => match level {
             0 => format!("🚢 {name}"),
             _ => format!("🚢 {namespace}/{name}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,12 @@ enum SubCommand {
     Attach {
         /// Convoy, vessel, role, terminal session, or unique prefix
         reference: String,
+        /// Internal attach mode used by temporary TUI excursions.
+        #[arg(long, hide = true)]
+        transient: bool,
+        /// Restrict internal attach resolution to the daemon owning this row.
+        #[arg(long, hide = true)]
+        host: Option<String>,
     },
     /// Emit this host's store-backed fleet replica snapshot
     #[command(hide = true)]
@@ -243,7 +249,7 @@ async fn main() -> Result<()> {
         Some(SubCommand::Watch) => run_watch(&cli, format).await,
         Some(SubCommand::Topology) => run_topology_command(&cli, format).await,
         Some(SubCommand::Ls) => run_fleet_list(&cli, format).await,
-        Some(SubCommand::Attach { reference }) => run_attach(&cli, &reference, format).await,
+        Some(SubCommand::Attach { reference, transient, host }) => run_attach(&cli, &reference, transient, host.as_deref(), format).await,
         Some(SubCommand::ReplicaSnapshot) => run_replica_snapshot(&cli).await,
         Some(SubCommand::Hook { harness, event_type }) => run_hook(&cli, &harness, &event_type).await,
         Some(SubCommand::Hooks { command }) => run_hooks_command(&command).await,
@@ -497,7 +503,7 @@ async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) 
     flotilla_tui::cli::run_command(&*daemon, command, format).await.map_err(|e| color_eyre::eyre::eyre!(e))
 }
 
-async fn run_attach(cli: &Cli, reference: &str, format: OutputFormat) -> Result<()> {
+async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&str>, format: OutputFormat) -> Result<()> {
     reset_sigpipe();
     let daemon = connect_daemon(cli).await?;
     let result = daemon
@@ -506,7 +512,11 @@ async fn run_attach(cli: &Cli, reference: &str, format: OutputFormat) -> Result<
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: reference.to_string() },
+                action: if transient {
+                    CommandAction::AttachTransient { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
+                } else {
+                    CommandAction::Attach { reference: reference.to_string() }
+                },
             },
             uuid::Uuid::new_v4(),
         )
@@ -520,7 +530,9 @@ async fn run_attach(cli: &Cli, reference: &str, format: OutputFormat) -> Result<
                 Ok(())
             }
             OutputFormat::Human => {
-                stamp_pane_identity(reference, binding.as_ref()).await;
+                if !transient {
+                    stamp_pane_identity(reference, binding.as_ref()).await;
+                }
                 exec_attach_command(&command)
             }
         },
@@ -1155,7 +1167,21 @@ mod tests {
     #[test]
     fn cli_parses_attach_subcommand() {
         let cli = Cli::try_parse_from(["flotilla", "attach", "convoy-a/implement/coder"]).expect("attach cli should parse");
-        assert!(matches!(cli.command, Some(SubCommand::Attach { reference }) if reference == "convoy-a/implement/coder"));
+        assert!(matches!(
+            cli.command,
+            Some(SubCommand::Attach { reference, transient: false, host: None }) if reference == "convoy-a/implement/coder"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_internal_transient_attach_target() {
+        let cli = Cli::try_parse_from(["flotilla", "attach", "--transient", "--host", "feta", "terminal-scratch"])
+            .expect("transient attach cli should parse");
+        assert!(matches!(
+            cli.command,
+            Some(SubCommand::Attach { reference, transient: true, host: Some(host) })
+                if reference == "terminal-scratch" && host == "feta"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an addressable independents table with typed name, repo, host, phase, and attach columns
- keep the table live from Independents result sets and deltas, including removal when a session is adopted into a convoy
- add host-qualified temporary pane attach across local and remotely observed sessions

## Design note

TUI attach is a temporary foreground excursion and deliberately does not alter PM pane metadata. This supersedes the issue's identity-stamp clause based on the agreed design: the enclosing project or archipelago metadata retains its meaning. Normal human `flotilla attach` behavior remains unchanged.

## Tests

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #734
