### PR TITLE
fix: validate convoy agent adapter availability

### DIFF
--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -179,6 +179,7 @@ pub async fn create_docker_worktree_policy(backend: &ResourceBackend, namespace:
             .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                 host_ref: fixture.host_ref,
                 image: fixture.image,
+                agent_adapters: Default::default(),
                 default_cwd: fixture.default_cwd,
                 env: Default::default(),
                 checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: fixture.mount_path },

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -674,6 +674,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
             .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                 host_ref: HOST_REF.to_string(),
                 image: "ghcr.io/flotilla/dev:latest".to_string(),
+                agent_adapters: Default::default(),
                 default_cwd: None,
                 env: Default::default(),
                 checkout: DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace/".to_string() },
@@ -872,6 +873,7 @@ async fn contained_requirement_runs_in_contained_docker_placement() {
             .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                 host_ref: HOST_REF.to_string(),
                 image: "ghcr.io/flotilla/dev:latest".to_string(),
+                agent_adapters: Default::default(),
                 default_cwd: None,
                 env: Default::default(),
                 checkout: DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },
@@ -1062,6 +1064,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: HOST_REF.to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
+            agent_adapters: Default::default(),
             default_cwd: None,
             env: Default::default(),
             checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".to_string() },
@@ -1087,6 +1090,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: HOST_REF.to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
+            agent_adapters: Default::default(),
             default_cwd: Some("/app".to_string()),
             env: Default::default(),
             checkout: DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -176,6 +176,10 @@ impl AgentAdapterRegistry {
     pub fn get(&self, id: &str) -> Option<&Arc<dyn AgentAdapter>> {
         self.adapters.get(id)
     }
+
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.adapters.keys().map(String::as_str)
+    }
 }
 
 #[cfg(test)]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -31,10 +31,10 @@ use flotilla_resources::{
     external_patches as convoy_external_patches, normalize_project_spec, resolve_project_issue_sources, terminal_session_attach_target,
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch,
-    CrewSource, Environment as ResourceEnvironment, InMemoryBackend, InputMeta, InputValue, IssueSnapshot, IssueSourceResolution,
-    IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project,
-    ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
+    CrewSource, Environment as ResourceEnvironment, Host as ResourceHost, InMemoryBackend, InputMeta, InputValue, IssueSnapshot,
+    IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
+    PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend,
+    ResourceError, ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
     TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
     Vessel, WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL,
     REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
@@ -46,6 +46,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
+    agent_adapter::CapabilityTable,
     aggregator_projection::AggregatorProjectionState,
     config::{ConfigStore, RemoteHostConfig, StaticEnvironmentConfig},
     convert::snapshot_to_proto,
@@ -2471,6 +2472,55 @@ fn required_admission_value<'a>(value: &'a str, field: &str) -> Result<&'a str, 
     }
 }
 
+async fn validate_workflow_agent_adapters(
+    backend: &ResourceBackend,
+    namespace: &str,
+    workflow: &WorkflowTemplateSpec,
+    placement: Option<&ResourceObject<PlacementPolicy>>,
+) -> Result<(), String> {
+    let capabilities = CapabilityTable::seeded();
+    let mut required_adapters = BTreeSet::new();
+    for crew in workflow.vessels.iter().flat_map(|vessel| &vessel.crew) {
+        if let CrewSource::Agent { selector, .. } = &crew.source {
+            required_adapters.insert(capabilities.resolve(&selector.capability)?.adapter.clone());
+        }
+    }
+
+    for adapter in required_adapters {
+        let Some(placement) = placement else {
+            return Err(format!("workflow requires agent adapter `{adapter}`, but no placement is available"));
+        };
+        let (available_adapters, detail) = if let Some(docker) = &placement.spec.docker_per_vessel {
+            (docker.agent_adapters.clone(), format!("image `{}`", docker.image))
+        } else if let Some(host_direct) = &placement.spec.host_direct {
+            let host = backend.clone().using::<ResourceHost>(namespace).get(&host_direct.host_ref).await.map_err(|error| {
+                format!("placement `{}` host `{}` is not ready: {error}", placement.metadata.name, host_direct.host_ref)
+            })?;
+            let status = host
+                .status
+                .ok_or_else(|| format!("placement `{}` host `{}` has no observed status", placement.metadata.name, host_direct.host_ref))?;
+            let available_adapters = status.agent_adapters().map_err(|error| {
+                format!(
+                    "placement `{}` host `{}` has invalid agent adapter capabilities: {error}",
+                    placement.metadata.name, host_direct.host_ref
+                )
+            })?;
+            (available_adapters, format!("host `{}`", host_direct.host_ref))
+        } else {
+            (BTreeSet::new(), "unknown target environment".to_string())
+        };
+        if available_adapters.contains(&adapter) {
+            continue;
+        }
+        return Err(format!(
+            "workflow requires agent adapter `{adapter}`, which is not available in placement `{}` ({detail})",
+            placement.metadata.name
+        ));
+    }
+
+    Ok(())
+}
+
 fn convoy_fallback_slug(title: &str, id: &str) -> String {
     let slug = format!("{title}-{id}")
         .chars()
@@ -2670,7 +2720,7 @@ impl InProcessDaemon {
             Err(error) => return Err(error.to_string()),
         }
         let contained = workflow.spec.vessels.iter().any(|vessel| vessel.stance == flotilla_resources::Stance::Contained);
-        let placement_policy = match &intent.placement_policy {
+        let placement = match &intent.placement_policy {
             Some(policy) => {
                 let policy = required_admission_value(policy, "placement policy")?;
                 let resolved = self
@@ -2683,16 +2733,28 @@ impl InProcessDaemon {
                 if contained && resolved.spec.docker_per_vessel.is_none() {
                     return Err(format!("contained workflow requires a docker placement policy, but {policy} is not contained"));
                 }
-                Some(policy.to_string())
+                Some(resolved)
             }
             None => {
                 let policy = default_convoy_placement_policy(&self.resource_backend, namespace, contained).await;
                 if contained && policy.is_none() {
                     return Err("contained workflow requires an available docker placement policy".to_string());
                 }
-                policy
+                match policy {
+                    Some(policy) => Some(
+                        self.resource_backend
+                            .clone()
+                            .using::<PlacementPolicy>(namespace)
+                            .get(&policy)
+                            .await
+                            .map_err(|error| format!("placement policy {policy}: {error}"))?,
+                    ),
+                    None => None,
+                }
             }
         };
+        validate_workflow_agent_adapters(&self.resource_backend, namespace, &workflow.spec, placement.as_ref()).await?;
+        let placement_policy = placement.map(|placement| placement.metadata.name);
         let spec = ConvoySpec {
             workflow_ref,
             inputs: intent.inputs.iter().map(|(key, value)| (key.clone(), InputValue::String(value.clone()))).collect(),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2719,8 +2719,31 @@ impl InProcessDaemon {
             Err(ResourceError::NotFound { .. }) => {}
             Err(error) => return Err(error.to_string()),
         }
-        let contained = workflow.spec.vessels.iter().any(|vessel| vessel.stance == flotilla_resources::Stance::Contained);
-        let placement = match &intent.placement_policy {
+        let placement = self.resolve_and_validate_convoy_placement(namespace, &workflow.spec, intent.placement_policy.as_deref()).await?;
+        let placement_policy = placement.map(|placement| placement.metadata.name);
+        let spec = ConvoySpec {
+            workflow_ref,
+            inputs: intent.inputs.iter().map(|(key, value)| (key.clone(), InputValue::String(value.clone()))).collect(),
+            placement_policy,
+            repositories,
+            r#ref: Some(branch),
+            project_ref: Some(project_ref.to_string()),
+            adopted_checkout_refs: BTreeMap::new(),
+            issue,
+            instruction: intent.instruction.clone(),
+        };
+        convoys.create(&InputMeta::builder().name(name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
+        Ok(name)
+    }
+
+    async fn resolve_and_validate_convoy_placement(
+        &self,
+        namespace: &str,
+        workflow: &WorkflowTemplateSpec,
+        placement_policy: Option<&str>,
+    ) -> Result<Option<ResourceObject<PlacementPolicy>>, String> {
+        let contained = workflow.vessels.iter().any(|vessel| vessel.stance == flotilla_resources::Stance::Contained);
+        let placement = match placement_policy {
             Some(policy) => {
                 let policy = required_admission_value(policy, "placement policy")?;
                 let resolved = self
@@ -2753,21 +2776,8 @@ impl InProcessDaemon {
                 }
             }
         };
-        validate_workflow_agent_adapters(&self.resource_backend, namespace, &workflow.spec, placement.as_ref()).await?;
-        let placement_policy = placement.map(|placement| placement.metadata.name);
-        let spec = ConvoySpec {
-            workflow_ref,
-            inputs: intent.inputs.iter().map(|(key, value)| (key.clone(), InputValue::String(value.clone()))).collect(),
-            placement_policy,
-            repositories,
-            r#ref: Some(branch),
-            project_ref: Some(project_ref.to_string()),
-            adopted_checkout_refs: BTreeMap::new(),
-            issue,
-            instruction: intent.instruction.clone(),
-        };
-        convoys.create(&InputMeta::builder().name(name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
-        Ok(name)
+        validate_workflow_agent_adapters(&self.resource_backend, namespace, workflow, placement.as_ref()).await?;
+        Ok(placement)
     }
 
     async fn run_convoy_start(&self, task: ConvoyStartTask) {
@@ -4599,6 +4609,40 @@ impl InProcessDaemon {
                     return Ok(id);
                 }
             }
+            let workflow = match self
+                .resource_backend
+                .clone()
+                .using::<WorkflowTemplate>(&namespace)
+                .get(workflow_ref)
+                .await
+                .map_err(|error| format!("workflow template {workflow_ref}: {error}"))
+            {
+                Ok(workflow) => workflow,
+                Err(message) => {
+                    let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                        command_id: id,
+                        node_id: self.node_id.clone(),
+                        repo_identity: empty_identity,
+                        repo: None,
+                        result: flotilla_protocol::CommandValue::Error { message },
+                    });
+                    return Ok(id);
+                }
+            };
+            let placement_policy =
+                match self.resolve_and_validate_convoy_placement(&namespace, &workflow.spec, placement_policy.as_deref()).await {
+                    Ok(placement) => placement.map(|placement| placement.metadata.name),
+                    Err(message) => {
+                        let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                            command_id: id,
+                            node_id: self.node_id.clone(),
+                            repo_identity: empty_identity,
+                            repo: None,
+                            result: flotilla_protocol::CommandValue::Error { message },
+                        });
+                        return Ok(id);
+                    }
+                };
             let project_repositories = if let Some(project_ref) = project_ref {
                 match self.snapshot_project_repositories(&namespace, project_ref).await {
                     Ok(repositories) => Some(repositories),
@@ -4627,10 +4671,6 @@ impl InProcessDaemon {
                 });
                 return Ok(id);
             }
-            let placement_policy = match placement_policy {
-                Some(policy) => Some(policy.clone()),
-                None => default_convoy_placement_policy(&self.resource_backend, &namespace, false).await,
-            };
             let mut direct_repository_url = repository_url.clone();
             let mut r#ref = r#ref.clone();
             let adopted_checkout = match adopted_checkout {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -16,13 +16,15 @@ use flotilla_protocol::{
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, CrewWorkPhase,
-    CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec, InputMeta,
-    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, Project, ProjectRepositorySpec, ProjectSpec, Repository,
-    RepositorySpec, RepositoryStatus, Selector, TerminalBrief, TerminalCrewContext, TerminalSession as ResourceTerminalSession,
-    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec,
-    TerminalSessionStatus as ResourceTerminalSessionStatus, Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus,
-    WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL,
-    CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
+    ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, RepositoryStatus, Selector, Stance, TerminalBrief, TerminalCrewContext,
+    TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource,
+    TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus, Vessel, VesselPhase,
+    VesselRequirement, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
+    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL,
+    VESSEL_REF_LABEL,
 };
 
 use super::*;
@@ -72,6 +74,45 @@ fn convoy_branch_validation_rejects_refs_that_checkout_cannot_create() {
         assert!(validate_convoy_branch(branch).is_err(), "{branch} should be rejected");
     }
     validate_convoy_branch("fix/issue-732").expect("normal branch should be accepted");
+}
+
+#[tokio::test]
+async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_required_adapter() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = hosts.create(&InputMeta::builder().name("host-test".to_string()).build(), &HostSpec {}).await.expect("host create");
+    hosts
+        .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
+            capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["claude-code"]))].into_iter().collect(),
+            heartbeat_at: None,
+            ready: true,
+            resource_store: None,
+        })
+        .await
+        .expect("host status update");
+    let placement = backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &InputMeta::builder().name("host-direct-test".to_string()).build(),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: host.metadata.name,
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("placement create");
+    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
+    workflow.vessels[0].stance = Stance::Trusted;
+
+    let error = validate_workflow_agent_adapters(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect_err("host without codex must be rejected");
+
+    assert_eq!(error, "workflow requires agent adapter `codex`, which is not available in placement `host-direct-test` (host `host-test`)");
 }
 
 #[test]
@@ -2573,6 +2614,15 @@ async fn convoy_admission_snapshots_every_project_repository() {
     assert_eq!(convoy.spec.repositories[1].subpaths, ["crates/flotilla-core", "crates/flotilla-tui"]);
 }
 
+async fn create_empty_workflow(backend: &ResourceBackend, name: &str) {
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&empty_input_meta(name), &WorkflowTemplateSpec { inputs: Vec::new(), vessels: Vec::new() })
+        .await
+        .expect("workflow create should succeed");
+}
+
 #[tokio::test]
 async fn direct_repository_admission_snapshots_its_resolved_default_branch() {
     let temp = tempfile::tempdir().expect("create tempdir");
@@ -2581,6 +2631,7 @@ async fn direct_repository_admission_snapshots_its_resolved_default_branch() {
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
     let daemon =
         InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    create_empty_workflow(&daemon.resource_backend(), "scratch").await;
     let repositories = daemon.resource_backend().using::<Repository>("flotilla");
     let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository");
     let created =
@@ -2628,6 +2679,7 @@ async fn direct_repository_admission_does_not_guess_a_default_branch() {
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
     let daemon =
         InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    create_empty_workflow(&daemon.resource_backend(), "scratch").await;
 
     let mut events = daemon.subscribe();
     let command_id = daemon
@@ -2675,6 +2727,7 @@ impl AdoptedConvoyFixture {
         let daemon =
             InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), git_process_discovery(false), HostName::local())
                 .await;
+        create_empty_workflow(&daemon.resource_backend(), "scratch").await;
         Self { _temp: temp, daemon, checkout_path }
     }
 
@@ -2808,6 +2861,7 @@ async fn duplicate_adopted_convoy_create_does_not_repoint_existing_checkout() {
 
     let daemon =
         InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), git_process_discovery(false), HostName::local()).await;
+    create_empty_workflow(&daemon.resource_backend(), "scratch").await;
     let mut events = daemon.subscribe();
 
     let first_id = daemon

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -657,7 +657,7 @@ async fn fetch_issue_by_ref_does_not_require_a_tracked_checkout() {
     assert!(daemon.list_repos().await.expect("list repos").is_empty());
 }
 
-async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBackend) {
+async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBackend, image: &str, agent_adapters: BTreeSet<String>) {
     backend
         .clone()
         .using::<PlacementPolicy>("flotilla")
@@ -667,7 +667,8 @@ async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBack
                 .pool("passthrough".to_string())
                 .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                     host_ref: "host-test".into(),
-                    image: "flotilla-test".into(),
+                    image: image.into(),
+                    agent_adapters,
                     default_cwd: Some("/workspace".into()),
                     env: Default::default(),
                     checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".into() },
@@ -692,7 +693,7 @@ async fn create_test_convoy_project(backend: &flotilla_resources::ResourceBacken
         .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
         .await
         .expect("workflow create");
-    create_test_contained_policy(backend).await;
+    create_test_contained_policy(backend, "flotilla-test", BTreeSet::from(["codex".to_string()])).await;
     backend
         .clone()
         .using::<Project>("flotilla")
@@ -704,6 +705,83 @@ async fn create_test_convoy_project(backend: &flotilla_resources::ResourceBacken
         })
         .await
         .expect("project create");
+}
+
+#[tokio::test]
+async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config_store(temp.path().join("config"));
+    let daemon = InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::local()).await;
+    let backend = daemon.resource_backend();
+    let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository.key().to_string()).build(), &repository)
+        .await
+        .expect("repository create");
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
+        .await
+        .expect("workflow create");
+    create_test_contained_policy(&backend, "ubuntu:24.04", BTreeSet::new()).await;
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
+            display_name: "Flotilla".into(),
+            default_workflow_ref: "single-agent-contained".into(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project create");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".into(),
+                    issue: None,
+                    name: Some("missing-adapter".into()),
+                    branch: Some("fix/missing-adapter".into()),
+                    workflow_ref: None,
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: Some("docker-test".into()),
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("start command accepted");
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("start command should finish");
+
+    assert_eq!(result, CommandValue::Error {
+        message: "workflow requires agent adapter `codex`, which is not available in placement `docker-test` (image `ubuntu:24.04`)"
+            .to_string()
+    });
+    assert!(matches!(
+        backend.using::<ResourceConvoy>("flotilla").get("missing-adapter").await,
+        Err(flotilla_resources::ResourceError::NotFound { .. })
+    ));
 }
 
 #[tokio::test]
@@ -735,7 +813,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
         .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
         .await
         .expect("workflow create");
-    create_test_contained_policy(&backend).await;
+    create_test_contained_policy(&backend, "flotilla-test", BTreeSet::from(["codex".to_string()])).await;
     backend
         .clone()
         .using::<Project>("flotilla")
@@ -988,7 +1066,7 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
         .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
         .await
         .expect("workflow create");
-    create_test_contained_policy(&backend).await;
+    create_test_contained_policy(&backend, "flotilla-test", BTreeSet::from(["codex".to_string()])).await;
     backend
         .clone()
         .using::<Project>("flotilla")

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -782,6 +782,45 @@ async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
         backend.using::<ResourceConvoy>("flotilla").get("missing-adapter").await,
         Err(flotilla_resources::ResourceError::NotFound { .. })
     ));
+
+    let legacy_command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "missing-adapter-legacy".into(),
+                workflow_ref: "single-agent-contained".into(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: Some("fix/missing-adapter-legacy".into()),
+                project_ref: Some("flotilla".into()),
+                placement_policy: Some("docker-test".into()),
+                adopted_checkout: None,
+            },
+        })
+        .await
+        .expect("legacy create command accepted");
+    let legacy_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == legacy_command_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("legacy create command should finish");
+
+    assert_eq!(legacy_result, CommandValue::Error {
+        message: "workflow requires agent adapter `codex`, which is not available in placement `docker-test` (image `ubuntu:24.04`)"
+            .to_string()
+    });
+    assert!(matches!(
+        backend.using::<ResourceConvoy>("flotilla").get("missing-adapter-legacy").await,
+        Err(flotilla_resources::ResourceError::NotFound { .. })
+    ));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     future::Future,
     path::{Path, PathBuf},
     sync::Arc,
@@ -34,7 +34,7 @@ use flotilla_resources::{
     CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
     InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Repository, ResourceBackend, ResourceError, ResourceObject,
-    Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -152,6 +152,7 @@ struct LocalProvisioningProfile {
     host_direct_pool: String,
     docker_pool: String,
     available_pools: Vec<String>,
+    available_agent_adapters: BTreeSet<String>,
     docker_available: bool,
 }
 
@@ -260,6 +261,7 @@ fn build_local_profile(daemon: &Arc<InProcessDaemon>, local_registry: &ProviderR
     let host_direct_pool = local_registry.terminal_pools.preferred_name().unwrap_or("passthrough").to_string();
     let docker_pool =
         if local_registry.terminal_pools.contains_key("passthrough") { "passthrough".to_string() } else { host_direct_pool.clone() };
+    let available_agent_adapters = local_registry.agent_adapters.ids().map(ToString::to_string).collect();
 
     Ok(LocalProvisioningProfile {
         host_id,
@@ -267,6 +269,7 @@ fn build_local_profile(daemon: &Arc<InProcessDaemon>, local_registry: &ProviderR
         host_direct_pool,
         docker_pool,
         available_pools,
+        available_agent_adapters,
         docker_available: local_registry.environment_providers.contains_key("docker"),
     })
 }
@@ -460,6 +463,7 @@ async fn ensure_default_policies(backend: &ResourceBackend, namespace: &str, pro
                         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                             host_ref: profile.host_id.clone(),
                             image: DEFAULT_DOCKER_IMAGE.to_string(),
+                            agent_adapters: BTreeSet::new(),
                             default_cwd: Some("/workspace".to_string()),
                             env: BTreeMap::new(),
                             checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".to_string() },
@@ -564,6 +568,7 @@ async fn apply_host_heartbeat(daemon: &Arc<InProcessDaemon>, namespace: &str, pr
 
 fn host_capabilities(_summary: &HostSummary, profile: &LocalProvisioningProfile) -> BTreeMap<String, serde_json::Value> {
     BTreeMap::from([
+        (AGENT_ADAPTERS_CAPABILITY.to_string(), json!(profile.available_agent_adapters)),
         ("docker".to_string(), json!(profile.docker_available)),
         ("terminal_pools".to_string(), json!(profile.available_pools)),
     ])
@@ -1657,6 +1662,7 @@ mod tests {
             host_direct_pool: "passthrough".to_string(),
             docker_pool: "passthrough".to_string(),
             available_pools: vec!["passthrough".to_string()],
+            available_agent_adapters: BTreeSet::new(),
             docker_available,
         }
     }
@@ -1938,6 +1944,7 @@ mod tests {
 
         let status = wait_for_host_status(&hosts, &host_id).await;
         assert!(status.ready, "heartbeat should mark host ready");
+        assert_eq!(status.agent_adapters().expect("valid agent adapter capability"), BTreeSet::new());
         assert_eq!(status.capabilities.get("docker"), Some(&json!(false)));
         assert_eq!(status.capabilities.get("terminal_pools"), Some(&json!(["passthrough"])));
         assert!(

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2605,21 +2605,10 @@ mod tests {
             })
             .await
             .expect("create unknown convoy");
-        assert_eq!(wait_for_command_result(&mut rx, create_id).await, CommandValue::ConvoyCreated { name: "unknown-convoy".to_string() });
-        wait_until(|| {
-            let convoys = convoys.clone();
-            async move {
-                convoys
-                    .get("unknown-convoy")
-                    .await
-                    .ok()
-                    .and_then(|convoy| convoy.status)
-                    .is_some_and(|status| status.phase == ConvoyPhase::Failed)
-            }
-        })
-        .await;
-        let failed = convoys.get("unknown-convoy").await.expect("unknown convoy").status.expect("unknown status");
-        assert_eq!(failed.work.get("implement").and_then(|task| task.message.as_deref()), Some("unknown agent capability `architect`"));
+        assert_eq!(wait_for_command_result(&mut rx, create_id).await, CommandValue::Error {
+            message: "unknown agent capability `architect`".to_string()
+        });
+        assert!(convoys.get("unknown-convoy").await.is_err(), "rejected convoy should not be persisted");
 
         for handle in controller_handles {
             handle.abort();

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -439,10 +439,12 @@ fn input_value_string(value: &InputValue) -> String {
 }
 
 fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
-    let any_failed = status.work.values().any(|state| state.phase == WorkPhase::Failed);
-    if !any_failed {
-        return None;
-    }
+    let failure_message = status
+        .work
+        .values()
+        .filter(|state| state.phase == WorkPhase::Failed)
+        .find_map(|state| state.message.clone())
+        .or_else(|| status.work.values().any(|state| state.phase == WorkPhase::Failed).then(|| "work failure detected".to_string()))?;
 
     let cancelled_work = status
         .work
@@ -464,7 +466,7 @@ fn fail_fast_outcome(status: &super::ConvoyStatus, now: DateTime<Utc>) -> Option
     }
 
     Some(InternalReconcileOutcome {
-        patch: Some(controller_patches::fail_convoy(cancelled_work, now, Some("work failure detected".to_string()))),
+        patch: Some(controller_patches::fail_convoy(cancelled_work, now, Some(failure_message))),
         actuations: Vec::new(),
         events,
     })

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::{resource::define_resource, retention::ResourceStoreDiagnostics, status_patch::StatusPatch};
 
 define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch);
+
+pub const AGENT_ADAPTERS_CAPABILITY: &str = "agent_adapters";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostSpec {}
@@ -20,6 +22,12 @@ pub struct HostStatus {
     pub ready: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_store: Option<ResourceStoreDiagnostics>,
+}
+
+impl HostStatus {
+    pub fn agent_adapters(&self) -> Result<BTreeSet<String>, serde_json::Error> {
+        self.capabilities.get(AGENT_ADAPTERS_CAPABILITY).cloned().map(serde_json::from_value).transpose().map(Option::unwrap_or_default)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -39,7 +39,7 @@ pub use environment::{
     EnvironmentStatusPatch, HostDirectEnvironmentSpec,
 };
 pub use error::ResourceError;
-pub use host::{Host, HostSpec, HostStatus, HostStatusPatch};
+pub use host::{Host, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY};
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use labels::{

--- a/crates/flotilla-resources/src/placement_policy.rs
+++ b/crates/flotilla-resources/src/placement_policy.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -31,6 +31,9 @@ pub enum HostDirectPlacementPolicyCheckout {
 pub struct DockerPerVesselPlacementPolicySpec {
     pub host_ref: String,
     pub image: String,
+    /// Agent adapters the image recipe promises will be available after provisioning.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub agent_adapters: BTreeSet<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_cwd: Option<String>,
     #[serde(default)]

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -427,6 +427,7 @@ fn failed_task_triggers_fail_fast() {
     status.phase = ConvoyPhase::Active;
     status.work.get_mut("implement").expect("implement").phase = WorkPhase::Failed;
     status.work.get_mut("implement").expect("implement").finished_at = Some(timestamp(12));
+    status.work.get_mut("implement").expect("implement").message = Some("agent adapter codex unavailable".to_string());
     status.work.get_mut("review").expect("review").phase = WorkPhase::Running;
     status.work.get_mut("review").expect("review").started_at = Some(timestamp(11));
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
@@ -438,7 +439,7 @@ fn failed_task_triggers_fail_fast() {
         Some(controller_patches::fail_convoy(
             [("review".to_string(), timestamp(30))].into_iter().collect(),
             timestamp(30),
-            Some("work failure detected".to_string())
+            Some("agent adapter codex unavailable".to_string())
         ))
     );
 }

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -168,6 +168,7 @@ fn docker_per_vessel_policy_uses_vessel_spelling_in_serialized_resources() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: "01HXYZ".to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
+            agent_adapters: Default::default(),
             default_cwd: Some("/workspace".to_string()),
             env: [("FOO".to_string(), "bar".to_string())].into_iter().collect(),
             checkout: DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },


### PR DESCRIPTION
## What changed

- validate every agent crew capability against the selected placement before persisting a convoy
- advertise host-direct adapters through live host capabilities and let Docker image recipes declare bundled adapters
- reject the stock `ubuntu:24.04` contained placement with an error naming the missing adapter, placement, and image
- propagate a failed work item's concrete message into convoy-level status

## Why

The default contained workflow resolves `code` to the `codex` adapter, but the stock Docker image contains no adapter. That made a guaranteed failure pass admission, spend time provisioning, and then surface only the generic `work failure detected` message.

Admission now fails immediately, while post-admission failures retain their actionable cause across existing project, convoy, and CLI views.

## Impact

Impossible convoy starts are rejected before persistence. Operators see the concrete adapter or work failure instead of waiting for provisioning and drilling into per-work status.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR=/private/tmp cargo test --workspace --locked`
- independent Standards and Spec reviews

Closes #784
