### PR TITLE
feat: compose project table panels

### DIFF
--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -280,7 +280,6 @@ pub type NamespaceMap = HashMap<String, NamespaceModel>;
 pub struct NamespaceModel {
     pub convoys: IndexMap<crate::convoy_model::ConvoyId, crate::convoy_model::ConvoySummary>,
     pub independents: IndexMap<ResourceRef, flotilla_protocol::IndependentRow>,
-    pub project_issues: HashMap<String, Vec<flotilla_protocol::IssueRow>>,
     pub last_seq: u64,
 }
 
@@ -337,15 +336,6 @@ pub fn table_rows<'a>(
     crate::table_view::TableRows {
         convoys: namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect(),
         independents: namespaces.values().flat_map(|namespace| namespace.independents.values()).collect(),
-        project_issues: namespaces
-            .iter()
-            .flat_map(|(namespace, model)| {
-                model
-                    .project_issues
-                    .iter()
-                    .flat_map(move |(project, rows)| rows.iter().map(move |row| (namespace.as_str(), project.as_str(), row)))
-            })
-            .collect(),
         issue_results: queries
             .issues
             .iter()
@@ -585,7 +575,7 @@ impl App {
         let mut queries = Vec::new();
         for view in self.views.iter() {
             let Some(address) = view.address() else { continue };
-            for query in view_kind::queries(address, view.table_state.source_search.as_deref()) {
+            for query in view_kind::queries(address, view.source_search()) {
                 if !queries.contains(&query) {
                     queries.push(query);
                 }
@@ -965,14 +955,6 @@ impl App {
         }
     }
 
-    fn sync_project_issue_rows(&mut self, query: &flotilla_protocol::QueryId) {
-        let flotilla_protocol::QueryId::Issues { scope, search: None } = query else {
-            return;
-        };
-        let rows = self.query_tables.issues.get(query).map(|result| result.rows.clone()).unwrap_or_default();
-        self.namespaces.entry(scope.namespace.clone()).or_default().project_issues.insert(scope.name.clone(), rows);
-    }
-
     // ── Widget stack helpers ──
 
     /// Pop all modal widgets from the stack.
@@ -1192,7 +1174,7 @@ impl App {
                     let queries = self
                         .views
                         .active_address()
-                        .map(|address| view_kind::queries(address, self.views.active_table_state().source_search.as_deref()))
+                        .map(|address| view_kind::queries(address, self.views.active_source_search()))
                         .unwrap_or_default();
                     if !queries.is_empty() {
                         for query in queries {
@@ -1372,7 +1354,6 @@ impl App {
                         self.query_tables
                             .issues
                             .insert(query.clone(), QueryTableResult { rows: rows.clone(), state: result_set.state.clone() });
-                        self.sync_project_issue_rows(&query);
                     }
                     flotilla_protocol::Rows::Checkouts { rows, .. } => {
                         self.query_tables.checkouts.insert(query, QueryTableResult { rows: rows.clone(), state: result_set.state.clone() });
@@ -1419,7 +1400,6 @@ impl App {
                             |row| row.reference.clone(),
                             |left, right| right.issue.as_of.cmp(&left.issue.as_of).then_with(|| left.reference.cmp(&right.reference)),
                         );
-                        self.sync_project_issue_rows(&query);
                     }
                     flotilla_protocol::QueryChanges::Checkouts { changed, removed, .. } => {
                         let result = self.query_tables.checkouts.entry(query).or_default();

--- a/crates/flotilla-tui/src/app/open_views.rs
+++ b/crates/flotilla-tui/src/app/open_views.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use flotilla_core::config::OpenViewEntry;
 use flotilla_protocol::{RepoIdentity, RepositoryKey, ViewAddress};
 
-use crate::table_view::TableState;
+use crate::table_view::{ProjectTableState, TableState};
 
 /// What an open tab points at: a parsed View address, or the raw entry that
 /// failed to parse. A broken entry renders an error view in place — it never
@@ -27,6 +27,7 @@ pub struct OpenView {
     /// User-set label. Display-only; never part of view identity.
     pub label_override: Option<String>,
     pub table_state: TableState,
+    pub project_table_state: ProjectTableState,
     /// Addresses left behind by in-place drill navigation in this tab.
     /// History is ephemeral and deliberately not persisted.
     pub(crate) history: Vec<NavigationFrame>,
@@ -36,6 +37,7 @@ pub struct OpenView {
 pub(crate) struct NavigationFrame {
     target: ViewTarget,
     table_state: TableState,
+    project_table_state: ProjectTableState,
 }
 
 impl OpenView {
@@ -44,17 +46,52 @@ impl OpenView {
             Ok(address) => ViewTarget::View(address),
             Err(error) => ViewTarget::Broken { raw: entry.address, error },
         };
-        Self { target, label_override: entry.label, table_state: TableState::default(), history: Vec::new() }
+        Self {
+            target,
+            label_override: entry.label,
+            table_state: TableState::default(),
+            project_table_state: ProjectTableState::default(),
+            history: Vec::new(),
+        }
     }
 
     fn of(address: ViewAddress) -> Self {
-        Self { target: ViewTarget::View(address), label_override: None, table_state: TableState::default(), history: Vec::new() }
+        Self {
+            target: ViewTarget::View(address),
+            label_override: None,
+            table_state: TableState::default(),
+            project_table_state: ProjectTableState::default(),
+            history: Vec::new(),
+        }
     }
 
     pub fn address(&self) -> Option<&ViewAddress> {
         match &self.target {
             ViewTarget::View(address) => Some(address),
             ViewTarget::Broken { .. } => None,
+        }
+    }
+
+    pub fn source_search(&self) -> Option<&str> {
+        match self.address() {
+            Some(ViewAddress::Project { .. }) => self.project_table_state.issue_source_search(),
+            _ => self.table_state.source_search.as_deref(),
+        }
+    }
+
+    fn focused_table_state(&self) -> &TableState {
+        match self.address() {
+            Some(ViewAddress::Project { .. }) => self.project_table_state.active_table(),
+            _ => &self.table_state,
+        }
+    }
+
+    fn focused_table_state_mut(&mut self) -> &mut TableState {
+        let is_project = matches!(self.address(), Some(ViewAddress::Project { .. }));
+        if is_project {
+            self.project_table_state.active_table_mut()
+        } else {
+            &mut self.table_state
         }
     }
 
@@ -234,6 +271,7 @@ impl OpenViews {
         let Some(frame) = view.history.pop() else { return false };
         view.target = frame.target;
         view.table_state = frame.table_state;
+        view.project_table_state = frame.project_table_state;
         true
     }
 
@@ -250,6 +288,7 @@ impl OpenViews {
         let previous = NavigationFrame {
             target: std::mem::replace(&mut view.target, ViewTarget::View(address)),
             table_state: std::mem::take(&mut view.table_state),
+            project_table_state: std::mem::take(&mut view.project_table_state),
         };
         view.history.push(previous);
         true
@@ -292,11 +331,23 @@ impl OpenViews {
     }
 
     pub fn active_table_state(&self) -> &TableState {
-        &self.active().table_state
+        self.active().focused_table_state()
     }
 
     pub fn active_table_state_mut(&mut self) -> &mut TableState {
-        &mut self.active_mut().table_state
+        self.active_mut().focused_table_state_mut()
+    }
+
+    pub fn active_project_table_state(&self) -> &ProjectTableState {
+        &self.active().project_table_state
+    }
+
+    pub fn active_project_table_state_mut(&mut self) -> &mut ProjectTableState {
+        &mut self.active_mut().project_table_state
+    }
+
+    pub fn active_source_search(&self) -> Option<&str> {
+        self.active().source_search()
     }
 
     /// The active View's address, if the active tab isn't broken.

--- a/crates/flotilla-tui/src/app/view_kind.rs
+++ b/crates/flotilla-tui/src/app/view_kind.rs
@@ -16,7 +16,10 @@ pub(crate) fn queries(address: &ViewAddress, source_search: Option<&str>) -> Vec
     match address {
         ViewAddress::Convoys { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. } => vec![QueryId::Convoys],
         ViewAddress::Project { namespace, name } => {
-            vec![QueryId::Convoys, QueryId::Issues { scope: QueryScope::new(namespace, name), search: None }]
+            vec![QueryId::Convoys, QueryId::Checkouts { scope: Some(QueryScope::new(namespace, name)) }, QueryId::Issues {
+                scope: QueryScope::new(namespace, name),
+                search: source_search.filter(|search| !search.is_empty()).map(str::to_owned),
+            }]
         }
         ViewAddress::Independents => vec![QueryId::Independents],
         ViewAddress::Issues { .. } | ViewAddress::Checkouts { .. } => {
@@ -54,13 +57,13 @@ pub(crate) fn kind_modes(address: Option<&ViewAddress>) -> Vec<BindingModeId> {
         Some(
             ViewAddress::Convoys { .. }
             | ViewAddress::Independents
-            | ViewAddress::Project { .. }
             | ViewAddress::Convoy { .. }
             | ViewAddress::Vessel { .. }
             | ViewAddress::Checkouts { .. },
         ) => {
             vec![BindingModeId::Convoys]
         }
+        Some(ViewAddress::Project { .. }) => vec![BindingModeId::Convoys, BindingModeId::DemandTable],
         Some(ViewAddress::Issues { .. }) => vec![BindingModeId::Convoys, BindingModeId::DemandTable],
         Some(ViewAddress::Repo { .. }) => vec![BindingModeId::Normal],
         None => vec![],
@@ -79,10 +82,11 @@ mod tests {
     #[test]
     fn project_view_composes_store_and_demand_backed_queries() {
         let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
-        assert_eq!(queries(&address, None), vec![QueryId::Convoys, QueryId::Issues {
-            scope: QueryScope::new("flotilla", "roadmap"),
-            search: None,
-        },]);
+        assert_eq!(queries(&address, None), vec![
+            QueryId::Convoys,
+            QueryId::Checkouts { scope: Some(QueryScope::new("flotilla", "roadmap")) },
+            QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None },
+        ]);
     }
 
     #[test]

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -109,14 +109,14 @@ pub struct ProjectTableState {
 
 impl Default for ProjectTableState {
     fn default() -> Self {
-        Self {
-            active: ProjectPanelKind::Convoys,
-            header_focused: false,
-            convoys: TableState::default(),
-            checkouts: TableState::default(),
-            issues: TableState::default(),
-            scroll_offset: 0,
-        }
+        Self::builder()
+            .active(ProjectPanelKind::Convoys)
+            .header_focused(false)
+            .convoys(TableState::default())
+            .checkouts(TableState::default())
+            .issues(TableState::default())
+            .scroll_offset(0)
+            .build()
     }
 }
 
@@ -139,6 +139,14 @@ impl ProjectTableState {
 
     pub fn focus_rows(&mut self) {
         self.header_focused = false;
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn set_scroll_offset(&mut self, offset: usize) {
+        self.scroll_offset = offset;
     }
 
     pub fn table(&self, kind: ProjectPanelKind) -> &TableState {
@@ -531,20 +539,21 @@ fn pending_project_table(address: &ViewAddress) -> TableView {
 }
 
 fn result_set_meta(state: &ResultSetState) -> TableMeta {
-    TableMeta {
-        as_of: state.demand.as_ref().map(|metadata| metadata.as_of),
-        has_more: state.demand.as_ref().is_some_and(|metadata| metadata.has_more),
-        conditions: state
-            .conditions
-            .iter()
-            .map(|condition| match condition {
-                ResultSetCondition::IssueSourceUnavailable { message, .. } | ResultSetCondition::QueryScopeUnavailable { message, .. } => {
-                    message.clone()
-                }
-            })
-            .collect(),
-        availability: TableAvailability::Ready,
-    }
+    TableMeta::builder()
+        .maybe_as_of(state.demand.as_ref().map(|metadata| metadata.as_of))
+        .has_more(state.demand.as_ref().is_some_and(|metadata| metadata.has_more))
+        .conditions(
+            state
+                .conditions
+                .iter()
+                .map(|condition| match condition {
+                    ResultSetCondition::IssueSourceUnavailable { message, .. }
+                    | ResultSetCondition::QueryScopeUnavailable { message, .. } => message.clone(),
+                })
+                .collect(),
+        )
+        .availability(TableAvailability::Ready)
+        .build()
 }
 
 fn find_convoy<'a>(convoys: &'a [&ConvoySummary], namespace: &str, name: &str) -> Result<&'a ConvoySummary, String> {

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -37,6 +37,10 @@ impl TableState {
         self.selected.as_ref()
     }
 
+    pub fn clear_selection(&mut self) {
+        self.selected = None;
+    }
+
     pub fn selected_index(&self, view: &TableView) -> Option<usize> {
         let selected = self.selected.as_ref()?;
         view.rows.iter().position(|row| &row.id == selected)
@@ -87,6 +91,82 @@ impl TableState {
     pub fn selected_row<'a>(&self, view: &'a TableView) -> Option<&'a ProjectedRow> {
         let selected = self.selected.as_ref()?;
         view.rows.iter().find(|row| &row.id == selected)
+    }
+}
+
+/// Cursor and transient search state for the fixed Project composition. Each
+/// panel keeps the same tab-local state a standalone table owns; the page
+/// cursor selects which panel participates in keyboard actions.
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
+pub struct ProjectTableState {
+    active: ProjectPanelKind,
+    header_focused: bool,
+    convoys: TableState,
+    checkouts: TableState,
+    issues: TableState,
+    pub scroll_offset: usize,
+}
+
+impl Default for ProjectTableState {
+    fn default() -> Self {
+        Self {
+            active: ProjectPanelKind::Convoys,
+            header_focused: false,
+            convoys: TableState::default(),
+            checkouts: TableState::default(),
+            issues: TableState::default(),
+            scroll_offset: 0,
+        }
+    }
+}
+
+impl ProjectTableState {
+    pub fn active(&self) -> ProjectPanelKind {
+        self.active
+    }
+
+    pub fn set_active(&mut self, kind: ProjectPanelKind) {
+        self.active = kind;
+    }
+
+    pub fn header_focused(&self) -> bool {
+        self.header_focused
+    }
+
+    pub fn focus_header(&mut self) {
+        self.header_focused = true;
+    }
+
+    pub fn focus_rows(&mut self) {
+        self.header_focused = false;
+    }
+
+    pub fn table(&self, kind: ProjectPanelKind) -> &TableState {
+        match kind {
+            ProjectPanelKind::Convoys => &self.convoys,
+            ProjectPanelKind::Checkouts => &self.checkouts,
+            ProjectPanelKind::Issues => &self.issues,
+        }
+    }
+
+    pub fn table_mut(&mut self, kind: ProjectPanelKind) -> &mut TableState {
+        match kind {
+            ProjectPanelKind::Convoys => &mut self.convoys,
+            ProjectPanelKind::Checkouts => &mut self.checkouts,
+            ProjectPanelKind::Issues => &mut self.issues,
+        }
+    }
+
+    pub fn active_table(&self) -> &TableState {
+        self.table(self.active)
+    }
+
+    pub fn active_table_mut(&mut self) -> &mut TableState {
+        self.table_mut(self.active)
+    }
+
+    pub fn issue_source_search(&self) -> Option<&str> {
+        self.issues.source_search.as_deref()
     }
 }
 
@@ -228,11 +308,36 @@ pub struct TableView {
     pub meta: TableMeta,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+/// One fixed panel in the Project composite View. The panel owns no layout or
+/// input policy: it is the same curated table projection a single-kind View
+/// renders, with the address its header expands into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectPanelKind {
+    Convoys,
+    Checkouts,
+    Issues,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectPanel {
+    pub kind: ProjectPanelKind,
+    pub target: ViewAddress,
+    pub table: TableView,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TableAvailability {
+    #[default]
+    Ready,
+    Loading,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, bon::Builder)]
 pub struct TableMeta {
     pub as_of: Option<Timestamp>,
     pub has_more: bool,
     pub conditions: Vec<String>,
+    pub availability: TableAvailability,
 }
 
 impl TableView {
@@ -273,12 +378,6 @@ struct ScopedIssueProjection {
     row: IssueRow,
 }
 
-#[derive(Clone)]
-enum ProjectProjection {
-    Convoy(ConvoySummary),
-    Issue { namespace: String, project: String, row: IssueRow },
-}
-
 /// Typed query rows currently available to the table registry. Surfaces build
 /// this once from their query caches; adding a query family grows this input
 /// without teaching the reusable widget about that family.
@@ -286,7 +385,6 @@ enum ProjectProjection {
 pub struct TableRows<'a> {
     pub convoys: Vec<&'a ConvoySummary>,
     pub independents: Vec<&'a IndependentRow>,
-    pub project_issues: Vec<(&'a str, &'a str, &'a IssueRow)>,
     pub issue_results: Vec<QueryRows<'a, IssueRow>>,
     pub checkout_results: Vec<QueryRows<'a, CheckoutRow>>,
     pub source_search: Option<&'a str>,
@@ -328,22 +426,7 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
             });
             Ok(independent_spec().project("Independents".to_string(), rows.into_iter().cloned()))
         }
-        ViewAddress::Project { namespace, name } => {
-            let mut rows = data
-                .convoys
-                .iter()
-                .copied()
-                .filter(|convoy| &convoy.namespace == namespace && convoy.project_ref.as_deref() == Some(name))
-                .cloned()
-                .map(ProjectProjection::Convoy)
-                .collect::<Vec<_>>();
-            rows.extend(
-                data.project_issues.iter().filter(|(row_namespace, project, _)| *row_namespace == namespace && *project == name).map(
-                    |(_, _, row)| ProjectProjection::Issue { namespace: namespace.clone(), project: name.clone(), row: (*row).clone() },
-                ),
-            );
-            Ok(project_spec().project(format!("Project · {name}"), rows))
-        }
+        ViewAddress::Project { .. } => Err(format!("project views are composite: {address}")),
         ViewAddress::Convoy { namespace, name } => {
             let convoy = find_convoy(&data.convoys, namespace, name)?;
             let rows = stable_topological_vessels(&convoy.vessels).into_iter().map(|vessel| VesselProjection {
@@ -400,6 +483,53 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
     }
 }
 
+/// The fixed v1 Project composition. Each entry deliberately reuses the
+/// standalone family projection so columns, row actions, result conditions,
+/// and future registry changes stay identical in the embedded panel.
+pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec<ProjectPanel>, String> {
+    let ViewAddress::Project { namespace, name } = address else {
+        return Err(format!("view is not project-backed: {address}"));
+    };
+    let scope = QueryScope::new(namespace, name);
+    let convoys = convoy_spec().project(
+        "Convoys".to_string(),
+        data.convoys
+            .iter()
+            .copied()
+            .filter(|convoy| &convoy.namespace == namespace && convoy.project_ref.as_deref() == Some(name))
+            .cloned(),
+    );
+    let checkouts_address = ViewAddress::Checkouts { scope: Some(scope.clone()) };
+    let issues_address = ViewAddress::Issues { scope };
+    let mut checkouts = project(&checkouts_address, data).unwrap_or_else(|_| pending_project_table(&checkouts_address));
+    let mut issues = project(&issues_address, data).unwrap_or_else(|_| pending_project_table(&issues_address));
+    checkouts.title = "Checkouts".to_string();
+    issues.title = "Issues".to_string();
+
+    Ok(vec![
+        ProjectPanel { kind: ProjectPanelKind::Convoys, target: ViewAddress::Convoys { namespace: namespace.clone() }, table: convoys },
+        ProjectPanel { kind: ProjectPanelKind::Checkouts, target: checkouts_address, table: checkouts },
+        ProjectPanel { kind: ProjectPanelKind::Issues, target: issues_address, table: issues },
+    ])
+}
+
+fn pending_project_table(address: &ViewAddress) -> TableView {
+    let mut table = match address {
+        ViewAddress::Checkouts { scope } => checkout_spec().project(
+            scope
+                .as_ref()
+                .map_or_else(|| "Checkouts · fleet".to_string(), |scope| format!("Checkouts · {}/{}", scope.namespace, scope.name)),
+            std::iter::empty::<CheckoutRow>(),
+        ),
+        ViewAddress::Issues { scope } => {
+            issue_spec().project(format!("Issues · {}/{}", scope.namespace, scope.name), std::iter::empty::<ScopedIssueProjection>())
+        }
+        _ => unreachable!("only demand-backed project panels can be pending"),
+    };
+    table.meta.availability = TableAvailability::Loading;
+    table
+}
+
 fn result_set_meta(state: &ResultSetState) -> TableMeta {
     TableMeta {
         as_of: state.demand.as_ref().map(|metadata| metadata.as_of),
@@ -413,6 +543,7 @@ fn result_set_meta(state: &ResultSetState) -> TableMeta {
                 }
             })
             .collect(),
+        availability: TableAvailability::Ready,
     }
 }
 
@@ -453,14 +584,6 @@ fn stable_topological_vessels(vessels: &[VesselSummary]) -> Vec<&VesselSummary> 
 
 fn convoy_spec() -> TableSpec<ConvoySummary> {
     TableSpec { columns: &CONVOY_COLUMNS, actions: &[], row: RowSpec { id: convoy_id, drill: convoy_drill, describe: convoy_description } }
-}
-
-fn project_spec() -> TableSpec<ProjectProjection> {
-    TableSpec {
-        columns: &PROJECT_COLUMNS,
-        actions: &PROJECT_ACTIONS,
-        row: RowSpec { id: project_row_id, drill: project_row_drill, describe: project_row_description },
-    }
 }
 
 fn vessel_spec() -> TableSpec<VesselProjection> {
@@ -527,61 +650,6 @@ static CONVOY_COLUMNS: [ColumnSpec<ConvoySummary>; 6] = [
         extract: |row| CellValue::plain(row.message.as_deref().unwrap_or_default()),
     },
 ];
-
-static PROJECT_COLUMNS: [ColumnSpec<ProjectProjection>; 4] = [
-    ColumnSpec {
-        id: "kind",
-        label: "KIND",
-        width: WidthHint::Fixed(8),
-        alignment: Alignment::Left,
-        extract: |row| {
-            CellValue::toned(
-                match row {
-                    ProjectProjection::Convoy(_) => "convoy",
-                    ProjectProjection::Issue { .. } => "issue",
-                },
-                CellTone::Muted,
-            )
-        },
-    },
-    ColumnSpec {
-        id: "name",
-        label: "WORK",
-        width: WidthHint::Flexible { minimum: 18, weight: 2 },
-        alignment: Alignment::Left,
-        extract: |row| {
-            CellValue::plain(match row {
-                ProjectProjection::Convoy(convoy) => convoy.name.clone(),
-                ProjectProjection::Issue { row, .. } => format!("{} · {}", row.reference.id, row.issue.title),
-            })
-        },
-    },
-    ColumnSpec {
-        id: "state",
-        label: "STATE",
-        width: WidthHint::Fixed(12),
-        alignment: Alignment::Left,
-        extract: |row| match row {
-            ProjectProjection::Convoy(convoy) => convoy_phase(convoy),
-            ProjectProjection::Issue { row, .. } => CellValue::plain(format!("{:?}", row.issue.state).to_lowercase()),
-        },
-    },
-    ColumnSpec {
-        id: "detail",
-        label: "DETAIL",
-        width: WidthHint::Flexible { minimum: 18, weight: 2 },
-        alignment: Alignment::Left,
-        extract: |row| {
-            CellValue::plain(match row {
-                ProjectProjection::Convoy(convoy) => convoy.message.clone().unwrap_or_default(),
-                ProjectProjection::Issue { row, .. } => row.issue.labels.join(", "),
-            })
-        },
-    },
-];
-
-static PROJECT_ACTIONS: [ActionSpec<ProjectProjection>; 1] =
-    [ActionSpec { id: "start", label: "Start convoy", key: 's', resolve: start_project_issue }];
 
 static VESSEL_COLUMNS: [ColumnSpec<VesselProjection>; 6] = [
     ColumnSpec {
@@ -745,46 +813,6 @@ static CHECKOUT_COLUMNS: [ColumnSpec<CheckoutRow>; 5] = [
 
 fn convoy_id(row: &ConvoySummary) -> RowId {
     RowId::new(row.id.as_str())
-}
-
-fn project_row_id(row: &ProjectProjection) -> RowId {
-    match row {
-        ProjectProjection::Convoy(convoy) => RowId::new(format!("convoy:{}", convoy.id.as_str())),
-        ProjectProjection::Issue { namespace, project, row } => RowId::new(format!(
-            "issue:{namespace}:{project}:{}:{}:{}",
-            row.reference.source.service, row.reference.source.scope, row.reference.id
-        )),
-    }
-}
-
-fn project_row_drill(row: &ProjectProjection) -> Option<ViewAddress> {
-    match row {
-        ProjectProjection::Convoy(convoy) => convoy_drill(convoy),
-        ProjectProjection::Issue { .. } => None,
-    }
-}
-
-fn project_row_description(row: &ProjectProjection) -> Vec<DetailField> {
-    match row {
-        ProjectProjection::Convoy(convoy) => convoy_description(convoy),
-        ProjectProjection::Issue { namespace, project, row } => vec![
-            DetailField { label: "Namespace", value: namespace.clone() },
-            DetailField { label: "Project", value: project.clone() },
-            DetailField { label: "Issue", value: row.reference.id.clone() },
-            DetailField { label: "Title", value: row.issue.title.clone() },
-            DetailField { label: "Source", value: format!("{} / {}", row.reference.source.service, row.reference.source.scope) },
-            DetailField { label: "As of", value: row.issue.as_of.to_rfc3339() },
-        ],
-    }
-}
-
-fn start_project_issue(row: &ProjectProjection) -> Option<TableIntent> {
-    match row {
-        ProjectProjection::Issue { namespace, project, row } => {
-            Some(TableIntent::StartConvoy { namespace: namespace.clone(), project: project.clone(), issue: row.reference.clone() })
-        }
-        ProjectProjection::Convoy(_) => None,
-    }
 }
 
 fn convoy_drill(row: &ConvoySummary) -> Option<ViewAddress> {
@@ -960,7 +988,6 @@ mod tests {
         project(&address.parse().expect("valid address"), &TableRows {
             convoys: convoys.to_vec(),
             independents: vec![],
-            project_issues: vec![],
             ..TableRows::default()
         })
     }
@@ -1042,15 +1069,12 @@ mod tests {
     }
 
     #[test]
-    fn project_and_vessel_addresses_scope_rows_without_changing_the_widget_contract() {
+    fn vessel_address_scopes_rows_without_changing_the_widget_contract() {
         let in_project = convoy(vec![vessel("implement", &[], WorkPhase::Running), vessel("review", &["implement"], WorkPhase::Pending)]);
         let mut elsewhere = convoy(vec![]);
         elsewhere.id = ConvoyId::new("dev", "elsewhere");
         elsewhere.name = "elsewhere".into();
         elsewhere.project_ref = Some("other".into());
-
-        let project_view = project_convoys("project/dev/flotilla", &[&in_project, &elsewhere]).expect("project table");
-        assert_eq!(project_view.rows.iter().map(|row| row.cells[1].text.as_str()).collect::<Vec<_>>(), vec!["tables"]);
 
         let vessel = project_convoys("vessel/dev/tables/review", &[&in_project, &elsewhere]).expect("vessel table");
         assert_eq!(vessel.rows.len(), 1);
@@ -1077,7 +1101,6 @@ mod tests {
         let view = project(&ViewAddress::Independents, &TableRows {
             convoys: vec![],
             independents: vec![&unavailable, &available],
-            project_issues: vec![],
             ..TableRows::default()
         })
         .expect("independents table");
@@ -1094,26 +1117,67 @@ mod tests {
     }
 
     #[test]
-    fn project_issue_row_exposes_one_start_convoy_action_with_the_qualified_reference() {
-        let issue = TestIssue::new("Start convoy from issue").id("ENG-ab12").build();
-        let row = IssueRow { reference: issue.reference.clone(), issue };
+    fn project_panels_compose_scoped_tables_in_convoys_checkouts_issues_order() {
+        let scope = QueryScope::new("flotilla", "roadmap");
+        let mut convoy = convoy(vec![vessel("implement", &[], WorkPhase::Running)]);
+        convoy.id = ConvoyId::new("flotilla", "tables");
+        convoy.namespace = "flotilla".into();
+        convoy.project_ref = Some("roadmap".into());
+        let checkout = CheckoutRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "roadmap"))
+            .repo(RepositoryKey("repo_flotilla".into()))
+            .path("/work/flotilla")
+            .branch("main")
+            .host(HostName::new("kiwi"))
+            .authority(LifecycleAuthority::Observed)
+            .build();
+        let issue = TestIssue::new("Composite project issue").id("ENG-42").build();
+        let issue_row = IssueRow { reference: issue.reference.clone(), issue };
+        let issue_query = QueryId::Issues { scope: scope.clone(), search: None };
+        let checkout_query = QueryId::Checkouts { scope: Some(scope.clone()) };
+        let state = ResultSetState::default();
         let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
 
-        let view = project(&address, &TableRows {
-            convoys: vec![],
-            independents: vec![],
-            project_issues: vec![("flotilla", "roadmap", &row)],
+        let panels = project_panels(&address, &TableRows {
+            convoys: vec![&convoy],
+            issue_results: vec![QueryRows { query: &issue_query, rows: std::slice::from_ref(&issue_row), state: &state }],
+            checkout_results: vec![QueryRows { query: &checkout_query, rows: std::slice::from_ref(&checkout), state: &state }],
             ..TableRows::default()
         })
-        .expect("project issue table");
+        .expect("project panels");
 
-        assert_eq!(view.rows.len(), 1);
-        assert_eq!(view.rows[0].actions, vec![AvailableAction {
-            id: "start",
-            label: "Start convoy",
-            key: 's',
-            intent: TableIntent::StartConvoy { namespace: "flotilla".into(), project: "roadmap".into(), issue: row.reference },
-        }]);
+        assert_eq!(panels.iter().map(|panel| panel.kind).collect::<Vec<_>>(), vec![
+            ProjectPanelKind::Convoys,
+            ProjectPanelKind::Checkouts,
+            ProjectPanelKind::Issues
+        ]);
+        assert_eq!(panels.iter().map(|panel| panel.target.to_string()).collect::<Vec<_>>(), vec![
+            "convoys/flotilla",
+            "checkouts?project=flotilla%2Froadmap",
+            "issues?project=flotilla%2Froadmap",
+        ]);
+        assert_eq!(panels[0].table.rows[0].cells[0].text, "tables");
+        assert_eq!(panels[1].table.rows[0].cells[1].text, "/work/flotilla");
+        assert_eq!(panels[2].table.rows[0].actions[0].intent, TableIntent::StartConvoy {
+            namespace: "flotilla".into(),
+            project: "roadmap".into(),
+            issue: issue_row.reference,
+        });
+    }
+
+    #[test]
+    fn project_panels_keep_available_content_while_scoped_results_are_loading() {
+        let mut convoy = convoy(vec![vessel("implement", &[], WorkPhase::Running)]);
+        convoy.id = ConvoyId::new("flotilla", "tables");
+        convoy.namespace = "flotilla".into();
+        convoy.project_ref = Some("roadmap".into());
+        let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+
+        let panels = project_panels(&address, &TableRows { convoys: vec![&convoy], ..TableRows::default() }).expect("project panels");
+
+        assert_eq!(panels[0].table.rows[0].cells[0].text, "tables");
+        assert_eq!(panels[1].table.meta.availability, TableAvailability::Loading);
+        assert_eq!(panels[2].table.meta.availability, TableAvailability::Loading);
     }
 
     #[test]
@@ -1131,7 +1195,6 @@ mod tests {
         let view = project(&address, &TableRows {
             convoys: vec![],
             independents: vec![],
-            project_issues: vec![],
             issue_results: vec![QueryRows { query: &query, rows: std::slice::from_ref(&row), state: &state }],
             ..TableRows::default()
         })
@@ -1191,21 +1254,15 @@ mod tests {
         second.id = ConvoyId::new("dev", "other");
         second.name = "other".into();
         let address = "convoys/dev".parse().expect("valid address");
-        let view = project(&address, &TableRows {
-            convoys: vec![&first, &second],
-            independents: vec![],
-            project_issues: vec![],
-            ..TableRows::default()
-        })
-        .expect("project table");
+        let view = project(&address, &TableRows { convoys: vec![&first, &second], independents: vec![], ..TableRows::default() })
+            .expect("project table");
         let mut state = TableState::default();
         state.reconcile(&view);
         state.select_delta(&view, 1);
         assert_eq!(state.selected_row(&view).map(|row| row.cells[0].text.as_str()), Some("other"));
 
         let changed =
-            project(&address, &TableRows { convoys: vec![&first], independents: vec![], project_issues: vec![], ..TableRows::default() })
-                .expect("project table");
+            project(&address, &TableRows { convoys: vec![&first], independents: vec![], ..TableRows::default() }).expect("project table");
         state.reconcile(&changed);
         assert_eq!(state.selected_row(&changed).map(|row| row.cells[0].text.as_str()), Some("tables"));
     }

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -104,7 +104,7 @@ pub struct ProjectTableState {
     convoys: TableState,
     checkouts: TableState,
     issues: TableState,
-    pub scroll_offset: usize,
+    scroll_offset: usize,
 }
 
 impl Default for ProjectTableState {

--- a/crates/flotilla-tui/src/widgets/mod.rs
+++ b/crates/flotilla-tui/src/widgets/mod.rs
@@ -11,6 +11,7 @@ pub mod help;
 pub mod issue_search;
 pub mod overview_page;
 pub mod preview_panel;
+pub mod project_page;
 pub mod repo_page;
 pub mod screen;
 pub mod section_table;

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -9,6 +9,7 @@ use super::{
     Outcome, RenderContext, WidgetContext,
 };
 use crate::{
+    app::{NamespaceMap, QueryTableCache},
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
     table_view::{self, ProjectPanel, ProjectPanelKind, ProjectTableState, RowId},
@@ -56,20 +57,26 @@ impl ProjectPageWidget {
             .collect()
     }
 
+    fn project_panels(
+        address: &ViewAddress,
+        namespaces: &NamespaceMap,
+        query_tables: &QueryTableCache,
+        state: &ProjectTableState,
+    ) -> Result<Vec<ProjectPanel>, String> {
+        let rows = crate::app::table_rows(namespaces, query_tables, state.issue_source_search());
+        Self::filtered_panels(address, &rows, state)
+    }
+
     fn panels(ctx: &WidgetContext<'_>) -> Result<Vec<ProjectPanel>, String> {
         let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
         let state = ctx.views.active_project_table_state();
-        let source_search = state.issue_source_search();
-        let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
-        Self::filtered_panels(address, &rows, state)
+        Self::project_panels(address, ctx.namespaces, ctx.query_tables, state)
     }
 
     fn render_panels(ctx: &RenderContext<'_>) -> Result<Vec<ProjectPanel>, String> {
         let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
         let state = ctx.views.active_project_table_state();
-        let source_search = state.issue_source_search();
-        let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
-        Self::filtered_panels(address, &rows, state)
+        Self::project_panels(address, ctx.namespaces, ctx.query_tables, state)
     }
 
     fn layouts(panels: &[ProjectPanel]) -> Vec<PanelLayout<'_>> {
@@ -89,7 +96,7 @@ impl ProjectPageWidget {
     }
 
     fn line_area(&self, content_line: usize, state: &ProjectTableState) -> Option<Rect> {
-        let visible = content_line.checked_sub(state.scroll_offset)?;
+        let visible = content_line.checked_sub(state.scroll_offset())?;
         (visible < self.area.height as usize).then_some(Rect { y: self.area.y + visible as u16, height: 1, ..self.area })
     }
 
@@ -109,13 +116,13 @@ impl ProjectPageWidget {
         };
         let visible = self.area.height as usize;
         if visible == 0 {
-            state.scroll_offset = 0;
-        } else if line < state.scroll_offset {
-            state.scroll_offset = line;
-        } else if line >= state.scroll_offset.saturating_add(visible) {
-            state.scroll_offset = line + 1 - visible;
+            state.set_scroll_offset(0);
+        } else if line < state.scroll_offset() {
+            state.set_scroll_offset(line);
+        } else if line >= state.scroll_offset().saturating_add(visible) {
+            state.set_scroll_offset(line + 1 - visible);
         }
-        state.scroll_offset = state.scroll_offset.min(Self::content_height(layouts).saturating_sub(visible));
+        state.set_scroll_offset(state.scroll_offset().min(Self::content_height(layouts).saturating_sub(visible)));
     }
 
     fn select_delta(layouts: &[PanelLayout<'_>], state: &mut ProjectTableState, delta: isize) {
@@ -223,8 +230,8 @@ impl ProjectPageWidget {
             if let Some(columns_area) = self.line_area(layout.columns_line, state) {
                 super::table::TablePanel::render_header(frame, columns_area, theme, &layout.panel.table);
             }
-            let first = state.scroll_offset.saturating_sub(layout.rows_start);
-            let visible_end = state.scroll_offset.saturating_add(area.height as usize);
+            let first = state.scroll_offset().saturating_sub(layout.rows_start);
+            let visible_end = state.scroll_offset().saturating_add(area.height as usize);
             let end = layout.rows_end().min(visible_end);
             if first < layout.panel.table.rows.len() && end > layout.rows_start.saturating_add(first) {
                 let count = end - layout.rows_start - first;
@@ -337,7 +344,7 @@ impl InteractiveWidget for ProjectPageWidget {
         }
         let Ok(panels) = Self::panels(ctx) else { return Outcome::Ignored };
         let layouts = Self::layouts(&panels);
-        let line = ctx.views.active_project_table_state().scroll_offset + (mouse.row - self.area.y) as usize;
+        let line = ctx.views.active_project_table_state().scroll_offset() + (mouse.row - self.area.y) as usize;
         match mouse.kind {
             MouseEventKind::ScrollDown => return self.handle_action(Action::SelectNext, ctx),
             MouseEventKind::ScrollUp => return self.handle_action(Action::SelectPrev, ctx),

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -1,0 +1,515 @@
+use std::time::{Duration, Instant};
+
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use flotilla_protocol::{QueryId, ViewAddress};
+use ratatui::{layout::Rect, style::Modifier, widgets::Paragraph, Frame};
+
+use super::{
+    describe::DescribeWidget, table_action_menu::TableActionMenuWidget, table_search::TableSearchWidget, AppAction, InteractiveWidget,
+    Outcome, RenderContext, WidgetContext,
+};
+use crate::{
+    binding_table::{BindingModeId, KeyBindingMode},
+    keymap::Action,
+    table_view::{self, ProjectPanel, ProjectPanelKind, ProjectTableState, RowId},
+    theme::Theme,
+};
+
+const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(500);
+
+#[derive(bon::Builder)]
+struct PanelLayout<'a> {
+    panel: &'a ProjectPanel,
+    header_line: usize,
+    columns_line: usize,
+    rows_start: usize,
+}
+
+impl<'a> PanelLayout<'a> {
+    fn rows_end(&self) -> usize {
+        self.rows_start + self.panel.table.rows.len()
+    }
+}
+
+#[derive(Default)]
+pub struct ProjectPageWidget {
+    area: Rect,
+    last_click: Option<(ProjectPanelKind, RowId, Instant)>,
+}
+
+impl ProjectPageWidget {
+    fn filtered_panels(
+        address: &ViewAddress,
+        rows: &table_view::TableRows<'_>,
+        state: &ProjectTableState,
+    ) -> Result<Vec<ProjectPanel>, String> {
+        table_view::project_panels(address, rows).map(|panels| Self::apply_filters(panels, state))
+    }
+
+    fn apply_filters(panels: Vec<ProjectPanel>, state: &ProjectTableState) -> Vec<ProjectPanel> {
+        panels
+            .into_iter()
+            .map(|mut panel| {
+                panel.table = panel.table.filtered(&state.table(panel.kind).filter);
+                panel
+            })
+            .collect()
+    }
+
+    fn panels(ctx: &WidgetContext<'_>) -> Result<Vec<ProjectPanel>, String> {
+        let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
+        let state = ctx.views.active_project_table_state();
+        let source_search = state.issue_source_search();
+        let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
+        Self::filtered_panels(address, &rows, state)
+    }
+
+    fn render_panels(ctx: &RenderContext<'_>) -> Result<Vec<ProjectPanel>, String> {
+        let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
+        let state = ctx.views.active_project_table_state();
+        let source_search = state.issue_source_search();
+        let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
+        Self::filtered_panels(address, &rows, state)
+    }
+
+    fn layouts(panels: &[ProjectPanel]) -> Vec<PanelLayout<'_>> {
+        let mut next = 0;
+        panels
+            .iter()
+            .map(|panel| {
+                let layout = PanelLayout::builder().panel(panel).header_line(next).columns_line(next + 1).rows_start(next + 2).build();
+                next = layout.rows_end() + 1;
+                layout
+            })
+            .collect()
+    }
+
+    fn content_height(layouts: &[PanelLayout<'_>]) -> usize {
+        layouts.last().map_or(0, |layout| layout.rows_end())
+    }
+
+    fn line_area(&self, content_line: usize, state: &ProjectTableState) -> Option<Rect> {
+        let visible = content_line.checked_sub(state.scroll_offset)?;
+        (visible < self.area.height as usize).then_some(Rect { y: self.area.y + visible as u16, height: 1, ..self.area })
+    }
+
+    fn reconcile(layouts: &[PanelLayout<'_>], state: &mut ProjectTableState) {
+        for layout in layouts {
+            state.table_mut(layout.panel.kind).reconcile(&layout.panel.table);
+        }
+    }
+
+    fn ensure_active_visible(&self, layouts: &[PanelLayout<'_>], state: &mut ProjectTableState) {
+        let Some(layout) = layouts.iter().find(|layout| layout.panel.kind == state.active()) else { return };
+        let selected = state.table(layout.panel.kind).selected_index(&layout.panel.table);
+        let line = if state.header_focused() {
+            layout.header_line
+        } else {
+            selected.map_or(layout.header_line, |selected| layout.rows_start + selected)
+        };
+        let visible = self.area.height as usize;
+        if visible == 0 {
+            state.scroll_offset = 0;
+        } else if line < state.scroll_offset {
+            state.scroll_offset = line;
+        } else if line >= state.scroll_offset.saturating_add(visible) {
+            state.scroll_offset = line + 1 - visible;
+        }
+        state.scroll_offset = state.scroll_offset.min(Self::content_height(layouts).saturating_sub(visible));
+    }
+
+    fn select_delta(layouts: &[PanelLayout<'_>], state: &mut ProjectTableState, delta: isize) {
+        let Some(index) = layouts.iter().position(|layout| layout.panel.kind == state.active()) else { return };
+        let current = &layouts[index];
+        if state.header_focused() && delta > 0 && !current.panel.table.rows.is_empty() {
+            state.focus_rows();
+            state.table_mut(current.panel.kind).select_index(&current.panel.table, 0);
+            return;
+        }
+        let selected = state.table(current.panel.kind).selected_index(&current.panel.table).unwrap_or(0);
+        let last = current.panel.table.rows.len().saturating_sub(1);
+        if !state.header_focused() && delta > 0 && selected < last {
+            state.table_mut(current.panel.kind).select_delta(&current.panel.table, 1);
+            return;
+        }
+        if !state.header_focused() && delta < 0 && selected > 0 {
+            state.table_mut(current.panel.kind).select_delta(&current.panel.table, -1);
+            return;
+        }
+        if !state.header_focused() && delta < 0 {
+            state.focus_header();
+            return;
+        }
+        let mut indices: Box<dyn Iterator<Item = usize>> =
+            if delta > 0 { Box::new(index.saturating_add(1)..layouts.len()) } else { Box::new((0..index).rev()) };
+        if let Some(candidate) = indices.next() {
+            let next = &layouts[candidate];
+            state.set_active(next.panel.kind);
+            state.table_mut(next.panel.kind).reconcile(&next.panel.table);
+            if delta < 0 && !next.panel.table.rows.is_empty() {
+                state.focus_rows();
+                let last = next.panel.table.rows.len() - 1;
+                state.table_mut(next.panel.kind).select_index(&next.panel.table, last);
+            } else {
+                state.focus_header();
+            }
+        }
+    }
+
+    fn fetch_more_query(layouts: &[PanelLayout<'_>], state: &ProjectTableState, trigger: super::table::FetchTrigger) -> Option<QueryId> {
+        let layout = layouts.iter().find(|layout| layout.panel.kind == state.active())?;
+        if layout.panel.kind != ProjectPanelKind::Issues
+            || !super::table::TablePanel::should_fetch_more(&layout.panel.table, state.table(layout.panel.kind), trigger)
+        {
+            return None;
+        }
+        let ViewAddress::Issues { scope } = &layout.panel.target else { return None };
+        Some(QueryId::Issues {
+            scope: scope.clone(),
+            search: state.issue_source_search().filter(|search| !search.is_empty()).map(str::to_owned),
+        })
+    }
+
+    fn active_row<'a>(
+        layouts: &'a [PanelLayout<'a>],
+        state: &'a ProjectTableState,
+    ) -> Option<(&'a ProjectPanel, &'a table_view::ProjectedRow)> {
+        let layout = layouts.iter().find(|layout| layout.panel.kind == state.active())?;
+        if state.header_focused() {
+            return None;
+        }
+        state.table(layout.panel.kind).selected_row(&layout.panel.table).map(|row| (layout.panel, row))
+    }
+
+    fn active_action(layouts: &[PanelLayout<'_>], state: &ProjectTableState) -> Option<AppAction> {
+        if state.header_focused() {
+            return layouts
+                .iter()
+                .find(|layout| layout.panel.kind == state.active())
+                .map(|layout| AppAction::DrillView(layout.panel.target.clone()));
+        }
+        Self::active_row(layouts, state).and_then(|(_, row)| super::table::TablePanel::row_action(row))
+    }
+
+    fn render_composite(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, panels: &[ProjectPanel], state: &mut ProjectTableState) {
+        self.area = area;
+        let layouts = Self::layouts(panels);
+        Self::reconcile(&layouts, state);
+        self.ensure_active_visible(&layouts, state);
+        for layout in &layouts {
+            if let Some(header_area) = self.line_area(layout.header_line, state) {
+                let mut label = format!(" {}  › {}", layout.panel.table.title, layout.panel.target);
+                if let Some(as_of) = layout.panel.table.meta.as_of {
+                    label.push_str(&format!(" · as of {}", as_of.format("%Y-%m-%d %H:%M")));
+                }
+                if layout.panel.table.meta.has_more {
+                    label.push_str(" · more available");
+                }
+                if layout.panel.table.meta.availability == table_view::TableAvailability::Loading {
+                    label.push_str(" · loading");
+                }
+                if !layout.panel.table.meta.conditions.is_empty() {
+                    label.push_str(&format!(" · ⚠ {}", layout.panel.table.meta.conditions.join("; ")));
+                }
+                let style = if state.active() == layout.panel.kind && state.header_focused() {
+                    theme.header_style().add_modifier(Modifier::BOLD | Modifier::REVERSED)
+                } else if state.active() == layout.panel.kind {
+                    theme.header_style().add_modifier(Modifier::BOLD)
+                } else {
+                    theme.header_style()
+                };
+                frame.render_widget(Paragraph::new(label).style(style), header_area);
+            }
+            if let Some(columns_area) = self.line_area(layout.columns_line, state) {
+                super::table::TablePanel::render_header(frame, columns_area, theme, &layout.panel.table);
+            }
+            let first = state.scroll_offset.saturating_sub(layout.rows_start);
+            let visible_end = state.scroll_offset.saturating_add(area.height as usize);
+            let end = layout.rows_end().min(visible_end);
+            if first < layout.panel.table.rows.len() && end > layout.rows_start.saturating_add(first) {
+                let count = end - layout.rows_start - first;
+                if let Some(rows_area) = self.line_area(layout.rows_start + first, state) {
+                    let rows_area = Rect { height: count as u16, ..rows_area };
+                    let mut unfocused_state = state.table(layout.panel.kind).clone();
+                    if state.active() == layout.panel.kind && state.header_focused() {
+                        unfocused_state.clear_selection();
+                    }
+                    super::table::TablePanel::render_rows(frame, rows_area, theme, &layout.panel.table, &unfocused_state, first, count);
+                }
+            }
+        }
+    }
+}
+
+impl InteractiveWidget for ProjectPageWidget {
+    fn handle_action(&mut self, action: Action, ctx: &mut WidgetContext) -> Outcome {
+        let Ok(panels) = Self::panels(ctx) else { return Outcome::Ignored };
+        let layouts = Self::layouts(&panels);
+        Self::reconcile(&layouts, ctx.views.active_project_table_state_mut());
+        match action {
+            Action::OpenTableFilter => {
+                return Outcome::Push(Box::new(TableSearchWidget::local(&ctx.views.active_table_state().filter)));
+            }
+            Action::OpenSourceSearch => {
+                let state = ctx.views.active_project_table_state();
+                if state.active() != ProjectPanelKind::Issues {
+                    ctx.app_actions.push(AppAction::ShowStatus("Source search is only available for the Issues panel".into()));
+                    return Outcome::Consumed;
+                }
+                let Some(panel) = panels.iter().find(|panel| panel.kind == ProjectPanelKind::Issues) else { return Outcome::Consumed };
+                let ViewAddress::Issues { scope } = &panel.target else { return Outcome::Consumed };
+                return Outcome::Push(Box::new(TableSearchWidget::source(
+                    state.issue_source_search(),
+                    &format!("{}/{}", scope.namespace, scope.name),
+                )));
+            }
+            Action::Dismiss
+                if ctx.views.active_project_table_state().active() == ProjectPanelKind::Issues
+                    && ctx.views.active_project_table_state().active_table().source_search.is_some() =>
+            {
+                ctx.app_actions.push(AppAction::SetSourceSearch(None));
+                return Outcome::Consumed;
+            }
+            _ => {}
+        }
+        match action {
+            Action::SelectNext => {
+                let query = {
+                    let state = ctx.views.active_project_table_state_mut();
+                    Self::select_delta(&layouts, state, 1);
+                    let query = Self::fetch_more_query(&layouts, state, super::table::FetchTrigger::NearBottom);
+                    self.ensure_active_visible(&layouts, state);
+                    query
+                };
+                if let Some(query) = query {
+                    ctx.app_actions.push(AppAction::FetchMore(query));
+                }
+                Outcome::Consumed
+            }
+            Action::SelectPrev => {
+                let state = ctx.views.active_project_table_state_mut();
+                Self::select_delta(&layouts, state, -1);
+                self.ensure_active_visible(&layouts, state);
+                Outcome::Consumed
+            }
+            Action::Confirm => {
+                let action = Self::active_action(&layouts, ctx.views.active_project_table_state());
+                if let Some(action) = action {
+                    ctx.app_actions.push(action);
+                }
+                Outcome::Consumed
+            }
+            Action::Dismiss => {
+                ctx.app_actions.push(AppAction::BackView);
+                Outcome::Consumed
+            }
+            Action::FetchMore => {
+                if let Some(query) =
+                    Self::fetch_more_query(&layouts, ctx.views.active_project_table_state(), super::table::FetchTrigger::Explicit)
+                {
+                    ctx.app_actions.push(AppAction::FetchMore(query));
+                }
+                Outcome::Consumed
+            }
+            Action::Describe => match Self::active_row(&layouts, ctx.views.active_project_table_state()) {
+                Some((panel, row)) => Outcome::Push(Box::new(DescribeWidget::new(panel.table.title.clone(), row.describe.clone()))),
+                None => Outcome::Consumed,
+            },
+            Action::OpenActionMenu => match Self::active_row(&layouts, ctx.views.active_project_table_state()) {
+                Some((_, row)) if !row.actions.is_empty() => Outcome::Push(Box::new(TableActionMenuWidget::new(row.actions.clone()))),
+                Some(_) => {
+                    ctx.app_actions.push(AppAction::ShowStatus("No actions available for the selected row".into()));
+                    Outcome::Consumed
+                }
+                None => Outcome::Consumed,
+            },
+            _ => Outcome::Ignored,
+        }
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent, ctx: &mut WidgetContext) -> Outcome {
+        if mouse.column < self.area.x
+            || mouse.column >= self.area.x.saturating_add(self.area.width)
+            || mouse.row < self.area.y
+            || mouse.row >= self.area.y.saturating_add(self.area.height)
+        {
+            return Outcome::Ignored;
+        }
+        let Ok(panels) = Self::panels(ctx) else { return Outcome::Ignored };
+        let layouts = Self::layouts(&panels);
+        let line = ctx.views.active_project_table_state().scroll_offset + (mouse.row - self.area.y) as usize;
+        match mouse.kind {
+            MouseEventKind::ScrollDown => return self.handle_action(Action::SelectNext, ctx),
+            MouseEventKind::ScrollUp => return self.handle_action(Action::SelectPrev, ctx),
+            MouseEventKind::Down(MouseButton::Left | MouseButton::Right) => {}
+            _ => return Outcome::Ignored,
+        }
+        let Some(layout) =
+            layouts.iter().find(|layout| line == layout.header_line || (line >= layout.rows_start && line < layout.rows_end()))
+        else {
+            return Outcome::Ignored;
+        };
+        if line == layout.header_line {
+            ctx.app_actions.push(AppAction::DrillView(layout.panel.target.clone()));
+            return Outcome::Consumed;
+        }
+        let row_index = line - layout.rows_start;
+        let query = {
+            let state = ctx.views.active_project_table_state_mut();
+            state.set_active(layout.panel.kind);
+            state.focus_rows();
+            state.table_mut(layout.panel.kind).select_index(&layout.panel.table, row_index);
+            Self::fetch_more_query(&layouts, state, super::table::FetchTrigger::NearBottom)
+        };
+        if let Some(query) = query {
+            ctx.app_actions.push(AppAction::FetchMore(query));
+        }
+        let row = &layout.panel.table.rows[row_index];
+        if mouse.kind == MouseEventKind::Down(MouseButton::Right) {
+            return if row.actions.is_empty() {
+                ctx.app_actions.push(AppAction::ShowStatus("No actions available for the selected row".into()));
+                Outcome::Consumed
+            } else {
+                Outcome::Push(Box::new(TableActionMenuWidget::new(row.actions.clone())))
+            };
+        }
+        let now = Instant::now();
+        let double_click = self
+            .last_click
+            .as_ref()
+            .is_some_and(|(kind, id, at)| *kind == layout.panel.kind && id == &row.id && now.duration_since(*at) <= DOUBLE_CLICK_WINDOW);
+        self.last_click = Some((layout.panel.kind, row.id.clone(), now));
+        if double_click {
+            self.last_click = None;
+            if let Some(action) = super::table::TablePanel::row_action(row) {
+                ctx.app_actions.push(action);
+            }
+        }
+        Outcome::Consumed
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: &mut RenderContext) {
+        let Ok(panels) = Self::render_panels(ctx) else { return };
+        self.render_composite(frame, area, ctx.theme, &panels, ctx.views.active_project_table_state_mut());
+    }
+
+    fn binding_mode(&self) -> KeyBindingMode {
+        BindingModeId::Convoys.into()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{backend::TestBackend, Terminal};
+
+    use super::*;
+    use crate::table_view::{Alignment, CellTone, CellValue, ProjectedColumn, ProjectedRow, TableMeta, TableView, WidthHint};
+
+    fn panel(kind: ProjectPanelKind, title: &str, target: &str, row: &str) -> ProjectPanel {
+        ProjectPanel {
+            kind,
+            target: target.parse().expect("valid address"),
+            table: TableView {
+                title: title.into(),
+                columns: vec![ProjectedColumn {
+                    id: "name",
+                    label: "NAME",
+                    width: WidthHint::Flexible { minimum: 8, weight: 1 },
+                    alignment: Alignment::Left,
+                }],
+                rows: vec![ProjectedRow {
+                    id: RowId::new(row),
+                    cells: vec![CellValue { text: row.into(), tone: CellTone::Plain }],
+                    drill: None,
+                    describe: vec![],
+                    actions: vec![],
+                }],
+                meta: TableMeta::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn composite_renders_the_three_panels_as_one_stacked_page() {
+        let panels = vec![
+            panel(ProjectPanelKind::Convoys, "Convoys", "convoys/flotilla", "convoy-a"),
+            panel(ProjectPanelKind::Checkouts, "Checkouts", "checkouts?project=flotilla%2Froadmap", "checkout-a"),
+            panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "issue-a"),
+        ];
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).expect("terminal");
+        let mut widget = ProjectPageWidget::default();
+        let mut state = ProjectTableState::default();
+        terminal.draw(|frame| widget.render_composite(frame, frame.area(), &Theme::classic(), &panels, &mut state)).expect("render");
+
+        let rendered = terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect::<String>();
+        let convoy = rendered.find("Convoys").expect("convoys header");
+        let checkout = rendered.find("Checkouts").expect("checkouts header");
+        let issue = rendered.find("Issues").expect("issues header");
+        assert!(convoy < checkout && checkout < issue, "panels should retain the fixed v1 order");
+        assert!(rendered.contains("convoy-a"));
+        assert!(rendered.contains("checkout-a"));
+        assert!(rendered.contains("issue-a"));
+    }
+
+    #[test]
+    fn empty_issue_panel_can_be_selected_and_expanded_or_fetched() {
+        let mut panels = vec![
+            panel(ProjectPanelKind::Convoys, "Convoys", "convoys/flotilla", "convoy-a"),
+            panel(ProjectPanelKind::Checkouts, "Checkouts", "checkouts?project=flotilla%2Froadmap", "checkout-a"),
+            panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "placeholder"),
+        ];
+        panels[2].table.rows.clear();
+        panels[2].table.meta.has_more = true;
+        let layouts = ProjectPageWidget::layouts(&panels);
+        let mut state = ProjectTableState::default();
+        state.set_active(ProjectPanelKind::Checkouts);
+
+        ProjectPageWidget::select_delta(&layouts, &mut state, 1);
+
+        assert_eq!(state.active(), ProjectPanelKind::Issues);
+        assert!(ProjectPageWidget::fetch_more_query(&layouts, &state, crate::widgets::table::FetchTrigger::Explicit).is_some());
+        assert!(matches!(ProjectPageWidget::active_action(&layouts, &state), Some(AppAction::DrillView(ViewAddress::Issues { .. }))));
+    }
+
+    #[test]
+    fn populated_panel_header_is_keyboard_focusable_and_expands_independently_of_rows() {
+        let panels = vec![
+            panel(ProjectPanelKind::Convoys, "Convoys", "convoys/flotilla", "convoy-a"),
+            panel(ProjectPanelKind::Checkouts, "Checkouts", "checkouts?project=flotilla%2Froadmap", "checkout-a"),
+            panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "issue-a"),
+        ];
+        let layouts = ProjectPageWidget::layouts(&panels);
+        let mut state = ProjectTableState::default();
+        ProjectPageWidget::reconcile(&layouts, &mut state);
+
+        ProjectPageWidget::select_delta(&layouts, &mut state, -1);
+
+        assert!(state.header_focused());
+        assert!(matches!(ProjectPageWidget::active_action(&layouts, &state), Some(AppAction::DrillView(ViewAddress::Convoys { .. }))));
+    }
+
+    #[test]
+    fn each_panel_keeps_its_own_local_filter() {
+        let panels = vec![
+            panel(ProjectPanelKind::Convoys, "Convoys", "convoys/flotilla", "convoy-a"),
+            panel(ProjectPanelKind::Checkouts, "Checkouts", "checkouts?project=flotilla%2Froadmap", "checkout-a"),
+            panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "issue-a"),
+        ];
+        let mut state = ProjectTableState::default();
+        state.table_mut(ProjectPanelKind::Checkouts).filter = "missing".into();
+
+        let panels = ProjectPageWidget::apply_filters(panels, &state);
+
+        assert_eq!(panels[0].table.rows.len(), 1);
+        assert!(panels[1].table.rows.is_empty());
+        assert_eq!(panels[2].table.rows.len(), 1);
+    }
+}

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -11,6 +11,7 @@ use ratatui::{
 
 use super::{
     overview_page::OverviewPage,
+    project_page::ProjectPageWidget,
     repo_page::RepoPage,
     status_bar_widget::{self, StatusBarWidget},
     table::TableWidget,
@@ -30,6 +31,7 @@ use crate::{
 enum ActivePage {
     Overview,
     Table,
+    Project,
     Repo(RepoIdentity),
     /// A repo view whose repo is no longer tracked, or an address that
     /// failed to parse: renders its own error, handles only shell actions.
@@ -57,6 +59,7 @@ pub struct Screen {
     pub repo_pages: HashMap<RepoIdentity, RepoPage>,
     pub overview_page: OverviewPage,
     pub table: TableWidget,
+    pub project_page: ProjectPageWidget,
 }
 
 impl Default for Screen {
@@ -74,6 +77,7 @@ impl Screen {
             repo_pages: HashMap::new(),
             overview_page: OverviewPage::new(),
             table: TableWidget::default(),
+            project_page: ProjectPageWidget::default(),
         }
     }
 
@@ -120,12 +124,12 @@ impl Screen {
             ViewTarget::View(
                 ViewAddress::Convoys { .. }
                 | ViewAddress::Independents
-                | ViewAddress::Project { .. }
                 | ViewAddress::Convoy { .. }
                 | ViewAddress::Vessel { .. }
                 | ViewAddress::Issues { .. }
                 | ViewAddress::Checkouts { .. },
             ) => ActivePage::Table,
+            ViewTarget::View(ViewAddress::Project { .. }) => ActivePage::Project,
             ViewTarget::View(ViewAddress::Repo { identity, .. }) => {
                 if repos.contains_key(identity) {
                     ActivePage::Repo(identity.clone())
@@ -240,6 +244,14 @@ impl InteractiveWidget for Screen {
                     outcome
                 }
             }
+            ActivePage::Project => {
+                let outcome = self.project_page.handle_action(action, ctx);
+                if matches!(outcome, Outcome::Ignored) {
+                    Self::fallback_page_action(action, ctx)
+                } else {
+                    outcome
+                }
+            }
             ActivePage::Error { .. } => Self::fallback_page_action(action, ctx),
             ActivePage::Repo(identity) => match self.repo_pages.get_mut(&identity) {
                 Some(page) => page.handle_action(action, ctx),
@@ -267,7 +279,7 @@ impl InteractiveWidget for Screen {
         // No modal — dispatch to the active View's page
         let outcome = match self.active_page(ctx.views.active(), &ctx.model.repos) {
             ActivePage::Overview => self.overview_page.handle_raw_key(key, ctx),
-            ActivePage::Table | ActivePage::Error { .. } => Outcome::Ignored,
+            ActivePage::Table | ActivePage::Project | ActivePage::Error { .. } => Outcome::Ignored,
             ActivePage::Repo(identity) => match self.repo_pages.get_mut(&identity) {
                 Some(page) => page.handle_raw_key(key, ctx),
                 None => Outcome::Ignored,
@@ -339,6 +351,7 @@ impl InteractiveWidget for Screen {
         let outcome = match self.active_page(ctx.views.active(), &ctx.model.repos) {
             ActivePage::Overview => self.overview_page.handle_mouse(mouse, ctx),
             ActivePage::Table => self.table.handle_mouse(mouse, ctx),
+            ActivePage::Project => self.project_page.handle_mouse(mouse, ctx),
             ActivePage::Error { .. } => Outcome::Ignored,
             ActivePage::Repo(identity) => match self.repo_pages.get_mut(&identity) {
                 Some(page) => page.handle_mouse(mouse, ctx),
@@ -383,6 +396,7 @@ impl InteractiveWidget for Screen {
                     Err(detail) => Self::render_error_page(frame, chunks[1], ctx.theme, "table view unavailable", &detail),
                 }
             }
+            ActivePage::Project => self.project_page.render(frame, chunks[1], ctx),
             ActivePage::Overview => self.overview_page.render(frame, chunks[1], ctx),
             ActivePage::Repo(identity) => {
                 let identity = identity.clone();
@@ -421,7 +435,7 @@ impl InteractiveWidget for Screen {
                     Some(page) => (view_kind::compose_with_shell(scoped, page.binding_mode().modes()), page.status_fragment()),
                     None => (view_kind::compose_with_shell(scoped, []), StatusFragment::default()),
                 },
-                ActivePage::Table => (view_kind::binding_mode(address, scoped), StatusFragment::default()),
+                ActivePage::Table | ActivePage::Project => (view_kind::binding_mode(address, scoped), StatusFragment::default()),
                 ActivePage::Error { .. } => (view_kind::compose_with_shell(scoped, []), StatusFragment::default()),
             }
         };

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -22,9 +22,63 @@ use crate::{
 const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(500);
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum FetchTrigger {
+pub(crate) enum FetchTrigger {
     NearBottom,
     Explicit,
+}
+
+/// Reusable presentation and interaction policy for a curated table embedded
+/// in any surface. `TableWidget` adds its border and breadcrumbs; the Project
+/// page composes several panels into its one scrolling document.
+pub(crate) struct TablePanel;
+
+impl TablePanel {
+    pub(crate) fn row_action(row: &table_view::ProjectedRow) -> Option<AppAction> {
+        if let Some(target) = row.drill.clone() {
+            Some(AppAction::DrillView(target))
+        } else if let [action] = row.actions.as_slice() {
+            Some(AppAction::ExecuteTableIntent(action.intent.clone()))
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn should_fetch_more(view: &TableView, state: &table_view::TableState, trigger: FetchTrigger) -> bool {
+        view.meta.has_more
+            && (trigger == FetchTrigger::Explicit || view.rows.len().saturating_sub(state.selected_index(view).unwrap_or(0) + 1) <= 5)
+    }
+
+    pub(crate) fn render_header(frame: &mut Frame, area: Rect, theme: &Theme, view: &TableView) {
+        let header =
+            Row::new(view.columns.iter().map(|column| Cell::from(Line::from(column.label).alignment(ratatui_alignment(column.alignment)))))
+                .style(theme.header_style());
+        let widths = width_constraints(&view.columns, area.width);
+        frame.render_widget(Table::new(Vec::<Row>::new(), widths).header(header).column_spacing(1), area);
+    }
+
+    pub(crate) fn render_rows(
+        frame: &mut Frame,
+        area: Rect,
+        theme: &Theme,
+        view: &TableView,
+        state: &table_view::TableState,
+        first: usize,
+        count: usize,
+    ) {
+        if count == 0 {
+            return;
+        }
+        let rows = view.rows.iter().skip(first).take(count).map(|row| {
+            let selected = state.selected() == Some(&row.id);
+            let cells = row.cells.iter().zip(&view.columns).map(|(cell, column)| {
+                Cell::from(Line::from(cell.text.clone()).alignment(ratatui_alignment(column.alignment))).style(cell_style(cell.tone, theme))
+            });
+            let style = if selected { Style::default().bg(theme.row_highlight).add_modifier(Modifier::BOLD) } else { Style::default() };
+            Row::new(cells).style(style)
+        });
+        let widths = width_constraints(&view.columns, area.width);
+        frame.render_widget(Table::new(rows, widths).column_spacing(1), area);
+    }
 }
 
 #[derive(Default)]
@@ -66,9 +120,7 @@ impl TableWidget {
         if !view.meta.has_more {
             return;
         }
-        let selected = ctx.views.active_table_state().selected_index(view).unwrap_or(0);
-        let near_bottom = view.rows.len().saturating_sub(selected + 1) <= 5;
-        if trigger == FetchTrigger::Explicit || near_bottom {
+        if TablePanel::should_fetch_more(view, ctx.views.active_table_state(), trigger) {
             if let Some(query) = Self::demand_query(ctx) {
                 ctx.app_actions.push(AppAction::FetchMore(query));
             }
@@ -92,6 +144,9 @@ impl TableWidget {
         if view.meta.has_more {
             title.push_str(" · more available");
         }
+        if view.meta.availability == table_view::TableAvailability::Loading {
+            title.push_str(" · loading");
+        }
         if !view.meta.conditions.is_empty() {
             title.push_str(&format!(" · ⚠ {}", view.meta.conditions.join("; ")));
         }
@@ -109,31 +164,19 @@ impl TableWidget {
         self.rows_area = Rect { y: table_area.y.saturating_add(1), height: table_area.height.saturating_sub(1), ..table_area };
         state.ensure_selected_visible(view, self.rows_area.height as usize);
 
-        let header =
-            Row::new(view.columns.iter().map(|column| Cell::from(Line::from(column.label).alignment(ratatui_alignment(column.alignment)))))
-                .style(theme.header_style())
-                .height(1);
-        let rows = view.rows.iter().skip(state.scroll_offset).take(self.rows_area.height as usize).map(|row| {
-            let selected = state.selected() == Some(&row.id);
-            let cells = row.cells.iter().zip(&view.columns).map(|(cell, column)| {
-                Cell::from(Line::from(cell.text.clone()).alignment(ratatui_alignment(column.alignment))).style(cell_style(cell.tone, theme))
-            });
-            let style = if selected { Style::default().bg(theme.row_highlight).add_modifier(Modifier::BOLD) } else { Style::default() };
-            Row::new(cells).style(style)
-        });
-        let widths = width_constraints(&view.columns, table_area.width);
-        frame.render_widget(Table::new(rows, widths).header(header).column_spacing(1), table_area);
+        TablePanel::render_header(frame, Rect { height: 1, ..table_area }, theme, view);
+        TablePanel::render_rows(frame, self.rows_area, theme, view, state, state.scroll_offset, self.rows_area.height as usize);
     }
 }
 
-fn ratatui_alignment(alignment: Alignment) -> RatatuiAlignment {
+pub(crate) fn ratatui_alignment(alignment: Alignment) -> RatatuiAlignment {
     match alignment {
         Alignment::Left => RatatuiAlignment::Left,
         Alignment::Right => RatatuiAlignment::Right,
     }
 }
 
-fn width_constraints(columns: &[ProjectedColumn], available_width: u16) -> Vec<Constraint> {
+pub(crate) fn width_constraints(columns: &[ProjectedColumn], available_width: u16) -> Vec<Constraint> {
     let spacing = columns.len().saturating_sub(1) as u16;
     let minimum_width = columns.iter().fold(spacing, |total, column| {
         total.saturating_add(match column.width {
@@ -162,7 +205,7 @@ fn width_constraints(columns: &[ProjectedColumn], available_width: u16) -> Vec<C
         .collect()
 }
 
-fn cell_style(tone: CellTone, theme: &Theme) -> Style {
+pub(crate) fn cell_style(tone: CellTone, theme: &Theme) -> Style {
     let color: Color = match tone {
         CellTone::Plain => theme.text,
         CellTone::Muted => theme.muted,
@@ -205,12 +248,8 @@ impl InteractiveWidget for TableWidget {
                 Outcome::Consumed
             }
             Action::Confirm => {
-                if let Some(row) = ctx.views.active_table_state().selected_row(&view) {
-                    if let Some(target) = row.drill.clone() {
-                        ctx.app_actions.push(AppAction::DrillView(target));
-                    } else if let [action] = row.actions.as_slice() {
-                        ctx.app_actions.push(AppAction::ExecuteTableIntent(action.intent.clone()));
-                    }
+                if let Some(action) = ctx.views.active_table_state().selected_row(&view).and_then(TablePanel::row_action) {
+                    ctx.app_actions.push(action);
                 }
                 Outcome::Consumed
             }
@@ -287,8 +326,8 @@ impl InteractiveWidget for TableWidget {
         self.last_click = Some((row.id.clone(), now));
         if double_click {
             self.last_click = None;
-            if let Some(target) = &row.drill {
-                ctx.app_actions.push(AppAction::DrillView(target.clone()));
+            if let Some(action) = TablePanel::row_action(row) {
+                ctx.app_actions.push(action);
             }
         }
         Outcome::Consumed
@@ -403,7 +442,6 @@ mod tests {
         table_view::project(&"convoys/dev".parse().expect("valid address"), &table_view::TableRows {
             convoys: rows,
             independents: vec![],
-            project_issues: vec![],
             ..table_view::TableRows::default()
         })
         .expect("project snapshot table")


### PR DESCRIPTION
## Summary

- compose Project views into one scrolling Convoys → Checkouts → Issues page
- preserve each panel's table behaviour, filters, loading state, and issue pagination/source search
- keep standalone repository pages unchanged and share the table-panel rendering/interaction layer

Closes #764.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
