### PR TITLE
fix: reconcile adopted checkout persistence

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -582,8 +582,14 @@ async fn create_adopted_checkout_resource(
     );
     let status = ResourceCheckoutStatus::builder().phase(ResourceCheckoutPhase::Ready).path(path_str).build();
 
-    persist_adopted_checkout(durable_backend, namespace, &checkout_ref, &meta, &spec, &status).await?;
-    persist_adopted_checkout(observed_backend, namespace, &checkout_ref, &meta, &spec, &status).await?;
+    let durable = persist_adopted_checkout(durable_backend, namespace, &checkout_ref, &meta, &spec, &status).await?;
+    match crate::observed_resources::project_adopted_checkout(observed_backend, namespace, &durable).await {
+        Ok(()) => {}
+        Err(ResourceError::Invalid { message }) => return Err(message),
+        Err(error) => {
+            warn!(checkout = %checkout_ref, %error, "adopted checkout committed durably but observed publication failed; reconciliation will retry");
+        }
+    }
 
     Ok((checkout_ref, repository_url.to_string(), git_ref.to_string()))
 }
@@ -595,7 +601,7 @@ async fn persist_adopted_checkout(
     meta: &InputMeta,
     spec: &ResourceCheckoutSpec,
     status: &ResourceCheckoutStatus,
-) -> Result<(), String> {
+) -> Result<ResourceObject<ResourceCheckout>, String> {
     let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
     let checkout = match checkouts.create(meta, spec).await {
         Ok(checkout) => checkout,
@@ -611,8 +617,11 @@ async fn persist_adopted_checkout(
         }
         Err(err) => return Err(err.to_string()),
     };
-    checkouts.update_status(checkout_ref, &checkout.metadata.resource_version, status).await.map_err(|err| err.to_string())?;
-    Ok(())
+    if checkout.status.is_some() {
+        Ok(checkout)
+    } else {
+        checkouts.update_status(checkout_ref, &checkout.metadata.resource_version, status).await.map_err(|err| err.to_string())
+    }
 }
 
 async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str, contained: bool) -> Option<String> {
@@ -1489,6 +1498,15 @@ impl InProcessDaemon {
 
     pub fn observed_resource_backend(&self) -> ResourceBackend {
         self.observed_resource_backend.clone()
+    }
+
+    /// Restore the ephemeral adopted Checkout projection from durable
+    /// controller-facing Checkout resources.
+    pub async fn reconcile_adopted_checkouts(&self, namespace: &str) -> Result<(), String> {
+        let _reconciliation = self.observed_checkout_reconciliation.lock().await;
+        crate::observed_resources::reconcile_adopted_checkouts(&self.resource_backend, &self.observed_resource_backend, namespace)
+            .await
+            .map_err(|error| error.to_string())
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -4343,6 +4361,7 @@ impl InProcessDaemon {
                             .as_deref()
                             .ok_or_else(|| "an adopted checkout requires a repository transport URL".to_string())?;
                         let git_ref = r#ref.as_deref().unwrap_or(&inspection.checkout.git_ref);
+                        let _reconciliation = self.observed_checkout_reconciliation.lock().await;
                         let (checkout_ref, inferred_repository_url, inferred_ref) = create_adopted_checkout_resource(
                             &self.resource_backend,
                             &self.observed_resource_backend,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2589,54 +2589,62 @@ async fn direct_repository_admission_does_not_guess_a_default_branch() {
     ));
 }
 
+const ADOPTED_CHECKOUT_REMOTE: &str = "git@github.com:flotilla-org/flotilla.git";
+
+struct AdoptedConvoyFixture {
+    _temp: tempfile::TempDir,
+    daemon: Arc<InProcessDaemon>,
+    checkout_path: PathBuf,
+}
+
+impl AdoptedConvoyFixture {
+    async fn new() -> Self {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let config_base = temp.path().join("config");
+        std::fs::create_dir_all(&config_base).expect("create config dir");
+        std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+        let checkout_path = temp.path().join("repo");
+        init_git_repo_with_remote(&checkout_path, ADOPTED_CHECKOUT_REMOTE);
+        let daemon =
+            InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), git_process_discovery(false), HostName::local())
+                .await;
+        Self { _temp: temp, daemon, checkout_path }
+    }
+
+    async fn create_convoy(&self) -> CommandValue {
+        let mut events = self.daemon.subscribe();
+        let command_id = self
+            .daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyCreate {
+                    name: "convoy-adopted".to_string(),
+                    workflow_ref: "scratch".to_string(),
+                    inputs: Vec::new(),
+                    repository_url: None,
+                    r#ref: None,
+                    project_ref: None,
+                    placement_policy: None,
+                    adopted_checkout: Some(Box::new(self.checkout_path.clone())),
+                },
+            })
+            .await
+            .expect("execute should return a command id");
+        wait_for_command_result(&mut events, command_id).await
+    }
+}
+
 #[tokio::test]
 async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource() {
-    let temp = tempfile::tempdir().expect("create tempdir");
-    let config_base = temp.path().join("config");
-    std::fs::create_dir_all(&config_base).expect("create config dir");
-    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-    let checkout_path = temp.path().join("repo");
-    let remote = "git@github.com:flotilla-org/flotilla.git";
-    init_git_repo_with_remote(&checkout_path, remote);
+    let fixture = AdoptedConvoyFixture::new().await;
+    let daemon = &fixture.daemon;
+    let checkout_path = &fixture.checkout_path;
 
-    let daemon =
-        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), git_process_discovery(false), HostName::local()).await;
-
-    let mut events = daemon.subscribe();
-    let command_id = daemon
-        .execute(Command {
-            node_id: None,
-            provisioning_target: None,
-            context_repo: None,
-            action: CommandAction::ConvoyCreate {
-                name: "convoy-adopted".to_string(),
-                workflow_ref: "scratch".to_string(),
-                inputs: Vec::new(),
-                repository_url: None,
-                r#ref: None,
-                project_ref: None,
-                placement_policy: None,
-                adopted_checkout: Some(Box::new(checkout_path.clone())),
-            },
-        })
-        .await
-        .expect("execute should return a command id");
-
-    let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
-        loop {
-            match events.recv().await {
-                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
-                Ok(_) => {}
-                Err(err) => panic!("unexpected event error: {err}"),
-            }
-        }
-    })
-    .await
-    .expect("timeout waiting for command result");
-
-    assert_eq!(result, CommandValue::ConvoyCreated { name: "convoy-adopted".to_string() });
+    assert_eq!(fixture.create_convoy().await, CommandValue::ConvoyCreated { name: "convoy-adopted".to_string() });
     let convoy = daemon.resource_backend().using::<Convoy>("flotilla").get("convoy-adopted").await.expect("convoy should exist");
-    assert_eq!(convoy.spec.repositories.first().map(|repo| repo.url.as_str()), Some(remote));
+    assert_eq!(convoy.spec.repositories.first().map(|repo| repo.url.as_str()), Some(ADOPTED_CHECKOUT_REMOTE));
     assert_eq!(convoy.spec.r#ref.as_deref(), Some("main"));
     assert_eq!(convoy.spec.adopted_checkout_refs.values().next().map(String::as_str), Some("adopted-checkout-convoy-adopted"));
 
@@ -2659,7 +2667,7 @@ async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource()
     match checkout.spec {
         ResourceCheckoutSpec::Observed(spec) => {
             assert_eq!(spec.r#ref, "main");
-            assert_eq!(spec.path, std::fs::canonicalize(&checkout_path).expect("canonical path").display().to_string());
+            assert_eq!(spec.path, std::fs::canonicalize(checkout_path).expect("canonical path").display().to_string());
             assert_eq!(
                 spec.repo_ref,
                 flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec").key()
@@ -2669,7 +2677,54 @@ async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource()
     }
     let status = checkout.status.expect("adopted checkout should be ready");
     assert_eq!(status.phase, ResourceCheckoutPhase::Ready);
-    assert_eq!(status.path.as_deref(), Some(std::fs::canonicalize(&checkout_path).expect("canonical path").to_string_lossy().as_ref()));
+    assert_eq!(status.path.as_deref(), Some(std::fs::canonicalize(checkout_path).expect("canonical path").to_string_lossy().as_ref()));
+}
+
+#[tokio::test]
+async fn convoy_create_preserves_status_of_a_matching_preexisting_adopted_checkout() {
+    let fixture = AdoptedConvoyFixture::new().await;
+    let daemon = &fixture.daemon;
+    let canonical_path = std::fs::canonicalize(&fixture.checkout_path).expect("canonical checkout path").to_string_lossy().into_owned();
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let created = checkouts
+        .create(
+            &InputMeta::builder()
+                .name("adopted-checkout-convoy-adopted".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-adopted".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &ResourceCheckoutSpec::Observed(
+                ResourceObservedCheckoutSpec::builder()
+                    .r#ref("main".to_string())
+                    .path(canonical_path.clone())
+                    .repo_ref(RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec").key())
+                    .host_ref(daemon.local_host_id().expect("local host id").to_string())
+                    .is_main(true)
+                    .build(),
+            ),
+        )
+        .await
+        .expect("preexisting adopted checkout should be created");
+    let failed_status = ResourceCheckoutStatus::builder()
+        .phase(ResourceCheckoutPhase::Failed)
+        .path(canonical_path)
+        .message("earlier adoption failure".to_string())
+        .build();
+    checkouts
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &failed_status)
+        .await
+        .expect("preexisting status should be stored");
+
+    assert_eq!(fixture.create_convoy().await, CommandValue::ConvoyCreated { name: "convoy-adopted".to_string() });
+    let durable = checkouts.get("adopted-checkout-convoy-adopted").await.expect("durable adopted checkout should remain");
+    assert_eq!(durable.status, Some(failed_status.clone()));
+    let observed = daemon
+        .observed_resource_backend()
+        .using::<ResourceCheckout>("flotilla")
+        .get("adopted-checkout-convoy-adopted")
+        .await
+        .expect("observed adopted checkout should be published");
+    assert_eq!(observed.status, Some(failed_status));
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/observed_resources.rs
+++ b/crates/flotilla-core/src/observed_resources.rs
@@ -2,10 +2,95 @@ use std::collections::{BTreeMap, HashMap};
 
 use flotilla_protocol::{qualified_path::QualifiedPath, ProviderData};
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, RepositoryKey,
-    ResourceBackend, ResourceError, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
+    Checkout as ResourceCheckout, CheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus, InputMeta, LifecycleAuthority,
+    ObservedCheckoutSpec, RepositoryKey, ResourceBackend, ResourceError, ResourceObject, AUTHORITY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
 };
 use sha2::{Digest, Sha256};
+
+/// Rebuild the query-facing adopted Checkout projection from the durable
+/// controller-facing resources.
+///
+/// Durable resources are authoritative. A missing durable status means the
+/// create was interrupted between its spec and status writes; an adopted
+/// observed Checkout requires no actuation, so its Ready status can be derived
+/// from the path already recorded in its spec.
+pub async fn reconcile_adopted_checkouts(
+    durable_backend: &ResourceBackend,
+    observed_backend: &ResourceBackend,
+    namespace: &str,
+) -> Result<(), ResourceError> {
+    let selector = BTreeMap::from([(AUTHORITY_LABEL.to_string(), LifecycleAuthority::Adopted.as_label_value().to_string())]);
+    let durable_checkouts = durable_backend.clone().using::<ResourceCheckout>(namespace);
+    let observed_checkouts = observed_backend.clone().using::<ResourceCheckout>(namespace);
+    let mut failures = Vec::new();
+
+    for checkout in durable_checkouts.list_matching_labels(&selector).await?.items {
+        let name = checkout.metadata.name.clone();
+        let result = async {
+            let checkout = ensure_adopted_checkout_status(&durable_checkouts, checkout).await?;
+            project_adopted_checkout_with(&observed_checkouts, &checkout).await
+        }
+        .await;
+        if let Err(error) = result {
+            failures.push(format!("{name}: {error}"));
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(ResourceError::other(format!("failed to reconcile adopted checkouts: {}", failures.join("; "))))
+    }
+}
+
+/// Publish one durable adopted Checkout into the ephemeral observed store.
+pub async fn project_adopted_checkout(
+    observed_backend: &ResourceBackend,
+    namespace: &str,
+    durable: &ResourceObject<ResourceCheckout>,
+) -> Result<(), ResourceError> {
+    project_adopted_checkout_with(&observed_backend.clone().using::<ResourceCheckout>(namespace), durable).await
+}
+
+async fn ensure_adopted_checkout_status(
+    checkouts: &flotilla_resources::TypedResolver<ResourceCheckout>,
+    checkout: ResourceObject<ResourceCheckout>,
+) -> Result<ResourceObject<ResourceCheckout>, ResourceError> {
+    if checkout.status.is_some() {
+        return Ok(checkout);
+    }
+    let ResourceCheckoutSpec::Observed(spec) = &checkout.spec else {
+        return Err(ResourceError::invalid(format!("adopted checkout {} must use an observed checkout spec", checkout.metadata.name)));
+    };
+    let status = CheckoutStatus::builder().phase(CheckoutPhase::Ready).path(spec.path.clone()).build();
+    checkouts.update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &status).await
+}
+
+async fn project_adopted_checkout_with(
+    checkouts: &flotilla_resources::TypedResolver<ResourceCheckout>,
+    durable: &ResourceObject<ResourceCheckout>,
+) -> Result<(), ResourceError> {
+    let meta = InputMeta::from(&durable.metadata);
+    let projected = match checkouts.create(&meta, &durable.spec).await {
+        Ok(created) => created,
+        Err(ResourceError::Conflict { .. }) => {
+            let existing = checkouts.get(&durable.metadata.name).await?;
+            if existing.metadata.lifecycle_authority()? != Some(LifecycleAuthority::Adopted) {
+                return Err(ResourceError::invalid(format!(
+                    "checkout {} already exists in the observed store but is not adopted",
+                    durable.metadata.name
+                )));
+            }
+            checkouts.update(&meta, &existing.metadata.resource_version, &durable.spec).await?
+        }
+        Err(error) => return Err(error),
+    };
+
+    if let Some(status) = &durable.status {
+        checkouts.update_status(&durable.metadata.name, &projected.metadata.resource_version, status).await?;
+    }
+    Ok(())
+}
 
 /// Publish the checkout facts discovered for one local repository into the
 /// daemon's ephemeral observed-resource store.

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -46,10 +46,10 @@ use flotilla_protocol::{
     RepoIdentity, RepoSelector, StreamKey, SystemInfo, ToolInventory, TopologyRoute, WorkItemKind,
 };
 use flotilla_resources::{
-    single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy as ResourceConvoy,
-    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy,
-    PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, TypedResolver, WorkflowTemplate,
-    REPO_KEY_LABEL, REPO_LABEL,
+    single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase,
+    CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, DockerCheckoutStrategy,
+    DockerPerVesselPlacementPolicySpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
+    ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, TypedResolver, WorkflowTemplate, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -2221,6 +2221,90 @@ async fn repo_refresh_reconciles_observed_checkouts() {
     let third = observed.list().await.expect("final observed checkout list should succeed");
     assert_eq!(third.items.len(), 1, "adopted checkout must not be deleted by observed reconciliation");
     assert_eq!(third.items[0].metadata.name, "adopted-checkout-feature");
+}
+
+#[tokio::test]
+async fn adopted_checkout_reconciliation_repairs_partial_durable_creation() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let daemon =
+        InProcessDaemon::new(Vec::new(), test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
+    let durable = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let spec = ResourceCheckoutSpec::Observed(
+        ObservedCheckoutSpec::builder()
+            .r#ref("feature/reconcile".to_string())
+            .path("/work/reconcile".to_string())
+            .repo_ref(flotilla_resources::RepositoryKey("widgets-api".to_string()))
+            .host_ref("host-01".to_string())
+            .is_main(false)
+            .build(),
+    );
+    durable
+        .create(
+            &InputMeta::builder()
+                .name("adopted-checkout-reconcile".to_string())
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &spec,
+        )
+        .await
+        .expect("durable checkout create should succeed");
+
+    daemon.reconcile_adopted_checkouts("flotilla").await.expect("adopted checkout reconciliation should succeed");
+
+    let durable_checkout = durable.get("adopted-checkout-reconcile").await.expect("durable checkout should remain");
+    assert_eq!(
+        durable_checkout.status,
+        Some(ResourceCheckoutStatus::builder().phase(ResourceCheckoutPhase::Ready).path("/work/reconcile".to_string()).build())
+    );
+    let observed_checkout = observed.get("adopted-checkout-reconcile").await.expect("observed checkout should be projected");
+    assert_eq!(observed_checkout.spec, durable_checkout.spec);
+    assert_eq!(observed_checkout.status, durable_checkout.status);
+    assert_eq!(observed_checkout.metadata.labels, durable_checkout.metadata.labels);
+}
+
+#[tokio::test]
+async fn adopted_checkout_reconciliation_isolates_an_observed_name_collision() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let daemon =
+        InProcessDaemon::new(Vec::new(), test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
+    let durable = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
+    let checkout_spec = |path: &str| {
+        ResourceCheckoutSpec::Observed(
+            ObservedCheckoutSpec::builder()
+                .r#ref("feature/reconcile".to_string())
+                .path(path.to_string())
+                .repo_ref(flotilla_resources::RepositoryKey("widgets-api".to_string()))
+                .host_ref("host-01".to_string())
+                .is_main(false)
+                .build(),
+        )
+    };
+    for (name, path) in [("a-collision", "/work/collision"), ("z-valid", "/work/valid")] {
+        durable
+            .create(
+                &InputMeta::builder().name(name.to_string()).build().with_lifecycle_authority(LifecycleAuthority::Adopted),
+                &checkout_spec(path),
+            )
+            .await
+            .expect("durable checkout create should succeed");
+    }
+    observed
+        .create(
+            &InputMeta::builder().name("a-collision".to_string()).build().with_lifecycle_authority(LifecycleAuthority::Observed),
+            &checkout_spec("/work/unrelated"),
+        )
+        .await
+        .expect("unrelated observed checkout should be created");
+
+    let error = daemon.reconcile_adopted_checkouts("flotilla").await.expect_err("the name collision should be reported");
+
+    assert!(error.contains("a-collision"), "{error}");
+    let collision = observed.get("a-collision").await.expect("colliding observation should remain");
+    assert_eq!(collision.metadata.lifecycle_authority().expect("authority should parse"), Some(LifecycleAuthority::Observed));
+    let valid = observed.get("z-valid").await.expect("other durable adopted checkouts should still be projected");
+    assert_eq!(valid.metadata.lifecycle_authority().expect("authority should parse"), Some(LifecycleAuthority::Adopted));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap},
+    future::Future,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -47,7 +48,7 @@ use crate::{
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, bon::Builder)]
 pub struct RuntimeOptions {
     pub namespace: String,
     pub heartbeat_interval: Duration,
@@ -97,10 +98,14 @@ impl DaemonRuntime {
         let profile = build_local_profile(&daemon, &local_registry)?;
         register_startup_resources(&daemon, &options.namespace, &profile).await?;
         apply_host_heartbeat(&daemon, &options.namespace, &profile).await?;
+        if let Err(error) = daemon.reconcile_adopted_checkouts(&options.namespace).await {
+            warn!(%error, "failed to restore adopted checkout observations during startup; periodic reconciliation will retry");
+        }
 
         let mut tasks = vec![
             spawn_heartbeat_task(Arc::clone(&daemon), options.namespace.clone(), profile.clone(), options.heartbeat_interval),
             spawn_replica_refresh_task(Arc::clone(&daemon), options.heartbeat_interval),
+            spawn_adopted_checkout_reconciliation_task(Arc::clone(&daemon), options.namespace.clone(), options.controller_resync_interval),
             spawn_aggregator_task(
                 Arc::clone(&daemon),
                 options.namespace.clone(),
@@ -474,11 +479,11 @@ fn spawn_heartbeat_task(
     profile: LocalProvisioningProfile,
     interval: Duration,
 ) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            ticker.tick().await;
+    spawn_periodic_task(interval, PeriodicTaskStart::Immediate, move || {
+        let daemon = Arc::clone(&daemon);
+        let namespace = namespace.clone();
+        let profile = profile.clone();
+        async move {
             if let Err(err) = apply_host_heartbeat(&daemon, &namespace, &profile).await {
                 warn!(%err, "failed to publish host heartbeat");
             }
@@ -487,14 +492,49 @@ fn spawn_heartbeat_task(
 }
 
 fn spawn_replica_refresh_task(daemon: Arc<InProcessDaemon>, interval: Duration) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(interval);
-        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            ticker.tick().await;
+    spawn_periodic_task(interval, PeriodicTaskStart::Immediate, move || {
+        let daemon = Arc::clone(&daemon);
+        async move {
             if let Err(err) = daemon.refresh_fleet_replicas_once().await {
                 warn!(%err, "failed to refresh fleet replicas");
             }
+        }
+    })
+}
+
+fn spawn_adopted_checkout_reconciliation_task(daemon: Arc<InProcessDaemon>, namespace: String, interval: Duration) -> JoinHandle<()> {
+    spawn_periodic_task(interval, PeriodicTaskStart::AfterInterval, move || {
+        let daemon = Arc::clone(&daemon);
+        let namespace = namespace.clone();
+        async move {
+            if let Err(error) = daemon.reconcile_adopted_checkouts(&namespace).await {
+                warn!(%error, "failed to reconcile adopted checkout observations");
+            }
+        }
+    })
+}
+
+#[derive(Clone, Copy)]
+enum PeriodicTaskStart {
+    Immediate,
+    AfterInterval,
+}
+
+fn spawn_periodic_task<Operation, OperationFuture>(interval: Duration, start: PeriodicTaskStart, mut operation: Operation) -> JoinHandle<()>
+where
+    Operation: FnMut() -> OperationFuture + Send + 'static,
+    OperationFuture: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let start = match start {
+            PeriodicTaskStart::Immediate => tokio::time::Instant::now(),
+            PeriodicTaskStart::AfterInterval => tokio::time::Instant::now() + interval,
+        };
+        let mut ticker = tokio::time::interval_at(start, interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            operation().await;
         }
     })
 }
@@ -1259,9 +1299,10 @@ mod tests {
     };
     use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent};
     use flotilla_resources::{
-        Checkout as ResourceCheckout, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
-        PlacementPolicy, RepositorySpec, Selector, SqliteBackend, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement,
-        WorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+        Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+        CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
+        ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, RepositorySpec, Selector, SqliteBackend, TerminalSession,
+        TerminalSessionPhase, TypedResolver, VesselRequirement, WorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
     };
     use tempfile::TempDir;
 
@@ -1905,6 +1946,54 @@ mod tests {
 
         heartbeat.abort();
         let _ = heartbeat.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn adopted_checkout_reconciliation_task_runs_after_interval() {
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path()));
+        let daemon = in_memory_daemon(Vec::new(), config).await;
+        let durable = daemon.resource_backend().using::<ResourceCheckout>(NAMESPACE);
+        let created = durable
+            .create(
+                &InputMeta::builder()
+                    .name("adopted-checkout-periodic".to_string())
+                    .build()
+                    .with_lifecycle_authority(LifecycleAuthority::Adopted),
+                &ResourceCheckoutSpec::Observed(
+                    ResourceObservedCheckoutSpec::builder()
+                        .r#ref("feature/periodic".to_string())
+                        .path("/work/periodic".to_string())
+                        .repo_ref(flotilla_resources::RepositoryKey("widgets-api".to_string()))
+                        .host_ref("host-01".to_string())
+                        .is_main(false)
+                        .build(),
+                ),
+            )
+            .await
+            .expect("durable adopted checkout should be created");
+        durable
+            .update_status(
+                &created.metadata.name,
+                &created.metadata.resource_version,
+                &ResourceCheckoutStatus::builder().phase(ResourceCheckoutPhase::Ready).path("/work/periodic".to_string()).build(),
+            )
+            .await
+            .expect("durable checkout status should be stored");
+        let interval = Duration::from_secs(60);
+        let reconciliation = spawn_adopted_checkout_reconciliation_task(Arc::clone(&daemon), NAMESPACE.to_string(), interval);
+        tokio::task::yield_now().await;
+        let observed = daemon.observed_resource_backend().using::<ResourceCheckout>(NAMESPACE);
+        assert!(
+            matches!(observed.get("adopted-checkout-periodic").await, Err(ResourceError::NotFound { .. })),
+            "the periodic task should wait for its first interval"
+        );
+
+        tokio::time::advance(interval).await;
+        tokio::task::yield_now().await;
+
+        observed.get("adopted-checkout-periodic").await.expect("periodic reconciliation should restore the observed checkout");
+        reconciliation.abort();
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -24,11 +24,11 @@ use flotilla_protocol::{
     DaemonEvent, HostName, LifecycleAuthority, QueryCursor, QueryScope,
 };
 use flotilla_resources::{
-    Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, Environment, EnvironmentSpec,
-    HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObservedCheckoutSpec, Project, ProjectRepositorySpec, ProjectSpec, Repository,
-    RepositorySpec, ResourceBackend, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
-    TerminalSessionStatus, VesselRequirement, WorkPhase as ResourceWorkPhase, WorkState, WorkflowSnapshot, CONVOY_LABEL, REPO_LABEL,
-    VESSEL_LABEL,
+    Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus,
+    Environment, EnvironmentSpec, HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObservedCheckoutSpec, Project,
+    ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, ResourceBackend, TerminalSession, TerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkPhase as ResourceWorkPhase, WorkState,
+    WorkflowSnapshot, CONVOY_LABEL, REPO_LABEL, VESSEL_LABEL,
 };
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -250,6 +250,87 @@ async fn scoped_checkout_queries_emit_observed_rows_and_removal_deltas() {
     for query in [&repository_query, &project_query] {
         assert_eq!(removals.get(query).expect("scoped removal").changes.removed_resources().expect("checkout removals").len(), 1);
     }
+}
+
+#[tokio::test]
+async fn runtime_start_republishes_durable_adopted_checkouts_before_query_bootstrap() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/widgets/api.git").expect("remote repository");
+    let repository_key = repository_spec.key();
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository_key.to_string()).build(), &repository_spec)
+        .await
+        .expect("create repository");
+    backend
+        .clone()
+        .using::<Checkout>("flotilla")
+        .create(
+            &InputMeta::builder()
+                .name("adopted-checkout-restart".to_string())
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &CheckoutSpec::Observed(
+                ObservedCheckoutSpec::builder()
+                    .r#ref("feature/restart".to_string())
+                    .path("/work/widgets".to_string())
+                    .repo_ref(repository_key.clone())
+                    .host_ref("host-before-restart".to_string())
+                    .is_main(false)
+                    .build(),
+            ),
+        )
+        .await
+        .expect("persist durable adopted checkout without status");
+
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    let options = RuntimeOptions::builder()
+        .namespace("flotilla".to_string())
+        .heartbeat_interval(Duration::from_secs(300))
+        .controller_resync_interval(Duration::from_secs(300))
+        .controller_supervision(Default::default())
+        .start_controllers(false)
+        .build();
+    let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("start runtime");
+    let query = QueryId::Checkouts { scope: QueryScope::Repository(repository_key) };
+
+    let result_set = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let events = daemon
+                .subscribe_queries(uuid::Uuid::new_v4(), &[QueryCursor { query: query.clone(), since: None }])
+                .await
+                .expect("subscribe checkout query");
+            if let Some(result_set) = events.into_iter().find_map(|event| match event {
+                DaemonEvent::ResultSet(result_set)
+                    if result_set.query() == query && result_set.rows.as_checkouts().is_some_and(|rows| !rows.is_empty()) =>
+                {
+                    Some(result_set)
+                }
+                _ => None,
+            }) {
+                break result_set;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("adopted checkout should be present in the bootstrapped query");
+
+    let rows = result_set.rows.as_checkouts().expect("checkout rows");
+    assert!(matches!(rows, [row] if row.authority == LifecycleAuthority::Adopted && row.branch == "feature/restart"));
+    let durable =
+        backend.using::<Checkout>("flotilla").get("adopted-checkout-restart").await.expect("durable adopted checkout should remain");
+    assert_eq!(durable.status, Some(CheckoutStatus::builder().phase(CheckoutPhase::Ready).path("/work/widgets".to_string()).build()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- persist adopted checkouts durably before projecting them into the observed store
- restore and periodically reconcile adopted checkout projections across daemon restarts
- preserve durable status, heal interrupted status writes, and isolate observed-store collisions

## Validation
- cargo clippy --workspace --all-targets --locked -- -D warnings
- daemon unit tests: 202 passed
- daemon aggregator tests: 6 passed
- core adopted-checkout reconciliation tests passed