### PR TITLE
Materialize Projects for every tracked repository

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,7 +22,10 @@ _Avoid_: using "Island" as a code/identifier name — it is the metaphor, not th
 **Project**:
 The definition resource that structurally groups work (convoys) belonging to
 one codebase, which may span one or more **Repositories** or repository slices.
-The concrete form of the **Island** metaphor.
+Tracking a Repository materialises an ordinary whole-repository Project as the
+human-intent-backed default; that Project remains user-editable and may grow to
+cover more Repositories or select a different Issue Source. The concrete form
+of the **Island** metaphor.
 _Avoid_: Repo (a Project may span more than the bare git remote), Workspace.
 
 **Repository**:

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2310,15 +2310,15 @@ async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, names
     }
 }
 
-fn normalize_project_name(name: &str) -> Result<String, String> {
-    let normalized = normalized_project_name(name)?;
+fn validate_project_name(name: &str) -> Result<(), String> {
+    let normalized = normalize_project_name(name)?;
     if normalized != name {
         return Err(format!("project name `{name}` is invalid; use `{normalized}`"));
     }
-    Ok(normalized)
+    Ok(())
 }
 
-fn normalized_project_name(name: &str) -> Result<String, String> {
+fn normalize_project_name(name: &str) -> Result<String, String> {
     let normalized = name
         .trim()
         .chars()
@@ -2332,6 +2332,27 @@ fn normalized_project_name(name: &str) -> Result<String, String> {
         return Err("project name must contain an alphanumeric character".to_string());
     }
     Ok(normalized)
+}
+
+async fn ensure_repository_and_default_project_workflow(
+    backend: &ResourceBackend,
+    namespace: &str,
+    repository_key: &RepositoryKey,
+    repository_spec: &RepositorySpec,
+) -> Result<(), String> {
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(namespace), repository_key, repository_spec)
+        .await
+        .map_err(|error| error.to_string())?;
+    ensure_single_agent_contained_workflow(backend, namespace).await
+}
+
+fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: String) -> Result<ProjectSpec, String> {
+    normalize_project_spec(ProjectSpec {
+        display_name,
+        default_workflow_ref: "single-agent-contained".to_string(),
+        issue_source: None,
+        repositories: vec![ProjectRepositorySpec { repo: repository_key, subpath: None, default_branch: None }],
+    })
 }
 
 fn normalize_workspace_slug(candidate: &str) -> String {
@@ -2770,15 +2791,14 @@ impl InProcessDaemon {
             (None, None) => return Err(format!("`{target}` is neither a repository path nor a repository catalog slug")),
         };
 
-        flotilla_resources::ensure_repository(&repositories, &key, &repository_spec).await.map_err(|error| error.to_string())?;
+        ensure_repository_and_default_project_workflow(&self.resource_backend, &namespace, &key, &repository_spec).await?;
         if let Some(checkout) = checkout {
             self.ensure_project_checkout(&namespace, &key, &repository_spec, checkout).await?;
         }
-        ensure_single_agent_contained_workflow(&self.resource_backend, &namespace).await?;
 
         let default_name = normalize_project_name(&repository_spec.leaf_slug())?;
         let project_name = explicit_name.map(str::to_string).unwrap_or(default_name.clone());
-        normalize_project_name(&project_name)?;
+        validate_project_name(&project_name)?;
         let projects = self.resource_backend.clone().using::<Project>(&namespace);
         match projects.get(&project_name).await {
             Ok(existing) => {
@@ -2801,27 +2821,15 @@ impl InProcessDaemon {
             Err(error) => return Err(error.to_string()),
         }
 
-        let spec = normalize_project_spec(ProjectSpec {
-            display_name: explicit_display_name.map(str::to_string).unwrap_or(default_name),
-            default_workflow_ref: "single-agent-contained".to_string(),
-            issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: key, subpath: None, default_branch: None }],
-        })?;
+        let spec = whole_repository_project_spec(key, explicit_display_name.map(str::to_string).unwrap_or(default_name))?;
         projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
         Ok(project_name)
     }
 
-    async fn ensure_degenerate_project(&self, repository_spec: &RepositorySpec) -> Result<String, String> {
+    async fn ensure_whole_repository_project(&self, repository_spec: &RepositorySpec) -> Result<String, String> {
         let namespace = self.provisioning_namespace().await;
         let repository_key = repository_spec.key();
-        flotilla_resources::ensure_repository(
-            &self.resource_backend.clone().using::<Repository>(&namespace),
-            &repository_key,
-            repository_spec,
-        )
-        .await
-        .map_err(|error| error.to_string())?;
-        ensure_single_agent_contained_workflow(&self.resource_backend, &namespace).await?;
+        ensure_repository_and_default_project_workflow(&self.resource_backend, &namespace, &repository_key, repository_spec).await?;
 
         let projects = self.resource_backend.clone().using::<Project>(&namespace);
         if let Some(existing) = projects
@@ -2835,8 +2843,8 @@ impl InProcessDaemon {
             return Ok(existing.metadata.name);
         }
 
-        let display_name = normalized_project_name(&repository_spec.leaf_slug())?;
-        let catalog_name = normalized_project_name(&repository_spec.catalog_slug())?;
+        let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
+        let catalog_name = normalize_project_name(&repository_spec.catalog_slug())?;
         let key_suffix = repository_key.0.chars().take(8).collect::<String>();
         let disambiguated_name = format!("{catalog_name}-{key_suffix}");
         let mut candidates = Vec::new();
@@ -2846,12 +2854,7 @@ impl InProcessDaemon {
             }
         }
 
-        let spec = normalize_project_spec(ProjectSpec {
-            display_name,
-            default_workflow_ref: "single-agent-contained".to_string(),
-            issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: repository_key.clone(), subpath: None, default_branch: None }],
-        })?;
+        let spec = whole_repository_project_spec(repository_key.clone(), display_name)?;
         for project_name in candidates {
             match projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await {
                 Ok(_) => return Ok(project_name),
@@ -2869,16 +2872,13 @@ impl InProcessDaemon {
 
     pub async fn materialize_tracked_repo_projects(&self) -> Result<(), String> {
         for repo_path in self.tracked_repo_paths().await {
-            let inspection = match self.inspect_repository_path(&repo_path, None).await {
-                Ok(inspection) => inspection,
-                Err(error) => {
-                    warn!(repo = %repo_path.display(), %error, "skipping degenerate Project because repository identity resolution failed");
-                    continue;
-                }
-            };
-            self.ensure_degenerate_project(&inspection.spec)
+            let inspection = self
+                .inspect_repository_path(&repo_path, None)
                 .await
-                .map_err(|error| format!("materialize degenerate Project for {}: {error}", repo_path.display()))?;
+                .map_err(|error| format!("inspect tracked repository {} for Project materialization: {error}", repo_path.display()))?;
+            self.ensure_whole_repository_project(&inspection.spec)
+                .await
+                .map_err(|error| format!("materialize whole-repository Project for {}: {error}", repo_path.display()))?;
         }
         Ok(())
     }
@@ -3020,19 +3020,14 @@ impl InProcessDaemon {
         let identity = repo_identity_from_bag_or_path(&path, &host_repo_bag);
         // Resolve the storage identity before publishing RepoTracked so a
         // surface can subscribe to issues{repository} immediately. The
-        // background refresh still ensures the Repository resource and
-        // reconciles observed Checkouts.
-        let repository_inspection = match self.inspect_repository_path(&path, None).await {
-            Ok(inspection) => Some(inspection),
-            Err(error) => {
-                warn!(repo = %path.display(), %error, "repository key is unavailable while tracking repo");
-                None
-            }
-        };
-        let repository_key = repository_inspection.as_ref().map(RepositoryInspection::key);
-        if let Some(inspection) = repository_inspection.as_ref() {
-            self.ensure_degenerate_project(&inspection.spec).await?;
-        }
+        // background refresh also reconciles the Repository resource and
+        // observed Checkouts.
+        let repository_inspection = self
+            .inspect_repository_path(&path, None)
+            .await
+            .map_err(|error| format!("inspect repository {} for Project materialization: {error}", path.display()))?;
+        let repository_key = Some(repository_inspection.key());
+        self.ensure_whole_repository_project(&repository_inspection.spec).await?;
         if let Some(tracked_identity) = self.tracked_repo_identity_for_path(&path).await {
             if tracked_identity == identity {
                 let key_became_available = {
@@ -4620,7 +4615,7 @@ impl InProcessDaemon {
             });
             let namespace = self.provisioning_namespace().await;
             let projects = self.resource_backend.clone().using::<Project>(&namespace);
-            let result = match normalize_project_name(name).and_then(|_| parse_project_yaml(spec_yaml)) {
+            let result = match validate_project_name(name).and_then(|_| parse_project_yaml(spec_yaml)) {
                 Ok(spec) => match normalize_project_spec(spec) {
                     Ok(spec) => {
                         let meta = InputMeta::builder().name(name.clone()).build();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2311,6 +2311,14 @@ async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, names
 }
 
 fn normalize_project_name(name: &str) -> Result<String, String> {
+    let normalized = normalized_project_name(name)?;
+    if normalized != name {
+        return Err(format!("project name `{name}` is invalid; use `{normalized}`"));
+    }
+    Ok(normalized)
+}
+
+fn normalized_project_name(name: &str) -> Result<String, String> {
     let normalized = name
         .trim()
         .chars()
@@ -2322,9 +2330,6 @@ fn normalize_project_name(name: &str) -> Result<String, String> {
         .join("-");
     if normalized.is_empty() {
         return Err("project name must contain an alphanumeric character".to_string());
-    }
-    if normalized != name {
-        return Err(format!("project name `{name}` is invalid; use `{normalized}`"));
     }
     Ok(normalized)
 }
@@ -2806,6 +2811,78 @@ impl InProcessDaemon {
         Ok(project_name)
     }
 
+    async fn ensure_degenerate_project(&self, repository_spec: &RepositorySpec) -> Result<String, String> {
+        let namespace = self.provisioning_namespace().await;
+        let repository_key = repository_spec.key();
+        flotilla_resources::ensure_repository(
+            &self.resource_backend.clone().using::<Repository>(&namespace),
+            &repository_key,
+            repository_spec,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        ensure_single_agent_contained_workflow(&self.resource_backend, &namespace).await?;
+
+        let projects = self.resource_backend.clone().using::<Project>(&namespace);
+        if let Some(existing) = projects
+            .list()
+            .await
+            .map_err(|error| error.to_string())?
+            .items
+            .into_iter()
+            .find(|project| project.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()))
+        {
+            return Ok(existing.metadata.name);
+        }
+
+        let display_name = normalized_project_name(&repository_spec.leaf_slug())?;
+        let catalog_name = normalized_project_name(&repository_spec.catalog_slug())?;
+        let key_suffix = repository_key.0.chars().take(8).collect::<String>();
+        let disambiguated_name = format!("{catalog_name}-{key_suffix}");
+        let mut candidates = Vec::new();
+        for candidate in [display_name.clone(), catalog_name, disambiguated_name] {
+            if !candidates.contains(&candidate) {
+                candidates.push(candidate);
+            }
+        }
+
+        let spec = normalize_project_spec(ProjectSpec {
+            display_name,
+            default_workflow_ref: "single-agent-contained".to_string(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: repository_key.clone(), subpath: None, default_branch: None }],
+        })?;
+        for project_name in candidates {
+            match projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await {
+                Ok(_) => return Ok(project_name),
+                Err(ResourceError::Conflict { .. }) => {
+                    let existing = projects.get(&project_name).await.map_err(|error| error.to_string())?;
+                    if existing.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()) {
+                        return Ok(project_name);
+                    }
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+        Err(format!("could not allocate a deterministic Project name for repository {repository_key}"))
+    }
+
+    pub async fn materialize_tracked_repo_projects(&self) -> Result<(), String> {
+        for repo_path in self.tracked_repo_paths().await {
+            let inspection = match self.inspect_repository_path(&repo_path, None).await {
+                Ok(inspection) => inspection,
+                Err(error) => {
+                    warn!(repo = %repo_path.display(), %error, "skipping degenerate Project because repository identity resolution failed");
+                    continue;
+                }
+            };
+            self.ensure_degenerate_project(&inspection.spec)
+                .await
+                .map_err(|error| format!("materialize degenerate Project for {}: {error}", repo_path.display()))?;
+        }
+        Ok(())
+    }
+
     async fn ensure_project_checkout(
         &self,
         namespace: &str,
@@ -2945,13 +3022,17 @@ impl InProcessDaemon {
         // surface can subscribe to issues{repository} immediately. The
         // background refresh still ensures the Repository resource and
         // reconciles observed Checkouts.
-        let repository_key = match self.inspect_repository_path(&path, None).await {
-            Ok(inspection) => Some(inspection.key()),
+        let repository_inspection = match self.inspect_repository_path(&path, None).await {
+            Ok(inspection) => Some(inspection),
             Err(error) => {
                 warn!(repo = %path.display(), %error, "repository key is unavailable while tracking repo");
                 None
             }
         };
+        let repository_key = repository_inspection.as_ref().map(RepositoryInspection::key);
+        if let Some(inspection) = repository_inspection.as_ref() {
+            self.ensure_degenerate_project(&inspection.spec).await?;
+        }
         if let Some(tracked_identity) = self.tracked_repo_identity_for_path(&path).await {
             if tracked_identity == identity {
                 let key_became_available = {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2872,10 +2872,13 @@ impl InProcessDaemon {
 
     pub async fn materialize_tracked_repo_projects(&self) -> Result<(), String> {
         for repo_path in self.tracked_repo_paths().await {
-            let inspection = self
-                .inspect_repository_path(&repo_path, None)
-                .await
-                .map_err(|error| format!("inspect tracked repository {} for Project materialization: {error}", repo_path.display()))?;
+            let inspection = match self.inspect_repository_path(&repo_path, None).await {
+                Ok(inspection) => inspection,
+                Err(error) => {
+                    warn!(repo = %repo_path.display(), %error, "skipping Project backfill because repository identity resolution failed");
+                    continue;
+                }
+            };
             self.ensure_whole_repository_project(&inspection.spec)
                 .await
                 .map_err(|error| format!("materialize whole-repository Project for {}: {error}", repo_path.display()))?;
@@ -3025,7 +3028,7 @@ impl InProcessDaemon {
         let repository_inspection = self
             .inspect_repository_path(&path, None)
             .await
-            .map_err(|error| format!("inspect repository {} for Project materialization: {error}", path.display()))?;
+            .map_err(|error| format!("cannot track repository {}: {error}", path.display()))?;
         let repository_key = Some(repository_inspection.key());
         self.ensure_whole_repository_project(&repository_inspection.spec).await?;
         if let Some(tracked_identity) = self.tracked_repo_identity_for_path(&path).await {

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -141,6 +141,8 @@ impl RepositoryInspector for GitRepositoryInspector {
         let top_level = PathBuf::from(self.git(&path, &["rev-parse", "--show-toplevel"]).await?);
         let top_level = std::fs::canonicalize(&top_level)
             .map_err(|error| format!("repository root {} cannot be resolved: {error}", top_level.display()))?;
+        // `rev-parse HEAD` can fail before the first commit, while the symbolic
+        // ref still exposes the initial branch name.
         let branch = match self.git(&top_level, &["rev-parse", "--abbrev-ref", "HEAD"]).await {
             Ok(branch) => branch,
             Err(_) => self.git(&top_level, &["symbolic-ref", "--short", "HEAD"]).await?,

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -141,7 +141,10 @@ impl RepositoryInspector for GitRepositoryInspector {
         let top_level = PathBuf::from(self.git(&path, &["rev-parse", "--show-toplevel"]).await?);
         let top_level = std::fs::canonicalize(&top_level)
             .map_err(|error| format!("repository root {} cannot be resolved: {error}", top_level.display()))?;
-        let branch = self.git(&top_level, &["rev-parse", "--abbrev-ref", "HEAD"]).await?;
+        let branch = match self.git(&top_level, &["rev-parse", "--abbrev-ref", "HEAD"]).await {
+            Ok(branch) => branch,
+            Err(_) => self.git(&top_level, &["symbolic-ref", "--short", "HEAD"]).await?,
+        };
         let git_ref = if branch == "HEAD" { self.git(&top_level, &["rev-parse", "HEAD"]).await? } else { branch.clone() };
         let selected_remote = self.selected_remote(&top_level, &branch, remote).await?;
         let (spec, transport_url) = match selected_remote {
@@ -285,6 +288,25 @@ mod tests {
         let second = inspector.inspect_path(&second, None).await.expect("second inspection");
 
         assert_eq!(first.key(), second.key());
+    }
+
+    #[tokio::test]
+    async fn unborn_head_uses_the_symbolic_branch_name() {
+        let (_temp, root) = git_repo();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["rev-parse", "--show-toplevel"], Ok(root.to_string_lossy().into_owned()))
+            .on_run("git", &["rev-parse", "--abbrev-ref", "HEAD"], Err("unborn HEAD".to_string()))
+            .on_run("git", &["symbolic-ref", "--short", "HEAD"], Ok("main\n".to_string()))
+            .on_run("git", &["remote"], Ok(String::new()))
+            .on_run("git", &["rev-parse", "--git-common-dir"], Ok(".git\n".to_string()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+
+        let inspected = inspector.inspect_path(&root, None).await.expect("unborn repository should be inspected");
+
+        assert!(matches!(inspected.spec.identity(), RepositoryIdentity::Local { host_ref, .. } if host_ref == "host-01"));
+        assert_eq!(inspected.checkout.git_ref, "main");
+        assert!(inspected.checkout.is_main);
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -3815,6 +3815,7 @@ async fn adding_local_clone_promotes_remote_only_identity_to_local_execution() {
     let identity = test_repo_identity();
     let config = test_config_store(temp.path().join("config"));
     let daemon = InProcessDaemon::new(vec![], config, local_bare_remote_discovery(), HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
 
     daemon
         .add_virtual_repo(identity.clone(), None, PathBuf::from("/remote/desktop/owner/repo"), vec![], 0)
@@ -4626,6 +4627,7 @@ async fn add_repo_uses_manager_backed_local_environment_for_repo_identity() {
     let config = test_config_store(temp.path().join("config"));
     let daemon =
         InProcessDaemon::new(vec![], config, fake_discovery_with_provider_set(FakeDiscoveryProviders::new()), HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("manager-backed-repo".to_string()))).await;
 
     daemon
         .replace_local_environment_bag_for_test(EnvironmentBag::new().with(EnvironmentAssertion::remote_host(
@@ -4659,6 +4661,7 @@ async fn add_repo_uses_manager_backed_local_environment_for_provider_discovery()
         .terminal_pools
         .push(Box::new(EnvGatedTerminalPoolFactory { required_env_var: "ENABLE_MANAGER_TERMINALS", pool: terminal_pool }));
     let daemon = InProcessDaemon::new(vec![], config, discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("provider-discovery".to_string()))).await;
 
     daemon
         .replace_local_environment_bag_for_test(EnvironmentBag::new().with(EnvironmentAssertion::env_var("ENABLE_MANAGER_TERMINALS", "1")))

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -277,6 +277,7 @@ async fn register_startup_resources(
     discover_local_clones(daemon, &backend, namespace, profile).await?;
     ensure_default_policies(&backend, namespace, profile).await?;
     ensure_default_workflow_templates(&backend, namespace).await?;
+    daemon.materialize_tracked_repo_projects().await?;
     Ok(())
 }
 

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -257,9 +257,11 @@ async fn dispatch_request_handles_error_response_for_untracked_repo() {
 
 #[tokio::test]
 async fn dispatch_add_list_remove_repo_round_trip() {
-    let (tmp, daemon) = empty_daemon().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(tmp.path().join("config"));
+    let daemon = InProcessDaemon::new(vec![], config, git_process_discovery(false), HostName::local()).await;
     let repo_path = tmp.path().join("repo-a");
-    std::fs::create_dir_all(&repo_path).expect("create repo directory");
+    init_git_repo_with_remote(&repo_path, "git@github.com:owner/repo-a.git");
 
     let add = dispatch_request_test(&daemon, 10, Request::AddRepo { path: repo_path.clone() }).await;
     assert!(matches!(ok_response(add, 10), Response::AddRepo));

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -212,7 +212,7 @@ async fn daemon_start_backfills_project_idempotently_and_preserves_edits() {
 }
 
 #[tokio::test]
-async fn daemon_start_fails_when_a_tracked_repo_cannot_be_backfilled() {
+async fn daemon_start_skips_a_tracked_repo_that_cannot_be_backfilled() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let config = test_config(tmp.path().join("config"));
     let checkout_path = tmp.path().join("uninspectable");
@@ -223,22 +223,17 @@ async fn daemon_start_fails_when_a_tracked_repo_cannot_be_backfilled() {
         Arc::clone(&config),
         fake_discovery(false),
         HostName::new("local"),
-        backend,
+        backend.clone(),
     )
     .await;
     daemon.set_repository_inspector(Arc::new(FailingInspector)).await;
 
-    let error = match DaemonRuntime::start_with_options(daemon, config, None, RuntimeOptions {
-        start_controllers: false,
-        ..RuntimeOptions::default()
-    })
-    .await
-    {
-        Ok(_) => panic!("runtime start should fail"),
-        Err(error) => error,
-    };
+    let _runtime =
+        DaemonRuntime::start_with_options(daemon, config, None, RuntimeOptions { start_controllers: false, ..RuntimeOptions::default() })
+            .await
+            .expect("runtime should skip the uninspectable repository");
 
-    assert!(error.contains("cannot inspect"));
+    assert!(backend.using::<Project>("flotilla").list().await.expect("project list").items.is_empty());
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -110,6 +110,141 @@ async fn execute_project_add(
 }
 
 #[tokio::test]
+async fn tracking_repo_materializes_whole_repo_project() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let repository_spec = RepositorySpec::remote("https://github.com/org/tracked.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
+    let checkout_path = tmp.path().join("tracked");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+
+    daemon.add_repo(&checkout_path).await.expect("track repo");
+
+    let project = backend.using::<Project>("flotilla").get("tracked").await.expect("degenerate project should exist");
+    assert_eq!(project.spec.display_name, "tracked");
+    assert_eq!(project.spec.default_workflow_ref, "single-agent-contained");
+    assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
+        repo: repository_key,
+        subpath: None,
+        default_branch: None,
+    }]);
+}
+
+#[tokio::test]
+async fn daemon_start_backfills_project_idempotently_and_preserves_edits() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let checkout_path = tmp.path().join("backfilled");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![checkout_path],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    let repository_spec = RepositorySpec::remote("https://github.com/org/backfilled.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
+    let options = RuntimeOptions {
+        namespace: "flotilla".to_string(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_secs(300),
+        start_controllers: false,
+        ..RuntimeOptions::default()
+    };
+
+    let runtime =
+        DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options.clone()).await.expect("runtime start");
+
+    let projects = backend.clone().using::<Project>("flotilla");
+    let project = projects.get("backfilled").await.expect("backfilled project should exist");
+    assert_eq!(project.spec.repositories[0].repo, repository_key);
+    let mut evolved = project.spec;
+    evolved.display_name = "Backfilled product".to_string();
+    evolved.default_workflow_ref = "custom-workflow".to_string();
+    evolved.issue_source = Some(IssueSource { service: "linear".to_string(), scope: "BACK".to_string() });
+    evolved.repositories.push(flotilla_resources::ProjectRepositorySpec {
+        repo: RepositoryKey("second-repository".to_string()),
+        subpath: None,
+        default_branch: None,
+    });
+    projects
+        .update(&InputMeta::builder().name("backfilled".to_string()).build(), &project.metadata.resource_version, &evolved)
+        .await
+        .expect("evolve project");
+    drop(runtime);
+
+    let _restarted = DaemonRuntime::start_with_options(daemon, config, None, options).await.expect("runtime restart");
+
+    assert_eq!(projects.get("backfilled").await.expect("evolved project").spec, evolved);
+    assert_eq!(projects.list().await.expect("project list").items.len(), 1);
+}
+
+#[tokio::test]
+async fn tracking_repo_widens_project_name_without_overwriting_custom_project() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let projects = backend.clone().using::<Project>("flotilla");
+    let custom_spec = flotilla_resources::ProjectSpec {
+        display_name: "Shared product".to_string(),
+        default_workflow_ref: "custom-workflow".to_string(),
+        issue_source: None,
+        repositories: vec![flotilla_resources::ProjectRepositorySpec {
+            repo: RepositoryKey("other-repository".to_string()),
+            subpath: None,
+            default_branch: None,
+        }],
+    };
+    projects.create(&InputMeta::builder().name("shared".to_string()).build(), &custom_spec).await.expect("custom project create");
+    let repository_spec = RepositorySpec::remote("https://github.com/org-b/shared.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
+    let checkout_path = tmp.path().join("shared");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+
+    daemon.add_repo(&checkout_path).await.expect("track repo");
+
+    assert_eq!(projects.get("shared").await.expect("custom project").spec, custom_spec);
+    let generated = projects.get("github-com-org-b-shared").await.expect("collision-aware project should exist");
+    assert_eq!(generated.spec.repositories[0].repo, repository_key);
+}
+
+#[tokio::test]
+async fn tracking_repo_uses_repository_key_when_slug_candidates_collide() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let projects = backend.clone().using::<Project>("flotilla");
+    for (name, repo_ref) in [("shared", "first-repository"), ("github-com-org-b-shared", "second-repository")] {
+        projects
+            .create(&InputMeta::builder().name(name.to_string()).build(), &flotilla_resources::ProjectSpec {
+                display_name: name.to_string(),
+                default_workflow_ref: "custom-workflow".to_string(),
+                issue_source: None,
+                repositories: vec![flotilla_resources::ProjectRepositorySpec {
+                    repo: RepositoryKey(repo_ref.to_string()),
+                    subpath: None,
+                    default_branch: None,
+                }],
+            })
+            .await
+            .expect("occupied project create");
+    }
+    let repository_spec = RepositorySpec::remote("https://github.com/org-b/shared.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
+    let checkout_path = tmp.path().join("shared");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+
+    daemon.add_repo(&checkout_path).await.expect("track repo");
+
+    let key_prefix = repository_key.0.chars().take(8).collect::<String>();
+    let generated_name = format!("github-com-org-b-shared-{key_prefix}");
+    let generated = projects.get(&generated_name).await.expect("key-disambiguated project should exist");
+    assert_eq!(generated.spec.repositories[0].repo, repository_key);
+}
+
+#[tokio::test]
 async fn project_add_untracked_path_ensures_repository_checkout_and_whole_repo_project() {
     let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
     let repository_spec = RepositorySpec::remote("https://github.com/org/repo.git").expect("repository spec");

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -72,6 +72,26 @@ impl RepositoryInspector for FixedInspector {
     }
 }
 
+#[derive(Clone)]
+struct FailingInspector;
+
+#[async_trait]
+impl RepositoryInspector for FailingInspector {
+    async fn inspect_path(&self, path: &Path, _remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        Err(format!("cannot inspect {}", path.display()))
+    }
+}
+
+async fn track_repository(daemon: &Arc<InProcessDaemon>, tmp: &tempfile::TempDir, directory_name: &str, remote: &str) -> RepositoryKey {
+    let repository_spec = RepositorySpec::remote(remote).expect("repository spec");
+    let repository_key = repository_spec.key();
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
+    let checkout_path = tmp.path().join(directory_name);
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    daemon.add_repo(&checkout_path).await.expect("track repo");
+    repository_key
+}
+
 async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
@@ -112,15 +132,9 @@ async fn execute_project_add(
 #[tokio::test]
 async fn tracking_repo_materializes_whole_repo_project() {
     let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
-    let repository_spec = RepositorySpec::remote("https://github.com/org/tracked.git").expect("repository spec");
-    let repository_key = repository_spec.key();
-    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
-    let checkout_path = tmp.path().join("tracked");
-    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let repository_key = track_repository(&daemon, &tmp, "tracked", "https://github.com/org/tracked.git").await;
 
-    daemon.add_repo(&checkout_path).await.expect("track repo");
-
-    let project = backend.using::<Project>("flotilla").get("tracked").await.expect("degenerate project should exist");
+    let project = backend.using::<Project>("flotilla").get("tracked").await.expect("whole-repository project should exist");
     assert_eq!(project.spec.display_name, "tracked");
     assert_eq!(project.spec.default_workflow_ref, "single-agent-contained");
     assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
@@ -128,6 +142,20 @@ async fn tracking_repo_materializes_whole_repo_project() {
         subpath: None,
         default_branch: None,
     }]);
+}
+
+#[tokio::test]
+async fn tracking_repo_fails_when_its_project_cannot_be_materialized() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    daemon.set_repository_inspector(Arc::new(FailingInspector)).await;
+    let checkout_path = tmp.path().join("uninspectable");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+
+    let error = daemon.add_repo(&checkout_path).await.expect_err("tracking should fail");
+
+    assert!(error.contains("cannot inspect"));
+    assert!(!daemon.tracked_repo_paths().await.contains(&checkout_path));
+    assert!(backend.using::<Project>("flotilla").list().await.expect("project list").items.is_empty());
 }
 
 #[tokio::test]
@@ -184,6 +212,36 @@ async fn daemon_start_backfills_project_idempotently_and_preserves_edits() {
 }
 
 #[tokio::test]
+async fn daemon_start_fails_when_a_tracked_repo_cannot_be_backfilled() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let checkout_path = tmp.path().join("uninspectable");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![checkout_path],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend,
+    )
+    .await;
+    daemon.set_repository_inspector(Arc::new(FailingInspector)).await;
+
+    let error = match DaemonRuntime::start_with_options(daemon, config, None, RuntimeOptions {
+        start_controllers: false,
+        ..RuntimeOptions::default()
+    })
+    .await
+    {
+        Ok(_) => panic!("runtime start should fail"),
+        Err(error) => error,
+    };
+
+    assert!(error.contains("cannot inspect"));
+}
+
+#[tokio::test]
 async fn tracking_repo_widens_project_name_without_overwriting_custom_project() {
     let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
     let projects = backend.clone().using::<Project>("flotilla");
@@ -198,13 +256,7 @@ async fn tracking_repo_widens_project_name_without_overwriting_custom_project() 
         }],
     };
     projects.create(&InputMeta::builder().name("shared".to_string()).build(), &custom_spec).await.expect("custom project create");
-    let repository_spec = RepositorySpec::remote("https://github.com/org-b/shared.git").expect("repository spec");
-    let repository_key = repository_spec.key();
-    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
-    let checkout_path = tmp.path().join("shared");
-    std::fs::create_dir(&checkout_path).expect("checkout dir");
-
-    daemon.add_repo(&checkout_path).await.expect("track repo");
+    let repository_key = track_repository(&daemon, &tmp, "shared", "https://github.com/org-b/shared.git").await;
 
     assert_eq!(projects.get("shared").await.expect("custom project").spec, custom_spec);
     let generated = projects.get("github-com-org-b-shared").await.expect("collision-aware project should exist");
@@ -230,13 +282,7 @@ async fn tracking_repo_uses_repository_key_when_slug_candidates_collide() {
             .await
             .expect("occupied project create");
     }
-    let repository_spec = RepositorySpec::remote("https://github.com/org-b/shared.git").expect("repository spec");
-    let repository_key = repository_spec.key();
-    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
-    let checkout_path = tmp.path().join("shared");
-    std::fs::create_dir(&checkout_path).expect("checkout dir");
-
-    daemon.add_repo(&checkout_path).await.expect("track repo");
+    let repository_key = track_repository(&daemon, &tmp, "shared", "https://github.com/org-b/shared.git").await;
 
     let key_prefix = repository_key.0.chars().take(8).collect::<String>();
     let generated_name = format!("github-com-org-b-shared-{key_prefix}");


### PR DESCRIPTION
## Summary

- materialize an ordinary whole-repository Project whenever a repository is tracked
- backfill Projects for repositories that were already tracked when the daemon starts
- allocate deterministic, collision-safe Project names while preserving Projects that users have expanded or customized
- fail tracking or startup when the required Project cannot be materialized
- support inspecting brand-new Git repositories whose `HEAD` is still unborn

## Why

The view layer now scopes work through Projects. Repository tracking is the human intent that establishes the default Project, so every tracked repository must have a usable Project without a separate setup step or a virtual-Project special case.

Closes #766.

## User impact

Tracking a repository immediately yields a usable Project backed by the `single-agent-contained` workflow. Existing tracked repositories receive the same Project idempotently on restart, and those Projects remain ordinary editable resources that can grow to include more repositories or an issue-source override.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" RUSTC_WRAPPER= cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
