### PR TITLE
fix: cap splash image at native resolution and log picked protocol

### DIFF
--- a/crates/flotilla-tui/examples/splash_probe.rs
+++ b/crates/flotilla-tui/examples/splash_probe.rs
@@ -1,0 +1,111 @@
+//! Measure image-protocol detection and splash render cost in the current
+//! terminal. Run inside a zellij pane and directly in the host terminal to
+//! compare:
+//!
+//! ```sh
+//! cargo run -p flotilla-tui --example splash_probe [query_timeout_ms]
+//! ```
+
+use std::time::{Duration, Instant};
+
+use ratatui_image::{
+    picker::{cap_parser::QueryStdioOptions, Picker},
+    StatefulImage,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let timeout_ms = std::env::args().nth(1).and_then(|raw| raw.parse::<u64>().ok()).unwrap_or(2000);
+
+    let img_bytes = include_bytes!("../../../assets/splash.webp");
+    let t = Instant::now();
+    let dyn_img = image::load_from_memory(img_bytes)?;
+    let decode = t.elapsed();
+    let (img_w, img_h) = (dyn_img.width() as f64, dyn_img.height() as f64);
+
+    let mut terminal = ratatui::init();
+
+    let mut query_options = QueryStdioOptions::default();
+    query_options.timeout = Duration::from_millis(timeout_ms);
+    let t = Instant::now();
+    let picker_result = Picker::from_query_stdio_with_options(query_options);
+    let query = t.elapsed();
+    let (picker, query_err) = match picker_result {
+        Ok(picker) => (picker, None),
+        Err(err) => (Picker::halfblocks(), Some(err.to_string())),
+    };
+    let protocol_type = picker.protocol_type();
+    let font_size = picker.font_size();
+
+    let mut protocol = picker.new_resize_protocol(dyn_img);
+
+    while crossterm::event::poll(Duration::from_millis(10))? {
+        let _ = crossterm::event::read()?;
+    }
+
+    fn draw(
+        terminal: &mut ratatui::DefaultTerminal,
+        protocol: &mut ratatui_image::protocol::StatefulProtocol,
+        (img_w, img_h): (f64, f64),
+        rendered: &mut (u16, u16),
+    ) -> std::io::Result<()> {
+        terminal.draw(|f| {
+            use ratatui::layout::{Constraint, Flex, Layout};
+            let area = f.area();
+            let scale = (area.width as f64 / img_w).min(area.height as f64 * 2.0 / img_h);
+            let rw = (img_w * scale) as u16;
+            let rh = (img_h * scale / 2.0) as u16;
+            *rendered = (rw.min(area.width), rh.min(area.height));
+            let [area] = Layout::horizontal([Constraint::Length(rendered.0)]).flex(Flex::Center).areas(area);
+            let [area] = Layout::vertical([Constraint::Length(rendered.1)]).flex(Flex::Center).areas(area);
+            f.render_stateful_widget(StatefulImage::default(), area, protocol);
+        })?;
+        Ok(())
+    }
+
+    let mut rendered = (0u16, 0u16);
+
+    // First draw: resize + encode + transmit image data.
+    let t = Instant::now();
+    draw(&mut terminal, &mut protocol, (img_w, img_h), &mut rendered)?;
+    let first_draw = t.elapsed();
+
+    std::thread::sleep(Duration::from_millis(400));
+
+    // Second draw: protocol already encoded; measures placement/redraw only.
+    let t = Instant::now();
+    draw(&mut terminal, &mut protocol, (img_w, img_h), &mut rendered)?;
+    let second_draw = t.elapsed();
+
+    std::thread::sleep(Duration::from_millis(400));
+    ratatui::restore();
+
+    let cells = (rendered.0 as u32, rendered.1 as u32);
+    let px = (cells.0 * font_size.0 as u32, cells.1 * font_size.1 as u32);
+    let rgba_bytes = px.0 as u64 * px.1 as u64 * 4;
+    println!("splash probe");
+    println!(
+        "  TERM={} ZELLIJ={} TERM_PROGRAM={}",
+        std::env::var("TERM").unwrap_or_default(),
+        std::env::var("ZELLIJ").is_ok(),
+        std::env::var("TERM_PROGRAM").unwrap_or_default()
+    );
+    println!("  webp decode:        {decode:>10.2?}");
+    println!(
+        "  picker query:       {query:>10.2?} (timeout {timeout_ms}ms{})",
+        query_err.map(|e| format!(", ERROR: {e}")).unwrap_or_default()
+    );
+    println!("  protocol picked:    {protocol_type:?}");
+    println!("  font size:          {font_size:?}");
+    println!(
+        "  render area:        {}x{} cells = {}x{} px (~{} KiB raw rgba, ~{} KiB base64)",
+        cells.0,
+        cells.1,
+        px.0,
+        px.1,
+        rgba_bytes / 1024,
+        rgba_bytes * 4 / 3 / 1024
+    );
+    println!("  first draw (encode+transmit): {first_draw:>10.2?}");
+    println!("  second draw (placement only): {second_draw:>10.2?}");
+    Ok(())
+}

--- a/crates/flotilla-tui/examples/splash_probe.rs
+++ b/crates/flotilla-tui/examples/splash_probe.rs
@@ -3,18 +3,26 @@
 //! compare:
 //!
 //! ```sh
-//! cargo run -p flotilla-tui --example splash_probe [query_timeout_ms]
+//! cargo run -p flotilla-tui --example splash_probe [query_timeout_ms] [--uncapped]
 //! ```
+//!
+//! By default the draw applies the same native-resolution cap as the real
+//! splash (`flotilla_tui::splash::splash_scale`). Pass `--uncapped` to
+//! transmit at the full fit-to-area size instead — useful for stressing a
+//! multiplexer's ingest throughput with a deliberately large payload.
 
 use std::time::{Duration, Instant};
 
+use flotilla_tui::splash::splash_scale;
 use ratatui_image::{
     picker::{cap_parser::QueryStdioOptions, Picker},
     StatefulImage,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let timeout_ms = std::env::args().nth(1).and_then(|raw| raw.parse::<u64>().ok()).unwrap_or(2000);
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let uncapped = args.iter().any(|arg| arg == "--uncapped");
+    let timeout_ms = args.iter().find_map(|raw| raw.parse::<u64>().ok()).unwrap_or(2000);
 
     let img_bytes = include_bytes!("../../../assets/splash.webp");
     let t = Instant::now();
@@ -46,12 +54,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         terminal: &mut ratatui::DefaultTerminal,
         protocol: &mut ratatui_image::protocol::StatefulProtocol,
         (img_w, img_h): (f64, f64),
+        pixel_font_size: Option<(u16, u16)>,
         rendered: &mut (u16, u16),
     ) -> std::io::Result<()> {
         terminal.draw(|f| {
             use ratatui::layout::{Constraint, Flex, Layout};
             let area = f.area();
-            let scale = (area.width as f64 / img_w).min(area.height as f64 * 2.0 / img_h);
+            let scale = splash_scale(img_w, img_h, area.width, area.height, pixel_font_size);
             let rw = (img_w * scale) as u16;
             let rh = (img_h * scale / 2.0) as u16;
             *rendered = (rw.min(area.width), rh.min(area.height));
@@ -62,18 +71,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
+    // Mirror the real splash: pixel protocols are capped at native resolution
+    // unless --uncapped asks for the full fit-to-area payload.
+    let pixel_font_size = (!uncapped && !matches!(protocol_type, ratatui_image::picker::ProtocolType::Halfblocks)).then_some(font_size);
+
     let mut rendered = (0u16, 0u16);
 
     // First draw: resize + encode + transmit image data.
     let t = Instant::now();
-    draw(&mut terminal, &mut protocol, (img_w, img_h), &mut rendered)?;
+    draw(&mut terminal, &mut protocol, (img_w, img_h), pixel_font_size, &mut rendered)?;
     let first_draw = t.elapsed();
 
     std::thread::sleep(Duration::from_millis(400));
 
     // Second draw: protocol already encoded; measures placement/redraw only.
     let t = Instant::now();
-    draw(&mut terminal, &mut protocol, (img_w, img_h), &mut rendered)?;
+    draw(&mut terminal, &mut protocol, (img_w, img_h), pixel_font_size, &mut rendered)?;
     let second_draw = t.elapsed();
 
     std::thread::sleep(Duration::from_millis(400));
@@ -96,6 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     println!("  protocol picked:    {protocol_type:?}");
     println!("  font size:          {font_size:?}");
+    println!("  native-res cap:     {}", if pixel_font_size.is_some() { "applied (as in production splash)" } else { "off" });
     println!(
         "  render area:        {}x{} cells = {}x{} px (~{} KiB raw rgba, ~{} KiB base64)",
         cells.0,

--- a/crates/flotilla-tui/src/splash.rs
+++ b/crates/flotilla-tui/src/splash.rs
@@ -15,7 +15,14 @@ pub async fn show_splash(terminal: &mut ratatui::DefaultTerminal) -> Result<()> 
     let query_timeout_ms = std::env::var("FLOTILLA_SPLASH_QUERY_TIMEOUT_MS").ok().and_then(|raw| raw.parse::<u64>().ok()).unwrap_or(120);
     let mut query_options = QueryStdioOptions::default();
     query_options.timeout = Duration::from_millis(query_timeout_ms);
+    let query_started = std::time::Instant::now();
     let picker = Picker::from_query_stdio_with_options(query_options).unwrap_or_else(|_| Picker::halfblocks());
+    tracing::info!(
+        query_ms = query_started.elapsed().as_millis() as u64,
+        protocol = ?picker.protocol_type(),
+        font_size = ?picker.font_size(),
+        "splash image protocol picked"
+    );
 
     let mut protocol = picker.new_resize_protocol(dyn_img);
 
@@ -26,10 +33,21 @@ pub async fn show_splash(terminal: &mut ratatui::DefaultTerminal) -> Result<()> 
 
     // Guarantee a minimum visible time after first render (not just after splash setup).
     let min_visible = Duration::from_millis(700);
+    let draw_started = std::time::Instant::now();
+    let font_size = picker.font_size();
+    let pixel_protocol = !matches!(picker.protocol_type(), ratatui_image::picker::ProtocolType::Halfblocks);
     terminal.draw(|f| {
         use ratatui::layout::{Constraint, Flex, Layout};
         let area = f.area();
-        let scale = (area.width as f64 / img_w).min(area.height as f64 * 2.0 / img_h);
+        let mut scale = (area.width as f64 / img_w).min(area.height as f64 * 2.0 / img_h);
+        if pixel_protocol {
+            // Pixel protocols transmit uncompressed RGBA at the rendered cell
+            // area's pixel size — upscaling past the image's native resolution
+            // multiplies the payload for no visual gain (especially through a
+            // multiplexer that has to re-parse every byte). Cap the rendered
+            // area so the transmitted image never exceeds native pixels.
+            scale = scale.min(1.0 / font_size.0 as f64).min(2.0 / font_size.1 as f64);
+        }
         let rw = (img_w * scale) as u16;
         let rh = (img_h * scale / 2.0) as u16;
         let [area] = Layout::horizontal([Constraint::Length(rw.min(area.width))]).flex(Flex::Center).areas(area);
@@ -37,6 +55,7 @@ pub async fn show_splash(terminal: &mut ratatui::DefaultTerminal) -> Result<()> 
         let widget = StatefulImage::default();
         f.render_stateful_widget(widget, area, &mut protocol);
     })?;
+    tracing::info!(draw_ms = draw_started.elapsed().as_millis() as u64, "splash rendered");
 
     tokio::time::sleep(min_visible).await;
 

--- a/crates/flotilla-tui/src/splash.rs
+++ b/crates/flotilla-tui/src/splash.rs
@@ -34,20 +34,11 @@ pub async fn show_splash(terminal: &mut ratatui::DefaultTerminal) -> Result<()> 
     // Guarantee a minimum visible time after first render (not just after splash setup).
     let min_visible = Duration::from_millis(700);
     let draw_started = std::time::Instant::now();
-    let font_size = picker.font_size();
-    let pixel_protocol = !matches!(picker.protocol_type(), ratatui_image::picker::ProtocolType::Halfblocks);
+    let pixel_font_size = (!matches!(picker.protocol_type(), ratatui_image::picker::ProtocolType::Halfblocks)).then(|| picker.font_size());
     terminal.draw(|f| {
         use ratatui::layout::{Constraint, Flex, Layout};
         let area = f.area();
-        let mut scale = (area.width as f64 / img_w).min(area.height as f64 * 2.0 / img_h);
-        if pixel_protocol {
-            // Pixel protocols transmit uncompressed RGBA at the rendered cell
-            // area's pixel size — upscaling past the image's native resolution
-            // multiplies the payload for no visual gain (especially through a
-            // multiplexer that has to re-parse every byte). Cap the rendered
-            // area so the transmitted image never exceeds native pixels.
-            scale = scale.min(1.0 / font_size.0 as f64).min(2.0 / font_size.1 as f64);
-        }
+        let scale = splash_scale(img_w, img_h, area.width, area.height, pixel_font_size);
         let rw = (img_w * scale) as u16;
         let rh = (img_h * scale / 2.0) as u16;
         let [area] = Layout::horizontal([Constraint::Length(rw.min(area.width))]).flex(Flex::Center).areas(area);
@@ -65,4 +56,67 @@ pub async fn show_splash(terminal: &mut ratatui::DefaultTerminal) -> Result<()> 
         let _ = crossterm::event::read()?;
     }
     Ok(())
+}
+
+/// Scale factor (in cells per image pixel, halfblock aspect: one cell ≈ 1×2
+/// pixel units) fitting an `img_w`×`img_h` image into an `area_w`×`area_h`
+/// cell area. With `pixel_font_size` set (pixel protocols), the scale is
+/// additionally capped so the rendered cell area never exceeds the image's
+/// native pixel size: pixel protocols transmit uncompressed RGBA at the
+/// rendered area's pixel dimensions, so upscaling multiplies the payload for
+/// no visual gain (especially through a multiplexer re-parsing every byte).
+pub fn splash_scale(img_w: f64, img_h: f64, area_w: u16, area_h: u16, pixel_font_size: Option<(u16, u16)>) -> f64 {
+    let scale = (area_w as f64 / img_w).min(area_h as f64 * 2.0 / img_h);
+    match pixel_font_size {
+        Some((font_w, font_h)) => scale.min(1.0 / font_w as f64).min(2.0 / font_h as f64),
+        None => scale,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::splash_scale;
+
+    const IMG: (f64, f64) = (1024.0, 559.0);
+
+    fn rendered_px(scale: f64, font: (u16, u16)) -> (f64, f64) {
+        let cells_w = (IMG.0 * scale).floor();
+        let cells_h = (IMG.1 * scale / 2.0).floor();
+        (cells_w * font.0 as f64, cells_h * font.1 as f64)
+    }
+
+    #[test]
+    fn pixel_protocol_never_transmits_above_native_resolution() {
+        // Large retina-font terminal: uncapped fit would upscale well past native.
+        let font = (16, 34);
+        let scale = splash_scale(IMG.0, IMG.1, 238, 65, Some(font));
+        let (px_w, px_h) = rendered_px(scale, font);
+        assert!(px_w <= IMG.0, "width {px_w} exceeds native {}", IMG.0);
+        assert!(px_h <= IMG.1, "height {px_h} exceeds native {}", IMG.1);
+    }
+
+    #[test]
+    fn small_areas_still_fit_within_the_area() {
+        let scale = splash_scale(IMG.0, IMG.1, 40, 12, Some((16, 34)));
+        assert!((IMG.0 * scale) as u16 <= 40);
+        assert!((IMG.1 * scale / 2.0) as u16 <= 12);
+    }
+
+    #[test]
+    fn halfblocks_is_uncapped_and_fills_the_area() {
+        // No pixel cost: the image should scale up to fill the fit dimension.
+        let scale = splash_scale(IMG.0, IMG.1, 238, 65, None);
+        let fills_width = (IMG.0 * scale).round() as u16 >= 237;
+        let fills_height = (IMG.1 * scale / 2.0).round() as u16 >= 64;
+        assert!(fills_width || fills_height, "uncapped fit should reach an area edge (scale {scale})");
+    }
+
+    #[test]
+    fn cap_preserves_aspect_ratio() {
+        let capped = splash_scale(IMG.0, IMG.1, 238, 65, Some((16, 34)));
+        let uncapped = splash_scale(IMG.0, IMG.1, 238, 65, None);
+        // A cap only shrinks the single shared scale factor, so aspect is
+        // preserved by construction; sanity-check it actually shrank here.
+        assert!(capped < uncapped);
+    }
 }


### PR DESCRIPTION
## What

The splash was scaling the 1024x559 splash image up to fill the terminal area before transmission. Pixel protocols (kitty) transmit the rendered area's pixels as uncompressed RGBA (`f=32,t=d` — the only medium ratatui-image implements), so on a retina font this shipped 9.5MB of base64 escape data inside a 112x30 zellij pane and 43MB on a full-screen ghostty — for a 233KB source image. Through a multiplexer that must re-parse every byte, this made the splash glacial (measured ~10s ingest at ~1MB/s through zellij vs ~1.2s directly in ghostty).

- Cap the rendered area so the transmitted image never exceeds the image's native pixel size (no-op for halfblocks, which has no pixel cost). Cuts the payload to ~3MB in both cases and eliminates the upscale resize cost.
- Log the picked protocol, font size, query duration, and first-draw duration from the real splash path so `tui.log` answers "what did detection pick" without a debugging session.
- Add `examples/splash_probe.rs`: runs the same detection + draw with timings printed after terminal restore; run it inside a multiplexer and directly in the host terminal to localize where splash time goes (query / encode+transmit / placement backpressure).

Measured with the probe on kiwi (ghostty 1.2, zellij fork, font 16x34); numbers in the table are in the linked discussion context.

Follow-ups tracked separately: ratatui-image only implements `f=32,t=d` (no `o=z`, no `t=s`/`t=f`, no PNG) — upstream opportunity; zellij-side `t=d` ingest rate (~1MB/s) profiling happens in the zellij fork.