### PR TITLE
Add scoped checkout queries

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -11,13 +11,13 @@ use std::{
 };
 
 use flotilla_protocol::{
-    result_set::{ConvoyRow, IndependentRow, IssueRow, QueryId, ResultDelta, ResultSet, ResultSetState, Rows},
-    HostName, IssueRef, QueryCursor, ResourceRef,
+    result_set::{CheckoutRow, ConvoyRow, IndependentRow, IssueRow, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetState, Rows},
+    HostName, IssueRef, QueryCursor, RepositoryKey, ResourceRef,
 };
 use tokio::sync::{broadcast, watch, RwLock, RwLockWriteGuard};
 use uuid::Uuid;
 
-use crate::query_registry::QueryRegistry;
+use crate::{query_registry::QueryRegistry, scoped_checkouts::ScopedCheckoutProjection};
 
 /// A typed row of some named query's result set.
 pub trait QueryRow: Clone {
@@ -112,10 +112,11 @@ impl<R: QueryRow + PartialEq> QueryProjection<R> {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, bon::Builder)]
 pub struct AggregatorProjectionState {
     convoys: Arc<RwLock<QueryProjection<ConvoyRow>>>,
     independents: Arc<RwLock<QueryProjection<IndependentRow>>>,
+    checkouts: Arc<RwLock<ScopedCheckoutProjection>>,
     /// Subscriber ownership and demand-backed materializations belong to the
     /// Aggregator state, shared with the daemon's subscription transport.
     demand_backed: QueryRegistry,
@@ -161,7 +162,25 @@ impl AggregatorProjectionState {
     /// This host's local store-backed result sets. Demand-backed reference
     /// data is never included in fleet replica snapshots.
     pub async fn local_result_sets(&self) -> Vec<ResultSet> {
-        vec![self.local_result_set().await, self.local_independents_result_set().await]
+        let mut sets = vec![self.local_result_set().await, self.local_independents_result_set().await];
+        sets.extend(self.checkouts.read().await.local_result_sets());
+        sets
+    }
+
+    pub async fn replace_checkout_catalog(
+        &self,
+        repositories: HashSet<RepositoryKey>,
+        projects: HashMap<QueryScope, Vec<RepositoryKey>>,
+    ) -> Vec<ResultDelta> {
+        self.checkouts.write().await.replace_catalog(repositories, projects)
+    }
+
+    pub async fn replace_local_checkout_rows(&self, rows: Vec<CheckoutRow>) -> Vec<ResultDelta> {
+        self.checkouts.write().await.replace_local_rows(rows)
+    }
+
+    pub async fn replace_checkout_replica_rows(&self, replicas: HashMap<HostName, Vec<CheckoutRow>>) -> Vec<ResultDelta> {
+        self.checkouts.write().await.replace_replica_rows(replicas)
     }
 
     /// Replace one subscriber's complete demand and return queries whose
@@ -211,6 +230,7 @@ impl AggregatorProjectionState {
             QueryId::Convoys => Some(self.result_set().await),
             QueryId::Independents => Some(self.independents_result_set().await),
             QueryId::Issues { .. } => self.demand_backed.result_set(query),
+            QueryId::Checkouts { scope } => Some(self.checkouts.write().await.result_set(scope)),
         }
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -551,7 +551,8 @@ struct AdoptedCheckoutRequest<'a> {
 }
 
 async fn create_adopted_checkout_resource(
-    backend: &ResourceBackend,
+    durable_backend: &ResourceBackend,
+    observed_backend: &ResourceBackend,
     request: AdoptedCheckoutRequest<'_>,
 ) -> Result<(String, String, String), String> {
     let AdoptedCheckoutRequest { namespace, convoy_name, checkout_path, repository_spec, repository_url, git_ref, host_ref } = request;
@@ -560,48 +561,56 @@ async fn create_adopted_checkout_resource(
     let path_str = path.to_string_lossy().to_string();
     let checkout_ref = adopted_checkout_name(convoy_name);
     let repository_key = repository_spec.key();
-    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(namespace), &repository_key, repository_spec)
+    flotilla_resources::ensure_repository(&durable_backend.clone().using::<Repository>(namespace), &repository_key, repository_spec)
         .await
         .map_err(|error| error.to_string())?;
-    let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
     let meta = InputMeta::builder()
         .name(checkout_ref.clone())
         .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy_name.to_string())]))
         .build()
         .with_lifecycle_authority(LifecycleAuthority::Adopted);
-    let spec = ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
-        r#ref: git_ref.to_string(),
-        path: path_str.clone(),
-        repo_ref: repository_key,
-        host_ref: host_ref.to_string(),
-        is_main: matches!(git_ref, "main" | "master" | "trunk"),
-    });
+    let spec = ResourceCheckoutSpec::Observed(
+        ResourceObservedCheckoutSpec::builder()
+            .r#ref(git_ref.to_string())
+            .path(path_str.clone())
+            .repo_ref(repository_key)
+            .host_ref(host_ref.to_string())
+            .is_main(matches!(git_ref, "main" | "master" | "trunk"))
+            .build(),
+    );
+    let status = ResourceCheckoutStatus::builder().phase(ResourceCheckoutPhase::Ready).path(path_str).build();
 
-    let checkout = match checkouts.create(&meta, &spec).await {
+    persist_adopted_checkout(durable_backend, namespace, &checkout_ref, &meta, &spec, &status).await?;
+    persist_adopted_checkout(observed_backend, namespace, &checkout_ref, &meta, &spec, &status).await?;
+
+    Ok((checkout_ref, repository_url.to_string(), git_ref.to_string()))
+}
+
+async fn persist_adopted_checkout(
+    backend: &ResourceBackend,
+    namespace: &str,
+    checkout_ref: &str,
+    meta: &InputMeta,
+    spec: &ResourceCheckoutSpec,
+    status: &ResourceCheckoutStatus,
+) -> Result<(), String> {
+    let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
+    let checkout = match checkouts.create(meta, spec).await {
         Ok(checkout) => checkout,
         Err(ResourceError::Conflict { .. }) => {
-            let existing = checkouts.get(&checkout_ref).await.map_err(|err| err.to_string())?;
+            let existing = checkouts.get(checkout_ref).await.map_err(|err| err.to_string())?;
             if existing.metadata.lifecycle_authority().map_err(|err| err.to_string())? != Some(LifecycleAuthority::Adopted) {
                 return Err(format!("checkout {checkout_ref} already exists but is not adopted"));
             }
-            if existing.spec != spec {
+            if &existing.spec != spec {
                 return Err(format!("checkout {checkout_ref} already exists with different adopted checkout details"));
             }
             existing
         }
         Err(err) => return Err(err.to_string()),
     };
-    checkouts
-        .update_status(&checkout_ref, &checkout.metadata.resource_version, &ResourceCheckoutStatus {
-            phase: ResourceCheckoutPhase::Ready,
-            path: Some(path_str),
-            commit: None,
-            message: None,
-        })
-        .await
-        .map_err(|err| err.to_string())?;
-
-    Ok((checkout_ref, repository_url.to_string(), git_ref.to_string()))
+    checkouts.update_status(checkout_ref, &checkout.metadata.resource_version, status).await.map_err(|err| err.to_string())?;
+    Ok(())
 }
 
 async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str) -> Option<String> {
@@ -4040,6 +4049,7 @@ impl InProcessDaemon {
                         let git_ref = r#ref.as_deref().unwrap_or(&inspection.checkout.git_ref);
                         let (checkout_ref, inferred_repository_url, inferred_ref) = create_adopted_checkout_resource(
                             &self.resource_backend,
+                            &self.observed_resource_backend,
                             AdoptedCheckoutRequest::builder()
                                 .namespace(&namespace)
                                 .convoy_name(name)

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2624,7 +2624,16 @@ async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource()
         .get("adopted-checkout-convoy-adopted")
         .await
         .expect("adopted checkout should exist");
+    let observed_checkout = daemon
+        .observed_resource_backend()
+        .using::<ResourceCheckout>("flotilla")
+        .get("adopted-checkout-convoy-adopted")
+        .await
+        .expect("adopted checkout should be published as an observed fact");
     assert_eq!(checkout.metadata.lifecycle_authority().expect("authority should parse"), Some(LifecycleAuthority::Adopted));
+    assert_eq!(observed_checkout.metadata.lifecycle_authority().expect("authority should parse"), Some(LifecycleAuthority::Adopted));
+    assert_eq!(observed_checkout.spec, checkout.spec);
+    assert_eq!(observed_checkout.status, checkout.status);
     match checkout.spec {
         ResourceCheckoutSpec::Observed(spec) => {
             assert_eq!(spec.r#ref, "main");

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod refresh;
 pub(crate) mod repo_state;
 pub mod repository_inspection;
 pub mod resolve;
+mod scoped_checkouts;
 pub mod step;
 pub mod template;
 pub mod terminal_manager;

--- a/crates/flotilla-core/src/scoped_checkouts.rs
+++ b/crates/flotilla-core/src/scoped_checkouts.rs
@@ -1,0 +1,280 @@
+//! Warm scoped checkout projections over fleet-merged observed facts.
+
+use std::collections::{HashMap, HashSet};
+
+use flotilla_protocol::{
+    CheckoutRow, HostName, QueryChanges, QueryScope, RepositoryKey, ResourceRef, ResultDelta, ResultSet, ResultSetCondition,
+    ResultSetState, Rows,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MaterializedSet {
+    seq: u64,
+    rows: HashMap<ResourceRef, CheckoutRow>,
+    state: ResultSetState,
+}
+
+impl MaterializedSet {
+    fn unavailable(scope: &QueryScope, message: String) -> Self {
+        Self {
+            seq: 0,
+            rows: HashMap::new(),
+            state: ResultSetState {
+                demand: None,
+                conditions: vec![ResultSetCondition::QueryScopeUnavailable { scope: scope.clone(), message }],
+            },
+        }
+    }
+
+    fn result_set(&self, scope: &QueryScope) -> ResultSet {
+        let mut rows = self.rows.values().cloned().collect::<Vec<_>>();
+        rows.sort_by(|left, right| {
+            (&left.host, &left.path, &left.resource.namespace, &left.resource.name).cmp(&(
+                &right.host,
+                &right.path,
+                &right.resource.namespace,
+                &right.resource.name,
+            ))
+        });
+        ResultSet { seq: self.seq, rows: Rows::Checkouts { scope: scope.clone(), rows }, state: self.state.clone() }
+    }
+}
+
+/// All warm checkout facts and their finite referent-backed scoped views.
+#[derive(Debug, Default, bon::Builder)]
+#[builder(builder_type(vis = "pub(crate)"))]
+pub struct ScopedCheckoutProjection {
+    known_repositories: HashSet<RepositoryKey>,
+    projects: HashMap<QueryScope, Vec<RepositoryKey>>,
+    local_by_repo: HashMap<RepositoryKey, HashMap<ResourceRef, CheckoutRow>>,
+    replicas_by_repo: HashMap<RepositoryKey, HashMap<HostName, HashMap<ResourceRef, CheckoutRow>>>,
+    sets: HashMap<QueryScope, MaterializedSet>,
+}
+
+impl ScopedCheckoutProjection {
+    pub fn replace_catalog(
+        &mut self,
+        repositories: HashSet<RepositoryKey>,
+        projects: HashMap<QueryScope, Vec<RepositoryKey>>,
+    ) -> Vec<ResultDelta> {
+        self.known_repositories = repositories;
+        self.projects = projects;
+        self.recompute_all()
+    }
+
+    pub fn replace_local_rows(&mut self, rows: Vec<CheckoutRow>) -> Vec<ResultDelta> {
+        self.local_by_repo = group_rows(rows);
+        self.recompute_all()
+    }
+
+    pub fn replace_replica_rows(&mut self, replicas: HashMap<HostName, Vec<CheckoutRow>>) -> Vec<ResultDelta> {
+        self.replicas_by_repo.clear();
+        for (host, rows) in replicas {
+            for (repo, rows) in group_rows(rows) {
+                self.replicas_by_repo.entry(repo).or_default().insert(host.clone(), rows);
+            }
+        }
+        self.recompute_all()
+    }
+
+    pub fn result_set(&mut self, scope: &QueryScope) -> ResultSet {
+        if !self.sets.contains_key(scope) {
+            let materialized = self.materialize(scope);
+            self.sets.insert(scope.clone(), materialized);
+        }
+        self.sets.get(scope).expect("checkout scope inserted").result_set(scope)
+    }
+
+    /// Local Repository-scoped facts are the federation unit. Project views
+    /// are derived after the receiver has merged every Repository scope.
+    pub fn local_result_sets(&self) -> Vec<ResultSet> {
+        let mut scopes = self.known_repositories.iter().cloned().collect::<Vec<_>>();
+        scopes.sort();
+        scopes
+            .into_iter()
+            .map(|repo| {
+                let rows = self.local_by_repo.get(&repo).cloned().unwrap_or_default();
+                let scope = QueryScope::Repository(repo);
+                let seq = self.sets.get(&scope).map_or(0, |set| set.seq);
+                let materialized = MaterializedSet { seq, rows, state: ResultSetState::default() };
+                materialized.result_set(&scope)
+            })
+            .collect()
+    }
+
+    fn recompute_all(&mut self) -> Vec<ResultDelta> {
+        let mut scopes = self.sets.keys().cloned().collect::<HashSet<_>>();
+        scopes.extend(self.known_repositories.iter().cloned().map(QueryScope::Repository));
+        scopes.extend(self.projects.keys().cloned());
+        scopes.extend(self.local_by_repo.keys().cloned().map(QueryScope::Repository));
+        scopes.extend(self.replicas_by_repo.keys().cloned().map(QueryScope::Repository));
+
+        let mut scopes = scopes.into_iter().collect::<Vec<_>>();
+        scopes.sort_by_key(scope_sort_key);
+        scopes.into_iter().filter_map(|scope| self.recompute_scope(scope)).collect()
+    }
+
+    fn recompute_scope(&mut self, scope: QueryScope) -> Option<ResultDelta> {
+        let replacement = self.materialize(&scope);
+        let previous = self.sets.remove(&scope).unwrap_or_else(|| MaterializedSet::unavailable(&scope, unavailable_message(&scope)));
+        let changed = replacement
+            .rows
+            .iter()
+            .filter(|(reference, row)| previous.rows.get(*reference) != Some(*row))
+            .map(|(_, row)| row.clone())
+            .collect::<Vec<_>>();
+        let removed = previous.rows.keys().filter(|reference| !replacement.rows.contains_key(*reference)).cloned().collect::<Vec<_>>();
+        let state = (previous.state != replacement.state).then(|| replacement.state.clone());
+        if changed.is_empty() && removed.is_empty() && state.is_none() {
+            self.sets.insert(scope, previous);
+            return None;
+        }
+
+        let materialized = MaterializedSet { seq: previous.seq.saturating_add(1), ..replacement };
+        let seq = materialized.seq;
+        self.sets.insert(scope.clone(), materialized);
+        Some(ResultDelta { seq, changes: QueryChanges::Checkouts { scope, changed, removed }, state })
+    }
+
+    fn materialize(&self, scope: &QueryScope) -> MaterializedSet {
+        match scope {
+            QueryScope::Repository(repo) => {
+                if !self.known_repositories.contains(repo) {
+                    return MaterializedSet::unavailable(scope, unavailable_message(scope));
+                }
+                MaterializedSet { seq: 0, rows: self.rows_for_repo(repo), state: ResultSetState::default() }
+            }
+            QueryScope::Project { namespace, name } => {
+                let Some(repositories) = self.projects.get(scope) else {
+                    return MaterializedSet::unavailable(scope, unavailable_message(scope));
+                };
+                let missing = repositories.iter().filter(|repo| !self.known_repositories.contains(*repo)).collect::<Vec<_>>();
+                if !missing.is_empty() {
+                    let missing = missing.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
+                    return MaterializedSet::unavailable(
+                        scope,
+                        format!("project {namespace}/{name} references unavailable repositories: {missing}"),
+                    );
+                }
+                let rows = repositories.iter().flat_map(|repo| self.rows_for_repo(repo)).collect();
+                MaterializedSet { seq: 0, rows, state: ResultSetState::default() }
+            }
+        }
+    }
+
+    fn rows_for_repo(&self, repo: &RepositoryKey) -> HashMap<ResourceRef, CheckoutRow> {
+        let mut rows = self.local_by_repo.get(repo).cloned().unwrap_or_default();
+        if let Some(replicas) = self.replicas_by_repo.get(repo) {
+            rows.extend(replicas.values().flat_map(|rows| rows.iter()).map(|(reference, row)| (reference.clone(), row.clone())));
+        }
+        rows
+    }
+}
+
+fn group_rows(rows: Vec<CheckoutRow>) -> HashMap<RepositoryKey, HashMap<ResourceRef, CheckoutRow>> {
+    let mut grouped: HashMap<RepositoryKey, HashMap<ResourceRef, CheckoutRow>> = HashMap::new();
+    for row in rows {
+        grouped.entry(row.repo.clone()).or_default().insert(row.resource.clone(), row);
+    }
+    grouped
+}
+
+fn unavailable_message(scope: &QueryScope) -> String {
+    match scope {
+        QueryScope::Repository(repo) => format!("repository {repo} is unavailable"),
+        QueryScope::Project { namespace, name } => format!("project {namespace}/{name} is unavailable"),
+    }
+}
+
+fn scope_sort_key(scope: &QueryScope) -> String {
+    match scope {
+        QueryScope::Repository(repo) => format!("repository/{repo}"),
+        QueryScope::Project { namespace, name } => format!("project/{namespace}/{name}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flotilla_protocol::{LifecycleAuthority, QueryId};
+
+    use super::*;
+
+    fn repo(value: &str) -> RepositoryKey {
+        RepositoryKey(value.into())
+    }
+
+    fn row(repo: &str, name: &str, host: &str) -> CheckoutRow {
+        CheckoutRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", name).on_host(HostName::new(host)))
+            .repo(self::repo(repo))
+            .path(format!("/work/{name}"))
+            .branch("main")
+            .host(HostName::new(host))
+            .authority(LifecycleAuthority::Observed)
+            .build()
+    }
+
+    #[test]
+    fn repository_scope_distinguishes_unavailable_from_valid_empty() {
+        let mut projection = ScopedCheckoutProjection::default();
+        let scope = QueryScope::Repository(repo("repo-a"));
+        let missing = projection.result_set(&scope);
+        assert!(matches!(missing.state.conditions.as_slice(), [ResultSetCondition::QueryScopeUnavailable { .. }]));
+
+        let deltas = projection.replace_catalog(HashSet::from([repo("repo-a")]), HashMap::new());
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].query(), QueryId::Checkouts { scope: scope.clone() });
+        assert!(deltas[0].state.as_ref().expect("condition clear").conditions.is_empty());
+        let available = projection.result_set(&scope);
+        assert!(available.rows.is_empty());
+        assert!(available.state.conditions.is_empty());
+    }
+
+    #[test]
+    fn project_scope_unions_local_and_replica_repository_rows() {
+        let mut projection = ScopedCheckoutProjection::default();
+        let project = QueryScope::Project { namespace: "flotilla".into(), name: "suite".into() };
+        projection.replace_catalog(
+            HashSet::from([repo("repo-a"), repo("repo-b")]),
+            HashMap::from([(project.clone(), vec![repo("repo-a"), repo("repo-b")])]),
+        );
+        projection.replace_local_rows(vec![row("repo-a", "local", "laptop")]);
+        projection.replace_replica_rows(HashMap::from([(HostName::new("kiwi"), vec![row("repo-b", "remote", "kiwi")])]));
+
+        let result = projection.result_set(&project);
+        let rows = result.rows.as_checkouts().expect("checkout rows");
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().any(|row| row.host == HostName::new("laptop")));
+        assert!(rows.iter().any(|row| row.host == HostName::new("kiwi")));
+    }
+
+    #[test]
+    fn fleet_export_includes_empty_repository_scopes_and_excludes_projects() {
+        let mut projection = ScopedCheckoutProjection::default();
+        let repository = repo("repo-a");
+        let project = QueryScope::Project { namespace: "flotilla".into(), name: "suite".into() };
+        projection.replace_catalog(HashSet::from([repository.clone()]), HashMap::from([(project, vec![repository.clone()])]));
+
+        let sets = projection.local_result_sets();
+
+        assert_eq!(sets.len(), 1);
+        assert_eq!(sets[0].query(), QueryId::Checkouts { scope: QueryScope::Repository(repository) });
+        assert!(sets[0].rows.is_empty());
+        assert!(sets[0].state.conditions.is_empty());
+    }
+
+    #[test]
+    fn project_membership_change_emits_typed_addition_and_removal() {
+        let mut projection = ScopedCheckoutProjection::default();
+        let project = QueryScope::Project { namespace: "flotilla".into(), name: "suite".into() };
+        projection
+            .replace_catalog(HashSet::from([repo("repo-a"), repo("repo-b")]), HashMap::from([(project.clone(), vec![repo("repo-a")])]));
+        projection.replace_local_rows(vec![row("repo-a", "a", "local"), row("repo-b", "b", "local")]);
+
+        let deltas = projection
+            .replace_catalog(HashSet::from([repo("repo-a"), repo("repo-b")]), HashMap::from([(project.clone(), vec![repo("repo-b")])]));
+        let delta = deltas.into_iter().find(|delta| delta.query() == QueryId::Checkouts { scope: project.clone() }).expect("project delta");
+        assert_eq!(delta.changes.as_checkouts().expect("changed checkout")[0].resource.name, "b");
+        assert_eq!(delta.changes.removed_resources().expect("removed checkout")[0].name, "a");
+    }
+}

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -9,15 +9,16 @@ use async_trait::async_trait;
 use flotilla_core::{aggregator_projection::AggregatorProjectionState, in_process::InProcessDaemon};
 use flotilla_protocol::{
     result_set::{
-        ConvoyPhase, ConvoyRow, CrewMemberSummary, IndependentRow, QueryChanges, QueryId, ResultDelta, Rows, SessionPhase, VesselRow,
-        WorkPhase,
+        CheckoutRow, ConvoyPhase, ConvoyRow, CrewMemberSummary, IndependentRow, QueryChanges, QueryId, QueryScope, ResultDelta, Rows,
+        SessionPhase, VesselRow, WorkPhase,
     },
-    DaemonEvent, FleetReplicaSnapshot, HostName, ResourceRef,
+    DaemonEvent, FleetReplicaSnapshot, HostName, LifecycleAuthority, RepositoryKey, ResourceRef,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Environment, Presentation, Resource, ResourceError,
-    ResourceList, ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WatchEvent, WatchStart,
-    WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_LABEL, VESSEL_LABEL,
+    api_version, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Environment, Presentation,
+    Project, Repository, Resource, ResourceError, ResourceList, ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver,
+    VesselRequirement, WatchEvent, WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_LABEL,
+    VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::broadcast;
@@ -33,9 +34,12 @@ pub struct AggregatorResolvers {
     durable_environments: TypedResolver<Environment>,
     durable_presentations: TypedResolver<Presentation>,
     durable_sessions: TypedResolver<TerminalSession>,
+    durable_projects: TypedResolver<Project>,
+    durable_repositories: TypedResolver<Repository>,
     observed_convoys: TypedResolver<Convoy>,
     observed_presentations: TypedResolver<Presentation>,
     observed_sessions: TypedResolver<TerminalSession>,
+    observed_checkouts: TypedResolver<Checkout>,
 }
 
 #[derive(bon::Builder)]
@@ -44,9 +48,12 @@ struct AggregatorSourceRefs<'a> {
     durable_environments: &'a dyn AggregatorWatchSource<Environment>,
     durable_presentations: &'a dyn AggregatorWatchSource<Presentation>,
     durable_sessions: &'a dyn AggregatorWatchSource<TerminalSession>,
+    durable_projects: &'a dyn AggregatorWatchSource<Project>,
+    durable_repositories: &'a dyn AggregatorWatchSource<Repository>,
     observed_convoys: &'a dyn AggregatorWatchSource<Convoy>,
     observed_presentations: &'a dyn AggregatorWatchSource<Presentation>,
     observed_sessions: &'a dyn AggregatorWatchSource<TerminalSession>,
+    observed_checkouts: &'a dyn AggregatorWatchSource<Checkout>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -98,6 +105,9 @@ pub struct Aggregator {
     sessions_by_source: HashMap<LocalSource, HashMap<SessionKey, ResourceObject<TerminalSession>>>,
     presentation_workspaces: HashMap<PresentationKey, String>,
     terminal_sessions: HashMap<SessionKey, ResourceObject<TerminalSession>>,
+    projects: HashMap<(String, String), ResourceObject<Project>>,
+    repositories: HashMap<RepositoryKey, ResourceObject<Repository>>,
+    observed_checkouts: HashMap<ResourceRef, ResourceObject<Checkout>>,
     bootstrapping: bool,
     emitted_queries: HashSet<QueryId>,
     #[builder(skip)]
@@ -119,6 +129,9 @@ impl Aggregator {
             sessions_by_source: HashMap::new(),
             presentation_workspaces: HashMap::new(),
             terminal_sessions: HashMap::new(),
+            projects: HashMap::new(),
+            repositories: HashMap::new(),
+            observed_checkouts: HashMap::new(),
             bootstrapping: false,
             emitted_queries: HashSet::new(),
             attach_resolver: None,
@@ -153,18 +166,24 @@ impl Aggregator {
             durable_environments,
             durable_presentations,
             durable_sessions,
+            durable_projects,
+            durable_repositories,
             observed_convoys,
             observed_presentations,
             observed_sessions,
+            observed_checkouts,
         } = resolvers;
         let sources = AggregatorSourceRefs::builder()
             .durable_convoys(&durable_convoys)
             .durable_environments(&durable_environments)
             .durable_presentations(&durable_presentations)
             .durable_sessions(&durable_sessions)
+            .durable_projects(&durable_projects)
+            .durable_repositories(&durable_repositories)
             .observed_convoys(&observed_convoys)
             .observed_presentations(&observed_presentations)
             .observed_sessions(&observed_sessions)
+            .observed_checkouts(&observed_checkouts)
             .build();
         self.run_with_sources(sources, replica_rx).await
     }
@@ -179,9 +198,12 @@ impl Aggregator {
             durable_environments,
             durable_presentations,
             durable_sessions,
+            durable_projects,
+            durable_repositories,
             observed_convoys,
             observed_presentations,
             observed_sessions,
+            observed_checkouts,
         } = sources;
         // Subscribe before any source bootstrap awaits so demand arriving
         // during recovery remains observable. Also consume the initial value
@@ -212,9 +234,12 @@ impl Aggregator {
         let mut durable_environment_stream = self.recover_environment_watch(durable_environments).await?;
         let mut durable_presentation_stream = self.recover_presentation_watch(LocalSource::Durable, durable_presentations).await?;
         let mut durable_session_stream = self.recover_session_watch(LocalSource::Durable, durable_sessions).await?;
+        let mut durable_project_stream = self.recover_project_watch(durable_projects).await?;
+        let mut durable_repository_stream = self.recover_repository_watch(durable_repositories).await?;
         let mut observed_convoy_stream = self.recover_convoy_watch(LocalSource::Observed, observed_convoys).await?;
         let mut observed_presentation_stream = self.recover_presentation_watch(LocalSource::Observed, observed_presentations).await?;
         let mut observed_session_stream = self.recover_session_watch(LocalSource::Observed, observed_sessions).await?;
+        let mut observed_checkout_stream = self.recover_checkout_watch(observed_checkouts).await?;
         self.bootstrapping = false;
         self.emitted_queries.extend(QueryId::ALWAYS_MATERIALIZED.iter().cloned());
         let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.result_set().await)));
@@ -276,6 +301,22 @@ impl Aggregator {
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator durable terminal session watch ended")),
                 },
+                event = durable_project_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_project_event(event).await,
+                    Some(Err(ResourceError::WatchExpired { .. })) => {
+                        durable_project_stream = self.recover_project_watch(durable_projects).await?;
+                    }
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator durable project watch ended")),
+                },
+                event = durable_repository_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_repository_event(event).await,
+                    Some(Err(ResourceError::WatchExpired { .. })) => {
+                        durable_repository_stream = self.recover_repository_watch(durable_repositories).await?;
+                    }
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator durable repository watch ended")),
+                },
                 event = observed_convoy_stream.next() => match event {
                     Some(Ok(event)) => self.apply_convoy_event_from(LocalSource::Observed, event).await,
                     Some(Err(ResourceError::WatchExpired { .. })) => {
@@ -299,6 +340,14 @@ impl Aggregator {
                     }
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator observed terminal session watch ended")),
+                },
+                event = observed_checkout_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_checkout_event(event).await?,
+                    Some(Err(ResourceError::WatchExpired { .. })) => {
+                        observed_checkout_stream = self.recover_checkout_watch(observed_checkouts).await?;
+                    }
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator observed checkout watch ended")),
                 },
                 replica = replica_rx.recv() => match replica {
                     Ok(snapshots) => self.apply_replica_cache(snapshots).await,
@@ -364,6 +413,42 @@ impl Aggregator {
         }
     }
 
+    async fn recover_project_watch(
+        &mut self,
+        resolver: &dyn AggregatorWatchSource<Project>,
+    ) -> Result<WatchStream<Project>, ResourceError> {
+        loop {
+            match self.list_and_watch_projects(resolver).await {
+                Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
+                result => return result,
+            }
+        }
+    }
+
+    async fn recover_repository_watch(
+        &mut self,
+        resolver: &dyn AggregatorWatchSource<Repository>,
+    ) -> Result<WatchStream<Repository>, ResourceError> {
+        loop {
+            match self.list_and_watch_repositories(resolver).await {
+                Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
+                result => return result,
+            }
+        }
+    }
+
+    async fn recover_checkout_watch(
+        &mut self,
+        resolver: &dyn AggregatorWatchSource<Checkout>,
+    ) -> Result<WatchStream<Checkout>, ResourceError> {
+        loop {
+            match self.list_and_watch_checkouts(resolver).await {
+                Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
+                result => return result,
+            }
+        }
+    }
+
     async fn list_and_watch_convoys(
         &mut self,
         source: LocalSource,
@@ -414,6 +499,47 @@ impl Aggregator {
         let start = watch_start(&listed);
         let watch = resolver.watch(start).await?;
         self.replace_session_source(source, listed.items).await;
+        Ok(watch)
+    }
+
+    async fn list_and_watch_projects(
+        &mut self,
+        resolver: &dyn AggregatorWatchSource<Project>,
+    ) -> Result<WatchStream<Project>, ResourceError> {
+        let listed = resolver.list().await?;
+        let watch = resolver.watch(watch_start(&listed)).await?;
+        self.projects = listed
+            .items
+            .into_iter()
+            .map(|project| ((project.metadata.namespace.clone(), project.metadata.name.clone()), project))
+            .collect();
+        self.rebuild_checkout_catalog().await;
+        Ok(watch)
+    }
+
+    async fn list_and_watch_repositories(
+        &mut self,
+        resolver: &dyn AggregatorWatchSource<Repository>,
+    ) -> Result<WatchStream<Repository>, ResourceError> {
+        let listed = resolver.list().await?;
+        let watch = resolver.watch(watch_start(&listed)).await?;
+        self.repositories = listed.items.into_iter().map(|repository| (repository.spec.key(), repository)).collect();
+        self.rebuild_checkout_catalog().await;
+        Ok(watch)
+    }
+
+    async fn list_and_watch_checkouts(
+        &mut self,
+        resolver: &dyn AggregatorWatchSource<Checkout>,
+    ) -> Result<WatchStream<Checkout>, ResourceError> {
+        let listed = resolver.list().await?;
+        let watch = resolver.watch(watch_start(&listed)).await?;
+        self.observed_checkouts = listed
+            .items
+            .into_iter()
+            .map(|checkout| (self.checkout_ref(&checkout.metadata.namespace, &checkout.metadata.name), checkout))
+            .collect();
+        self.rebuild_checkout_rows().await?;
         Ok(watch)
     }
 
@@ -555,6 +681,90 @@ impl Aggregator {
         self.rebuild_independents_projection().await;
     }
 
+    async fn apply_project_event(&mut self, event: WatchEvent<Project>) {
+        match event {
+            WatchEvent::Added(project) | WatchEvent::Modified(project) => {
+                self.projects.insert((project.metadata.namespace.clone(), project.metadata.name.clone()), project);
+            }
+            WatchEvent::Deleted(project) => {
+                self.projects.remove(&(project.metadata.namespace, project.metadata.name));
+            }
+        }
+        self.rebuild_checkout_catalog().await;
+    }
+
+    async fn apply_repository_event(&mut self, event: WatchEvent<Repository>) {
+        match event {
+            WatchEvent::Added(repository) | WatchEvent::Modified(repository) => {
+                self.repositories.insert(repository.spec.key(), repository);
+            }
+            WatchEvent::Deleted(repository) => {
+                self.repositories.remove(&repository.spec.key());
+            }
+        }
+        self.rebuild_checkout_catalog().await;
+    }
+
+    async fn apply_checkout_event(&mut self, event: WatchEvent<Checkout>) -> Result<(), ResourceError> {
+        match event {
+            WatchEvent::Added(checkout) | WatchEvent::Modified(checkout) => {
+                let reference = self.checkout_ref(&checkout.metadata.namespace, &checkout.metadata.name);
+                self.observed_checkouts.insert(reference, checkout);
+            }
+            WatchEvent::Deleted(checkout) => {
+                let reference = self.checkout_ref(&checkout.metadata.namespace, &checkout.metadata.name);
+                self.observed_checkouts.remove(&reference);
+            }
+        }
+        self.rebuild_checkout_rows().await
+    }
+
+    async fn rebuild_checkout_catalog(&self) {
+        let repositories = self.repositories.keys().cloned().collect();
+        let projects = self
+            .projects
+            .values()
+            .map(|project| {
+                let scope = QueryScope::Project { namespace: project.metadata.namespace.clone(), name: project.metadata.name.clone() };
+                let repositories = project.spec.repositories.iter().map(|repository| repository.repo.clone()).collect();
+                (scope, repositories)
+            })
+            .collect();
+        let deltas = self.state.replace_checkout_catalog(repositories, projects).await;
+        self.emit_checkout_deltas(deltas);
+    }
+
+    async fn rebuild_checkout_rows(&self) -> Result<(), ResourceError> {
+        let rows = self
+            .observed_checkouts
+            .values()
+            .filter_map(|checkout| {
+                let CheckoutSpec::Observed(spec) = &checkout.spec else { return None };
+                Some((checkout, spec))
+            })
+            .map(|(checkout, spec)| {
+                let authority = checkout.metadata.lifecycle_authority()?.unwrap_or(LifecycleAuthority::Managed);
+                Ok(CheckoutRow::builder()
+                    .resource(self.checkout_ref(&checkout.metadata.namespace, &checkout.metadata.name))
+                    .repo(spec.repo_ref.clone())
+                    .path(spec.path.clone())
+                    .branch(spec.r#ref.clone())
+                    .host(self.local_host.clone())
+                    .authority(authority)
+                    .build())
+            })
+            .collect::<Result<Vec<_>, ResourceError>>()?;
+        let deltas = self.state.replace_local_checkout_rows(rows).await;
+        self.emit_checkout_deltas(deltas);
+        Ok(())
+    }
+
+    fn emit_checkout_deltas(&self, deltas: Vec<ResultDelta>) {
+        for delta in deltas {
+            let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
+        }
+    }
+
     async fn rebuild_independents_projection(&mut self) {
         let mut effective_sessions = HashMap::new();
         for source in LOCAL_SOURCE_PRECEDENCE {
@@ -613,10 +823,12 @@ impl Aggregator {
     pub async fn apply_replica_cache(&mut self, snapshots: Vec<FleetReplicaSnapshot>) {
         let mut convoy_replacements = HashMap::new();
         let mut independent_replacements = HashMap::new();
+        let mut checkout_replacements = HashMap::new();
         for snapshot in snapshots {
             let host = snapshot.host;
             let mut convoy_rows = HashMap::new();
             let mut independent_rows = HashMap::new();
+            let mut checkout_rows = Vec::new();
             for result_set in snapshot.result_sets {
                 match result_set.rows {
                     Rows::Convoys(convoys) => {
@@ -634,10 +846,20 @@ impl Aggregator {
                     Rows::Issues { .. } => {
                         tracing::warn!(host = %host, "ignoring demand-backed issues in fleet replica snapshot");
                     }
+                    Rows::Checkouts { scope: QueryScope::Repository(_), rows } => {
+                        for mut row in rows {
+                            set_checkout_row_host(&mut row, &host);
+                            checkout_rows.push(row);
+                        }
+                    }
+                    Rows::Checkouts { scope: QueryScope::Project { .. }, .. } => {
+                        tracing::warn!(host = %host, "ignoring derived project checkout set in fleet replica snapshot");
+                    }
                 }
             }
             convoy_replacements.insert(host.clone(), convoy_rows);
-            independent_replacements.insert(host, independent_rows);
+            independent_replacements.insert(host.clone(), independent_rows);
+            checkout_replacements.insert(host, checkout_rows);
         }
 
         let convoy_change = {
@@ -665,6 +887,9 @@ impl Aggregator {
                 let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.independents_result_set().await)));
             }
         }
+
+        let checkout_deltas = self.state.replace_checkout_replica_rows(checkout_replacements).await;
+        self.emit_checkout_deltas(checkout_deltas);
     }
 
     async fn emit_delta(&self, changed: Vec<ConvoyRow>, removed: Vec<ResourceRef>) {
@@ -691,6 +916,10 @@ impl Aggregator {
     fn session_ref(&self, namespace: &str, name: &str) -> ResourceRef {
         ResourceRef::new(api_version(TerminalSession::API_PATHS), TerminalSession::API_PATHS.kind, namespace, name)
             .on_host(self.local_host.clone())
+    }
+
+    fn checkout_ref(&self, namespace: &str, name: &str) -> ResourceRef {
+        ResourceRef::new(api_version(Checkout::API_PATHS), Checkout::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
     }
 
     fn summarize_independent(
@@ -829,6 +1058,11 @@ fn set_independent_row_host(row: &mut IndependentRow, host: &HostName) {
     row.host = host.clone();
 }
 
+fn set_checkout_row_host(row: &mut CheckoutRow, host: &HostName) {
+    row.resource.host = Some(host.clone());
+    row.host = host.clone();
+}
+
 fn convoy_phase(phase: ResourceConvoyPhase) -> ConvoyPhase {
     match phase {
         ResourceConvoyPhase::Pending => ConvoyPhase::Pending,
@@ -871,7 +1105,7 @@ mod tests {
     };
 
     use chrono::Utc;
-    use flotilla_protocol::result_set::ResultSet;
+    use flotilla_protocol::result_set::{ResultSet, ResultSetState};
     use flotilla_resources::{
         ConvoySpec, CrewSpec, InMemoryBackend, InputMeta, ObjectMeta, PlacementStatus, PresentationPhase, PresentationSpec,
         PresentationStatus, ResourceBackend, Stance, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement,
@@ -959,15 +1193,21 @@ mod tests {
     ) -> Result<(), ResourceError> {
         let durable_environments = ScriptedSource::<Environment>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let durable_sessions = ScriptedSource::<TerminalSession>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_projects = ScriptedSource::<Project>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_repositories = ScriptedSource::<Repository>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let observed_sessions = ScriptedSource::<TerminalSession>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let observed_checkouts = ScriptedSource::<Checkout>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let sources = AggregatorSourceRefs::builder()
             .durable_convoys(durable_convoys)
             .durable_environments(&durable_environments)
             .durable_presentations(durable_presentations)
             .durable_sessions(&durable_sessions)
+            .durable_projects(&durable_projects)
+            .durable_repositories(&durable_repositories)
             .observed_convoys(observed_convoys)
             .observed_presentations(observed_presentations)
             .observed_sessions(&observed_sessions)
+            .observed_checkouts(&observed_checkouts)
             .build();
         aggregator.run_with_sources(sources, replica_rx).await
     }
@@ -1264,6 +1504,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replica_cache_merges_repository_checkout_rows_and_sets_origin_host() {
+        let state = AggregatorProjectionState::new();
+        let repo = RepositoryKey("repo-widgets".into());
+        state.replace_checkout_catalog(HashSet::from([repo.clone()]), HashMap::new()).await;
+        let scope = QueryScope::Repository(repo.clone());
+        let row = CheckoutRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "remote-checkout"))
+            .repo(repo)
+            .path("/srv/widgets")
+            .branch("main")
+            .host(HostName::new("incorrect-source-host"))
+            .authority(LifecycleAuthority::Observed)
+            .build();
+        let snapshot = FleetReplicaSnapshot {
+            host: HostName::new("kiwi"),
+            generation: None,
+            rows: vec![],
+            result_sets: vec![ResultSet {
+                seq: 4,
+                rows: Rows::Checkouts { scope: scope.clone(), rows: vec![row] },
+                state: ResultSetState::default(),
+            }],
+        };
+        let (event_tx, _) = broadcast::channel(8);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+
+        aggregator.apply_replica_cache(vec![snapshot]).await;
+
+        let set = state.result_set_for(&QueryId::Checkouts { scope }).await.expect("checkout result set");
+        let rows = set.rows.as_checkouts().expect("checkout rows");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].host, HostName::new("kiwi"));
+        assert_eq!(rows[0].resource.host, Some(HostName::new("kiwi")));
+    }
+
+    #[tokio::test]
     async fn replica_cache_unions_independents_and_stamps_origin_host() {
         let state = AggregatorProjectionState::new();
         let (tx, mut rx) = broadcast::channel(8);
@@ -1324,9 +1600,12 @@ mod tests {
                     .durable_environments(durable.clone().using::<Environment>("flotilla"))
                     .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
                     .durable_sessions(durable.using::<TerminalSession>("flotilla"))
+                    .durable_projects(durable.using::<Project>("flotilla"))
+                    .durable_repositories(durable.using::<Repository>("flotilla"))
                     .observed_convoys(observed.clone().using::<Convoy>("flotilla"))
                     .observed_presentations(observed.clone().using::<Presentation>("flotilla"))
                     .observed_sessions(observed.using::<TerminalSession>("flotilla"))
+                    .observed_checkouts(observed.using::<Checkout>("flotilla"))
                     .build(),
                 replica_rx,
             )
@@ -1400,9 +1679,12 @@ mod tests {
             vec![ResourceList { items: vec![stale], resource_version: "1".to_string(), generation: None }, empty_list()],
             vec![Ok(expiring_watch()), Ok(pending_watch())],
         ));
+        let durable_projects = Arc::new(ScriptedSource::<Project>::new(vec![empty_list()], vec![Ok(pending_watch())]));
+        let durable_repositories = Arc::new(ScriptedSource::<Repository>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let observed_convoys = Arc::new(ScriptedSource::<Convoy>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let observed_presentations = Arc::new(ScriptedSource::<Presentation>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let observed_sessions = Arc::new(ScriptedSource::<TerminalSession>::new(vec![empty_list()], vec![Ok(pending_watch())]));
+        let observed_checkouts = Arc::new(ScriptedSource::<Checkout>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let state = AggregatorProjectionState::new();
         let (event_tx, mut event_rx) = broadcast::channel(8);
         let (_replica_tx, replica_rx) = broadcast::channel(1);
@@ -1415,9 +1697,12 @@ mod tests {
                 .durable_environments(durable_environments.as_ref())
                 .durable_presentations(durable_presentations.as_ref())
                 .durable_sessions(run_durable_sessions.as_ref())
+                .durable_projects(durable_projects.as_ref())
+                .durable_repositories(durable_repositories.as_ref())
                 .observed_convoys(observed_convoys.as_ref())
                 .observed_presentations(observed_presentations.as_ref())
                 .observed_sessions(observed_sessions.as_ref())
+                .observed_checkouts(observed_checkouts.as_ref())
                 .build();
             Aggregator::new(run_state, HostName::new("local"), event_tx).run_with_sources(sources, replica_rx).await
         });

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -743,7 +743,7 @@ impl Aggregator {
                 Some((checkout, spec))
             })
             .map(|(checkout, spec)| {
-                let authority = checkout.metadata.lifecycle_authority()?.unwrap_or(LifecycleAuthority::Managed);
+                let authority = checkout.metadata.lifecycle_authority()?.unwrap_or(LifecycleAuthority::Observed);
                 Ok(CheckoutRow::builder()
                     .resource(self.checkout_ref(&checkout.metadata.namespace, &checkout.metadata.name))
                     .repo(spec.repo_ref.clone())
@@ -760,6 +760,9 @@ impl Aggregator {
     }
 
     fn emit_checkout_deltas(&self, deltas: Vec<ResultDelta>) {
+        if self.bootstrapping {
+            return;
+        }
         for delta in deltas {
             let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
         }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -29,11 +29,11 @@ use flotilla_core::{
 };
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
 use flotilla_resources::{
-    clone_key, controller::ControllerLoop, descriptive_repo_slug, Clone, CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec,
-    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
+    clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, Clone, CloneSpec, Convoy, ConvoyReconciler, CrewSource,
+    CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
-    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Repository, ResourceBackend, ResourceError, ResourceObject, Stance,
-    TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Repository, ResourceBackend, ResourceError, ResourceObject,
+    Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -810,9 +810,12 @@ fn spawn_aggregator_task(
                             .durable_environments(durable.clone().using::<Environment>(&namespace))
                             .durable_presentations(durable.using::<Presentation>(&namespace))
                             .durable_sessions(durable.using::<flotilla_resources::TerminalSession>(&namespace))
+                            .durable_projects(durable.using::<Project>(&namespace))
+                            .durable_repositories(durable.using::<Repository>(&namespace))
                             .observed_convoys(observed.clone().using::<Convoy>(&namespace))
                             .observed_presentations(observed.using::<Presentation>(&namespace))
                             .observed_sessions(observed.using::<flotilla_resources::TerminalSession>(&namespace))
+                            .observed_checkouts(observed.using::<Checkout>(&namespace))
                             .build(),
                         daemon.subscribe_fleet_replicas(),
                     )

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -3,7 +3,11 @@
 //! Verifies that creating a Convoy resource causes a ResultSet event to
 //! reach subscribed clients through the daemon's broadcast event bus.
 
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 use flotilla_core::{
     config::ConfigStore,
@@ -17,13 +21,14 @@ use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{
     result_set::{ConvoyRow, IndependentRow, QueryId, ResultSet},
     test_support::TestIssue,
-    DaemonEvent, HostName, QueryCursor, QueryScope,
+    DaemonEvent, HostName, LifecycleAuthority, QueryCursor, QueryScope,
 };
 use flotilla_resources::{
-    Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, Environment, EnvironmentSpec, HostDirectEnvironmentSpec,
-    InMemoryBackend, InputMeta, Repository, RepositorySpec, ResourceBackend, TerminalSession, TerminalSessionPhase, TerminalSessionSource,
-    TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkPhase as ResourceWorkPhase, WorkState, WorkflowSnapshot,
-    CONVOY_LABEL, REPO_LABEL, VESSEL_LABEL,
+    Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, Environment, EnvironmentSpec,
+    HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObservedCheckoutSpec, Project, ProjectRepositorySpec, ProjectSpec, Repository,
+    RepositorySpec, ResourceBackend, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, VesselRequirement, WorkPhase as ResourceWorkPhase, WorkState, WorkflowSnapshot, CONVOY_LABEL, REPO_LABEL,
+    VESSEL_LABEL,
 };
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -61,6 +66,188 @@ fn convoy_rows(result_set: &ResultSet) -> &[ConvoyRow] {
 
 fn independent_rows(result_set: &ResultSet) -> &[IndependentRow] {
     result_set.rows.as_independents().expect("independent rows")
+}
+
+#[tokio::test]
+async fn scoped_checkout_queries_emit_observed_rows_and_removal_deltas() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/widgets/api.git").expect("remote repository");
+    let repository_key = repository_spec.key();
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository_key.to_string()).build(), &repository_spec)
+        .await
+        .expect("create repository");
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(
+            &InputMeta::builder().name("widgets".to_string()).build(),
+            &ProjectSpec::builder()
+                .display_name("Widgets".to_string())
+                .default_workflow_ref("single-agent-contained".to_string())
+                .repositories(vec![ProjectRepositorySpec::builder().repo(repository_key.clone()).build()])
+                .build(),
+        )
+        .await
+        .expect("create project");
+    let daemon =
+        InProcessDaemon::new_with_resource_backend(vec![], Arc::clone(&config), fake_discovery(false), HostName::new("local"), backend)
+            .await;
+    let observed = daemon.observed_resource_backend();
+    let options = RuntimeOptions {
+        namespace: "flotilla".into(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_secs(300),
+        ..RuntimeOptions::default()
+    };
+    let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("start runtime");
+    let repository_query = QueryId::Checkouts { scope: QueryScope::Repository(repository_key.clone()) };
+    let project_query = QueryId::Checkouts { scope: QueryScope::Project { namespace: "flotilla".into(), name: "widgets".into() } };
+    let subscriber = uuid::Uuid::new_v4();
+
+    let initial_sequences = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let events = daemon
+                .subscribe_queries(subscriber, &[QueryCursor { query: repository_query.clone(), since: None }, QueryCursor {
+                    query: project_query.clone(),
+                    since: None,
+                }])
+                .await
+                .expect("subscribe checkout queries");
+            let result_sets = events
+                .iter()
+                .filter_map(|event| match event {
+                    DaemonEvent::ResultSet(set) if matches!(set.query(), QueryId::Checkouts { .. }) => Some(set),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            if result_sets.len() == 2 && result_sets.iter().all(|set| set.state.conditions.is_empty()) {
+                break result_sets.iter().map(|set| (set.query(), set.seq)).collect::<HashMap<_, _>>();
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("checkout scopes become available");
+
+    let mut events = daemon.subscribe();
+    let checkouts = observed.using::<Checkout>("flotilla");
+    let checkout = checkouts
+        .create(
+            &InputMeta::builder().name("checkout-widgets".to_string()).build().with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &CheckoutSpec::Observed(
+                ObservedCheckoutSpec::builder()
+                    .r#ref("feature/query".to_string())
+                    .path("/work/widgets".to_string())
+                    .repo_ref(repository_key.clone())
+                    .host_ref(daemon.local_host_id().expect("local host id").to_string())
+                    .is_main(false)
+                    .build(),
+            ),
+        )
+        .await
+        .expect("create observed checkout");
+
+    let mut additions = HashMap::new();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while additions.len() < 2 {
+            if let DaemonEvent::ResultDelta(delta) = events.recv().await.expect("checkout event") {
+                if matches!(delta.query(), QueryId::Checkouts { .. }) {
+                    additions.insert(delta.query(), delta);
+                }
+            }
+        }
+    })
+    .await
+    .expect("repository and project checkout additions");
+    for query in [&repository_query, &project_query] {
+        let rows = additions.get(query).expect("scoped addition").changes.as_checkouts().expect("checkout changes");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].path, "/work/widgets");
+        assert_eq!(rows[0].branch, "feature/query");
+        assert_eq!(rows[0].authority, LifecycleAuthority::Adopted);
+        assert_eq!(rows[0].host, HostName::new("local"));
+    }
+
+    let checkout = checkouts
+        .update(
+            &InputMeta::builder().name(checkout.metadata.name.clone()).build().with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &checkout.metadata.resource_version,
+            &CheckoutSpec::Observed(
+                ObservedCheckoutSpec::builder()
+                    .r#ref("feature/revised".to_string())
+                    .path("/work/widgets-revised".to_string())
+                    .repo_ref(repository_key)
+                    .host_ref(daemon.local_host_id().expect("local host id").to_string())
+                    .is_main(false)
+                    .build(),
+            ),
+        )
+        .await
+        .expect("modify observed checkout");
+    let mut modifications = HashMap::new();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while modifications.len() < 2 {
+            if let DaemonEvent::ResultDelta(delta) = events.recv().await.expect("checkout event") {
+                if matches!(delta.query(), QueryId::Checkouts { .. }) && delta.changes.as_checkouts().is_some_and(|rows| !rows.is_empty()) {
+                    modifications.insert(delta.query(), delta);
+                }
+            }
+        }
+    })
+    .await
+    .expect("repository and project checkout modifications");
+    for query in [&repository_query, &project_query] {
+        let rows = modifications.get(query).expect("scoped modification").changes.as_checkouts().expect("checkout changes");
+        assert_eq!(rows[0].path, "/work/widgets-revised");
+        assert_eq!(rows[0].branch, "feature/revised");
+    }
+
+    let stale_replay = daemon
+        .subscribe_queries(subscriber, &[
+            QueryCursor { query: repository_query.clone(), since: initial_sequences.get(&repository_query).copied() },
+            QueryCursor { query: project_query.clone(), since: initial_sequences.get(&project_query).copied() },
+        ])
+        .await
+        .expect("replay stale checkout cursors");
+    assert_eq!(stale_replay.iter().filter(|event| matches!(event, DaemonEvent::ResultSet(_))).count(), 2);
+    assert!(stale_replay
+        .iter()
+        .filter_map(|event| match event {
+            DaemonEvent::ResultSet(set) => set.rows.as_checkouts(),
+            _ => None,
+        })
+        .all(|rows| rows.len() == 1 && rows[0].branch == "feature/revised"));
+
+    let current_replay = daemon
+        .subscribe_queries(subscriber, &[
+            QueryCursor { query: repository_query.clone(), since: modifications.get(&repository_query).map(|delta| delta.seq) },
+            QueryCursor { query: project_query.clone(), since: modifications.get(&project_query).map(|delta| delta.seq) },
+        ])
+        .await
+        .expect("subscribe with current checkout cursors");
+    assert!(current_replay.is_empty());
+
+    checkouts.delete(&checkout.metadata.name).await.expect("delete observed checkout");
+    let mut removals = HashMap::new();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while removals.len() < 2 {
+            if let DaemonEvent::ResultDelta(delta) = events.recv().await.expect("checkout event") {
+                if matches!(delta.query(), QueryId::Checkouts { .. }) && !delta.changes.removed_resources().unwrap_or_default().is_empty() {
+                    removals.insert(delta.query(), delta);
+                }
+            }
+        }
+    })
+    .await
+    .expect("repository and project checkout removals");
+    for query in [&repository_query, &project_query] {
+        assert_eq!(removals.get(query).expect("scoped removal").changes.removed_resources().expect("checkout removals").len(), 1);
+    }
 }
 
 #[tokio::test]

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -6,6 +6,7 @@ pub mod framing;
 mod host;
 mod host_summary;
 pub mod issue_query;
+mod lifecycle;
 pub mod output;
 pub mod path_context;
 pub mod peer;
@@ -30,6 +31,7 @@ pub use host::{HostName, HostPath, RepoIdentity};
 pub use host_summary::{
     DiscoveryFact, HostEnvironment, HostProviderStatus, HostSnapshot, HostSummary, NodeInfo, SystemInfo, ToolInventory,
 };
+pub use lifecycle::LifecycleAuthority;
 pub use path_context::{DaemonHostPath, ExecutionEnvironmentPath};
 pub use peer::{CommandPeerEvent, GoodbyeReason, PeerDataKind, PeerDataMessage, PeerWireMessage, RoutedPeerMessage, VectorClock};
 pub use provisioning_target::ProvisioningTarget;
@@ -101,8 +103,8 @@ pub use query::{
 };
 pub use resource_ref::ResourceRef;
 pub use result_set::{
-    ConvoyPhase, ConvoyRow, CrewMemberSummary, DemandBackedMetadata, IndependentRow, IssueRow, QueryChanges, QueryId, QueryScope,
-    ResultDelta, ResultSet, ResultSetCondition, ResultSetState, Rows, SessionPhase, VesselRow, WorkPhase,
+    CheckoutRow, ConvoyPhase, ConvoyRow, CrewMemberSummary, DemandBackedMetadata, IndependentRow, IssueRow, QueryChanges, QueryId,
+    QueryScope, ResultDelta, ResultSet, ResultSetCondition, ResultSetState, Rows, SessionPhase, VesselRow, WorkPhase,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/flotilla-protocol/src/lifecycle.rs
+++ b/crates/flotilla-protocol/src/lifecycle.rs
@@ -1,0 +1,30 @@
+//! Resource lifecycle ownership shared by resource storage and query rows.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LifecycleAuthority {
+    Observed,
+    Adopted,
+    Managed,
+}
+
+impl LifecycleAuthority {
+    pub fn as_label_value(self) -> &'static str {
+        match self {
+            Self::Observed => "observed",
+            Self::Adopted => "adopted",
+            Self::Managed => "managed",
+        }
+    }
+
+    pub fn from_label_value(value: &str) -> Result<Self, String> {
+        match value {
+            "observed" => Ok(Self::Observed),
+            "adopted" => Ok(Self::Adopted),
+            "managed" => Ok(Self::Managed),
+            other => Err(format!("invalid lifecycle authority '{other}'")),
+        }
+    }
+}

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -13,7 +13,10 @@ use std::fmt;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{host::HostName, provider_data::Issue, resource_ref::ResourceRef, snapshot::RepoKey, IssueRef, IssueSource, RepositoryKey};
+use crate::{
+    host::HostName, provider_data::Issue, resource_ref::ResourceRef, snapshot::RepoKey, IssueRef, IssueSource, LifecycleAuthority,
+    RepositoryKey,
+};
 
 pub type Timestamp = DateTime<Utc>;
 
@@ -30,6 +33,8 @@ pub enum QueryId {
     /// Open issues in one Project or Repository scope. Rows are populated
     /// only while at least one client subscribes to this query.
     Issues { scope: QueryScope },
+    /// Concrete observed checkouts in one Project or Repository scope.
+    Checkouts { scope: QueryScope },
 }
 
 /// Scope parameters owned by a curated query family.
@@ -50,6 +55,7 @@ impl QueryId {
             Self::Convoys => "convoys",
             Self::Independents => "independents",
             Self::Issues { .. } => "issues",
+            Self::Checkouts { .. } => "checkouts",
         }
     }
 }
@@ -120,6 +126,12 @@ pub enum QueryChanges {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         removed: Vec<IssueRef>,
     },
+    Checkouts {
+        scope: QueryScope,
+        changed: Vec<CheckoutRow>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        removed: Vec<ResourceRef>,
+    },
 }
 
 impl QueryChanges {
@@ -128,6 +140,7 @@ impl QueryChanges {
             Self::Convoys { .. } => QueryId::Convoys,
             Self::Independents { .. } => QueryId::Independents,
             Self::Issues { scope, .. } => QueryId::Issues { scope: scope.clone() },
+            Self::Checkouts { scope, .. } => QueryId::Checkouts { scope: scope.clone() },
         }
     }
 
@@ -136,12 +149,13 @@ impl QueryChanges {
             Self::Convoys { changed, .. } => changed.len(),
             Self::Independents { changed, .. } => changed.len(),
             Self::Issues { changed, .. } => changed.len(),
+            Self::Checkouts { changed, .. } => changed.len(),
         }
     }
 
     pub fn removed_len(&self) -> usize {
         match self {
-            Self::Convoys { removed, .. } | Self::Independents { removed, .. } => removed.len(),
+            Self::Convoys { removed, .. } | Self::Independents { removed, .. } | Self::Checkouts { removed, .. } => removed.len(),
             Self::Issues { removed, .. } => removed.len(),
         }
     }
@@ -171,9 +185,16 @@ impl QueryChanges {
         }
     }
 
+    pub fn as_checkouts(&self) -> Option<&[CheckoutRow]> {
+        match self {
+            Self::Checkouts { changed, .. } => Some(changed),
+            _ => None,
+        }
+    }
+
     pub fn removed_resources(&self) -> Option<&[ResourceRef]> {
         match self {
-            Self::Convoys { removed, .. } | Self::Independents { removed, .. } => Some(removed),
+            Self::Convoys { removed, .. } | Self::Independents { removed, .. } | Self::Checkouts { removed, .. } => Some(removed),
             Self::Issues { .. } => None,
         }
     }
@@ -218,6 +239,10 @@ pub enum ResultSetCondition {
         source: Option<IssueSource>,
         message: String,
     },
+    QueryScopeUnavailable {
+        scope: QueryScope,
+        message: String,
+    },
 }
 
 /// Typed rows of a query result. The variant always matches the enclosing
@@ -228,6 +253,7 @@ pub enum Rows {
     Convoys(Vec<ConvoyRow>),
     Independents(Vec<IndependentRow>),
     Issues { scope: QueryScope, rows: Vec<IssueRow> },
+    Checkouts { scope: QueryScope, rows: Vec<CheckoutRow> },
 }
 
 impl Rows {
@@ -236,6 +262,7 @@ impl Rows {
             Self::Convoys(_) => QueryId::Convoys,
             Self::Independents(_) => QueryId::Independents,
             Self::Issues { scope, .. } => QueryId::Issues { scope: scope.clone() },
+            Self::Checkouts { scope, .. } => QueryId::Checkouts { scope: scope.clone() },
         }
     }
 
@@ -244,6 +271,7 @@ impl Rows {
             Self::Convoys(rows) => rows.len(),
             Self::Independents(rows) => rows.len(),
             Self::Issues { rows, .. } => rows.len(),
+            Self::Checkouts { rows, .. } => rows.len(),
         }
     }
 
@@ -271,6 +299,13 @@ impl Rows {
             _ => None,
         }
     }
+
+    pub fn as_checkouts(&self) -> Option<&[CheckoutRow]> {
+        match self {
+            Self::Checkouts { rows, .. } => Some(rows),
+            _ => None,
+        }
+    }
 }
 
 /// One row in an `issues{scope}` result set.
@@ -278,6 +313,18 @@ impl Rows {
 pub struct IssueRow {
     pub reference: IssueRef,
     pub issue: Issue,
+}
+
+/// One concrete checkout observation in a scoped result set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[builder(on(String, into))]
+pub struct CheckoutRow {
+    pub resource: ResourceRef,
+    pub repo: RepositoryKey,
+    pub path: String,
+    pub branch: String,
+    pub host: HostName,
+    pub authority: LifecycleAuthority,
 }
 
 /// Lifecycle phase of an independent terminal session.
@@ -475,8 +522,69 @@ pub struct CrewMemberSummary {
 mod tests {
     use chrono::{TimeZone, Utc};
 
-    use super::{DemandBackedMetadata, IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSetState};
-    use crate::{provider_data::Issue, IssueRef, IssueSource, IssueState, RepositoryKey};
+    use super::{
+        CheckoutRow, DemandBackedMetadata, IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetState, Rows,
+    };
+    use crate::{provider_data::Issue, HostName, IssueRef, IssueSource, IssueState, LifecycleAuthority, RepositoryKey, ResourceRef};
+
+    #[test]
+    fn checkout_result_set_round_trip_preserves_scope_host_and_authority() {
+        let scope = QueryScope::Repository(RepositoryKey("repo_abc123".into()));
+        let set = ResultSet {
+            seq: 7,
+            rows: Rows::Checkouts {
+                scope: scope.clone(),
+                rows: vec![CheckoutRow::builder()
+                    .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout-a").on_host(HostName::new("kiwi")))
+                    .repo(RepositoryKey("repo_abc123".into()))
+                    .path("/work/flotilla")
+                    .branch("feature/query")
+                    .host(HostName::new("kiwi"))
+                    .authority(LifecycleAuthority::Adopted)
+                    .build()],
+            },
+            state: ResultSetState::default(),
+        };
+
+        assert_eq!(set.query(), QueryId::Checkouts { scope });
+        let json = serde_json::to_string(&set).expect("serialize checkout set");
+        let decoded = serde_json::from_str::<ResultSet>(&json).expect("deserialize checkout set");
+        assert_eq!(decoded, set);
+    }
+
+    #[test]
+    fn checkout_delta_round_trip_preserves_scope_rows_and_removals() {
+        let scope = QueryScope::Project { namespace: "flotilla".into(), name: "dashboard".into() };
+        let removed = ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout-old").on_host(HostName::new("kiwi"));
+        let delta = ResultDelta {
+            seq: 8,
+            changes: QueryChanges::Checkouts {
+                scope: scope.clone(),
+                changed: vec![CheckoutRow::builder()
+                    .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout-new").on_host(HostName::new("mango")))
+                    .repo(RepositoryKey("repo_abc123".into()))
+                    .path("/work/flotilla")
+                    .branch("feature/query")
+                    .host(HostName::new("mango"))
+                    .authority(LifecycleAuthority::Observed)
+                    .build()],
+                removed: vec![removed.clone()],
+            },
+            state: Some(ResultSetState {
+                demand: None,
+                conditions: vec![super::ResultSetCondition::QueryScopeUnavailable {
+                    scope: scope.clone(),
+                    message: "repository definition is temporarily unavailable".into(),
+                }],
+            }),
+        };
+
+        assert_eq!(delta.query(), QueryId::Checkouts { scope });
+        let json = serde_json::to_string(&delta).expect("serialize checkout delta");
+        let decoded = serde_json::from_str::<ResultDelta>(&json).expect("deserialize checkout delta");
+        assert_eq!(decoded, delta);
+        assert_eq!(decoded.changes.removed_resources().expect("checkout removals"), &[removed]);
+    }
 
     #[test]
     fn issues_query_round_trips_with_owned_project_scope() {

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -90,7 +90,7 @@ pub enum CheckoutPhase {
     Failed,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct CheckoutStatus {
     pub phase: CheckoutPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/flotilla-resources/src/labels.rs
+++ b/crates/flotilla-resources/src/labels.rs
@@ -1,6 +1,4 @@
-use serde::{Deserialize, Serialize};
-
-use crate::error::ResourceError;
+pub use flotilla_protocol::LifecycleAuthority;
 
 pub const AUTHORITY_LABEL: &str = "flotilla.work/authority";
 pub const CONVOY_LABEL: &str = "flotilla.work/convoy";
@@ -12,32 +10,3 @@ pub const VESSEL_ORDINAL_LABEL: &str = "flotilla.work/vessel_ordinal";
 pub const CREW_ORDINAL_LABEL: &str = "flotilla.work/crew_ordinal";
 pub const REPO_LABEL: &str = "flotilla.work/repo";
 pub const RESERVED_PREFIX: &str = "flotilla.work/";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum LifecycleAuthority {
-    #[serde(rename = "observed")]
-    Observed,
-    #[serde(rename = "adopted")]
-    Adopted,
-    #[serde(rename = "managed")]
-    Managed,
-}
-
-impl LifecycleAuthority {
-    pub fn as_label_value(self) -> &'static str {
-        match self {
-            Self::Observed => "observed",
-            Self::Adopted => "adopted",
-            Self::Managed => "managed",
-        }
-    }
-
-    pub fn from_label_value(value: &str) -> Result<Self, ResourceError> {
-        match value {
-            "observed" => Ok(Self::Observed),
-            "adopted" => Ok(Self::Adopted),
-            "managed" => Ok(Self::Managed),
-            other => Err(ResourceError::invalid(format!("invalid lifecycle authority '{other}'"))),
-        }
-    }
-}

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -103,7 +103,10 @@ pub struct InputMeta {
 
 impl InputMeta {
     pub fn lifecycle_authority(&self) -> Result<Option<LifecycleAuthority>, ResourceError> {
-        self.labels.get(AUTHORITY_LABEL).map(|value| LifecycleAuthority::from_label_value(value)).transpose()
+        self.labels
+            .get(AUTHORITY_LABEL)
+            .map(|value| LifecycleAuthority::from_label_value(value).map_err(ResourceError::invalid))
+            .transpose()
     }
 
     pub fn set_lifecycle_authority(&mut self, authority: LifecycleAuthority) {
@@ -147,7 +150,10 @@ pub struct ObjectMeta {
 
 impl ObjectMeta {
     pub fn lifecycle_authority(&self) -> Result<Option<LifecycleAuthority>, ResourceError> {
-        self.labels.get(AUTHORITY_LABEL).map(|value| LifecycleAuthority::from_label_value(value)).transpose()
+        self.labels
+            .get(AUTHORITY_LABEL)
+            .map(|value| LifecycleAuthority::from_label_value(value).map_err(ResourceError::invalid))
+            .transpose()
     }
 
     pub fn is_pending_finalization(&self) -> bool {

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -1300,6 +1300,7 @@ impl App {
                         self.materialized_issue_states.insert(query.clone(), result_set.state.clone());
                         self.push_materialized_issue_items_to_repo_data(&query);
                     }
+                    flotilla_protocol::Rows::Checkouts { .. } => {}
                 }
             }
             DaemonEvent::ResultDelta(delta) => {
@@ -1351,6 +1352,7 @@ impl App {
                         }
                         self.push_materialized_issue_items_to_repo_data(&query);
                     }
+                    flotilla_protocol::QueryChanges::Checkouts { .. } => {}
                 }
             }
         }

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -108,7 +108,7 @@ impl ConnectorState {
         match &set.rows {
             Rows::Convoys(rows) => self.convoys = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect(),
             Rows::Independents(rows) => self.independents = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect(),
-            Rows::Issues { .. } => return Applied::Ignored,
+            Rows::Issues { .. } | Rows::Checkouts { .. } => return Applied::Ignored,
         }
         self.seqs.insert(query, set.seq);
         Applied::Updated
@@ -142,7 +142,7 @@ impl ConnectorState {
                     self.independents.remove(removed);
                 }
             }
-            QueryChanges::Issues { .. } => {
+            QueryChanges::Issues { .. } | QueryChanges::Checkouts { .. } => {
                 return Applied::Gap(query);
             }
         }


### PR DESCRIPTION
## Summary

- add the typed `checkouts{scope}` protocol family for Repository and Project scopes
- maintain always-warm referent-backed projections with explicit unavailable-scope conditions
- exchange only Repository-scoped local checkout facts across the fleet and derive Project views locally
- publish adopted checkouts into the observed fact store while retaining their durable controller representation
- move `LifecycleAuthority` to the protocol and re-export it from resources

## Impact

Clients can subscribe to concrete observed and adopted checkout facts by Repository or Project, receive contiguous typed deltas as facts or Project membership change, and distinguish a valid empty scope from an unavailable referent. Project-tab rendering remains out of scope.

Closes #730.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- two-axis review against repository standards and issue #730
