### PR TITLE
feat: add repository-backed projects

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,9 +20,17 @@ happens. Realised concretely as the **Project** resource.
 _Avoid_: using "Island" as a code/identifier name — it is the metaphor, not the type.
 
 **Project**:
-The resource that structurally groups work (convoys) belonging to one
-repository/codebase. The concrete form of the **Island** metaphor.
+The definition resource that structurally groups work (convoys) belonging to
+one codebase, which may span one or more **Repositories** or repository slices.
+The concrete form of the **Island** metaphor.
 _Avoid_: Repo (a Project may span more than the bare git remote), Workspace.
+
+**Repository**:
+The machine-independent identity of one source repository, shared by every
+checkout, clone, and Project reference to it. A Repository persists even when
+no checkout currently exists.
+_Avoid_: Project (the stewarded work context), Checkout (one materialisation),
+Repo (too easily conflates all three).
 
 **Convoy**:
 A named instance of a workflow — the primary unit of *launched* work. What a
@@ -148,6 +156,18 @@ lifecycle of — **ChangeRequest** (PR), **Issue**. Not resources: they live in 
 cache layer, fetched per external-service+repo (not per host), and the
 **Aggregator** links them to resources for views.
 _Avoid_: Resource (they are not), entity.
+
+**Forge**:
+The external service and repository scope hosting a **Repository**'s source
+collaboration — change requests and, by default, issues. It is a portable
+external identity, not a local provider implementation or credential choice.
+_Avoid_: Tracker binding, provider, remote (a Git transport spelling).
+
+**Issue Source**:
+An external service and scope supplying issues. A **Project** may select one
+override (for example, a Linear project); otherwise each constituent
+Repository's Forge is its Issue Source.
+_Avoid_: Tracker binding, issue cache, provider.
 
 **Demand-backed Query**:
 An **Aggregator** query family materialized only while subscribed, fetched

--- a/crates/flotilla-commands/src/commands/project.rs
+++ b/crates/flotilla-commands/src/commands/project.rs
@@ -12,32 +12,30 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(about = "Manage projects")]
 pub struct ProjectNoun {
-    /// Project name (used as metadata.name on the resource)
-    pub subject: String,
-
     #[command(subcommand)]
     pub verb: ProjectVerb,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum ProjectVerb {
-    /// Create a project (single-repo convenience form; use `apply` for multi-repo)
-    Create {
-        /// Human-readable name displayed in UIs
+    /// Add a whole-repository project from a local path or repository catalog slug
+    Add {
+        /// Local checkout path or repository catalog slug
+        target: String,
+        /// Project resource name (defaults to the repository leaf slug)
+        #[arg(long)]
+        name: Option<String>,
+        /// Human-readable name (defaults to the repository leaf slug)
         #[arg(long = "display-name")]
         display_name: Option<String>,
-        /// Repository URL (creates a single-entry `repositories` list)
-        #[arg(long = "repo")]
-        repository_url: Option<String>,
-        /// Subpath within the repository (monorepo slice). Requires `--repo`.
-        #[arg(long = "subpath", requires = "repository_url")]
-        subpath: Option<String>,
-        /// Default branch for the repository. Requires `--repo`.
-        #[arg(long = "ref", requires = "repository_url")]
-        r#ref: Option<String>,
+        /// Git remote name or URL to select when repository identity is ambiguous
+        #[arg(long)]
+        remote: Option<String>,
     },
-    /// Apply a project spec from a YAML file (full multi-repo form)
+    /// Apply a complete project definition from YAML
     Apply {
+        /// Project resource name
+        name: String,
         /// Path to a YAML file containing the ProjectSpec body
         #[arg(long = "file", short = 'f')]
         file: PathBuf,
@@ -46,54 +44,40 @@ pub enum ProjectVerb {
 
 impl ProjectNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
-        match self.verb {
-            ProjectVerb::Create { display_name, repository_url, subpath, r#ref } => Ok(Resolved::NeedsContext {
-                command: Command {
-                    node_id: None,
-                    provisioning_target: None,
-                    context_repo: None,
-                    action: CommandAction::ProjectCreate { name: self.subject, display_name, repository_url, subpath, r#ref },
-                },
-                repo: RepoContext::None,
-                host: HostResolution::Local,
-            }),
-            ProjectVerb::Apply { file } => {
+        let action = match self.verb {
+            ProjectVerb::Add { target, name, display_name, remote } => CommandAction::ProjectAdd { target, name, display_name, remote },
+            ProjectVerb::Apply { name, file } => {
                 let spec_yaml = std::fs::read_to_string(&file).map_err(|e| format!("read {}: {e}", file.display()))?;
-                Ok(Resolved::NeedsContext {
-                    command: Command {
-                        node_id: None,
-                        provisioning_target: None,
-                        context_repo: None,
-                        action: CommandAction::ProjectApply { name: self.subject, spec_yaml },
-                    },
-                    repo: RepoContext::None,
-                    host: HostResolution::Local,
-                })
+                CommandAction::ProjectApply { name, spec_yaml }
             }
-        }
+        };
+        Ok(Resolved::NeedsContext {
+            command: Command { node_id: None, provisioning_target: None, context_repo: None, action },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        })
     }
 }
 
 impl std::fmt::Display for ProjectNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "project {}", quote_value(&self.subject))?;
+        write!(f, "project")?;
         match &self.verb {
-            ProjectVerb::Create { display_name, repository_url, subpath, r#ref } => {
-                write!(f, " create")?;
-                if let Some(name) = display_name {
-                    write!(f, " --display-name {}", quote_value(name))?;
+            ProjectVerb::Add { target, name, display_name, remote } => {
+                write!(f, " add {}", quote_value(target))?;
+                if let Some(name) = name {
+                    write!(f, " --name {}", quote_value(name))?;
                 }
-                if let Some(url) = repository_url {
-                    write!(f, " --repo {}", quote_value(url))?;
+                if let Some(display_name) = display_name {
+                    write!(f, " --display-name {}", quote_value(display_name))?;
                 }
-                if let Some(sub) = subpath {
-                    write!(f, " --subpath {}", quote_value(sub))?;
-                }
-                if let Some(reference) = r#ref {
-                    write!(f, " --ref {}", quote_value(reference))?;
+                if let Some(remote) = remote {
+                    write!(f, " --remote {}", quote_value(remote))?;
                 }
             }
-            ProjectVerb::Apply { file } => write!(f, " apply --file {}", quote_value(&file.display().to_string()))?,
+            ProjectVerb::Apply { name, file } => {
+                write!(f, " apply {} --file {}", quote_value(name), quote_value(&file.display().to_string()))?;
+            }
         }
         Ok(())
     }
@@ -116,33 +100,21 @@ mod tests {
     }
 
     #[test]
-    fn project_create_resolves() {
-        let resolved = parse(&[
-            "project",
-            "my-project",
-            "create",
-            "--display-name",
-            "My Project",
-            "--repo",
-            "https://github.com/org/repo.git",
-            "--subpath",
-            "apps/frontend",
-            "--ref",
-            "main",
-        ])
-        .resolve()
-        .expect("resolve");
+    fn project_add_is_verb_first_and_resolves_path_or_slug() {
+        let resolved =
+            parse(&["project", "add", "/src/flotilla", "--name", "core", "--display-name", "Flotilla Core", "--remote", "origin"])
+                .resolve()
+                .expect("resolve");
         assert_eq!(resolved, Resolved::NeedsContext {
             command: Command {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ProjectCreate {
-                    name: "my-project".into(),
-                    display_name: Some("My Project".into()),
-                    repository_url: Some("https://github.com/org/repo.git".into()),
-                    subpath: Some("apps/frontend".into()),
-                    r#ref: Some("main".into()),
+                action: CommandAction::ProjectAdd {
+                    target: "/src/flotilla".into(),
+                    name: Some("core".into()),
+                    display_name: Some("Flotilla Core".into()),
+                    remote: Some("origin".into()),
                 },
             },
             repo: RepoContext::None,
@@ -151,78 +123,51 @@ mod tests {
     }
 
     #[test]
-    fn project_create_minimal_resolves() {
-        let resolved = parse(&["project", "empty", "create"]).resolve().expect("resolve");
-        assert_eq!(resolved, Resolved::NeedsContext {
-            command: Command {
-                node_id: None,
-                provisioning_target: None,
-                context_repo: None,
-                action: CommandAction::ProjectCreate {
-                    name: "empty".into(),
-                    display_name: None,
-                    repository_url: None,
-                    subpath: None,
-                    r#ref: None,
-                },
-            },
-            repo: RepoContext::None,
-            host: HostResolution::Local,
-        });
+    fn project_add_minimal_resolves() {
+        let resolved = parse(&["project", "add", "flotilla"]).resolve().expect("resolve");
+        assert!(matches!(
+            resolved,
+            Resolved::NeedsContext {
+                command: Command { action: CommandAction::ProjectAdd { target, name: None, display_name: None, remote: None }, .. },
+                ..
+            } if target == "flotilla"
+        ));
     }
 
     #[test]
     fn project_apply_reads_file() {
         let tmp = tempfile::NamedTempFile::new().expect("tempfile");
-        std::fs::write(tmp.path(), "repositories: []\n").expect("write");
+        std::fs::write(tmp.path(), "display_name: Scratch\n").expect("write");
         let path = tmp.path().to_string_lossy().to_string();
 
-        let resolved = parse(&["project", "scratch", "apply", "--file", &path]).resolve().expect("resolve");
-        assert_eq!(resolved, Resolved::NeedsContext {
-            command: Command {
-                node_id: None,
-                provisioning_target: None,
-                context_repo: None,
-                action: CommandAction::ProjectApply { name: "scratch".into(), spec_yaml: "repositories: []\n".into() },
-            },
-            repo: RepoContext::None,
-            host: HostResolution::Local,
-        });
+        let resolved = parse(&["project", "apply", "scratch", "--file", &path]).resolve().expect("resolve");
+        assert!(matches!(
+            resolved,
+            Resolved::NeedsContext {
+                command: Command { action: CommandAction::ProjectApply { name, spec_yaml }, .. },
+                ..
+            } if name == "scratch" && spec_yaml == "display_name: Scratch\n"
+        ));
     }
 
     #[test]
-    fn round_trip_create() {
+    fn command_shapes_round_trip() {
         assert_round_trip::<ProjectNoun>(&[
             "project",
-            "p",
-            "create",
+            "add",
+            "flotilla",
+            "--name",
+            "core",
             "--display-name",
-            "MyProj",
-            "--repo",
-            "https://example.com/repo.git",
-            "--subpath",
-            "apps/x",
-            "--ref",
-            "main",
+            "Flotilla",
+            "--remote",
+            "upstream",
         ]);
+        assert_round_trip::<ProjectNoun>(&["project", "apply", "core", "--file", "/tmp/project.yaml"]);
     }
 
     #[test]
-    fn round_trip_apply() {
-        // `assert_round_trip` only exercises the parse → Display → reparse cycle on the
-        // clap struct, not the file-reading path in `resolve()` — the path doesn't need to exist.
-        assert_round_trip::<ProjectNoun>(&["project", "p", "apply", "--file", "/tmp/p.yaml"]);
-    }
-
-    #[test]
-    fn subpath_without_repo_is_rejected() {
-        let err = ProjectNoun::try_parse_from(["project", "p", "create", "--subpath", "apps/x"]).expect_err("should fail");
-        assert!(err.to_string().contains("--subpath"), "error should mention --subpath: {err}");
-    }
-
-    #[test]
-    fn ref_without_repo_is_rejected() {
-        let err = ProjectNoun::try_parse_from(["project", "p", "create", "--ref", "main"]).expect_err("should fail");
-        assert!(err.to_string().contains("--ref"), "error should mention --ref: {err}");
+    fn removed_create_shape_is_rejected() {
+        assert!(ProjectNoun::try_parse_from(["project", "core", "create"]).is_err());
     }
 }

--- a/crates/flotilla-controllers/src/reconcilers/clone.rs
+++ b/crates/flotilla-controllers/src/reconcilers/clone.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use flotilla_resources::{
-    canonicalize_repo_url, clone_key,
+    clone_key,
     controller::{ReconcileOutcome, Reconciler},
-    Clone, ClonePhase, CloneStatusPatch, ResourceError, ResourceObject,
+    Clone, ClonePhase, CloneStatusPatch, Repository, RepositoryIdentity, ResourceError, ResourceObject, TypedResolver,
 };
 
 #[async_trait]
@@ -15,11 +15,12 @@ pub trait CloneRuntime: Send + Sync {
 
 pub struct CloneReconciler<R> {
     runtime: Arc<R>,
+    repositories: TypedResolver<Repository>,
 }
 
 impl<R> CloneReconciler<R> {
-    pub fn new(runtime: Arc<R>) -> Self {
-        Self { runtime }
+    pub fn new(runtime: Arc<R>, repositories: TypedResolver<Repository>) -> Self {
+        Self { runtime, repositories }
     }
 }
 
@@ -37,6 +38,22 @@ where
     type Dependencies = CloneDeps;
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        let repository = match self.repositories.get(&obj.spec.repo_ref.to_string()).await {
+            Ok(repository) => repository,
+            Err(ResourceError::NotFound { .. }) => return Ok(CloneDeps::Failed(format!("repository {} not found", obj.spec.repo_ref))),
+            Err(error) => return Err(error),
+        };
+        if let Err(message) = repository.spec.verify_key(&obj.spec.repo_ref) {
+            return Ok(CloneDeps::Failed(message));
+        }
+        let canonical_repo = match repository.spec.identity() {
+            RepositoryIdentity::Remote { canonical_remote } => canonical_remote,
+            RepositoryIdentity::Local { .. } => return Ok(CloneDeps::Failed("clone repository must have a transport remote".to_string())),
+        };
+        let expected_name = format!("clone-{}", clone_key(canonical_repo, &obj.spec.env_ref));
+        if obj.metadata.name != expected_name {
+            return Ok(CloneDeps::Failed(format!("clone name mismatch: expected {expected_name}")));
+        }
         if obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending) != ClonePhase::Pending {
             return Ok(CloneDeps::None);
         }
@@ -58,22 +75,14 @@ where
         deps: &Self::Dependencies,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> ReconcileOutcome<Self::Resource> {
-        let patch = match canonicalize_repo_url(&obj.spec.url) {
-            Ok(canonical) => {
-                let expected_name = format!("clone-{}", clone_key(&canonical, &obj.spec.env_ref));
-                if obj.metadata.name != expected_name {
-                    Some(CloneStatusPatch::MarkFailed { message: format!("clone name mismatch: expected {expected_name}") })
-                } else if obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending) == ClonePhase::Pending {
-                    match deps {
-                        CloneDeps::Ready { default_branch } => Some(CloneStatusPatch::MarkReady { default_branch: default_branch.clone() }),
-                        CloneDeps::Failed(message) => Some(CloneStatusPatch::MarkFailed { message: message.clone() }),
-                        CloneDeps::None => None,
-                    }
-                } else {
-                    None
-                }
+        let patch = if obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending) == ClonePhase::Pending {
+            match deps {
+                CloneDeps::Ready { default_branch } => Some(CloneStatusPatch::MarkReady { default_branch: default_branch.clone() }),
+                CloneDeps::Failed(message) => Some(CloneStatusPatch::MarkFailed { message: message.clone() }),
+                CloneDeps::None => None,
             }
-            Err(err) => Some(CloneStatusPatch::MarkFailed { message: err }),
+        } else {
+            None
         };
 
         ReconcileOutcome::new(patch)

--- a/crates/flotilla-controllers/src/reconcilers/mod.rs
+++ b/crates/flotilla-controllers/src/reconcilers/mod.rs
@@ -2,6 +2,7 @@ pub mod checkout;
 pub mod clone;
 pub mod environment;
 pub mod presentation;
+pub mod repository;
 pub mod terminal_session;
 pub mod vessel;
 
@@ -13,5 +14,6 @@ pub use presentation::{
     PresentationPolicy, PresentationPolicyRegistry, PresentationReconciler, PresentationRuntime, PreviousWorkspace,
     ProviderPresentationRuntime, RenderedWorkspace, ResolvedProcess,
 };
+pub use repository::RepositoryReconciler;
 pub use terminal_session::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
 pub use vessel::{VesselDeps, VesselReconciler};

--- a/crates/flotilla-controllers/src/reconcilers/mod.rs
+++ b/crates/flotilla-controllers/src/reconcilers/mod.rs
@@ -14,6 +14,6 @@ pub use presentation::{
     PresentationPolicy, PresentationPolicyRegistry, PresentationReconciler, PresentationRuntime, PreviousWorkspace,
     ProviderPresentationRuntime, RenderedWorkspace, ResolvedProcess,
 };
-pub use repository::RepositoryReconciler;
+pub use repository::{ForgeDefaultBranchResolver, RepositoryReconciler};
 pub use terminal_session::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
 pub use vessel::{VesselDeps, VesselReconciler};

--- a/crates/flotilla-controllers/src/reconcilers/repository.rs
+++ b/crates/flotilla-controllers/src/reconcilers/repository.rs
@@ -1,17 +1,25 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     controller::{LabelMappedWatch, ReconcileOutcome, Reconciler, ResolverLabelMappedWatch, SecondaryWatch},
-    resolve_default_branch, Checkout, CheckoutSpec, Clone, DefaultBranchObservation, DefaultBranchProvenance, Environment,
-    LifecycleAuthority, Repository, RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryKey, RepositoryStatus, RepositoryStatusPatch,
-    ResourceBackend, ResourceError, ResourceObject, TypedResolver, REPO_KEY_LABEL,
+    resolve_default_branch, Checkout, CheckoutSpec, Clone, DefaultBranchObservation, DefaultBranchProvenance, Environment, ForgeIdentity,
+    LifecycleAuthority, Repository, RepositoryCheckoutRef, RepositoryKey, RepositoryStatus, RepositoryStatusPatch, ResourceBackend,
+    ResourceError, ResourceObject, TypedResolver, REPO_KEY_LABEL,
 };
 
+#[async_trait]
+pub trait ForgeDefaultBranchResolver: Send + Sync {
+    async fn default_branch(&self, forge: &ForgeIdentity) -> Result<Option<String>, String>;
+}
+
+#[derive(bon::Builder)]
 pub struct RepositoryReconciler {
     checkout_sources: Vec<TypedResolver<Checkout>>,
     clones: TypedResolver<Clone>,
     environments: TypedResolver<Environment>,
+    forge_default_branch_resolver: Option<Arc<dyn ForgeDefaultBranchResolver>>,
 }
 
 impl RepositoryReconciler {
@@ -20,7 +28,13 @@ impl RepositoryReconciler {
             checkout_sources: vec![durable.clone().using::<Checkout>(namespace), observed.using::<Checkout>(namespace)],
             clones: durable.clone().using::<Clone>(namespace),
             environments: durable.using::<Environment>(namespace),
+            forge_default_branch_resolver: None,
         }
+    }
+
+    pub fn with_forge_default_branch_resolver(mut self, resolver: Arc<dyn ForgeDefaultBranchResolver>) -> Self {
+        self.forge_default_branch_resolver = Some(resolver);
+        self
     }
 
     pub fn secondary_watches(observed: ResourceBackend, namespace: &str) -> Vec<Box<dyn SecondaryWatch<Primary = Repository>>> {
@@ -68,6 +82,16 @@ impl Reconciler for RepositoryReconciler {
         obj.spec.verify_key(&repository_key).map_err(ResourceError::invalid)?;
         let mut status = RepositoryStatus::default();
 
+        if let (Some(forge), Some(resolver)) = (obj.spec.forge(), &self.forge_default_branch_resolver) {
+            match resolver.default_branch(forge).await {
+                Ok(Some(branch)) => {
+                    status.default_branch_observations.push(DefaultBranchObservation { branch, provenance: DefaultBranchProvenance::Forge })
+                }
+                Ok(None) => {}
+                Err(diagnostic) => status.diagnostics.push(format!("forge default branch observation failed: {diagnostic}")),
+            }
+        }
+
         for source in &self.checkout_sources {
             for checkout in source.list().await?.items {
                 if checkout.spec.repo_ref() != &repository_key {
@@ -80,19 +104,14 @@ impl Reconciler for RepositoryReconciler {
                         continue;
                     }
                 };
-                let kind = match &checkout.spec {
-                    CheckoutSpec::Observed(spec) => {
-                        if spec.is_main && matches!(spec.r#ref.as_str(), "main" | "master" | "trunk") {
-                            status.default_branch_observations.push(DefaultBranchObservation {
-                                branch: spec.r#ref.clone(),
-                                provenance: DefaultBranchProvenance::LocalTrunk,
-                            });
-                        }
-                        RepositoryCheckoutKind::Observed
+                if let CheckoutSpec::Observed(spec) = &checkout.spec {
+                    if spec.is_main && matches!(spec.r#ref.as_str(), "main" | "master" | "trunk") {
+                        status
+                            .default_branch_observations
+                            .push(DefaultBranchObservation { branch: spec.r#ref.clone(), provenance: DefaultBranchProvenance::LocalTrunk });
                     }
-                    CheckoutSpec::Worktree(_) => RepositoryCheckoutKind::Worktree,
-                    CheckoutSpec::FreshClone(_) => RepositoryCheckoutKind::FreshClone,
-                };
+                }
+                let kind = checkout.spec.repository_checkout_kind();
                 let authority = checkout.metadata.lifecycle_authority()?.unwrap_or(LifecycleAuthority::Managed);
                 status.checkouts_by_host.entry(host_ref).or_default().push(RepositoryCheckoutRef {
                     checkout_ref: checkout.metadata.name,

--- a/crates/flotilla-controllers/src/reconcilers/repository.rs
+++ b/crates/flotilla-controllers/src/reconcilers/repository.rs
@@ -1,0 +1,146 @@
+use std::marker::PhantomData;
+
+use chrono::{DateTime, Utc};
+use flotilla_resources::{
+    controller::{LabelMappedWatch, ReconcileOutcome, Reconciler, ResolverLabelMappedWatch, SecondaryWatch},
+    resolve_default_branch, Checkout, CheckoutSpec, Clone, DefaultBranchObservation, DefaultBranchProvenance, Environment,
+    LifecycleAuthority, Repository, RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryKey, RepositoryStatus, RepositoryStatusPatch,
+    ResourceBackend, ResourceError, ResourceObject, TypedResolver, REPO_KEY_LABEL,
+};
+
+pub struct RepositoryReconciler {
+    checkout_sources: Vec<TypedResolver<Checkout>>,
+    clones: TypedResolver<Clone>,
+    environments: TypedResolver<Environment>,
+}
+
+impl RepositoryReconciler {
+    pub fn new(durable: ResourceBackend, observed: ResourceBackend, namespace: &str) -> Self {
+        Self {
+            checkout_sources: vec![durable.clone().using::<Checkout>(namespace), observed.using::<Checkout>(namespace)],
+            clones: durable.clone().using::<Clone>(namespace),
+            environments: durable.using::<Environment>(namespace),
+        }
+    }
+
+    pub fn secondary_watches(observed: ResourceBackend, namespace: &str) -> Vec<Box<dyn SecondaryWatch<Primary = Repository>>> {
+        vec![
+            Box::new(LabelMappedWatch::<Checkout, Repository> { label_key: REPO_KEY_LABEL, _marker: PhantomData }),
+            Box::new(LabelMappedWatch::<Clone, Repository> { label_key: REPO_KEY_LABEL, _marker: PhantomData }),
+            Box::new(ResolverLabelMappedWatch::<Checkout, Repository> {
+                label_key: REPO_KEY_LABEL,
+                resolver: observed.using::<Checkout>(namespace),
+                _marker: PhantomData,
+            }),
+        ]
+    }
+
+    async fn checkout_host(&self, checkout: &CheckoutSpec) -> Result<String, String> {
+        match checkout {
+            CheckoutSpec::Observed(spec) => Ok(spec.host_ref.clone()),
+            CheckoutSpec::Worktree(spec) => self.environment_host(&spec.env_ref).await,
+            CheckoutSpec::FreshClone(spec) => self.environment_host(&spec.env_ref).await,
+        }
+    }
+
+    async fn environment_host(&self, environment_ref: &str) -> Result<String, String> {
+        let environment = self
+            .environments
+            .get(environment_ref)
+            .await
+            .map_err(|error| format!("cannot resolve host for environment {environment_ref}: {error}"))?;
+        environment
+            .spec
+            .host_direct
+            .as_ref()
+            .map(|spec| spec.host_ref.clone())
+            .or_else(|| environment.spec.docker.as_ref().map(|spec| spec.host_ref.clone()))
+            .ok_or_else(|| format!("environment {environment_ref} has no host association"))
+    }
+}
+
+impl Reconciler for RepositoryReconciler {
+    type Resource = Repository;
+    type Dependencies = RepositoryStatus;
+
+    async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        let repository_key = RepositoryKey(obj.metadata.name.clone());
+        obj.spec.verify_key(&repository_key).map_err(ResourceError::invalid)?;
+        let mut status = RepositoryStatus::default();
+
+        for source in &self.checkout_sources {
+            for checkout in source.list().await?.items {
+                if checkout.spec.repo_ref() != &repository_key {
+                    continue;
+                }
+                let host_ref = match self.checkout_host(&checkout.spec).await {
+                    Ok(host_ref) => host_ref,
+                    Err(diagnostic) => {
+                        status.diagnostics.push(diagnostic);
+                        continue;
+                    }
+                };
+                let kind = match &checkout.spec {
+                    CheckoutSpec::Observed(spec) => {
+                        if spec.is_main && matches!(spec.r#ref.as_str(), "main" | "master" | "trunk") {
+                            status.default_branch_observations.push(DefaultBranchObservation {
+                                branch: spec.r#ref.clone(),
+                                provenance: DefaultBranchProvenance::LocalTrunk,
+                            });
+                        }
+                        RepositoryCheckoutKind::Observed
+                    }
+                    CheckoutSpec::Worktree(_) => RepositoryCheckoutKind::Worktree,
+                    CheckoutSpec::FreshClone(_) => RepositoryCheckoutKind::FreshClone,
+                };
+                let authority = checkout.metadata.lifecycle_authority()?.unwrap_or(LifecycleAuthority::Managed);
+                status.checkouts_by_host.entry(host_ref).or_default().push(RepositoryCheckoutRef {
+                    checkout_ref: checkout.metadata.name,
+                    kind,
+                    authority,
+                });
+            }
+        }
+
+        for clone in self.clones.list().await?.items {
+            if clone.spec.repo_ref != repository_key {
+                continue;
+            }
+            if let Some(branch) = clone.status.and_then(|status| status.default_branch) {
+                status
+                    .default_branch_observations
+                    .push(DefaultBranchObservation { branch, provenance: DefaultBranchProvenance::RemoteSymbolicHead });
+            }
+        }
+
+        for checkouts in status.checkouts_by_host.values_mut() {
+            checkouts.sort_by(|left, right| left.checkout_ref.cmp(&right.checkout_ref));
+            checkouts.dedup();
+        }
+        status.default_branch_observations.sort();
+        status.default_branch_observations.dedup();
+        let (default_branch, diagnostics) = resolve_default_branch(&status.default_branch_observations);
+        status.default_branch = default_branch;
+        status.diagnostics.extend(diagnostics);
+        status.diagnostics.sort();
+        status.diagnostics.dedup();
+        Ok(status)
+    }
+
+    fn reconcile(
+        &self,
+        _obj: &ResourceObject<Self::Resource>,
+        deps: &Self::Dependencies,
+        _now: DateTime<Utc>,
+    ) -> ReconcileOutcome<Self::Resource> {
+        ReconcileOutcome::new(Some(RepositoryStatusPatch::Replace(deps.clone())))
+    }
+
+    async fn run_finalizer(&self, _obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
+        Ok(())
+    }
+
+    fn finalizer_name(&self) -> Option<&'static str> {
+        None
+    }
+}

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -3,16 +3,16 @@ use std::{collections::BTreeMap, marker::PhantomData};
 use chrono::{DateTime, Utc};
 use flotilla_core::agent_adapter::{build_crew_brief, CrewBriefMember};
 use flotilla_resources::{
-    canonicalize_repo_url, clone_key,
+    clone_key,
     controller::{
         delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
     },
-    descriptive_repo_slug, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
-    CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase,
-    EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
-    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, RepositoryKey, Resource, ResourceBackend, ResourceError,
-    ResourceObject, Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel,
-    VesselPhase, VesselStatusPatch, VESSEL_REF_LABEL,
+    Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy, CrewSource, DockerCheckoutStrategy,
+    DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, FreshCloneCheckoutSpec,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy,
+    PlacementPolicySpec, Repository, RepositoryIdentity, Resource, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch,
+    VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -21,6 +21,7 @@ const ENV_LABEL: &str = "flotilla.work/env";
 
 pub struct VesselReconciler {
     convoys: TypedResolver<Convoy>,
+    repositories: TypedResolver<Repository>,
     placement_policies: TypedResolver<PlacementPolicy>,
     environments: TypedResolver<Environment>,
     clones: TypedResolver<Clone>,
@@ -33,6 +34,7 @@ impl VesselReconciler {
     pub fn new(backend: ResourceBackend, namespace: &str) -> Self {
         Self {
             convoys: backend.clone().using::<Convoy>(namespace),
+            repositories: backend.clone().using::<Repository>(namespace),
             placement_policies: backend.clone().using::<PlacementPolicy>(namespace),
             environments: backend.clone().using::<Environment>(namespace),
             clones: backend.clone().using::<Clone>(namespace),
@@ -176,20 +178,32 @@ impl Reconciler for VesselReconciler {
             )));
         }
 
-        let repo_url = match convoy.spec.repository.as_ref().map(|repository| repository.url.clone()) {
-            Some(url) => url,
+        let convoy_repository = match convoy.spec.repository.as_ref() {
+            Some(repository) => repository,
             None => return Ok(VesselDeps::failed("convoy repository URL is missing".to_string())),
         };
+        let repo_url = convoy_repository.url.clone();
         let git_ref = match convoy.spec.r#ref.clone() {
             Some(git_ref) => git_ref,
             None => return Ok(VesselDeps::failed("convoy ref is missing".to_string())),
         };
-        let canonical_repo = match canonicalize_repo_url(&repo_url) {
-            Ok(url) => url,
-            Err(err) => return Ok(VesselDeps::failed(err)),
+        let repository = match self.repositories.get(&convoy_repository.repo_ref.to_string()).await {
+            Ok(repository) => repository,
+            Err(ResourceError::NotFound { .. }) => {
+                return Ok(VesselDeps::failed(format!("repository {} not found", convoy_repository.repo_ref)))
+            }
+            Err(err) => return Err(err),
         };
-        let repo_key = repo_key(&canonical_repo);
-        let repo_slug = descriptive_repo_slug(&canonical_repo);
+        if let Err(message) = repository.spec.verify_key(&convoy_repository.repo_ref) {
+            return Ok(VesselDeps::failed(message));
+        }
+        let canonical_repo = match repository.spec.identity() {
+            RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
+            RepositoryIdentity::Local { .. } => return Ok(VesselDeps::failed("convoy repository must have a transport remote")),
+        };
+        let repository_key = convoy_repository.repo_ref.clone();
+        let repo_key = repository_key.to_string();
+        let repo_slug = repository.spec.catalog_slug();
         let adopted_checkout_ref = obj.spec.adopted_checkout_ref.clone();
 
         let clone_env_ref = host_direct_environment_name(strategy.host_ref());
@@ -215,11 +229,7 @@ impl Reconciler for VesselReconciler {
             let clone_path = format!("{}/{}", clone_env_spec.repo_default_dir.trim_end_matches('/'), repo_key);
             match self.clones.get(&clone_name).await {
                 Ok(existing) => {
-                    let existing_repo = match canonicalize_repo_url(&existing.spec.url) {
-                        Ok(url) => url,
-                        Err(err) => return Ok(VesselDeps::failed(err)),
-                    };
-                    if existing_repo != canonical_repo || existing.spec.env_ref != clone_env_ref {
+                    if existing.spec.repo_ref != repository_key || existing.spec.env_ref != clone_env_ref {
                         return Ok(VesselDeps::failed(format!("clone {clone_name} does not match expected repo/env tuple")));
                     }
                     if existing.status.as_ref().map(|status| status.phase) == Some(ClonePhase::Failed) {
@@ -245,7 +255,7 @@ impl Reconciler for VesselReconciler {
                             ]))
                             .build(),
                         spec: CloneSpec {
-                            repo_ref: RepositoryKey(repo_key.clone()),
+                            repo_ref: repository_key.clone(),
                             url: repo_url.clone(),
                             env_ref: clone_env_ref.clone(),
                             path: clone_path,
@@ -354,7 +364,7 @@ impl Reconciler for VesselReconciler {
                 let spec = match &strategy {
                     PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
                         CheckoutSpec::Worktree(CheckoutWorktreeSpec {
-                            repo_ref: RepositoryKey(repo_key.clone()),
+                            repo_ref: repository_key.clone(),
                             env_ref: clone_env_ref.clone(),
                             r#ref: git_ref,
                             target_path: checkout_target_path.clone(),
@@ -362,7 +372,7 @@ impl Reconciler for VesselReconciler {
                         })
                     }
                     PlacementStrategy::DockerFreshCloneInContainer { .. } => CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
-                        repo_ref: RepositoryKey(repo_key.clone()),
+                        repo_ref: repository_key.clone(),
                         env_ref: precreated_environment_ref.clone().expect("fresh-clone strategy should precreate environment"),
                         r#ref: git_ref,
                         target_path: checkout_target_path.clone(),

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -10,9 +10,9 @@ use flotilla_resources::{
     descriptive_repo_slug, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
     CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase,
     EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
-    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Resource, ResourceBackend, ResourceError, ResourceObject,
-    Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase,
-    VesselStatusPatch, VESSEL_REF_LABEL,
+    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, RepositoryKey, Resource, ResourceBackend, ResourceError,
+    ResourceObject, Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel,
+    VesselPhase, VesselStatusPatch, VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -244,7 +244,12 @@ impl Reconciler for VesselReconciler {
                                 (REPO_LABEL.to_string(), repo_slug.clone()),
                             ]))
                             .build(),
-                        spec: CloneSpec { url: repo_url.clone(), env_ref: clone_env_ref.clone(), path: clone_path },
+                        spec: CloneSpec {
+                            repo_ref: RepositoryKey(repo_key.clone()),
+                            url: repo_url.clone(),
+                            env_ref: clone_env_ref.clone(),
+                            path: clone_path,
+                        },
                     });
                     return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                 }
@@ -349,6 +354,7 @@ impl Reconciler for VesselReconciler {
                 let spec = match &strategy {
                     PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
                         CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                            repo_ref: RepositoryKey(repo_key.clone()),
                             env_ref: clone_env_ref.clone(),
                             r#ref: git_ref,
                             target_path: checkout_target_path.clone(),
@@ -356,6 +362,7 @@ impl Reconciler for VesselReconciler {
                         })
                     }
                     PlacementStrategy::DockerFreshCloneInContainer { .. } => CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                        repo_ref: RepositoryKey(repo_key.clone()),
                         env_ref: precreated_environment_ref.clone().expect("fresh-clone strategy should precreate environment"),
                         r#ref: git_ref,
                         target_path: checkout_target_path.clone(),
@@ -364,7 +371,11 @@ impl Reconciler for VesselReconciler {
                 };
                 let env_ref = spec.env_ref().expect("managed checkout should have an env_ref").to_string();
                 actuations.push(Actuation::CreateCheckout {
-                    meta: owned_child_meta(&checkout_name, obj, BTreeMap::from([(ENV_LABEL.to_string(), env_ref)])),
+                    meta: owned_child_meta(
+                        &checkout_name,
+                        obj,
+                        BTreeMap::from([(ENV_LABEL.to_string(), env_ref), (REPO_KEY_LABEL.to_string(), repo_key.clone())]),
+                    ),
                     spec,
                 });
                 return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -11,7 +11,7 @@ use flotilla_resources::{
     CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase,
     EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
     LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Resource, ResourceBackend, ResourceError, ResourceObject,
-    TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase,
+    Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase,
     VesselStatusPatch, VESSEL_REF_LABEL,
 };
 
@@ -79,9 +79,20 @@ enum PlacementStrategy {
 #[derive(Debug, Clone)]
 enum PlannedPatch {
     None,
-    Provisioning { observed_policy_ref: String, observed_policy_version: String },
-    Ready { environment_ref: String, checkout_ref: String, terminal_session_refs: Vec<String> },
-    Failed { message: String },
+    Provisioning {
+        observed_policy_ref: String,
+        observed_policy_version: String,
+    },
+    Ready {
+        environment_ref: String,
+        checkout_ref: String,
+        terminal_session_refs: Vec<String>,
+        requested_stance: Stance,
+        effective_stance: Stance,
+    },
+    Failed {
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -99,8 +110,18 @@ impl VesselDeps {
         Self { patch: provisioning_patch(obj, placement_policy), actuations }
     }
 
-    fn ready(environment_ref: String, checkout_ref: String, terminal_session_refs: Vec<String>, actuations: Vec<Actuation>) -> Self {
-        Self { patch: PlannedPatch::Ready { environment_ref, checkout_ref, terminal_session_refs }, actuations }
+    fn ready(
+        environment_ref: String,
+        checkout_ref: String,
+        terminal_session_refs: Vec<String>,
+        requested_stance: Stance,
+        effective_stance: Stance,
+        actuations: Vec<Actuation>,
+    ) -> Self {
+        Self {
+            patch: PlannedPatch::Ready { environment_ref, checkout_ref, terminal_session_refs, requested_stance, effective_stance },
+            actuations,
+        }
     }
 
     fn failed(message: impl Into<String>) -> Self {
@@ -143,6 +164,17 @@ impl Reconciler for VesselReconciler {
             Some((vessel_index, requirement)) => (vessel_index, requirement),
             None => return Ok(VesselDeps::failed(format!("vessel {} missing from convoy snapshot", obj.spec.vessel_name))),
         };
+        let effective_stance = strategy.effective_stance();
+        if effective_stance < requirement.stance {
+            return Ok(VesselDeps::failed(format!(
+                "vessel {} requires {} stance, but placement policy {} uses {} placement with effective {} stance",
+                obj.spec.vessel_name,
+                requirement.stance,
+                placement_policy.metadata.name,
+                strategy.description(),
+                effective_stance,
+            )));
+        }
 
         let repo_url = match convoy.spec.repository.as_ref().map(|repository| repository.url.clone()) {
             Some(url) => url,
@@ -488,7 +520,7 @@ impl Reconciler for VesselReconciler {
             }
         }
 
-        Ok(VesselDeps::ready(resolved_environment_ref, checkout_name, terminal_refs, actuations))
+        Ok(VesselDeps::ready(resolved_environment_ref, checkout_name, terminal_refs, requirement.stance, effective_stance, actuations))
     }
 
     fn reconcile(
@@ -504,12 +536,16 @@ impl Reconciler for VesselReconciler {
                 observed_policy_version: observed_policy_version.clone(),
                 started_at: now,
             }),
-            PlannedPatch::Ready { environment_ref, checkout_ref, terminal_session_refs } => Some(VesselStatusPatch::MarkReady {
-                environment_ref: Some(environment_ref.clone()),
-                checkout_ref: Some(checkout_ref.clone()),
-                terminal_session_refs: terminal_session_refs.clone(),
-                ready_at: now,
-            }),
+            PlannedPatch::Ready { environment_ref, checkout_ref, terminal_session_refs, requested_stance, effective_stance } => {
+                Some(VesselStatusPatch::MarkReady {
+                    environment_ref: Some(environment_ref.clone()),
+                    checkout_ref: Some(checkout_ref.clone()),
+                    terminal_session_refs: terminal_session_refs.clone(),
+                    requested_stance: *requested_stance,
+                    effective_stance: *effective_stance,
+                    ready_at: now,
+                })
+            }
             PlannedPatch::Failed { message } => Some(VesselStatusPatch::MarkFailed { message: message.clone() }),
         };
 
@@ -602,6 +638,21 @@ fn owned_child_meta(name: &str, workspace: &ResourceObject<Vessel>, mut extra_la
 }
 
 impl PlacementStrategy {
+    fn effective_stance(&self) -> Stance {
+        match self {
+            Self::HostDirect { .. } => Stance::Trusted,
+            Self::DockerWorktreeOnHostAndMount { .. } | Self::DockerFreshCloneInContainer { .. } => Stance::Contained,
+        }
+    }
+
+    fn description(&self) -> &'static str {
+        match self {
+            Self::HostDirect { .. } => "host-direct",
+            Self::DockerWorktreeOnHostAndMount { .. } => "docker-worktree",
+            Self::DockerFreshCloneInContainer { .. } => "docker-fresh-clone",
+        }
+    }
+
     fn host_ref(&self) -> &str {
         match self {
             Self::HostDirect { host_ref, .. }

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -19,6 +19,7 @@ const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
 const REPO_LABEL: &str = "flotilla.work/repo";
 const ENV_LABEL: &str = "flotilla.work/env";
 
+#[derive(bon::Builder)]
 pub struct VesselReconciler {
     convoys: TypedResolver<Convoy>,
     repositories: TypedResolver<Repository>,

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -134,6 +134,7 @@ async fn terminal_actuator_uses_literal_command_and_cwd() {
 #[tokio::test]
 async fn checkout_actuator_exposes_fresh_clone_transport_url() {
     let spec = FreshCloneCheckoutSpec {
+        repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
         env_ref: "env-a".to_string(),
         r#ref: "main".to_string(),
         target_path: "/workspace".to_string(),

--- a/crates/flotilla-controllers/tests/clone_reconciler.rs
+++ b/crates/flotilla-controllers/tests/clone_reconciler.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use flotilla_controllers::reconcilers::{CloneReconciler, CloneRuntime};
-use flotilla_resources::{controller::Reconciler, CloneSpec, ResourceBackend};
+use flotilla_resources::{clone_key, controller::Reconciler, CloneSpec, Repository, RepositorySpec, ResourceBackend};
 
 mod common;
 use common::meta;
@@ -24,19 +24,53 @@ impl CloneRuntime for FakeCloneRuntime {
 #[tokio::test]
 async fn mismatched_clone_name_fails() {
     let backend = ResourceBackend::InMemory(Default::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    let repository_key = repository_spec.key();
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>("flotilla"), &repository_key, &repository_spec)
+        .await
+        .expect("repository create should succeed");
     let resolver = backend.using::<flotilla_resources::Clone>("flotilla");
     let clone = resolver
         .create(&meta("clone-wrong"), &CloneSpec {
-            repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
+            repo_ref: repository_key,
             url: "git@github.com:flotilla-org/flotilla.git".to_string(),
             env_ref: "host-direct-01HXYZ".to_string(),
             path: "/Users/alice/dev/flotilla".to_string(),
         })
         .await
         .expect("create should succeed");
-    let reconciler = CloneReconciler::new(Arc::new(FakeCloneRuntime));
+    let reconciler = CloneReconciler::new(Arc::new(FakeCloneRuntime), backend.using("flotilla"));
     let deps = reconciler.fetch_dependencies(&clone).await.expect("deps should load");
     let outcome = reconciler.reconcile(&clone, &deps, chrono::Utc::now());
 
     assert!(matches!(outcome.patch, Some(flotilla_resources::CloneStatusPatch::MarkFailed { .. })));
+}
+
+#[tokio::test]
+async fn alias_transport_uses_typed_repository_identity_for_clone_name() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    let repository_key = repository_spec.key();
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>("flotilla"), &repository_key, &repository_spec)
+        .await
+        .expect("repository create should succeed");
+    let env_ref = "host-direct-01HXYZ";
+    let clone_name = format!("clone-{}", clone_key("https://github.com/flotilla-org/flotilla", env_ref));
+    let clone = backend
+        .clone()
+        .using::<flotilla_resources::Clone>("flotilla")
+        .create(&meta(&clone_name), &CloneSpec {
+            repo_ref: repository_key,
+            url: "git@github.work:flotilla-org/flotilla.git".to_string(),
+            env_ref: env_ref.to_string(),
+            path: "/Users/alice/dev/flotilla".to_string(),
+        })
+        .await
+        .expect("clone should create");
+    let reconciler = CloneReconciler::new(Arc::new(FakeCloneRuntime), backend.using("flotilla"));
+
+    let deps = reconciler.fetch_dependencies(&clone).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&clone, &deps, chrono::Utc::now());
+
+    assert!(matches!(outcome.patch, Some(flotilla_resources::CloneStatusPatch::MarkReady { .. })));
 }

--- a/crates/flotilla-controllers/tests/clone_reconciler.rs
+++ b/crates/flotilla-controllers/tests/clone_reconciler.rs
@@ -27,6 +27,7 @@ async fn mismatched_clone_name_fails() {
     let resolver = backend.using::<flotilla_resources::Clone>("flotilla");
     let clone = resolver
         .create(&meta("clone-wrong"), &CloneSpec {
+            repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
             url: "git@github.com:flotilla-org/flotilla.git".to_string(),
             env_ref: "host-direct-01HXYZ".to_string(),
             path: "/Users/alice/dev/flotilla".to_string(),

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -86,6 +86,7 @@ pub async fn create_convoy_with_single_task(
             workflow_snapshot: Some(WorkflowSnapshot {
                 vessels: vec![VesselRequirement {
                     name: task.to_string(),
+                    stance: Default::default(),
                     depends_on: Vec::new(),
                     crew: vec![CrewSpec::builder()
                         .role("coder".to_string())

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -231,7 +231,12 @@ pub async fn create_ready_clone(
 ) -> flotilla_resources::ResourceObject<Clone> {
     let clones = backend.clone().using::<Clone>(namespace);
     let created = clones
-        .create(&meta(name), &CloneSpec { url: repo_url.to_string(), env_ref: env_ref.to_string(), path: path.to_string() })
+        .create(&meta(name), &CloneSpec {
+            repo_ref: flotilla_resources::RepositoryKey(repo_key(&canonicalize_repo_url(repo_url).expect("repo URL should canonicalize"))),
+            url: repo_url.to_string(),
+            env_ref: env_ref.to_string(),
+            path: path.to_string(),
+        })
         .await
         .expect("clone create should succeed");
     clones

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -4,12 +4,12 @@ use std::{collections::BTreeMap, future::Future, time::Duration};
 
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
-    canonicalize_repo_url, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, Clone, ClonePhase, CloneSpec, CloneStatus,
-    Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
-    DockerPerVesselPlacementPolicySpec, Environment, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus, HostDirectEnvironmentSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend,
-    TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec,
-    WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    canonicalize_repo_url, ensure_repository, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, Clone, ClonePhase,
+    CloneSpec, CloneStatus, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy,
+    DockerEnvironmentSpec, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, PlacementPolicy,
+    PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend, TerminalSession, TerminalSessionPhase, TerminalSessionSpec,
+    TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
 };
 use tokio::{
     task::JoinHandle,
@@ -68,13 +68,19 @@ pub async fn create_convoy_with_single_task(
     repo_url: &str,
     git_ref: &str,
 ) -> flotilla_resources::ResourceObject<Convoy> {
+    let canonical_repo = canonicalize_repo_url(repo_url).expect("repository URL should canonicalize");
+    let repository_spec = RepositorySpec::remote(canonical_repo).expect("canonical repository identity should be valid");
+    let repository_key = repository_spec.key();
+    ensure_repository(&backend.clone().using::<Repository>(namespace), &repository_key, &repository_spec)
+        .await
+        .expect("repository create should succeed");
     let convoys = backend.clone().using::<Convoy>(namespace);
     let convoy = convoys
         .create(&meta(name), &ConvoySpec {
             workflow_ref: "wf".to_string(),
             inputs: Default::default(),
             placement_policy: None,
-            repository: Some(ConvoyRepositorySpec { url: repo_url.to_string() }),
+            repository: Some(ConvoyRepositorySpec { url: repo_url.to_string(), repo_ref: repository_key }),
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
             adopted_checkout_ref: None,

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -232,6 +232,14 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
 async fn clone_controller_marks_clone_ready() {
     let backend = ResourceBackend::InMemory(Default::default());
     create_ready_host_direct_environment(&backend, NAMESPACE, "01HXYZ", "/Users/alice/dev/flotilla-repos").await;
+    let repository_spec = flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    flotilla_resources::ensure_repository(
+        &backend.clone().using::<flotilla_resources::Repository>(NAMESPACE),
+        &repository_spec.key(),
+        &repository_spec,
+    )
+    .await
+    .expect("repository create should succeed");
 
     let clones = backend.clone().using::<Clone>(NAMESPACE);
     let clone_name = format!("clone-{}", clone_key("https://github.com/flotilla-org/flotilla", "host-direct-01HXYZ"));
@@ -655,7 +663,7 @@ fn clone_harness(backend: ResourceBackend) -> ControllerLoopHarness {
         ControllerLoop {
             primary: backend.clone().using::<Clone>(NAMESPACE),
             secondaries: vec![],
-            reconciler: CloneReconciler::new(Arc::new(FakeCloneRuntime)),
+            reconciler: CloneReconciler::new(Arc::new(FakeCloneRuntime), backend.clone().using(NAMESPACE)),
             resync_interval: Duration::from_millis(50),
             backend,
         }
@@ -700,7 +708,7 @@ fn full_controller_harness(backend: ResourceBackend) -> ControllerLoopHarness {
         ControllerLoop {
             primary: backend.clone().using::<Clone>(NAMESPACE),
             secondaries: vec![],
-            reconciler: CloneReconciler::new(Arc::new(FakeCloneRuntime)),
+            reconciler: CloneReconciler::new(Arc::new(FakeCloneRuntime), backend.clone().using(NAMESPACE)),
             resync_interval: Duration::from_millis(50),
             backend: backend.clone(),
         }

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -237,6 +237,7 @@ async fn clone_controller_marks_clone_ready() {
     let clone_name = format!("clone-{}", clone_key("https://github.com/flotilla-org/flotilla", "host-direct-01HXYZ"));
     clones
         .create(&controller_meta().name(&clone_name).call(), &CloneSpec {
+            repo_ref: flotilla_resources::RepositoryKey(flotilla_resources::repo_key("https://github.com/flotilla-org/flotilla")),
             url: "git@github.com:flotilla-org/flotilla.git".to_string(),
             env_ref: "host-direct-01HXYZ".to_string(),
             path: "/Users/alice/dev/flotilla".to_string(),
@@ -322,6 +323,7 @@ async fn checkout_controller_marks_worktree_checkout_ready() {
         .create(
             &controller_meta().name("checkout-a").call(),
             &flotilla_resources::CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: flotilla_resources::RepositoryKey(flotilla_resources::repo_key("https://github.com/flotilla-org/flotilla")),
                 env_ref: "host-direct-01HXYZ".to_string(),
                 r#ref: "feat/convoy-resource".to_string(),
                 target_path: "/Users/alice/dev/flotilla.feat-123".to_string(),
@@ -556,6 +558,7 @@ async fn vessel_controller_finalizer_deletes_labeled_children_on_delete() {
                 .labels([(VESSEL_REF_LABEL.to_string(), "workspace-delete".to_string())].into_iter().collect())
                 .call(),
             &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: flotilla_resources::RepositoryKey(flotilla_resources::repo_key("https://github.com/flotilla-org/flotilla")),
                 env_ref: "host-direct-01HXYZ".to_string(),
                 r#ref: "feat/task-provisioning".to_string(),
                 target_path: "/Users/alice/dev/flotilla-repos/workspace-delete".to_string(),

--- a/crates/flotilla-controllers/tests/repository_reconciler.rs
+++ b/crates/flotilla-controllers/tests/repository_reconciler.rs
@@ -1,14 +1,26 @@
 mod common;
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
 use common::meta;
-use flotilla_controllers::reconcilers::RepositoryReconciler;
+use flotilla_controllers::reconcilers::{ForgeDefaultBranchResolver, RepositoryReconciler};
 use flotilla_resources::{
     controller::Reconciler, Checkout, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, CloneStatus, Environment,
-    EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectEnvironmentSpec, LifecycleAuthority, ObservedCheckoutSpec, Repository,
-    RepositoryCheckoutKind, RepositorySpec, ResourceBackend,
+    EnvironmentSpec, ForgeIdentity, FreshCloneCheckoutSpec, HostDirectEnvironmentSpec, LifecycleAuthority, ObservedCheckoutSpec,
+    Repository, RepositoryCheckoutKind, RepositorySpec, ResourceBackend,
 };
 
 const NAMESPACE: &str = "flotilla";
+
+struct FixedForgeDefaultBranch(&'static str);
+
+#[async_trait]
+impl ForgeDefaultBranchResolver for FixedForgeDefaultBranch {
+    async fn default_branch(&self, _forge: &ForgeIdentity) -> Result<Option<String>, String> {
+        Ok(Some(self.0.to_string()))
+    }
+}
 
 #[tokio::test]
 async fn repository_status_groups_typed_checkout_associations_by_explicit_host() {
@@ -95,7 +107,8 @@ async fn repository_status_groups_typed_checkout_associations_by_explicit_host()
         .await
         .expect("clone status");
 
-    let reconciler = RepositoryReconciler::new(durable, observed, NAMESPACE);
+    let reconciler = RepositoryReconciler::new(durable, observed, NAMESPACE)
+        .with_forge_default_branch_resolver(Arc::new(FixedForgeDefaultBranch("stable")));
     let status = reconciler.fetch_dependencies(&repository).await.expect("status projection");
 
     assert_eq!(status.checkouts_by_host["host-a"][0].checkout_ref, "managed-worktree");
@@ -103,7 +116,7 @@ async fn repository_status_groups_typed_checkout_associations_by_explicit_host()
     assert_eq!(status.checkouts_by_host["host-a"][1].kind, RepositoryCheckoutKind::FreshClone);
     assert_eq!(status.checkouts_by_host["host-b"][0].checkout_ref, "observed-main");
     assert_eq!(status.checkouts_by_host["host-b"][0].authority, LifecycleAuthority::Observed);
-    assert_eq!(status.default_branch.as_deref(), Some("main"), "remote symbolic HEAD outranks local trunk");
+    assert_eq!(status.default_branch.as_deref(), Some("stable"), "forge metadata outranks remote symbolic HEAD and local trunk");
     assert!(!status.diagnostics.is_empty(), "branch disagreement should be retained as a diagnostic");
 }
 

--- a/crates/flotilla-controllers/tests/repository_reconciler.rs
+++ b/crates/flotilla-controllers/tests/repository_reconciler.rs
@@ -1,0 +1,123 @@
+mod common;
+
+use common::meta;
+use flotilla_controllers::reconcilers::RepositoryReconciler;
+use flotilla_resources::{
+    controller::Reconciler, Checkout, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, CloneStatus, Environment,
+    EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectEnvironmentSpec, LifecycleAuthority, ObservedCheckoutSpec, Repository,
+    RepositoryCheckoutKind, RepositorySpec, ResourceBackend,
+};
+
+const NAMESPACE: &str = "flotilla";
+
+#[tokio::test]
+async fn repository_status_groups_typed_checkout_associations_by_explicit_host() {
+    let durable = ResourceBackend::InMemory(Default::default());
+    let observed = ResourceBackend::InMemory(flotilla_resources::InMemoryBackend::observed());
+    let repository_spec = RepositorySpec::remote("https://github.com/org/repo.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    let repository = durable
+        .clone()
+        .using::<Repository>(NAMESPACE)
+        .create(&meta(&repository_key.to_string()), &repository_spec)
+        .await
+        .expect("repository create");
+    durable
+        .clone()
+        .using::<Environment>(NAMESPACE)
+        .create(&meta("env-host-a"), &EnvironmentSpec {
+            host_direct: Some(HostDirectEnvironmentSpec { host_ref: "host-a".to_string(), repo_default_dir: "/repos".to_string() }),
+            docker: None,
+        })
+        .await
+        .expect("environment create");
+    durable
+        .clone()
+        .using::<Checkout>(NAMESPACE)
+        .create(
+            &meta("managed-worktree"),
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: repository_key.clone(),
+                env_ref: "env-host-a".to_string(),
+                r#ref: "feature".to_string(),
+                target_path: "/repos/repo.feature".to_string(),
+                clone_ref: "clone-a".to_string(),
+            }),
+        )
+        .await
+        .expect("worktree create");
+    durable
+        .clone()
+        .using::<Checkout>(NAMESPACE)
+        .create(
+            &meta("transient-clone"),
+            &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                repo_ref: repository_key.clone(),
+                env_ref: "env-host-a".to_string(),
+                r#ref: "main".to_string(),
+                target_path: "/workspace".to_string(),
+                url: "https://github.com/org/repo.git".to_string(),
+            }),
+        )
+        .await
+        .expect("fresh clone checkout create");
+    observed
+        .clone()
+        .using::<Checkout>(NAMESPACE)
+        .create(
+            &meta("observed-main").with_lifecycle_authority(LifecycleAuthority::Observed),
+            &CheckoutSpec::Observed(ObservedCheckoutSpec {
+                repo_ref: repository_key.clone(),
+                host_ref: "host-b".to_string(),
+                r#ref: "trunk".to_string(),
+                path: "/work/repo".to_string(),
+                is_main: true,
+            }),
+        )
+        .await
+        .expect("observed checkout create");
+    let clones = durable.clone().using::<Clone>(NAMESPACE);
+    let clone = clones
+        .create(&meta("clone-a"), &CloneSpec {
+            repo_ref: repository_key.clone(),
+            url: "https://github.com/org/repo.git".to_string(),
+            env_ref: "env-host-a".to_string(),
+            path: "/repos/repo".to_string(),
+        })
+        .await
+        .expect("clone create");
+    clones
+        .update_status("clone-a", &clone.metadata.resource_version, &CloneStatus {
+            phase: ClonePhase::Ready,
+            default_branch: Some("main".to_string()),
+            message: None,
+        })
+        .await
+        .expect("clone status");
+
+    let reconciler = RepositoryReconciler::new(durable, observed, NAMESPACE);
+    let status = reconciler.fetch_dependencies(&repository).await.expect("status projection");
+
+    assert_eq!(status.checkouts_by_host["host-a"][0].checkout_ref, "managed-worktree");
+    assert_eq!(status.checkouts_by_host["host-a"][0].kind, RepositoryCheckoutKind::Worktree);
+    assert_eq!(status.checkouts_by_host["host-a"][1].kind, RepositoryCheckoutKind::FreshClone);
+    assert_eq!(status.checkouts_by_host["host-b"][0].checkout_ref, "observed-main");
+    assert_eq!(status.checkouts_by_host["host-b"][0].authority, LifecycleAuthority::Observed);
+    assert_eq!(status.default_branch.as_deref(), Some("main"), "remote symbolic HEAD outranks local trunk");
+    assert!(!status.diagnostics.is_empty(), "branch disagreement should be retained as a diagnostic");
+}
+
+#[tokio::test]
+async fn repository_with_no_checkouts_projects_empty_status_without_deletion() {
+    let durable = ResourceBackend::InMemory(Default::default());
+    let observed = ResourceBackend::InMemory(flotilla_resources::InMemoryBackend::observed());
+    let spec = RepositorySpec::remote("https://github.com/org/empty.git").expect("repository spec");
+    let repository =
+        durable.clone().using::<Repository>(NAMESPACE).create(&meta(&spec.key().to_string()), &spec).await.expect("repository create");
+
+    let reconciler = RepositoryReconciler::new(durable, observed, NAMESPACE);
+    let status = reconciler.fetch_dependencies(&repository).await.expect("status projection");
+
+    assert!(status.checkouts_by_host.is_empty());
+    assert_eq!(status.default_branch, None);
+}

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -16,14 +16,14 @@ use flotilla_resources::{
     ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
     DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
     HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec,
-    ResourceBackend, ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
-    TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
-    CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    Repository, RepositorySpec, ResourceBackend, ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkflowSnapshot,
+    WorkflowTemplate, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
 const NAMESPACE: &str = "flotilla";
-const REPO_URL: &str = "git@github.com:flotilla-org/flotilla.git";
+const REPO_URL: &str = "https://github.com/flotilla-org/flotilla.git";
 const GIT_REF: &str = "feat/task-provisioning";
 const HOST_REF: &str = "01HXYZ";
 
@@ -839,13 +839,18 @@ async fn create_convoy_with_labeled_processes(
     repo_url: &str,
     git_ref: &str,
 ) -> flotilla_resources::ResourceObject<Convoy> {
+    let repository_spec = RepositorySpec::remote(repo_url).expect("repository URL should be canonical");
+    let repository_key = repository_spec.key();
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(namespace), &repository_key, &repository_spec)
+        .await
+        .expect("repository create should succeed");
     let convoys = backend.clone().using::<Convoy>(namespace);
     let convoy = convoys
         .create(&meta(name), &ConvoySpec {
             workflow_ref: "wf".to_string(),
             inputs: Default::default(),
             placement_policy: None,
-            repository: Some(ConvoyRepositorySpec { url: repo_url.to_string() }),
+            repository: Some(ConvoyRepositorySpec { url: repo_url.to_string(), repo_ref: repository_key }),
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
             adopted_checkout_ref: None,

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -16,7 +16,7 @@ use flotilla_resources::{
     ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
     DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
     HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec,
-    ResourceBackend, ResourceError, Selector, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    ResourceBackend, ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
     TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
     CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
@@ -26,6 +26,164 @@ const NAMESPACE: &str = "flotilla";
 const REPO_URL: &str = "git@github.com:flotilla-org/flotilla.git";
 const GIT_REF: &str = "feat/task-provisioning";
 const HOST_REF: &str = "01HXYZ";
+
+#[tokio::test]
+async fn contained_requirement_rejects_host_direct_placement() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-contained", "implement", REPO_URL, GIT_REF).await;
+    let mut status = convoy.status.expect("convoy should have status");
+    status.workflow_snapshot.as_mut().expect("convoy should have workflow snapshot").vessels[0].stance = Stance::Contained;
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .update_status("convoy-contained", &convoy.metadata.resource_version, &status)
+        .await
+        .expect("convoy status should update");
+    create_host_direct_policy(&backend, NAMESPACE, "policy-host", HOST_REF, "cleat").await;
+    let workspace =
+        create_workspace(&backend, NAMESPACE, "workspace-contained", "convoy-contained", "implement", "policy-host", REPO_URL).await;
+
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::VesselStatusPatch::MarkFailed { ref message })
+            if message.contains("requires contained stance") && message.contains("host-direct")
+    ));
+    assert!(outcome.actuations.is_empty());
+}
+
+#[tokio::test]
+async fn ready_vessel_records_requested_and_effective_stance() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-stance", "implement", REPO_URL, GIT_REF).await;
+    create_host_direct_policy(&backend, NAMESPACE, "policy-stance", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    let clone_name =
+        format!("clone-{}", clone_key(&canonicalize_repo_url(REPO_URL).expect("repo canonicalization"), &host_direct_env_name()));
+    create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/tmp/clone").await;
+    let checkout_path = "/Users/alice/dev/flotilla-repos/workspace-stance";
+    create_ready_checkout(
+        &backend,
+        NAMESPACE,
+        ReadyCheckoutFixture::builder()
+            .name("checkout-workspace-stance".to_string())
+            .env_ref(host_direct_env_name())
+            .git_ref(GIT_REF.to_string())
+            .path(checkout_path.to_string())
+            .maybe_worktree(Some(worktree_checkout_spec(&host_direct_env_name(), GIT_REF, checkout_path, &clone_name)))
+            .build(),
+    )
+    .await;
+    create_running_terminal(
+        &backend,
+        NAMESPACE,
+        "terminal-workspace-stance-coder",
+        &host_direct_env_name(),
+        "coder",
+        "cargo test",
+        checkout_path,
+        "cleat",
+    )
+    .await;
+    let workspace =
+        create_workspace(&backend, NAMESPACE, "workspace-stance", "convoy-stance", "implement", "policy-stance", REPO_URL).await;
+
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::VesselStatusPatch::MarkReady { requested_stance: Stance::Trusted, effective_stance: Stance::Trusted, .. })
+    ));
+}
+
+#[tokio::test]
+async fn contained_requirement_runs_in_contained_docker_placement() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-docker-stance", "implement", REPO_URL, GIT_REF).await;
+    let mut status = convoy.status.expect("convoy should have status");
+    status.workflow_snapshot.as_mut().expect("convoy should have workflow snapshot").vessels[0].stance = Stance::Contained;
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .update_status("convoy-docker-stance", &convoy.metadata.resource_version, &status)
+        .await
+        .expect("convoy status should update");
+    create_policy(
+        &backend,
+        NAMESPACE,
+        "policy-docker-stance",
+        PlacementPolicySpec::builder()
+            .pool("cleat".to_string())
+            .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
+                host_ref: HOST_REF.to_string(),
+                image: "ghcr.io/flotilla/dev:latest".to_string(),
+                default_cwd: None,
+                env: Default::default(),
+                checkout: DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },
+            })
+            .build(),
+    )
+    .await;
+    let environment_ref = "env-workspace-docker-stance";
+    create_ready_docker_environment(&backend, NAMESPACE, environment_ref, DockerEnvironmentSpec {
+        host_ref: HOST_REF.to_string(),
+        image: "ghcr.io/flotilla/dev:latest".to_string(),
+        mounts: Vec::new(),
+        env: Default::default(),
+    })
+    .await;
+    create_ready_checkout(
+        &backend,
+        NAMESPACE,
+        ReadyCheckoutFixture::builder()
+            .name("checkout-workspace-docker-stance".to_string())
+            .env_ref(environment_ref.to_string())
+            .git_ref(GIT_REF.to_string())
+            .path("/workspace".to_string())
+            .maybe_fresh_clone(Some(fresh_clone_checkout_spec(environment_ref, GIT_REF, "/workspace", REPO_URL)))
+            .build(),
+    )
+    .await;
+    create_running_terminal(
+        &backend,
+        NAMESPACE,
+        "terminal-workspace-docker-stance-coder",
+        environment_ref,
+        "coder",
+        "cargo test",
+        "/workspace",
+        "cleat",
+    )
+    .await;
+    let workspace = create_workspace(
+        &backend,
+        NAMESPACE,
+        "workspace-docker-stance",
+        "convoy-docker-stance",
+        "implement",
+        "policy-docker-stance",
+        REPO_URL,
+    )
+    .await;
+
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::VesselStatusPatch::MarkReady {
+            requested_stance: Stance::Contained,
+            effective_stance: Stance::Contained,
+            ..
+        })
+    ));
+}
 
 #[tokio::test]
 async fn missing_placement_policy_marks_workspace_failed() {
@@ -694,6 +852,7 @@ async fn create_convoy_with_labeled_processes(
                 vessels: vec![
                     VesselRequirement {
                         name: "implement".to_string(),
+                        stance: Default::default(),
                         depends_on: Vec::new(),
                         crew: vec![CrewSpec::builder()
                             .role("coder".to_string())
@@ -702,6 +861,7 @@ async fn create_convoy_with_labeled_processes(
                     },
                     VesselRequirement {
                         name: "review".to_string(),
+                        stance: Default::default(),
                         depends_on: vec!["implement".to_string()],
                         crew: vec![
                             CrewSpec::builder()

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -810,6 +810,9 @@ fn host_direct_env_name() -> String {
 
 fn worktree_checkout_spec(env_ref: &str, git_ref: &str, target_path: &str, clone_ref: &str) -> CheckoutWorktreeSpec {
     CheckoutWorktreeSpec {
+        repo_ref: flotilla_resources::RepositoryKey(flotilla_resources::repo_key(
+            &canonicalize_repo_url(REPO_URL).expect("repo canonicalization"),
+        )),
         env_ref: env_ref.to_string(),
         r#ref: git_ref.to_string(),
         target_path: target_path.to_string(),
@@ -819,6 +822,9 @@ fn worktree_checkout_spec(env_ref: &str, git_ref: &str, target_path: &str, clone
 
 fn fresh_clone_checkout_spec(env_ref: &str, git_ref: &str, target_path: &str, url: &str) -> flotilla_resources::FreshCloneCheckoutSpec {
     flotilla_resources::FreshCloneCheckoutSpec {
+        repo_ref: flotilla_resources::RepositoryKey(flotilla_resources::repo_key(
+            &canonicalize_repo_url(REPO_URL).expect("repo canonicalization"),
+        )),
         env_ref: env_ref.to_string(),
         r#ref: git_ref.to_string(),
         target_path: target_path.to_string(),
@@ -976,7 +982,8 @@ async fn create_labeled_adopted_checkout(backend: &ResourceBackend, namespace: &
             &CheckoutSpec::Observed(ObservedCheckoutSpec {
                 r#ref: GIT_REF.to_string(),
                 path: format!("/Users/alice/dev/flotilla-repos/{workspace_name}"),
-                repo_ref: "repo-flotilla".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey("repo-flotilla".to_string()),
+                host_ref: HOST_REF.to_string(),
                 is_main: false,
             }),
         )
@@ -992,7 +999,8 @@ async fn create_ready_adopted_checkout(backend: &ResourceBackend, namespace: &st
             &CheckoutSpec::Observed(ObservedCheckoutSpec {
                 r#ref: GIT_REF.to_string(),
                 path: path.to_string(),
-                repo_ref: "repo-flotilla".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey("repo-flotilla".to_string()),
+                host_ref: HOST_REF.to_string(),
                 is_main: false,
             }),
         )
@@ -1017,7 +1025,8 @@ async fn create_ready_observed_checkout_without_status_path(backend: &ResourceBa
             &CheckoutSpec::Observed(ObservedCheckoutSpec {
                 r#ref: GIT_REF.to_string(),
                 path: "/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-observed".to_string(),
-                repo_ref: "repo-flotilla".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey("repo-flotilla".to_string()),
+                host_ref: HOST_REF.to_string(),
                 is_main: false,
             }),
         )

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -327,7 +327,7 @@ pub async fn build_plan(
         | CommandAction::CrewHandoff { .. }
         | CommandAction::ConvoyCreate { .. }
         | CommandAction::WorkflowTemplateApply { .. }
-        | CommandAction::ProjectCreate { .. }
+        | CommandAction::ProjectAdd { .. }
         | CommandAction::ProjectApply { .. }
         | CommandAction::TrackRepoPath { .. }
         | CommandAction::UntrackRepo { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1203,6 +1203,10 @@ impl InProcessDaemon {
         self.repository_inspector().await?.inspect_path(path, remote).await
     }
 
+    async fn resolve_repository_remote(&self, remote: &str) -> Result<RepositorySpec, String> {
+        self.repository_inspector().await?.resolve_remote(remote).await
+    }
+
     async fn inspect_adopted_checkout(
         &self,
         path: &Path,
@@ -3741,11 +3745,41 @@ impl InProcessDaemon {
                 }
                 None => None,
             };
+            let repository = if let Some(url) = repository_url {
+                let resolved = async {
+                    let repository_spec = self.resolve_repository_remote(&url).await?;
+                    let repo_ref = repository_spec.key();
+                    flotilla_resources::ensure_repository(
+                        &self.resource_backend.clone().using::<Repository>(&namespace),
+                        &repo_ref,
+                        &repository_spec,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                    Ok::<_, String>(ConvoyRepositorySpec { url, repo_ref })
+                }
+                .await;
+                match resolved {
+                    Ok(repository) => Some(repository),
+                    Err(message) => {
+                        let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                            command_id: id,
+                            node_id: self.node_id.clone(),
+                            repo_identity: empty_identity,
+                            repo: None,
+                            result: flotilla_protocol::CommandValue::Error { message },
+                        });
+                        return Ok(id);
+                    }
+                }
+            } else {
+                None
+            };
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),
                 inputs: inputs.iter().map(|(k, v)| (k.clone(), InputValue::String(v.clone()))).collect(),
                 placement_policy,
-                repository: repository_url.map(|url| ConvoyRepositorySpec { url }),
+                repository,
                 r#ref,
                 project_ref: project_ref.clone(),
                 adopted_checkout_ref,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -66,7 +66,7 @@ use crate::{
     },
     refresh::RefreshSnapshot,
     repo_state::{RepoRootState, RepoState, SnapshotBuildContext},
-    repository_inspection::{GitRepositoryInspector, RepositoryInspector},
+    repository_inspection::{GitRepositoryInspector, RepositoryInspection, RepositoryInspector},
     step::{
         run_step_plan_with_remote_executor, RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, StepOutcome, StepResolver,
     },
@@ -521,47 +521,30 @@ fn adopted_checkout_name(convoy_name: &str) -> String {
     format!("adopted-checkout-{convoy_name}")
 }
 
-async fn git_stdout(runner: &dyn CommandRunner, checkout_path: &Path, args: &[&str], description: &str) -> Result<String, String> {
-    runner
-        .run("git", args, checkout_path, &ChannelLabel::Noop)
-        .await
-        .map(|stdout| stdout.trim().to_string())
-        .map_err(|err| format!("{description} for {}: {err}", checkout_path.display()))
-}
-
-async fn infer_adopted_checkout_ref(runner: &dyn CommandRunner, checkout_path: &Path) -> Result<String, String> {
-    let branch = git_stdout(runner, checkout_path, &["rev-parse", "--abbrev-ref", "HEAD"], "failed to read checkout ref").await?;
-    if branch != "HEAD" {
-        return Ok(branch);
-    }
-    git_stdout(runner, checkout_path, &["rev-parse", "HEAD"], "failed to read checkout commit").await
+#[derive(bon::Builder)]
+struct AdoptedCheckoutRequest<'a> {
+    namespace: &'a str,
+    convoy_name: &'a str,
+    checkout_path: &'a Path,
+    repository_spec: &'a RepositorySpec,
+    repository_url: &'a str,
+    git_ref: &'a str,
+    host_ref: &'a str,
 }
 
 async fn create_adopted_checkout_resource(
     backend: &ResourceBackend,
-    namespace: &str,
-    convoy_name: &str,
-    checkout_path: &Path,
-    repository_url: Option<&String>,
-    git_ref: Option<&String>,
-    runner: &dyn CommandRunner,
-    host_ref: &str,
+    request: AdoptedCheckoutRequest<'_>,
 ) -> Result<(String, String, String), String> {
+    let AdoptedCheckoutRequest { namespace, convoy_name, checkout_path, repository_spec, repository_url, git_ref, host_ref } = request;
     let path = std::fs::canonicalize(checkout_path)
         .map_err(|err| format!("adopted checkout path {} cannot be resolved: {err}", checkout_path.display()))?;
     let path_str = path.to_string_lossy().to_string();
-    let repo_url = match repository_url {
-        Some(url) => url.clone(),
-        None => git_stdout(runner, &path, &["config", "--get", "remote.origin.url"], "failed to read origin URL").await?,
-    };
-    let git_ref = match git_ref {
-        Some(git_ref) => git_ref.clone(),
-        None => infer_adopted_checkout_ref(runner, &path).await?,
-    };
     let checkout_ref = adopted_checkout_name(convoy_name);
-    let repository_spec = RepositorySpec::remote(&repo_url)?;
     let repository_key = repository_spec.key();
-    ensure_repository(&backend.clone().using::<Repository>(namespace), &repository_key, &repository_spec).await?;
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(namespace), &repository_key, repository_spec)
+        .await
+        .map_err(|error| error.to_string())?;
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
     let meta = InputMeta::builder()
         .name(checkout_ref.clone())
@@ -569,11 +552,11 @@ async fn create_adopted_checkout_resource(
         .build()
         .with_lifecycle_authority(LifecycleAuthority::Adopted);
     let spec = ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
-        r#ref: git_ref.clone(),
+        r#ref: git_ref.to_string(),
         path: path_str.clone(),
         repo_ref: repository_key,
         host_ref: host_ref.to_string(),
-        is_main: matches!(git_ref.as_str(), "main" | "master" | "trunk"),
+        is_main: matches!(git_ref, "main" | "master" | "trunk"),
     });
 
     let checkout = match checkouts.create(&meta, &spec).await {
@@ -600,7 +583,7 @@ async fn create_adopted_checkout_resource(
         .await
         .map_err(|err| err.to_string())?;
 
-    Ok((checkout_ref, repo_url, git_ref))
+    Ok((checkout_ref, repository_url.to_string(), git_ref.to_string()))
 }
 
 async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str) -> Option<String> {
@@ -984,6 +967,10 @@ pub struct InProcessDaemon {
     // repos/repo_order; add_repo intentionally takes it last while already
     // holding those write locks.
     path_identities: RwLock<HashMap<PathBuf, flotilla_protocol::RepoIdentity>>,
+    /// Repository identity last projected for each local tracked path.
+    /// Mutated under `observed_checkout_reconciliation` so removal deletes
+    /// observations using the identity that originally created them.
+    repository_keys_by_path: RwLock<HashMap<PathBuf, RepositoryKey>>,
     host_registry: crate::host_registry::HostRegistry,
     local_environment_id: EnvironmentId,
     environment_manager: Arc<EnvironmentManager>,
@@ -1130,6 +1117,7 @@ impl InProcessDaemon {
             peer_providers: RwLock::new(HashMap::new()),
             peer_overlay_versions: RwLock::new(HashMap::new()),
             path_identities: RwLock::new(path_identities),
+            repository_keys_by_path: RwLock::new(HashMap::new()),
             host_registry: crate::host_registry::HostRegistry::new(
                 NodeInfo::new(local_node_id.clone(), host_name.to_string()),
                 local_host_summary,
@@ -1209,6 +1197,36 @@ impl InProcessDaemon {
         let runner = self.local_command_runner().ok_or_else(|| "local repository inspector is unavailable".to_string())?;
         let host_ref = self.local_host_id().ok_or_else(|| "local Host identity is unavailable".to_string())?;
         Ok(Arc::new(GitRepositoryInspector::new(runner, host_ref.to_string())))
+    }
+
+    pub async fn inspect_repository_path(&self, path: &Path, remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        self.repository_inspector().await?.inspect_path(path, remote).await
+    }
+
+    async fn inspect_adopted_checkout(
+        &self,
+        path: &Path,
+        repository_url: Option<&str>,
+        git_ref: Option<&str>,
+    ) -> Result<RepositoryInspection, String> {
+        if let (Some(repository_url), Some(git_ref)) = (repository_url, git_ref) {
+            if let Ok(spec) = RepositorySpec::remote(repository_url) {
+                let path = std::fs::canonicalize(path)
+                    .map_err(|error| format!("adopted checkout path {} cannot be resolved: {error}", path.display()))?;
+                let host_ref = self.local_host_id().ok_or_else(|| "local Host identity is unavailable".to_string())?.to_string();
+                return Ok(RepositoryInspection {
+                    spec,
+                    checkout: crate::repository_inspection::LocalCheckoutInspection {
+                        path,
+                        host_ref,
+                        git_ref: git_ref.to_string(),
+                        is_main: matches!(git_ref, "main" | "master" | "trunk"),
+                    },
+                    transport_url: Some(repository_url.to_string()),
+                });
+            }
+        }
+        self.inspect_repository_path(path, repository_url).await
     }
 
     pub fn local_environment_bag(&self) -> Option<EnvironmentBag> {
@@ -1821,15 +1839,44 @@ impl InProcessDaemon {
                 warn!(repo = %identity.path, "skipping observed checkout reconciliation after checkout discovery failed");
                 continue;
             }
-            let _reconciliation = self.observed_checkout_reconciliation.lock().await;
-            let has_local_root = self.repos.read().await.get(identity).is_some_and(|state| !state.local_paths().is_empty());
-            if !has_local_root {
+            let local_root = self.repos.read().await.get(identity).and_then(|state| state.local_paths().into_iter().next());
+            let Some(local_root) = local_root else {
                 continue;
+            };
+            let inspection = match self.inspect_repository_path(&local_root, None).await {
+                Ok(inspection) => inspection,
+                Err(error) => {
+                    warn!(repo = %identity.path, %error, "failed to resolve repository identity for observed checkouts");
+                    continue;
+                }
+            };
+            let repository_key = inspection.key();
+            if let Err(error) = flotilla_resources::ensure_repository(
+                &self.resource_backend.clone().using::<Repository>(&namespace),
+                &repository_key,
+                &inspection.spec,
+            )
+            .await
+            {
+                warn!(repo = %identity.path, %error, "failed to ensure repository for observed checkouts");
+                continue;
+            }
+            let _reconciliation = self.observed_checkout_reconciliation.lock().await;
+            let local_paths = self.repos.read().await.get(identity).map(RepoState::local_paths).unwrap_or_default();
+            if !local_paths.contains(&local_root) {
+                continue;
+            }
+            {
+                let mut keys_by_path = self.repository_keys_by_path.write().await;
+                for path in local_paths {
+                    keys_by_path.insert(path, repository_key.clone());
+                }
             }
             if let Err(error) = crate::observed_resources::reconcile_checkouts(
                 &self.observed_resource_backend,
                 &namespace,
-                identity,
+                &repository_key,
+                &inspection.spec.catalog_slug(),
                 local_providers,
                 &self.local_host_id().expect("local host id is established at daemon construction").to_string(),
             )
@@ -2099,37 +2146,7 @@ impl InProcessDaemon {
 /// Non-trait methods that are called directly on the concrete `InProcessDaemon`
 /// type by the daemon server peer-overlay code and by the `execute()` implementation.
 fn repository_matches_target(repository: &ResourceObject<Repository>, target: &str) -> bool {
-    if repository.metadata.name == target || repository.spec.leaf_slug() == target {
-        return true;
-    }
-    match &repository.spec.identity {
-        flotilla_resources::RepositoryIdentity::Remote { canonical_remote } => {
-            repository.spec.forge.as_ref().is_some_and(|forge| forge.repository == target)
-                || flotilla_resources::descriptive_repo_slug(canonical_remote) == target
-        }
-        flotilla_resources::RepositoryIdentity::Local { .. } => false,
-    }
-}
-
-async fn ensure_repository(
-    repositories: &flotilla_resources::TypedResolver<Repository>,
-    key: &RepositoryKey,
-    spec: &RepositorySpec,
-) -> Result<(), String> {
-    let meta = InputMeta::builder().name(key.to_string()).build();
-    match repositories.create(&meta, spec).await {
-        Ok(created) => created.spec.verify_key(key),
-        Err(ResourceError::Conflict { .. }) => {
-            let existing = repositories.get(&key.to_string()).await.map_err(|error| error.to_string())?;
-            existing.spec.verify_key(key)?;
-            if existing.spec == *spec {
-                Ok(())
-            } else {
-                Err(format!("repository key {key} already refers to a different canonical identity"))
-            }
-        }
-        Err(error) => Err(error.to_string()),
-    }
+    repository.metadata.name == target || repository.spec.matches_catalog_target(target)
 }
 
 async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
@@ -2158,6 +2175,24 @@ fn normalize_project_name(name: &str) -> Result<String, String> {
         return Err(format!("project name `{name}` is invalid; use `{normalized}`"));
     }
     Ok(normalized)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectTargetSyntax {
+    ExplicitPath,
+    QualifiedSlug,
+    Ambiguous,
+}
+
+fn project_target_syntax(target: &str) -> ProjectTargetSyntax {
+    let path = Path::new(target);
+    if path.is_absolute() || target.starts_with("./") || target.starts_with("../") {
+        ProjectTargetSyntax::ExplicitPath
+    } else if target.contains('/') {
+        ProjectTargetSyntax::QualifiedSlug
+    } else {
+        ProjectTargetSyntax::Ambiguous
+    }
 }
 
 impl InProcessDaemon {
@@ -2202,8 +2237,10 @@ impl InProcessDaemon {
         let namespace = self.provisioning_namespace().await;
         let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
         let target_path = Path::new(target);
-        let path_is_explicit = target_path.is_absolute();
-        let path_candidate = if target_path.exists() {
+        let target_syntax = project_target_syntax(target);
+        let path_is_explicit = target_syntax == ProjectTargetSyntax::ExplicitPath;
+        let qualified_slug = target_syntax == ProjectTargetSyntax::QualifiedSlug;
+        let path_candidate = if !qualified_slug && target_path.exists() {
             Some(self.repository_inspector().await?.inspect_path(target_path, remote).await?)
         } else if path_is_explicit {
             return Err(format!("repository path {} does not exist", target_path.display()));
@@ -2252,7 +2289,7 @@ impl InProcessDaemon {
             (None, None) => return Err(format!("`{target}` is neither a repository path nor a repository catalog slug")),
         };
 
-        ensure_repository(&repositories, &key, &repository_spec).await?;
+        flotilla_resources::ensure_repository(&repositories, &key, &repository_spec).await.map_err(|error| error.to_string())?;
         if let Some(checkout) = checkout {
             self.ensure_project_checkout(&namespace, &key, &repository_spec, checkout).await?;
         }
@@ -2316,7 +2353,7 @@ impl InProcessDaemon {
             .name(checkout_name.clone())
             .labels(BTreeMap::from([
                 (REPO_KEY_LABEL.to_string(), repository_key.to_string()),
-                (REPO_LABEL.to_string(), repository_spec.leaf_slug()),
+                (REPO_LABEL.to_string(), repository_spec.catalog_slug()),
             ]))
             .build()
             .with_lifecycle_authority(LifecycleAuthority::Observed);
@@ -2495,6 +2532,10 @@ impl InProcessDaemon {
         let path = path.to_path_buf();
         let repo_identity = self.tracked_repo_identity_for_path(&path).await.unwrap_or_else(|| fallback_repo_identity(&path));
         let observed_reconciliation = self.observed_checkout_reconciliation.lock().await;
+        let repository_key = match self.repository_keys_by_path.read().await.get(&path).cloned() {
+            Some(key) => Some(key),
+            None => self.inspect_repository_path(&path, None).await.ok().map(|inspection| inspection.key()),
+        };
 
         let mut removed_identity = false;
         let removed_final_local_root;
@@ -2526,6 +2567,7 @@ impl InProcessDaemon {
 
         // Remove from identity map and peer overlay
         self.path_identities.write().await.remove(&path);
+        self.repository_keys_by_path.write().await.remove(&path);
         if removed_identity {
             let mut pp = self.peer_providers.write().await;
             pp.remove(&repo_identity);
@@ -2535,10 +2577,14 @@ impl InProcessDaemon {
 
         if removed_final_local_root {
             let namespace = self.provisioning_namespace().await;
-            if let Err(error) =
-                crate::observed_resources::delete_observed_checkouts(&self.observed_resource_backend, &namespace, &repo_identity).await
-            {
-                warn!(repo = %repo_identity.path, %error, "failed to delete observed checkouts for untracked repo");
+            if let Some(repository_key) = repository_key {
+                if let Err(error) =
+                    crate::observed_resources::delete_observed_checkouts(&self.observed_resource_backend, &namespace, &repository_key).await
+                {
+                    warn!(repo = %repo_identity.path, %error, "failed to delete observed checkouts for untracked repo");
+                }
+            } else {
+                warn!(repo = %repo_identity.path, "could not resolve repository identity while deleting observed checkouts");
             }
         }
         drop(observed_reconciliation);
@@ -3651,19 +3697,30 @@ impl InProcessDaemon {
             let mut repository_url = repository_url.clone();
             let mut r#ref = r#ref.clone();
             let adopted_checkout_ref = match adopted_checkout {
-                Some(path) => match self.local_command_runner() {
-                    Some(runner) => match create_adopted_checkout_resource(
-                        &self.resource_backend,
-                        &namespace,
-                        name,
-                        path.as_ref(),
-                        repository_url.as_ref(),
-                        r#ref.as_ref(),
-                        runner.as_ref(),
-                        &self.local_host_id().expect("local host id is established at daemon construction").to_string(),
-                    )
-                    .await
-                    {
+                Some(path) => {
+                    let adopted_result = async {
+                        let inspection = self.inspect_adopted_checkout(path.as_ref(), repository_url.as_deref(), r#ref.as_deref()).await?;
+                        let transport_url = inspection
+                            .transport_url
+                            .as_deref()
+                            .ok_or_else(|| "an adopted checkout requires a repository transport URL".to_string())?;
+                        let git_ref = r#ref.as_deref().unwrap_or(&inspection.checkout.git_ref);
+                        create_adopted_checkout_resource(
+                            &self.resource_backend,
+                            AdoptedCheckoutRequest::builder()
+                                .namespace(&namespace)
+                                .convoy_name(name)
+                                .checkout_path(&inspection.checkout.path)
+                                .repository_spec(&inspection.spec)
+                                .repository_url(transport_url)
+                                .git_ref(git_ref)
+                                .host_ref(&inspection.checkout.host_ref)
+                                .build(),
+                        )
+                        .await
+                    }
+                    .await;
+                    match adopted_result {
                         Ok((checkout_ref, inferred_repository_url, inferred_ref)) => {
                             repository_url.get_or_insert(inferred_repository_url);
                             r#ref.get_or_insert(inferred_ref);
@@ -3680,19 +3737,8 @@ impl InProcessDaemon {
                             });
                             return Ok(id);
                         }
-                    },
-                    None => {
-                        let result = flotilla_protocol::CommandValue::Error { message: "local command runner unavailable".to_string() };
-                        let _ = self.event_tx.send(DaemonEvent::CommandFinished {
-                            command_id: id,
-                            node_id: self.node_id.clone(),
-                            repo_identity: empty_identity,
-                            repo: None,
-                            result,
-                        });
-                        return Ok(id);
                     }
-                },
+                }
                 None => None,
             };
             let spec = ConvoySpec {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -27,14 +27,14 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, apply_status_patch_checked as apply_resource_status_patch_checked,
-    external_patches as convoy_external_patches, terminal_session_attach_target, Checkout as ResourceCheckout,
+    external_patches as convoy_external_patches, normalize_project_spec, terminal_session_attach_target, Checkout as ResourceCheckout,
     CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus,
     Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CrewSource, Environment as ResourceEnvironment,
     InMemoryBackend, InputMeta, InputValue, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy,
-    Project, ProjectRepositorySpec, ProjectSpec, Resource, ResourceBackend, ResourceError, ResourceObject, TerminalBrief,
-    TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
-    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WorkflowTemplate,
-    WorkflowTemplateSpec, CONVOY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
+    ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
+    Vessel, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -66,6 +66,7 @@ use crate::{
     },
     refresh::RefreshSnapshot,
     repo_state::{RepoRootState, RepoState, SnapshotBuildContext},
+    repository_inspection::{GitRepositoryInspector, RepositoryInspector},
     step::{
         run_step_plan_with_remote_executor, RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, StepOutcome, StepResolver,
     },
@@ -544,6 +545,7 @@ async fn create_adopted_checkout_resource(
     repository_url: Option<&String>,
     git_ref: Option<&String>,
     runner: &dyn CommandRunner,
+    host_ref: &str,
 ) -> Result<(String, String, String), String> {
     let path = std::fs::canonicalize(checkout_path)
         .map_err(|err| format!("adopted checkout path {} cannot be resolved: {err}", checkout_path.display()))?;
@@ -557,6 +559,9 @@ async fn create_adopted_checkout_resource(
         None => infer_adopted_checkout_ref(runner, &path).await?,
     };
     let checkout_ref = adopted_checkout_name(convoy_name);
+    let repository_spec = RepositorySpec::remote(&repo_url)?;
+    let repository_key = repository_spec.key();
+    ensure_repository(&backend.clone().using::<Repository>(namespace), &repository_key, &repository_spec).await?;
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
     let meta = InputMeta::builder()
         .name(checkout_ref.clone())
@@ -566,7 +571,8 @@ async fn create_adopted_checkout_resource(
     let spec = ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
         r#ref: git_ref.clone(),
         path: path_str.clone(),
-        repo_ref: repo_url.clone(),
+        repo_ref: repository_key,
+        host_ref: host_ref.to_string(),
         is_main: matches!(git_ref.as_str(), "main" | "master" | "trunk"),
     });
 
@@ -1005,6 +1011,7 @@ pub struct InProcessDaemon {
     provisioning_namespace: RwLock<String>,
     fleet_replica_cache: RwLock<HashMap<HostName, FleetReplicaCacheEntry>>,
     fleet_replica_tx: broadcast::Sender<Vec<FleetReplicaSnapshot>>,
+    repository_inspector: RwLock<Option<Arc<dyn RepositoryInspector>>>,
 }
 
 /// Default provisioning namespace used until [`InProcessDaemon::set_provisioning_namespace`]
@@ -1141,6 +1148,7 @@ impl InProcessDaemon {
             provisioning_namespace: RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
             fleet_replica_cache: RwLock::new(HashMap::new()),
             fleet_replica_tx,
+            repository_inspector: RwLock::new(None),
         });
 
         // Spawn self-driving poll loop with a Weak reference.
@@ -1188,6 +1196,19 @@ impl InProcessDaemon {
 
     pub fn local_command_runner(&self) -> Option<Arc<dyn CommandRunner>> {
         self.environment_manager.environment_runner(&self.local_environment_id)
+    }
+
+    pub async fn set_repository_inspector(&self, inspector: Arc<dyn RepositoryInspector>) {
+        *self.repository_inspector.write().await = Some(inspector);
+    }
+
+    async fn repository_inspector(&self) -> Result<Arc<dyn RepositoryInspector>, String> {
+        if let Some(inspector) = self.repository_inspector.read().await.clone() {
+            return Ok(inspector);
+        }
+        let runner = self.local_command_runner().ok_or_else(|| "local repository inspector is unavailable".to_string())?;
+        let host_ref = self.local_host_id().ok_or_else(|| "local Host identity is unavailable".to_string())?;
+        Ok(Arc::new(GitRepositoryInspector::new(runner, host_ref.to_string())))
     }
 
     pub fn local_environment_bag(&self) -> Option<EnvironmentBag> {
@@ -1805,8 +1826,14 @@ impl InProcessDaemon {
             if !has_local_root {
                 continue;
             }
-            if let Err(error) =
-                crate::observed_resources::reconcile_checkouts(&self.observed_resource_backend, &namespace, identity, local_providers).await
+            if let Err(error) = crate::observed_resources::reconcile_checkouts(
+                &self.observed_resource_backend,
+                &namespace,
+                identity,
+                local_providers,
+                &self.local_host_id().expect("local host id is established at daemon construction").to_string(),
+            )
+            .await
             {
                 warn!(repo = %identity.path, %error, "failed to reconcile observed checkouts");
             }
@@ -2071,7 +2098,254 @@ impl InProcessDaemon {
 
 /// Non-trait methods that are called directly on the concrete `InProcessDaemon`
 /// type by the daemon server peer-overlay code and by the `execute()` implementation.
+fn repository_matches_target(repository: &ResourceObject<Repository>, target: &str) -> bool {
+    if repository.metadata.name == target || repository.spec.leaf_slug() == target {
+        return true;
+    }
+    match &repository.spec.identity {
+        flotilla_resources::RepositoryIdentity::Remote { canonical_remote } => {
+            repository.spec.forge.as_ref().is_some_and(|forge| forge.repository == target)
+                || flotilla_resources::descriptive_repo_slug(canonical_remote) == target
+        }
+        flotilla_resources::RepositoryIdentity::Local { .. } => false,
+    }
+}
+
+async fn ensure_repository(
+    repositories: &flotilla_resources::TypedResolver<Repository>,
+    key: &RepositoryKey,
+    spec: &RepositorySpec,
+) -> Result<(), String> {
+    let meta = InputMeta::builder().name(key.to_string()).build();
+    match repositories.create(&meta, spec).await {
+        Ok(created) => created.spec.verify_key(key),
+        Err(ResourceError::Conflict { .. }) => {
+            let existing = repositories.get(&key.to_string()).await.map_err(|error| error.to_string())?;
+            existing.spec.verify_key(key)?;
+            if existing.spec == *spec {
+                Ok(())
+            } else {
+                Err(format!("repository key {key} already refers to a different canonical identity"))
+            }
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
+    let templates = backend.clone().using::<WorkflowTemplate>(namespace);
+    let meta = InputMeta::builder().name("single-agent-contained".to_string()).build();
+    match templates.create(&meta, &flotilla_resources::single_agent_contained_workflow_spec()).await {
+        Ok(_) | Err(ResourceError::Conflict { .. }) => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn normalize_project_name(name: &str) -> Result<String, String> {
+    let normalized = name
+        .trim()
+        .chars()
+        .map(|character| if character.is_ascii_alphanumeric() { character.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    if normalized.is_empty() {
+        return Err("project name must contain an alphanumeric character".to_string());
+    }
+    if normalized != name {
+        return Err(format!("project name `{name}` is invalid; use `{normalized}`"));
+    }
+    Ok(normalized)
+}
+
 impl InProcessDaemon {
+    async fn validate_project_readiness(&self, namespace: &str, project_ref: &str) -> Result<(), String> {
+        let project = self
+            .resource_backend
+            .clone()
+            .using::<Project>(namespace)
+            .get(project_ref)
+            .await
+            .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
+        let repositories = self.resource_backend.clone().using::<Repository>(namespace);
+        let mut unresolved = Vec::new();
+        for entry in &project.spec.repositories {
+            match repositories.get(&entry.repo.to_string()).await {
+                Ok(repository) => {
+                    if let Err(error) = repository.spec.verify_key(&entry.repo) {
+                        unresolved.push(error);
+                    }
+                }
+                Err(error) => unresolved.push(format!("repository {}: {error}", entry.repo)),
+            }
+        }
+        if let Err(error) = self.resource_backend.clone().using::<WorkflowTemplate>(namespace).get(&project.spec.default_workflow_ref).await
+        {
+            unresolved.push(format!("workflow template {}: {error}", project.spec.default_workflow_ref));
+        }
+        if unresolved.is_empty() {
+            Ok(())
+        } else {
+            Err(format!("project {project_ref} is not ready: {}", unresolved.join("; ")))
+        }
+    }
+
+    async fn project_add(
+        &self,
+        target: &str,
+        explicit_name: Option<&str>,
+        explicit_display_name: Option<&str>,
+        remote: Option<&str>,
+    ) -> Result<String, String> {
+        let namespace = self.provisioning_namespace().await;
+        let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
+        let target_path = Path::new(target);
+        let path_is_explicit = target_path.is_absolute();
+        let path_candidate = if target_path.exists() {
+            Some(self.repository_inspector().await?.inspect_path(target_path, remote).await?)
+        } else if path_is_explicit {
+            return Err(format!("repository path {} does not exist", target_path.display()));
+        } else {
+            None
+        };
+
+        let catalog_matches = if path_is_explicit {
+            Vec::new()
+        } else {
+            repositories
+                .list()
+                .await
+                .map_err(|error| error.to_string())?
+                .items
+                .into_iter()
+                .filter(|repository| repository_matches_target(repository, target))
+                .collect::<Vec<_>>()
+        };
+        let mut catalog_by_key = BTreeMap::new();
+        for repository in catalog_matches {
+            let key = RepositoryKey(repository.metadata.name.clone());
+            repository.spec.verify_key(&key)?;
+            catalog_by_key.insert(key, repository.spec);
+        }
+        if catalog_by_key.len() > 1 {
+            return Err(format!(
+                "repository slug `{target}` is ambiguous: {}",
+                catalog_by_key.keys().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+            ));
+        }
+        let catalog_candidate = catalog_by_key.into_iter().next();
+        if remote.is_some() && path_candidate.is_none() && catalog_candidate.is_some() {
+            return Err("--remote can only select identity while inspecting a local repository path".to_string());
+        }
+
+        let (key, repository_spec, checkout) = match (path_candidate, catalog_candidate) {
+            (Some(inspection), Some((catalog_key, _))) if inspection.key() != catalog_key => {
+                return Err(format!(
+                    "`{target}` resolves to different path and catalog repositories: {} and {catalog_key}",
+                    inspection.key()
+                ));
+            }
+            (Some(inspection), _) => (inspection.key(), inspection.spec, Some(inspection.checkout)),
+            (None, Some((key, spec))) => (key, spec, None),
+            (None, None) => return Err(format!("`{target}` is neither a repository path nor a repository catalog slug")),
+        };
+
+        ensure_repository(&repositories, &key, &repository_spec).await?;
+        if let Some(checkout) = checkout {
+            self.ensure_project_checkout(&namespace, &key, &repository_spec, checkout).await?;
+        }
+        ensure_single_agent_contained_workflow(&self.resource_backend, &namespace).await?;
+
+        let default_name = normalize_project_name(&repository_spec.leaf_slug())?;
+        let project_name = explicit_name.map(str::to_string).unwrap_or(default_name.clone());
+        normalize_project_name(&project_name)?;
+        let projects = self.resource_backend.clone().using::<Project>(&namespace);
+        match projects.get(&project_name).await {
+            Ok(existing) => {
+                let same_whole_repository = matches!(
+                    existing.spec.repositories.as_slice(),
+                    [entry] if entry.repo == key && entry.subpath.is_none()
+                );
+                if !same_whole_repository {
+                    return Err(format!("project {project_name} already exists with a different repository definition"));
+                }
+                if explicit_display_name.is_some_and(|display_name| display_name != existing.spec.display_name) {
+                    return Err(format!(
+                        "project {project_name} already exists with display name `{}`; use project apply to change it",
+                        existing.spec.display_name
+                    ));
+                }
+                return Ok(project_name);
+            }
+            Err(ResourceError::NotFound { .. }) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+
+        let spec = normalize_project_spec(ProjectSpec {
+            display_name: explicit_display_name.map(str::to_string).unwrap_or(default_name),
+            default_workflow_ref: "single-agent-contained".to_string(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: key, subpath: None, default_branch: None }],
+        })?;
+        projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
+        Ok(project_name)
+    }
+
+    async fn ensure_project_checkout(
+        &self,
+        namespace: &str,
+        repository_key: &RepositoryKey,
+        repository_spec: &RepositorySpec,
+        checkout: crate::repository_inspection::LocalCheckoutInspection,
+    ) -> Result<(), String> {
+        let checkouts = self.observed_resource_backend.clone().using::<ResourceCheckout>(namespace);
+        let checkout_name = format!(
+            "checkout-{}",
+            flotilla_resources::repo_key(&format!("{}\0{}\0{}", repository_key, checkout.host_ref, checkout.path.display()))
+        );
+        let spec = ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+            r#ref: checkout.git_ref,
+            path: checkout.path.to_string_lossy().into_owned(),
+            repo_ref: repository_key.clone(),
+            host_ref: checkout.host_ref,
+            is_main: checkout.is_main,
+        });
+        let meta = InputMeta::builder()
+            .name(checkout_name.clone())
+            .labels(BTreeMap::from([
+                (REPO_KEY_LABEL.to_string(), repository_key.to_string()),
+                (REPO_LABEL.to_string(), repository_spec.leaf_slug()),
+            ]))
+            .build()
+            .with_lifecycle_authority(LifecycleAuthority::Observed);
+        let stored = match checkouts.create(&meta, &spec).await {
+            Ok(created) => created,
+            Err(ResourceError::Conflict { .. }) => {
+                let existing = checkouts.get(&checkout_name).await.map_err(|error| error.to_string())?;
+                if existing.spec != spec {
+                    return Err(format!("checkout {checkout_name} already exists with a different observation"));
+                }
+                existing
+            }
+            Err(error) => return Err(error.to_string()),
+        };
+        checkouts
+            .update_status(&checkout_name, &stored.metadata.resource_version, &ResourceCheckoutStatus {
+                phase: ResourceCheckoutPhase::Ready,
+                path: spec.target_path().map(str::to_string).or_else(|| match &spec {
+                    ResourceCheckoutSpec::Observed(observed) => Some(observed.path.clone()),
+                    _ => None,
+                }),
+                commit: None,
+                message: None,
+            })
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
     pub async fn refresh(&self, repo: &flotilla_protocol::RepoSelector) -> Result<(), String> {
         let repo = self.resolve_repo_selector(repo).await?;
         {
@@ -3358,6 +3632,18 @@ impl InProcessDaemon {
                     return Ok(id);
                 }
             }
+            if let Some(project_ref) = project_ref {
+                if let Err(message) = self.validate_project_readiness(&namespace, project_ref).await {
+                    let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                        command_id: id,
+                        node_id: self.node_id.clone(),
+                        repo_identity: empty_identity,
+                        repo: None,
+                        result: flotilla_protocol::CommandValue::Error { message },
+                    });
+                    return Ok(id);
+                }
+            }
             let placement_policy = match placement_policy {
                 Some(policy) => Some(policy.clone()),
                 None => default_convoy_placement_policy(&self.resource_backend, &namespace).await,
@@ -3374,6 +3660,7 @@ impl InProcessDaemon {
                         repository_url.as_ref(),
                         r#ref.as_ref(),
                         runner.as_ref(),
+                        &self.local_host_id().expect("local host id is established at daemon construction").to_string(),
                     )
                     .await
                     {
@@ -3468,7 +3755,7 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ProjectCreate { name, display_name, repository_url, subpath, r#ref } = &command.action {
+        if let flotilla_protocol::CommandAction::ProjectAdd { target, name, display_name, remote } = &command.action {
             let empty_identity = empty_repo_identity();
             let _ = self.event_tx.send(DaemonEvent::CommandStarted {
                 command_id: id,
@@ -3477,17 +3764,9 @@ impl InProcessDaemon {
                 repo: None,
                 description: command.description().to_string(),
             });
-            let namespace = self.provisioning_namespace().await;
-            let projects = self.resource_backend.clone().using::<Project>(&namespace);
-            let repositories = match repository_url {
-                Some(url) => vec![ProjectRepositorySpec { repo: url.clone(), subpath: subpath.clone(), default_branch: r#ref.clone() }],
-                None => vec![],
-            };
-            let spec = ProjectSpec { display_name: display_name.clone(), repositories };
-            let meta = InputMeta::builder().name(name.clone()).build();
-            let result = match projects.create(&meta, &spec).await {
-                Ok(_) => flotilla_protocol::CommandValue::ProjectCreated { name: name.clone() },
-                Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+            let result = match self.project_add(target, name.as_deref(), display_name.as_deref(), remote.as_deref()).await {
+                Ok(name) => flotilla_protocol::CommandValue::ProjectAdded { name },
+                Err(message) => flotilla_protocol::CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {
                 command_id: id,
@@ -3510,19 +3789,22 @@ impl InProcessDaemon {
             });
             let namespace = self.provisioning_namespace().await;
             let projects = self.resource_backend.clone().using::<Project>(&namespace);
-            let result = match parse_project_yaml(spec_yaml) {
-                Ok(spec) => {
-                    let meta = InputMeta::builder().name(name.clone()).build();
-                    let outcome = match projects.get(name).await {
-                        Ok(existing) => projects.update(&meta, &existing.metadata.resource_version, &spec).await.map(|_| ()),
-                        Err(ResourceError::NotFound { .. }) => projects.create(&meta, &spec).await.map(|_| ()),
-                        Err(err) => Err(err),
-                    };
-                    match outcome {
-                        Ok(()) => flotilla_protocol::CommandValue::ProjectApplied { name: name.clone() },
-                        Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+            let result = match normalize_project_name(name).and_then(|_| parse_project_yaml(spec_yaml)) {
+                Ok(spec) => match normalize_project_spec(spec) {
+                    Ok(spec) => {
+                        let meta = InputMeta::builder().name(name.clone()).build();
+                        let outcome = match projects.get(name).await {
+                            Ok(existing) => projects.update(&meta, &existing.metadata.resource_version, &spec).await.map(|_| ()),
+                            Err(ResourceError::NotFound { .. }) => projects.create(&meta, &spec).await.map(|_| ()),
+                            Err(err) => Err(err),
+                        };
+                        match outcome {
+                            Ok(()) => flotilla_protocol::CommandValue::ProjectApplied { name: name.clone() },
+                            Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+                        }
                     }
-                }
+                    Err(message) => flotilla_protocol::CommandValue::Error { message },
+                },
                 Err(err) => flotilla_protocol::CommandValue::Error { message: err },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -279,7 +279,8 @@ async fn create_adopted_checkout_for_convoy(daemon: &InProcessDaemon, convoy: &s
             &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
                 r#ref: "main".to_string(),
                 path: "/repo".to_string(),
-                repo_ref: "git@example.com:owner/repo.git".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
+                host_ref: "host-01".to_string(),
                 is_main: true,
             }),
         )
@@ -2352,7 +2353,7 @@ async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource()
         ResourceCheckoutSpec::Observed(spec) => {
             assert_eq!(spec.r#ref, "main");
             assert_eq!(spec.path, std::fs::canonicalize(&checkout_path).expect("canonical path").display().to_string());
-            assert_eq!(spec.repo_ref, remote);
+            assert_eq!(spec.repo_ref, flotilla_resources::RepositorySpec::remote(remote).expect("repository spec").key());
         }
         other => panic!("expected observed checkout spec, got {other:?}"),
     }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -324,11 +324,10 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
         .update_status("demo", &convoy.metadata.resource_version, &ConvoyStatus {
             phase: ConvoyPhase::Active,
             workflow_snapshot: Some(WorkflowSnapshot {
-                vessels: vec![VesselRequirement { name: "prepare".into(), depends_on: Vec::new(), crew: Vec::new() }, VesselRequirement {
-                    name: "implement".into(),
-                    depends_on: Vec::new(),
-                    crew: processes,
-                }],
+                vessels: vec![
+                    VesselRequirement { name: "prepare".into(), stance: Default::default(), depends_on: Vec::new(), crew: Vec::new() },
+                    VesselRequirement { name: "implement".into(), stance: Default::default(), depends_on: Vec::new(), crew: processes },
+                ],
             }),
             work: BTreeMap::from([("implement".to_string(), WorkState {
                 phase: WorkPhase::Running,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -43,6 +43,14 @@ use crate::{
     },
 };
 
+#[test]
+fn project_target_syntax_disambiguates_paths_and_qualified_slugs() {
+    assert_eq!(project_target_syntax("/srv/repos/example"), ProjectTargetSyntax::ExplicitPath);
+    assert_eq!(project_target_syntax("./org/repo"), ProjectTargetSyntax::ExplicitPath);
+    assert_eq!(project_target_syntax("org/repo"), ProjectTargetSyntax::QualifiedSlug);
+    assert_eq!(project_target_syntax("repo"), ProjectTargetSyntax::Ambiguous);
+}
+
 fn convoy_row(namespace: &str, name: &str, phase: WireConvoyPhase, message: Option<&str>) -> ConvoyRow {
     ConvoyRow::builder()
         .resource(ResourceRef::new("flotilla.work/v1", "Convoy", namespace, name))

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2361,7 +2361,10 @@ async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource()
         ResourceCheckoutSpec::Observed(spec) => {
             assert_eq!(spec.r#ref, "main");
             assert_eq!(spec.path, std::fs::canonicalize(&checkout_path).expect("canonical path").display().to_string());
-            assert_eq!(spec.repo_ref, flotilla_resources::RepositorySpec::remote(remote).expect("repository spec").key());
+            assert_eq!(
+                spec.repo_ref,
+                flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec").key()
+            );
         }
         other => panic!("expected observed checkout spec, got {other:?}"),
     }

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod provider_data;
 pub mod providers;
 pub mod refresh;
 pub(crate) mod repo_state;
+pub mod repository_inspection;
 pub mod resolve;
 pub mod step;
 pub mod template;

--- a/crates/flotilla-core/src/observed_resources.rs
+++ b/crates/flotilla-core/src/observed_resources.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, HashMap};
 
-use flotilla_protocol::{qualified_path::QualifiedPath, ProviderData, RepoIdentity};
+use flotilla_protocol::{qualified_path::QualifiedPath, ProviderData};
 use flotilla_resources::{
-    canonicalize_repo_url, descriptive_repo_slug, repo_key, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta,
-    LifecycleAuthority, ObservedCheckoutSpec, RepositoryKey, ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
+    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, RepositoryKey,
+    ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
 };
 use sha2::{Digest, Sha256};
 
@@ -16,11 +16,12 @@ use sha2::{Digest, Sha256};
 pub async fn reconcile_checkouts(
     backend: &ResourceBackend,
     namespace: &str,
-    repo_identity: &RepoIdentity,
+    repository_key: &RepositoryKey,
+    repository_slug: &str,
     providers: &ProviderData,
     host_ref: &str,
 ) -> Result<(), ResourceError> {
-    let scope = observed_checkout_scope(repo_identity)?;
+    let scope = ObservedCheckoutScope { repo_key: repository_key.clone(), repo_slug: repository_slug.to_string() };
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
     let selector = scope.selector();
     let mut existing: HashMap<_, _> = checkouts
@@ -33,11 +34,11 @@ pub async fn reconcile_checkouts(
 
     for (path, checkout) in &providers.checkouts {
         let name = observed_checkout_name(&scope.repo_key, path);
-        let meta = observed_checkout_meta(&name, &scope.repo_key, &scope.repo_ref);
+        let meta = observed_checkout_meta(&name, &scope.repo_key, &scope.repo_slug);
         let spec = ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
             r#ref: checkout.branch.clone(),
             path: path.path.to_string_lossy().into_owned(),
-            repo_ref: RepositoryKey(scope.repo_key.clone()),
+            repo_ref: scope.repo_key.clone(),
             host_ref: host_ref.to_string(),
             is_main: checkout.is_main,
         });
@@ -67,9 +68,9 @@ pub async fn reconcile_checkouts(
 pub async fn delete_observed_checkouts(
     backend: &ResourceBackend,
     namespace: &str,
-    repo_identity: &RepoIdentity,
+    repository_key: &RepositoryKey,
 ) -> Result<(), ResourceError> {
-    let scope = observed_checkout_scope(repo_identity)?;
+    let scope = ObservedCheckoutScope { repo_key: repository_key.clone(), repo_slug: String::new() };
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
     let selector = scope.selector();
 
@@ -81,43 +82,31 @@ pub async fn delete_observed_checkouts(
 }
 
 struct ObservedCheckoutScope {
-    repo_key: String,
-    repo_ref: String,
+    repo_key: RepositoryKey,
+    repo_slug: String,
 }
 
 impl ObservedCheckoutScope {
     fn selector(&self) -> BTreeMap<String, String> {
         BTreeMap::from([
             (AUTHORITY_LABEL.to_string(), LifecycleAuthority::Observed.as_label_value().to_string()),
-            (REPO_KEY_LABEL.to_string(), self.repo_key.clone()),
+            (REPO_KEY_LABEL.to_string(), self.repo_key.to_string()),
         ])
     }
 }
 
-fn observed_checkout_scope(repo_identity: &RepoIdentity) -> Result<ObservedCheckoutScope, ResourceError> {
-    let canonical_repo = canonical_repo_url(repo_identity).map_err(ResourceError::invalid)?;
-    Ok(ObservedCheckoutScope { repo_key: repo_key(&canonical_repo), repo_ref: descriptive_repo_slug(&canonical_repo) })
-}
-
-fn canonical_repo_url(identity: &RepoIdentity) -> Result<String, String> {
-    if matches!(identity.authority.as_str(), "local" | "unknown") {
-        return Err("cannot derive observed checkout identity without a recognized repository remote".to_string());
-    }
-    canonicalize_repo_url(&format!("https://{}/{}", identity.authority, identity.path.trim_start_matches('/')))
-}
-
-fn observed_checkout_meta(name: &str, repo_key: &str, repo_ref: &str) -> InputMeta {
+fn observed_checkout_meta(name: &str, repo_key: &RepositoryKey, repo_slug: &str) -> InputMeta {
     InputMeta::builder()
         .name(name.to_string())
-        .labels(BTreeMap::from([(REPO_KEY_LABEL.to_string(), repo_key.to_string()), (REPO_LABEL.to_string(), repo_ref.to_string())]))
+        .labels(BTreeMap::from([(REPO_KEY_LABEL.to_string(), repo_key.to_string()), (REPO_LABEL.to_string(), repo_slug.to_string())]))
         .build()
         .with_lifecycle_authority(LifecycleAuthority::Observed)
 }
 
-fn observed_checkout_name(repo_key: &str, path: &QualifiedPath) -> String {
+fn observed_checkout_name(repo_key: &RepositoryKey, path: &QualifiedPath) -> String {
     let mut hash = Sha256::new();
     hash.update(b"observed-checkout-v1\0");
-    hash.update(repo_key.as_bytes());
+    hash.update(repo_key.0.as_bytes());
     hash.update([0]);
     hash.update(path.to_string().as_bytes());
     let digest = format!("{:x}", hash.finalize());
@@ -128,83 +117,54 @@ fn observed_checkout_name(repo_key: &str, path: &QualifiedPath) -> String {
 mod tests {
     use flotilla_protocol::{
         qualified_path::{HostId, QualifiedPath},
-        HostName, ProviderData, RepoIdentity,
+        Checkout, HostName, ProviderData,
     };
-    use flotilla_resources::{
-        Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InMemoryBackend, InputMeta, ObservedCheckoutSpec,
-        ResourceBackend, ResourceError,
-    };
+    use flotilla_resources::{Checkout as ResourceCheckout, InMemoryBackend, RepositoryKey, ResourceBackend};
 
-    use super::{canonical_repo_url, observed_checkout_name, reconcile_checkouts};
+    use super::{observed_checkout_name, reconcile_checkouts};
 
     #[test]
     fn observed_checkout_names_are_stable_and_host_scoped() {
         let path = "/workspace/flotilla";
-        let first = observed_checkout_name("repo-key", &QualifiedPath::host(HostId::new("host-a"), path));
-        let second = observed_checkout_name("repo-key", &QualifiedPath::host(HostId::new("host-a"), path));
-        let other_host = observed_checkout_name("repo-key", &QualifiedPath::from_host_name(&HostName::new("host-b"), path));
+        let repo_key = RepositoryKey("repo-key".to_string());
+        let first = observed_checkout_name(&repo_key, &QualifiedPath::host(HostId::new("host-a"), path));
+        let second = observed_checkout_name(&repo_key, &QualifiedPath::host(HostId::new("host-a"), path));
+        let other_host = observed_checkout_name(&repo_key, &QualifiedPath::from_host_name(&HostName::new("host-b"), path));
 
         assert_eq!(first, second);
         assert_ne!(first, other_host);
         assert!(first.len() <= 63);
     }
 
-    #[test]
-    fn canonical_repo_url_normalizes_the_remote_identity() {
-        let identity = RepoIdentity { authority: "github.com".to_string(), path: "flotilla-org/flotilla".to_string() };
-
-        assert_eq!(canonical_repo_url(&identity).expect("canonical repo URL"), "https://github.com/flotilla-org/flotilla");
-    }
-
-    #[test]
-    fn canonical_repo_url_normalizes_authority_case() {
-        let identity = RepoIdentity { authority: "GitHub.com".to_string(), path: "flotilla-org/flotilla".to_string() };
-
-        assert_eq!(canonical_repo_url(&identity).expect("canonical repo URL"), "https://github.com/flotilla-org/flotilla");
-    }
-
-    #[test]
-    fn canonical_repo_url_rejects_unknown_repo_identity() {
-        let identity = RepoIdentity { authority: "unknown".to_string(), path: "not-a-remote".to_string() };
-
-        assert!(canonical_repo_url(&identity).is_err());
-    }
-
-    #[test]
-    fn canonical_repo_url_rejects_local_path_identity() {
-        let identity = RepoIdentity { authority: "local".to_string(), path: "/Users/alice/dev/project".to_string() };
-
-        assert!(canonical_repo_url(&identity).is_err());
-    }
-
     #[tokio::test]
-    async fn unknown_repo_identity_leaves_existing_observed_checkouts_untouched() {
+    async fn explicit_repository_identity_supports_remote_less_observations() {
         let backend = ResourceBackend::InMemory(InMemoryBackend::observed());
         let checkouts = backend.using::<ResourceCheckout>("flotilla");
-        checkouts
-            .create(
-                &InputMeta::builder().name("existing".to_string()).build(),
-                &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
-                    r#ref: "main".to_string(),
-                    path: "/workspace/repo".to_string(),
-                    repo_ref: flotilla_resources::RepositoryKey("existing-repo".to_string()),
-                    host_ref: "host-01".to_string(),
-                    is_main: true,
-                }),
-            )
+        let repository_key = RepositoryKey("local-repository".to_string());
+        let path = QualifiedPath::host(HostId::new("host-01"), "/workspace/repo");
+        let providers = ProviderData {
+            checkouts: [(path, Checkout {
+                branch: "main".to_string(),
+                is_main: true,
+                trunk_ahead_behind: None,
+                remote_ahead_behind: None,
+                working_tree: None,
+                last_commit: None,
+                correlation_keys: Vec::new(),
+                association_keys: Vec::new(),
+                host_name: None,
+                environment_id: None,
+            })]
+            .into_iter()
+            .collect(),
+            ..ProviderData::default()
+        };
+
+        reconcile_checkouts(&backend, "flotilla", &repository_key, "local-repo", &providers, "host-01")
             .await
-            .expect("existing checkout should be created");
+            .expect("remote-less observation should reconcile");
 
-        let result = reconcile_checkouts(
-            &backend,
-            "flotilla",
-            &RepoIdentity { authority: "unknown".to_string(), path: "not-a-remote".to_string() },
-            &ProviderData::default(),
-            "host-01",
-        )
-        .await;
-
-        assert!(matches!(result, Err(ResourceError::Invalid { .. })));
-        assert_eq!(checkouts.list().await.expect("checkout list should succeed").items.len(), 1);
+        let stored = checkouts.list().await.expect("checkout list should succeed").items;
+        assert!(matches!(stored.as_slice(), [checkout] if checkout.spec.repo_ref() == &repository_key));
     }
 }

--- a/crates/flotilla-core/src/observed_resources.rs
+++ b/crates/flotilla-core/src/observed_resources.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use flotilla_protocol::{qualified_path::QualifiedPath, ProviderData, RepoIdentity};
 use flotilla_resources::{
     canonicalize_repo_url, descriptive_repo_slug, repo_key, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta,
-    LifecycleAuthority, ObservedCheckoutSpec, ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
+    LifecycleAuthority, ObservedCheckoutSpec, RepositoryKey, ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
 };
 use sha2::{Digest, Sha256};
 
@@ -18,6 +18,7 @@ pub async fn reconcile_checkouts(
     namespace: &str,
     repo_identity: &RepoIdentity,
     providers: &ProviderData,
+    host_ref: &str,
 ) -> Result<(), ResourceError> {
     let scope = observed_checkout_scope(repo_identity)?;
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
@@ -36,7 +37,8 @@ pub async fn reconcile_checkouts(
         let spec = ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
             r#ref: checkout.branch.clone(),
             path: path.path.to_string_lossy().into_owned(),
-            repo_ref: scope.repo_ref.clone(),
+            repo_ref: RepositoryKey(scope.repo_key.clone()),
+            host_ref: host_ref.to_string(),
             is_main: checkout.is_main,
         });
 
@@ -185,7 +187,8 @@ mod tests {
                 &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
                     r#ref: "main".to_string(),
                     path: "/workspace/repo".to_string(),
-                    repo_ref: "existing-repo".to_string(),
+                    repo_ref: flotilla_resources::RepositoryKey("existing-repo".to_string()),
+                    host_ref: "host-01".to_string(),
                     is_main: true,
                 }),
             )
@@ -197,6 +200,7 @@ mod tests {
             "flotilla",
             &RepoIdentity { authority: "unknown".to_string(), path: "not-a-remote".to_string() },
             &ProviderData::default(),
+            "host-01",
         )
         .await;
 

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -8,7 +8,7 @@ use flotilla_resources::{RepositoryKey, RepositorySpec};
 
 use crate::providers::{ChannelLabel, CommandRunner};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct LocalCheckoutInspection {
     pub path: PathBuf,
     pub host_ref: String,
@@ -20,6 +20,7 @@ pub struct LocalCheckoutInspection {
 pub struct RepositoryInspection {
     pub spec: RepositorySpec,
     pub checkout: LocalCheckoutInspection,
+    pub transport_url: Option<String>,
 }
 
 impl RepositoryInspection {
@@ -135,14 +136,14 @@ impl RepositoryInspector for GitRepositoryInspector {
         let branch = self.git(&top_level, &["rev-parse", "--abbrev-ref", "HEAD"]).await?;
         let git_ref = if branch == "HEAD" { self.git(&top_level, &["rev-parse", "HEAD"]).await? } else { branch.clone() };
         let selected_remote = self.selected_remote(&top_level, &branch, remote).await?;
-        let spec = match selected_remote {
-            Some(remote) => RepositorySpec::remote(self.canonical_remote(&top_level, &remote).await?)?,
+        let (spec, transport_url) = match selected_remote {
+            Some(remote) => (RepositorySpec::remote(self.canonical_remote(&top_level, &remote).await?)?, Some(remote)),
             None => {
                 let common_dir = PathBuf::from(self.git(&top_level, &["rev-parse", "--git-common-dir"]).await?);
                 let common_dir = if common_dir.is_absolute() { common_dir } else { top_level.join(common_dir) };
                 let common_dir = std::fs::canonicalize(&common_dir)
                     .map_err(|error| format!("git common directory {} cannot be resolved: {error}", common_dir.display()))?;
-                RepositorySpec::local(&self.host_ref, common_dir.to_string_lossy())?
+                (RepositorySpec::local(&self.host_ref, common_dir.to_string_lossy())?, None)
             }
         };
         Ok(RepositoryInspection {
@@ -153,6 +154,7 @@ impl RepositoryInspector for GitRepositoryInspector {
                 git_ref: git_ref.clone(),
                 is_main: matches!(git_ref.as_str(), "main" | "master" | "trunk"),
             },
+            transport_url,
         })
     }
 }
@@ -204,8 +206,8 @@ mod tests {
         let inspected = inspector.inspect_path(&root, None).await.expect("inspection should succeed");
 
         assert!(matches!(
-            inspected.spec.identity,
-            RepositoryIdentity::Remote { ref canonical_remote } if canonical_remote == "https://github.com/org/repo"
+            inspected.spec.identity(),
+            RepositoryIdentity::Remote { canonical_remote } if canonical_remote == "https://github.com/org/repo"
         ));
     }
 
@@ -286,8 +288,8 @@ mod tests {
         let inspected = inspector.inspect_path(&root, None).await.expect("same identity should be unambiguous");
 
         assert!(matches!(
-            inspected.spec.identity,
-            RepositoryIdentity::Remote { ref canonical_remote } if canonical_remote == "https://github.com/org/repo"
+            inspected.spec.identity(),
+            RepositoryIdentity::Remote { canonical_remote } if canonical_remote == "https://github.com/org/repo"
         ));
     }
 }

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -1,0 +1,293 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use flotilla_resources::{RepositoryKey, RepositorySpec};
+
+use crate::providers::{ChannelLabel, CommandRunner};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalCheckoutInspection {
+    pub path: PathBuf,
+    pub host_ref: String,
+    pub git_ref: String,
+    pub is_main: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryInspection {
+    pub spec: RepositorySpec,
+    pub checkout: LocalCheckoutInspection,
+}
+
+impl RepositoryInspection {
+    pub fn key(&self) -> RepositoryKey {
+        self.spec.key()
+    }
+}
+
+#[async_trait]
+pub trait RepositoryInspector: Send + Sync {
+    async fn inspect_path(&self, path: &Path, remote: Option<&str>) -> Result<RepositoryInspection, String>;
+}
+
+pub struct GitRepositoryInspector {
+    runner: Arc<dyn CommandRunner>,
+    host_ref: String,
+}
+
+impl GitRepositoryInspector {
+    pub fn new(runner: Arc<dyn CommandRunner>, host_ref: impl Into<String>) -> Self {
+        Self { runner, host_ref: host_ref.into() }
+    }
+
+    async fn git(&self, cwd: &Path, args: &[&str]) -> Result<String, String> {
+        self.runner
+            .run("git", args, cwd, &ChannelLabel::Noop)
+            .await
+            .map(|output| output.trim().to_string())
+            .map_err(|error| format!("git {} in {}: {error}", args.join(" "), cwd.display()))
+    }
+
+    async fn selected_remote(&self, cwd: &Path, branch: &str, requested: Option<&str>) -> Result<Option<String>, String> {
+        if let Some(requested) = requested {
+            if looks_like_remote_url(requested) {
+                return Ok(Some(requested.to_string()));
+            }
+            return self
+                .git(cwd, &["remote", "get-url", requested])
+                .await
+                .map(Some)
+                .map_err(|_| format!("remote `{requested}` is not configured for {}", cwd.display()));
+        }
+
+        let remotes = self
+            .git(cwd, &["remote"])
+            .await?
+            .lines()
+            .map(str::trim)
+            .filter(|remote| !remote.is_empty())
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        match remotes.as_slice() {
+            [] => Ok(None),
+            [remote] => self.git(cwd, &["remote", "get-url", remote]).await.map(Some),
+            _ => {
+                let branch_key = format!("branch.{branch}.remote");
+                let tracked = self.git(cwd, &["config", "--get", &branch_key]).await.ok();
+                match tracked.filter(|tracked| remotes.contains(tracked)) {
+                    Some(remote) => self.git(cwd, &["remote", "get-url", &remote]).await.map(Some),
+                    None => {
+                        let mut identities = std::collections::BTreeMap::new();
+                        for remote in &remotes {
+                            let url = self.git(cwd, &["remote", "get-url", remote]).await?;
+                            identities.insert(self.canonical_remote(cwd, &url).await?, url);
+                        }
+                        if identities.len() == 1 {
+                            Ok(identities.into_values().next())
+                        } else {
+                            Err(format!(
+                                "repository {} has multiple distinct remotes ({}); select one with --remote",
+                                cwd.display(),
+                                remotes.join(", ")
+                            ))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn canonical_remote(&self, cwd: &Path, remote: &str) -> Result<String, String> {
+        let Some(host) = ssh_remote_host(remote) else {
+            return flotilla_resources::canonicalize_repo_url(remote);
+        };
+        if host.contains('.') {
+            return flotilla_resources::canonicalize_repo_url(remote);
+        }
+        let ssh_config = self
+            .runner
+            .run("ssh", &["-G", host], cwd, &ChannelLabel::Noop)
+            .await
+            .map_err(|_| format!("unrecognised remote host alias `{host}`"))?;
+        let resolved = ssh_config
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.trim().split_once(char::is_whitespace)?;
+                key.eq_ignore_ascii_case("hostname").then(|| value.trim())
+            })
+            .filter(|resolved| !resolved.is_empty() && *resolved != host)
+            .ok_or_else(|| format!("unrecognised remote host alias `{host}`"))?;
+        flotilla_resources::canonicalize_repo_url(&remote.replacen(host, resolved, 1))
+    }
+}
+
+#[async_trait]
+impl RepositoryInspector for GitRepositoryInspector {
+    async fn inspect_path(&self, path: &Path, remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        let path =
+            std::fs::canonicalize(path).map_err(|error| format!("repository path {} cannot be resolved: {error}", path.display()))?;
+        let top_level = PathBuf::from(self.git(&path, &["rev-parse", "--show-toplevel"]).await?);
+        let top_level = std::fs::canonicalize(&top_level)
+            .map_err(|error| format!("repository root {} cannot be resolved: {error}", top_level.display()))?;
+        let branch = self.git(&top_level, &["rev-parse", "--abbrev-ref", "HEAD"]).await?;
+        let git_ref = if branch == "HEAD" { self.git(&top_level, &["rev-parse", "HEAD"]).await? } else { branch.clone() };
+        let selected_remote = self.selected_remote(&top_level, &branch, remote).await?;
+        let spec = match selected_remote {
+            Some(remote) => RepositorySpec::remote(self.canonical_remote(&top_level, &remote).await?)?,
+            None => {
+                let common_dir = PathBuf::from(self.git(&top_level, &["rev-parse", "--git-common-dir"]).await?);
+                let common_dir = if common_dir.is_absolute() { common_dir } else { top_level.join(common_dir) };
+                let common_dir = std::fs::canonicalize(&common_dir)
+                    .map_err(|error| format!("git common directory {} cannot be resolved: {error}", common_dir.display()))?;
+                RepositorySpec::local(&self.host_ref, common_dir.to_string_lossy())?
+            }
+        };
+        Ok(RepositoryInspection {
+            spec,
+            checkout: LocalCheckoutInspection {
+                path: top_level,
+                host_ref: self.host_ref.clone(),
+                git_ref: git_ref.clone(),
+                is_main: matches!(git_ref.as_str(), "main" | "master" | "trunk"),
+            },
+        })
+    }
+}
+
+fn looks_like_remote_url(value: &str) -> bool {
+    value.contains("://") || value.contains(':')
+}
+
+fn ssh_remote_host(remote: &str) -> Option<&str> {
+    if let Some(rest) = remote.strip_prefix("ssh://") {
+        return rest.split('/').next()?.rsplit_once('@').map_or(Some(rest.split('/').next()?), |(_, host)| Some(host));
+    }
+    if remote.contains("://") {
+        return None;
+    }
+    let (authority, path) = remote.split_once(':')?;
+    (!path.is_empty()).then(|| authority.rsplit_once('@').map_or(authority, |(_, host)| host))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use flotilla_resources::RepositoryIdentity;
+
+    use super::{GitRepositoryInspector, RepositoryInspector};
+    use crate::providers::discovery::test_support::DiscoveryMockRunner;
+
+    fn git_repo() -> (tempfile::TempDir, std::path::PathBuf) {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let root = temp.path().join("repo");
+        std::fs::create_dir(&root).expect("repo dir");
+        std::fs::create_dir(root.join(".git")).expect("git dir");
+        (temp, root)
+    }
+
+    #[tokio::test]
+    async fn ssh_alias_resolves_to_machine_independent_remote_identity() {
+        let (_temp, root) = git_repo();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(root.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Ok("main\n".to_string()))
+            .on_run("git", &["remote"], Ok("origin\n".to_string()))
+            .on_run("git", &["remote", "get-url", "origin"], Ok("work-github:org/repo.git\n".to_string()))
+            .on_run("ssh", &["-G", "work-github"], Ok("hostname github.com\nuser git\n".to_string()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+
+        let inspected = inspector.inspect_path(&root, None).await.expect("inspection should succeed");
+
+        assert!(matches!(
+            inspected.spec.identity,
+            RepositoryIdentity::Remote { ref canonical_remote } if canonical_remote == "https://github.com/org/repo"
+        ));
+    }
+
+    #[tokio::test]
+    async fn unresolved_ssh_alias_fails_instead_of_becoming_a_repository_key() {
+        let (_temp, root) = git_repo();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(root.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Ok("main\n".to_string()))
+            .on_run("git", &["remote"], Ok("origin\n".to_string()))
+            .on_run("git", &["remote", "get-url", "origin"], Ok("mystery:org/repo.git\n".to_string()))
+            .on_run("ssh", &["-G", "mystery"], Ok("hostname mystery\n".to_string()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+
+        let error = inspector.inspect_path(&root, None).await.expect_err("unknown alias should fail");
+
+        assert!(error.contains("unrecognised remote host alias"));
+    }
+
+    #[tokio::test]
+    async fn remote_less_worktrees_with_one_common_dir_converge() {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        let common = temp.path().join("common.git");
+        std::fs::create_dir(&first).expect("first");
+        std::fs::create_dir(&second).expect("second");
+        std::fs::create_dir(&common).expect("common");
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(first.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(second.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Ok("main\n".to_string()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Ok("feature\n".to_string()))
+            .on_run("git", &["remote"], Ok(String::new()))
+            .on_run("git", &["remote"], Ok(String::new()))
+            .on_run("git", &["rev-parse", "--git-common-dir"], Ok(common.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--git-common-dir"], Ok(common.to_string_lossy().into_owned()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+
+        let first = inspector.inspect_path(&first, None).await.expect("first inspection");
+        let second = inspector.inspect_path(&second, None).await.expect("second inspection");
+
+        assert_eq!(first.key(), second.key());
+    }
+
+    #[tokio::test]
+    async fn ambiguous_multiple_remotes_require_an_explicit_selection() {
+        let (_temp, root) = git_repo();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(root.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Ok("main\n".to_string()))
+            .on_run("git", &["remote"], Ok("origin\nupstream\n".to_string()))
+            .on_run("git", &["remote", "get-url", "origin"], Ok("https://github.com/fork/repo.git\n".to_string()))
+            .on_run("git", &["remote", "get-url", "upstream"], Ok("https://github.com/upstream/repo.git\n".to_string()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+
+        let error = inspector.inspect_path(&root, None).await.expect_err("ambiguous remotes should fail");
+
+        assert!(error.contains("multiple distinct remotes"));
+        assert!(error.contains("--remote"));
+    }
+
+    #[tokio::test]
+    async fn multiple_remote_names_with_one_normalized_identity_are_unambiguous() {
+        let (_temp, root) = git_repo();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(root.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Ok("main\n".to_string()))
+            .on_run("git", &["remote"], Ok("origin\nmirror\n".to_string()))
+            .on_run("git", &["remote", "get-url", "origin"], Ok("https://github.com/org/repo.git\n".to_string()))
+            .on_run("git", &["remote", "get-url", "mirror"], Ok("git@github.com:org/repo.git\n".to_string()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+
+        let inspected = inspector.inspect_path(&root, None).await.expect("same identity should be unambiguous");
+
+        assert!(matches!(
+            inspected.spec.identity,
+            RepositoryIdentity::Remote { ref canonical_remote } if canonical_remote == "https://github.com/org/repo"
+        ));
+    }
+}

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -32,6 +32,10 @@ impl RepositoryInspection {
 #[async_trait]
 pub trait RepositoryInspector: Send + Sync {
     async fn inspect_path(&self, path: &Path, remote: Option<&str>) -> Result<RepositoryInspection, String>;
+
+    async fn resolve_remote(&self, remote: &str) -> Result<RepositorySpec, String> {
+        RepositorySpec::remote(remote)
+    }
 }
 
 pub struct GitRepositoryInspector {
@@ -105,9 +109,6 @@ impl GitRepositoryInspector {
         let Some(host) = ssh_remote_host(remote) else {
             return flotilla_resources::canonicalize_repo_url(remote);
         };
-        if host.contains('.') {
-            return flotilla_resources::canonicalize_repo_url(remote);
-        }
         let ssh_config = self
             .runner
             .run("ssh", &["-G", host], cwd, &ChannelLabel::Noop)
@@ -119,9 +120,16 @@ impl GitRepositoryInspector {
                 let (key, value) = line.trim().split_once(char::is_whitespace)?;
                 key.eq_ignore_ascii_case("hostname").then(|| value.trim())
             })
-            .filter(|resolved| !resolved.is_empty() && *resolved != host)
+            .filter(|resolved| !resolved.is_empty())
             .ok_or_else(|| format!("unrecognised remote host alias `{host}`"))?;
-        flotilla_resources::canonicalize_repo_url(&remote.replacen(host, resolved, 1))
+        if resolved == host {
+            if !host.contains('.') {
+                return Err(format!("unrecognised remote host alias `{host}`"));
+            }
+            flotilla_resources::canonicalize_repo_url(remote)
+        } else {
+            flotilla_resources::canonicalize_repo_url(&remote.replacen(host, resolved, 1))
+        }
     }
 }
 
@@ -156,6 +164,10 @@ impl RepositoryInspector for GitRepositoryInspector {
             },
             transport_url,
         })
+    }
+
+    async fn resolve_remote(&self, remote: &str) -> Result<RepositorySpec, String> {
+        RepositorySpec::remote(self.canonical_remote(Path::new("/"), remote).await?)
     }
 }
 
@@ -229,6 +241,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dotted_ssh_alias_is_resolved_instead_of_assumed_to_be_a_hostname() {
+        let (_temp, root) = git_repo();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(root.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Ok("main\n".to_string()))
+            .on_run("git", &["remote"], Ok("origin\n".to_string()))
+            .on_run("git", &["remote", "get-url", "origin"], Ok("github.work:org/repo.git\n".to_string()))
+            .on_run("ssh", &["-G", "github.work"], Ok("hostname github.com\nuser git\n".to_string()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+
+        let inspected = inspector.inspect_path(&root, None).await.expect("dotted alias should resolve");
+
+        assert!(matches!(
+            inspected.spec.identity(),
+            RepositoryIdentity::Remote { canonical_remote } if canonical_remote == "https://github.com/org/repo"
+        ));
+    }
+
+    #[tokio::test]
     async fn remote_less_worktrees_with_one_common_dir_converge() {
         let temp = tempfile::TempDir::new().expect("tempdir");
         let first = temp.path().join("first");
@@ -282,6 +314,8 @@ mod tests {
             .on_run("git", &["remote"], Ok("origin\nmirror\n".to_string()))
             .on_run("git", &["remote", "get-url", "origin"], Ok("https://github.com/org/repo.git\n".to_string()))
             .on_run("git", &["remote", "get-url", "mirror"], Ok("git@github.com:org/repo.git\n".to_string()))
+            .on_run("ssh", &["-G", "github.com"], Ok("hostname github.com\nuser git\n".to_string()))
+            .on_run("ssh", &["-G", "github.com"], Ok("hostname github.com\nuser git\n".to_string()))
             .build();
         let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -32,6 +32,7 @@ use flotilla_core::{
         types::{ChangeRequest, CloudAgentSession, RepoCriteria, SessionStatus, Workspace},
         ChannelLabel, CommandRunner,
     },
+    repository_inspection::{LocalCheckoutInspection, RepositoryInspection, RepositoryInspector},
 };
 use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
@@ -41,8 +42,8 @@ use flotilla_protocol::{
     TopologyRoute, WorkItemKind,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, TypedResolver,
-    REPO_KEY_LABEL, REPO_LABEL,
+    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec,
+    RepositorySpec, TypedResolver, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -54,6 +55,35 @@ struct FixedRemoteHostDetector {
 struct MutableRemoteHostDetector {
     owner: &'static str,
     repo: Arc<std::sync::RwLock<String>>,
+}
+
+struct TestRepositoryInspector {
+    repository: Arc<std::sync::RwLock<String>>,
+    fixed_repository_by_path: HashMap<PathBuf, String>,
+}
+
+#[async_trait]
+impl RepositoryInspector for TestRepositoryInspector {
+    async fn inspect_path(&self, path: &Path, _remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        let repository = match self.fixed_repository_by_path.get(path) {
+            Some(repository) => repository.clone(),
+            None => self.repository.read().map_err(|_| "test repository identity lock poisoned".to_string())?.clone(),
+        };
+        Ok(RepositoryInspection {
+            spec: RepositorySpec::remote(format!("https://github.com/owner/{repository}"))?,
+            checkout: LocalCheckoutInspection {
+                path: path.to_path_buf(),
+                host_ref: "host-test".to_string(),
+                git_ref: "main".to_string(),
+                is_main: true,
+            },
+            transport_url: Some(format!("https://github.com/owner/{repository}")),
+        })
+    }
+}
+
+async fn install_test_repository_inspector(daemon: &InProcessDaemon, repository: Arc<std::sync::RwLock<String>>) {
+    daemon.set_repository_inspector(Arc::new(TestRepositoryInspector { repository, fixed_repository_by_path: HashMap::new() })).await;
 }
 
 fn qpath(host: &HostName, path: impl Into<PathBuf>) -> QualifiedPath {
@@ -538,6 +568,7 @@ async fn daemon_for_plain_dir_with_discovery(discovery: DiscoveryRuntime) -> (te
     std::fs::create_dir_all(&repo).expect("create repo dir");
     let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo.clone()], config, discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
     (temp, repo, daemon)
 }
 
@@ -1352,6 +1383,7 @@ async fn daemon_for_duplicate_fake_repos() -> (tempfile::TempDir, PathBuf, PathB
 
     let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![repo_a.clone(), repo_b.clone()], config, discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
     (temp, repo_a, repo_b, daemon)
 }
 
@@ -1677,6 +1709,7 @@ async fn repo_refresh_reconciles_observed_checkouts() {
 
     let daemon =
         InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
     let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
     let mut events = daemon.subscribe();
 
@@ -1767,6 +1800,7 @@ async fn removing_final_local_root_deletes_observed_checkouts() {
 
     let daemon =
         InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
     let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
     let mut events = daemon.subscribe();
 
@@ -1790,6 +1824,7 @@ async fn removing_final_local_root_preserves_adopted_checkouts() {
 
     let daemon =
         InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
     let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
     let mut events = daemon.subscribe();
 
@@ -1873,6 +1908,7 @@ async fn removing_final_local_root_deletes_observed_checkouts_when_virtual_root_
     discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
 
     let daemon = InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
     let identity = RepoIdentity { authority: "github.com".to_string(), path: "owner/repo".to_string() };
     daemon.add_virtual_repo(identity.clone(), virtual_repo.clone(), vec![], 0).await.expect("add virtual root");
     daemon.add_repo(&repo).await.expect("add local root");
@@ -1901,6 +1937,7 @@ async fn repository_identity_change_removes_old_repo_key_observed_checkouts() {
 
     let daemon =
         InProcessDaemon::new(vec![repo.clone()], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::clone(&discovered_repo)).await;
     let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
     let mut events = daemon.subscribe();
 
@@ -1942,6 +1979,12 @@ async fn repository_identity_change_reconciles_old_identity_shared_by_another_ro
         HostName::local(),
     )
     .await;
+    daemon
+        .set_repository_inspector(Arc::new(TestRepositoryInspector {
+            repository: Arc::clone(&discovered_repo),
+            fixed_repository_by_path: HashMap::from([(repo_b.clone(), "old-repo".to_string())]),
+        }))
+        .await;
     let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
     let mut events = daemon.subscribe();
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1700,7 +1700,7 @@ async fn repo_refresh_reconciles_observed_checkouts() {
     assert_eq!(main.metadata.labels.get(REPO_LABEL).map(String::as_str), Some("github-com-owner-repo"));
     assert_eq!(main.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
     match &main.spec {
-        ResourceCheckoutSpec::Observed(spec) => assert_eq!(spec.repo_ref, "github-com-owner-repo"),
+        ResourceCheckoutSpec::Observed(spec) => assert_eq!(spec.repo_ref, flotilla_resources::RepositoryKey(repo_key.clone())),
         other => panic!("expected observed checkout spec, got {other:?}"),
     }
 
@@ -1716,10 +1716,10 @@ async fn repo_refresh_reconciles_observed_checkouts() {
     assert_eq!(second.items.len(), 1);
     assert_eq!(second.items[0].metadata.name, feature_name, "checkout identity should follow its stable path");
     match &second.items[0].spec {
-        ResourceCheckoutSpec::Observed(ObservedCheckoutSpec { r#ref, path, repo_ref, is_main }) => {
+        ResourceCheckoutSpec::Observed(ObservedCheckoutSpec { r#ref, path, repo_ref, is_main, .. }) => {
             assert_eq!(r#ref, "feature-renamed");
             assert_eq!(path, &feature_path_string);
-            assert_eq!(repo_ref, "github-com-owner-repo");
+            assert_eq!(repo_ref, &flotilla_resources::RepositoryKey(repo_key.clone()));
             assert!(!is_main);
         }
         other => panic!("expected observed checkout spec, got {other:?}"),
@@ -1731,13 +1731,14 @@ async fn repo_refresh_reconciles_observed_checkouts() {
                 .name("adopted-checkout-feature".to_string())
                 .labels(std::collections::BTreeMap::from([
                     (flotilla_resources::AUTHORITY_LABEL.to_string(), LifecycleAuthority::Adopted.as_label_value().to_string()),
-                    (REPO_KEY_LABEL.to_string(), repo_key),
+                    (REPO_KEY_LABEL.to_string(), repo_key.clone()),
                 ]))
                 .build(),
             &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
                 r#ref: "feature-renamed".to_string(),
                 path: feature_path_string,
-                repo_ref: "github-com-owner-repo".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey(repo_key.clone()),
+                host_ref: "host-01".to_string(),
                 is_main: false,
             }),
         )
@@ -1801,13 +1802,14 @@ async fn removing_final_local_root_preserves_adopted_checkouts() {
                 .name("adopted-checkout".to_string())
                 .labels(std::collections::BTreeMap::from([
                     (flotilla_resources::AUTHORITY_LABEL.to_string(), LifecycleAuthority::Adopted.as_label_value().to_string()),
-                    (REPO_KEY_LABEL.to_string(), repo_key),
+                    (REPO_KEY_LABEL.to_string(), repo_key.clone()),
                 ]))
                 .build(),
             &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
                 r#ref: "main".to_string(),
                 path: repo.to_string_lossy().into_owned(),
-                repo_ref: "github-com-owner-repo".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey(repo_key.clone()),
+                host_ref: "host-01".to_string(),
                 is_main: true,
             }),
         )

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -696,6 +696,12 @@ impl Aggregator {
     }
 
     fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {
+        let requested_stance = definition.stance.to_string();
+        let effective_stance = state
+            .and_then(|state| state.placement.as_ref())
+            .and_then(|placement| placement.fields.get("effective_stance"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
         let crew = definition
             .crew
             .iter()
@@ -704,7 +710,12 @@ impl Aggregator {
                     CrewSource::Tool { command } => command.clone(),
                     CrewSource::Agent { selector, prompt } => prompt.clone().unwrap_or_else(|| selector.capability.clone()),
                 };
-                CrewMemberSummary { role: process.role.clone(), command_preview }
+                CrewMemberSummary {
+                    role: process.role.clone(),
+                    command_preview,
+                    requested_stance: Some(requested_stance.clone()),
+                    effective_stance: effective_stance.clone(),
+                }
             })
             .collect();
         VesselRow::builder()
@@ -716,6 +727,8 @@ impl Aggregator {
             .maybe_started_at(state.and_then(|state| state.started_at))
             .maybe_finished_at(state.and_then(|state| state.finished_at))
             .maybe_message(state.and_then(|state| state.message.clone()))
+            .requested_stance(requested_stance)
+            .maybe_effective_stance(effective_stance)
             .depends_on(definition.depends_on.clone())
             .host(self.local_host.clone())
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
@@ -803,8 +816,9 @@ mod tests {
     use chrono::Utc;
     use flotilla_protocol::result_set::ResultSet;
     use flotilla_resources::{
-        ConvoySpec, InMemoryBackend, InputMeta, ObjectMeta, PresentationPhase, PresentationSpec, PresentationStatus, ResourceBackend,
-        TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
+        ConvoySpec, CrewSpec, InMemoryBackend, InputMeta, ObjectMeta, PlacementStatus, PresentationPhase, PresentationSpec,
+        PresentationStatus, ResourceBackend, Stance, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement,
+        WorkflowSnapshot,
     };
     use futures::stream;
     use tokio::{sync::Mutex, time::timeout};
@@ -1120,6 +1134,30 @@ mod tests {
         let vessel = emitted_vessel(convoy_with_work().convoy_phase(ResourceConvoyPhase::Active).call()).await;
 
         assert!(!vessel.complete_work);
+    }
+
+    #[tokio::test]
+    async fn vessel_and_crew_rows_expose_requested_and_effective_stance() {
+        let mut convoy = convoy_with_work().convoy_phase(ResourceConvoyPhase::Active).work_phase(ResourceWorkPhase::Running).call();
+        let status = convoy.status.as_mut().expect("convoy status");
+        let definition = &mut status.workflow_snapshot.as_mut().expect("workflow snapshot").vessels[0];
+        definition.stance = Stance::WorkspaceWrite;
+        definition
+            .crew
+            .push(CrewSpec::builder().role("coder".to_string()).source(CrewSource::Tool { command: "cargo test".to_string() }).build());
+        status.work.get_mut("implement").expect("work state").placement = Some(PlacementStatus {
+            fields: BTreeMap::from([
+                ("requested_stance".to_string(), serde_json::json!("workspace-write")),
+                ("effective_stance".to_string(), serde_json::json!("contained")),
+            ]),
+        });
+
+        let vessel = emitted_vessel(convoy).await;
+
+        assert_eq!(vessel.requested_stance.as_deref(), Some("workspace-write"));
+        assert_eq!(vessel.effective_stance.as_deref(), Some("contained"));
+        assert_eq!(vessel.crew[0].requested_stance.as_deref(), Some("workspace-write"));
+        assert_eq!(vessel.crew[0].effective_stance.as_deref(), Some("contained"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -613,7 +613,10 @@ fn spawn_controller_loops(
                         ControllerLoop {
                             primary: backend.clone().using::<Clone>(&namespace_string),
                             secondaries: vec![],
-                            reconciler: CloneReconciler::new(Arc::new(CloneControllerRuntime { runner })),
+                            reconciler: CloneReconciler::new(
+                                Arc::new(CloneControllerRuntime { runner }),
+                                backend.clone().using::<Repository>(&namespace_string),
+                            ),
                             resync_interval: controller_resync_interval,
                             backend,
                         }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{
     CheckoutReconciler, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime, EnvironmentReconciler, HopChainContext,
-    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, TerminalRuntime, TerminalRuntimeState,
-    TerminalSessionReconciler, VesselReconciler,
+    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, RepositoryReconciler, TerminalRuntime,
+    TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
 };
 use flotilla_core::{
     agent_adapter::{AgentLaunchRequest, CapabilityTable},
@@ -29,11 +29,11 @@ use flotilla_core::{
 };
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
 use flotilla_resources::{
-    canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, repo_key, Clone, CloneSpec, Convoy,
-    ConvoyReconciler, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, Host,
+    canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, Clone, CloneSpec, Convoy, ConvoyReconciler,
+    CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
-    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, ResourceBackend, ResourceError, ResourceObject, Selector, Stance,
-    TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Repository, RepositoryKey, RepositorySpec, ResourceBackend,
+    ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -282,19 +282,7 @@ fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
                     .build()])
                 .build(),
         ),
-        (
-            "single-agent-contained",
-            WorkflowTemplateSpec::builder()
-                .vessels(vec![VesselRequirement::builder()
-                    .name("work".to_string())
-                    .stance(Stance::Contained)
-                    .crew(vec![CrewSpec::builder()
-                        .role("coder".to_string())
-                        .source(CrewSource::Agent { selector: Selector { capability: "code".to_string() }, prompt: None })
-                        .build()])
-                    .build()])
-                .build(),
-        ),
+        ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
     ]
 }
 
@@ -309,6 +297,28 @@ async fn ensure_default_workflow_templates(backend: &ResourceBackend, namespace:
         templates.create(&empty_meta(name), &spec).await.map(|_| ()).map_err(|err| format!("seed workflow template {name}: {err}"))?;
     }
     Ok(())
+}
+
+async fn ensure_repository_exists(
+    backend: &ResourceBackend,
+    namespace: &str,
+    key: &RepositoryKey,
+    spec: &RepositorySpec,
+) -> Result<(), String> {
+    let repositories = backend.clone().using::<Repository>(namespace);
+    match repositories.create(&empty_meta(&key.to_string()), spec).await {
+        Ok(_) => Ok(()),
+        Err(ResourceError::Conflict { .. }) => {
+            let existing = repositories.get(&key.to_string()).await.map_err(|error| error.to_string())?;
+            existing.spec.verify_key(key)?;
+            if existing.spec == *spec {
+                Ok(())
+            } else {
+                Err(format!("repository key {key} already refers to a different canonical identity"))
+            }
+        }
+        Err(error) => Err(error.to_string()),
+    }
 }
 
 async fn ensure_host_exists(backend: &ResourceBackend, namespace: &str, host_name: &str) -> Result<(), String> {
@@ -383,10 +393,17 @@ async fn discover_local_clones(
             }
         };
 
-        let repo_key_value = repo_key(&canonical_url);
+        let repository_spec = RepositorySpec::remote(&canonical_url).expect("already-canonical repository URL should remain valid");
+        let repository_key = repository_spec.key();
+        ensure_repository_exists(backend, namespace, &repository_key, &repository_spec).await?;
+        let repo_key_value = repository_key.to_string();
         let name = format!("clone-{}", clone_key(&canonical_url, &host_direct_env_ref));
-        let expected_spec =
-            CloneSpec { url: transport_url.clone(), env_ref: host_direct_env_ref.clone(), path: repo_path.display().to_string() };
+        let expected_spec = CloneSpec {
+            repo_ref: repository_key,
+            url: transport_url.clone(),
+            env_ref: host_direct_env_ref.clone(),
+            path: repo_path.display().to_string(),
+        };
         let expected_labels = BTreeMap::from([
             ("flotilla.work/discovered".to_string(), "true".to_string()),
             ("flotilla.work/repo-key".to_string(), repo_key_value),
@@ -541,8 +558,34 @@ fn spawn_controller_loops(
     supervision: ControllerSupervision,
 ) -> Vec<JoinHandle<()>> {
     let backend = state.daemon.resource_backend();
+    let observed_backend = state.daemon.observed_resource_backend();
     let namespace_string = namespace.to_string();
     vec![
+        tokio::spawn({
+            let backend = backend.clone();
+            let observed_backend = observed_backend.clone();
+            let namespace_string = namespace_string.clone();
+            let supervision = supervision.clone();
+            async move {
+                supervise("repository", supervision, move || {
+                    let backend = backend.clone();
+                    let observed_backend = observed_backend.clone();
+                    let namespace_string = namespace_string.clone();
+                    async move {
+                        ControllerLoop {
+                            primary: backend.clone().using::<Repository>(&namespace_string),
+                            secondaries: RepositoryReconciler::secondary_watches(observed_backend.clone(), &namespace_string),
+                            reconciler: RepositoryReconciler::new(backend.clone(), observed_backend, &namespace_string),
+                            resync_interval: controller_resync_interval,
+                            backend,
+                        }
+                        .run()
+                        .await
+                    }
+                })
+                .await;
+            }
+        }),
         tokio::spawn({
             let backend = backend.clone();
             let namespace_string = namespace_string.clone();

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -29,11 +29,11 @@ use flotilla_core::{
 };
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
 use flotilla_resources::{
-    canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, Clone, CloneSpec, Convoy, ConvoyReconciler,
-    CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, Host,
-    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
-    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Repository, RepositoryKey, RepositorySpec, ResourceBackend,
-    ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    clone_key, controller::ControllerLoop, descriptive_repo_slug, Clone, CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec,
+    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, Host, HostDirectEnvironmentSpec,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy,
+    PlacementPolicySpec, Presentation, Repository, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel,
+    VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -299,28 +299,6 @@ async fn ensure_default_workflow_templates(backend: &ResourceBackend, namespace:
     Ok(())
 }
 
-async fn ensure_repository_exists(
-    backend: &ResourceBackend,
-    namespace: &str,
-    key: &RepositoryKey,
-    spec: &RepositorySpec,
-) -> Result<(), String> {
-    let repositories = backend.clone().using::<Repository>(namespace);
-    match repositories.create(&empty_meta(&key.to_string()), spec).await {
-        Ok(_) => Ok(()),
-        Err(ResourceError::Conflict { .. }) => {
-            let existing = repositories.get(&key.to_string()).await.map_err(|error| error.to_string())?;
-            existing.spec.verify_key(key)?;
-            if existing.spec == *spec {
-                Ok(())
-            } else {
-                Err(format!("repository key {key} already refers to a different canonical identity"))
-            }
-        }
-        Err(error) => Err(error.to_string()),
-    }
-}
-
 async fn ensure_host_exists(backend: &ResourceBackend, namespace: &str, host_name: &str) -> Result<(), String> {
     let hosts = backend.clone().using::<Host>(namespace);
     match hosts.get(host_name).await {
@@ -363,43 +341,33 @@ async fn discover_local_clones(
     namespace: &str,
     profile: &LocalProvisioningProfile,
 ) -> Result<(), String> {
-    let runner = daemon.local_command_runner().ok_or_else(|| "local command runner unavailable".to_string())?;
     let clones = backend.clone().using::<Clone>(namespace);
     let host_direct_env_ref = profile.host_direct_environment_name();
 
     for repo_path in daemon.tracked_repo_paths().await {
-        let repo_path_str = match repo_path.to_str() {
-            Some(path) => path,
-            None => {
-                warn!(path = %repo_path.display(), "skipping clone discovery for non-utf8 repo path");
-                continue;
-            }
-        };
-
-        let transport_url =
-            match runner.run("git", &["-C", repo_path_str, "remote", "get-url", "origin"], Path::new("/"), &ChannelLabel::Noop).await {
-                Ok(url) => url.trim().to_string(),
-                Err(err) => {
-                    warn!(path = %repo_path.display(), %err, "skipping clone discovery because origin remote is unavailable");
-                    continue;
-                }
-            };
-
-        let canonical_url = match canonicalize_repo_url(&transport_url) {
-            Ok(url) => url,
+        let inspection = match daemon.inspect_repository_path(&repo_path, None).await {
+            Ok(inspection) => inspection,
             Err(err) => {
-                warn!(path = %repo_path.display(), %err, "skipping clone discovery because canonical url resolution failed");
+                warn!(path = %repo_path.display(), %err, "skipping clone discovery because repository identity resolution failed");
                 continue;
             }
         };
-
-        let repository_spec = RepositorySpec::remote(&canonical_url).expect("already-canonical repository URL should remain valid");
+        let Some(transport_url) = inspection.transport_url else {
+            continue;
+        };
+        let canonical_url = match inspection.spec.identity() {
+            flotilla_resources::RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
+            flotilla_resources::RepositoryIdentity::Local { .. } => continue,
+        };
+        let repository_spec = inspection.spec;
         let repository_key = repository_spec.key();
-        ensure_repository_exists(backend, namespace, &repository_key, &repository_spec).await?;
+        flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(namespace), &repository_key, &repository_spec)
+            .await
+            .map_err(|error| error.to_string())?;
         let repo_key_value = repository_key.to_string();
         let name = format!("clone-{}", clone_key(&canonical_url, &host_direct_env_ref));
         let expected_spec = CloneSpec {
-            repo_ref: repository_key,
+            repo_ref: repository_key.clone(),
             url: transport_url.clone(),
             env_ref: host_direct_env_ref.clone(),
             path: repo_path.display().to_string(),
@@ -416,14 +384,7 @@ async fn discover_local_clones(
                 if existing.metadata.deletion_timestamp.is_some() {
                     continue;
                 }
-                let existing_canonical = match canonicalize_repo_url(&existing.spec.url) {
-                    Ok(url) => url,
-                    Err(err) => {
-                        warn!(clone = %name, %err, "leaving discovered clone untouched because existing canonical url is invalid");
-                        continue;
-                    }
-                };
-                if existing_canonical != canonical_url || existing.spec.env_ref != host_direct_env_ref {
+                if existing.spec.repo_ref != repository_key || existing.spec.env_ref != host_direct_env_ref {
                     warn!(clone = %name, "leaving discovered clone untouched because the existing resource does not match the expected repo/env tuple");
                     continue;
                 }
@@ -1517,7 +1478,7 @@ mod tests {
         let clone_name = format!(
             "clone-{}",
             clone_key(
-                &canonicalize_repo_url("https://github.com/flotilla-org/flotilla.git").expect("canonical url"),
+                &flotilla_resources::canonicalize_repo_url("https://github.com/flotilla-org/flotilla.git").expect("canonical url"),
                 &format!("host-direct-{host_id}")
             )
         );

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -8,9 +8,9 @@ use std::{
 use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{
-    CheckoutReconciler, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime, EnvironmentReconciler, HopChainContext,
-    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, RepositoryReconciler, TerminalRuntime,
-    TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
+    CheckoutReconciler, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime, EnvironmentReconciler,
+    ForgeDefaultBranchResolver, HopChainContext, PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime,
+    RepositoryReconciler, TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
 };
 use flotilla_core::{
     agent_adapter::{AgentLaunchRequest, CapabilityTable},
@@ -30,10 +30,10 @@ use flotilla_core::{
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
 use flotilla_resources::{
     clone_key, controller::ControllerLoop, descriptive_repo_slug, Clone, CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec,
-    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, Host, HostDirectEnvironmentSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy,
-    PlacementPolicySpec, Presentation, Repository, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel,
-    VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
+    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Repository, ResourceBackend, ResourceError, ResourceObject, Stance,
+    TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -175,6 +175,23 @@ struct ControllerRuntimeState {
     host_direct_environment_name: String,
     provisioned_environments: Mutex<HashMap<String, ActiveProvisionedEnvironment>>,
     active_sessions: Mutex<HashMap<String, ActiveSession>>,
+}
+
+struct GhForgeDefaultBranchResolver {
+    runner: Arc<dyn CommandRunner>,
+}
+
+#[async_trait]
+impl ForgeDefaultBranchResolver for GhForgeDefaultBranchResolver {
+    async fn default_branch(&self, forge: &ForgeIdentity) -> Result<Option<String>, String> {
+        if forge.service_url.trim_end_matches('/') != "https://github.com" {
+            return Ok(None);
+        }
+        let endpoint = format!("repos/{}", forge.repository);
+        let output = self.runner.run("gh", &["api", &endpoint, "--jq", ".default_branch"], Path::new("/"), &ChannelLabel::Noop).await?;
+        let branch = output.trim();
+        Ok((!branch.is_empty()).then(|| branch.to_string()))
+    }
 }
 
 impl ControllerRuntimeState {
@@ -520,23 +537,33 @@ fn spawn_controller_loops(
 ) -> Vec<JoinHandle<()>> {
     let backend = state.daemon.resource_backend();
     let observed_backend = state.daemon.observed_resource_backend();
+    let forge_default_branch_resolver = state
+        .daemon
+        .local_command_runner()
+        .map(|runner| Arc::new(GhForgeDefaultBranchResolver { runner }) as Arc<dyn ForgeDefaultBranchResolver>);
     let namespace_string = namespace.to_string();
     vec![
         tokio::spawn({
             let backend = backend.clone();
             let observed_backend = observed_backend.clone();
             let namespace_string = namespace_string.clone();
+            let forge_default_branch_resolver = forge_default_branch_resolver.clone();
             let supervision = supervision.clone();
             async move {
                 supervise("repository", supervision, move || {
                     let backend = backend.clone();
                     let observed_backend = observed_backend.clone();
                     let namespace_string = namespace_string.clone();
+                    let forge_default_branch_resolver = forge_default_branch_resolver.clone();
                     async move {
+                        let mut reconciler = RepositoryReconciler::new(backend.clone(), observed_backend.clone(), &namespace_string);
+                        if let Some(resolver) = forge_default_branch_resolver {
+                            reconciler = reconciler.with_forge_default_branch_resolver(resolver);
+                        }
                         ControllerLoop {
                             primary: backend.clone().using::<Repository>(&namespace_string),
                             secondaries: RepositoryReconciler::secondary_watches(observed_backend.clone(), &namespace_string),
-                            reconciler: RepositoryReconciler::new(backend.clone(), observed_backend, &namespace_string),
+                            reconciler,
                             resync_interval: controller_resync_interval,
                             backend,
                         }
@@ -1134,8 +1161,8 @@ mod tests {
     use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent};
     use flotilla_resources::{
         Checkout as ResourceCheckout, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
-        PlacementPolicy, Selector, SqliteBackend, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WorkPhase,
-        WorkflowTemplate, WorkflowTemplateSpec,
+        PlacementPolicy, RepositorySpec, Selector, SqliteBackend, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement,
+        WorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
     };
     use tempfile::TempDir;
 
@@ -1287,6 +1314,11 @@ mod tests {
             )
             .await
             .expect("workflow template create should succeed");
+        let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla.git").expect("repository spec");
+        let repository_key = repository_spec.key();
+        flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(NAMESPACE), &repository_key, &repository_spec)
+            .await
+            .expect("repository create should succeed");
         backend
             .clone()
             .using::<Convoy>(NAMESPACE)
@@ -1294,7 +1326,10 @@ mod tests {
                 workflow_ref: "wf-a".to_string(),
                 inputs: BTreeMap::new(),
                 placement_policy: Some(format!("host-direct-{host_id}")),
-                repository: Some(ConvoyRepositorySpec { url: "https://github.com/flotilla-org/flotilla.git".to_string() }),
+                repository: Some(ConvoyRepositorySpec {
+                    url: "https://github.com/flotilla-org/flotilla.git".to_string(),
+                    repo_ref: repository_key,
+                }),
                 r#ref: Some("main".to_string()),
                 project_ref: None,
                 adopted_checkout_ref: None,

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -32,8 +32,8 @@ use flotilla_resources::{
     canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, repo_key, Clone, CloneSpec, Convoy,
     ConvoyReconciler, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
-    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, ResourceBackend, ResourceError, ResourceObject, TerminalSessionSource,
-    Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, ResourceBackend, ResourceError, ResourceObject, Selector, Stance,
+    TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -265,21 +265,37 @@ async fn register_startup_resources(
 }
 
 fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
-    vec![(
-        "scratch",
-        WorkflowTemplateSpec::builder()
-            .inputs(vec![InputDefinition { name: "topic".to_string(), description: Some("Short label for this convoy".into()) }])
-            .vessels(vec![VesselRequirement::builder()
-                .name("work".to_string())
-                .crew(vec![CrewSpec::builder()
-                    .role("shell".to_string())
-                    .source(CrewSource::Tool {
-                        command: r#"bash -c 'echo "Convoy {{workflow.name}} ({{inputs.topic}})"; exec bash'"#.to_string(),
-                    })
+    vec![
+        (
+            "scratch",
+            WorkflowTemplateSpec::builder()
+                .inputs(vec![InputDefinition { name: "topic".to_string(), description: Some("Short label for this convoy".into()) }])
+                .vessels(vec![VesselRequirement::builder()
+                    .name("work".to_string())
+                    .stance(Stance::Trusted)
+                    .crew(vec![CrewSpec::builder()
+                        .role("shell".to_string())
+                        .source(CrewSource::Tool {
+                            command: r#"bash -c 'echo "Convoy {{workflow.name}} ({{inputs.topic}})"; exec bash'"#.to_string(),
+                        })
+                        .build()])
                     .build()])
-                .build()])
-            .build(),
-    )]
+                .build(),
+        ),
+        (
+            "single-agent-contained",
+            WorkflowTemplateSpec::builder()
+                .vessels(vec![VesselRequirement::builder()
+                    .name("work".to_string())
+                    .stance(Stance::Contained)
+                    .crew(vec![CrewSpec::builder()
+                        .role("coder".to_string())
+                        .source(CrewSource::Agent { selector: Selector { capability: "code".to_string() }, prompt: None })
+                        .build()])
+                    .build()])
+                .build(),
+        ),
+    ]
 }
 
 async fn ensure_default_workflow_templates(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
@@ -1135,6 +1151,32 @@ mod tests {
             Arc::new(PassthroughTerminalPool),
         );
         Arc::new(registry)
+    }
+
+    #[tokio::test]
+    async fn startup_seeding_preserves_existing_contained_template_definition() {
+        let backend = ResourceBackend::InMemory(Default::default());
+        let templates = backend.clone().using::<WorkflowTemplate>(NAMESPACE);
+        let custom = WorkflowTemplateSpec::builder()
+            .vessels(vec![VesselRequirement::builder()
+                .name("custom".to_string())
+                .stance(Stance::Contained)
+                .crew(vec![CrewSpec::builder()
+                    .role("maintainer".to_string())
+                    .source(CrewSource::Agent {
+                        selector: Selector { capability: "custom-code".to_string() },
+                        prompt: Some("Keep this definition".to_string()),
+                    })
+                    .build()])
+                .build()])
+            .build();
+        templates.create(&empty_meta("single-agent-contained"), &custom).await.expect("custom template create should succeed");
+
+        ensure_default_workflow_templates(&backend, NAMESPACE).await.expect("startup seeding should succeed");
+        ensure_default_workflow_templates(&backend, NAMESPACE).await.expect("restart seeding should succeed");
+
+        let preserved = templates.get("single-agent-contained").await.expect("template should remain");
+        assert_eq!(preserved.spec, custom);
     }
 
     fn manual_profile(host_id: &str, docker_available: bool) -> LocalProvisioningProfile {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -326,7 +326,8 @@ async fn daemon_server_observed_resource_backend_is_ephemeral_per_restart() {
             &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
                 r#ref: "main".to_string(),
                 path: "/Users/alice/dev/flotilla".to_string(),
-                repo_ref: "project-flotilla".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey("project-flotilla".to_string()),
+                host_ref: "host-01".to_string(),
                 is_main: true,
             }),
         )

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -8,7 +8,7 @@ use flotilla_core::{
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName};
-use flotilla_resources::{Convoy, ConvoyPhase, InMemoryBackend, ResourceBackend, SqliteBackend, WorkflowTemplate};
+use flotilla_resources::{Convoy, ConvoyPhase, CrewSource, InMemoryBackend, ResourceBackend, SqliteBackend, Stance, WorkflowTemplate};
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&dir).expect("create config dir");
@@ -85,6 +85,16 @@ async fn scratch_workflow_template_is_seeded_at_startup() {
     assert_eq!(scratch.metadata.name, "scratch");
     assert_eq!(scratch.spec.vessels.len(), 1);
     assert_eq!(scratch.spec.vessels[0].name, "work");
+
+    let contained = templates.get("single-agent-contained").await.expect("contained template should be seeded");
+    assert_eq!(contained.spec.vessels.len(), 1);
+    assert_eq!(contained.spec.vessels[0].stance, Stance::Contained);
+    assert!(matches!(
+        contained.spec.vessels[0].crew.as_slice(),
+        [crew]
+            if crew.role == "coder"
+                && matches!(&crew.source, CrewSource::Agent { selector, .. } if selector.capability == "code")
+    ));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -1,16 +1,26 @@
-//! Integration tests for the `ProjectCreate` + `ProjectApply` daemon actions
-//! and the `project_ref` field on `ConvoyCreate`.
+//! Integration tests for ProjectAdd/ProjectApply and Project-backed convoy metadata.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
+use async_trait::async_trait;
 use flotilla_core::{
-    config::ConfigStore, daemon::DaemonHandle, in_process::InProcessDaemon, providers::discovery::test_support::fake_discovery,
+    config::ConfigStore,
+    daemon::DaemonHandle,
+    in_process::InProcessDaemon,
+    providers::discovery::test_support::fake_discovery,
+    repository_inspection::{LocalCheckoutInspection, RepositoryInspection, RepositoryInspector},
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName};
-use flotilla_resources::{Convoy, InMemoryBackend, Project, ResourceBackend};
+use flotilla_resources::{
+    Checkout, Convoy, InMemoryBackend, InputMeta, IssueSource, Project, Repository, RepositoryKey, RepositorySpec, ResourceBackend,
+};
 
-fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
+fn test_config(dir: PathBuf) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&dir).expect("create config dir");
     std::fs::write(dir.join("daemon.toml"), "machine_id = \"test-project-cli\"\n").expect("write daemon config");
     Arc::new(ConfigStore::with_base(dir))
@@ -39,6 +49,27 @@ async fn start_daemon() -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigSto
     (daemon, backend, config, runtime, tmp)
 }
 
+#[derive(Clone)]
+struct FixedInspector {
+    spec: RepositorySpec,
+    host_ref: String,
+}
+
+#[async_trait]
+impl RepositoryInspector for FixedInspector {
+    async fn inspect_path(&self, path: &Path, _remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        Ok(RepositoryInspection {
+            spec: self.spec.clone(),
+            checkout: LocalCheckoutInspection {
+                path: path.to_path_buf(),
+                host_ref: self.host_ref.clone(),
+                git_ref: "main".to_string(),
+                is_main: true,
+            },
+        })
+    }
+}
+
 async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
@@ -52,52 +83,163 @@ async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEv
     }
 }
 
-#[tokio::test]
-async fn project_create_command_creates_project_resource() {
-    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
-    let mut rx = daemon.subscribe();
-
+async fn execute_project_add(
+    daemon: &Arc<InProcessDaemon>,
+    rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>,
+    target: String,
+    name: Option<&str>,
+    display_name: Option<&str>,
+) -> CommandValue {
     let id = daemon
         .execute(Command {
             node_id: None,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ProjectCreate {
-                name: "my-project".into(),
-                display_name: Some("My Project".into()),
-                repository_url: Some("https://github.com/org/repo.git".into()),
-                subpath: Some("apps/frontend".into()),
-                r#ref: Some("main".into()),
+            action: CommandAction::ProjectAdd {
+                target,
+                name: name.map(str::to_string),
+                display_name: display_name.map(str::to_string),
+                remote: None,
             },
         })
         .await
         .expect("execute");
-
-    let result = await_command_result(&mut rx, id).await;
-    assert_eq!(result, CommandValue::ProjectCreated { name: "my-project".into() });
-
-    let projects = backend.using::<Project>("flotilla");
-    let project = projects.get("my-project").await.expect("project should exist");
-    assert_eq!(project.spec.display_name.as_deref(), Some("My Project"));
-    assert_eq!(project.spec.repositories.len(), 1);
-    assert_eq!(project.spec.repositories[0].repo, "https://github.com/org/repo.git");
-    assert_eq!(project.spec.repositories[0].subpath.as_deref(), Some("apps/frontend"));
-    assert_eq!(project.spec.repositories[0].default_branch.as_deref(), Some("main"));
+    await_command_result(rx, id).await
 }
 
 #[tokio::test]
-async fn project_apply_supports_multi_repo() {
-    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+async fn project_add_untracked_path_ensures_repository_checkout_and_whole_repo_project() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let repository_spec = RepositorySpec::remote("https://github.com/org/repo.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec.clone(), host_ref: "host-01".to_string() })).await;
+    let checkout_path = tmp.path().join("repo");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
     let mut rx = daemon.subscribe();
 
+    let result =
+        execute_project_add(&daemon, &mut rx, checkout_path.to_string_lossy().into_owned(), Some("my-project"), Some("My Project")).await;
+
+    assert_eq!(result, CommandValue::ProjectAdded { name: "my-project".into() });
+    let repository =
+        backend.clone().using::<Repository>("flotilla").get(&repository_key.to_string()).await.expect("repository should exist");
+    assert_eq!(repository.spec, repository_spec);
+    repository.spec.verify_key(&repository_key).expect("repository key should verify");
+    let checkouts = daemon.observed_resource_backend().using::<Checkout>("flotilla").list().await.expect("checkout list");
+    assert_eq!(checkouts.items.len(), 1);
+    let project = backend.using::<Project>("flotilla").get("my-project").await.expect("project should exist");
+    assert_eq!(project.spec.display_name, "My Project");
+    assert_eq!(project.spec.default_workflow_ref, "single-agent-contained");
+    assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
+        repo: repository_key,
+        subpath: None,
+        default_branch: None,
+    }]);
+}
+
+#[tokio::test]
+async fn project_add_catalog_slug_needs_no_local_checkout() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let spec = RepositorySpec::remote("https://github.com/org/catalog-only.git").expect("repository spec");
+    let key = spec.key();
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(key.to_string()).build(), &spec)
+        .await
+        .expect("repository create");
+    let mut rx = daemon.subscribe();
+
+    let result = execute_project_add(&daemon, &mut rx, "catalog-only".to_string(), None, None).await;
+
+    assert_eq!(result, CommandValue::ProjectAdded { name: "catalog-only".into() });
+    assert!(daemon.observed_resource_backend().using::<Checkout>("flotilla").list().await.expect("checkout list").items.is_empty());
+    let project = backend.using::<Project>("flotilla").get("catalog-only").await.expect("project should exist");
+    assert_eq!(project.spec.repositories[0].repo, key);
+}
+
+#[tokio::test]
+async fn concurrent_project_adds_of_one_identity_converge_on_one_verified_repository() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let spec = RepositorySpec::remote("https://github.com/org/shared.git").expect("repository spec");
+    let key = spec.key();
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: spec.clone(), host_ref: "host-01".to_string() })).await;
+    let first = tmp.path().join("first");
+    let second = tmp.path().join("second");
+    std::fs::create_dir(&first).expect("first checkout");
+    std::fs::create_dir(&second).expect("second checkout");
+    let mut first_rx = daemon.subscribe();
+    let mut second_rx = daemon.subscribe();
+    let command = |target: &Path, name: &str| Command {
+        node_id: None,
+        provisioning_target: None,
+        context_repo: None,
+        action: CommandAction::ProjectAdd {
+            target: target.to_string_lossy().into_owned(),
+            name: Some(name.to_string()),
+            display_name: None,
+            remote: None,
+        },
+    };
+
+    let (first_id, second_id) = tokio::join!(daemon.execute(command(&first, "first")), daemon.execute(command(&second, "second")));
+    let first_id = first_id.expect("first execute");
+    let second_id = second_id.expect("second execute");
+
+    assert_eq!(await_command_result(&mut first_rx, first_id).await, CommandValue::ProjectAdded { name: "first".into() });
+    assert_eq!(await_command_result(&mut second_rx, second_id).await, CommandValue::ProjectAdded { name: "second".into() });
+    let repositories = backend.using::<Repository>("flotilla").list().await.expect("repository list");
+    assert_eq!(repositories.items.len(), 1);
+    repositories.items[0].spec.verify_key(&key).expect("repository identity should verify");
+}
+
+#[tokio::test]
+async fn repeated_project_add_preserves_evolved_definition() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let spec = RepositorySpec::remote("https://github.com/org/repo.git").expect("repository spec");
+    let key = spec.key();
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(key.to_string()).build(), &spec)
+        .await
+        .expect("repository create");
+    let mut rx = daemon.subscribe();
+    assert_eq!(execute_project_add(&daemon, &mut rx, "repo".to_string(), Some("core"), None).await, CommandValue::ProjectAdded {
+        name: "core".into()
+    });
+    let projects = backend.clone().using::<Project>("flotilla");
+    let original = projects.get("core").await.expect("project");
+    let mut evolved = original.spec.clone();
+    evolved.display_name = "Evolved".to_string();
+    evolved.default_workflow_ref = "governor-refined".to_string();
+    evolved.issue_source = Some(IssueSource { service: "linear".to_string(), scope: "FLOT".to_string() });
+    projects
+        .update(&InputMeta::builder().name("core".to_string()).build(), &original.metadata.resource_version, &evolved)
+        .await
+        .expect("evolve project");
+
+    assert_eq!(execute_project_add(&daemon, &mut rx, "repo".to_string(), Some("core"), None).await, CommandValue::ProjectAdded {
+        name: "core".into()
+    });
+    assert_eq!(projects.get("core").await.expect("project").spec, evolved);
+    assert!(matches!(
+        execute_project_add(&daemon, &mut rx, "repo".to_string(), Some("core"), Some("Contradiction")).await,
+        CommandValue::Error { message } if message.contains("project apply")
+    ));
+}
+
+#[tokio::test]
+async fn project_apply_normalizes_typed_multi_repo_definition() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
     let yaml = r#"
-display_name: "Cross-Project Demo"
+display_name: Cross-Project Demo
+default_workflow_ref: single-agent-contained
 repositories:
-  - repo: https://github.com/org/repo-a.git
-    default_branch: main
-  - repo: https://github.com/org/repo-b.git
-    subpath: services/api
-    default_branch: develop
+  - repo: b
+    subpath: ./services/api
+  - repo: a
 "#;
 
     let id = daemon
@@ -111,53 +253,27 @@ repositories:
         .expect("execute");
 
     assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ProjectApplied { name: "cross".into() });
-
-    let projects = backend.using::<Project>("flotilla");
-    let project = projects.get("cross").await.expect("project should exist");
-    assert_eq!(project.spec.repositories.len(), 2);
-    assert_eq!(project.spec.repositories[0].repo, "https://github.com/org/repo-a.git");
+    let project = backend.using::<Project>("flotilla").get("cross").await.expect("project should exist");
+    assert_eq!(project.spec.repositories[0].repo, RepositoryKey("a".to_string()));
     assert_eq!(project.spec.repositories[1].subpath.as_deref(), Some("services/api"));
-}
-
-#[tokio::test]
-async fn project_apply_updates_existing() {
-    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
-    let mut rx = daemon.subscribe();
-
-    // First apply.
-    let id = daemon
-        .execute(Command {
-            node_id: None,
-            provisioning_target: None,
-            context_repo: None,
-            action: CommandAction::ProjectApply { name: "iter".into(), spec_yaml: "display_name: V1\nrepositories: []\n".into() },
-        })
-        .await
-        .expect("first apply");
-    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ProjectApplied { name: "iter".into() });
-
-    // Second apply same name, different content.
-    let id = daemon
-        .execute(Command {
-            node_id: None,
-            provisioning_target: None,
-            context_repo: None,
-            action: CommandAction::ProjectApply { name: "iter".into(), spec_yaml: "display_name: V2\nrepositories: []\n".into() },
-        })
-        .await
-        .expect("second apply");
-    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ProjectApplied { name: "iter".into() });
-
-    let projects = backend.using::<Project>("flotilla");
-    let project = projects.get("iter").await.expect("project should exist");
-    assert_eq!(project.spec.display_name.as_deref(), Some("V2"));
 }
 
 #[tokio::test]
 async fn convoy_create_carries_project_ref() {
     let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
     let mut rx = daemon.subscribe();
-
+    let repository_spec = RepositorySpec::remote("https://github.com/org/linked-repo.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository_key.to_string()).build(), &repository_spec)
+        .await
+        .expect("repository create");
+    assert_eq!(
+        execute_project_add(&daemon, &mut rx, "linked-repo".to_string(), Some("my-project"), None).await,
+        CommandValue::ProjectAdded { name: "my-project".into() }
+    );
     let id = daemon
         .execute(Command {
             node_id: None,
@@ -176,55 +292,71 @@ async fn convoy_create_carries_project_ref() {
         })
         .await
         .expect("execute");
-
     assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ConvoyCreated { name: "linked".into() });
-
-    let convoys = backend.using::<Convoy>("flotilla");
-    let convoy = convoys.get("linked").await.expect("convoy should exist");
-    assert_eq!(convoy.spec.project_ref.as_deref(), Some("my-project"));
+    assert_eq!(backend.using::<Convoy>("flotilla").get("linked").await.expect("convoy").spec.project_ref.as_deref(), Some("my-project"));
 }
 
 #[tokio::test]
-async fn project_apply_rejects_invalid_yaml() {
-    let (daemon, _backend, _config, _runtime, _tmp) = start_daemon().await;
+async fn unresolved_replicated_project_refs_store_but_block_convoy_admission() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
     let mut rx = daemon.subscribe();
-
-    let id = daemon
+    let apply_id = daemon
         .execute(Command {
             node_id: None,
             provisioning_target: None,
             context_repo: None,
             action: CommandAction::ProjectApply {
-                name: "broken".into(),
-                spec_yaml: "this is: not {valid yaml structure for: a project".into(),
+                name: "waiting".into(),
+                spec_yaml: "display_name: Waiting\ndefault_workflow_ref: single-agent-contained\nrepositories:\n  - repo: missing\n".into(),
             },
         })
         .await
-        .expect("execute");
+        .expect("apply execute");
+    assert_eq!(await_command_result(&mut rx, apply_id).await, CommandValue::ProjectApplied { name: "waiting".into() });
+    assert!(backend.using::<Project>("flotilla").get("waiting").await.is_ok(), "definition should persist before its referent");
 
-    let result = await_command_result(&mut rx, id).await;
-    assert!(matches!(result, CommandValue::Error { .. }), "expected Error, got {result:?}");
-}
-
-#[tokio::test]
-async fn project_apply_rejects_wrong_shape_yaml() {
-    // Valid YAML, but a `repositories` entry is missing the required `repo` field.
-    let (daemon, _backend, _config, _runtime, _tmp) = start_daemon().await;
-    let mut rx = daemon.subscribe();
-
-    let id = daemon
+    let convoy_id = daemon
         .execute(Command {
             node_id: None,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ProjectApply {
-                name: "shapeless".into(),
-                spec_yaml: "repositories:\n  - subpath: apps/x\n    default_branch: main\n".into(),
+            action: CommandAction::ConvoyCreate {
+                name: "blocked".into(),
+                workflow_ref: "scratch".into(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: Some("waiting".into()),
+                placement_policy: None,
+                adopted_checkout: None,
             },
         })
         .await
-        .expect("execute");
+        .expect("convoy execute");
+    assert!(matches!(
+        await_command_result(&mut rx, convoy_id).await,
+        CommandValue::Error { message } if message.contains("project waiting is not ready") && message.contains("missing")
+    ));
+}
 
-    let result = await_command_result(&mut rx, id).await;
-    assert!(matches!(result, CommandValue::Error { .. }), "expected Error, got {result:?}");
+#[tokio::test]
+async fn project_apply_rejects_invalid_or_incomplete_definitions() {
+    let (daemon, _backend, _config, _runtime, _tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+    for spec_yaml in [
+        "this is: not {valid yaml structure for: a project",
+        "display_name: Missing workflow\nrepositories:\n  - repo: a\n",
+        "display_name: Empty repos\ndefault_workflow_ref: wf\nrepositories: []\n",
+    ] {
+        let id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ProjectApply { name: "broken".into(), spec_yaml: spec_yaml.into() },
+            })
+            .await
+            .expect("execute");
+        assert!(matches!(await_command_result(&mut rx, id).await, CommandValue::Error { .. }));
+    }
 }

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -66,6 +66,7 @@ impl RepositoryInspector for FixedInspector {
                 git_ref: "main".to_string(),
                 is_main: true,
             },
+            transport_url: None,
         })
     }
 }

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -72,10 +72,20 @@ fn convoy_with_project_ref_projects_the_full_spine() {
                 .resource(reference.subresource("vessels/implement"))
                 .name("implement")
                 .phase(WorkPhase::Running)
-                .crew(vec![CrewMemberSummary { role: "coder".to_owned(), command_preview: "implement it".to_owned() }, CrewMemberSummary {
-                    role: "reviewer".to_owned(),
-                    command_preview: "review it".to_owned(),
-                }])
+                .crew(vec![
+                    CrewMemberSummary {
+                        role: "coder".to_owned(),
+                        command_preview: "implement it".to_owned(),
+                        requested_stance: None,
+                        effective_stance: None,
+                    },
+                    CrewMemberSummary {
+                        role: "reviewer".to_owned(),
+                        command_preview: "review it".to_owned(),
+                        requested_stance: None,
+                        effective_stance: None,
+                    },
+                ])
                 .host(HostName::new("feta"))
                 .attach("workspace-1")
                 .build(),

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -189,16 +189,14 @@ pub enum CommandAction {
         name: String,
         spec_yaml: String,
     },
-    ProjectCreate {
-        name: String,
+    ProjectAdd {
+        target: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         display_name: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        repository_url: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        subpath: Option<String>,
-        #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
-        r#ref: Option<String>,
+        remote: Option<String>,
     },
     ProjectApply {
         name: String,
@@ -304,7 +302,7 @@ impl Command {
             CommandAction::CrewFail { .. } => "Failing crew work...",
             CommandAction::ConvoyCreate { .. } => "Creating convoy...",
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
-            CommandAction::ProjectCreate { .. } => "Creating project...",
+            CommandAction::ProjectAdd { .. } => "Adding project...",
             CommandAction::ProjectApply { .. } => "Applying project...",
             CommandAction::TeleportSession { .. } => "Teleporting session...",
             CommandAction::TrackRepoPath { .. } => "Tracking repository...",
@@ -429,7 +427,7 @@ pub enum CommandValue {
     WorkflowTemplateApplied {
         name: String,
     },
-    ProjectCreated {
+    ProjectAdded {
         name: String,
     },
     ProjectApplied {
@@ -663,12 +661,11 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ProjectCreate {
-                    name: "my-project".into(),
+                action: CommandAction::ProjectAdd {
+                    target: "/src/flotilla".into(),
+                    name: Some("my-project".into()),
                     display_name: Some("My Project".into()),
-                    repository_url: Some("https://github.com/flotilla-org/flotilla.git".into()),
-                    subpath: Some("apps/frontend".into()),
-                    r#ref: Some("main".into()),
+                    remote: Some("origin".into()),
                 },
             },
             Command {
@@ -960,7 +957,7 @@ mod tests {
             CommandValue::IssuesByIds { items: vec![] },
             CommandValue::ConvoyCreated { name: "my-convoy".into() },
             CommandValue::WorkflowTemplateApplied { name: "scratch".into() },
-            CommandValue::ProjectCreated { name: "my-project".into() },
+            CommandValue::ProjectAdded { name: "my-project".into() },
             CommandValue::ProjectApplied { name: "my-project".into() },
         ];
 

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -567,7 +567,12 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
         .resource(implement_ref)
         .name("implement")
         .phase(WorkPhase::Running)
-        .crew(vec![CrewMemberSummary { role: "coder".into(), command_preview: "fix the bug".into() }])
+        .crew(vec![CrewMemberSummary {
+            role: "coder".into(),
+            command_preview: "fix the bug".into(),
+            requested_stance: None,
+            effective_stance: None,
+        }])
         .host(HostName::new("local"))
         .attach("ws-1".to_string())
         .complete_work(true)

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -286,6 +286,10 @@ pub struct VesselRow {
     pub finished_at: Option<Timestamp>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_stance: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_stance: Option<String>,
     /// Names of sibling vessels this vessel depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
@@ -307,4 +311,8 @@ pub struct VesselRow {
 pub struct CrewMemberSummary {
     pub role: String,
     pub command_preview: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_stance: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_stance: Option<String>,
 }

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryKey};
+use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryCheckoutKind, RepositoryKey};
 
 define_resource!(Checkout, "checkouts", CheckoutSpec, CheckoutStatus, CheckoutStatusPatch);
 
@@ -36,9 +36,17 @@ impl CheckoutSpec {
             Self::Observed(spec) => &spec.repo_ref,
         }
     }
+
+    pub fn repository_checkout_kind(&self) -> RepositoryCheckoutKind {
+        match self {
+            Self::Worktree(_) => RepositoryCheckoutKind::Worktree,
+            Self::FreshClone(_) => RepositoryCheckoutKind::FreshClone,
+            Self::Observed(_) => RepositoryCheckoutKind::Observed,
+        }
+    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct CheckoutWorktreeSpec {
     pub repo_ref: RepositoryKey,
     pub env_ref: String,
@@ -48,7 +56,7 @@ pub struct CheckoutWorktreeSpec {
     pub clone_ref: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct FreshCloneCheckoutSpec {
     pub repo_ref: RepositoryKey,
     pub env_ref: String,
@@ -58,7 +66,7 @@ pub struct FreshCloneCheckoutSpec {
     pub url: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ObservedCheckoutSpec {
     #[serde(rename = "ref")]
     pub r#ref: String,

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch};
+use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryKey};
 
 define_resource!(Checkout, "checkouts", CheckoutSpec, CheckoutStatus, CheckoutStatusPatch);
 
@@ -28,10 +28,19 @@ impl CheckoutSpec {
             Self::Observed(_) => None,
         }
     }
+
+    pub fn repo_ref(&self) -> &RepositoryKey {
+        match self {
+            Self::Worktree(spec) => &spec.repo_ref,
+            Self::FreshClone(spec) => &spec.repo_ref,
+            Self::Observed(spec) => &spec.repo_ref,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CheckoutWorktreeSpec {
+    pub repo_ref: RepositoryKey,
     pub env_ref: String,
     #[serde(rename = "ref")]
     pub r#ref: String,
@@ -41,6 +50,7 @@ pub struct CheckoutWorktreeSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FreshCloneCheckoutSpec {
+    pub repo_ref: RepositoryKey,
     pub env_ref: String,
     #[serde(rename = "ref")]
     pub r#ref: String,
@@ -53,7 +63,8 @@ pub struct ObservedCheckoutSpec {
     #[serde(rename = "ref")]
     pub r#ref: String,
     pub path: String,
-    pub repo_ref: String,
+    pub repo_ref: RepositoryKey,
+    pub host_ref: String,
     pub is_main: bool,
 }
 

--- a/crates/flotilla-resources/src/clone.rs
+++ b/crates/flotilla-resources/src/clone.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch};
+use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryKey};
 
 define_resource!(Clone, "clones", CloneSpec, CloneStatus, CloneStatusPatch);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CloneSpec {
+    pub repo_ref: RepositoryKey,
     pub url: String,
     pub env_ref: String,
     pub path: String,

--- a/crates/flotilla-resources/src/clone.rs
+++ b/crates/flotilla-resources/src/clone.rs
@@ -4,7 +4,7 @@ use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryKey}
 
 define_resource!(Clone, "clones", CloneSpec, CloneStatus, CloneStatusPatch);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct CloneSpec {
     pub repo_ref: RepositoryKey,
     pub url: String,

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -154,6 +154,44 @@ impl<W: Resource, P: Resource> SecondaryWatch for LabelMappedWatch<W, P> {
 }
 
 #[derive(Clone)]
+pub struct ResolverLabelMappedWatch<W: Resource, P: Resource> {
+    pub label_key: &'static str,
+    pub resolver: TypedResolver<W>,
+    pub _marker: PhantomData<P>,
+}
+
+impl<W: Resource, P: Resource> SecondaryWatch for ResolverLabelMappedWatch<W, P> {
+    type Primary = P;
+
+    fn clone_box(&self) -> Box<dyn SecondaryWatch<Primary = Self::Primary>> {
+        Box::new(Self { label_key: self.label_key, resolver: self.resolver.clone(), _marker: PhantomData })
+    }
+
+    fn spawn(
+        self: Box<Self>,
+        _backend: ResourceBackend,
+        _namespace: String,
+        sender: mpsc::Sender<String>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ResourceError>> + Send>> {
+        Box::pin(async move {
+            let listed = self.resolver.list().await?;
+            for object in &listed.items {
+                LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, object).await?;
+            }
+            let mut watch = self.resolver.watch(WatchStart::FromVersion(listed.resource_version)).await?;
+            while let Some(event) = watch.next().await {
+                match event? {
+                    WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {
+                        LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, &object).await?;
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+#[derive(Clone)]
 pub struct LabelJoinWatch<W: Resource, P: Resource> {
     pub label_key: &'static str,
     pub _marker: PhantomData<(W, P)>,

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement};
+use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement, RepositoryKey};
 
 mod reconcile;
 
@@ -34,6 +34,7 @@ pub struct ConvoySpec {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConvoyRepositorySpec {
     pub url: String,
+    pub repo_ref: RepositoryKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -285,6 +285,7 @@ fn bootstrap_outcome(
             .iter()
             .map(|vessel| VesselRequirement {
                 name: vessel.name.clone(),
+                stance: vessel.stance,
                 depends_on: vessel.depends_on.clone(),
                 crew: vessel.crew.iter().map(|member| instantiate_process(convoy, member)).collect(),
             })
@@ -777,6 +778,12 @@ fn placement_status(workspace: &ResourceObject<Vessel>) -> PlacementStatus {
             "placement_policy_ref",
             status.observed_policy_ref.clone().or_else(|| Some(workspace.spec.placement_policy_ref.clone())),
         );
+        if let Some(requested_stance) = status.requested_stance {
+            fields.insert("requested_stance".to_string(), json!(requested_stance));
+        }
+        if let Some(effective_stance) = status.effective_stance {
+            fields.insert("effective_stance".to_string(), json!(effective_stance));
+        }
     }
     PlacementStatus { fields }
 }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -11,7 +11,6 @@ use super::{
     WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
 };
 use crate::{
-    canonicalize_repo_url,
     controller::{
         delete_lifecycle_owned_matching, Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler,
         SecondaryWatch,
@@ -676,19 +675,9 @@ fn cleanup_actuations(
     actuations
 }
 
-fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, vessel: &str, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
+fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, vessel: &str, _now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
     let placement_policy_ref = convoy.spec.placement_policy.clone()?;
-    let repo_url = convoy.spec.repository.as_ref()?.url.clone();
-    let canonical_repo = match canonicalize_repo_url(&repo_url) {
-        Ok(canonical_repo) => canonical_repo,
-        Err(message) => {
-            return Some(InternalReconcileOutcome {
-                patch: Some(ConvoyStatusPatch::MarkWorkFailed { work: vessel.to_string(), finished_at: now, message }),
-                actuations: Vec::new(),
-                events: vec![ConvoyEvent::WorkPhaseChanged { work: vessel.to_string(), from: WorkPhase::Ready, to: WorkPhase::Failed }],
-            })
-        }
-    };
+    let repository_key = convoy.spec.repository.as_ref()?.repo_ref.to_string();
 
     Some(InternalReconcileOutcome {
         patch: None,
@@ -698,7 +687,7 @@ fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, vessel: &str, now: Dat
                 .labels(BTreeMap::from([
                     (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
                     (VESSEL_LABEL.to_string(), vessel.to_string()),
-                    (REPO_KEY_LABEL.to_string(), crate::repo_key(&canonical_repo)),
+                    (REPO_KEY_LABEL.to_string(), repository_key),
                 ]))
                 .owner_references(vec![OwnerReference {
                     api_version: format!("{}/{}", Convoy::API_PATHS.group, Convoy::API_PATHS.version),

--- a/crates/flotilla-resources/src/crds/convoy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/convoy.crd.yaml
@@ -49,6 +49,25 @@ spec:
                 placement_policy:
                   type: string
                   minLength: 1
+                repository:
+                  type: object
+                  required: [url, repo_ref]
+                  properties:
+                    url:
+                      type: string
+                      minLength: 1
+                    repo_ref:
+                      type: string
+                      minLength: 1
+                ref:
+                  type: string
+                  minLength: 1
+                project_ref:
+                  type: string
+                  minLength: 1
+                adopted_checkout_ref:
+                  type: string
+                  minLength: 1
             status:
               type: object
               properties:

--- a/crates/flotilla-resources/src/crds/convoy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/convoy.crd.yaml
@@ -74,6 +74,10 @@ spec:
                           name:
                             type: string
                             minLength: 1
+                          stance:
+                            type: string
+                            enum: [trusted, workspace-write, contained]
+                            default: trusted
                           depends_on:
                             type: array
                             items:

--- a/crates/flotilla-resources/src/crds/project.crd.yaml
+++ b/crates/flotilla-resources/src/crds/project.crd.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: projects.flotilla.work
+spec:
+  group: flotilla.work
+  scope: Namespaced
+  names:
+    plural: projects
+    singular: project
+    kind: Project
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [display_name, default_workflow_ref, repositories]
+              properties:
+                display_name:
+                  type: string
+                  minLength: 1
+                default_workflow_ref:
+                  type: string
+                  minLength: 1
+                issue_source:
+                  type: object
+                  required: [service, scope]
+                  properties:
+                    service:
+                      type: string
+                    scope:
+                      type: string
+                repositories:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    required: [repo]
+                    properties:
+                      repo:
+                        type: string
+                      subpath:
+                        type: string
+                      default_branch:
+                        type: string

--- a/crates/flotilla-resources/src/crds/repository.crd.yaml
+++ b/crates/flotilla-resources/src/crds/repository.crd.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: repositories.flotilla.work
+spec:
+  group: flotilla.work
+  scope: Namespaced
+  names:
+    plural: repositories
+    singular: repository
+    kind: Repository
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Default Branch
+          type: string
+          jsonPath: .status.default_branch
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [identity]
+              properties:
+                identity:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                forge:
+                  type: object
+                  required: [service_url, repository]
+                  properties:
+                    service_url:
+                      type: string
+                    repository:
+                      type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/crates/flotilla-resources/src/crds/repository.crd.yaml
+++ b/crates/flotilla-resources/src/crds/repository.crd.yaml
@@ -26,6 +26,11 @@ spec:
             spec:
               type: object
               required: [identity]
+              x-kubernetes-validations:
+                - rule: "self.identity == oldSelf.identity"
+                  message: "repository identity is immutable after creation"
+                - rule: "self.forge == oldSelf.forge"
+                  message: "repository forge is immutable and identity-derived"
               properties:
                 identity:
                   type: object

--- a/crates/flotilla-resources/src/crds/workflow_template.crd.yaml
+++ b/crates/flotilla-resources/src/crds/workflow_template.crd.yaml
@@ -48,6 +48,10 @@ spec:
                       name:
                         type: string
                         minLength: 1
+                      stance:
+                        type: string
+                        enum: [trusted, workspace-write, contained]
+                        default: trusted
                       depends_on:
                         type: array
                         items:

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -243,6 +243,7 @@ impl InMemoryBackend {
             if object.metadata.resource_version != resource_version {
                 return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
             }
+            T::validate_spec_update(&object.spec, spec)?;
             if object.matches_update(meta, spec)? {
                 return Ok(object);
             }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -67,6 +67,6 @@ pub use terminal_session::{
 pub use vessel::{Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch};
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
 pub use workflow_template::{
-    validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation, Selector, ValidationError,
+    validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation, Selector, Stance, ValidationError,
     VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -54,8 +54,9 @@ pub use presentation::{Presentation, PresentationPhase, PresentationSpec, Presen
 pub use project::{normalize_project_spec, IssueSource, Project, ProjectRepositorySpec, ProjectSpec};
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use repository::{
-    resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity, Repository, RepositoryCheckoutKind,
-    RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey, RepositorySpec, RepositoryStatus, RepositoryStatusPatch,
+    ensure_repository, resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity, Repository,
+    RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey, RepositorySpec, RepositoryStatus,
+    RepositoryStatusPatch,
 };
 pub use resource::{
     api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -13,6 +13,7 @@ mod placement_policy;
 mod presentation;
 mod project;
 mod provisioning_identity;
+mod repository;
 mod resource;
 mod retention;
 mod sqlite;
@@ -50,8 +51,12 @@ pub use placement_policy::{
     PlacementPolicy, PlacementPolicySpec,
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
-pub use project::{Project, ProjectRepositorySpec, ProjectSpec};
+pub use project::{normalize_project_spec, IssueSource, Project, ProjectRepositorySpec, ProjectSpec};
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
+pub use repository::{
+    resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity, Repository, RepositoryCheckoutKind,
+    RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey, RepositorySpec, RepositoryStatus, RepositoryStatusPatch,
+};
 pub use resource::{
     api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,
     OwnerReference, Resource, ResourceObject,
@@ -67,6 +72,6 @@ pub use terminal_session::{
 pub use vessel::{Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch};
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
 pub use workflow_template::{
-    validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation, Selector, Stance, ValidationError,
-    VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    single_agent_contained_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation,
+    Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/project.rs
+++ b/crates/flotilla-resources/src/project.rs
@@ -1,13 +1,15 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::NoStatusPatch};
+use crate::{resource::define_resource, status_patch::NoStatusPatch, RepositoryKey};
 
 define_resource!(Project, "projects", ProjectSpec, (), NoStatusPatch);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ProjectSpec {
+    pub display_name: String,
+    pub default_workflow_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<String>,
+    pub issue_source: Option<IssueSource>,
     #[builder(default)]
     #[serde(default)]
     pub repositories: Vec<ProjectRepositorySpec>,
@@ -15,10 +17,73 @@ pub struct ProjectSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ProjectRepositorySpec {
-    pub repo: String,
+    pub repo: RepositoryKey,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subpath: Option<String>,
-    /// Surfaced as `--ref` on the `flotilla project create` CLI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_branch: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueSource {
+    pub service: String,
+    pub scope: String,
+}
+
+pub fn normalize_project_spec(mut spec: ProjectSpec) -> Result<ProjectSpec, String> {
+    spec.display_name = required_value(spec.display_name, "display_name")?;
+    spec.default_workflow_ref = required_value(spec.default_workflow_ref, "default_workflow_ref")?;
+    if let Some(issue_source) = &mut spec.issue_source {
+        issue_source.service = required_value(std::mem::take(&mut issue_source.service), "issue_source.service")?;
+        issue_source.scope = required_value(std::mem::take(&mut issue_source.scope), "issue_source.scope")?;
+    }
+    if spec.repositories.is_empty() {
+        return Err("project must reference at least one repository".to_string());
+    }
+    for repository in &mut spec.repositories {
+        if repository.repo.0.trim().is_empty() {
+            return Err("project repository ref cannot be empty".to_string());
+        }
+        repository.subpath = repository.subpath.take().map(normalize_subpath).transpose()?;
+        repository.default_branch =
+            repository.default_branch.take().map(|branch| required_value(branch, "repositories[].default_branch")).transpose()?;
+    }
+    spec.repositories.sort_by(|left, right| (&left.repo, &left.subpath).cmp(&(&right.repo, &right.subpath)));
+    if spec.repositories.windows(2).any(|pair| pair[0].repo == pair[1].repo && pair[0].subpath == pair[1].subpath) {
+        return Err("project contains a duplicate repository and subpath entry".to_string());
+    }
+    Ok(spec)
+}
+
+fn required_value(value: String, field: &str) -> Result<String, String> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        Err(format!("{field} cannot be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn normalize_subpath(subpath: String) -> Result<String, String> {
+    if subpath.trim().is_empty() {
+        return Err("project repository subpath cannot be empty".to_string());
+    }
+    let path = std::path::Path::new(subpath.trim());
+    if path.is_absolute() {
+        return Err(format!("project repository subpath must be relative: {}", path.display()));
+    }
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(component) => components.push(component.to_string_lossy().into_owned()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir | std::path::Component::RootDir | std::path::Component::Prefix(_) => {
+                return Err(format!("project repository subpath may not traverse outside the repository: {}", path.display()));
+            }
+        }
+    }
+    if components.is_empty() {
+        return Err("project repository subpath must name a path within the repository".to_string());
+    }
+    Ok(components.join("/"))
 }

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch, LifecycleAuthority};
+use crate::{
+    resource::define_resource, status_patch::StatusPatch, InputMeta, LifecycleAuthority, ResourceError, ResourceObject, TypedResolver,
+};
 
 define_resource!(Repository, "repositories", RepositorySpec, RepositoryStatus, RepositoryStatusPatch);
 
@@ -40,16 +42,20 @@ pub struct ForgeIdentity {
     pub repository: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RepositorySpec {
-    pub identity: RepositoryIdentity,
+    identity: RepositoryIdentity,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub forge: Option<ForgeIdentity>,
+    forge: Option<ForgeIdentity>,
 }
 
 impl RepositorySpec {
-    pub fn remote(canonical_remote: impl Into<String>) -> Result<Self, String> {
-        let canonical_remote = crate::canonicalize_repo_url(&canonical_remote.into())?;
+    pub fn remote(remote: impl Into<String>) -> Result<Self, String> {
+        let remote = remote.into();
+        if let Some(alias) = unresolved_ssh_alias(&remote) {
+            return Err(format!("unrecognised remote host alias `{alias}`; resolve SSH host configuration before creating RepositorySpec"));
+        }
+        let canonical_remote = crate::canonicalize_repo_url(&remote)?;
         let forge = forge_from_canonical_remote(&canonical_remote)?;
         Ok(Self { identity: RepositoryIdentity::Remote { canonical_remote }, forge: Some(forge) })
     }
@@ -70,6 +76,14 @@ impl RepositorySpec {
 
     pub fn key(&self) -> RepositoryKey {
         RepositoryKey::from_identity(&self.identity)
+    }
+
+    pub fn identity(&self) -> &RepositoryIdentity {
+        &self.identity
+    }
+
+    pub fn forge(&self) -> Option<&ForgeIdentity> {
+        self.forge.as_ref()
     }
 
     pub fn verify_key(&self, key: &RepositoryKey) -> Result<(), String> {
@@ -93,6 +107,71 @@ impl RepositorySpec {
                 .unwrap_or("repository")
                 .to_ascii_lowercase(),
         }
+    }
+
+    pub fn matches_catalog_target(&self, target: &str) -> bool {
+        if self.leaf_slug() == target {
+            return true;
+        }
+        match &self.identity {
+            RepositoryIdentity::Remote { canonical_remote } => {
+                self.forge.as_ref().is_some_and(|forge| forge.repository == target)
+                    || crate::descriptive_repo_slug(canonical_remote) == target
+            }
+            RepositoryIdentity::Local { .. } => false,
+        }
+    }
+
+    pub fn catalog_slug(&self) -> String {
+        match &self.identity {
+            RepositoryIdentity::Remote { canonical_remote } => crate::descriptive_repo_slug(canonical_remote),
+            RepositoryIdentity::Local { .. } => self.leaf_slug(),
+        }
+    }
+}
+
+pub async fn ensure_repository(
+    repositories: &TypedResolver<Repository>,
+    key: &RepositoryKey,
+    spec: &RepositorySpec,
+) -> Result<ResourceObject<Repository>, ResourceError> {
+    let repository = match repositories.create(&InputMeta::builder().name(key.to_string()).build(), spec).await {
+        Ok(created) => created,
+        Err(ResourceError::Conflict { .. }) => repositories.get(&key.to_string()).await?,
+        Err(error) => return Err(error),
+    };
+    repository.spec.verify_key(key).map_err(ResourceError::invalid)?;
+    if repository.spec != *spec {
+        return Err(ResourceError::invalid(format!("repository key {key} already refers to a different canonical identity")));
+    }
+    Ok(repository)
+}
+
+impl<'de> Deserialize<'de> for RepositorySpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct StoredRepositorySpec {
+            identity: RepositoryIdentity,
+            #[serde(default)]
+            forge: Option<ForgeIdentity>,
+        }
+
+        let stored = StoredRepositorySpec::deserialize(deserializer)?;
+        let normalized = match &stored.identity {
+            RepositoryIdentity::Remote { canonical_remote } => RepositorySpec::remote(canonical_remote),
+            RepositoryIdentity::Local { host_ref, git_common_dir } => RepositorySpec::local(host_ref, git_common_dir),
+        }
+        .map_err(serde::de::Error::custom)?;
+        if normalized.identity != stored.identity {
+            return Err(serde::de::Error::custom("repository identity is not canonical"));
+        }
+        if normalized.forge != stored.forge {
+            return Err(serde::de::Error::custom("repository forge must be the identity-derived forge"));
+        }
+        Ok(normalized)
     }
 }
 
@@ -125,7 +204,7 @@ pub struct RepositoryCheckoutRef {
     pub authority: LifecycleAuthority,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct RepositoryStatus {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub checkouts_by_host: BTreeMap<String, Vec<RepositoryCheckoutRef>>,
@@ -205,4 +284,20 @@ fn identity_description(identity: &RepositoryIdentity) -> String {
         RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
         RepositoryIdentity::Local { host_ref, git_common_dir } => format!("{host_ref}:{git_common_dir}"),
     }
+}
+
+fn unresolved_ssh_alias(remote: &str) -> Option<&str> {
+    let host = if let Some(rest) = remote.strip_prefix("ssh://") {
+        let authority = rest.split('/').next()?;
+        authority.rsplit_once('@').map_or(authority, |(_, host)| host)
+    } else if remote.contains("://") {
+        return None;
+    } else {
+        let (authority, path) = remote.split_once(':')?;
+        if path.is_empty() {
+            return None;
+        }
+        authority.rsplit_once('@').map_or(authority, |(_, host)| host)
+    };
+    (!host.contains('.')).then_some(host)
 }

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -1,0 +1,208 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{resource::define_resource, status_patch::StatusPatch, LifecycleAuthority};
+
+define_resource!(Repository, "repositories", RepositorySpec, RepositoryStatus, RepositoryStatusPatch);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct RepositoryKey(pub String);
+
+impl RepositoryKey {
+    pub fn from_identity(identity: &RepositoryIdentity) -> Self {
+        match identity {
+            RepositoryIdentity::Remote { canonical_remote } => Self(crate::repo_key(canonical_remote)),
+            RepositoryIdentity::Local { host_ref, git_common_dir } => {
+                Self(crate::repo_key(&format!("local\0{host_ref}\0{git_common_dir}")))
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for RepositoryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RepositoryIdentity {
+    Remote { canonical_remote: String },
+    Local { host_ref: String, git_common_dir: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgeIdentity {
+    pub service_url: String,
+    pub repository: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositorySpec {
+    pub identity: RepositoryIdentity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forge: Option<ForgeIdentity>,
+}
+
+impl RepositorySpec {
+    pub fn remote(canonical_remote: impl Into<String>) -> Result<Self, String> {
+        let canonical_remote = crate::canonicalize_repo_url(&canonical_remote.into())?;
+        let forge = forge_from_canonical_remote(&canonical_remote)?;
+        Ok(Self { identity: RepositoryIdentity::Remote { canonical_remote }, forge: Some(forge) })
+    }
+
+    pub fn local(host_ref: impl Into<String>, git_common_dir: impl Into<String>) -> Result<Self, String> {
+        let host_ref = host_ref.into();
+        let git_common_dir = git_common_dir.into();
+        if host_ref.trim().is_empty() {
+            return Err("local repository host_ref cannot be empty".to_string());
+        }
+        let path = std::path::Path::new(&git_common_dir);
+        if !path.is_absolute() {
+            return Err("local repository git_common_dir must be absolute".to_string());
+        }
+        let normalized = normalize_absolute_path(path)?;
+        Ok(Self { identity: RepositoryIdentity::Local { host_ref, git_common_dir: normalized }, forge: None })
+    }
+
+    pub fn key(&self) -> RepositoryKey {
+        RepositoryKey::from_identity(&self.identity)
+    }
+
+    pub fn verify_key(&self, key: &RepositoryKey) -> Result<(), String> {
+        let actual = self.key();
+        if &actual == key {
+            Ok(())
+        } else {
+            Err(format!("repository key {key} resolves to identity {}, expected {actual}", identity_description(&self.identity)))
+        }
+    }
+
+    pub fn leaf_slug(&self) -> String {
+        match &self.identity {
+            RepositoryIdentity::Remote { canonical_remote } => {
+                canonical_remote.split('/').next_back().unwrap_or("repository").trim_end_matches(".git").to_ascii_lowercase()
+            }
+            RepositoryIdentity::Local { git_common_dir, .. } => std::path::Path::new(git_common_dir)
+                .parent()
+                .and_then(std::path::Path::file_name)
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or("repository")
+                .to_ascii_lowercase(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DefaultBranchProvenance {
+    LocalTrunk,
+    RemoteSymbolicHead,
+    Forge,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct DefaultBranchObservation {
+    pub branch: String,
+    pub provenance: DefaultBranchProvenance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryCheckoutKind {
+    Observed,
+    Worktree,
+    FreshClone,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryCheckoutRef {
+    pub checkout_ref: String,
+    pub kind: RepositoryCheckoutKind,
+    pub authority: LifecycleAuthority,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryStatus {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub checkouts_by_host: BTreeMap<String, Vec<RepositoryCheckoutRef>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub default_branch_observations: Vec<DefaultBranchObservation>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepositoryStatusPatch {
+    Replace(RepositoryStatus),
+}
+
+impl StatusPatch<RepositoryStatus> for RepositoryStatusPatch {
+    fn apply(&self, status: &mut RepositoryStatus) {
+        match self {
+            Self::Replace(replacement) => *status = replacement.clone(),
+        }
+    }
+}
+
+pub fn resolve_default_branch(observations: &[DefaultBranchObservation]) -> (Option<String>, Vec<String>) {
+    let mut diagnostics = Vec::new();
+    let all_branches = observations.iter().map(|observation| observation.branch.as_str()).collect::<BTreeSet<_>>();
+    if all_branches.len() > 1 {
+        diagnostics.push(format!("default branch observations disagree: {}", all_branches.into_iter().collect::<Vec<_>>().join(", ")));
+    }
+
+    for provenance in [DefaultBranchProvenance::Forge, DefaultBranchProvenance::RemoteSymbolicHead, DefaultBranchProvenance::LocalTrunk] {
+        let candidates = observations
+            .iter()
+            .filter(|observation| observation.provenance == provenance)
+            .map(|observation| observation.branch.clone())
+            .collect::<BTreeSet<_>>();
+        if candidates.len() == 1 {
+            return (candidates.into_iter().next(), diagnostics);
+        }
+        if candidates.len() > 1 {
+            diagnostics.push(format!("ambiguous {provenance:?} default branch observations"));
+            return (None, diagnostics);
+        }
+    }
+    (None, diagnostics)
+}
+
+fn forge_from_canonical_remote(canonical_remote: &str) -> Result<ForgeIdentity, String> {
+    let (scheme, rest) =
+        canonical_remote.split_once("://").ok_or_else(|| format!("canonical repository remote has no scheme: {canonical_remote}"))?;
+    let (host, repository) =
+        rest.split_once('/').ok_or_else(|| format!("canonical repository remote has no repository path: {canonical_remote}"))?;
+    Ok(ForgeIdentity { service_url: format!("{scheme}://{host}"), repository: repository.to_string() })
+}
+
+fn normalize_absolute_path(path: &std::path::Path) -> Result<String, String> {
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            std::path::Component::RootDir => normalized.push(std::path::MAIN_SEPARATOR.to_string()),
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(format!("path escapes its root: {}", path.display()));
+                }
+            }
+            std::path::Component::Normal(component) => normalized.push(component),
+        }
+    }
+    Ok(normalized.to_string_lossy().into_owned())
+}
+
+fn identity_description(identity: &RepositoryIdentity) -> String {
+    match identity {
+        RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
+        RepositoryIdentity::Local { host_ref, git_common_dir } => format!("{host_ref}:{git_common_dir}"),
+    }
+}

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -6,7 +6,7 @@ use crate::{
     resource::define_resource, status_patch::StatusPatch, InputMeta, LifecycleAuthority, ResourceError, ResourceObject, TypedResolver,
 };
 
-define_resource!(Repository, "repositories", RepositorySpec, RepositoryStatus, RepositoryStatusPatch);
+define_resource!(Repository, "repositories", RepositorySpec, RepositoryStatus, RepositoryStatusPatch, immutable_spec);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -52,8 +52,8 @@ pub struct RepositorySpec {
 impl RepositorySpec {
     pub fn remote(remote: impl Into<String>) -> Result<Self, String> {
         let remote = remote.into();
-        if let Some(alias) = unresolved_ssh_alias(&remote) {
-            return Err(format!("unrecognised remote host alias `{alias}`; resolve SSH host configuration before creating RepositorySpec"));
+        if let Some(host) = ssh_remote_host(&remote) {
+            return Err(format!("SSH remote host `{host}` must be resolved before creating RepositorySpec"));
         }
         let canonical_remote = crate::canonicalize_repo_url(&remote)?;
         let forge = forge_from_canonical_remote(&canonical_remote)?;
@@ -286,7 +286,7 @@ fn identity_description(identity: &RepositoryIdentity) -> String {
     }
 }
 
-fn unresolved_ssh_alias(remote: &str) -> Option<&str> {
+fn ssh_remote_host(remote: &str) -> Option<&str> {
     let host = if let Some(rest) = remote.strip_prefix("ssh://") {
         let authority = rest.split('/').next()?;
         authority.rsplit_once('@').map_or(authority, |(_, host)| host)
@@ -299,5 +299,5 @@ fn unresolved_ssh_alias(remote: &str) -> Option<&str> {
         }
         authority.rsplit_once('@').map_or(authority, |(_, host)| host)
     };
-    (!host.contains('.')).then_some(host)
+    Some(host)
 }

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -11,6 +11,31 @@ use crate::{
 };
 
 macro_rules! define_resource {
+    ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty, immutable_spec) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct $name;
+
+        impl $crate::resource::Resource for $name {
+            type Spec = $spec;
+            type Status = $status;
+            type StatusPatch = $patch;
+
+            const API_PATHS: $crate::resource::ApiPaths =
+                $crate::resource::ApiPaths { group: "flotilla.work", version: "v1", plural: $plural, kind: stringify!($name) };
+
+            fn validate_spec_update(current: &Self::Spec, requested: &Self::Spec) -> Result<(), $crate::ResourceError> {
+                let current = serde_json::to_value(current)
+                    .map_err(|error| $crate::ResourceError::decode(format!("serialize current spec: {error}")))?;
+                let requested = serde_json::to_value(requested)
+                    .map_err(|error| $crate::ResourceError::decode(format!("serialize requested spec: {error}")))?;
+                if current == requested {
+                    Ok(())
+                } else {
+                    Err($crate::ResourceError::invalid(concat!(stringify!($name), " spec is immutable after creation")))
+                }
+            }
+        }
+    };
     ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct $name;
@@ -42,6 +67,10 @@ pub trait Resource: Send + Sync + 'static {
     type StatusPatch: StatusPatch<Self::Status>;
 
     const API_PATHS: ApiPaths;
+
+    fn validate_spec_update(_current: &Self::Spec, _requested: &Self::Spec) -> Result<(), ResourceError> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -507,6 +507,7 @@ impl SqliteBackend {
             if object.metadata.resource_version != resource_version {
                 return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
             }
+            T::validate_spec_update(&object.spec, &spec)?;
             if object.matches_update(&meta, &spec)? {
                 return Ok(object);
             }

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch};
+use crate::{resource::define_resource, status_patch::StatusPatch, Stance};
 
 define_resource!(Vessel, "vessels", VesselSpec, VesselStatus, VesselStatusPatch);
 
@@ -44,14 +44,31 @@ pub struct VesselStatus {
     pub started_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ready_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requested_stance: Option<Stance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_stance: Option<Stance>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VesselStatusPatch {
-    MarkProvisioning { observed_policy_ref: String, observed_policy_version: String, started_at: DateTime<Utc> },
-    MarkReady { environment_ref: Option<String>, checkout_ref: Option<String>, terminal_session_refs: Vec<String>, ready_at: DateTime<Utc> },
+    MarkProvisioning {
+        observed_policy_ref: String,
+        observed_policy_version: String,
+        started_at: DateTime<Utc>,
+    },
+    MarkReady {
+        environment_ref: Option<String>,
+        checkout_ref: Option<String>,
+        terminal_session_refs: Vec<String>,
+        requested_stance: Stance,
+        effective_stance: Stance,
+        ready_at: DateTime<Utc>,
+    },
     MarkTearingDown,
-    MarkFailed { message: String },
+    MarkFailed {
+        message: String,
+    },
 }
 
 impl StatusPatch<VesselStatus> for VesselStatusPatch {
@@ -64,11 +81,13 @@ impl StatusPatch<VesselStatus> for VesselStatusPatch {
                 status.started_at.get_or_insert(*started_at);
                 status.message = None;
             }
-            Self::MarkReady { environment_ref, checkout_ref, terminal_session_refs, ready_at } => {
+            Self::MarkReady { environment_ref, checkout_ref, terminal_session_refs, requested_stance, effective_stance, ready_at } => {
                 status.phase = VesselPhase::Ready;
                 status.environment_ref = environment_ref.clone();
                 status.checkout_ref = checkout_ref.clone();
                 status.terminal_session_refs = terminal_session_refs.clone();
+                status.requested_stance = Some(*requested_stance);
+                status.effective_stance = Some(*effective_stance);
                 status.ready_at.get_or_insert(*ready_at);
                 status.message = None;
             }

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -81,6 +81,19 @@ pub struct Selector {
     pub capability: String,
 }
 
+pub fn single_agent_contained_workflow_spec() -> WorkflowTemplateSpec {
+    WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Contained)
+            .crew(vec![CrewSpec::builder()
+                .role("coder".to_string())
+                .source(CrewSource::Agent { selector: Selector { capability: "code".to_string() }, prompt: None })
+                .build()])
+            .build()])
+        .build()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
     DuplicateVesselName { name: String },

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -26,8 +26,31 @@ pub struct VesselRequirement {
     pub name: String,
     #[builder(default)]
     #[serde(default)]
+    pub stance: Stance,
+    #[builder(default)]
+    #[serde(default)]
     pub depends_on: Vec<String>,
     pub crew: Vec<CrewSpec>,
+}
+
+/// The minimum isolation guarantee required while a vessel runs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Stance {
+    #[default]
+    Trusted,
+    WorkspaceWrite,
+    Contained,
+}
+
+impl std::fmt::Display for Stance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Trusted => f.write_str("trusted"),
+            Self::WorkspaceWrite => f.write_str("workspace-write"),
+            Self::Contained => f.write_str("contained"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -360,7 +360,12 @@ pub fn bootstrapped_tool_only_convoy_status() -> RealConvoyStatus {
         vessels: tool_only_workflow_template_spec()
             .vessels
             .into_iter()
-            .map(|task| flotilla_resources::VesselRequirement { name: task.name, depends_on: task.depends_on, crew: task.crew })
+            .map(|task| flotilla_resources::VesselRequirement {
+                name: task.name,
+                stance: task.stance,
+                depends_on: task.depends_on,
+                crew: task.crew,
+            })
             .collect(),
     };
     let work = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -210,7 +210,12 @@ pub fn valid_convoy_spec() -> RealConvoySpec {
 
 pub fn task_provisioning_convoy_spec() -> RealConvoySpec {
     let mut spec = valid_convoy_spec();
-    spec.repository = Some(flotilla_resources::ConvoyRepositorySpec { url: "git@github.com:flotilla-org/flotilla.git".to_string() });
+    let repository = flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla.git")
+        .expect("repository URL should be canonical");
+    spec.repository = Some(flotilla_resources::ConvoyRepositorySpec {
+        url: "https://github.com/flotilla-org/flotilla.git".to_string(),
+        repo_ref: repository.key(),
+    });
     spec.r#ref = Some("feat/task-provisioning".to_string());
     spec
 }

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -213,7 +213,7 @@ pub fn task_provisioning_convoy_spec() -> RealConvoySpec {
     let repository = flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla.git")
         .expect("repository URL should be canonical");
     spec.repository = Some(flotilla_resources::ConvoyRepositorySpec {
-        url: "https://github.com/flotilla-org/flotilla.git".to_string(),
+        url: "git@github.work:flotilla-org/flotilla.git".to_string(),
         repo_ref: repository.key(),
     });
     spec.r#ref = Some("feat/task-provisioning".to_string());

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -226,6 +226,8 @@ async fn controller_loop_advances_task_via_vessel_secondary_watch() {
             terminal_session_refs: vec!["terminal-implement-coder".to_string()],
             started_at: Some(timestamp(18)),
             ready_at: Some(timestamp(19)),
+            requested_stance: None,
+            effective_stance: None,
         })
         .await
         .expect("workspace status update should succeed");

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -119,6 +119,8 @@ fn vessel_object(convoy_name: &str, task: &str, phase: VesselPhase, message: Opt
             terminal_session_refs: vec![format!("terminal-{task}-coder")],
             started_at: Some(timestamp(16)),
             ready_at: (phase == VesselPhase::Ready).then(|| timestamp(18)),
+            requested_stance: None,
+            effective_stance: None,
         }),
     }
 }
@@ -174,6 +176,7 @@ fn bootstrap_from_valid_template_returns_bootstrap_patch() {
             .iter()
             .map(|task| flotilla_resources::VesselRequirement {
                 name: task.name.clone(),
+                stance: task.stance,
                 depends_on: task.depends_on.clone(),
                 crew: task.crew.clone(),
             })
@@ -318,9 +321,24 @@ fn fan_out_advances_all_newly_ready_tasks() {
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
         vessels: vec![
-            flotilla_resources::VesselRequirement { name: "a".to_string(), depends_on: Vec::new(), crew: Vec::new() },
-            flotilla_resources::VesselRequirement { name: "b".to_string(), depends_on: Vec::new(), crew: Vec::new() },
-            flotilla_resources::VesselRequirement { name: "c".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement {
+                name: "a".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
+            flotilla_resources::VesselRequirement {
+                name: "b".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
+            flotilla_resources::VesselRequirement {
+                name: "c".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
         ],
     });
     status.crew_work =
@@ -346,10 +364,21 @@ fn fan_in_waits_until_all_dependencies_complete() {
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
         vessels: vec![
-            flotilla_resources::VesselRequirement { name: "implement".to_string(), depends_on: Vec::new(), crew: Vec::new() },
-            flotilla_resources::VesselRequirement { name: "verify".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement {
+                name: "implement".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
+            flotilla_resources::VesselRequirement {
+                name: "verify".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
             flotilla_resources::VesselRequirement {
                 name: "review".to_string(),
+                stance: Default::default(),
                 depends_on: vec!["implement".to_string(), "verify".to_string()],
                 crew: Vec::new(),
             },
@@ -478,9 +507,24 @@ fn advancing_ready_tasks_emits_task_phase_change_events() {
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
         vessels: vec![
-            flotilla_resources::VesselRequirement { name: "a".to_string(), depends_on: Vec::new(), crew: Vec::new() },
-            flotilla_resources::VesselRequirement { name: "b".to_string(), depends_on: Vec::new(), crew: Vec::new() },
-            flotilla_resources::VesselRequirement { name: "c".to_string(), depends_on: Vec::new(), crew: Vec::new() },
+            flotilla_resources::VesselRequirement {
+                name: "a".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
+            flotilla_resources::VesselRequirement {
+                name: "b".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
+            flotilla_resources::VesselRequirement {
+                name: "c".to_string(),
+                stance: Default::default(),
+                depends_on: Vec::new(),
+                crew: Vec::new(),
+            },
         ],
     });
     status.work =

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -8,12 +8,10 @@ use common::{
     workflow_template_meta,
 };
 use flotilla_resources::{
-    canonicalize_repo_url,
     controller::{Actuation, Reconciler},
-    controller_patches, reconcile, repo_key, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, CrewSource,
-    CrewWorkPhase, InMemoryBackend, InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ResourceBackend,
-    ValidationError, Vessel, VesselPhase, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkflowTemplate, CONVOY_LABEL,
-    VESSEL_LABEL,
+    controller_patches, reconcile, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, CrewSource, CrewWorkPhase,
+    InMemoryBackend, InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ResourceBackend, ValidationError, Vessel,
+    VesselPhase, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
 };
 
 async fn reconcile_once_with_resources(
@@ -78,13 +76,14 @@ async fn reconcile_once_with_resources(
 }
 
 fn vessel_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
-    let canonical_repo = canonicalize_repo_url("git@github.com:flotilla-org/flotilla.git").expect("repo url should canonicalize");
+    let repository_key =
+        flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository identity").key();
     InputMeta {
         name: name.to_string(),
         labels: [
             ("flotilla.work/convoy".to_string(), convoy_name.to_string()),
             ("flotilla.work/vessel".to_string(), task.to_string()),
-            ("flotilla.work/repo-key".to_string(), repo_key(&canonical_repo)),
+            ("flotilla.work/repo-key".to_string(), repository_key.to_string()),
         ]
         .into_iter()
         .collect(),
@@ -764,11 +763,11 @@ async fn ready_task_emits_vessel_creation_actuation() {
         .expect("task workspace actuation should be present")
     {
         Actuation::CreateVessel { meta, spec } => {
-            let canonical_repo = canonicalize_repo_url("git@github.com:flotilla-org/flotilla.git").expect("repo url should canonicalize");
+            let repository_key = convoy.spec.repository.as_ref().expect("repository association").repo_ref.to_string();
             assert_eq!(meta.name, "convoy-a-implement");
             assert_eq!(meta.labels.get("flotilla.work/convoy").map(String::as_str), Some("convoy-a"));
             assert_eq!(meta.labels.get("flotilla.work/vessel").map(String::as_str), Some("implement"));
-            assert_eq!(meta.labels.get("flotilla.work/repo-key").map(String::as_str), Some(repo_key(&canonical_repo).as_str()));
+            assert_eq!(meta.labels.get("flotilla.work/repo-key").map(String::as_str), Some(repository_key.as_str()));
             assert_eq!(meta.owner_references.len(), 1);
             assert_eq!(meta.owner_references[0].kind, "Convoy");
             assert_eq!(meta.owner_references[0].name, "convoy-a");

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -16,6 +16,7 @@ fn sample_snapshot() -> WorkflowSnapshot {
         vessels: vec![
             VesselRequirement {
                 name: "implement".to_string(),
+                stance: Default::default(),
                 depends_on: Vec::new(),
                 crew: vec![
                     CrewSpec {
@@ -35,6 +36,7 @@ fn sample_snapshot() -> WorkflowSnapshot {
             },
             VesselRequirement {
                 name: "review".to_string(),
+                stance: Default::default(),
                 depends_on: vec!["implement".to_string()],
                 crew: vec![CrewSpec {
                     role: "reviewer".to_string(),

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -113,6 +113,7 @@ async fn environment_and_checkout_specs_serialize_through_in_memory_backend() {
         }),
     };
     let checkout_spec = CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+        repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
         env_ref: "env-a".to_string(),
         r#ref: "feat/convoy-resource".to_string(),
         target_path: "/workspace".to_string(),

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -81,6 +81,8 @@ async fn vessel_metadata_and_status_roundtrip() {
             terminal_session_refs: vec!["term-a".to_string()],
             started_at: Some(Utc::now()),
             ready_at: Some(Utc::now()),
+            requested_stance: Some(flotilla_resources::Stance::WorkspaceWrite),
+            effective_stance: Some(flotilla_resources::Stance::Contained),
         })
         .await
         .expect("status update should succeed");

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -2,7 +2,7 @@ use chrono::{TimeZone, Utc};
 use flotilla_resources::{
     CheckoutPhase, CheckoutStatus, CheckoutStatusPatch, ClonePhase, CloneStatus, CloneStatusPatch, EnvironmentPhase, EnvironmentStatus,
     EnvironmentStatusPatch, HostStatus, HostStatusPatch, InnerCommandStatus, PresentationPhase, PresentationStatus,
-    PresentationStatusPatch, StatusPatch, TerminalSessionPhase, TerminalSessionStatus, TerminalSessionStatusPatch, VesselPhase,
+    PresentationStatusPatch, Stance, StatusPatch, TerminalSessionPhase, TerminalSessionStatus, TerminalSessionStatusPatch, VesselPhase,
     VesselStatus, VesselStatusPatch,
 };
 
@@ -157,6 +157,8 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
         environment_ref: Some("env-a".to_string()),
         checkout_ref: Some("checkout-a".to_string()),
         terminal_session_refs: vec!["term-a".to_string(), "term-b".to_string()],
+        requested_stance: Stance::WorkspaceWrite,
+        effective_stance: Stance::Contained,
         ready_at,
     }
     .apply(&mut status);
@@ -167,10 +169,14 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
         environment_ref: Some("env-a".to_string()),
         checkout_ref: Some("checkout-a".to_string()),
         terminal_session_refs: vec!["term-a".to_string(), "term-b".to_string()],
+        requested_stance: Stance::WorkspaceWrite,
+        effective_stance: Stance::Contained,
         ready_at: Utc.timestamp_opt(21, 0).single().expect("timestamp"),
     }
     .apply(&mut status);
     assert_eq!(status.ready_at, Some(ready_at), "reconcile must not restamp an established Ready transition");
+    assert_eq!(status.requested_stance, Some(Stance::WorkspaceWrite));
+    assert_eq!(status.effective_stance, Some(Stance::Contained));
 
     VesselStatusPatch::MarkFailed { message: "clone failed".to_string() }.apply(&mut status);
     assert_eq!(status.phase, VesselPhase::Failed);

--- a/crates/flotilla-resources/tests/repository_in_memory.rs
+++ b/crates/flotilla-resources/tests/repository_in_memory.rs
@@ -24,7 +24,18 @@ fn remote_less_worktrees_converge_on_host_and_git_common_directory() {
     let second = RepositorySpec::local("host-01", "/srv/repos/flotilla/.git").expect("local identity");
 
     assert_eq!(first.key(), second.key());
-    assert!(matches!(first.identity, RepositoryIdentity::Local { .. }));
+    assert!(matches!(first.identity(), RepositoryIdentity::Local { .. }));
+}
+
+#[test]
+fn repository_declarations_reject_unresolved_aliases_and_inconsistent_forges() {
+    assert!(RepositorySpec::remote("work-github:flotilla-org/flotilla.git").is_err());
+
+    let inconsistent = serde_json::json!({
+        "identity": { "kind": "remote", "canonical_remote": "https://github.com/flotilla-org/flotilla" },
+        "forge": { "service_url": "https://gitlab.com", "repository": "other/repo" }
+    });
+    assert!(serde_json::from_value::<RepositorySpec>(inconsistent).is_err());
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/repository_in_memory.rs
+++ b/crates/flotilla-resources/tests/repository_in_memory.rs
@@ -1,21 +1,32 @@
 use flotilla_resources::{
     normalize_project_spec, DefaultBranchObservation, DefaultBranchProvenance, InMemoryBackend, InputMeta, ProjectRepositorySpec,
-    ProjectSpec, Repository, RepositoryIdentity, RepositoryKey, RepositorySpec, ResourceBackend,
+    ProjectSpec, Repository, RepositoryIdentity, RepositoryKey, RepositorySpec, ResourceBackend, SqliteBackend,
 };
 
 #[tokio::test]
-async fn repository_roundtrips_and_verifies_its_derived_key() {
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    let repositories = backend.using::<Repository>("flotilla");
-    let spec = RepositorySpec::remote("git@GitHub.com:flotilla-org/flotilla.git").expect("remote should normalize");
-    let key = spec.key();
+async fn repository_roundtrips_and_is_immutable_in_local_backends() {
+    let backends = [
+        ResourceBackend::InMemory(InMemoryBackend::default()),
+        ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend should open")),
+    ];
+    for backend in backends {
+        let repositories = backend.using::<Repository>("flotilla");
+        let spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla.git").expect("remote should normalize");
+        let key = spec.key();
 
-    repositories.create(&InputMeta::builder().name(key.to_string()).build(), &spec).await.expect("repository should create");
-    let fetched = repositories.get(&key.to_string()).await.expect("repository should fetch");
+        repositories.create(&InputMeta::builder().name(key.to_string()).build(), &spec).await.expect("repository should create");
+        let fetched = repositories.get(&key.to_string()).await.expect("repository should fetch");
 
-    assert_eq!(fetched.spec, spec);
-    fetched.spec.verify_key(&key).expect("fetched identity should match key");
-    assert!(fetched.spec.verify_key(&RepositoryKey("wrong".to_string())).is_err());
+        assert_eq!(fetched.spec, spec);
+        fetched.spec.verify_key(&key).expect("fetched identity should match key");
+        assert!(fetched.spec.verify_key(&RepositoryKey("wrong".to_string())).is_err());
+
+        let replacement = RepositorySpec::remote("https://github.com/flotilla-org/other").expect("replacement spec");
+        let update = repositories
+            .update(&InputMeta::builder().name(key.to_string()).build(), &fetched.metadata.resource_version, &replacement)
+            .await;
+        assert!(update.expect_err("repository identity must be immutable").to_string().contains("immutable"));
+    }
 }
 
 #[test]
@@ -30,6 +41,7 @@ fn remote_less_worktrees_converge_on_host_and_git_common_directory() {
 #[test]
 fn repository_declarations_reject_unresolved_aliases_and_inconsistent_forges() {
     assert!(RepositorySpec::remote("work-github:flotilla-org/flotilla.git").is_err());
+    assert!(RepositorySpec::remote("git@github.com:flotilla-org/flotilla.git").is_err());
 
     let inconsistent = serde_json::json!({
         "identity": { "kind": "remote", "canonical_remote": "https://github.com/flotilla-org/flotilla" },

--- a/crates/flotilla-resources/tests/repository_in_memory.rs
+++ b/crates/flotilla-resources/tests/repository_in_memory.rs
@@ -1,0 +1,98 @@
+use flotilla_resources::{
+    normalize_project_spec, DefaultBranchObservation, DefaultBranchProvenance, InMemoryBackend, InputMeta, ProjectRepositorySpec,
+    ProjectSpec, Repository, RepositoryIdentity, RepositoryKey, RepositorySpec, ResourceBackend,
+};
+
+#[tokio::test]
+async fn repository_roundtrips_and_verifies_its_derived_key() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let repositories = backend.using::<Repository>("flotilla");
+    let spec = RepositorySpec::remote("git@GitHub.com:flotilla-org/flotilla.git").expect("remote should normalize");
+    let key = spec.key();
+
+    repositories.create(&InputMeta::builder().name(key.to_string()).build(), &spec).await.expect("repository should create");
+    let fetched = repositories.get(&key.to_string()).await.expect("repository should fetch");
+
+    assert_eq!(fetched.spec, spec);
+    fetched.spec.verify_key(&key).expect("fetched identity should match key");
+    assert!(fetched.spec.verify_key(&RepositoryKey("wrong".to_string())).is_err());
+}
+
+#[test]
+fn remote_less_worktrees_converge_on_host_and_git_common_directory() {
+    let first = RepositorySpec::local("host-01", "/srv/repos/flotilla/.git/./").expect("local identity");
+    let second = RepositorySpec::local("host-01", "/srv/repos/flotilla/.git").expect("local identity");
+
+    assert_eq!(first.key(), second.key());
+    assert!(matches!(first.identity, RepositoryIdentity::Local { .. }));
+}
+
+#[test]
+fn default_branch_resolution_preserves_provenance_and_authority_order() {
+    let observations = vec![
+        DefaultBranchObservation { branch: "trunk".to_string(), provenance: DefaultBranchProvenance::LocalTrunk },
+        DefaultBranchObservation { branch: "main".to_string(), provenance: DefaultBranchProvenance::RemoteSymbolicHead },
+        DefaultBranchObservation { branch: "stable".to_string(), provenance: DefaultBranchProvenance::Forge },
+    ];
+
+    let (resolved, diagnostics) = flotilla_resources::resolve_default_branch(&observations);
+
+    assert_eq!(resolved.as_deref(), Some("stable"));
+    assert!(!diagnostics.is_empty(), "disagreement should remain diagnostic");
+    assert_eq!(flotilla_resources::resolve_default_branch(&[]), (None, Vec::new()));
+}
+
+#[test]
+fn project_normalization_sorts_entries_omits_whole_repo_subpath_and_rejects_duplicates() {
+    let repo_a = RepositoryKey("a".to_string());
+    let repo_b = RepositoryKey("b".to_string());
+    let normalized = normalize_project_spec(ProjectSpec {
+        display_name: " Example ".to_string(),
+        default_workflow_ref: " single-agent-contained ".to_string(),
+        issue_source: None,
+        repositories: vec![
+            ProjectRepositorySpec { repo: repo_b.clone(), subpath: Some("./apps/api".to_string()), default_branch: None },
+            ProjectRepositorySpec { repo: repo_a.clone(), subpath: None, default_branch: None },
+        ],
+    })
+    .expect("project should normalize");
+
+    assert_eq!(normalized.display_name, "Example");
+    assert_eq!(normalized.default_workflow_ref, "single-agent-contained");
+    assert_eq!(normalized.repositories[0].repo, repo_a);
+    assert_eq!(normalized.repositories[0].subpath, None);
+    assert_eq!(normalized.repositories[1].subpath.as_deref(), Some("apps/api"));
+
+    let duplicate = ProjectSpec {
+        display_name: "Example".to_string(),
+        default_workflow_ref: "single-agent-contained".to_string(),
+        issue_source: None,
+        repositories: vec![ProjectRepositorySpec { repo: repo_b.clone(), subpath: None, default_branch: None }, ProjectRepositorySpec {
+            repo: repo_b,
+            subpath: None,
+            default_branch: None,
+        }],
+    };
+    assert!(normalize_project_spec(duplicate).expect_err("duplicates should fail").contains("duplicate"));
+
+    let serialized = serde_json::to_value(&normalized).expect("project should serialize");
+    assert!(serialized["repositories"][0].get("subpath").is_none(), "whole-repo subpath should be omitted");
+    assert!(serialized["repositories"][0].get("default_branch").is_none(), "inherited default branch should be omitted");
+}
+
+#[test]
+fn project_subpaths_reject_absolute_and_parent_traversal() {
+    for subpath in ["/tmp/app", "apps/../../secret", "."] {
+        let spec = ProjectSpec {
+            display_name: "Example".to_string(),
+            default_workflow_ref: "single-agent-contained".to_string(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec {
+                repo: RepositoryKey("repo".to_string()),
+                subpath: Some(subpath.to_string()),
+                default_branch: None,
+            }],
+        };
+        assert!(normalize_project_spec(spec).is_err(), "{subpath} should be rejected");
+    }
+}

--- a/crates/flotilla-resources/tests/resource_projection.rs
+++ b/crates/flotilla-resources/tests/resource_projection.rs
@@ -106,6 +106,7 @@ fn checkout_spec_worktree_variant_roundtrips_through_k8s_projection() {
     let object = ResourceObject::<Checkout> {
         metadata: common::object_meta("checkout-a", "flotilla", "3"),
         spec: CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+            repo_ref: flotilla_resources::RepositoryKey("project-flotilla".to_string()),
             env_ref: "env-a".to_string(),
             r#ref: "feature-a".to_string(),
             target_path: "/worktrees/feature-a".to_string(),
@@ -132,7 +133,8 @@ fn checkout_spec_observed_variant_carries_only_observed_facts() {
         spec: CheckoutSpec::Observed(ObservedCheckoutSpec {
             r#ref: "main".to_string(),
             path: "/Users/dev/flotilla".to_string(),
-            repo_ref: "project-flotilla".to_string(),
+            repo_ref: flotilla_resources::RepositoryKey("project-flotilla".to_string()),
+            host_ref: "host-01".to_string(),
             is_main: true,
         }),
         status: None,

--- a/crates/flotilla-resources/tests/workflow_template_validation.rs
+++ b/crates/flotilla-resources/tests/workflow_template_validation.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::{valid_workflow_template_spec, valid_workflow_template_yaml};
-use flotilla_resources::{validate, InterpolationField, InterpolationLocation, ValidationError, WorkflowTemplateSpec};
+use flotilla_resources::{validate, InterpolationField, InterpolationLocation, Stance, ValidationError, WorkflowTemplateSpec};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -243,4 +243,31 @@ fn parser_round_trip_preserves_sample_workflow() {
     let second: WorkflowTemplateSpec = serde_yml::from_str(&encoded).expect("re-parse workflow template spec");
 
     assert_eq!(second, first.spec);
+}
+
+#[test]
+fn parser_round_trip_preserves_all_stances() {
+    let yaml = r#"
+vessels:
+  - name: trusted
+    stance: trusted
+    crew: []
+  - name: workspace
+    stance: workspace-write
+    crew: []
+  - name: contained
+    stance: contained
+    crew: []
+"#;
+    let first = parse_spec(yaml);
+    assert_eq!(first.vessels.iter().map(|vessel| vessel.stance).collect::<Vec<_>>(), vec![
+        Stance::Trusted,
+        Stance::WorkspaceWrite,
+        Stance::Contained,
+    ]);
+
+    let encoded = serde_yml::to_string(&first).expect("serialize stances");
+    let second = parse_spec(&encoded);
+    assert_eq!(second, first);
+    assert!(validate(&second).is_ok());
 }

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -151,7 +151,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
             info!(%name, "workflow template applied");
             app.model.status_message = Some(format!("Workflow template applied: {name}"));
         }
-        CommandValue::ProjectCreated { name } => {
+        CommandValue::ProjectAdded { name } => {
             info!(%name, "project created");
             app.model.status_message = Some(format!("Project created: {name}"));
         }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1570,7 +1570,12 @@ fn wire_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_proto
             let crew = vessel
                 .crew
                 .into_iter()
-                .map(|process| CrewMemberSummary { role: process.role, command_preview: process.command_preview })
+                .map(|process| CrewMemberSummary {
+                    role: process.role,
+                    command_preview: process.command_preview,
+                    requested_stance: None,
+                    effective_stance: None,
+                })
                 .collect();
             VesselRow::builder()
                 .resource(resource.subresource(format!("vessels/{}", vessel.name)))

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -386,7 +386,7 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::IssuesByIds { items } => format!("issues by ids: {} items", items.len()),
         CommandValue::ConvoyCreated { name } => format!("convoy created: {name}"),
         CommandValue::WorkflowTemplateApplied { name } => format!("workflow template applied: {name}"),
-        CommandValue::ProjectCreated { name } => format!("project created: {name}"),
+        CommandValue::ProjectAdded { name } => format!("project added: {name}"),
         CommandValue::ProjectApplied { name } => format!("project applied: {name}"),
     }
 }

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -178,7 +178,9 @@ async fn x_then_enter_completes_work_via_palette() {
         message: None,
         placement: None,
     });
-    let snapshot = WorkflowSnapshot { vessels: vec![VesselRequirement { name: "implement".into(), depends_on: vec![], crew: vec![] }] };
+    let snapshot = WorkflowSnapshot {
+        vessels: vec![VesselRequirement { name: "implement".into(), stance: Default::default(), depends_on: vec![], crew: vec![] }],
+    };
     apply_status_patch(
         &convoys,
         "fix-bug-123",

--- a/docs/adr/0010-crew-provisioning.md
+++ b/docs/adr/0010-crew-provisioning.md
@@ -84,6 +84,11 @@ the resolver gets smarter.
   fanning over docker and host-direct keeps one effective permission stance
   or fails visibly. Over-confinement is permitted and **recorded**: effective
   stance lands on vessel/crew status for `ls`/panels.
+- **Names do not confer confinement**: no WorkflowTemplate may be described or
+  seeded as `contained` until placement actually enforces that floor and fails
+  under-realization. The stock single-agent contained workflow is an ordinary
+  create-if-absent WorkflowTemplate once that enforcement exists, not a second
+  hard-coded workflow mechanism.
 - **Non-lock-in note:** the walls confine the *task execution environment*
   (actuator). Where the *agent loop pump* (turn generator) runs is
   deliberately unconstrained — today's harnesses conflate the two, but

--- a/docs/adr/0014-curated-scoped-queries-demand-backed-materialization.md
+++ b/docs/adr/0014-curated-scoped-queries-demand-backed-materialization.md
@@ -44,7 +44,11 @@ the parameters are **scope**: a project reference or repo key. A project
 scope expands to its constituent repos inside the Aggregator — consumers
 never learn a project's composition. Scope rides the View address per ADR
 0013's `?key=value` channel. Global (unscoped) forms remain for fleet-wide
-tables. Subscription cost scales with what is on screen.
+tables. Subscription cost scales with what is on screen. For issue queries,
+a Project-level **Issue Source** override supplies one unified feed; without
+one, Project scope expands to each constituent Repository's Forge-backed issue
+source. The absence of a configured source is surfaced as unavailable, never
+as an ordinary empty issue set.
 
 ## Two materialization classes, one wire contract
 
@@ -74,14 +78,17 @@ not these adapters.
 
 ## Issues are never replicated
 
-The forge is the system of record. Flotilla holds exactly two forms of issue
-data: **references-on-work** — a repo key + issue number on a convoy/branch
-plus a small display snapshot (title, state, `as_of`) so boards render
-offline, bounded by active work — and the transient demand-backed windows
-above. Triage/board intelligence ("what should I or the governor pick up
-next") is add-on-program territory consuming these queries, never core
-features. Growing issue mutation/comment/label features in core is the
-reimplementing-the-tracker failure mode this section exists to forbid.
+The Forge or Project Issue Source is the system of record. Flotilla holds
+exactly two forms of issue data: **references-on-work** — a source-qualified,
+opaque external ID associated with the relevant repo key, plus a small display
+snapshot (title, state, `as_of`) so boards render offline, bounded by active
+work — and the transient demand-backed windows above. GitHub's `728` and
+Linear's `WIDGET-123` are both opaque IDs; no model assumes issues are numeric
+or that the Forge must supply them. Triage/board intelligence ("what should I
+or the governor pick up next") is add-on-program territory consuming these
+queries, never core features. Growing issue mutation/comment/label features in
+core is the reimplementing-the-tracker failure mode this section exists to
+forbid.
 
 ## `independents`, not `sessions`
 
@@ -97,12 +104,27 @@ in `independents`, never both.
 
 Scopes are made of repo identity, so repo identity becomes a real referent:
 **Repository is a resource** (convergent-facts class per the #688 model),
-natural-keyed by normalized canonical remote, with `host:path` fallback for
-remote-less repos. Remotes move as ordinary project lifecycle (transfers,
-renames, forge migrations), so the model commits to **`moved` pointers
-(old key → new key) and referent repair**; no referent shape anywhere may
-assume repo keys are immortal. The repair mechanism is built when first
-needed; the commitment is binding now.
+natural-keyed by normalized canonical remote. Remote-less repos use the stable
+Host identity plus normalized Git common directory, so worktrees of one local
+repo do not mint separate identities. Machine-local SSH aliases are resolved
+through host configuration; an alias that cannot be resolved is an
+"unrecognised remote", never a globally meaningful repo key.
+
+Repository remains genuinely convergent: its declaration holds immutable
+canonical identity and derived Forge identity; its status is a provenance-
+carrying union of default-branch observations and references to all associated
+Checkout resources, grouped by Host. Mutable human choices do not masquerade
+as convergent facts: branch overrides and the optional single Issue Source
+belong to the definitions-class Project. Repository persists with empty status
+when no checkout exists, including cloud-only Projects between ephemeral
+clones.
+
+Storage-safe typed Repository keys derive from the canonical identity, and
+every lookup verifies the referent. Remotes nevertheless move as ordinary
+project lifecycle (transfers, renames, forge migrations), so the model commits
+to **`moved` pointers (old key → new key) and referent repair**; no referent
+shape anywhere may assume repo keys are immortal. The repair mechanism is
+built when first needed; the commitment is binding now.
 
 ## Consequences
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1234,7 +1234,7 @@ mod tests {
 
     #[test]
     fn cli_parses_project_noun() {
-        let cli = Cli::try_parse_from(["flotilla", "project", "my-project", "create", "--repo", "https://example.com/repo.git"])
+        let cli = Cli::try_parse_from(["flotilla", "project", "add", "https://example.com/repo.git", "--name", "my-project"])
             .expect("project cli should parse");
         assert!(matches!(cli.command, Some(SubCommand::Project(_))));
     }


### PR DESCRIPTION
## Summary

- introduce immutable Repository resources with typed, portable repository keys
- resolve SSH aliases through the shared repository inspector before identities are minted
- project observed, adopted, worktree, fresh-clone, and clone state through typed repository associations
- add normalized multi-repository Project resources plus `flotilla project add` and `project apply`
- project default branches with Forge, remote HEAD, and local-trunk provenance
- enforce vessel stance requirements and seed the stock single-agent-contained workflow

## Why

Flotilla previously treated a tracked checkout and its raw transport URL as the repository identity. That breaks down for SSH aliases, remote-less repositories, ephemeral cloud checkouts, and projects that span or reference repositories independently of persistent local paths.

This establishes Repository as the stable identity boundary and makes the initial Project shape deliberately degenerate: a whole-repository project with one issue source and one default workflow, while retaining typed multi-repository storage for later use.

## Impact

Users can add projects from a checkout path or repository catalog slug, apply complete YAML project definitions, and create convoys whose repository associations remain portable across hosts. Existing compatibility syntax for project creation is intentionally not retained.

Repository specs are immutable across Kubernetes, SQLite, and in-memory storage. Generic storage may hold unresolved project references, while convoy admission rejects them until the referenced repositories and workflow exist.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- parallel Standards and Spec reviews completed with no hard violations or remaining #728 gaps

Implements #728.
Includes prerequisite #737.