### PR TITLE
Start convoys from project issues

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use flotilla_protocol::{Command, CommandAction};
+use flotilla_protocol::{Command, CommandAction, ConvoyStartIntent, IssueRef, IssueSelector, IssueSource};
 
 use crate::{
     quote::quote_value,
@@ -10,10 +10,10 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
-#[command(about = "Manage convoys")]
+#[command(about = "Manage convoys", subcommand_precedence_over_arg = true)]
 pub struct ConvoyNoun {
     /// Convoy name
-    pub subject: String,
+    pub subject: Option<String>,
 
     #[command(subcommand)]
     pub verb: ConvoyVerb,
@@ -23,6 +23,42 @@ pub struct ConvoyNoun {
 pub enum ConvoyVerb {
     /// Manage the work aboard a convoy's vessels
     Work(ConvoyWorkNoun),
+    /// Start a convoy through Project-scoped admission completion
+    Start {
+        /// Project whose definitions and repository set admission snapshots
+        #[arg(long)]
+        project: String,
+        /// Opaque external issue ID
+        #[arg(long)]
+        issue: Option<String>,
+        /// Portable issue service identity; requires --issue and --issue-scope
+        #[arg(long)]
+        issue_service: Option<String>,
+        /// Portable issue scope identity; requires --issue and --issue-service
+        #[arg(long)]
+        issue_scope: Option<String>,
+        /// Complete convoy resource name
+        #[arg(long)]
+        name: Option<String>,
+        /// Complete git branch name
+        #[arg(long)]
+        branch: Option<String>,
+        /// Workflow template; defaults from the Project
+        #[arg(long)]
+        workflow: Option<String>,
+        /// Workflow input value (repeatable): --input key=value
+        #[arg(long = "input", value_parser = parse_input_kv)]
+        inputs: Vec<(String, String)>,
+        /// Human free-text appended to the crew Brief
+        #[arg(long)]
+        instruction: Option<String>,
+        /// PlacementPolicy resource to use for vessel provisioning
+        #[arg(long = "placement-policy")]
+        placement_policy: Option<String>,
+        /// Create the convoy without attaching the caller to its first crew session
+        #[arg(long, default_value_t = false)]
+        no_attach: bool,
+    },
     /// Create a convoy from a workflow template
     Create {
         /// Workflow template to instantiate
@@ -93,20 +129,101 @@ impl ConvoyNoun {
                         node_id: None,
                         provisioning_target: None,
                         context_repo: None,
-                        action: CommandAction::ConvoyWorkForceComplete { convoy: self.subject, work: work.subject, message },
+                        action: CommandAction::ConvoyWorkForceComplete {
+                            convoy: self.subject.ok_or_else(|| "convoy name is required before `work`".to_string())?,
+                            work: work.subject,
+                            message,
+                        },
                     },
                     repo: RepoContext::None,
                     host: HostResolution::Local,
                 }),
             },
+            ConvoyVerb::Start {
+                project,
+                issue,
+                issue_service,
+                issue_scope,
+                name,
+                branch,
+                workflow,
+                inputs,
+                instruction,
+                placement_policy,
+                no_attach,
+            } => {
+                if self.subject.is_some() {
+                    return Err("convoy start does not take a positional convoy name; use --name".to_string());
+                }
+                let issue = match (issue, issue_service, issue_scope) {
+                    (None, None, None) => None,
+                    (Some(id), None, None) => Some(IssueSelector::Id(id)),
+                    (Some(id), Some(service), Some(scope)) => {
+                        Some(IssueSelector::Reference(IssueRef { source: IssueSource { service, scope }, id }))
+                    }
+                    (None, Some(_), _) | (None, _, Some(_)) => {
+                        return Err("--issue-service and --issue-scope require --issue".to_string());
+                    }
+                    (Some(_), Some(_), None) | (Some(_), None, Some(_)) => {
+                        return Err("--issue-service and --issue-scope must be supplied together".to_string());
+                    }
+                };
+                Ok(Resolved::NeedsContext {
+                    command: Command {
+                        node_id: None,
+                        provisioning_target: None,
+                        context_repo: None,
+                        action: CommandAction::ConvoyStart {
+                            intent: Box::new(ConvoyStartIntent {
+                                project_ref: project,
+                                issue,
+                                name,
+                                branch,
+                                workflow_ref: workflow,
+                                inputs,
+                                instruction,
+                                placement_policy,
+                                auto_attach: !no_attach,
+                            }),
+                        },
+                    },
+                    repo: RepoContext::None,
+                    host: HostResolution::Local,
+                })
+            }
             ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy, adopted_checkout } => {
+                let name = self.subject.ok_or_else(|| "convoy name is required before `create`".to_string())?;
+                if let Some(project_ref) = project_ref.as_ref().filter(|_| repository_url.is_none() && adopted_checkout.is_none()) {
+                    return Ok(Resolved::NeedsContext {
+                        command: Command {
+                            node_id: None,
+                            provisioning_target: None,
+                            context_repo: None,
+                            action: CommandAction::ConvoyStart {
+                                intent: Box::new(ConvoyStartIntent {
+                                    project_ref: project_ref.clone(),
+                                    issue: None,
+                                    name: Some(name),
+                                    branch: r#ref,
+                                    workflow_ref: Some(template),
+                                    inputs,
+                                    instruction: None,
+                                    placement_policy,
+                                    auto_attach: false,
+                                }),
+                            },
+                        },
+                        repo: RepoContext::None,
+                        host: HostResolution::Local,
+                    });
+                }
                 Ok(Resolved::NeedsContext {
                     command: Command {
                         node_id: None,
                         provisioning_target: None,
                         context_repo: None,
                         action: CommandAction::ConvoyCreate {
-                            name: self.subject,
+                            name,
                             workflow_ref: template,
                             inputs,
                             repository_url,
@@ -126,7 +243,10 @@ impl ConvoyNoun {
 
 impl std::fmt::Display for ConvoyNoun {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "convoy {}", self.subject)?;
+        write!(f, "convoy")?;
+        if let Some(subject) = &self.subject {
+            write!(f, " {subject}")?;
+        }
         match &self.verb {
             ConvoyVerb::Work(work) => {
                 write!(f, " work {}", work.subject)?;
@@ -140,6 +260,51 @@ impl std::fmt::Display for ConvoyNoun {
                             write!(f, " --message {message}")?;
                         }
                     }
+                }
+            }
+            ConvoyVerb::Start {
+                project,
+                issue,
+                issue_service,
+                issue_scope,
+                name,
+                branch,
+                workflow,
+                inputs,
+                instruction,
+                placement_policy,
+                no_attach,
+            } => {
+                write!(f, " start --project {}", quote_value(project))?;
+                if let Some(issue) = issue {
+                    write!(f, " --issue {}", quote_value(issue))?;
+                }
+                if let Some(service) = issue_service {
+                    write!(f, " --issue-service {}", quote_value(service))?;
+                }
+                if let Some(scope) = issue_scope {
+                    write!(f, " --issue-scope {}", quote_value(scope))?;
+                }
+                if let Some(name) = name {
+                    write!(f, " --name {}", quote_value(name))?;
+                }
+                if let Some(branch) = branch {
+                    write!(f, " --branch {}", quote_value(branch))?;
+                }
+                if let Some(workflow) = workflow {
+                    write!(f, " --workflow {}", quote_value(workflow))?;
+                }
+                for (key, value) in inputs {
+                    write!(f, " --input {}", quote_value(&format!("{key}={value}")))?;
+                }
+                if let Some(instruction) = instruction {
+                    write!(f, " --instruction {}", quote_value(instruction))?;
+                }
+                if let Some(placement_policy) = placement_policy {
+                    write!(f, " --placement-policy {}", quote_value(placement_policy))?;
+                }
+                if *no_attach {
+                    write!(f, " --no-attach")?;
                 }
             }
             ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy, adopted_checkout } => {
@@ -171,7 +336,7 @@ impl std::fmt::Display for ConvoyNoun {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
-    use flotilla_protocol::{Command, CommandAction};
+    use flotilla_protocol::{Command, CommandAction, ConvoyStartIntent, IssueRef, IssueSelector, IssueSource};
 
     use super::ConvoyNoun;
     use crate::{
@@ -227,6 +392,59 @@ mod tests {
     #[test]
     fn round_trip_complete() {
         assert_round_trip::<ConvoyNoun>(&["convoy", "convoy-a", "work", "implement", "complete"]);
+    }
+
+    #[test]
+    fn convoy_start_fully_specified_issue_intent_resolves() {
+        let resolved = parse(&[
+            "convoy",
+            "start",
+            "--project",
+            "widgets",
+            "--issue",
+            "WIDGET-732",
+            "--issue-service",
+            "https://linear.app",
+            "--issue-scope",
+            "WIDGET",
+            "--name",
+            "repair-widget-admission",
+            "--branch",
+            "fix/repair-widget-admission",
+            "--workflow",
+            "single-agent-contained",
+            "--instruction",
+            "Preserve the public API.",
+            "--no-attach",
+        ])
+        .resolve()
+        .expect("resolve");
+
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyStart {
+                    intent: Box::new(ConvoyStartIntent {
+                        project_ref: "widgets".into(),
+                        issue: Some(IssueSelector::Reference(IssueRef {
+                            source: IssueSource { service: "https://linear.app".into(), scope: "WIDGET".into() },
+                            id: "WIDGET-732".into(),
+                        })),
+                        name: Some("repair-widget-admission".into()),
+                        branch: Some("fix/repair-widget-admission".into()),
+                        workflow_ref: Some("single-agent-contained".into()),
+                        inputs: vec![],
+                        instruction: Some("Preserve the public API.".into()),
+                        placement_policy: None,
+                        auto_attach: false,
+                    }),
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
     }
 
     #[test]
@@ -290,6 +508,38 @@ mod tests {
             },
             repo: RepoContext::None,
             host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn project_backed_legacy_create_collapses_into_start_admission() {
+        let resolved = parse(&[
+            "convoy",
+            "project-work",
+            "create",
+            "--template",
+            "single-agent-contained",
+            "--project",
+            "widgets",
+            "--ref",
+            "fix/widgets",
+        ])
+        .resolve()
+        .expect("resolve");
+
+        let Resolved::NeedsContext { command, .. } = resolved else { panic!("expected daemon command") };
+        assert_eq!(command.action, CommandAction::ConvoyStart {
+            intent: Box::new(ConvoyStartIntent {
+                project_ref: "widgets".into(),
+                issue: None,
+                name: Some("project-work".into()),
+                branch: Some("fix/widgets".into()),
+                workflow_ref: Some("single-agent-contained".into()),
+                inputs: Vec::new(),
+                instruction: None,
+                placement_policy: None,
+                auto_attach: false,
+            }),
         });
     }
 

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -175,6 +175,7 @@ impl ConvoyNoun {
                         context_repo: None,
                         action: CommandAction::ConvoyStart {
                             intent: Box::new(ConvoyStartIntent {
+                                namespace: None,
                                 project_ref: project,
                                 issue,
                                 name,
@@ -201,6 +202,7 @@ impl ConvoyNoun {
                             context_repo: None,
                             action: CommandAction::ConvoyStart {
                                 intent: Box::new(ConvoyStartIntent {
+                                    namespace: None,
                                     project_ref: project_ref.clone(),
                                     issue: None,
                                     name: Some(name),
@@ -427,6 +429,7 @@ mod tests {
                 context_repo: None,
                 action: CommandAction::ConvoyStart {
                     intent: Box::new(ConvoyStartIntent {
+                        namespace: None,
                         project_ref: "widgets".into(),
                         issue: Some(IssueSelector::Reference(IssueRef {
                             source: IssueSource { service: "https://linear.app".into(), scope: "WIDGET".into() },
@@ -530,6 +533,7 @@ mod tests {
         let Resolved::NeedsContext { command, .. } = resolved else { panic!("expected daemon command") };
         assert_eq!(command.action, CommandAction::ConvoyStart {
             intent: Box::new(ConvoyStartIntent {
+                namespace: None,
                 project_ref: "widgets".into(),
                 issue: None,
                 name: Some("project-work".into()),

--- a/crates/flotilla-commands/src/commands/host.rs
+++ b/crates/flotilla-commands/src/commands/host.rs
@@ -54,7 +54,7 @@ pub enum HostVerb {
     Status,
     Providers,
     Refresh { repo: Option<String> },
-    Route(NounCommand),
+    Route(Box<NounCommand>),
 }
 
 // ---------------------------------------------------------------------------
@@ -80,7 +80,7 @@ impl Refinable for HostNounPartial {
                 let cmd = <NounCommand as Subcommand>::augment_subcommands(cmd);
                 let matches = cmd.try_get_matches_from(&tokens).map_err(crate::subject::format_parse_error)?;
                 let noun = <NounCommand as clap::FromArgMatches>::from_arg_matches(&matches).map_err(crate::subject::format_parse_error)?;
-                HostVerb::Route(noun)
+                HostVerb::Route(Box::new(noun))
             }
             None => return Err("missing host command".into()),
         };

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -10,7 +10,7 @@ use flotilla_resources::{
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy,
     PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey, Resource, ResourceBackend, ResourceError, ResourceObject, Stance,
     TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase,
-    VesselStatusPatch, VESSEL_REF_LABEL,
+    VesselStatusPatch, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -208,7 +208,7 @@ impl Reconciler for VesselReconciler {
             }
             convoy_repositories.push(repository);
         }
-        let multi_repository = convoy_repositories.len() > 1;
+        let multi_repository = convoy.spec.repositories.len() > 1;
         let workspace_slugs = convoy_repositories
             .iter()
             .map(|repository| (repository.repo_ref.clone(), repository.workspace_slug.clone()))
@@ -353,9 +353,14 @@ impl Reconciler for VesselReconciler {
             } else {
                 None
             };
-            let checkout_name = adopted_checkout_ref
-                .clone()
-                .unwrap_or_else(|| checkout_name(&obj.metadata.name, &convoy_repository.workspace_slug, multi_repository));
+            let checkout_name = adopted_checkout_ref.clone().unwrap_or_else(|| match &strategy {
+                PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
+                    checkout_name(&convoy.metadata.name, &convoy_repository.workspace_slug, multi_repository)
+                }
+                PlacementStrategy::DockerFreshCloneInContainer { .. } => {
+                    checkout_name(&obj.metadata.name, &convoy_repository.workspace_slug, multi_repository)
+                }
+            });
             let checkout_target_path = match &strategy {
                 PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
                     if multi_repository {
@@ -432,14 +437,14 @@ impl Reconciler for VesselReconciler {
                         }),
                     };
                     let env_ref = spec.env_ref().expect("managed checkout should have an env_ref").to_string();
-                    actuations.push(Actuation::CreateCheckout {
-                        meta: owned_child_meta(
-                            &checkout_name,
-                            obj,
-                            BTreeMap::from([(ENV_LABEL.to_string(), env_ref), (REPO_KEY_LABEL.to_string(), repo_key)]),
-                        ),
-                        spec,
-                    });
+                    let labels = BTreeMap::from([(ENV_LABEL.to_string(), env_ref), (REPO_KEY_LABEL.to_string(), repo_key)]);
+                    let meta = match &strategy {
+                        PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
+                            convoy_owned_child_meta(&checkout_name, &convoy, labels)
+                        }
+                        PlacementStrategy::DockerFreshCloneInContainer { .. } => owned_child_meta(&checkout_name, obj, labels),
+                    };
+                    actuations.push(Actuation::CreateCheckout { meta, spec });
                     waiting_for_checkouts = true;
                 }
                 Err(err) => return Err(err),
@@ -783,6 +788,20 @@ fn owned_child_meta(name: &str, workspace: &ResourceObject<Vessel>, mut extra_la
             api_version: format!("{}/{}", Vessel::API_PATHS.group, Vessel::API_PATHS.version),
             kind: Vessel::API_PATHS.kind.to_string(),
             name: workspace.metadata.name.clone(),
+            controller: true,
+        }])
+        .build()
+}
+
+fn convoy_owned_child_meta(name: &str, convoy: &ResourceObject<Convoy>, mut extra_labels: BTreeMap<String, String>) -> InputMeta {
+    extra_labels.insert(CONVOY_LABEL.to_string(), convoy.metadata.name.clone());
+    InputMeta::builder()
+        .name(name.to_string())
+        .labels(extra_labels)
+        .owner_references(vec![OwnerReference {
+            api_version: format!("{}/{}", Convoy::API_PATHS.group, Convoy::API_PATHS.version),
+            kind: Convoy::API_PATHS.kind.to_string(),
+            name: convoy.metadata.name.clone(),
             controller: true,
         }])
         .build()

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -195,6 +195,7 @@ impl Reconciler for VesselReconciler {
             }
         };
         let checkout_slug = git_ref.as_deref().map(checkout_path_component);
+        let convoy_checkout_slug = checkout_path_component(&convoy.metadata.name);
         if repository_refs.len() > 1 && !obj.spec.adopted_checkout_refs.is_empty() {
             return Ok(VesselDeps::failed("adopted checkouts are not supported for multi-repository vessel workspaces".to_string()));
         }
@@ -282,8 +283,9 @@ impl Reconciler for VesselReconciler {
             match &strategy {
                 PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
                     format!(
-                        "{}/{}",
+                        "{}/{}/{}",
                         shared_clone_root.as_deref().expect("shared-clone placement has a root").trim_end_matches('/'),
+                        convoy_checkout_slug,
                         checkout_slug.as_deref().expect("repository workspace requires a branch")
                     )
                 }
@@ -371,6 +373,7 @@ impl Reconciler for VesselReconciler {
                     } else {
                         checkout_target_path(
                             shared_clone_root.as_deref().expect("shared-clone placement has a root"),
+                            &convoy_checkout_slug,
                             &repository.spec.catalog_slug(),
                             checkout_slug.as_deref().expect("repository checkout requires a branch"),
                         )
@@ -747,8 +750,8 @@ fn checkout_path_component(branch: &str) -> String {
     }
 }
 
-fn checkout_target_path(repo_default_dir: &str, repo_slug: &str, branch_slug: &str) -> String {
-    format!("{}/{}.{}", repo_default_dir.trim_end_matches('/'), repo_slug, branch_slug)
+fn checkout_target_path(repo_default_dir: &str, convoy_slug: &str, repo_slug: &str, branch_slug: &str) -> String {
+    format!("{}/{}/{}.{}", repo_default_dir.trim_end_matches('/'), convoy_slug, repo_slug, branch_slug)
 }
 
 fn append_convoy_work_context(content: &mut String, convoy: &ResourceObject<Convoy>, repository_refs: &[RepositoryKey]) {

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -191,6 +191,7 @@ impl Reconciler for VesselReconciler {
                 None => return Ok(VesselDeps::failed("convoy ref is missing".to_string())),
             }
         };
+        let checkout_slug = git_ref.as_deref().map(checkout_path_component);
         if repository_refs.len() > 1 && !obj.spec.adopted_checkout_refs.is_empty() {
             return Ok(VesselDeps::failed("adopted checkouts are not supported for multi-repository vessel workspaces".to_string()));
         }
@@ -208,6 +209,10 @@ impl Reconciler for VesselReconciler {
             convoy_repositories.push(repository);
         }
         let multi_repository = convoy_repositories.len() > 1;
+        let workspace_slugs = convoy_repositories
+            .iter()
+            .map(|repository| (repository.repo_ref.clone(), repository.workspace_slug.clone()))
+            .collect::<BTreeMap<_, _>>();
 
         let clone_env_ref = host_direct_environment_name(strategy.host_ref());
         let mut actuations = Vec::new();
@@ -276,7 +281,7 @@ impl Reconciler for VesselReconciler {
                     format!(
                         "{}/{}",
                         shared_clone_root.as_deref().expect("shared-clone placement has a root").trim_end_matches('/'),
-                        obj.metadata.name
+                        checkout_slug.as_deref().expect("repository workspace requires a branch")
                     )
                 }
                 PlacementStrategy::DockerFreshCloneInContainer { clone_path, .. } => clone_path.clone(),
@@ -359,7 +364,7 @@ impl Reconciler for VesselReconciler {
                         checkout_target_path(
                             shared_clone_root.as_deref().expect("shared-clone placement has a root"),
                             &repository.spec.catalog_slug(),
-                            &obj.metadata.name,
+                            checkout_slug.as_deref().expect("repository checkout requires a branch"),
                         )
                     }
                 }
@@ -516,6 +521,23 @@ impl Reconciler for VesselReconciler {
                 precreated_environment_ref.expect("fresh-clone strategy should resolve environment first")
             }
         };
+        let terminal_cwd = strategy.terminal_cwd(&workspace_root, multi_repository, has_repositories);
+        let brief_copies = checkout_paths
+            .iter()
+            .filter(|(repo_ref, _)| {
+                convoy.spec.issue.as_ref().and_then(|issue| issue.repository_ref.as_ref()).is_none_or(|relevant| relevant == *repo_ref)
+            })
+            .map(|(repo_ref, path)| match &strategy {
+                PlacementStrategy::DockerWorktreeOnHostAndMount { mount_path, .. } => {
+                    if multi_repository {
+                        format!("{}/{}", mount_path.trim_end_matches('/'), workspace_slugs[repo_ref])
+                    } else {
+                        mount_path.clone()
+                    }
+                }
+                PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerFreshCloneInContainer { .. } => path.clone(),
+            })
+            .collect::<Vec<_>>();
 
         let first_agent_index = requirement.crew.iter().position(|process| matches!(process.source, CrewSource::Agent { .. }));
         let mut terminal_refs = Vec::new();
@@ -579,12 +601,10 @@ impl Reconciler for VesselReconciler {
                                     is_agent: matches!(member.source, CrewSource::Agent { .. }),
                                 })
                                 .collect::<Vec<_>>();
-                            flotilla_resources::TerminalSessionSource::Agent {
-                                selector: selector.clone(),
-                                brief: build_crew_brief(&context, &obj.spec.vessel_name, &process.role, prompt.as_deref(), &members),
-                                context,
-                                message: None,
-                            }
+                            let mut brief = build_crew_brief(&context, &obj.spec.vessel_name, &process.role, prompt.as_deref(), &members);
+                            append_convoy_work_context(&mut brief.content, &convoy, &repository_refs);
+                            brief.copies = brief_copies.clone();
+                            flotilla_resources::TerminalSessionSource::Agent { selector: selector.clone(), brief, context, message: None }
                         }
                     };
                     actuations.push(Actuation::CreateTerminalSession {
@@ -593,7 +613,7 @@ impl Reconciler for VesselReconciler {
                             env_ref: resolved_environment_ref.clone(),
                             role: process.role.clone(),
                             source,
-                            cwd: strategy.terminal_cwd(&workspace_root, multi_repository, has_repositories),
+                            cwd: terminal_cwd.clone(),
                             pool: strategy.pool().to_string(),
                         },
                     });
@@ -706,8 +726,52 @@ fn checkout_name(vessel_name: &str, workspace_slug: &str, multi_repository: bool
     }
 }
 
-fn checkout_target_path(repo_default_dir: &str, repo_slug: &str, vessel_name: &str) -> String {
-    format!("{}/{}.{}", repo_default_dir.trim_end_matches('/'), repo_slug, vessel_name)
+fn checkout_path_component(branch: &str) -> String {
+    let normalized = branch
+        .chars()
+        .map(|character| if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') { character } else { '-' })
+        .collect::<String>();
+    let normalized = normalized.trim_matches(['-', '.']).to_string();
+    if normalized.is_empty() {
+        "work".to_string()
+    } else {
+        normalized
+    }
+}
+
+fn checkout_target_path(repo_default_dir: &str, repo_slug: &str, branch_slug: &str) -> String {
+    format!("{}/{}.{}", repo_default_dir.trim_end_matches('/'), repo_slug, branch_slug)
+}
+
+fn append_convoy_work_context(content: &mut String, convoy: &ResourceObject<Convoy>, repository_refs: &[RepositoryKey]) {
+    content.push_str("\n\n## Work context\n\n");
+    if let Some(branch) = &convoy.spec.r#ref {
+        content.push_str(&format!("- Branch: `{branch}`\n"));
+    }
+    content.push_str("- Repositories:\n");
+    for repository in convoy.spec.repositories.iter().filter(|repository| repository_refs.contains(&repository.repo_ref)) {
+        content.push_str(&format!("  - `{}` — {}\n", repository.repo_ref, repository.url));
+    }
+    if let Some(issue) = &convoy.spec.issue {
+        content.push_str("\n## Issue snapshot\n\n");
+        content.push_str(&format!(
+            "Source-qualified reference: `{}` / `{}` / `{}`\n\n",
+            issue.reference.source.service, issue.reference.source.scope, issue.reference.id
+        ));
+        content.push_str(&format!("Snapshot as of `{}`.\n\n", issue.snapshot.as_of.to_rfc3339()));
+        content.push_str(&format!("### {}\n\n", issue.snapshot.title));
+        content.push_str(&format!("State: `{:?}`\n\n", issue.snapshot.state).to_lowercase());
+        content.push_str(&format!("Labels: {}\n\n", issue.snapshot.labels.join(", ")));
+        if let Some(body) = &issue.snapshot.body {
+            content.push_str(body);
+            content.push('\n');
+        }
+    }
+    if let Some(instruction) = &convoy.spec.instruction {
+        content.push_str("\n## Human instruction\n\n");
+        content.push_str(instruction);
+        content.push('\n');
+    }
 }
 
 fn owned_child_meta(name: &str, workspace: &ResourceObject<Vessel>, mut extra_labels: BTreeMap<String, String>) -> InputMeta {

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -4,7 +4,9 @@ use chrono::{DateTime, Utc};
 use flotilla_core::agent_adapter::{build_crew_brief, CrewBriefMember};
 use flotilla_resources::{
     clone_key,
-    controller::{delete_lifecycle_owned_matching, Actuation, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
+    controller::{
+        delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
+    },
     Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy, CrewSource, DockerCheckoutStrategy,
     DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, FreshCloneCheckoutSpec,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy,
@@ -47,6 +49,7 @@ impl VesselReconciler {
         vec![
             Box::new(LabelMappedWatch::<Environment, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
             Box::new(LabelMappedWatch::<Checkout, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
+            Box::new(LabelJoinWatch::<Checkout, Vessel> { label_key: CONVOY_LABEL, _marker: PhantomData }),
             Box::new(LabelMappedWatch::<TerminalSession, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
         ]
     }

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -126,8 +126,10 @@ pub async fn create_workspace(
     repo_url: &str,
 ) -> flotilla_resources::ResourceObject<Vessel> {
     let workspaces = backend.clone().using::<Vessel>(namespace);
+    let mut meta = vessel_meta(name, repo_url);
+    meta.labels.insert(flotilla_resources::CONVOY_LABEL.to_string(), convoy_ref.to_string());
     workspaces
-        .create(&vessel_meta(name, repo_url), &VesselSpec {
+        .create(&meta, &VesselSpec {
             convoy_ref: convoy_ref.to_string(),
             vessel_name: task.to_string(),
             placement_policy_ref: placement_policy_ref.to_string(),

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -90,6 +90,8 @@ pub async fn create_convoy_with_single_task(
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -226,7 +226,7 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
     let status = workspace.status.expect("workspace status should be present");
     assert_eq!(status.phase, VesselPhase::Ready);
     assert_eq!(status.environment_ref.as_deref(), Some("host-direct-01HXYZ"));
-    assert_eq!(status.checkout_refs.values().next().map(String::as_str), Some("checkout-workspace-a"));
+    assert_eq!(status.checkout_refs.values().next().map(String::as_str), Some("checkout-convoy-a"));
     assert_eq!(status.terminal_session_refs, vec!["terminal-workspace-a-coder".to_string()]);
 
     tokio::time::sleep(Duration::from_millis(200)).await;

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -753,7 +753,9 @@ fn full_controller_harness(backend: ResourceBackend) -> ControllerLoopHarness {
             primary: backend.clone().using::<Vessel>(NAMESPACE),
             secondaries: VesselReconciler::secondary_watches(),
             reconciler: VesselReconciler::new(backend.clone(), NAMESPACE),
-            resync_interval: Duration::from_millis(50),
+            // This must progress through Checkout Ready events rather than a
+            // periodic Vessel relist; production resync is also deliberately slow.
+            resync_interval: Duration::from_secs(60),
             backend,
         }
         .run(),

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -80,7 +80,11 @@ async fn a_disappeared_running_session_is_observed_as_stopped() {
             role: "coder".to_string(),
             source: flotilla_resources::TerminalSessionSource::Agent {
                 selector: flotilla_resources::Selector { capability: "coding".to_string() },
-                brief: flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into() },
+                brief: flotilla_resources::TerminalBrief {
+                    path: ".flotilla/briefs/coder.md".into(),
+                    content: "brief".into(),
+                    copies: Vec::new(),
+                },
                 context: flotilla_resources::TerminalCrewContext {
                     namespace: "flotilla".into(),
                     convoy: "demo".into(),
@@ -143,7 +147,11 @@ async fn a_message_queued_during_startup_is_delivered_after_the_session_becomes_
             role: "reviewer".to_string(),
             source: flotilla_resources::TerminalSessionSource::Agent {
                 selector: flotilla_resources::Selector { capability: "review".to_string() },
-                brief: flotilla_resources::TerminalBrief { path: ".flotilla/briefs/reviewer.md".into(), content: "brief".into() },
+                brief: flotilla_resources::TerminalBrief {
+                    path: ".flotilla/briefs/reviewer.md".into(),
+                    content: "brief".into(),
+                    copies: Vec::new(),
+                },
                 context: flotilla_resources::TerminalCrewContext {
                     namespace: "flotilla".into(),
                     convoy: "demo".into(),

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -243,6 +243,42 @@ async fn sequential_vessels_share_a_convoy_owned_worktree_checkout() {
 }
 
 #[tokio::test]
+async fn unrelated_convoys_with_the_same_branch_use_distinct_worktree_paths() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-one", "implement", REPO_URL, GIT_REF).await;
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-two", "implement", REPO_URL, GIT_REF).await;
+    create_host_direct_policy(&backend, NAMESPACE, "policy-shared-branch", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    let clone_name =
+        format!("clone-{}", clone_key(&canonicalize_repo_url(REPO_URL).expect("repo canonicalization"), &host_direct_env_name()));
+    create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/tmp/clone").await;
+    let first = create_workspace(&backend, NAMESPACE, "workspace-one", "convoy-one", "implement", "policy-shared-branch", REPO_URL).await;
+    let second = create_workspace(&backend, NAMESPACE, "workspace-two", "convoy-two", "implement", "policy-shared-branch", REPO_URL).await;
+
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let first_deps = reconciler.fetch_dependencies(&first).await.expect("first dependencies");
+    let second_deps = reconciler.fetch_dependencies(&second).await.expect("second dependencies");
+    let first_outcome = reconciler.reconcile(&first, &first_deps, Utc::now());
+    let second_outcome = reconciler.reconcile(&second, &second_deps, Utc::now());
+    let checkout_path = |outcome: &flotilla_resources::controller::ReconcileOutcome<_>| {
+        outcome
+            .actuations
+            .iter()
+            .find_map(|actuation| match actuation {
+                Actuation::CreateCheckout { spec, .. } => spec.target_path().map(str::to_string),
+                _ => None,
+            })
+            .expect("convoy should create a checkout")
+    };
+    let first_path = checkout_path(&first_outcome);
+    let second_path = checkout_path(&second_outcome);
+
+    assert_eq!(first_path, "/Users/alice/dev/flotilla-repos/convoy-one/github-com-flotilla-org-flotilla.feat-task-provisioning");
+    assert_eq!(second_path, "/Users/alice/dev/flotilla-repos/convoy-two/github-com-flotilla-org-flotilla.feat-task-provisioning");
+    assert_ne!(first_path, second_path);
+}
+
+#[tokio::test]
 async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_workspace_root() {
     let backend = ResourceBackend::InMemory(Default::default());
     let repository_specs = [
@@ -365,8 +401,8 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         .collect::<Vec<_>>();
     assert_eq!(checkout_actuations.len(), 2);
     assert_eq!(checkout_actuations.iter().map(|(_, spec)| spec.target_path().expect("managed checkout path")).collect::<Vec<_>>(), [
-        "/Users/alice/dev/flotilla-repos/feature-multi/cleat",
-        "/Users/alice/dev/flotilla-repos/feature-multi/flotilla",
+        "/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi/cleat",
+        "/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi/flotilla",
     ]);
     for (meta, spec) in checkout_actuations {
         let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
@@ -389,10 +425,10 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         matches!(
             actuation,
             Actuation::CreateTerminalSession { spec, .. }
-                if spec.cwd == "/Users/alice/dev/flotilla-repos/feature-multi"
+                if spec.cwd == "/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi"
                     && matches!(&spec.source, TerminalSessionSource::Agent { brief, .. }
                         if brief.path == ".flotilla/briefs/coder.md"
-                            && brief.copies == ["/Users/alice/dev/flotilla-repos/feature-multi/flotilla"]
+                            && brief.copies == ["/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi/flotilla"]
                             && brief.content.contains("https://github.com` / `flotilla-org/flotilla` / `732")
                             && brief.content.contains("Snapshot as of `2026-07-18T09:30:00+00:00`")
                             && brief.content.contains("Persist this exact issue body.")
@@ -407,7 +443,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         &host_direct_env_name(),
         "coder",
         "cargo test",
-        "/Users/alice/dev/flotilla-repos/feature-multi",
+        "/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi",
         "cleat",
     )
     .await;
@@ -546,7 +582,7 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
     });
     let mounts = mounts.expect("docker environment should be created");
     assert_eq!(mounts.len(), 1);
-    assert_eq!(mounts[0].source_path, "/Users/alice/dev/flotilla-repos/feature-multi");
+    assert_eq!(mounts[0].source_path, "/Users/alice/dev/flotilla-repos/convoy-multi-docker/feature-multi");
     assert_eq!(mounts[0].target_path, "/workspace");
 
     let mixed = backend
@@ -764,7 +800,7 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
         .expect("scoped checkout should be created");
     assert_eq!(checkout_name, "checkout-convoy-scoped-cleat");
     assert_eq!(checkout.repo_ref(), &cleat.key());
-    assert_eq!(checkout.target_path(), Some("/Users/alice/dev/flotilla-repos/feature-scoped/cleat"));
+    assert_eq!(checkout.target_path(), Some("/Users/alice/dev/flotilla-repos/convoy-scoped/feature-scoped/cleat"));
 
     let adopted_path = "/Users/alice/dev/cleat-existing";
     let checkouts = backend.clone().using::<Checkout>(NAMESPACE);

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -138,7 +138,7 @@ async fn ready_vessel_records_requested_and_effective_stance() {
         &backend,
         NAMESPACE,
         ReadyCheckoutFixture::builder()
-            .name("checkout-workspace-stance".to_string())
+            .name("checkout-convoy-stance".to_string())
             .env_ref(host_direct_env_name())
             .git_ref(GIT_REF.to_string())
             .path(checkout_path.to_string())
@@ -168,6 +168,78 @@ async fn ready_vessel_records_requested_and_effective_stance() {
         outcome.patch,
         Some(flotilla_resources::VesselStatusPatch::MarkReady { requested_stance: Stance::Trusted, effective_stance: Stance::Trusted, .. })
     ));
+}
+
+#[tokio::test]
+async fn sequential_vessels_share_a_convoy_owned_worktree_checkout() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-shared", "implement", REPO_URL, GIT_REF).await;
+    let mut status = convoy.status.clone().expect("convoy status");
+    status.workflow_snapshot.as_mut().expect("workflow snapshot").vessels.push(VesselRequirement {
+        name: "review".to_string(),
+        stance: Stance::Trusted,
+        depends_on: vec!["implement".to_string()],
+        repository_refs: None,
+        crew: Vec::new(),
+    });
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .update_status("convoy-shared", &convoy.metadata.resource_version, &status)
+        .await
+        .expect("second vessel should be recorded");
+    create_host_direct_policy(&backend, NAMESPACE, "policy-shared", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    let clone_name =
+        format!("clone-{}", clone_key(&canonicalize_repo_url(REPO_URL).expect("repo canonicalization"), &host_direct_env_name()));
+    create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/tmp/clone").await;
+    let implement =
+        create_workspace(&backend, NAMESPACE, "workspace-shared-implement", "convoy-shared", "implement", "policy-shared", REPO_URL).await;
+    let review =
+        create_workspace(&backend, NAMESPACE, "workspace-shared-review", "convoy-shared", "review", "policy-shared", REPO_URL).await;
+
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
+    let implement_deps = reconciler.fetch_dependencies(&implement).await.expect("implement dependencies");
+    let implement_outcome = reconciler.reconcile(&implement, &implement_deps, Utc::now());
+    let (checkout_meta, checkout_spec) = implement_outcome
+        .actuations
+        .iter()
+        .find_map(|actuation| match actuation {
+            Actuation::CreateCheckout { meta, spec } => Some((meta.clone(), spec.clone())),
+            _ => None,
+        })
+        .expect("first vessel should create the shared checkout");
+    assert_eq!(checkout_meta.name, "checkout-convoy-shared");
+    assert_eq!(checkout_meta.labels.get(CONVOY_LABEL).map(String::as_str), Some("convoy-shared"));
+    assert!(!checkout_meta.labels.contains_key(VESSEL_REF_LABEL));
+
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    let checkout = checkouts.create(&checkout_meta, &checkout_spec).await.expect("shared checkout create");
+    checkouts
+        .update_status(&checkout_meta.name, &checkout.metadata.resource_version, &CheckoutStatus {
+            phase: CheckoutPhase::Ready,
+            path: checkout_spec.target_path().map(str::to_string),
+            commit: None,
+            message: None,
+        })
+        .await
+        .expect("shared checkout ready");
+
+    let review_deps = reconciler.fetch_dependencies(&review).await.expect("review dependencies");
+    let review_outcome = reconciler.reconcile(&review, &review_deps, Utc::now());
+    assert!(
+        review_outcome.actuations.iter().all(|actuation| !matches!(actuation, Actuation::CreateCheckout { .. })),
+        "later vessels should reuse the convoy checkout"
+    );
+
+    reconciler.run_finalizer(&implement).await.expect("vessel finalization");
+    checkouts.get(&checkout_meta.name).await.expect("vessel finalization must preserve convoy checkout");
+    ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(NAMESPACE))
+        .with_checkouts(checkouts.clone())
+        .run_finalizer(&convoy)
+        .await
+        .expect("convoy finalization");
+    assert!(matches!(checkouts.get(&checkout_meta.name).await, Err(ResourceError::NotFound { .. })));
 }
 
 #[tokio::test]
@@ -426,7 +498,7 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
     create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
 
     for (repository, slug) in [(&repositories[0], "flotilla"), (&repositories[1], "cleat")] {
-        let name = format!("checkout-workspace-multi-docker-{slug}");
+        let name = format!("checkout-convoy-multi-docker-{slug}");
         let path = format!("/Users/alice/dev/flotilla-repos/workspace-multi-docker/{slug}");
         let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
         let created = checkouts
@@ -682,16 +754,17 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
     let deps = reconciler.fetch_dependencies(&vessel).await.expect("deps should load");
     let outcome = reconciler.reconcile(&vessel, &deps, Utc::now());
     assert_eq!(outcome.actuations.iter().filter(|actuation| matches!(actuation, Actuation::CreateClone { .. })).count(), 1);
-    let checkout = outcome
+    let (checkout_name, checkout) = outcome
         .actuations
         .iter()
         .find_map(|actuation| match actuation {
-            Actuation::CreateCheckout { spec, .. } => Some(spec),
+            Actuation::CreateCheckout { meta, spec } => Some((meta.name.as_str(), spec)),
             _ => None,
         })
         .expect("scoped checkout should be created");
+    assert_eq!(checkout_name, "checkout-convoy-scoped-cleat");
     assert_eq!(checkout.repo_ref(), &cleat.key());
-    assert_eq!(checkout.target_path(), Some("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-cleat.feature-scoped"));
+    assert_eq!(checkout.target_path(), Some("/Users/alice/dev/flotilla-repos/feature-scoped/cleat"));
 
     let adopted_path = "/Users/alice/dev/cleat-existing";
     let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
@@ -902,7 +975,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         &backend,
         NAMESPACE,
         ReadyCheckoutFixture::builder()
-            .name("checkout-workspace-c".to_string())
+            .name("checkout-convoy-c".to_string())
             .env_ref(host_direct_env_name())
             .git_ref(GIT_REF.to_string())
             .path("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-c".to_string())
@@ -1017,7 +1090,7 @@ async fn child_failure_propagates_to_workspace_failure() {
         &backend,
         NAMESPACE,
         ReadyCheckoutFixture::builder()
-            .name("checkout-workspace-f".to_string())
+            .name("checkout-convoy-f".to_string())
             .env_ref(host_direct_env_name())
             .git_ref(GIT_REF.to_string())
             .path("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-f".to_string())
@@ -1175,7 +1248,7 @@ async fn observed_checkout_at_managed_name_marks_workspace_failed() {
     let canonical_repo = canonicalize_repo_url(REPO_URL).expect("repo canonicalization");
     let clone_name = format!("clone-{}", clone_key(&canonical_repo, &host_direct_env_name()));
     create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/Users/alice/dev/flotilla-repos/clone").await;
-    create_ready_observed_checkout_without_status_path(&backend, NAMESPACE, "checkout-workspace-observed").await;
+    create_ready_observed_checkout_without_status_path(&backend, NAMESPACE, "checkout-convoy-observed").await;
     let workspace =
         create_workspace(&backend, NAMESPACE, "workspace-observed", "convoy-observed", "implement", "policy-observed", REPO_URL).await;
 
@@ -1187,7 +1260,7 @@ async fn observed_checkout_at_managed_name_marks_workspace_failed() {
         matches!(
             outcome.patch,
             Some(flotilla_resources::VesselStatusPatch::MarkFailed { ref message })
-                if message == "checkout checkout-workspace-observed is ready but has no target path"
+                if message == "checkout checkout-convoy-observed is ready but has no target path"
         ),
         "unexpected patch: {:?}",
         outcome.patch
@@ -1337,7 +1410,7 @@ async fn terminal_session_actuation_includes_system_and_user_labels() {
         &backend,
         NAMESPACE,
         ReadyCheckoutFixture::builder()
-            .name("checkout-workspace-labels".to_string())
+            .name("checkout-convoy-labels".to_string())
             .env_ref(host_direct_env_name())
             .git_ref(GIT_REF.to_string())
             .path("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-labels".to_string())
@@ -1417,7 +1490,11 @@ async fn assert_terminal_cwd_for_strategy(
         &backend,
         NAMESPACE,
         ReadyCheckoutFixture::builder()
-            .name(format!("checkout-{workspace_name}"))
+            .name(if checkout_path == "/workspace" && workspace_name == "workspace-docker-fresh" {
+                format!("checkout-{workspace_name}")
+            } else {
+                "checkout-convoy-cwd".to_string()
+            })
             .env_ref(checkout_env_ref.clone())
             .git_ref(GIT_REF.to_string())
             .path(checkout_path.to_string())

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -9,16 +9,18 @@ use common::{
     labeled_meta, meta, vessel_meta, work_state, DockerWorktreePolicyFixture, ReadyCheckoutFixture, StoppedTerminalFixture,
 };
 use flotilla_controllers::reconcilers::VesselReconciler;
+use flotilla_protocol::{IssueRef, IssueSource, IssueState};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{Actuation, Reconciler},
-    ensure_repository, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyPhase, ConvoyReconciler,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
+    ensure_repository, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyIssue, ConvoyPhase,
+    ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
     DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec,
-    Repository, RepositorySpec, ResourceBackend, ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkflowSnapshot,
-    WorkflowTemplate, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec,
+    PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend, ResourceError, Selector, Stance, TerminalSession,
+    TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec,
+    WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL,
+    VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
@@ -41,6 +43,8 @@ async fn repositoryless_vessel_runs_tools_without_provisioning_a_checkout() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy should create");
@@ -204,6 +208,21 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
             r#ref: Some("feature/multi".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
+            issue: Some(ConvoyIssue {
+                reference: IssueRef {
+                    source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+                    id: "732".into(),
+                },
+                repository_ref: Some(repository_specs[0].key()),
+                snapshot: IssueSnapshot {
+                    title: "Start convoy from an issue".into(),
+                    body: Some("Persist this exact issue body.".into()),
+                    state: IssueState::Open,
+                    labels: vec!["enhancement".into()],
+                    as_of: "2026-07-18T09:30:00Z".parse().expect("timestamp"),
+                },
+            }),
+            instruction: Some("Keep the public seam stable.".into()),
         })
         .await
         .expect("convoy should create");
@@ -274,8 +293,8 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         .collect::<Vec<_>>();
     assert_eq!(checkout_actuations.len(), 2);
     assert_eq!(checkout_actuations.iter().map(|(_, spec)| spec.target_path().expect("managed checkout path")).collect::<Vec<_>>(), [
-        "/Users/alice/dev/flotilla-repos/workspace-multi/cleat",
-        "/Users/alice/dev/flotilla-repos/workspace-multi/flotilla",
+        "/Users/alice/dev/flotilla-repos/feature-multi/cleat",
+        "/Users/alice/dev/flotilla-repos/feature-multi/flotilla",
     ]);
     for (meta, spec) in checkout_actuations {
         let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
@@ -298,9 +317,14 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         matches!(
             actuation,
             Actuation::CreateTerminalSession { spec, .. }
-                if spec.cwd == "/Users/alice/dev/flotilla-repos/workspace-multi"
+                if spec.cwd == "/Users/alice/dev/flotilla-repos/feature-multi"
                     && matches!(&spec.source, TerminalSessionSource::Agent { brief, .. }
-                        if brief.path == ".flotilla/briefs/coder.md")
+                        if brief.path == ".flotilla/briefs/coder.md"
+                            && brief.copies == ["/Users/alice/dev/flotilla-repos/feature-multi/flotilla"]
+                            && brief.content.contains("https://github.com` / `flotilla-org/flotilla` / `732")
+                            && brief.content.contains("Snapshot as of `2026-07-18T09:30:00+00:00`")
+                            && brief.content.contains("Persist this exact issue body.")
+                            && brief.content.contains("Keep the public seam stable."))
         )
     }));
 
@@ -311,7 +335,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         &host_direct_env_name(),
         "coder",
         "cargo test",
-        "/Users/alice/dev/flotilla-repos/workspace-multi",
+        "/Users/alice/dev/flotilla-repos/feature-multi",
         "cleat",
     )
     .await;
@@ -362,6 +386,8 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
             r#ref: Some("feature/multi".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy should create");
@@ -448,7 +474,7 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
     });
     let mounts = mounts.expect("docker environment should be created");
     assert_eq!(mounts.len(), 1);
-    assert_eq!(mounts[0].source_path, "/Users/alice/dev/flotilla-repos/workspace-multi-docker");
+    assert_eq!(mounts[0].source_path, "/Users/alice/dev/flotilla-repos/feature-multi");
     assert_eq!(mounts[0].target_path, "/workspace");
 
     let mixed = backend
@@ -509,6 +535,8 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
             r#ref: Some("feature/multi".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy should create");
@@ -614,6 +642,8 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
             r#ref: Some("feature/scoped".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy should create");
@@ -661,7 +691,7 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
         })
         .expect("scoped checkout should be created");
     assert_eq!(checkout.repo_ref(), &cleat.key());
-    assert_eq!(checkout.target_path(), Some("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-cleat.workspace-scoped"));
+    assert_eq!(checkout.target_path(), Some("/Users/alice/dev/flotilla-repos/github-com-flotilla-org-cleat.feature-scoped"));
 
     let adopted_path = "/Users/alice/dev/cleat-existing";
     let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
@@ -1125,7 +1155,7 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
     assert!(brief.content.contains("- `reviewer`: latent"));
     assert!(brief.content.contains("flotilla crew reviewer handoff --message"));
     assert!(brief.content.contains("flotilla crew complete"));
-    assert!(brief.content.ends_with("Implement issue 668.\n"));
+    assert!(brief.content.contains("## Assignment\n\nImplement issue 668.\n"));
     assert_eq!(context.namespace, NAMESPACE);
     assert_eq!(context.vessel_ref, "workspace-crew");
     assert_eq!(message, &None);
@@ -1479,6 +1509,8 @@ async fn create_convoy_with_labeled_processes(
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -48,7 +48,7 @@ pub fn build_crew_brief(
         "Complete your assignment with `flotilla crew complete --message '...'`. If it cannot be completed, report the failure with `flotilla crew fail --message '...'`.\n\n## Assignment\n\n{}\n",
         prompt.unwrap_or("No additional assignment was provided.")
     ));
-    flotilla_resources::TerminalBrief { path: crew_brief_path(role), content }
+    flotilla_resources::TerminalBrief { path: crew_brief_path(role), content, copies: Vec::new() }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -222,6 +222,7 @@ mod tests {
         let brief = flotilla_resources::TerminalBrief {
             path: ".flotilla/briefs/coder.md".into(),
             content: "protocol preamble\n\nImplement the issue.".into(),
+            copies: Vec::new(),
         };
 
         let codex = registry.get("codex").expect("codex adapter");

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -337,6 +337,7 @@ pub async fn build_plan(
         | CommandAction::CrewFail { .. }
         | CommandAction::CrewHandoff { .. }
         | CommandAction::ConvoyCreate { .. }
+        | CommandAction::ConvoyStart { .. }
         | CommandAction::WorkflowTemplateApply { .. }
         | CommandAction::ProjectAdd { .. }
         | CommandAction::ProjectApply { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -37,6 +37,7 @@ use flotilla_resources::{
     TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
     Vessel, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
+use sha2::{Digest, Sha256};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -2381,11 +2382,47 @@ fn convoy_fallback_slug(title: &str, id: &str) -> String {
             }
         })
         .0;
-    if slug.is_empty() {
-        "convoy".to_string()
-    } else {
-        slug
+    let slug = if slug.is_empty() { "convoy".to_string() } else { slug };
+    const MAX_CONVOY_NAME_LEN: usize = 63;
+    if slug.len() <= MAX_CONVOY_NAME_LEN {
+        return slug;
     }
+    let digest = format!("{:x}", Sha256::digest(slug.as_bytes()));
+    let suffix = &digest[..8];
+    let max_base_len = MAX_CONVOY_NAME_LEN - suffix.len() - 1;
+    let base = slug.chars().take(max_base_len).collect::<String>().trim_matches('-').to_string();
+    format!("{base}-{suffix}")
+}
+
+fn validate_convoy_name(name: &str) -> Result<(), String> {
+    if name.len() > 63
+        || !name.bytes().all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        || !name.bytes().next().is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+        || !name.bytes().last().is_some_and(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    {
+        return Err(format!("convoy name `{name}` must be a lowercase DNS label of at most 63 characters"));
+    }
+    Ok(())
+}
+
+fn validate_convoy_branch(branch: &str) -> Result<(), String> {
+    let invalid_character =
+        branch.bytes().any(|byte| byte <= b' ' || byte == 0x7f || matches!(byte, b'~' | b'^' | b':' | b'?' | b'*' | b'[' | b'\\'));
+    let invalid_component =
+        branch.split('/').any(|component| component.is_empty() || component.starts_with('.') || component.ends_with(".lock"));
+    if branch.len() > 1024
+        || branch == "@"
+        || branch.starts_with('-')
+        || branch.starts_with("refs/")
+        || branch.ends_with('.')
+        || branch.contains("..")
+        || branch.contains("@{")
+        || invalid_character
+        || invalid_component
+    {
+        return Err(format!("branch `{branch}` is not a valid git branch name"));
+    }
+    Ok(())
 }
 
 impl InProcessDaemon {
@@ -2448,6 +2485,7 @@ impl InProcessDaemon {
         }
         let repository_ref = match matching_repositories.as_slice() {
             [repository] => Some(repository.clone()),
+            [] if project.spec.repositories.len() == 1 => Some(project.spec.repositories[0].repo.clone()),
             _ => None,
         };
 
@@ -2515,10 +2553,12 @@ impl InProcessDaemon {
             .map(|name| required_admission_value(name, "name").map(str::to_string))
             .transpose()?
             .unwrap_or_else(|| convoy_fallback_slug(&generated.name, "").trim_end_matches('-').to_string());
+        validate_convoy_name(&name)?;
         let branch = match intent.branch.as_deref() {
             Some(branch) => required_admission_value(branch, "branch")?.to_string(),
             None => required_admission_value(&generated.branch, "generated branch")?.to_string(),
         };
+        validate_convoy_branch(&branch)?;
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
         match convoys.get(&name).await {
             Ok(_) => return Err(format!("convoy {name} already exists")),
@@ -2602,10 +2642,6 @@ impl InProcessDaemon {
                 }
                 Err(error) => unresolved.push(format!("repository {}: {error}", entry.repo)),
             }
-        }
-        if let Err(error) = self.resource_backend.clone().using::<WorkflowTemplate>(namespace).get(&project.spec.default_workflow_ref).await
-        {
-            unresolved.push(format!("workflow template {}: {error}", project.spec.default_workflow_ref));
         }
         for (repo_ref, (_, _, _, base_ref, _)) in &snapshots {
             if base_ref.is_none() {
@@ -4170,29 +4206,38 @@ impl InProcessDaemon {
         if let flotilla_protocol::CommandAction::ConvoyStart { intent } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
             let namespace = self.provisioning_namespace().await;
-            let result = match self.admit_convoy_start(&namespace, intent).await {
-                Ok(name) if intent.auto_attach => {
-                    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
-                    let resolved = loop {
-                        match self.resolve_attach_command_internal(&name).await {
-                            Ok(resolved) => break Ok(resolved),
-                            Err(message) if tokio::time::Instant::now() >= deadline => {
-                                break Err(format!("convoy {name} was created but no crew session became attachable: {message}"));
-                            }
-                            Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
-                        }
-                    };
-                    match resolved {
-                        Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
-                            name,
-                            attach_command: Some(resolved.command),
-                            binding: resolved.binding,
-                        },
-                        Err(message) => flotilla_protocol::CommandValue::Error { message },
-                    }
+            let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
+            let result = if requested_namespace != namespace {
+                flotilla_protocol::CommandValue::Error {
+                    message: format!(
+                        "namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"
+                    ),
                 }
-                Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
-                Err(message) => flotilla_protocol::CommandValue::Error { message },
+            } else {
+                match self.admit_convoy_start(&namespace, intent).await {
+                    Ok(name) if intent.auto_attach => {
+                        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+                        let resolved = loop {
+                            match self.resolve_attach_command_internal(&name).await {
+                                Ok(resolved) => break Ok(resolved),
+                                Err(message) if tokio::time::Instant::now() >= deadline => {
+                                    break Err(format!("convoy {name} was created but no crew session became attachable: {message}"));
+                                }
+                                Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+                            }
+                        };
+                        match resolved {
+                            Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
+                                name,
+                                attach_command: Some(resolved.command),
+                                binding: resolved.binding,
+                            },
+                            Err(message) => flotilla_protocol::CommandValue::Error { message },
+                        }
+                    }
+                    Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
+                    Err(message) => flotilla_protocol::CommandValue::Error { message },
+                }
             };
             self.finish_context_free_command(id, empty_identity, result);
             return Ok(id);

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -29,13 +29,13 @@ use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, apply_status_patch_checked as apply_resource_status_patch_checked,
     external_patches as convoy_external_patches, normalize_project_spec, resolve_project_issue_sources, terminal_session_attach_target,
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CrewSource,
-    Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue, IssueSourceResolution, IssueSourceUnavailable,
-    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec,
-    Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, TerminalBrief,
-    TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
-    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WorkflowTemplate,
-    WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch,
+    CrewSource, Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue, IssueSnapshot, IssueSourceResolution,
+    IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project,
+    ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
+    ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
+    Vessel, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -58,6 +58,7 @@ use crate::{
     model::{provider_names_from_registry, repo_name, RepoModel},
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
+        ai_utility::{AiUtility, ConvoyNames},
         discovery::{
             discover_providers_with_host_scoped, run_host_detectors, DiscoveryResult, DiscoveryRuntime, EnvironmentAssertion,
             EnvironmentBag,
@@ -604,7 +605,7 @@ async fn create_adopted_checkout_resource(
     Ok((checkout_ref, repository_url.to_string(), git_ref.to_string()))
 }
 
-async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str) -> Option<String> {
+async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str, contained: bool) -> Option<String> {
     let mut policies = match backend.clone().using::<PlacementPolicy>(namespace).list().await {
         Ok(list) => list.items,
         Err(err) => {
@@ -613,11 +614,12 @@ async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &
         }
     };
     policies.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
-    let policy = policies
-        .iter()
-        .find(|policy| policy.metadata.name.starts_with("host-direct-"))
-        .or_else(|| policies.first())
-        .map(|policy| policy.metadata.name.clone());
+    let policy = if contained {
+        policies.iter().find(|policy| policy.spec.docker_per_vessel.is_some())
+    } else {
+        policies.iter().find(|policy| policy.metadata.name.starts_with("host-direct-")).or_else(|| policies.first())
+    }
+    .map(|policy| policy.metadata.name.clone());
     if policy.is_none() {
         warn!(%namespace, "no placement policy found; convoy will remain Pending until one is registered");
     }
@@ -1027,6 +1029,18 @@ const FLEET_REPLICA_FRESH_SECS: i64 = 90;
 const FLEET_REPLICA_REFRESH_TIMEOUT: Duration = Duration::from_secs(2);
 
 impl InProcessDaemon {
+    async fn admission_ai_utility(&self) -> Option<Arc<dyn AiUtility>> {
+        let environment = self.environment_manager.environment_bag(&self.local_environment_id)?;
+        let runner = self.environment_manager.environment_runner(&self.local_environment_id)?;
+        let probe_root = ExecutionEnvironmentPath::new(self.config.base_path().as_ref());
+        for factory in &self.discovery.factories.ai_utilities {
+            if let Ok(utility) = factory.probe(&environment, &self.config, &probe_root, Arc::clone(&runner)).await {
+                return Some(utility);
+            }
+        }
+        None
+    }
+
     /// Create a new in-process daemon tracking the given repo paths.
     ///
     /// Returns `Arc<Self>` because a background poll task is spawned that
@@ -2343,7 +2357,213 @@ fn project_target_syntax(target: &str) -> ProjectTargetSyntax {
     }
 }
 
+fn required_admission_value<'a>(value: &'a str, field: &str) -> Result<&'a str, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        Err(format!("{field} cannot be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn convoy_fallback_slug(title: &str, id: &str) -> String {
+    let slug = format!("{title}-{id}")
+        .chars()
+        .fold((String::new(), false), |(mut output, pending_separator), character| {
+            if character.is_ascii_alphanumeric() {
+                if pending_separator && !output.is_empty() {
+                    output.push('-');
+                }
+                output.push(character.to_ascii_lowercase());
+                (output, false)
+            } else {
+                (output, true)
+            }
+        })
+        .0;
+    if slug.is_empty() {
+        "convoy".to_string()
+    } else {
+        slug
+    }
+}
+
 impl InProcessDaemon {
+    async fn resolve_convoy_issue(
+        &self,
+        namespace: &str,
+        project: &ResourceObject<Project>,
+        selector: &flotilla_protocol::IssueSelector,
+    ) -> Result<ConvoyIssue, String> {
+        let sources =
+            match resolve_project_issue_sources(&self.resource_backend.clone().using::<Repository>(namespace), &project.spec).await {
+                IssueSourceResolution::Available { sources } => sources,
+                IssueSourceResolution::Unavailable(IssueSourceUnavailable::RepositoryUnavailable { repository, message }) => {
+                    return Err(format!("repository {repository}: {message}"));
+                }
+                IssueSourceResolution::Unavailable(IssueSourceUnavailable::NoIssueSource) => {
+                    return Err(format!("project {} has no issue source", project.metadata.name));
+                }
+            };
+        let issue = match selector {
+            flotilla_protocol::IssueSelector::Reference(reference) => {
+                if !sources.contains(&reference.source) {
+                    return Err(format!(
+                        "issue source {} {} is not part of project {}",
+                        reference.source.service, reference.source.scope, project.metadata.name
+                    ));
+                }
+                self.fetch_issue_by_ref(reference).await?
+            }
+            flotilla_protocol::IssueSelector::Id(id) => {
+                let mut matches = Vec::new();
+                let mut failures = Vec::new();
+                for source in sources {
+                    let reference = flotilla_protocol::IssueRef { source, id: id.clone() };
+                    match self.fetch_issue_by_ref(&reference).await {
+                        Ok(issue) => matches.push(issue),
+                        Err(error) => failures.push(error),
+                    }
+                }
+                match matches.len() {
+                    1 => matches.remove(0),
+                    0 => return Err(format!("issue {id} was not found for project {}: {}", project.metadata.name, failures.join("; "))),
+                    count => return Err(format!("issue {id} is ambiguous across {count} project issue sources")),
+                }
+            }
+        };
+
+        let repositories = self.resource_backend.clone().using::<Repository>(namespace);
+        let mut matching_repositories = Vec::new();
+        for project_repository in &project.spec.repositories {
+            let repository = repositories
+                .get(&project_repository.repo.to_string())
+                .await
+                .map_err(|error| format!("repository {}: {error}", project_repository.repo))?;
+            if repository.spec.forge().is_some_and(|forge| {
+                forge.service_url == issue.reference.source.service && forge.repository == issue.reference.source.scope
+            }) {
+                matching_repositories.push(project_repository.repo.clone());
+            }
+        }
+        let repository_ref = match matching_repositories.as_slice() {
+            [repository] => Some(repository.clone()),
+            _ => None,
+        };
+
+        Ok(ConvoyIssue {
+            reference: issue.reference,
+            repository_ref,
+            snapshot: IssueSnapshot { title: issue.title, body: issue.body, state: issue.state, labels: issue.labels, as_of: issue.as_of },
+        })
+    }
+
+    async fn admit_convoy_start(&self, namespace: &str, intent: &flotilla_protocol::ConvoyStartIntent) -> Result<String, String> {
+        let project_ref = required_admission_value(&intent.project_ref, "project")?;
+        let project = self
+            .resource_backend
+            .clone()
+            .using::<Project>(namespace)
+            .get(project_ref)
+            .await
+            .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
+        let repositories = self.snapshot_project_repositories(namespace, project_ref).await?;
+        let issue = match &intent.issue {
+            Some(selector) => Some(self.resolve_convoy_issue(namespace, &project, selector).await?),
+            None => None,
+        };
+        let workflow_ref = match intent.workflow_ref.as_deref() {
+            Some(workflow_ref) => required_admission_value(workflow_ref, "workflow")?.to_string(),
+            None => project.spec.default_workflow_ref.clone(),
+        };
+        let workflow = self
+            .resource_backend
+            .clone()
+            .using::<WorkflowTemplate>(namespace)
+            .get(&workflow_ref)
+            .await
+            .map_err(|error| format!("workflow template {workflow_ref}: {error}"))?;
+
+        let fallback_slug = issue
+            .as_ref()
+            .map(|issue| convoy_fallback_slug(&issue.snapshot.title, &issue.reference.id))
+            .unwrap_or_else(|| convoy_fallback_slug(&project.spec.display_name, project_ref));
+        let generated = if intent.name.is_none() || intent.branch.is_none() {
+            let issue_context = issue.as_ref().map(|issue| {
+                format!("Issue {}: {}\n{}", issue.reference.id, issue.snapshot.title, issue.snapshot.body.as_deref().unwrap_or_default())
+            });
+            let context = [
+                Some(format!("Project: {}", project.spec.display_name)),
+                issue_context,
+                intent.instruction.as_ref().map(|instruction| format!("Instruction: {instruction}")),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join("\n");
+            match self.admission_ai_utility().await {
+                Some(utility) => utility.generate_convoy_names(&context).await.ok(),
+                None => None,
+            }
+        } else {
+            None
+        };
+        let generated = generated.unwrap_or_else(|| ConvoyNames { name: fallback_slug.clone(), branch: fallback_slug.clone() });
+        let name = intent
+            .name
+            .as_deref()
+            .map(|name| required_admission_value(name, "name").map(str::to_string))
+            .transpose()?
+            .unwrap_or_else(|| convoy_fallback_slug(&generated.name, "").trim_end_matches('-').to_string());
+        let branch = match intent.branch.as_deref() {
+            Some(branch) => required_admission_value(branch, "branch")?.to_string(),
+            None => required_admission_value(&generated.branch, "generated branch")?.to_string(),
+        };
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
+        match convoys.get(&name).await {
+            Ok(_) => return Err(format!("convoy {name} already exists")),
+            Err(ResourceError::NotFound { .. }) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+        let contained = workflow.spec.vessels.iter().any(|vessel| vessel.stance == flotilla_resources::Stance::Contained);
+        let placement_policy = match &intent.placement_policy {
+            Some(policy) => {
+                let policy = required_admission_value(policy, "placement policy")?;
+                let resolved = self
+                    .resource_backend
+                    .clone()
+                    .using::<PlacementPolicy>(namespace)
+                    .get(policy)
+                    .await
+                    .map_err(|error| format!("placement policy {policy}: {error}"))?;
+                if contained && resolved.spec.docker_per_vessel.is_none() {
+                    return Err(format!("contained workflow requires a docker placement policy, but {policy} is not contained"));
+                }
+                Some(policy.to_string())
+            }
+            None => {
+                let policy = default_convoy_placement_policy(&self.resource_backend, namespace, contained).await;
+                if contained && policy.is_none() {
+                    return Err("contained workflow requires an available docker placement policy".to_string());
+                }
+                policy
+            }
+        };
+        let spec = ConvoySpec {
+            workflow_ref,
+            inputs: intent.inputs.iter().map(|(key, value)| (key.clone(), InputValue::String(value.clone()))).collect(),
+            placement_policy,
+            repositories,
+            r#ref: Some(branch),
+            project_ref: Some(project_ref.to_string()),
+            adopted_checkout_refs: BTreeMap::new(),
+            issue,
+            instruction: intent.instruction.clone(),
+        };
+        convoys.create(&InputMeta::builder().name(name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
+        Ok(name)
+    }
+
     async fn snapshot_project_repositories(&self, namespace: &str, project_ref: &str) -> Result<Vec<ConvoyRepositorySpec>, String> {
         let project = self
             .resource_backend
@@ -3947,6 +4167,37 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
+        if let flotilla_protocol::CommandAction::ConvoyStart { intent } = &command.action {
+            let empty_identity = self.start_context_free_command(id, command.description().to_string());
+            let namespace = self.provisioning_namespace().await;
+            let result = match self.admit_convoy_start(&namespace, intent).await {
+                Ok(name) if intent.auto_attach => {
+                    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+                    let resolved = loop {
+                        match self.resolve_attach_command_internal(&name).await {
+                            Ok(resolved) => break Ok(resolved),
+                            Err(message) if tokio::time::Instant::now() >= deadline => {
+                                break Err(format!("convoy {name} was created but no crew session became attachable: {message}"));
+                            }
+                            Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
+                        }
+                    };
+                    match resolved {
+                        Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
+                            name,
+                            attach_command: Some(resolved.command),
+                            binding: resolved.binding,
+                        },
+                        Err(message) => flotilla_protocol::CommandValue::Error { message },
+                    }
+                }
+                Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
+                Err(message) => flotilla_protocol::CommandValue::Error { message },
+            };
+            self.finish_context_free_command(id, empty_identity, result);
+            return Ok(id);
+        }
+
         if let flotilla_protocol::CommandAction::ConvoyCreate {
             name,
             workflow_ref,
@@ -4023,7 +4274,7 @@ impl InProcessDaemon {
             }
             let placement_policy = match placement_policy {
                 Some(policy) => Some(policy.clone()),
-                None => default_convoy_placement_policy(&self.resource_backend, &namespace).await,
+                None => default_convoy_placement_policy(&self.resource_backend, &namespace, false).await,
             };
             let mut direct_repository_url = repository_url.clone();
             let mut r#ref = r#ref.clone();
@@ -4145,6 +4396,8 @@ impl InProcessDaemon {
                 r#ref,
                 project_ref: project_ref.clone(),
                 adopted_checkout_refs,
+                issue: None,
+                instruction: None,
             };
             let meta = InputMeta::builder().name(name.clone()).build();
             let result = match convoys.create(&meta, &spec).await {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -57,6 +57,24 @@ fn workspace_slugs_are_dns_safe_bounded_and_disambiguatable() {
 }
 
 #[test]
+fn convoy_fallback_names_are_dns_safe_bounded_and_deterministic() {
+    let title = "A very long issue title ".repeat(10);
+    let left = convoy_fallback_slug(&title, "LINEAR-732");
+    let right = convoy_fallback_slug(&title, "LINEAR-732");
+    assert_eq!(left, right);
+    assert!(left.len() <= 63);
+    validate_convoy_name(&left).expect("fallback should be a valid resource name");
+}
+
+#[test]
+fn convoy_branch_validation_rejects_refs_that_checkout_cannot_create() {
+    for branch in ["bad branch", "-invalid", "refs/heads/nested", "topic..nested", ".hidden/topic", "topic.lock"] {
+        assert!(validate_convoy_branch(branch).is_err(), "{branch} should be rejected");
+    }
+    validate_convoy_branch("fix/issue-732").expect("normal branch should be accepted");
+}
+
+#[test]
 fn project_target_syntax_disambiguates_paths_and_qualified_slugs() {
     assert_eq!(project_target_syntax("/srv/repos/example"), ProjectTargetSyntax::ExplicitPath);
     assert_eq!(project_target_syntax("./org/repo"), ProjectTargetSyntax::ExplicitPath);

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -329,6 +329,8 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("create convoy");
@@ -427,7 +429,7 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
                 role: "coder".into(),
                 source: TerminalSessionSource::Agent {
                     selector: Selector { capability: "coding".into() },
-                    brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "coder brief".into() },
+                    brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "coder brief".into(), copies: Vec::new() },
                     context: TerminalCrewContext {
                         namespace: "flotilla".into(),
                         convoy: "demo".into(),
@@ -1158,7 +1160,7 @@ async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command(
                 role: "coder".to_string(),
                 source: TerminalSessionSource::Agent {
                     selector: Selector { capability: "coding".to_string() },
-                    brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into() },
+                    brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() },
                     context: TerminalCrewContext {
                         namespace: "flotilla".into(),
                         convoy: "convoy-a".into(),
@@ -2357,6 +2359,8 @@ async fn convoy_completion_command_updates_convoy_task_status() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy create should succeed");
@@ -2735,6 +2739,8 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-core/src/providers/ai_utility/claude_api.rs
+++ b/crates/flotilla-core/src/providers/ai_utility/claude_api.rs
@@ -91,4 +91,13 @@ impl super::AiUtility for ClaudeApiAiUtility {
             Ok(branch)
         }
     }
+
+    async fn generate_convoy_names(&self, context: &str) -> Result<super::ConvoyNames, String> {
+        info!("ai: generating convoy and branch names via API");
+        let prompt = format!(
+            "Suggest a coherent short convoy resource name and git branch name for this context. \
+             Return ONLY JSON with string fields name and branch. Use lowercase kebab-case; the branch may contain one slash: {context}"
+        );
+        super::parse_convoy_names(&self.prompt(Model::Haiku, &prompt).await?)
+    }
 }

--- a/crates/flotilla-core/src/providers/ai_utility/claude_cli.rs
+++ b/crates/flotilla-core/src/providers/ai_utility/claude_cli.rs
@@ -59,4 +59,13 @@ impl super::AiUtility for ClaudeCliAiUtility {
             Ok(branch)
         }
     }
+
+    async fn generate_convoy_names(&self, context: &str) -> Result<super::ConvoyNames, String> {
+        info!("ai: generating convoy and branch names via CLI");
+        let prompt = format!(
+            "Suggest a coherent short convoy resource name and git branch name for this context. \
+             Return ONLY JSON with string fields name and branch. Use lowercase kebab-case; the branch may contain one slash: {context}"
+        );
+        super::parse_convoy_names(&self.prompt(Model::Haiku, &prompt).await?)
+    }
 }

--- a/crates/flotilla-core/src/providers/ai_utility/mod.rs
+++ b/crates/flotilla-core/src/providers/ai_utility/mod.rs
@@ -2,6 +2,13 @@ pub mod claude_api;
 pub mod claude_cli;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvoyNames {
+    pub name: String,
+    pub branch: String,
+}
 
 /// Which Claude model to use for a request.
 #[derive(Debug, Clone, Copy)]
@@ -34,4 +41,21 @@ impl Model {
 #[async_trait]
 pub trait AiUtility: Send + Sync {
     async fn generate_branch_name(&self, context: &str) -> Result<String, String>;
+
+    /// Generate the coupled resource and branch names in one model request.
+    async fn generate_convoy_names(&self, context: &str) -> Result<ConvoyNames, String> {
+        let branch = self.generate_branch_name(context).await?;
+        Ok(ConvoyNames { name: branch.replace('/', "-"), branch })
+    }
+}
+
+pub(super) fn parse_convoy_names(output: &str) -> Result<ConvoyNames, String> {
+    let output = output.trim().trim_matches('`').trim();
+    let output = output.strip_prefix("json").map(str::trim).unwrap_or(output);
+    let names: ConvoyNames = serde_json::from_str(output).map_err(|error| format!("invalid convoy names response: {error}"))?;
+    if names.name.trim().is_empty() || names.branch.trim().is_empty() {
+        Err("claude returned an empty convoy or branch name".to_string())
+    } else {
+        Ok(names)
+    }
 }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -14,7 +17,7 @@ use flotilla_core::{
     model::RepoModel,
     path_context::ExecutionEnvironmentPath,
     providers::{
-        ai_utility::AiUtility,
+        ai_utility::{AiUtility, ConvoyNames},
         change_request::ChangeRequestTracker,
         coding_agent::CloudAgentService,
         discovery::{
@@ -37,14 +40,16 @@ use flotilla_core::{
 use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
     test_support::TestIssue,
-    AssociationKey, Change, Checkout, CheckoutSelector, CheckoutTarget, Command, CommandAction, CommandValue, CorrelationKey, DaemonEvent,
-    EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostEnvironment, HostName, HostPath, HostProviderStatus, HostSummary, ImageId,
-    IssueRef, IssueSource, NodeId, NodeInfo, PeerConnectionState, ProviderData, RepoIdentity, RepoSelector, StreamKey, SystemInfo,
-    ToolInventory, TopologyRoute, WorkItemKind,
+    AssociationKey, Change, Checkout, CheckoutSelector, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyStartIntent,
+    CorrelationKey, DaemonEvent, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostEnvironment, HostName, HostPath,
+    HostProviderStatus, HostSummary, ImageId, IssueRef, IssueSelector, IssueSource, NodeId, NodeInfo, PeerConnectionState, ProviderData,
+    RepoIdentity, RepoSelector, StreamKey, SystemInfo, ToolInventory, TopologyRoute, WorkItemKind,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec,
-    RepositorySpec, TypedResolver, REPO_KEY_LABEL, REPO_LABEL,
+    single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy as ResourceConvoy,
+    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy,
+    PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, TypedResolver, WorkflowTemplate,
+    REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -320,6 +325,52 @@ fn slow_ai_discovery(utility: Arc<SlowAiUtility>) -> DiscoveryRuntime {
     let mut runtime = fake_discovery(false);
     runtime.factories.ai_utilities.push(Box::new(SlowAiUtilityFactory { utility }));
     runtime
+}
+
+struct CountingConvoyAiUtility {
+    calls: AtomicUsize,
+    fail: AtomicBool,
+}
+
+#[async_trait]
+impl AiUtility for CountingConvoyAiUtility {
+    async fn generate_branch_name(&self, _: &str) -> Result<String, String> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok("unexpected-branch-only-call".into())
+    }
+
+    async fn generate_convoy_names(&self, _: &str) -> Result<ConvoyNames, String> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail.load(Ordering::SeqCst) {
+            Err("offline".into())
+        } else {
+            Ok(ConvoyNames { name: "generated-convoy".into(), branch: "fix/generated-convoy".into() })
+        }
+    }
+}
+
+struct CountingConvoyAiUtilityFactory {
+    utility: Arc<CountingConvoyAiUtility>,
+}
+
+#[async_trait]
+impl Factory for CountingConvoyAiUtilityFactory {
+    type Descriptor = ProviderDescriptor;
+    type Output = dyn AiUtility;
+
+    fn descriptor(&self) -> ProviderDescriptor {
+        ProviderDescriptor::named(ProviderCategory::AiUtility, "counting-ai")
+    }
+
+    async fn probe(
+        &self,
+        _: &EnvironmentBag,
+        _: &ConfigStore,
+        _: &ExecutionEnvironmentPath,
+        _: Arc<dyn flotilla_core::providers::CommandRunner>,
+    ) -> Result<Arc<Self::Output>, Vec<UnmetRequirement>> {
+        Ok(Arc::clone(&self.utility) as Arc<dyn AiUtility>)
+    }
 }
 
 struct TestProvisionedEnvironment {
@@ -602,6 +653,237 @@ async fn fetch_issue_by_ref_does_not_require_a_tracked_checkout() {
     assert_eq!(fetched.reference, reference);
     assert_eq!(fetched.title, "Source-addressed issue fetch seam");
     assert!(daemon.list_repos().await.expect("list repos").is_empty());
+}
+
+async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBackend) {
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &InputMeta::builder().name("docker-test".to_string()).build(),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
+                    host_ref: "host-test".into(),
+                    image: "flotilla-test".into(),
+                    default_cwd: Some("/workspace".into()),
+                    env: Default::default(),
+                    checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".into() },
+                })
+                .build(),
+        )
+        .await
+        .expect("contained policy create");
+}
+
+#[tokio::test]
+async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snapshot() {
+    let reference =
+        IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "732".into() };
+    let mut issue = TestIssue::new("Start convoy from an issue").id("732").with_labels(vec!["enhancement".into()]).build();
+    issue.reference = reference.clone();
+    issue.body = Some("Capture the issue at admission time.".into());
+    let provider = Arc::new(FakeIssueProvider::new());
+    provider.add_issues(vec![(reference.id.clone(), issue.clone())]).await;
+    let utility = Arc::new(CountingConvoyAiUtility { calls: AtomicUsize::new(0), fail: AtomicBool::new(false) });
+    let mut discovery = fake_discovery_with_provider_set(
+        FakeDiscoveryProviders::new().with_issue_tracker(provider as Arc<dyn flotilla_core::providers::issue_tracker::IssueProvider>),
+    );
+    discovery.factories.ai_utilities.push(Box::new(CountingConvoyAiUtilityFactory { utility: Arc::clone(&utility) }));
+    let (temp, _repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    let backend = daemon.resource_backend();
+    let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository.key().to_string()).build(), &repository)
+        .await
+        .expect("repository create");
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
+        .await
+        .expect("workflow create");
+    create_test_contained_policy(&backend).await;
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
+            display_name: "Flotilla".into(),
+            default_workflow_ref: "single-agent-contained".into(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project create");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    project_ref: "flotilla".into(),
+                    issue: Some(IssueSelector::Reference(reference.clone())),
+                    name: Some("issue-732".into()),
+                    branch: Some("fix/issue-732".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: vec![("review".into(), "required".into())],
+                    instruction: Some("Keep the snapshot durable.".into()),
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("start command accepted");
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("start command should finish");
+
+    assert_eq!(result, CommandValue::ConvoyStarted { name: "issue-732".into(), attach_command: None, binding: None });
+    let persisted = backend.using::<ResourceConvoy>("flotilla").get("issue-732").await.expect("persisted convoy");
+    assert_eq!(persisted.spec.project_ref.as_deref(), Some("flotilla"));
+    assert_eq!(persisted.spec.workflow_ref, "single-agent-contained");
+    assert_eq!(persisted.spec.r#ref.as_deref(), Some("fix/issue-732"));
+    assert_eq!(persisted.spec.placement_policy.as_deref(), Some("docker-test"));
+    assert_eq!(persisted.spec.repositories.len(), 1);
+    assert_eq!(persisted.spec.instruction.as_deref(), Some("Keep the snapshot durable."));
+    let persisted_issue = persisted.spec.issue.expect("issue snapshot");
+    assert_eq!(persisted_issue.reference, reference);
+    assert_eq!(persisted_issue.repository_ref, Some(repository.key()));
+    assert_eq!(persisted_issue.snapshot.title, issue.title);
+    assert_eq!(persisted_issue.snapshot.body, issue.body);
+    assert_eq!(utility.calls.load(Ordering::SeqCst), 0, "fully specified admission must not call AI");
+
+    utility.fail.store(true, Ordering::SeqCst);
+    let fallback_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    project_ref: "flotilla".into(),
+                    issue: Some(IssueSelector::Reference(reference)),
+                    name: None,
+                    branch: None,
+                    workflow_ref: None,
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("offline fallback command accepted");
+    let fallback_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == fallback_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("offline fallback should finish");
+    assert_eq!(fallback_result, CommandValue::ConvoyStarted {
+        name: "start-convoy-from-an-issue-732".into(),
+        attach_command: None,
+        binding: None,
+    });
+    let fallback = backend.using::<ResourceConvoy>("flotilla").get("start-convoy-from-an-issue-732").await.expect("fallback convoy");
+    assert_eq!(fallback.spec.r#ref.as_deref(), Some("start-convoy-from-an-issue-732"));
+    assert_eq!(utility.calls.load(Ordering::SeqCst), 1);
+
+    drop(temp);
+}
+
+#[tokio::test]
+async fn convoy_start_completes_both_names_with_one_ai_call() {
+    let utility = Arc::new(CountingConvoyAiUtility { calls: AtomicUsize::new(0), fail: AtomicBool::new(false) });
+    let mut discovery = fake_discovery(false);
+    discovery.factories.ai_utilities.push(Box::new(CountingConvoyAiUtilityFactory { utility: Arc::clone(&utility) }));
+    let (temp, _repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    let backend = daemon.resource_backend();
+    let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository.key().to_string()).build(), &repository)
+        .await
+        .expect("repository create");
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
+        .await
+        .expect("workflow create");
+    create_test_contained_policy(&backend).await;
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
+            display_name: "Flotilla".into(),
+            default_workflow_ref: "single-agent-contained".into(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project create");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    project_ref: "flotilla".into(),
+                    issue: None,
+                    name: None,
+                    branch: None,
+                    workflow_ref: None,
+                    inputs: Vec::new(),
+                    instruction: Some("Implement the admission snapshot.".into()),
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("start command accepted");
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("start command should finish");
+
+    assert_eq!(result, CommandValue::ConvoyStarted { name: "generated-convoy".into(), attach_command: None, binding: None });
+    let persisted = backend.using::<ResourceConvoy>("flotilla").get("generated-convoy").await.expect("persisted convoy");
+    assert_eq!(persisted.spec.r#ref.as_deref(), Some("fix/generated-convoy"));
+    assert_eq!(utility.calls.load(Ordering::SeqCst), 1);
+    drop(temp);
 }
 
 fn static_ssh_test_discovery(runner: Arc<dyn CommandRunner>) -> DiscoveryRuntime {

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -679,7 +679,7 @@ async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBack
 #[tokio::test]
 async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snapshot() {
     let reference =
-        IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "732".into() };
+        IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/planning".into() }, id: "732".into() };
     let mut issue = TestIssue::new("Start convoy from an issue").id("732").with_labels(vec!["enhancement".into()]).build();
     issue.reference = reference.clone();
     issue.body = Some("Capture the issue at admission time.".into());
@@ -712,7 +712,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
         .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
             display_name: "Flotilla".into(),
             default_workflow_ref: "single-agent-contained".into(),
-            issue_source: None,
+            issue_source: Some(reference.source.clone()),
             repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
         })
         .await
@@ -726,6 +726,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
             context_repo: None,
             action: CommandAction::ConvoyStart {
                 intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
                     project_ref: "flotilla".into(),
                     issue: Some(IssueSelector::Reference(reference.clone())),
                     name: Some("issue-732".into()),
@@ -775,6 +776,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
             context_repo: None,
             action: CommandAction::ConvoyStart {
                 intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
                     project_ref: "flotilla".into(),
                     issue: Some(IssueSelector::Reference(reference)),
                     name: None,
@@ -808,6 +810,130 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     let fallback = backend.using::<ResourceConvoy>("flotilla").get("start-convoy-from-an-issue-732").await.expect("fallback convoy");
     assert_eq!(fallback.spec.r#ref.as_deref(), Some("start-convoy-from-an-issue-732"));
     assert_eq!(utility.calls.load(Ordering::SeqCst), 1);
+
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("explicit-workflow".to_string()).build(), &ProjectSpec {
+            display_name: "Explicit workflow".into(),
+            default_workflow_ref: "missing-default".into(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project with unresolved default should persist");
+    let explicit_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: Some("flotilla".into()),
+                    project_ref: "explicit-workflow".into(),
+                    issue: None,
+                    name: Some("explicit-workflow".into()),
+                    branch: Some("fix/explicit-workflow".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("explicit workflow command accepted");
+    let explicit_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == explicit_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("explicit workflow should not consult the missing default");
+    assert_eq!(explicit_result, CommandValue::ConvoyStarted { name: "explicit-workflow".into(), attach_command: None, binding: None });
+
+    let wrong_namespace_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: Some("other".into()),
+                    project_ref: "flotilla".into(),
+                    issue: None,
+                    name: Some("wrong-namespace".into()),
+                    branch: Some("fix/wrong-namespace".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("namespace rejection command accepted");
+    let wrong_namespace_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == wrong_namespace_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("wrong namespace should fail visibly");
+    assert!(matches!(wrong_namespace_result, CommandValue::Error { message } if message.contains("not served by this daemon")));
+    assert!(matches!(
+        backend.using::<ResourceConvoy>("flotilla").get("wrong-namespace").await,
+        Err(flotilla_resources::ResourceError::NotFound { .. })
+    ));
+
+    let invalid_branch_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".into(),
+                    issue: None,
+                    name: Some("invalid-branch".into()),
+                    branch: Some("bad branch".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("invalid branch command accepted");
+    let invalid_branch_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == invalid_branch_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("invalid branch should fail before persistence");
+    assert!(matches!(invalid_branch_result, CommandValue::Error { message } if message.contains("valid git branch")));
+    assert!(matches!(
+        backend.using::<ResourceConvoy>("flotilla").get("invalid-branch").await,
+        Err(flotilla_resources::ResourceError::NotFound { .. })
+    ));
 
     drop(temp);
 }
@@ -853,6 +979,7 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
             context_repo: None,
             action: CommandAction::ConvoyStart {
                 intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
                     project_ref: "flotilla".into(),
                     issue: None,
                     name: None,

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1087,6 +1087,12 @@ impl TerminalRuntime for TerminalControllerRuntime {
                     .get(&requirement.adapter)
                     .ok_or_else(|| format!("agent adapter {} unavailable for environment {}", requirement.adapter, spec.env_ref))?;
                 adapter.prepare(&cwd, brief).await?;
+                for copy_root in &brief.copies {
+                    let copy_root = ExecutionEnvironmentPath::new(copy_root);
+                    if copy_root != cwd {
+                        adapter.prepare(&copy_root, brief).await?;
+                    }
+                }
                 let plan = adapter.launch(&AgentLaunchRequest {
                     role: spec.role.clone(),
                     model: requirement.model.clone(),
@@ -1657,6 +1663,26 @@ mod tests {
         (daemon, pool)
     }
 
+    async fn crew_daemon_with_process_runner(config: Arc<ConfigStore>) -> (Arc<InProcessDaemon>, Arc<FakeTerminalPool>) {
+        let pool = Arc::new(FakeTerminalPool::new());
+        let mut discovery = fake_discovery_with_provider_set(
+            FakeDiscoveryProviders::new()
+                .with_terminal_pool(Arc::clone(&pool) as Arc<dyn flotilla_core::providers::terminal::TerminalPool>),
+        );
+        discovery.runner = Arc::new(ProcessCommandRunner);
+        let daemon = InProcessDaemon::new(Vec::new(), config, discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        daemon
+            .replace_local_environment_bag_for_test(
+                EnvironmentBag::new()
+                    .with(EnvironmentAssertion::env_var("HOME", "/Users/tester"))
+                    .with(EnvironmentAssertion::binary("git", "/usr/bin/git"))
+                    .with(EnvironmentAssertion::binary("codex", "/tools/codex"))
+                    .with(EnvironmentAssertion::binary("claude", "/tools/claude")),
+            )
+            .expect("crew environment bag");
+        (daemon, pool)
+    }
+
     async fn run_stage4a_flow_reaches_running_and_completes_convoy(
         daemon: Arc<InProcessDaemon>,
         config: Arc<ConfigStore>,
@@ -1724,6 +1750,8 @@ mod tests {
                 r#ref: Some("main".to_string()),
                 project_ref: None,
                 adopted_checkout_refs: BTreeMap::new(),
+                issue: None,
+                instruction: None,
             })
             .await
             .expect("convoy create should succeed");
@@ -1984,7 +2012,7 @@ mod tests {
         std::fs::create_dir_all(&config_path).expect("config dir");
         std::fs::write(config_path.join("daemon.toml"), "machine_id = \"dinghy-test\"\n").expect("daemon config");
         let config = Arc::new(ConfigStore::with_base(config_path));
-        let (daemon, pool) = crew_daemon(Arc::clone(&config)).await;
+        let (daemon, pool) = crew_daemon_with_process_runner(Arc::clone(&config)).await;
         let local_registry = probe_local_provider_registry(&daemon, &config).await.expect("crew provider registry");
         let profile = build_local_profile(&daemon, &local_registry).expect("local profile");
         let state = Arc::new(ControllerRuntimeState::new(
@@ -2005,6 +2033,10 @@ mod tests {
         }])
         .await;
         let runtime = TerminalControllerRuntime { state };
+        let session_cwd = temp.path().join("session-cwd");
+        std::fs::create_dir_all(&session_cwd).expect("session cwd");
+        let durable_checkout = temp.path().join("durable-checkout");
+        std::fs::create_dir_all(&durable_checkout).expect("durable checkout dir");
         let spec = flotilla_resources::TerminalSessionSpec {
             env_ref: profile.host_direct_environment_name(),
             role: "coder".to_string(),
@@ -2013,6 +2045,7 @@ mod tests {
                 brief: flotilla_resources::TerminalBrief {
                     path: ".flotilla/briefs/coder.md".to_string(),
                     content: "Implement the issue.".to_string(),
+                    copies: vec![durable_checkout.display().to_string()],
                 },
                 context: flotilla_resources::TerminalCrewContext {
                     namespace: NAMESPACE.to_string(),
@@ -2021,7 +2054,7 @@ mod tests {
                 },
                 message: None,
             },
-            cwd: "/repo".to_string(),
+            cwd: session_cwd.display().to_string(),
             pool: "fake-terminals".to_string(),
         };
 
@@ -2030,6 +2063,10 @@ mod tests {
         assert_eq!(pool.killed.lock().await.as_slice(), &[session_name.to_string()]);
         assert_eq!(pool.ensured.lock().await.len(), 1, "the fresh agent command must actually be launched");
         assert!(launched.crew.is_some(), "the replacement gets a fresh crew identity");
+        assert_eq!(
+            std::fs::read_to_string(durable_checkout.join(".flotilla/briefs/coder.md")).expect("durable brief copy"),
+            "Implement the issue."
+        );
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -29,8 +29,8 @@ use flotilla_core::{
 };
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
 use flotilla_resources::{
-    clone_key, controller::ControllerLoop, descriptive_repo_slug, Clone, CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec,
-    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
+    clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, Clone, CloneSpec, Convoy, ConvoyReconciler, CrewSource,
+    CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
     InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Repository, ResourceBackend, ResourceError, ResourceObject, Stance,
     TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
@@ -769,7 +769,8 @@ fn spawn_controller_loops(
                             secondaries: ConvoyReconciler::secondary_watches(),
                             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(&namespace_string))
                                 .with_vessels(backend.clone().using::<Vessel>(&namespace_string))
-                                .with_presentations(backend.clone().using::<Presentation>(&namespace_string)),
+                                .with_presentations(backend.clone().using::<Presentation>(&namespace_string))
+                                .with_checkouts(backend.clone().using::<Checkout>(&namespace_string)),
                             resync_interval: controller_resync_interval,
                             backend,
                         }

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -302,6 +302,8 @@ async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
+            issue: None,
+            instruction: None,
         })
         .await
         .expect("convoy create should succeed");

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -52,6 +52,8 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
+        issue: None,
+        instruction: None,
     }
 }
 

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -103,6 +103,8 @@ pub enum IssueSelector {
 /// intent must never enter the resource store.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoyStartIntent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
     pub project_ref: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issue: Option<IssueSelector>,

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -10,7 +10,7 @@ use crate::{
         CrewCommandContext, CrewListResponse, FleetListResponse, FleetReplicaSnapshot, HostListResponse, HostProvidersResponse,
         HostStatusResponse, RepoDetailResponse, RepoProvidersResponse, RepoWorkResponse,
     },
-    AttachableSetId, RepoIdentity,
+    AttachableSetId, IssueRef, RepoIdentity,
 };
 #[cfg(test)]
 use crate::{qualified_path::HostId, EnvironmentId};
@@ -84,6 +84,44 @@ pub struct Command {
     pub context_repo: Option<RepoSelector>,
     #[serde(flatten)]
     pub action: CommandAction,
+}
+
+/// An issue supplied to convoy admission either as a fully source-qualified
+/// reference or as an opaque ID whose source must be resolved through the
+/// Project.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IssueSelector {
+    Id(String),
+    Reference(IssueRef),
+}
+
+/// Partial intent accepted by the convoy start verb. Admission completes any
+/// omitted fields before persisting a `ConvoySpec`.
+///
+/// This type lives in protocol rather than resources because incomplete
+/// intent must never enter the resource store.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct ConvoyStartIntent {
+    pub project_ref: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue: Option<IssueSelector>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_ref: Option<String>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<(String, String)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instruction: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_policy: Option<String>,
+    #[builder(default)]
+    #[serde(default)]
+    pub auto_attach: bool,
 }
 
 /// Commands the client can send to the daemon.
@@ -191,6 +229,9 @@ pub enum CommandAction {
         placement_policy: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         adopted_checkout: Option<Box<PathBuf>>,
+    },
+    ConvoyStart {
+        intent: Box<ConvoyStartIntent>,
     },
     WorkflowTemplateApply {
         name: String,
@@ -310,6 +351,7 @@ impl Command {
             CommandAction::CrewComplete { .. } => "Completing crew work...",
             CommandAction::CrewFail { .. } => "Failing crew work...",
             CommandAction::ConvoyCreate { .. } => "Creating convoy...",
+            CommandAction::ConvoyStart { .. } => "Starting convoy...",
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
             CommandAction::ProjectAdd { .. } => "Adding project...",
             CommandAction::ProjectApply { .. } => "Applying project...",
@@ -432,6 +474,13 @@ pub enum CommandValue {
     },
     ConvoyCreated {
         name: String,
+    },
+    ConvoyStarted {
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attach_command: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        binding: Option<AttachBinding>,
     },
     WorkflowTemplateApplied {
         name: String,

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -83,8 +83,8 @@ pub(crate) mod test_helpers {
 }
 
 pub use commands::{
-    AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, PreparedTerminalCommand,
-    PreparedWorkspace, RepoSelector, ResolvedPaneCommand, StepStatus,
+    AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyStartIntent,
+    IssueSelector, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{

--- a/crates/flotilla-resources/examples/convoy_controller.rs
+++ b/crates/flotilla-resources/examples/convoy_controller.rs
@@ -5,8 +5,8 @@ use flotilla_controllers::reconcilers::{
 };
 use flotilla_core::{path_context::DaemonHostPath, providers::registry::ProviderRegistry, HostName};
 use flotilla_resources::{
-    controller::ControllerLoop, ensure_crd, ensure_namespace, Convoy, ConvoyReconciler, HttpBackend, Presentation, ResourceBackend, Vessel,
-    WorkflowTemplate,
+    controller::ControllerLoop, ensure_crd, ensure_namespace, Checkout, Convoy, ConvoyReconciler, HttpBackend, Presentation,
+    ResourceBackend, Vessel, WorkflowTemplate,
 };
 use tracing::info;
 
@@ -93,7 +93,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 secondaries: ConvoyReconciler::secondary_watches(),
                 reconciler: ConvoyReconciler::new(templates)
                     .with_vessels(convoy_backend.clone().using::<Vessel>(&namespace))
-                    .with_presentations(convoy_backend.clone().using::<Presentation>(&namespace)),
+                    .with_presentations(convoy_backend.clone().using::<Presentation>(&namespace))
+                    .with_checkouts(convoy_backend.clone().using::<Checkout>(&namespace)),
                 resync_interval: Duration::from_secs(60),
                 backend: convoy_backend,
             }

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -52,6 +52,8 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: Default::default(),
+        issue: None,
+        instruction: None,
     }
 }
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
+use flotilla_protocol::{IssueRef, IssueState};
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement, RepositoryKey};
@@ -30,6 +31,32 @@ pub struct ConvoySpec {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub adopted_checkout_refs: BTreeMap<RepositoryKey, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue: Option<ConvoyIssue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instruction: Option<String>,
+}
+
+/// Durable source-qualified issue context captured when a convoy is admitted.
+/// The reference remains stable if the Project later changes its Issue Source;
+/// the snapshot records exactly what the crew was asked to act on.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvoyIssue {
+    pub reference: IssueRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repository_ref: Option<RepositoryKey>,
+    pub snapshot: IssueSnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueSnapshot {
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+    pub state: IssueState,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+    pub as_of: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -11,6 +11,7 @@ use super::{
     WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
 };
 use crate::{
+    checkout::Checkout,
     controller::{
         delete_lifecycle_owned_matching, Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler,
         SecondaryWatch,
@@ -52,6 +53,7 @@ pub struct ConvoyReconciler {
     templates: TypedResolver<WorkflowTemplate>,
     vessels: Option<TypedResolver<Vessel>>,
     presentations: Option<TypedResolver<Presentation>>,
+    checkouts: Option<TypedResolver<Checkout>>,
 }
 
 #[derive(Debug, Clone)]
@@ -63,7 +65,7 @@ pub struct ConvoyDependencies {
 
 impl ConvoyReconciler {
     pub fn new(templates: TypedResolver<WorkflowTemplate>) -> Self {
-        Self { templates, vessels: None, presentations: None }
+        Self { templates, vessels: None, presentations: None, checkouts: None }
     }
 
     pub fn with_vessels(mut self, vessels: TypedResolver<Vessel>) -> Self {
@@ -76,10 +78,16 @@ impl ConvoyReconciler {
         self
     }
 
+    pub fn with_checkouts(mut self, checkouts: TypedResolver<Checkout>) -> Self {
+        self.checkouts = Some(checkouts);
+        self
+    }
+
     pub fn secondary_watches() -> Vec<Box<dyn SecondaryWatch<Primary = Convoy>>> {
         vec![
             Box::new(LabelMappedWatch::<Vessel, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
             Box::new(LabelMappedWatch::<Presentation, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
+            Box::new(LabelMappedWatch::<Checkout, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
         ]
     }
 }
@@ -143,6 +151,9 @@ impl Reconciler for ConvoyReconciler {
         }
         if let Some(vessels) = &self.vessels {
             delete_lifecycle_owned_matching(vessels, &selector).await?;
+        }
+        if let Some(checkouts) = &self.checkouts {
+            delete_lifecycle_owned_matching(checkouts, &selector).await?;
         }
         Ok(())
     }

--- a/crates/flotilla-resources/src/crds/convoy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/convoy.crd.yaml
@@ -82,6 +82,51 @@ spec:
                   additionalProperties:
                     type: string
                     minLength: 1
+                issue:
+                  type: object
+                  required: [reference, snapshot]
+                  properties:
+                    reference:
+                      type: object
+                      required: [source, id]
+                      properties:
+                        source:
+                          type: object
+                          required: [service, scope]
+                          properties:
+                            service:
+                              type: string
+                              minLength: 1
+                            scope:
+                              type: string
+                              minLength: 1
+                        id:
+                          type: string
+                          minLength: 1
+                    repository_ref:
+                      type: string
+                      minLength: 1
+                    snapshot:
+                      type: object
+                      required: [title, state, labels, as_of]
+                      properties:
+                        title:
+                          type: string
+                          minLength: 1
+                        body:
+                          type: string
+                        state:
+                          type: string
+                          enum: [open, closed]
+                        labels:
+                          type: array
+                          items:
+                            type: string
+                        as_of:
+                          type: string
+                          format: date-time
+                instruction:
+                  type: string
             status:
               type: object
               properties:

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -30,9 +30,9 @@ pub use checkout::{
 };
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
-    controller_patches, external_patches, provisioning_patches, reconcile, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InputValue, PlacementStatus,
-    ReconcileOutcome, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    controller_patches, external_patches, provisioning_patches, reconcile, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot,
+    PlacementStatus, ReconcileOutcome, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
 };
 pub use environment::{
     DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus,

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -103,6 +103,10 @@ pub enum TerminalSessionSource {
 pub struct TerminalBrief {
     pub path: String,
     pub content: String,
+    /// Additional checkout roots that receive the same durable brief. The
+    /// session cwd still receives the canonical launch copy.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub copies: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -205,6 +205,8 @@ pub fn valid_convoy_spec() -> RealConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
+        issue: None,
+        instruction: None,
     }
 }
 

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -4,10 +4,11 @@ use common::{
     bootstrapped_tool_only_convoy_status, convoy_meta, task_provisioning_convoy_spec, timestamp, tool_only_workflow_template_object,
     valid_convoy_spec, workflow_template_meta,
 };
+use flotilla_protocol::{IssueRef, IssueSource, IssueState};
 use flotilla_resources::{
-    apply_status_patch, controller::ControllerLoop, external_patches, reconcile, Convoy, ConvoyPhase, ConvoyReconciler, InMemoryBackend,
-    InputMeta, LifecycleAuthority, Presentation, PresentationSpec, ResourceBackend, ResourceError, Vessel, VesselPhase, VesselStatus,
-    WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
+    apply_status_patch, controller::ControllerLoop, external_patches, reconcile, Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
+    InMemoryBackend, InputMeta, IssueSnapshot, LifecycleAuthority, Presentation, PresentationSpec, RepositorySpec, ResourceBackend,
+    ResourceError, Vessel, VesselPhase, VesselStatus, WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
 };
 use tokio::time::{timeout, Duration};
 
@@ -35,6 +36,35 @@ async fn reconcile_once(
     } else {
         None
     }
+}
+
+#[tokio::test]
+async fn convoy_persists_source_qualified_issue_snapshot_and_instruction() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let convoys = backend.using::<Convoy>("flotilla");
+    let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository");
+    let mut spec = valid_convoy_spec();
+    spec.issue = Some(ConvoyIssue {
+        reference: IssueRef {
+            source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+            id: "WIDGET-732".into(),
+        },
+        repository_ref: Some(repository.key()),
+        snapshot: IssueSnapshot {
+            title: "Start convoy from issue".into(),
+            body: Some("Build the admission path.".into()),
+            state: IssueState::Open,
+            labels: vec!["enhancement".into()],
+            as_of: timestamp(42),
+        },
+    });
+    spec.instruction = Some("Preserve the public API.".into());
+
+    convoys.create(&convoy_meta("issue-work"), &spec).await.expect("convoy create");
+    let persisted = convoys.get("issue-work").await.expect("convoy get");
+
+    assert_eq!(persisted.spec.issue, spec.issue);
+    assert_eq!(persisted.spec.instruction.as_deref(), Some("Preserve the public API."));
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -39,6 +39,8 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: Default::default(),
+        issue: None,
+        instruction: None,
     }
 }
 

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -148,6 +148,7 @@ async fn agent_terminal_session_preserves_structured_launch_and_canonical_brief(
             brief: TerminalBrief {
                 path: ".flotilla/briefs/coder.md".into(),
                 content: "You are coder in convoy demo.\n\nImplement the change.".into(),
+                copies: Vec::new(),
             },
             context: TerminalCrewContext { namespace: "flotilla".into(), convoy: "demo".into(), vessel_ref: "demo-implement".into() },
             message: None,

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -165,6 +165,13 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
             info!(%name, "convoy created");
             app.model.status_message = Some(format!("Convoy created: {name}"));
         }
+        CommandValue::ConvoyStarted { name, attach_command, .. } => {
+            info!(%name, "convoy started");
+            app.model.status_message = Some(format!("Convoy started: {name}"));
+            if let Some(command) = attach_command {
+                app.pending_attach_command = Some(command);
+            }
+        }
         CommandValue::WorkflowTemplateApplied { name } => {
             info!(%name, "workflow template applied");
             app.model.status_message = Some(format!("Workflow template applied: {name}"));

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
-use flotilla_protocol::{Command, CommandAction, HostName, NodeId, RepoIdentity, RepoKey, WorkItem};
+use flotilla_protocol::{Command, CommandAction, ConvoyStartIntent, HostName, IssueSelector, NodeId, RepoIdentity, RepoKey, WorkItem};
 
 use super::{ui_state::PendingActionContext, App, BranchInputKind, Intent, OwnedSelectedRow};
 use crate::{
@@ -413,6 +413,22 @@ impl App {
             }
             TableIntent::ForceCompleteWork { convoy, vessel, host } => {
                 (self.command(CommandAction::ConvoyWorkForceComplete { convoy, work: vessel, message: None }), host)
+            }
+            TableIntent::StartConvoy { namespace: _, project, issue } => {
+                self.proto_commands.push(self.command(CommandAction::ConvoyStart {
+                    intent: Box::new(ConvoyStartIntent {
+                        project_ref: project,
+                        issue: Some(IssueSelector::Reference(issue)),
+                        name: None,
+                        branch: None,
+                        workflow_ref: None,
+                        inputs: Vec::new(),
+                        instruction: None,
+                        placement_policy: None,
+                        auto_attach: true,
+                    }),
+                }));
+                return;
             }
         };
         let node_id = match self.panel_target_node(&host) {

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -414,9 +414,10 @@ impl App {
             TableIntent::ForceCompleteWork { convoy, vessel, host } => {
                 (self.command(CommandAction::ConvoyWorkForceComplete { convoy, work: vessel, message: None }), host)
             }
-            TableIntent::StartConvoy { namespace: _, project, issue } => {
+            TableIntent::StartConvoy { namespace, project, issue } => {
                 self.proto_commands.push(self.command(CommandAction::ConvoyStart {
                     intent: Box::new(ConvoyStartIntent {
+                        namespace: Some(namespace),
                         project_ref: project,
                         issue: Some(IssueSelector::Reference(issue)),
                         name: None,

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -44,6 +44,22 @@ fn setup_native_issue_rows(app: &mut App, issue_ids: &[&str]) {
     }
 }
 
+#[test]
+fn project_issue_start_preserves_the_selected_namespace() {
+    let mut app = stub_app();
+    let issue = flotilla_protocol::IssueRef {
+        source: flotilla_protocol::IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+        id: "732".into(),
+    };
+    app.execute_table_intent(TableIntent::StartConvoy { namespace: "other-team".into(), project: "roadmap".into(), issue: issue.clone() });
+
+    let (command, _) = app.proto_commands.take_next().expect("start command");
+    let flotilla_protocol::CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
+    assert_eq!(intent.namespace.as_deref(), Some("other-team"));
+    assert_eq!(intent.project_ref, "roadmap");
+    assert_eq!(intent.issue, Some(flotilla_protocol::IssueSelector::Reference(issue)));
+}
+
 /// Read the active RepoPage's selected flat index.
 fn active_selection(app: &App) -> Option<usize> {
     let identity = app.model.active_repo.as_ref().expect("active tab should be a repo view");

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -280,6 +280,7 @@ pub type NamespaceMap = HashMap<String, NamespaceModel>;
 pub struct NamespaceModel {
     pub convoys: IndexMap<crate::convoy_model::ConvoyId, crate::convoy_model::ConvoySummary>,
     pub independents: IndexMap<ResourceRef, flotilla_protocol::IndependentRow>,
+    pub project_issues: HashMap<String, Vec<flotilla_protocol::IssueRow>>,
     pub last_seq: u64,
 }
 
@@ -287,6 +288,15 @@ pub fn table_rows(namespaces: &NamespaceMap) -> crate::table_view::TableRows<'_>
     crate::table_view::TableRows {
         convoys: namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect(),
         independents: namespaces.values().flat_map(|namespace| namespace.independents.values()).collect(),
+        project_issues: namespaces
+            .iter()
+            .flat_map(|(namespace, model)| {
+                model
+                    .project_issues
+                    .iter()
+                    .flat_map(move |(project, rows)| rows.iter().map(move |row| (namespace.as_str(), project.as_str(), row)))
+            })
+            .collect(),
     }
 }
 
@@ -924,6 +934,14 @@ impl App {
         }
     }
 
+    fn sync_project_issue_rows(&mut self, query: &flotilla_protocol::QueryId) {
+        let flotilla_protocol::QueryId::Issues { scope: flotilla_protocol::QueryScope::Project { namespace, name } } = query else {
+            return;
+        };
+        let rows = self.materialized_issue_rows.get(query).cloned().unwrap_or_default();
+        self.namespaces.entry(namespace.clone()).or_default().project_issues.insert(name.clone(), rows);
+    }
+
     // ── Widget stack helpers ──
 
     /// Pop all modal widgets from the stack.
@@ -1299,6 +1317,7 @@ impl App {
                         self.materialized_issue_rows.insert(query.clone(), rows.clone());
                         self.materialized_issue_states.insert(query.clone(), result_set.state.clone());
                         self.push_materialized_issue_items_to_repo_data(&query);
+                        self.sync_project_issue_rows(&query);
                     }
                 }
             }
@@ -1350,6 +1369,7 @@ impl App {
                             self.materialized_issue_states.insert(query.clone(), state.clone());
                         }
                         self.push_materialized_issue_items_to_repo_data(&query);
+                        self.sync_project_issue_rows(&query);
                     }
                 }
             }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1932,7 +1932,8 @@ fn snapshot_with(convoys: Vec<crate::convoy_model::ConvoySummary>) -> crate::con
 fn selected_table_name(app: &App) -> Option<String> {
     let address = app.views.active_address()?;
     let name_column = match address {
-        ViewAddress::Convoys { .. } | ViewAddress::Independents | ViewAddress::Project { .. } => 0,
+        ViewAddress::Convoys { .. } | ViewAddress::Independents => 0,
+        ViewAddress::Project { .. } => 1,
         ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. } => 1,
         ViewAddress::Overview | ViewAddress::Repo { .. } => return None,
     };

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -395,6 +395,9 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::IssuePage(page) => format!("issue page: {} items, has_more={}", page.items.len(), page.has_more),
         CommandValue::IssuesByIds { items } => format!("issues by ids: {} items", items.len()),
         CommandValue::ConvoyCreated { name } => format!("convoy created: {name}"),
+        CommandValue::ConvoyStarted { name, attach_command, .. } => {
+            format!("convoy started: {name}{}", if attach_command.is_some() { " (crew ready)" } else { "" })
+        }
         CommandValue::WorkflowTemplateApplied { name } => format!("workflow template applied: {name}"),
         CommandValue::ProjectAdded { name } => format!("project added: {name}"),
         CommandValue::ProjectApplied { name } => format!("project applied: {name}"),
@@ -708,7 +711,7 @@ async fn run_watch_connection(daemon: std::sync::Arc<dyn DaemonHandle>, format: 
     }
 }
 
-pub async fn run_command(daemon: &dyn DaemonHandle, command: Command, format: OutputFormat) -> Result<(), String> {
+pub async fn run_command(daemon: &dyn DaemonHandle, command: Command, format: OutputFormat) -> Result<CommandValue, String> {
     if command.action.is_query() {
         return run_query_command(daemon, command, format).await;
     }
@@ -741,7 +744,7 @@ pub async fn run_command(daemon: &dyn DaemonHandle, command: Command, format: Ou
                 return match result {
                     CommandValue::Error { message } => Err(message),
                     CommandValue::Cancelled => Err("command cancelled".into()),
-                    _ => Ok(()),
+                    result => Ok(result),
                 };
             }
             Ok(_) => {}
@@ -757,7 +760,7 @@ pub async fn run_command(daemon: &dyn DaemonHandle, command: Command, format: Ou
     }
 }
 
-async fn run_query_command(daemon: &dyn DaemonHandle, command: Command, format: OutputFormat) -> Result<(), String> {
+async fn run_query_command(daemon: &dyn DaemonHandle, command: Command, format: OutputFormat) -> Result<CommandValue, String> {
     let result = daemon.execute_query(command, uuid::Uuid::new_v4()).await?;
     match format {
         OutputFormat::Human => {
@@ -770,7 +773,7 @@ async fn run_query_command(daemon: &dyn DaemonHandle, command: Command, format: 
     match result {
         CommandValue::Error { message } => Err(message),
         CommandValue::Cancelled => Err("command cancelled".into()),
-        _ => Ok(()),
+        result => Ok(result),
     }
 }
 

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use flotilla_protocol::{HostName, IndependentRow, RepoKey, SessionPhase, ViewAddress};
+use flotilla_protocol::{HostName, IndependentRow, IssueRef, IssueRow, RepoKey, SessionPhase, ViewAddress};
 
 use crate::convoy_model::{ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase};
 
@@ -194,6 +194,7 @@ pub enum TableIntent {
     AttachWorkspace { workspace_ref: String, host: HostName, repo_hint: Option<RepoKey> },
     AttachPane { reference: String, host: HostName },
     ForceCompleteWork { convoy: String, vessel: String, host: HostName },
+    StartConvoy { namespace: String, project: String, issue: IssueRef },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
@@ -238,6 +239,12 @@ struct VesselProjection {
     vessel: VesselSummary,
 }
 
+#[derive(Clone)]
+enum ProjectProjection {
+    Convoy(ConvoySummary),
+    Issue { namespace: String, project: String, row: IssueRow },
+}
+
 /// Typed query rows currently available to the table registry. Surfaces build
 /// this once from their query caches; adding a query family grows this input
 /// without teaching the reusable widget about that family.
@@ -245,6 +252,7 @@ struct VesselProjection {
 pub struct TableRows<'a> {
     pub convoys: Vec<&'a ConvoySummary>,
     pub independents: Vec<&'a IndependentRow>,
+    pub project_issues: Vec<(&'a str, &'a str, &'a IssueRow)>,
 }
 
 pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView, String> {
@@ -265,13 +273,20 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
             Ok(independent_spec().project("Independents".to_string(), rows.into_iter().cloned()))
         }
         ViewAddress::Project { namespace, name } => {
-            let rows = data
+            let mut rows = data
                 .convoys
                 .iter()
                 .copied()
                 .filter(|convoy| &convoy.namespace == namespace && convoy.project_ref.as_deref() == Some(name))
-                .cloned();
-            Ok(convoy_spec().project(format!("Project · {name}"), rows))
+                .cloned()
+                .map(ProjectProjection::Convoy)
+                .collect::<Vec<_>>();
+            rows.extend(
+                data.project_issues.iter().filter(|(row_namespace, project, _)| *row_namespace == namespace && *project == name).map(
+                    |(_, _, row)| ProjectProjection::Issue { namespace: namespace.clone(), project: name.clone(), row: (*row).clone() },
+                ),
+            );
+            Ok(project_spec().project(format!("Project · {name}"), rows))
         }
         ViewAddress::Convoy { namespace, name } => {
             let convoy = find_convoy(&data.convoys, namespace, name)?;
@@ -340,6 +355,14 @@ fn convoy_spec() -> TableSpec<ConvoySummary> {
     TableSpec { columns: &CONVOY_COLUMNS, actions: &[], row: RowSpec { id: convoy_id, drill: convoy_drill, describe: convoy_description } }
 }
 
+fn project_spec() -> TableSpec<ProjectProjection> {
+    TableSpec {
+        columns: &PROJECT_COLUMNS,
+        actions: &PROJECT_ACTIONS,
+        row: RowSpec { id: project_row_id, drill: project_row_drill, describe: project_row_description },
+    }
+}
+
 fn vessel_spec() -> TableSpec<VesselProjection> {
     TableSpec {
         columns: &VESSEL_COLUMNS,
@@ -388,6 +411,61 @@ static CONVOY_COLUMNS: [ColumnSpec<ConvoySummary>; 6] = [
         extract: |row| CellValue::plain(row.message.as_deref().unwrap_or_default()),
     },
 ];
+
+static PROJECT_COLUMNS: [ColumnSpec<ProjectProjection>; 4] = [
+    ColumnSpec {
+        id: "kind",
+        label: "KIND",
+        width: WidthHint::Fixed(8),
+        alignment: Alignment::Left,
+        extract: |row| {
+            CellValue::toned(
+                match row {
+                    ProjectProjection::Convoy(_) => "convoy",
+                    ProjectProjection::Issue { .. } => "issue",
+                },
+                CellTone::Muted,
+            )
+        },
+    },
+    ColumnSpec {
+        id: "name",
+        label: "WORK",
+        width: WidthHint::Flexible { minimum: 18, weight: 2 },
+        alignment: Alignment::Left,
+        extract: |row| {
+            CellValue::plain(match row {
+                ProjectProjection::Convoy(convoy) => convoy.name.clone(),
+                ProjectProjection::Issue { row, .. } => format!("{} · {}", row.reference.id, row.issue.title),
+            })
+        },
+    },
+    ColumnSpec {
+        id: "state",
+        label: "STATE",
+        width: WidthHint::Fixed(12),
+        alignment: Alignment::Left,
+        extract: |row| match row {
+            ProjectProjection::Convoy(convoy) => convoy_phase(convoy),
+            ProjectProjection::Issue { row, .. } => CellValue::plain(format!("{:?}", row.issue.state).to_lowercase()),
+        },
+    },
+    ColumnSpec {
+        id: "detail",
+        label: "DETAIL",
+        width: WidthHint::Flexible { minimum: 18, weight: 2 },
+        alignment: Alignment::Left,
+        extract: |row| {
+            CellValue::plain(match row {
+                ProjectProjection::Convoy(convoy) => convoy.message.clone().unwrap_or_default(),
+                ProjectProjection::Issue { row, .. } => row.issue.labels.join(", "),
+            })
+        },
+    },
+];
+
+static PROJECT_ACTIONS: [ActionSpec<ProjectProjection>; 1] =
+    [ActionSpec { id: "start", label: "Start convoy", key: 's', resolve: start_project_issue }];
 
 static VESSEL_COLUMNS: [ColumnSpec<VesselProjection>; 6] = [
     ColumnSpec {
@@ -479,6 +557,46 @@ static INDEPENDENT_ACTIONS: [ActionSpec<IndependentRow>; 1] =
 
 fn convoy_id(row: &ConvoySummary) -> RowId {
     RowId::new(row.id.as_str())
+}
+
+fn project_row_id(row: &ProjectProjection) -> RowId {
+    match row {
+        ProjectProjection::Convoy(convoy) => RowId::new(format!("convoy:{}", convoy.id.as_str())),
+        ProjectProjection::Issue { namespace, project, row } => RowId::new(format!(
+            "issue:{namespace}:{project}:{}:{}:{}",
+            row.reference.source.service, row.reference.source.scope, row.reference.id
+        )),
+    }
+}
+
+fn project_row_drill(row: &ProjectProjection) -> Option<ViewAddress> {
+    match row {
+        ProjectProjection::Convoy(convoy) => convoy_drill(convoy),
+        ProjectProjection::Issue { .. } => None,
+    }
+}
+
+fn project_row_description(row: &ProjectProjection) -> Vec<DetailField> {
+    match row {
+        ProjectProjection::Convoy(convoy) => convoy_description(convoy),
+        ProjectProjection::Issue { namespace, project, row } => vec![
+            DetailField { label: "Namespace", value: namespace.clone() },
+            DetailField { label: "Project", value: project.clone() },
+            DetailField { label: "Issue", value: row.reference.id.clone() },
+            DetailField { label: "Title", value: row.issue.title.clone() },
+            DetailField { label: "Source", value: format!("{} / {}", row.reference.source.service, row.reference.source.scope) },
+            DetailField { label: "As of", value: row.issue.as_of.to_rfc3339() },
+        ],
+    }
+}
+
+fn start_project_issue(row: &ProjectProjection) -> Option<TableIntent> {
+    match row {
+        ProjectProjection::Issue { namespace, project, row } => {
+            Some(TableIntent::StartConvoy { namespace: namespace.clone(), project: project.clone(), issue: row.reference.clone() })
+        }
+        ProjectProjection::Convoy(_) => None,
+    }
 }
 
 fn convoy_drill(row: &ConvoySummary) -> Option<ViewAddress> {
@@ -602,13 +720,17 @@ fn attach_independent(row: &IndependentRow) -> Option<TableIntent> {
 
 #[cfg(test)]
 mod tests {
-    use flotilla_protocol::ResourceRef;
+    use flotilla_protocol::{test_support::TestIssue, ResourceRef};
 
     use super::*;
     use crate::convoy_model::{ConvoyId, ProcessSummary, WorkCompletionTarget};
 
     fn project_convoys(address: &str, convoys: &[&ConvoySummary]) -> Result<TableView, String> {
-        project(&address.parse().expect("valid address"), &TableRows { convoys: convoys.to_vec(), independents: vec![] })
+        project(&address.parse().expect("valid address"), &TableRows {
+            convoys: convoys.to_vec(),
+            independents: vec![],
+            project_issues: vec![],
+        })
     }
 
     fn vessel(name: &str, depends_on: &[&str], phase: WorkPhase) -> VesselSummary {
@@ -696,7 +818,7 @@ mod tests {
         elsewhere.project_ref = Some("other".into());
 
         let project_view = project_convoys("project/dev/flotilla", &[&in_project, &elsewhere]).expect("project table");
-        assert_eq!(project_view.rows.iter().map(|row| row.cells[0].text.as_str()).collect::<Vec<_>>(), vec!["tables"]);
+        assert_eq!(project_view.rows.iter().map(|row| row.cells[1].text.as_str()).collect::<Vec<_>>(), vec!["tables"]);
 
         let vessel = project_convoys("vessel/dev/tables/review", &[&in_project, &elsewhere]).expect("vessel table");
         assert_eq!(vessel.rows.len(), 1);
@@ -720,8 +842,12 @@ mod tests {
     fn independent_projection_has_typed_columns_and_truthful_attach_action() {
         let available = independent("scratch", "kiwi", Some("terminal-scratch"));
         let unavailable = independent("wedged", "feta", None);
-        let view = project(&ViewAddress::Independents, &TableRows { convoys: vec![], independents: vec![&unavailable, &available] })
-            .expect("independents table");
+        let view = project(&ViewAddress::Independents, &TableRows {
+            convoys: vec![],
+            independents: vec![&unavailable, &available],
+            project_issues: vec![],
+        })
+        .expect("independents table");
 
         assert_eq!(view.columns.iter().map(|column| column.id).collect::<Vec<_>>(), vec!["name", "repo", "host", "phase", "attach"]);
         assert_eq!(view.rows.iter().map(|row| row.cells[0].text.as_str()).collect::<Vec<_>>(), vec!["scratch", "wedged"]);
@@ -735,19 +861,40 @@ mod tests {
     }
 
     #[test]
+    fn project_issue_row_exposes_one_start_convoy_action_with_the_qualified_reference() {
+        let issue = TestIssue::new("Start convoy from issue").id("ENG-ab12").build();
+        let row = IssueRow { reference: issue.reference.clone(), issue };
+        let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+
+        let view =
+            project(&address, &TableRows { convoys: vec![], independents: vec![], project_issues: vec![("flotilla", "roadmap", &row)] })
+                .expect("project issue table");
+
+        assert_eq!(view.rows.len(), 1);
+        assert_eq!(view.rows[0].actions, vec![AvailableAction {
+            id: "start",
+            label: "Start convoy",
+            key: 's',
+            intent: TableIntent::StartConvoy { namespace: "flotilla".into(), project: "roadmap".into(), issue: row.reference },
+        }]);
+    }
+
+    #[test]
     fn table_state_preserves_identity_and_clamps_when_rows_disappear() {
         let first = convoy(vec![]);
         let mut second = convoy(vec![]);
         second.id = ConvoyId::new("dev", "other");
         second.name = "other".into();
         let address = "convoys/dev".parse().expect("valid address");
-        let view = project(&address, &TableRows { convoys: vec![&first, &second], independents: vec![] }).expect("project table");
+        let view = project(&address, &TableRows { convoys: vec![&first, &second], independents: vec![], project_issues: vec![] })
+            .expect("project table");
         let mut state = TableState::default();
         state.reconcile(&view);
         state.select_delta(&view, 1);
         assert_eq!(state.selected_row(&view).map(|row| row.cells[0].text.as_str()), Some("other"));
 
-        let changed = project(&address, &TableRows { convoys: vec![&first], independents: vec![] }).expect("project table");
+        let changed =
+            project(&address, &TableRows { convoys: vec![&first], independents: vec![], project_issues: vec![] }).expect("project table");
         state.reconcile(&changed);
         assert_eq!(state.selected_row(&changed).map(|row| row.cells[0].text.as_str()), Some("tables"));
     }

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -152,8 +152,12 @@ impl InteractiveWidget for TableWidget {
                 Outcome::Consumed
             }
             Action::Confirm => {
-                if let Some(target) = ctx.views.active_table_state().selected_row(&view).and_then(|row| row.drill.clone()) {
-                    ctx.app_actions.push(AppAction::DrillView(target));
+                if let Some(row) = ctx.views.active_table_state().selected_row(&view) {
+                    if let Some(target) = row.drill.clone() {
+                        ctx.app_actions.push(AppAction::DrillView(target));
+                    } else if let [action] = row.actions.as_slice() {
+                        ctx.app_actions.push(AppAction::ExecuteTableIntent(action.intent.clone()));
+                    }
                 }
                 Outcome::Consumed
             }
@@ -335,8 +339,12 @@ mod tests {
             ),
         ];
         let rows = convoys.iter().collect::<Vec<_>>();
-        table_view::project(&"convoys/dev".parse().expect("valid address"), &table_view::TableRows { convoys: rows, independents: vec![] })
-            .expect("project snapshot table")
+        table_view::project(&"convoys/dev".parse().expect("valid address"), &table_view::TableRows {
+            convoys: rows,
+            independents: vec![],
+            project_issues: vec![],
+        })
+        .expect("project snapshot table")
     }
 
     #[test]

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -47,6 +47,8 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
+        issue: None,
+        instruction: None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -545,7 +545,14 @@ async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
 async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) -> Result<()> {
     reset_sigpipe();
     let daemon = connect_daemon(cli).await?;
-    flotilla_tui::cli::run_command(&*daemon, command, format).await.map_err(|e| color_eyre::eyre::eyre!(e))
+    let result = flotilla_tui::cli::run_command(&*daemon, command, format).await.map_err(|e| color_eyre::eyre::eyre!(e))?;
+    if let CommandValue::ConvoyStarted { name, attach_command: Some(command), binding } = result {
+        if matches!(format, OutputFormat::Human) {
+            stamp_pane_identity(&name, binding.as_ref()).await;
+            return exec_attach_command(&command);
+        }
+    }
+    Ok(())
 }
 
 async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&str>, format: OutputFormat) -> Result<()> {


### PR DESCRIPTION
Closes #732.

## What changed

- Add one structured `convoy start` intent shared by the CLI and TUI issue-row action.
- Resolve issue sources through the selected Project, preserving source-qualified opaque issue IDs and a durable as-of issue snapshot in `ConvoySpec`.
- Complete admission before persistence: workflow, repository, placement, generated/fallback convoy name, and branch are all resolved and validated atomically.
- Generate the Snapshot Brief with the source-qualified issue reference, timestamped title/body/state/labels, repository context, branch, role, completion verbs, and human instruction.
- Auto-attach interactive starts to an actual contained crew session.
- Reuse convoy-owned branch worktrees across vessels and wake vessel reconciliation from shared Checkout readiness events.

## Why

Starting work from a Project issue previously lacked a single flag-complete control-plane path. This makes the same admission operation available to humans in the TUI, automation through the CLI, and future governor callers while ensuring the resource store never observes a half-specified Convoy.

## User impact

A user can now start a convoy from a Project issue with one TUI action or one non-interactive CLI invocation. Numeric and opaque provider-native issue IDs round-trip, keyless/offline starts receive deterministic names, and the resulting crew begins with a durable issue snapshot and Brief.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `git diff --check`

The implementation also completed independent standards and issue-spec reviews; all findings were addressed and both closure reviews returned no findings.