### PR TITLE
fix: daily driver uses native-plugins zellij

### DIFF
--- a/layouts/daily-driver.kdl
+++ b/layouts/daily-driver.kdl
@@ -9,8 +9,12 @@
 // Launch via scripts/run-daily-driver.sh, which sets the env vars used
 // below: ANDAMENTO_ROOT, FLOTILLA_BIN.
 
+// Native (Rust-linked) andamento plugins — the wasm plugin path has
+// unacceptable serde/runtime overhead for daily driving. Requires the
+// spike/native-plugins zellij built with native-plugins-all (see
+// scripts/run-daily-driver.sh); plugin names resolve via the native registry.
 plugins {
-    andamento-controller location="file:$ANDAMENTO_ROOT/target/wasm32-wasip1/release/andamento-controller.wasm" {
+    andamento-controller location="native:andamento-controller" {
         rail_structure "joined-cells"
         rail_sizing "active-large"
         rail_grouping "directory"
@@ -18,12 +22,12 @@ plugins {
         template_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
         grouping_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
     }
-    andamento-rail location="file:$ANDAMENTO_ROOT/target/wasm32-wasip1/release/andamento-rail.wasm" {
+    andamento-rail location="native:andamento-rail" {
         controller_plugin_url "andamento-controller"
         config_plugin_url "andamento-config"
         rail_placement "left"
     }
-    andamento-config location="file:$ANDAMENTO_ROOT/target/wasm32-wasip1/release/andamento-config.wasm"
+    andamento-config location="native:andamento-config"
 }
 
 load_plugins {

--- a/scripts/run-daily-driver.sh
+++ b/scripts/run-daily-driver.sh
@@ -2,15 +2,19 @@
 # Launch the daily-driver zellij session: andamento rail + git-watcher +
 # the flotilla manifest connector (layouts/daily-driver.kdl, #708).
 #
-# Builds the andamento plugins, checks the flotilla dev binaries exist and
-# are properly signed (macOS 26.5.x syspolicyd mitigation, #689 — signing
-# itself stays a manual step), then execs zellij with the composed layout.
+# Uses the native-plugins zellij (spike/native-plugins worktree) with
+# andamento compiled in — the wasm plugin path has unacceptable perf for
+# daily driving. Builds that zellij via its build-native-andamento script,
+# checks the flotilla dev binaries exist and are properly signed (macOS
+# 26.5.x syspolicyd mitigation, #689 — signing itself stays a manual step),
+# then execs zellij with the composed layout.
 set -euo pipefail
 
 FLOTILLA_ROOT=${FLOTILLA_ROOT:-"$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"}
 export ANDAMENTO_ROOT=${ANDAMENTO_ROOT:-"$HOME/dev/andamento"}
 export FLOTILLA_BIN=${FLOTILLA_BIN:-"$FLOTILLA_ROOT/target/debug/flotilla"}
-ZELLIJ_BIN=${ZELLIJ_BIN:-"$HOME/dev/zellij/target/dev-opt/zellij"}
+ZELLIJ_NATIVE_ROOT=${ZELLIJ_NATIVE_ROOT:-"$HOME/dev/zellij.native-plugins"}
+ZELLIJ_BIN=${ZELLIJ_BIN:-"$ZELLIJ_NATIVE_ROOT/target/dev-opt/zellij"}
 
 if [[ ! -x "$FLOTILLA_BIN" ]]; then
     echo "error: flotilla binary not found at $FLOTILLA_BIN — run cargo build first" >&2
@@ -28,6 +32,16 @@ if command -v codesign >/dev/null 2>&1; then
     done
 fi
 
-cargo build --manifest-path "$ANDAMENTO_ROOT/Cargo.toml" --workspace --target wasm32-wasip1 --release
+# Build the native-plugins zellij with andamento compiled in. The worktree's
+# script handles the zellij-tile package-identity patching; skip it entirely
+# when the caller points ZELLIJ_BIN somewhere else.
+if [[ "$ZELLIJ_BIN" == "$ZELLIJ_NATIVE_ROOT/target/dev-opt/zellij" ]]; then
+    if [[ ! -x "$ZELLIJ_NATIVE_ROOT/scripts/build-native-andamento" ]]; then
+        echo "error: native-plugins zellij worktree not found at $ZELLIJ_NATIVE_ROOT" >&2
+        echo "       (set ZELLIJ_NATIVE_ROOT, or set ZELLIJ_BIN to skip the built-in build)" >&2
+        exit 1
+    fi
+    "$ZELLIJ_NATIVE_ROOT/scripts/build-native-andamento"
+fi
 
 exec "$ZELLIJ_BIN" --layout "$FLOTILLA_ROOT/layouts/daily-driver.kdl"


### PR DESCRIPTION
The daily-driver script targeted plain (wasm-plugin) zellij, which has unacceptable performance for daily driving (wasm serde overhead + plugin system design). Caught by Robert reviewing the script ahead of the #708 acceptance run.

- `scripts/run-daily-driver.sh`: default `ZELLIJ_BIN` moves to the `spike/native-plugins` worktree's dev-opt build (`ZELLIJ_NATIVE_ROOT`, overridable); the wasm andamento build step is replaced by the worktree's `build-native-andamento` script, which handles the zellij-tile package-identity `--config` patching so native plugin factories share the host binary's types. Setting `ZELLIJ_BIN` explicitly skips the built-in build.
- `layouts/daily-driver.kdl`: the three andamento plugins move to `native:` registry locations, exactly matching andamento's own `layouts/andamento-native.kdl` reference (status-bar deliberately stays plain, as in the reference). `ANDAMENTO_ROOT` is still required for template files and the git-watcher pane.

Verified against the spike: `native:` parses in layouts (`zellij-utils/src/input/layout.rs:603`), registry names match (`status-bar`, `andamento-controller`, `andamento-rail`, `andamento-config`), and a `native-plugins-all` dev-opt binary already builds. The live pass is the #708 acceptance run itself.

Refs #708.