### PR TITLE
Codify lifecycle timestamp semantics

### DIFF
--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -286,7 +286,11 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                 }
             }
             Self::FailConvoy { cancelled_work, finished_at, message } => {
+                let previous_phase = status.phase;
                 status.phase = ConvoyPhase::Failed;
+                if previous_phase != ConvoyPhase::Failed {
+                    status.finished_at = None;
+                }
                 status.finished_at.get_or_insert(*finished_at);
                 status.message = message.clone();
                 for (work, cancelled_at) in cancelled_work {
@@ -298,6 +302,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
             }
             Self::RollUpPhase { phase, started_at, finished_at } => {
                 // Derived Active roll-up is a continuation of the convoy voyage, not a new attempt.
+                let previous_phase = status.phase;
                 status.phase = *phase;
                 if *phase == ConvoyPhase::Active {
                     status.finished_at = None;
@@ -306,6 +311,10 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                     status.started_at.get_or_insert(*started_at);
                 }
                 if let Some(finished_at) = finished_at {
+                    // A changed terminal outcome settles at its own transition time.
+                    if previous_phase != *phase {
+                        status.finished_at = None;
+                    }
                     status.finished_at.get_or_insert(*finished_at);
                 }
             }

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -297,6 +297,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                 }
             }
             Self::RollUpPhase { phase, started_at, finished_at } => {
+                // Derived Active roll-up is a continuation of the convoy voyage, not a new attempt.
                 status.phase = *phase;
                 if *phase == ConvoyPhase::Active {
                     status.finished_at = None;
@@ -350,6 +351,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
             }
             Self::MarkCrewCompleted { vessel, role, finished_at, message } => {
                 if let Some(state) = status.crew_work.get_mut(vessel).and_then(|crew| crew.get_mut(role)) {
+                    // Duplicate settlement is sticky; changing the settled outcome records its own time.
                     if state.phase != CrewWorkPhase::Done {
                         state.finished_at = None;
                     }
@@ -363,6 +365,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                     work.completion_authority = WorkCompletionAuthority::CrewRollup;
                 }
                 if let Some(state) = status.crew_work.get_mut(vessel).and_then(|crew| crew.get_mut(role)) {
+                    // Duplicate settlement is sticky; changing the settled outcome records its own time.
                     if state.phase != CrewWorkPhase::Failed {
                         state.finished_at = None;
                     }
@@ -381,6 +384,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                 let target_was_done = crew.get(target_role).is_some_and(|state| state.phase == CrewWorkPhase::Done);
                 if let Some(target) = crew.get_mut(target_role) {
                     if matches!(target.phase, CrewWorkPhase::Pending | CrewWorkPhase::Done | CrewWorkPhase::HandedBack) {
+                        // Hand-back continues the same crew process, preserving its original start.
                         target.phase = CrewWorkPhase::Working;
                         target.started_at.get_or_insert(*handed_off_at);
                         target.finished_at = None;
@@ -397,12 +401,17 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
             }
             Self::RollUpWork { work, phase, transitioned_at, message } => {
                 if let Some(state) = status.work.get_mut(work) {
+                    // Work roll-up reports the same process across continuation and re-settlement.
+                    let previous_phase = state.phase;
                     state.phase = *phase;
                     state.completion_authority = WorkCompletionAuthority::CrewRollup;
                     state.message = message.clone();
                     match phase {
                         WorkPhase::Complete | WorkPhase::Failed | WorkPhase::Cancelled => {
-                            state.finished_at = Some(*transitioned_at);
+                            if previous_phase != *phase {
+                                state.finished_at = None;
+                            }
+                            state.finished_at.get_or_insert(*transitioned_at);
                         }
                         WorkPhase::Pending | WorkPhase::Ready | WorkPhase::Launching | WorkPhase::Running => {
                             state.finished_at = None;

--- a/crates/flotilla-resources/src/presentation.rs
+++ b/crates/flotilla-resources/src/presentation.rs
@@ -43,9 +43,19 @@ pub struct PresentationStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PresentationStatusPatch {
-    MarkActive { presentation_manager: String, workspace_ref: String, spec_hash: String, ready_at: DateTime<Utc> },
-    MarkTornDown { message: Option<String> },
-    MarkFailed { message: String },
+    /// Duplicate-safe while already active; from another phase this records a new realization attempt.
+    MarkActive {
+        presentation_manager: String,
+        workspace_ref: String,
+        spec_hash: String,
+        ready_at: DateTime<Utc>,
+    },
+    MarkTornDown {
+        message: Option<String>,
+    },
+    MarkFailed {
+        message: String,
+    },
 }
 
 impl StatusPatch<PresentationStatus> for PresentationStatusPatch {

--- a/crates/flotilla-resources/src/status_patch.rs
+++ b/crates/flotilla-resources/src/status_patch.rs
@@ -8,6 +8,22 @@ use crate::{
 
 const MAX_RETRIES: usize = 3;
 
+/// Applies a semantic status transition to a resource.
+///
+/// # Lifecycle timestamps
+///
+/// Status patches that mutate lifecycle timestamps must classify each legal transition and follow
+/// the corresponding contract:
+///
+/// - A duplicate application of the same transition is a semantic no-op. An established timestamp
+///   is kept even if a later reconciliation supplies a newer wall-clock value.
+/// - A continuation makes a settled process active again. It preserves the original start timestamp
+///   and clears the finish timestamp; settling again records a new finish timestamp.
+/// - A new attempt is an explicit transition distinct from continuation. It replaces attempt-scoped
+///   timestamps by clearing the old finish timestamp and recording the new attempt's start.
+///
+/// A resource's lifetime remains represented by its metadata creation timestamp. Attempt history,
+/// if needed, belongs in events or conditions rather than additional status timestamp fields.
 pub trait StatusPatch<S>: Send + Sync {
     fn apply(&self, status: &mut S);
 }

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -170,6 +170,8 @@ pub struct CrewSessionStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TerminalSessionStatusPatch {
+    /// Starts a new attempt after a stopped session by clearing the previous attempt's status.
+    /// Failed-session retry is not currently a legal controller transition.
     MarkStarting,
     MarkRunning {
         session_id: String,

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -6,8 +6,9 @@ use std::{
 use chrono::{DateTime, TimeZone, Utc};
 use flotilla_resources::{
     ConvoyPhase, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InnerCommandStatus, PlacementStatus, PresentationPhase,
-    PresentationStatus, PresentationStatusPatch, StatusPatch, TerminalSessionPhase, TerminalSessionStatus, TerminalSessionStatusPatch,
-    VesselPhase, VesselStatus, VesselStatusPatch, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    PresentationStatus, PresentationStatusPatch, Stance, StatusPatch, TerminalSessionPhase, TerminalSessionStatus,
+    TerminalSessionStatusPatch, VesselPhase, VesselStatus, VesselStatusPatch, WorkCompletionAuthority, WorkPhase, WorkState,
+    WorkflowSnapshot,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -575,6 +576,8 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                     environment_ref: Some("env-a".to_string()),
                     checkout_ref: Some("checkout-a".to_string()),
                     terminal_session_refs: Vec::new(),
+                    requested_stance: Stance::WorkspaceWrite,
+                    effective_stance: Stance::Contained,
                     ready_at: ts(30),
                 };
                 apply_and_replay(&mut status, &patch);

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -1,0 +1,801 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
+
+use chrono::{DateTime, TimeZone, Utc};
+use flotilla_resources::{
+    ConvoyPhase, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InnerCommandStatus, PlacementStatus, PresentationPhase,
+    PresentationStatus, PresentationStatusPatch, StatusPatch, TerminalSessionPhase, TerminalSessionStatus, TerminalSessionStatusPatch,
+    VesselPhase, VesselStatus, VesselStatusPatch, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LifecycleClass {
+    Duplicate,
+    Continuation,
+    NewAttempt,
+    Resettlement,
+}
+
+const NONE: &[LifecycleClass] = &[];
+const DUPLICATE: &[LifecycleClass] = &[LifecycleClass::Duplicate];
+const CONTINUATION: &[LifecycleClass] = &[LifecycleClass::Continuation];
+const NEW_ATTEMPT: &[LifecycleClass] = &[LifecycleClass::NewAttempt];
+const DUPLICATE_NEW_ATTEMPT: &[LifecycleClass] = &[LifecycleClass::Duplicate, LifecycleClass::NewAttempt];
+const DUPLICATE_CONTINUATION: &[LifecycleClass] = &[LifecycleClass::Duplicate, LifecycleClass::Continuation];
+const DUPLICATE_RESETTLEMENT: &[LifecycleClass] = &[LifecycleClass::Duplicate, LifecycleClass::Resettlement];
+const DUPLICATE_CONTINUATION_RESETTLEMENT: &[LifecycleClass] =
+    &[LifecycleClass::Duplicate, LifecycleClass::Continuation, LifecycleClass::Resettlement];
+
+macro_rules! define_patch_kinds {
+    ($($kind:ident => $classes:expr),+ $(,)?) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        enum PatchKind {
+            $($kind),+
+        }
+
+        const ALL_PATCH_KINDS: &[PatchKind] = &[$(PatchKind::$kind),+];
+
+        impl PatchKind {
+            fn classes(self) -> &'static [LifecycleClass] {
+                match self {
+                    $(Self::$kind => $classes),+
+                }
+            }
+        }
+    };
+}
+
+define_patch_kinds! {
+    ConvoyBootstrap => DUPLICATE,
+    ConvoyBackfillCrewWork => NONE,
+    ConvoyFailInit => DUPLICATE,
+    ConvoyAdvanceWorkToReady => DUPLICATE,
+    ConvoyFail => DUPLICATE,
+    ConvoyRollUpPhase => DUPLICATE_CONTINUATION,
+    ConvoyWorkLaunching => DUPLICATE,
+    ConvoyWorkRunning => DUPLICATE,
+    ConvoyForceWorkCompleted => DUPLICATE,
+    ConvoyMarkWorkFailed => DUPLICATE,
+    ConvoyMarkWorkCancelled => DUPLICATE,
+    ConvoyMarkCrewCompleted => DUPLICATE_RESETTLEMENT,
+    ConvoyMarkCrewFailed => DUPLICATE_RESETTLEMENT,
+    ConvoyHandoffCrewWork => CONTINUATION,
+    ConvoyRollUpWork => DUPLICATE_CONTINUATION_RESETTLEMENT,
+    TerminalMarkStarting => NEW_ATTEMPT,
+    TerminalMarkRunning => DUPLICATE,
+    TerminalMarkMessageDelivered => NONE,
+    TerminalMarkStopped => DUPLICATE,
+    TerminalMarkFailed => DUPLICATE,
+    VesselMarkProvisioning => DUPLICATE,
+    VesselMarkReady => DUPLICATE,
+    VesselMarkTearingDown => NONE,
+    VesselMarkFailed => NONE,
+    PresentationMarkActive => DUPLICATE_NEW_ATTEMPT,
+    PresentationMarkTornDown => NONE,
+    PresentationMarkFailed => NONE,
+}
+
+fn convoy_patch_kind(patch: &ConvoyStatusPatch) -> PatchKind {
+    match patch {
+        ConvoyStatusPatch::Bootstrap { .. } => PatchKind::ConvoyBootstrap,
+        ConvoyStatusPatch::BackfillCrewWork { .. } => PatchKind::ConvoyBackfillCrewWork,
+        ConvoyStatusPatch::FailInit { .. } => PatchKind::ConvoyFailInit,
+        ConvoyStatusPatch::AdvanceWorkToReady { .. } => PatchKind::ConvoyAdvanceWorkToReady,
+        ConvoyStatusPatch::FailConvoy { .. } => PatchKind::ConvoyFail,
+        ConvoyStatusPatch::RollUpPhase { .. } => PatchKind::ConvoyRollUpPhase,
+        ConvoyStatusPatch::WorkLaunching { .. } => PatchKind::ConvoyWorkLaunching,
+        ConvoyStatusPatch::WorkRunning { .. } => PatchKind::ConvoyWorkRunning,
+        ConvoyStatusPatch::ForceWorkCompleted { .. } => PatchKind::ConvoyForceWorkCompleted,
+        ConvoyStatusPatch::MarkWorkFailed { .. } => PatchKind::ConvoyMarkWorkFailed,
+        ConvoyStatusPatch::MarkWorkCancelled { .. } => PatchKind::ConvoyMarkWorkCancelled,
+        ConvoyStatusPatch::MarkCrewCompleted { .. } => PatchKind::ConvoyMarkCrewCompleted,
+        ConvoyStatusPatch::MarkCrewFailed { .. } => PatchKind::ConvoyMarkCrewFailed,
+        ConvoyStatusPatch::HandoffCrewWork { .. } => PatchKind::ConvoyHandoffCrewWork,
+        ConvoyStatusPatch::RollUpWork { .. } => PatchKind::ConvoyRollUpWork,
+    }
+}
+
+fn terminal_session_patch_kind(patch: &TerminalSessionStatusPatch) -> PatchKind {
+    match patch {
+        TerminalSessionStatusPatch::MarkStarting => PatchKind::TerminalMarkStarting,
+        TerminalSessionStatusPatch::MarkRunning { .. } => PatchKind::TerminalMarkRunning,
+        TerminalSessionStatusPatch::MarkMessageDelivered { .. } => PatchKind::TerminalMarkMessageDelivered,
+        TerminalSessionStatusPatch::MarkStopped { .. } => PatchKind::TerminalMarkStopped,
+        TerminalSessionStatusPatch::MarkFailed { .. } => PatchKind::TerminalMarkFailed,
+    }
+}
+
+fn vessel_patch_kind(patch: &VesselStatusPatch) -> PatchKind {
+    match patch {
+        VesselStatusPatch::MarkProvisioning { .. } => PatchKind::VesselMarkProvisioning,
+        VesselStatusPatch::MarkReady { .. } => PatchKind::VesselMarkReady,
+        VesselStatusPatch::MarkTearingDown => PatchKind::VesselMarkTearingDown,
+        VesselStatusPatch::MarkFailed { .. } => PatchKind::VesselMarkFailed,
+    }
+}
+
+fn presentation_patch_kind(patch: &PresentationStatusPatch) -> PatchKind {
+    match patch {
+        PresentationStatusPatch::MarkActive { .. } => PatchKind::PresentationMarkActive,
+        PresentationStatusPatch::MarkTornDown { .. } => PatchKind::PresentationMarkTornDown,
+        PresentationStatusPatch::MarkFailed { .. } => PatchKind::PresentationMarkFailed,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LifecycleTimestamps {
+    started_at: Option<DateTime<Utc>>,
+    finished_at: Option<DateTime<Utc>>,
+}
+
+struct LifecycleCase {
+    name: &'static str,
+    kind: PatchKind,
+    exercise: fn() -> (LifecycleTimestamps, LifecycleTimestamps),
+}
+
+fn assert_case_coverage(class: LifecycleClass, cases: &[LifecycleCase]) {
+    let expected = ALL_PATCH_KINDS.iter().copied().filter(|kind| kind.classes().contains(&class)).collect::<BTreeSet<_>>();
+    let actual = cases.iter().map(|case| case.kind).collect::<BTreeSet<_>>();
+    assert_eq!(actual, expected, "every {class:?} patch kind must have a behavioral contract case");
+}
+
+fn apply_and_replay<S, P>(status: &mut S, patch: &P)
+where
+    S: Clone + Debug + PartialEq,
+    P: StatusPatch<S>,
+{
+    patch.apply(status);
+    let after_first_application = status.clone();
+    patch.apply(status);
+    assert_eq!(*status, after_first_application, "replaying the exact patch must be a semantic no-op");
+}
+
+fn ts(seconds: i64) -> DateTime<Utc> {
+    Utc.timestamp_opt(seconds, 0).single().expect("valid timestamp")
+}
+
+fn work_state(phase: WorkPhase, started_at: Option<DateTime<Utc>>, finished_at: Option<DateTime<Utc>>) -> WorkState {
+    WorkState {
+        phase,
+        completion_authority: WorkCompletionAuthority::CrewRollup,
+        ready_at: Some(ts(5)),
+        started_at,
+        finished_at,
+        message: None,
+        placement: None,
+    }
+}
+
+fn crew_state(phase: CrewWorkPhase, started_at: Option<DateTime<Utc>>, finished_at: Option<DateTime<Utc>>) -> CrewWorkState {
+    CrewWorkState { phase, started_at, finished_at, message: None }
+}
+
+fn active_convoy_status() -> ConvoyStatus {
+    ConvoyStatus {
+        phase: ConvoyPhase::Active,
+        workflow_snapshot: None,
+        work: BTreeMap::from([("implement".to_string(), work_state(WorkPhase::Running, Some(ts(10)), None))]),
+        crew_work: BTreeMap::from([(
+            "implement".to_string(),
+            BTreeMap::from([("coder".to_string(), crew_state(CrewWorkPhase::Working, Some(ts(10)), None))]),
+        )]),
+        message: None,
+        started_at: Some(ts(10)),
+        finished_at: None,
+        observed_workflow_ref: None,
+        observed_workflows: None,
+    }
+}
+
+fn settled_convoy_status() -> ConvoyStatus {
+    let mut status = active_convoy_status();
+    status.phase = ConvoyPhase::Completed;
+    status.finished_at = Some(ts(20));
+    status.work.insert("implement".to_string(), work_state(WorkPhase::Complete, Some(ts(10)), Some(ts(20))));
+    status.crew_work.insert(
+        "implement".to_string(),
+        BTreeMap::from([("coder".to_string(), crew_state(CrewWorkPhase::Done, Some(ts(10)), Some(ts(20))))]),
+    );
+    status
+}
+
+fn convoy_timestamps(status: &ConvoyStatus) -> LifecycleTimestamps {
+    LifecycleTimestamps { started_at: status.started_at, finished_at: status.finished_at }
+}
+
+fn work_timestamps(status: &ConvoyStatus) -> LifecycleTimestamps {
+    let work = status.work.get("implement").expect("implement work");
+    LifecycleTimestamps { started_at: work.started_at, finished_at: work.finished_at }
+}
+
+fn crew_timestamps(status: &ConvoyStatus) -> LifecycleTimestamps {
+    let crew = status.crew_work.get("implement").and_then(|crew| crew.get("coder")).expect("coder work");
+    LifecycleTimestamps { started_at: crew.started_at, finished_at: crew.finished_at }
+}
+
+#[test]
+fn patch_variants_exhaustively_declare_their_lifecycle_classes() {
+    // The exhaustive matches above make a newly-added patch variant fail to compile until its
+    // duplicate, continuation, new-attempt, and re-settlement semantics are declared here.
+    assert_eq!(
+        convoy_patch_kind(&ConvoyStatusPatch::HandoffCrewWork {
+            vessel: "implement".to_string(),
+            sender_role: "reviewer".to_string(),
+            target_role: "coder".to_string(),
+            handed_off_at: ts(30),
+            message: "address review".to_string(),
+        }),
+        PatchKind::ConvoyHandoffCrewWork
+    );
+    assert_eq!(terminal_session_patch_kind(&TerminalSessionStatusPatch::MarkStarting), PatchKind::TerminalMarkStarting);
+    assert_eq!(
+        vessel_patch_kind(&VesselStatusPatch::MarkProvisioning {
+            observed_policy_ref: "docker".to_string(),
+            observed_policy_version: "2".to_string(),
+            started_at: ts(30),
+        }),
+        PatchKind::VesselMarkProvisioning
+    );
+    assert_eq!(
+        presentation_patch_kind(&PresentationStatusPatch::MarkActive {
+            presentation_manager: "tmux".to_string(),
+            workspace_ref: "workspace-a".to_string(),
+            spec_hash: "hash-a".to_string(),
+            ready_at: ts(30),
+        }),
+        PatchKind::PresentationMarkActive
+    );
+}
+
+#[test]
+fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
+    let cases = [
+        LifecycleCase {
+            name: "convoy bootstrap",
+            kind: PatchKind::ConvoyBootstrap,
+            exercise: || {
+                let mut status = active_convoy_status();
+                let before = convoy_timestamps(&status);
+                let patch = ConvoyStatusPatch::Bootstrap {
+                    workflow_snapshot: WorkflowSnapshot { vessels: Vec::new() },
+                    observed_workflow_ref: "workflow-a".to_string(),
+                    observed_workflows: BTreeMap::new(),
+                    work: status.work.clone(),
+                    crew_work: status.crew_work.clone(),
+                    phase: ConvoyPhase::Active,
+                    started_at: Some(ts(30)),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "convoy initialization failure",
+            kind: PatchKind::ConvoyFailInit,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                status.phase = ConvoyPhase::Failed;
+                let before = convoy_timestamps(&status);
+                let patch =
+                    ConvoyStatusPatch::FailInit { phase: ConvoyPhase::Failed, message: "still failed".to_string(), finished_at: ts(30) };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work ready",
+            kind: PatchKind::ConvoyAdvanceWorkToReady,
+            exercise: || {
+                let mut status = active_convoy_status();
+                let work = status.work.get_mut("implement").expect("implement work");
+                work.phase = WorkPhase::Ready;
+                work.ready_at = Some(ts(10));
+                let before = LifecycleTimestamps { started_at: work.ready_at, finished_at: work.finished_at };
+                let patch = ConvoyStatusPatch::AdvanceWorkToReady { ready: BTreeMap::from([("implement".to_string(), ts(30))]) };
+                apply_and_replay(&mut status, &patch);
+                let work = status.work.get("implement").expect("implement work");
+                let after = LifecycleTimestamps { started_at: work.ready_at, finished_at: work.finished_at };
+                (before, after)
+            },
+        },
+        LifecycleCase {
+            name: "convoy failure",
+            kind: PatchKind::ConvoyFail,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                status.phase = ConvoyPhase::Failed;
+                status.work.get_mut("implement").expect("implement work").phase = WorkPhase::Cancelled;
+                let before = convoy_timestamps(&status);
+                let patch = ConvoyStatusPatch::FailConvoy {
+                    cancelled_work: BTreeMap::from([("implement".to_string(), ts(30))]),
+                    finished_at: ts(30),
+                    message: Some("still failed".to_string()),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work cancellation during convoy failure",
+            kind: PatchKind::ConvoyFail,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                status.phase = ConvoyPhase::Failed;
+                status.work.get_mut("implement").expect("implement work").phase = WorkPhase::Cancelled;
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::FailConvoy {
+                    cancelled_work: BTreeMap::from([("implement".to_string(), ts(30))]),
+                    finished_at: ts(30),
+                    message: Some("still failed".to_string()),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "convoy activation",
+            kind: PatchKind::ConvoyRollUpPhase,
+            exercise: || {
+                let mut status = active_convoy_status();
+                let before = convoy_timestamps(&status);
+                let patch = ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Active, started_at: Some(ts(30)), finished_at: None };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "convoy settlement",
+            kind: PatchKind::ConvoyRollUpPhase,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = convoy_timestamps(&status);
+                let patch = ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, started_at: None, finished_at: Some(ts(30)) };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work launch",
+            kind: PatchKind::ConvoyWorkLaunching,
+            exercise: || {
+                let mut status = active_convoy_status();
+                status.work.get_mut("implement").expect("implement work").phase = WorkPhase::Launching;
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::WorkLaunching {
+                    work: "implement".to_string(),
+                    started_at: ts(30),
+                    placement: PlacementStatus::default(),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work running starts crew",
+            kind: PatchKind::ConvoyWorkRunning,
+            exercise: || {
+                let mut status = active_convoy_status();
+                let crew = status.crew_work.get_mut("implement").and_then(|crew| crew.get_mut("coder")).expect("coder work");
+                crew.phase = CrewWorkPhase::Working;
+                let before = crew_timestamps(&status);
+                let patch = ConvoyStatusPatch::WorkRunning { work: "implement".to_string(), started_at: ts(30) };
+                apply_and_replay(&mut status, &patch);
+                (before, crew_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "forced work completion",
+            kind: PatchKind::ConvoyForceWorkCompleted,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::ForceWorkCompleted {
+                    work: "implement".to_string(),
+                    finished_at: ts(30),
+                    message: Some("still complete".to_string()),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work failure",
+            kind: PatchKind::ConvoyMarkWorkFailed,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                status.work.get_mut("implement").expect("implement work").phase = WorkPhase::Failed;
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::MarkWorkFailed {
+                    work: "implement".to_string(),
+                    finished_at: ts(30),
+                    message: "still failed".to_string(),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work cancellation",
+            kind: PatchKind::ConvoyMarkWorkCancelled,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                status.work.get_mut("implement").expect("implement work").phase = WorkPhase::Cancelled;
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::MarkWorkCancelled { work: "implement".to_string(), finished_at: ts(30) };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work settlement roll-up",
+            kind: PatchKind::ConvoyRollUpWork,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::RollUpWork {
+                    work: "implement".to_string(),
+                    phase: WorkPhase::Complete,
+                    transitioned_at: ts(30),
+                    message: None,
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "crew completion",
+            kind: PatchKind::ConvoyMarkCrewCompleted,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = crew_timestamps(&status);
+                let patch = ConvoyStatusPatch::MarkCrewCompleted {
+                    vessel: "implement".to_string(),
+                    role: "coder".to_string(),
+                    finished_at: ts(30),
+                    message: Some("still complete".to_string()),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, crew_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "crew failure",
+            kind: PatchKind::ConvoyMarkCrewFailed,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let crew = status.crew_work.get_mut("implement").and_then(|crew| crew.get_mut("coder")).expect("coder work");
+                crew.phase = CrewWorkPhase::Failed;
+                let before = crew_timestamps(&status);
+                let patch = ConvoyStatusPatch::MarkCrewFailed {
+                    vessel: "implement".to_string(),
+                    role: "coder".to_string(),
+                    finished_at: ts(30),
+                    message: "still failed".to_string(),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, crew_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "terminal running",
+            kind: PatchKind::TerminalMarkRunning,
+            exercise: || {
+                let mut status = TerminalSessionStatus {
+                    phase: TerminalSessionPhase::Running,
+                    session_id: Some("session-a".to_string()),
+                    pid: Some(42),
+                    started_at: Some(ts(10)),
+                    stopped_at: None,
+                    inner_command_status: Some(InnerCommandStatus::Running),
+                    inner_exit_code: None,
+                    message: None,
+                    crew: None,
+                    launch_command: Some("bash".to_string()),
+                    delivered_message_id: None,
+                };
+                let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                let patch = TerminalSessionStatusPatch::MarkRunning {
+                    session_id: "session-a".to_string(),
+                    pid: Some(42),
+                    started_at: ts(30),
+                    crew: None,
+                    launch_command: "bash".to_string(),
+                    delivered_message_id: None,
+                };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                (before, after)
+            },
+        },
+        LifecycleCase {
+            name: "terminal stopped",
+            kind: PatchKind::TerminalMarkStopped,
+            exercise: || {
+                let mut status = TerminalSessionStatus {
+                    phase: TerminalSessionPhase::Stopped,
+                    started_at: Some(ts(10)),
+                    stopped_at: Some(ts(20)),
+                    ..TerminalSessionStatus::default()
+                };
+                let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                let patch = TerminalSessionStatusPatch::MarkStopped {
+                    stopped_at: ts(30),
+                    inner_command_status: Some(InnerCommandStatus::Exited),
+                    inner_exit_code: Some(0),
+                    message: None,
+                };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                (before, after)
+            },
+        },
+        LifecycleCase {
+            name: "terminal failure",
+            kind: PatchKind::TerminalMarkFailed,
+            exercise: || {
+                let mut status = TerminalSessionStatus {
+                    phase: TerminalSessionPhase::Failed,
+                    started_at: Some(ts(10)),
+                    stopped_at: Some(ts(20)),
+                    ..TerminalSessionStatus::default()
+                };
+                let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                let patch = TerminalSessionStatusPatch::MarkFailed { message: "still failed".to_string(), stopped_at: Some(ts(30)) };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                (before, after)
+            },
+        },
+        LifecycleCase {
+            name: "vessel provisioning",
+            kind: PatchKind::VesselMarkProvisioning,
+            exercise: || {
+                let mut status = VesselStatus { phase: VesselPhase::Provisioning, started_at: Some(ts(10)), ..VesselStatus::default() };
+                let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };
+                let patch = VesselStatusPatch::MarkProvisioning {
+                    observed_policy_ref: "docker".to_string(),
+                    observed_policy_version: "2".to_string(),
+                    started_at: ts(30),
+                };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };
+                (before, after)
+            },
+        },
+        LifecycleCase {
+            name: "vessel ready",
+            kind: PatchKind::VesselMarkReady,
+            exercise: || {
+                let mut status =
+                    VesselStatus { phase: VesselPhase::Ready, started_at: Some(ts(10)), ready_at: Some(ts(20)), ..VesselStatus::default() };
+                let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };
+                let patch = VesselStatusPatch::MarkReady {
+                    environment_ref: Some("env-a".to_string()),
+                    checkout_ref: Some("checkout-a".to_string()),
+                    terminal_session_refs: Vec::new(),
+                    ready_at: ts(30),
+                };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };
+                (before, after)
+            },
+        },
+        LifecycleCase {
+            name: "presentation active",
+            kind: PatchKind::PresentationMarkActive,
+            exercise: || {
+                let mut status =
+                    PresentationStatus { phase: PresentationPhase::Active, ready_at: Some(ts(10)), ..PresentationStatus::default() };
+                let before = LifecycleTimestamps { started_at: status.ready_at, finished_at: None };
+                let patch = PresentationStatusPatch::MarkActive {
+                    presentation_manager: "tmux".to_string(),
+                    workspace_ref: "workspace-a".to_string(),
+                    spec_hash: "hash-a".to_string(),
+                    ready_at: ts(30),
+                };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.ready_at, finished_at: None };
+                (before, after)
+            },
+        },
+    ];
+
+    assert_case_coverage(LifecycleClass::Duplicate, &cases);
+    for case in &cases {
+        let (before, after) = (case.exercise)();
+        assert_eq!(after, before, "{} duplicate transition must preserve its timestamps", case.name);
+    }
+}
+
+#[test]
+fn continuation_transitions_keep_started_at_and_clear_finished_at() {
+    let cases = [
+        LifecycleCase {
+            name: "convoy reopens",
+            kind: PatchKind::ConvoyRollUpPhase,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = convoy_timestamps(&status);
+                let patch = ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Active, started_at: Some(ts(30)), finished_at: None };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work reopens",
+            kind: PatchKind::ConvoyRollUpWork,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::RollUpWork {
+                    work: "implement".to_string(),
+                    phase: WorkPhase::Running,
+                    transitioned_at: ts(30),
+                    message: None,
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "crew hand-back",
+            kind: PatchKind::ConvoyHandoffCrewWork,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = crew_timestamps(&status);
+                let patch = ConvoyStatusPatch::HandoffCrewWork {
+                    vessel: "implement".to_string(),
+                    sender_role: "reviewer".to_string(),
+                    target_role: "coder".to_string(),
+                    handed_off_at: ts(30),
+                    message: "address review".to_string(),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, crew_timestamps(&status))
+            },
+        },
+    ];
+
+    assert_case_coverage(LifecycleClass::Continuation, &cases);
+    for case in &cases {
+        let (before, after) = (case.exercise)();
+        assert_eq!(after.started_at, before.started_at, "{} continuation must keep started_at", case.name);
+        assert_eq!(after.finished_at, None, "{} continuation must clear finished_at", case.name);
+    }
+}
+
+#[test]
+fn new_attempt_transitions_replace_attempt_timestamps() {
+    let cases = [
+        LifecycleCase {
+            name: "terminal session restart",
+            kind: PatchKind::TerminalMarkStarting,
+            exercise: || {
+                let mut status = TerminalSessionStatus {
+                    phase: TerminalSessionPhase::Stopped,
+                    started_at: Some(ts(10)),
+                    stopped_at: Some(ts(20)),
+                    ..TerminalSessionStatus::default()
+                };
+                let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                apply_and_replay(&mut status, &TerminalSessionStatusPatch::MarkStarting);
+                let patch = TerminalSessionStatusPatch::MarkRunning {
+                    session_id: "session-b".to_string(),
+                    pid: Some(43),
+                    started_at: ts(30),
+                    crew: None,
+                    launch_command: "bash".to_string(),
+                    delivered_message_id: None,
+                };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
+                (before, after)
+            },
+        },
+        LifecycleCase {
+            name: "presentation realization",
+            kind: PatchKind::PresentationMarkActive,
+            exercise: || {
+                let mut status =
+                    PresentationStatus { phase: PresentationPhase::TornDown, ready_at: Some(ts(10)), ..PresentationStatus::default() };
+                let before = LifecycleTimestamps { started_at: status.ready_at, finished_at: None };
+                let patch = PresentationStatusPatch::MarkActive {
+                    presentation_manager: "tmux".to_string(),
+                    workspace_ref: "workspace-b".to_string(),
+                    spec_hash: "hash-b".to_string(),
+                    ready_at: ts(30),
+                };
+                apply_and_replay(&mut status, &patch);
+                let after = LifecycleTimestamps { started_at: status.ready_at, finished_at: None };
+                (before, after)
+            },
+        },
+    ];
+
+    assert_case_coverage(LifecycleClass::NewAttempt, &cases);
+    for case in &cases {
+        let (before, after) = (case.exercise)();
+        assert_ne!(after.started_at, before.started_at, "{} new attempt must replace its start timestamp", case.name);
+        assert_eq!(after.finished_at, None, "{} new attempt must clear its finish timestamp", case.name);
+    }
+}
+
+#[test]
+fn settling_again_after_a_continuation_records_the_new_outcome_time() {
+    let cases = [
+        LifecycleCase {
+            name: "work completes after reopening",
+            kind: PatchKind::ConvoyRollUpWork,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = work_timestamps(&status);
+                let reopen = ConvoyStatusPatch::RollUpWork {
+                    work: "implement".to_string(),
+                    phase: WorkPhase::Running,
+                    transitioned_at: ts(25),
+                    message: None,
+                };
+                apply_and_replay(&mut status, &reopen);
+                let resettle = ConvoyStatusPatch::RollUpWork {
+                    work: "implement".to_string(),
+                    phase: WorkPhase::Complete,
+                    transitioned_at: ts(30),
+                    message: None,
+                };
+                apply_and_replay(&mut status, &resettle);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "crew completes after hand-back",
+            kind: PatchKind::ConvoyMarkCrewCompleted,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = crew_timestamps(&status);
+                let hand_back = ConvoyStatusPatch::HandoffCrewWork {
+                    vessel: "implement".to_string(),
+                    sender_role: "reviewer".to_string(),
+                    target_role: "coder".to_string(),
+                    handed_off_at: ts(25),
+                    message: "address review".to_string(),
+                };
+                apply_and_replay(&mut status, &hand_back);
+                let resettle = ConvoyStatusPatch::MarkCrewCompleted {
+                    vessel: "implement".to_string(),
+                    role: "coder".to_string(),
+                    finished_at: ts(30),
+                    message: Some("addressed".to_string()),
+                };
+                apply_and_replay(&mut status, &resettle);
+                (before, crew_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "crew changes settled outcome",
+            kind: PatchKind::ConvoyMarkCrewFailed,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = crew_timestamps(&status);
+                let patch = ConvoyStatusPatch::MarkCrewFailed {
+                    vessel: "implement".to_string(),
+                    role: "coder".to_string(),
+                    finished_at: ts(30),
+                    message: "regression found".to_string(),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, crew_timestamps(&status))
+            },
+        },
+    ];
+
+    assert_case_coverage(LifecycleClass::Resettlement, &cases);
+    for case in &cases {
+        let (before, after) = (case.exercise)();
+        assert_eq!(after.started_at, before.started_at, "{} must keep the original start timestamp", case.name);
+        assert_ne!(after.finished_at, before.finished_at, "{} must replace the settled outcome timestamp", case.name);
+        assert_eq!(after.finished_at, Some(ts(30)), "{} must record the new settled outcome time", case.name);
+    }
+}

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -23,7 +23,6 @@ const DUPLICATE: &[LifecycleClass] = &[LifecycleClass::Duplicate];
 const CONTINUATION: &[LifecycleClass] = &[LifecycleClass::Continuation];
 const NEW_ATTEMPT: &[LifecycleClass] = &[LifecycleClass::NewAttempt];
 const DUPLICATE_NEW_ATTEMPT: &[LifecycleClass] = &[LifecycleClass::Duplicate, LifecycleClass::NewAttempt];
-const DUPLICATE_CONTINUATION: &[LifecycleClass] = &[LifecycleClass::Duplicate, LifecycleClass::Continuation];
 const DUPLICATE_RESETTLEMENT: &[LifecycleClass] = &[LifecycleClass::Duplicate, LifecycleClass::Resettlement];
 const DUPLICATE_CONTINUATION_RESETTLEMENT: &[LifecycleClass] =
     &[LifecycleClass::Duplicate, LifecycleClass::Continuation, LifecycleClass::Resettlement];
@@ -52,8 +51,8 @@ define_patch_kinds! {
     ConvoyBackfillCrewWork => NONE,
     ConvoyFailInit => DUPLICATE,
     ConvoyAdvanceWorkToReady => DUPLICATE,
-    ConvoyFail => DUPLICATE,
-    ConvoyRollUpPhase => DUPLICATE_CONTINUATION,
+    ConvoyFail => DUPLICATE_RESETTLEMENT,
+    ConvoyRollUpPhase => DUPLICATE_CONTINUATION_RESETTLEMENT,
     ConvoyWorkLaunching => DUPLICATE,
     ConvoyWorkRunning => DUPLICATE,
     ConvoyForceWorkCompleted => DUPLICATE,
@@ -726,6 +725,33 @@ fn new_attempt_transitions_replace_attempt_timestamps() {
 #[test]
 fn settling_again_after_a_continuation_records_the_new_outcome_time() {
     let cases = [
+        LifecycleCase {
+            name: "convoy roll-up changes settled outcome",
+            kind: PatchKind::ConvoyRollUpPhase,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                status.phase = ConvoyPhase::Failed;
+                let before = convoy_timestamps(&status);
+                let patch = ConvoyStatusPatch::RollUpPhase { phase: ConvoyPhase::Completed, started_at: None, finished_at: Some(ts(30)) };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "convoy fail-fast changes settled outcome",
+            kind: PatchKind::ConvoyFail,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = convoy_timestamps(&status);
+                let patch = ConvoyStatusPatch::FailConvoy {
+                    cancelled_work: BTreeMap::new(),
+                    finished_at: ts(30),
+                    message: Some("work failure detected".to_string()),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, convoy_timestamps(&status))
+            },
+        },
         LifecycleCase {
             name: "work completes after reopening",
             kind: PatchKind::ConvoyRollUpWork,


### PR DESCRIPTION
Closes #679.

## What changed

- document the shared lifecycle timestamp contract for status patches
- add exhaustive, table-driven contract coverage for duplicate, continuation, new-attempt, and re-settlement transitions
- require every timestamp-bearing patch kind/class pair to have a behavioral case
- preserve sticky `finished_at` values when terminal convoy work rollups are replayed
- clarify terminal-session restart and presentation realization semantics

## Why

Status patches can be reapplied after optimistic-concurrency conflicts or reconciliation retries. Lifecycle timestamps therefore need consistent semantics: duplicate transitions must be no-ops, continuations must retain their original start while clearing settlement, and genuine new attempts must explicitly restamp attempt timestamps.

The audit also exposed a concrete defect in `RollUpWork`: replaying the same terminal phase replaced `finished_at` with a later reconciliation time.

## Impact

Existing lifecycle behavior is now encoded as an exhaustive contract. A future patch variant cannot enter CI without declaring its lifecycle class and supplying corresponding behavioral coverage.

Duplicate terminal work rollups now retain the original settlement time; a changed terminal outcome still records its own new settlement time.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- independent Standards review: no findings
- independent Spec review: no findings