### PR TITLE
fix: resume controller watches within store generation

### DIFF
--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -449,7 +449,7 @@ impl Aggregator {
         resolver: &dyn AggregatorWatchSource<Convoy>,
     ) -> Result<WatchStream<Convoy>, ResourceError> {
         let listed = resolver.list().await?;
-        let start = watch_start(&listed);
+        let start = WatchStart::resuming_from(&listed);
         let watch = resolver.watch(start).await?;
         self.replace_convoy_source(source, listed.items).await;
         Ok(watch)
@@ -461,7 +461,7 @@ impl Aggregator {
         resolver: &dyn AggregatorWatchSource<Presentation>,
     ) -> Result<WatchStream<Presentation>, ResourceError> {
         let listed = resolver.list().await?;
-        let start = watch_start(&listed);
+        let start = WatchStart::resuming_from(&listed);
         let watch = resolver.watch(start).await?;
         self.replace_presentation_source(source, listed.items).await;
         Ok(watch)
@@ -479,7 +479,7 @@ impl Aggregator {
         resolver: &dyn AggregatorWatchSource<Environment>,
     ) -> Result<WatchStream<Environment>, ResourceError> {
         let listed = resolver.list().await?;
-        let watch = resolver.watch(watch_start(&listed)).await?;
+        let watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
         self.rebuild_independents_projection().await;
         Ok(watch)
     }
@@ -490,7 +490,7 @@ impl Aggregator {
         resolver: &dyn AggregatorWatchSource<TerminalSession>,
     ) -> Result<WatchStream<TerminalSession>, ResourceError> {
         let listed = resolver.list().await?;
-        let start = watch_start(&listed);
+        let start = WatchStart::resuming_from(&listed);
         let watch = resolver.watch(start).await?;
         self.replace_session_source(source, listed.items).await;
         Ok(watch)
@@ -501,7 +501,7 @@ impl Aggregator {
         resolver: &dyn AggregatorWatchSource<Project>,
     ) -> Result<WatchStream<Project>, ResourceError> {
         let listed = resolver.list().await?;
-        let watch = resolver.watch(watch_start(&listed)).await?;
+        let watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
         self.projects = listed
             .items
             .into_iter()
@@ -516,7 +516,7 @@ impl Aggregator {
         resolver: &dyn AggregatorWatchSource<Repository>,
     ) -> Result<WatchStream<Repository>, ResourceError> {
         let listed = resolver.list().await?;
-        let watch = resolver.watch(watch_start(&listed)).await?;
+        let watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
         self.repositories = listed.items.into_iter().map(|repository| (repository.spec.key(), repository)).collect();
         self.rebuild_store_catalog().await;
         Ok(watch)
@@ -527,7 +527,7 @@ impl Aggregator {
         resolver: &dyn AggregatorWatchSource<Checkout>,
     ) -> Result<WatchStream<Checkout>, ResourceError> {
         let listed = resolver.list().await?;
-        let watch = resolver.watch(watch_start(&listed)).await?;
+        let watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
         self.observed_checkouts = listed
             .items
             .into_iter()
@@ -977,15 +977,6 @@ impl Aggregator {
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
             .complete_work(state.is_some_and(|state| !state.phase.is_terminal()))
             .build()
-    }
-}
-
-fn watch_start<T: Resource>(listed: &ResourceList<T>) -> WatchStart {
-    match &listed.generation {
-        Some(generation) => {
-            WatchStart::FromVersionInGeneration { generation: generation.clone(), resource_version: listed.resource_version.clone() }
-        }
-        None => WatchStart::FromVersion(listed.resource_version.clone()),
     }
 }
 

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listed = convoy_resolver.list().await?;
     println!("listed {} convoys at rv={}", listed.items.len(), listed.resource_version);
 
-    let mut watch = convoy_resolver.watch(WatchStart::FromVersion(listed.resource_version.clone())).await?;
+    let mut watch = convoy_resolver.watch(WatchStart::resuming_from(&listed)).await?;
     println!("updating convoy status");
     let updated_convoy = convoy_resolver
         .update_status(&created_convoy.metadata.name, &created_convoy.metadata.resource_version, &ConvoyStatus {

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -140,7 +140,7 @@ impl<W: Resource, P: Resource> SecondaryWatch for LabelMappedWatch<W, P> {
                 Self::enqueue_from_object(self.label_key, &sender, object).await?;
             }
 
-            let mut watch = resolver.watch(WatchStart::FromVersion(listed.resource_version)).await?;
+            let mut watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
             while let Some(event) = watch.next().await {
                 match event? {
                     WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {
@@ -178,7 +178,7 @@ impl<W: Resource, P: Resource> SecondaryWatch for ResolverLabelMappedWatch<W, P>
             for object in &listed.items {
                 LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, object).await?;
             }
-            let mut watch = self.resolver.watch(WatchStart::FromVersion(listed.resource_version)).await?;
+            let mut watch = self.resolver.watch(WatchStart::resuming_from(&listed)).await?;
             while let Some(event) = watch.next().await {
                 match event? {
                     WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {
@@ -240,7 +240,7 @@ impl<W: Resource, P: Resource> SecondaryWatch for LabelJoinWatch<W, P> {
                 Self::enqueue_matching_primaries(self.label_key, &sender, object, &primaries).await?;
             }
 
-            let mut watch = watched.watch(WatchStart::FromVersion(listed.resource_version)).await?;
+            let mut watch = watched.watch(WatchStart::resuming_from(&listed)).await?;
             while let Some(event) = watch.next().await {
                 match event? {
                     WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {
@@ -355,7 +355,7 @@ impl<R: Reconciler> ControllerLoop<R> {
                         .map_err(|_| ResourceError::other("controller queue closed while forwarding initial primary list"))?;
                 }
 
-                let mut watch = primary.watch(WatchStart::FromVersion(listed.resource_version)).await?;
+                let mut watch = primary.watch(WatchStart::resuming_from(&listed)).await?;
                 while let Some(event) = watch.next().await {
                     match event? {
                         WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {

--- a/crates/flotilla-resources/src/watch.rs
+++ b/crates/flotilla-resources/src/watch.rs
@@ -51,6 +51,21 @@ pub enum WatchStart {
     FromVersionInGeneration { generation: String, resource_version: String },
 }
 
+impl WatchStart {
+    /// Resume a watch from where a list left off, carrying the list's store
+    /// generation when it has one. Generational stores reject a plain
+    /// `FromVersion` resume, so every list-then-watch caller must go through
+    /// this instead of constructing `FromVersion` directly.
+    pub fn resuming_from<T: Resource>(listed: &ResourceList<T>) -> Self {
+        match &listed.generation {
+            Some(generation) => {
+                Self::FromVersionInGeneration { generation: generation.clone(), resource_version: listed.resource_version.clone() }
+            }
+            None => Self::FromVersion(listed.resource_version.clone()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "T::Spec: Serialize, T::Status: Serialize",

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -10,7 +10,7 @@ use std::{
 
 use common::{resource_meta, TestLoopHarness};
 use flotilla_resources::{
-    controller::{Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler},
+    controller::{Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, ResolverLabelMappedWatch},
     ApiPaths, InMemoryBackend, InputMeta, LifecycleAuthority, NoStatusPatch, Presentation, PresentationSpec, Resource, ResourceBackend,
     ResourceError, ResourceObject, StatusPatch, TypedResolver, Vessel, VesselSpec,
 };
@@ -442,6 +442,124 @@ async fn controller_loop_reconciles_existing_primary_objects_from_initial_list()
     })
     .await
     .expect("initial list should reconcile alpha");
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_loop_watches_survive_resume_on_a_generational_backend() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::observed());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    let secondaries = backend.clone().using::<SecondaryResource>("flotilla");
+    primaries.create(&primary_meta("alpha"), &PrimarySpec { value: "one".to_string() }).await.expect("primary create should succeed");
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries,
+            secondaries: vec![Box::new(LabelMappedWatch::<SecondaryResource, PrimaryResource> {
+                label_key: "flotilla.work/primary",
+                _marker: std::marker::PhantomData,
+            })],
+            reconciler: RecordingReconciler::new(Arc::clone(&reconciled)),
+            resync_interval: Duration::from_secs(60),
+            backend: backend.clone(),
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("primary watch should resume within the store generation");
+
+    {
+        let mut reconciled = reconciled.lock().expect("reconciled lock");
+        reconciled.clear();
+    }
+
+    secondaries
+        .create(&secondary_meta("secondary-a", "alpha"), &SecondarySpec { value: "wake".to_string() })
+        .await
+        .expect("secondary create should succeed");
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("secondary watch should resume within the store generation");
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn resolver_label_mapped_watch_resumes_on_a_generational_observed_backend() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let observed = ResourceBackend::InMemory(InMemoryBackend::observed());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    let observed_secondaries = observed.clone().using::<SecondaryResource>("flotilla");
+    primaries.create(&primary_meta("alpha"), &PrimarySpec { value: "one".to_string() }).await.expect("primary create should succeed");
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries,
+            secondaries: vec![Box::new(ResolverLabelMappedWatch::<SecondaryResource, PrimaryResource> {
+                label_key: "flotilla.work/primary",
+                resolver: observed_secondaries.clone(),
+                _marker: std::marker::PhantomData,
+            })],
+            reconciler: RecordingReconciler::new(Arc::clone(&reconciled)),
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("initial list should reconcile alpha");
+
+    {
+        let mut reconciled = reconciled.lock().expect("reconciled lock");
+        reconciled.clear();
+    }
+
+    observed_secondaries
+        .create(&secondary_meta("secondary-a", "alpha"), &SecondarySpec { value: "wake".to_string() })
+        .await
+        .expect("observed secondary create should succeed");
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("observed secondary watch should resume within the store generation");
 
     harness.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- `ControllerLoop` resumed every list-then-watch with a plain `WatchStart::FromVersion`, which generational stores reject — the repository controller's secondary watches sit on the observed (generational) backend, so `flotillad` crash-looped at startup with `invalid resource: generational in-memory watches require a generation` (supervisor restarting the `repository` controller forever)
- promote the aggregator's generation-aware resume (`aggregator.rs`'s local `watch_start`) into `WatchStart::resuming_from` in `flotilla-resources` and use it at every list-then-watch site (four in `ControllerLoop`, seven in the aggregator)

## Why CI never caught it

Every `controller_loop` test used `InMemoryBackend::default()` (non-generational). The new regression tests run a `ControllerLoop` entirely on a generational backend (primary + `LabelMappedWatch` resume) and a `ResolverLabelMappedWatch` over a generational observed backend — the exact shape `RepositoryReconciler::secondary_watches` uses. Both fail without the fix.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — one pre-existing macOS-only failure (`dispatch_add_list_remove_repo_round_trip`, `/private/var` vs `/var` tmpdir canonicalization) reproduces on unmodified main; unrelated
- found live: daemon at 4b5aeff3 crash-looped on kiwi even on a fresh store; with this fix the repository controller starts cleanly