### PR TITLE
fix: restore default issue fetch on repo pages

### DIFF
--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -902,9 +902,6 @@ impl App {
 
     /// Fetch default issues for a repo if they haven't been fetched yet.
     fn maybe_fetch_default_issues(&mut self, repo_identity: &RepoIdentity) {
-        if self.model.repos.get(repo_identity).is_some_and(|repo| repo.repository_key.is_some()) {
-            return;
-        }
         if self.model.repos.get(repo_identity).is_some_and(|r| r.path.starts_with("<remote>")) {
             return;
         }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -377,6 +377,31 @@ async fn repeated_snapshots_do_not_queue_duplicate_initial_issue_pages() {
     drain_until_first_issue(&mut app, &repo_identity, "1").await;
 }
 
+/// Regression test for #786: every production repo carries a `repository_key`
+/// (the daemon's `list_repos` always resolves one), and a guard introduced in
+/// #759 skipped the default issue fetch for keyed repos — leaving the repo
+/// page's issues section permanently empty. The fake-discovery harness leaves
+/// the key unset (the temp dir is not a git repo), so mirror the production
+/// shape through the repo-added enrichment path before the snapshot arrives.
+#[tokio::test]
+async fn snapshot_triggers_default_issue_fetch_for_repo_with_repository_key() {
+    let service = Arc::new(ScriptedIssueProvider::new(vec![QueryStep { expected_page: 1, gate: None, result: issue_page(1..=1, false) }]));
+    let (_temp, repo, daemon, mut app) = app_with_issue_provider(service.clone()).await;
+
+    let repo_identity = app.model.active_repo_identity().clone();
+    let mut info = repo_info(app.model.repos[&repo_identity].path.clone(), "repo", RepoLabels::default());
+    info.identity = repo_identity.clone();
+    info.repository_key = Some(flotilla_protocol::RepositoryKey("repo_test".into()));
+    app.handle_repo_added(info);
+    assert!(app.model.repos[&repo_identity].repository_key.is_some(), "test setup should mirror production keyed repos");
+
+    let snapshot = daemon.get_state(&RepoSelector::Path(repo)).await.expect("repo snapshot");
+    app.handle_daemon_event(DaemonEvent::RepoSnapshot(Box::new(snapshot)));
+
+    drain_until_requests(&mut app, &service, &[1]).await;
+    drain_until_first_issue(&mut app, &repo_identity, "1").await;
+}
+
 #[tokio::test]
 async fn manual_refresh_replaces_default_issue_page_when_fresh_results_arrive() {
     let refreshed_page_gate = Arc::new(Semaphore::new(0));


### PR DESCRIPTION
## Root cause

PR #759 added an early-return guard in `maybe_fetch_default_issues` (`crates/flotilla-tui/src/app/mod.rs`) that skipped the default `QueryIssues` fetch whenever the repo carried a `repository_key`. The same PR made every repo carry a `repository_key` (the daemon's `list_repos` always resolves one, falling back to `RepositorySpec::local`), so the guard fired unconditionally. Since the classic repo page's issues section is fed only by that default fetch (via `issue_views`) — the materialized scoped-query path the guard deferred to is consumed only by the project page — the section was permanently empty.

Existing tests missed it because they either injected `issue_rows` directly, or ran through the fake-discovery harness where the temp dir is not a git repo, so repository inspection fails and `repository_key` stays `None` — the one shape the guard didn't suppress.

## Fix

Remove the `repository_key.is_some()` early-return, keeping the `<remote>` and tokio-runtime guards. Plane-A bugfix — restores pre-#759 behavior; the daemon-side materialized queries are independent and unaffected.

## Regression test

`app::tests::snapshot_triggers_default_issue_fetch_for_repo_with_repository_key` exercises the fetch-trigger path (snapshot → `maybe_fetch_default_issues` → `ScriptedIssueProvider`) with the production shape: a repo enriched with a `repository_key` via the repo-added path. Verified it fails with the guard present (times out waiting for the issue query) and passes with it removed.

Closes #786