### PR TITLE
fix: keep convoy starts responsive

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
+        Arc, Weak,
     },
     time::Duration,
 };
@@ -36,8 +36,10 @@ use flotilla_resources::{
     ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
     ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
     TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
-    Vessel, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    Vessel, WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL,
+    REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
+use futures::StreamExt;
 use sha2::{Digest, Sha256};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -981,6 +983,71 @@ async fn queue_pending_crew_message(
         .map_err(|err| err.to_string())
 }
 
+struct ConvoyStartTask {
+    command_id: u64,
+    intent: flotilla_protocol::ConvoyStartIntent,
+    key: ConvoyStartKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ConvoyStartKey {
+    namespace: String,
+    project_ref: String,
+    subject: ConvoyStartSubject,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum ConvoyStartSubject {
+    IssueId(String),
+    IssueReference(flotilla_protocol::IssueRef),
+    Name(String),
+    Anonymous {
+        branch: Option<String>,
+        workflow_ref: Option<String>,
+        inputs: Vec<(String, String)>,
+        instruction: Option<String>,
+        placement_policy: Option<String>,
+    },
+}
+
+impl ConvoyStartKey {
+    fn new(namespace: String, intent: &flotilla_protocol::ConvoyStartIntent) -> Self {
+        let subject = match &intent.issue {
+            Some(flotilla_protocol::IssueSelector::Id(id)) => ConvoyStartSubject::IssueId(id.clone()),
+            Some(flotilla_protocol::IssueSelector::Reference(reference)) => ConvoyStartSubject::IssueReference(reference.clone()),
+            None => match &intent.name {
+                Some(name) => ConvoyStartSubject::Name(name.clone()),
+                None => ConvoyStartSubject::Anonymous {
+                    branch: intent.branch.clone(),
+                    workflow_ref: intent.workflow_ref.clone(),
+                    inputs: intent.inputs.clone(),
+                    instruction: intent.instruction.clone(),
+                    placement_policy: intent.placement_policy.clone(),
+                },
+            },
+        };
+        Self { namespace, project_ref: intent.project_ref.clone(), subject }
+    }
+}
+
+fn convoy_start_failure(convoy: &ResourceObject<ResourceConvoy>) -> Option<String> {
+    let status = convoy.status.as_ref()?;
+    if let Some((work, state)) = status.work.iter().find(|(_, state)| state.phase == ResourceWorkPhase::Failed) {
+        let detail = state.message.as_deref().filter(|message| !message.trim().is_empty()).unwrap_or("work failed without a message");
+        return Some(format!("convoy {} failed while starting work {work}: {detail}", convoy.metadata.name));
+    }
+    match status.phase {
+        flotilla_resources::ConvoyPhase::Failed => Some(match status.message.as_deref().filter(|message| !message.trim().is_empty()) {
+            Some(message) => format!("convoy {} failed while starting: {message}", convoy.metadata.name),
+            None => format!("convoy {} failed while starting", convoy.metadata.name),
+        }),
+        flotilla_resources::ConvoyPhase::Cancelled => Some(format!("convoy {} was cancelled while starting", convoy.metadata.name)),
+        flotilla_resources::ConvoyPhase::Pending | flotilla_resources::ConvoyPhase::Active | flotilla_resources::ConvoyPhase::Completed => {
+            None
+        }
+    }
+}
+
 pub struct InProcessDaemon {
     repos: RwLock<HashMap<flotilla_protocol::RepoIdentity, RepoState>>,
     repo_order: RwLock<Vec<flotilla_protocol::RepoIdentity>>,
@@ -1019,6 +1086,8 @@ pub struct InProcessDaemon {
     discovery: DiscoveryRuntime,
     /// Running commands, keyed by command ID, for cancellation.
     active_commands: Arc<Mutex<HashMap<u64, CancellationToken>>>,
+    self_weak: Weak<InProcessDaemon>,
+    pending_convoy_starts: Mutex<HashSet<ConvoyStartKey>>,
     /// Unique identity for this daemon instance, generated at startup.
     /// Used in peer Hello handshake to detect remote daemon restarts.
     session_id: uuid::Uuid,
@@ -1167,7 +1236,7 @@ impl InProcessDaemon {
         .await;
 
         let (fleet_replica_tx, _) = broadcast::channel(32);
-        let daemon = Arc::new(Self {
+        let daemon = Arc::new_cyclic(|self_weak| Self {
             repos: RwLock::new(repos),
             repo_order: RwLock::new(order),
             event_tx,
@@ -1188,6 +1257,8 @@ impl InProcessDaemon {
             environment_manager,
             discovery,
             active_commands: Arc::new(Mutex::new(HashMap::new())),
+            self_weak: self_weak.clone(),
+            pending_convoy_starts: Mutex::new(HashSet::new()),
             session_id: uuid::Uuid::new_v4(),
             agent_state_store,
             daemon_socket_path: RwLock::new(None),
@@ -2635,6 +2706,77 @@ impl InProcessDaemon {
         };
         convoys.create(&InputMeta::builder().name(name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
         Ok(name)
+    }
+
+    async fn run_convoy_start(&self, task: ConvoyStartTask) {
+        let ConvoyStartTask { command_id, intent, key } = task;
+        let namespace = self.provisioning_namespace().await;
+        let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
+        let result = if requested_namespace != namespace {
+            flotilla_protocol::CommandValue::Error {
+                message: format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"),
+            }
+        } else {
+            match self.admit_convoy_start(&namespace, &intent).await {
+                Ok(name) if intent.auto_attach => match self.wait_for_convoy_attach(&namespace, &name).await {
+                    Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
+                        name,
+                        attach_command: Some(resolved.command),
+                        binding: resolved.binding,
+                    },
+                    Err(message) => flotilla_protocol::CommandValue::Error { message },
+                },
+                Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
+                Err(message) => flotilla_protocol::CommandValue::Error { message },
+            }
+        };
+        self.finish_context_free_command(command_id, empty_repo_identity(), result);
+        self.pending_convoy_starts.lock().await.remove(&key);
+    }
+
+    async fn wait_for_convoy_attach(&self, namespace: &str, name: &str) -> Result<ResolvedAttach, String> {
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
+        let listed = convoys.list().await.map_err(|error| format!("watch convoy {name} while waiting to attach: {error}"))?;
+        if let Some(message) = listed.items.iter().find(|convoy| convoy.metadata.name == name).and_then(convoy_start_failure) {
+            return Err(message);
+        }
+        let mut watch = convoys
+            .watch(WatchStart::resuming_from(&listed))
+            .await
+            .map_err(|error| format!("watch convoy {name} while waiting to attach: {error}"))?;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let mut retry = tokio::time::interval(Duration::from_millis(100));
+        retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut last_attach_error = "attach target is not available yet".to_string();
+
+        loop {
+            tokio::select! {
+                _ = retry.tick() => {
+                    match self.resolve_attach_command_internal(name).await {
+                        Ok(resolved) => return Ok(resolved),
+                        Err(message) => last_attach_error = message,
+                    }
+                }
+                event = watch.next() => {
+                    match event {
+                        Some(Ok(WatchEvent::Added(convoy) | WatchEvent::Modified(convoy))) if convoy.metadata.name == name => {
+                            if let Some(message) = convoy_start_failure(&convoy) {
+                                return Err(message);
+                            }
+                        }
+                        Some(Ok(WatchEvent::Deleted(convoy))) if convoy.metadata.name == name => {
+                            return Err(format!("convoy {name} was deleted while waiting for a crew session"));
+                        }
+                        Some(Ok(_)) => {}
+                        Some(Err(error)) => return Err(format!("watch convoy {name} while waiting to attach: {error}")),
+                        None => return Err(format!("convoy {name} status watch ended while waiting to attach")),
+                    }
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    return Err(format!("convoy {name} was created but no crew session became attachable: {last_attach_error}"));
+                }
+            }
+        }
     }
 
     async fn snapshot_project_repositories(&self, namespace: &str, project_ref: &str) -> Result<Vec<ConvoyRepositorySpec>, String> {
@@ -4327,41 +4469,25 @@ impl InProcessDaemon {
 
         if let flotilla_protocol::CommandAction::ConvoyStart { intent } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
-            let namespace = self.provisioning_namespace().await;
-            let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
-            let result = if requested_namespace != namespace {
-                flotilla_protocol::CommandValue::Error {
-                    message: format!(
-                        "namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"
-                    ),
-                }
+            let namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
+            let key = ConvoyStartKey::new(namespace, intent);
+            if !self.pending_convoy_starts.lock().await.insert(key.clone()) {
+                self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error {
+                    message: format!("convoy start for project {} is already in progress", intent.project_ref),
+                });
+                return Ok(id);
+            }
+            let task = ConvoyStartTask { command_id: id, intent: intent.as_ref().clone(), key: key.clone() };
+            if let Some(daemon) = self.self_weak.upgrade() {
+                tokio::spawn(async move {
+                    daemon.run_convoy_start(task).await;
+                });
             } else {
-                match self.admit_convoy_start(&namespace, intent).await {
-                    Ok(name) if intent.auto_attach => {
-                        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
-                        let resolved = loop {
-                            match self.resolve_attach_command_internal(&name).await {
-                                Ok(resolved) => break Ok(resolved),
-                                Err(message) if tokio::time::Instant::now() >= deadline => {
-                                    break Err(format!("convoy {name} was created but no crew session became attachable: {message}"));
-                                }
-                                Err(_) => tokio::time::sleep(Duration::from_millis(100)).await,
-                            }
-                        };
-                        match resolved {
-                            Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
-                                name,
-                                attach_command: Some(resolved.command),
-                                binding: resolved.binding,
-                            },
-                            Err(message) => flotilla_protocol::CommandValue::Error { message },
-                        }
-                    }
-                    Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
-                    Err(message) => flotilla_protocol::CommandValue::Error { message },
-                }
-            };
-            self.finish_context_free_command(id, empty_identity, result);
+                self.pending_convoy_starts.lock().await.remove(&key);
+                self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error {
+                    message: "convoy start worker is unavailable".to_string(),
+                });
+            }
             return Ok(id);
         }
 

--- a/crates/flotilla-core/src/providers/ai_utility/claude_api.rs
+++ b/crates/flotilla-core/src/providers/ai_utility/claude_api.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -12,6 +12,7 @@ static REQUEST_FACTORY: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLo
 const API_BASE: &str = "https://api.anthropic.com";
 const API_VERSION: &str = "2023-06-01";
 const SYSTEM_PROMPT: &str = "You are a concise assistant. Output only what is asked, with no explanation or formatting.";
+const ANTHROPIC_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub struct ClaudeApiAiUtility {
     api_key: String,
@@ -41,7 +42,9 @@ impl ClaudeApiAiUtility {
             .build()
             .map_err(|e| e.to_string())?;
 
-        let resp = http_execute!(self.http, request)?;
+        let resp = tokio::time::timeout(ANTHROPIC_REQUEST_TIMEOUT, async { http_execute!(self.http, request) })
+            .await
+            .map_err(|_| format!("Anthropic API request timed out after {}s", ANTHROPIC_REQUEST_TIMEOUT.as_secs()))??;
         let status = resp.status().as_u16();
         let body_bytes = resp.into_body();
         let body_str = std::str::from_utf8(&body_bytes).map_err(|e| e.to_string())?;
@@ -99,5 +102,35 @@ impl super::AiUtility for ClaudeApiAiUtility {
              Return ONLY JSON with string fields name and branch. Use lowercase kebab-case; the branch may contain one slash: {context}"
         );
         super::parse_convoy_names(&self.prompt(Model::Haiku, &prompt).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{future, sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+
+    use super::ClaudeApiAiUtility;
+    use crate::providers::{ai_utility::AiUtility, ChannelLabel, HttpClient};
+
+    struct HangingHttpClient;
+
+    #[async_trait]
+    impl HttpClient for HangingHttpClient {
+        async fn execute(&self, _: reqwest::Request, _: &ChannelLabel) -> Result<http::Response<bytes::Bytes>, String> {
+            future::pending().await
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn convoy_name_generation_times_out_when_anthropic_does_not_respond() {
+        let utility = ClaudeApiAiUtility::new("test-key".into(), Arc::new(HangingHttpClient));
+
+        let result = tokio::time::timeout(Duration::from_secs(16), utility.generate_convoy_names("Issue 782"))
+            .await
+            .expect("Anthropic request should enforce its own shorter deadline");
+
+        assert!(matches!(result, Err(message) if message.contains("timed out after 15s")));
     }
 }

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -448,7 +448,9 @@ pub struct ReqwestHttpClient {
 
 impl ReqwestHttpClient {
     pub fn new() -> Self {
-        Self { client: reqwest::Client::new() }
+        const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+        let client = reqwest::Client::builder().timeout(REQUEST_TIMEOUT).build().expect("build HTTP client");
+        Self { client }
     }
 }
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -46,10 +46,12 @@ use flotilla_protocol::{
     RepoIdentity, RepoSelector, StreamKey, SystemInfo, ToolInventory, TopologyRoute, WorkItemKind,
 };
 use flotilla_resources::{
-    single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase,
-    CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, DockerCheckoutStrategy,
+    apply_status_patch, controller_patches as convoy_controller_patches, single_agent_contained_workflow_spec,
+    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
     DockerPerVesselPlacementPolicySpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
-    ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, TypedResolver, WorkflowTemplate, REPO_KEY_LABEL, REPO_LABEL,
+    ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, TypedResolver, WorkPhase, WorkState, WorkflowSnapshot,
+    WorkflowTemplate, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -676,6 +678,34 @@ async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBack
         .expect("contained policy create");
 }
 
+async fn create_test_convoy_project(backend: &flotilla_resources::ResourceBackend, issue_source: Option<IssueSource>) {
+    let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository.key().to_string()).build(), &repository)
+        .await
+        .expect("repository create");
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
+        .await
+        .expect("workflow create");
+    create_test_contained_policy(backend).await;
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
+            display_name: "Flotilla".into(),
+            default_workflow_ref: "single-agent-contained".into(),
+            issue_source,
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project create");
+}
+
 #[tokio::test]
 async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snapshot() {
     let reference =
@@ -1010,6 +1040,225 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
     let persisted = backend.using::<ResourceConvoy>("flotilla").get("generated-convoy").await.expect("persisted convoy");
     assert_eq!(persisted.spec.r#ref.as_deref(), Some("fix/generated-convoy"));
     assert_eq!(utility.calls.load(Ordering::SeqCst), 1);
+    drop(temp);
+}
+
+#[tokio::test]
+async fn convoy_start_acknowledges_while_admission_is_in_flight() {
+    let utility = Arc::new(SlowAiUtility::new());
+    let discovery = slow_ai_discovery(Arc::clone(&utility));
+    let (temp, _repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    let backend = daemon.resource_backend();
+    create_test_convoy_project(&backend, None).await;
+
+    let mut execution = tokio::spawn({
+        let daemon = Arc::clone(&daemon);
+        async move {
+            daemon
+                .execute(Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::ConvoyStart {
+                        intent: Box::new(ConvoyStartIntent {
+                            namespace: None,
+                            project_ref: "flotilla".into(),
+                            issue: None,
+                            name: None,
+                            branch: None,
+                            workflow_ref: None,
+                            inputs: Vec::new(),
+                            instruction: None,
+                            placement_policy: None,
+                            auto_attach: false,
+                        }),
+                    },
+                })
+                .await
+        }
+    });
+    utility.wait_for_generation_start().await;
+
+    let command_id = tokio::time::timeout(Duration::from_millis(100), &mut execution)
+        .await
+        .expect("convoy start should acknowledge while admission is still in flight")
+        .expect("execute task should not panic")
+        .expect("convoy start should be accepted");
+
+    let mut events = daemon.subscribe();
+    utility.release_generation();
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("convoy start should finish after admission is released");
+    assert!(matches!(result, CommandValue::ConvoyStarted { .. }));
+
+    drop(temp);
+}
+
+#[tokio::test]
+async fn convoy_start_rejects_the_same_project_start_while_admission_is_in_flight() {
+    let reference =
+        IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "782".into() };
+    let mut issue = TestIssue::new("Convoy start freezes the TUI").id("782").build();
+    issue.reference = reference.clone();
+    let provider = Arc::new(FakeIssueProvider::new());
+    provider.add_issues(vec![(reference.id.clone(), issue)]).await;
+    let utility = Arc::new(SlowAiUtility::new());
+    let mut discovery = fake_discovery_with_provider_set(
+        FakeDiscoveryProviders::new().with_issue_tracker(provider as Arc<dyn flotilla_core::providers::issue_tracker::IssueProvider>),
+    );
+    discovery.factories.ai_utilities.push(Box::new(SlowAiUtilityFactory { utility: Arc::clone(&utility) }));
+    let (temp, _repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    let backend = daemon.resource_backend();
+    create_test_convoy_project(&backend, Some(reference.source.clone())).await;
+    let command = Command {
+        node_id: None,
+        provisioning_target: None,
+        context_repo: None,
+        action: CommandAction::ConvoyStart {
+            intent: Box::new(ConvoyStartIntent {
+                namespace: None,
+                project_ref: "flotilla".into(),
+                issue: Some(IssueSelector::Reference(reference)),
+                name: None,
+                branch: None,
+                workflow_ref: None,
+                inputs: Vec::new(),
+                instruction: Some("Implement issue 782".into()),
+                placement_policy: None,
+                auto_attach: false,
+            }),
+        },
+    };
+    let mut events = daemon.subscribe();
+
+    let first_id = daemon.execute(command.clone()).await.expect("first convoy start should be accepted");
+    utility.wait_for_generation_start().await;
+    let duplicate_id = daemon.execute(command).await.expect("duplicate command should receive an asynchronous result");
+    let duplicate_result = tokio::time::timeout(Duration::from_millis(100), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == duplicate_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("duplicate convoy start should finish without waiting for admission");
+    assert!(matches!(duplicate_result, CommandValue::Error { message } if message.contains("already in progress")));
+
+    utility.release_generation();
+    let first_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == first_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("first convoy start should finish after admission is released");
+    assert!(matches!(first_result, CommandValue::ConvoyStarted { .. }));
+
+    drop(temp);
+}
+
+#[tokio::test]
+async fn convoy_start_reports_failed_work_without_waiting_for_auto_attach_timeout() {
+    let (temp, _repo, daemon) = daemon_for_plain_dir_with_discovery(fake_discovery(false)).await;
+    let backend = daemon.resource_backend();
+    create_test_convoy_project(&backend, None).await;
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".into(),
+                    issue: None,
+                    name: Some("bootstrap-failure".into()),
+                    branch: Some("fix/bootstrap-failure".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: true,
+                }),
+            },
+        })
+        .await
+        .expect("convoy start should be accepted");
+    let convoys = backend.using::<ResourceConvoy>("flotilla");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if convoys.get("bootstrap-failure").await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("convoy should be persisted");
+
+    let workflow = single_agent_contained_workflow_spec();
+    apply_status_patch(
+        &convoys,
+        "bootstrap-failure",
+        &convoy_controller_patches::bootstrap(
+            WorkflowSnapshot { vessels: workflow.vessels },
+            "single-agent-contained".into(),
+            BTreeMap::new(),
+            BTreeMap::from([("work".into(), WorkState::builder().phase(WorkPhase::Pending).build())]),
+            BTreeMap::new(),
+            ConvoyPhase::Pending,
+            None,
+        ),
+    )
+    .await
+    .expect("convoy bootstrap patch");
+
+    let work_message = "agent adapter claude cannot realize contained stance";
+    apply_status_patch(
+        &convoys,
+        "bootstrap-failure",
+        &convoy_controller_patches::roll_up_work("work".into(), WorkPhase::Failed, chrono::Utc::now(), Some(work_message.into())),
+    )
+    .await
+    .expect("work failure patch");
+    apply_status_patch(
+        &convoys,
+        "bootstrap-failure",
+        &convoy_controller_patches::fail_convoy(BTreeMap::new(), chrono::Utc::now(), Some("convoy bootstrap failed".into())),
+    )
+    .await
+    .expect("convoy failure patch");
+
+    let result = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("failed convoy should stop auto-attach promptly");
+    assert!(matches!(result, CommandValue::Error { message } if message.contains(work_message)));
+
     drop(temp);
 }
 

--- a/crates/flotilla-tui/src/widgets/status_bar_widget.rs
+++ b/crates/flotilla-tui/src/widgets/status_bar_widget.rs
@@ -249,8 +249,13 @@ impl InteractiveWidget for StatusBarWidget {
 
 /// Resolve the active in-flight task description for the current repo.
 pub(crate) fn active_task(model: &TuiModel, in_flight: &HashMap<u64, InFlightCommand>) -> Option<TaskSection> {
-    let active_repo = model.active_repo.as_ref()?;
-    let repo_cmds: Vec<(&u64, &InFlightCommand)> = in_flight.iter().filter(|(_, cmd)| &cmd.repo_identity == active_repo).collect();
+    let repo_cmds: Vec<(&u64, &InFlightCommand)> = in_flight
+        .iter()
+        .filter(|(_, cmd)| match model.active_repo.as_ref() {
+            Some(active_repo) => &cmd.repo_identity == active_repo,
+            None => cmd.repo_identity.authority.is_empty() && cmd.repo_identity.path.is_empty(),
+        })
+        .collect();
 
     // Highest command ID = most recently started (IDs are monotonically increasing AtomicU64).
     let (_, most_recent) = repo_cmds.iter().max_by_key(|(id, _)| *id)?;
@@ -313,7 +318,7 @@ pub(crate) fn resolve_task_from_fragment(fragment: &StatusFragment) -> Option<Ta
 mod tests {
     use std::path::PathBuf;
 
-    use flotilla_protocol::RepoLabels;
+    use flotilla_protocol::{RepoIdentity, RepoLabels};
     use ratatui::layout::Rect;
 
     use super::*;
@@ -387,6 +392,23 @@ mod tests {
 
         let task = active_task(&model, &in_flight).expect("should have an active task");
         assert_eq!(task.description, "only command");
+    }
+
+    #[test]
+    fn active_task_shows_context_free_command_on_project_view() {
+        let ri = repo_info("/tmp/test-repo", "test-repo", RepoLabels::default());
+        let mut model = TuiModel::from_repo_info(vec![ri]);
+        model.active_repo = None;
+        let mut in_flight = HashMap::new();
+        in_flight.insert(42, InFlightCommand {
+            repo_identity: RepoIdentity { authority: String::new(), path: String::new() },
+            repo: PathBuf::new(),
+            description: "Starting convoy...".into(),
+        });
+
+        let task = active_task(&model, &in_flight).expect("project view should show context-free command progress");
+
+        assert_eq!(task.description, "Starting convoy...");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- run convoy admission and auto-attach asynchronously so the TUI remains responsive
- reject duplicate in-flight convoy starts and surface context-free progress in project view
- stop auto-attach promptly on failed work, preserving the detailed failure message
- bound Anthropic and general Reqwest request durations

Closes #782

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --workspace --all-targets --locked`
- focused convoy-start, Anthropic-timeout, and TUI status-bar regression tests

The full local workspace suite reaches one unrelated macOS path-alias failure in `dispatch_add_list_remove_repo_round_trip`: the actual path begins with `/private/var` while the expected path begins with `/var`.
