### PR TITLE
Stream zellij metadata patches through a persistent pipe

### DIFF
--- a/crates/flotilla-manifest/Cargo.toml
+++ b/crates/flotilla-manifest/Cargo.toml
@@ -10,7 +10,7 @@ bon = { workspace = true }
 flotilla-protocol = { path = "../flotilla-protocol" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1", features = ["process", "net", "io-util"] }
+tokio = { version = "1", features = ["process", "net", "io-util", "sync", "time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/flotilla-manifest/src/sink.rs
+++ b/crates/flotilla-manifest/src/sink.rs
@@ -3,12 +3,23 @@
 //! Per the manifest architecture, producers swap only their send function —
 //! the same projection drives zellij (CLI pipe) and wheelhouse (unix socket).
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::Stdio, time::Duration};
 
 use async_trait::async_trait;
-use tokio::{io::AsyncWriteExt, net::UnixStream, process::Command};
+use tokio::{
+    io::AsyncWriteExt,
+    net::UnixStream,
+    process::{Child, ChildStdin, Command},
+    sync::Mutex,
+};
+use tracing::warn;
 
 use crate::{keys::APPLY_METADATA_PATCH_PIPE, wire::MetadataPatch};
+
+const BLOCKED_WRITE_WARNING_AFTER: Duration = Duration::from_secs(5);
+const RESPAWN_INITIAL_DELAY: Duration = Duration::from_millis(500);
+const RESPAWN_MAX_DELAY: Duration = Duration::from_secs(30);
+const RESPAWN_STABLE_AFTER: Duration = Duration::from_secs(5);
 
 #[async_trait]
 pub trait PatchSink: Send + Sync {
@@ -23,11 +34,47 @@ pub struct ZellijPipeSink {
     /// Restrict pipe delivery to one plugin instance; without it the pipe
     /// broadcasts to every listening controller.
     plugin_url: Option<String>,
+    state: Mutex<ZellijPipeState>,
+}
+
+struct ZellijPipeState {
+    process: Option<ZellijPipeProcess>,
+    next_respawn_delay: Duration,
+    respawn_not_before: Option<tokio::time::Instant>,
+}
+
+struct ZellijPipeProcess {
+    child: Child,
+    stdin: ChildStdin,
+    started_at: tokio::time::Instant,
+}
+
+impl Default for ZellijPipeState {
+    fn default() -> Self {
+        Self { process: None, next_respawn_delay: RESPAWN_INITIAL_DELAY, respawn_not_before: None }
+    }
+}
+
+impl ZellijPipeState {
+    fn schedule_respawn(&mut self) -> Duration {
+        self.process = None;
+        let delay = self.next_respawn_delay;
+        self.next_respawn_delay = std::cmp::min(delay.saturating_mul(2), RESPAWN_MAX_DELAY);
+        self.respawn_not_before = Some(tokio::time::Instant::now() + delay);
+        delay
+    }
+
+    fn mark_healthy_if_stable(&mut self) {
+        if self.process.as_ref().is_some_and(|process| process.started_at.elapsed() >= RESPAWN_STABLE_AFTER) {
+            self.next_respawn_delay = RESPAWN_INITIAL_DELAY;
+            self.respawn_not_before = None;
+        }
+    }
 }
 
 impl ZellijPipeSink {
     pub fn new(zellij_bin: impl Into<String>) -> Self {
-        ZellijPipeSink { zellij_bin: zellij_bin.into(), plugin_url: None }
+        ZellijPipeSink { zellij_bin: zellij_bin.into(), plugin_url: None, state: Mutex::new(ZellijPipeState::default()) }
     }
 
     pub fn with_plugin_url(mut self, plugin_url: impl Into<String>) -> Self {
@@ -35,32 +82,111 @@ impl ZellijPipeSink {
         self
     }
 
-    fn pipe_args(&self, payload: &str) -> Vec<String> {
+    fn pipe_args(&self) -> Vec<String> {
         let mut args = vec!["pipe".to_owned(), "--name".to_owned(), APPLY_METADATA_PATCH_PIPE.to_owned()];
         if let Some(plugin_url) = &self.plugin_url {
             args.push("--plugin".to_owned());
             args.push(plugin_url.clone());
         }
-        args.push("--".to_owned());
-        args.push(payload.to_owned());
         args
+    }
+
+    fn spawn_process(&self) -> Result<ZellijPipeProcess, String> {
+        let mut child = Command::new(&self.zellij_bin)
+            .args(self.pipe_args())
+            .kill_on_drop(true)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|error| format!("spawn {}: {error}", self.zellij_bin))?;
+        let stdin = child.stdin.take().ok_or_else(|| format!("{} pipe child has no stdin", self.zellij_bin))?;
+        Ok(ZellijPipeProcess { child, stdin, started_at: tokio::time::Instant::now() })
+    }
+
+    async fn ensure_process<'a>(&self, state: &'a mut ZellijPipeState) -> Result<&'a mut ZellijPipeProcess, String> {
+        let respawn = if let Some(running) = state.process.as_mut() {
+            match running.child.try_wait() {
+                Ok(None) => false,
+                Ok(Some(status)) => {
+                    warn!(%status, "zellij metadata pipe exited; respawning");
+                    true
+                }
+                Err(error) => {
+                    warn!(%error, "failed to inspect zellij metadata pipe; respawning");
+                    true
+                }
+            }
+        } else {
+            false
+        };
+        if respawn {
+            state.mark_healthy_if_stable();
+            let delay = state.schedule_respawn();
+            warn!(delay_ms = delay.as_millis(), "waiting to respawn zellij metadata pipe");
+        }
+        if state.process.is_none() {
+            if let Some(deadline) = state.respawn_not_before.take() {
+                tokio::time::sleep_until(deadline).await;
+            }
+            match self.spawn_process() {
+                Ok(process) => state.process = Some(process),
+                Err(error) => {
+                    let delay = state.schedule_respawn();
+                    return Err(format!("{error}; next respawn attempt in {}ms", delay.as_millis()));
+                }
+            }
+        }
+        Ok(state.process.as_mut().expect("zellij pipe process is installed"))
+    }
+
+    async fn write_payload(&self, process: &mut ZellijPipeProcess, payload: &[u8]) -> Result<(), String> {
+        let write = async {
+            process.stdin.write_all(payload).await?;
+            process.stdin.flush().await
+        };
+        tokio::pin!(write);
+        let result = tokio::select! {
+            result = &mut write => result,
+            () = tokio::time::sleep(BLOCKED_WRITE_WARNING_AFTER) => {
+                warn!(
+                    blocked_secs = BLOCKED_WRITE_WARNING_AFTER.as_secs(),
+                    "zellij metadata pipe is applying backpressure"
+                );
+                write.await
+            }
+        };
+        result.map_err(|error| format!("write {} metadata pipe: {error}", self.zellij_bin))
     }
 }
 
 #[async_trait]
 impl PatchSink for ZellijPipeSink {
     async fn send(&self, patch: &MetadataPatch) -> Result<(), String> {
-        let payload = patch.to_pipe_payload();
-        let output = Command::new(&self.zellij_bin)
-            .args(self.pipe_args(&payload))
-            .output()
-            .await
-            .map_err(|error| format!("spawn {}: {error}", self.zellij_bin))?;
-        if output.status.success() {
-            Ok(())
+        let mut payload = patch.to_pipe_payload();
+        payload.push('\n');
+
+        let mut state = self.state.lock().await;
+        let running = self.ensure_process(&mut state).await?;
+        let first_attempt = self.write_payload(running, payload.as_bytes()).await;
+        if let Err(error) = first_attempt {
+            state.mark_healthy_if_stable();
+            let delay = state.schedule_respawn();
+            warn!(%error, delay_ms = delay.as_millis(), "zellij metadata pipe write failed; respawning and retrying patch");
+            let running = self.ensure_process(&mut state).await?;
+            match self.write_payload(running, payload.as_bytes()).await {
+                Ok(()) => {
+                    state.mark_healthy_if_stable();
+                    Ok(())
+                }
+                Err(retry_error) => {
+                    state.schedule_respawn();
+                    Err(format!("{retry_error} after respawn (initial error: {error})"))
+                }
+            }
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            Err(format!("zellij pipe failed ({}): {}", output.status, stderr.trim()))
+            state.mark_healthy_if_stable();
+            Ok(())
         }
     }
 }
@@ -92,6 +218,8 @@ impl PatchSink for UnixSocketSink {
 
 #[cfg(test)]
 mod tests {
+    use std::{os::unix::fs::PermissionsExt, path::Path, time::Duration};
+
     use tokio::{
         io::{AsyncBufReadExt, BufReader},
         net::UnixListener,
@@ -113,21 +241,169 @@ mod tests {
         }
     }
 
-    #[test]
-    fn zellij_pipe_args_match_the_cli_contract() {
-        let sink = ZellijPipeSink::new("zellij");
-        assert_eq!(sink.pipe_args("{}"), vec!["pipe", "--name", "andamento-apply-metadata-patch", "--", "{}"]);
+    fn write_fake_zellij(dir: &Path, script: &str) -> String {
+        let script_path = dir.join("zellij");
+        std::fs::write(&script_path, script).expect("write fake zellij");
+        let mut permissions = std::fs::metadata(&script_path).expect("fake zellij metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script_path, permissions).expect("make fake zellij executable");
+        script_path.to_string_lossy().into_owned()
+    }
 
-        let scoped = ZellijPipeSink::new("zellij").with_plugin_url("file:/plugins/andamento.wasm");
-        assert_eq!(scoped.pipe_args("{}"), vec![
-            "pipe",
-            "--name",
-            "andamento-apply-metadata-patch",
-            "--plugin",
-            "file:/plugins/andamento.wasm",
-            "--",
-            "{}"
-        ]);
+    enum FakeZellijMode {
+        Stream,
+        CloseFirstChildStdin,
+        ExitFirstChild,
+        BlockStdin,
+    }
+
+    impl FakeZellijMode {
+        fn as_str(&self) -> &'static str {
+            match self {
+                FakeZellijMode::Stream => "stream",
+                FakeZellijMode::CloseFirstChildStdin => "close-first-child-stdin",
+                FakeZellijMode::ExitFirstChild => "exit-first-child",
+                FakeZellijMode::BlockStdin => "block-stdin",
+            }
+        }
+    }
+
+    fn fake_zellij(dir: &Path, mode: FakeZellijMode) -> String {
+        std::fs::write(dir.join("mode"), mode.as_str()).expect("write fake zellij mode");
+        write_fake_zellij(
+            dir,
+            r#"#!/bin/sh
+set -eu
+dir=$(dirname "$0")
+mode=$(cat "$dir/mode")
+printf 'spawn\n' >> "$dir/spawns"
+printf '%s\n' "$@" >> "$dir/args"
+case "$mode" in
+    close-first-child-stdin)
+        if [ ! -e "$dir/first-child" ]; then
+            touch "$dir/first-child"
+            IFS= read -r first_line
+            exec 0<&-
+            touch "$dir/stdin-closed"
+            sleep 5
+            exit 0
+        fi
+        ;;
+    exit-first-child)
+        if [ ! -e "$dir/first-child" ]; then
+            touch "$dir/first-child"
+            IFS= read -r first_line
+            touch "$dir/first-child-exited"
+            exit 0
+        fi
+        ;;
+    block-stdin)
+        touch "$dir/blocked"
+        while [ ! -e "$dir/unblock" ]; do
+            sleep 0.01
+        done
+        ;;
+esac
+while IFS= read -r line; do
+    printf '%s\n' "$line" >> "$dir/lines"
+done
+"#,
+        )
+    }
+
+    async fn wait_for_line_count(path: &Path, expected: usize) -> Vec<String> {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let lines = std::fs::read_to_string(path).unwrap_or_default().lines().map(str::to_owned).collect::<Vec<_>>();
+                if lines.len() >= expected {
+                    return lines;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("fake zellij output timeout")
+    }
+
+    async fn wait_for_path(path: &Path) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !path.exists() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("fake zellij marker timeout");
+    }
+
+    #[tokio::test]
+    async fn zellij_pipe_sink_streams_multiple_patches_through_one_child() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sink = ZellijPipeSink::new(fake_zellij(dir.path(), FakeZellijMode::Stream)).with_plugin_url("file:/plugins/andamento.wasm");
+        let first = stamp_patch();
+        let mut second = stamp_patch();
+        second.source_id = "second-source".to_owned();
+
+        sink.send(&first).await.expect("send first patch");
+        sink.send(&second).await.expect("send second patch");
+
+        let lines = wait_for_line_count(&dir.path().join("lines"), 2).await;
+        assert_eq!(std::fs::read_to_string(dir.path().join("spawns")).expect("spawn log"), "spawn\n");
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("args")).expect("argument log"),
+            "pipe\n--name\nandamento-apply-metadata-patch\n--plugin\nfile:/plugins/andamento.wasm\n"
+        );
+        assert_eq!(lines, vec![first.to_pipe_payload(), second.to_pipe_payload()]);
+    }
+
+    #[tokio::test]
+    async fn zellij_pipe_sink_retries_patch_after_child_stdin_closes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sink = ZellijPipeSink::new(fake_zellij(dir.path(), FakeZellijMode::CloseFirstChildStdin));
+        let first = stamp_patch();
+        sink.send(&first).await.expect("start first pipe child");
+        wait_for_path(&dir.path().join("stdin-closed")).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let mut retried = stamp_patch();
+        retried.source_id = "retried-source".to_owned();
+        let retry_started = tokio::time::Instant::now();
+        sink.send(&retried).await.expect("retry patch through replacement child");
+
+        assert!(retry_started.elapsed() >= Duration::from_millis(450), "child respawn should be paced by the initial backoff");
+        assert_eq!(wait_for_line_count(&dir.path().join("lines"), 1).await, vec![retried.to_pipe_payload()]);
+        assert_eq!(std::fs::read_to_string(dir.path().join("spawns")).expect("spawn log"), "spawn\nspawn\n");
+    }
+
+    #[tokio::test]
+    async fn zellij_pipe_sink_respawns_child_that_exits_between_patches() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sink = ZellijPipeSink::new(fake_zellij(dir.path(), FakeZellijMode::ExitFirstChild));
+        sink.send(&stamp_patch()).await.expect("send through first child");
+        wait_for_path(&dir.path().join("first-child-exited")).await;
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let mut after_restart = stamp_patch();
+        after_restart.source_id = "after-zellij-restart".to_owned();
+        sink.send(&after_restart).await.expect("send through replacement child");
+
+        assert_eq!(wait_for_line_count(&dir.path().join("lines"), 1).await, vec![after_restart.to_pipe_payload()]);
+        assert_eq!(std::fs::read_to_string(dir.path().join("spawns")).expect("spawn log"), "spawn\nspawn\n");
+    }
+
+    #[tokio::test]
+    async fn zellij_pipe_sink_propagates_child_backpressure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sink = ZellijPipeSink::new(fake_zellij(dir.path(), FakeZellijMode::BlockStdin));
+        let mut patch = stamp_patch();
+        patch.source_id = "x".repeat(2 * 1024 * 1024);
+
+        let mut send = tokio::spawn(async move { sink.send(&patch).await });
+        wait_for_path(&dir.path().join("blocked")).await;
+        assert!(tokio::time::timeout(Duration::from_millis(50), &mut send).await.is_err(), "send should remain paced by child stdin");
+        std::fs::write(dir.path().join("unblock"), "").expect("unblock fake zellij");
+        send.await.expect("send task").expect("send after backpressure lifts");
+
+        assert_eq!(std::fs::read_to_string(dir.path().join("spawns")).expect("spawn log"), "spawn\n");
     }
 
     #[tokio::test]

--- a/crates/flotilla-manifest/src/wire.rs
+++ b/crates/flotilla-manifest/src/wire.rs
@@ -218,7 +218,9 @@ impl MetadataPatch {
     /// The compact payload written to the apply-patch pipe — the
     /// patch wrapped in andamento's externally-visible message envelope.
     pub fn to_pipe_payload(&self) -> String {
-        serde_json::to_string(&WireMessage::MetadataPatch(self.clone())).expect("metadata patch serializes")
+        let payload = serde_json::to_string(&WireMessage::MetadataPatch(self.clone())).expect("metadata patch serializes");
+        assert!(!payload.bytes().any(|byte| byte == b'\n' || byte == b'\r'), "metadata patch pipe payload must be a single line");
+        payload
     }
 }
 

--- a/crates/flotilla-manifest/src/wire/tests.rs
+++ b/crates/flotilla-manifest/src/wire/tests.rs
@@ -92,13 +92,18 @@ fn observed_identities_parse_merges_concatenated_responses() {
 
 #[test]
 fn pipe_payload_is_the_tagged_compact_envelope() {
-    let patch =
-        MetadataPatch { target: MetadataTarget::Root, source_id: "flotilla-connector".to_owned(), set: BTreeMap::new(), unset: vec![] };
+    let patch = MetadataPatch {
+        target: MetadataTarget::Root,
+        source_id: "flotilla\nconnector\rstream".to_owned(),
+        set: BTreeMap::new(),
+        unset: vec![],
+    };
     let payload = patch.to_pipe_payload();
     assert!(!payload.contains('\n'));
+    assert!(!payload.contains('\r'));
     let value: Value = serde_json::from_str(&payload).expect("payload is JSON");
     assert_eq!(value["type"], "metadata-patch");
-    assert_eq!(value["source_id"], "flotilla-connector");
+    assert_eq!(value["source_id"], "flotilla\nconnector\rstream");
 }
 
 #[test]


### PR DESCRIPTION
Closes #757.

## What changed

- keep one long-running `zellij pipe` child and send one metadata patch per stdin line
- serialize writes so plugin backpressure paces the connector, with a warning after sustained blockage
- recover from child exit or broken stdin with capped exponential respawn backoff
- enforce the single-line JSON payload invariant
- cover streaming, restart recovery, broken-pipe retry, backpressure, and escaped-newline framing

## Why

`ZellijPipeSink::send` previously launched a one-shot subprocess for every patch. Catalog reassertion therefore paid process startup and Zellij connection/handshake cost once per catalog entry every ten seconds. Zellij's intended pipe mode is a persistent stdin stream with plugin-driven per-message backpressure.

## Impact

Steady-state `pm connect` now maintains one Zellij pipe process regardless of catalog size or publish rate. Wheelhouse's Unix socket transport and catalog TTL/fade behavior are unchanged.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`