### PR TITLE
chore: bound claude-review job at 15 minutes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,7 @@ on:
     #   - "src/**/*.jsx"
 jobs:
   claude-review:
+    timeout-minutes: 15
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
Observed on PR #771: the review action posted its comment successfully at 19:37, then hung on shutdown — the check sat pending indefinitely (default job timeout is 6h). This bounds the job at 15 minutes (normal runs: 2–5), so a shutdown hang becomes a visible timeout failure with the review already delivered, instead of an eternally-pending check that looks like a token problem.