### PR TITLE
fix: dispatch TUI commands outside event loop

### DIFF
--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -55,8 +55,17 @@ pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionCo
     if let Some(ctx) = &pending_ctx {
         let action = PendingAction { status: PendingStatus::Submitting, description: ctx.description.clone() };
         if let Some(page) = app.screen.repo_pages.get_mut(&ctx.repo_identity) {
+            if page
+                .pending_actions
+                .get(&ctx.identity)
+                .is_some_and(|pending| matches!(pending.status, PendingStatus::Submitting | PendingStatus::InFlight { .. }))
+            {
+                app.model.status_message = Some("An action is already in progress for this item".into());
+                return;
+            }
             page.pending_actions.insert(ctx.identity.clone(), action);
         }
+        app.pending_dispatch_acks += 1;
     }
 
     let daemon = app.daemon.clone();
@@ -67,14 +76,14 @@ pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionCo
 }
 
 pub fn handle_dispatch_completion(result: Result<u64, String>, pending_ctx: Option<PendingActionContext>, app: &mut App) {
+    if pending_ctx.is_some() {
+        debug_assert!(app.pending_dispatch_acks > 0, "pending-action acknowledgement without a tracked dispatch");
+        app.pending_dispatch_acks = app.pending_dispatch_acks.saturating_sub(1);
+    }
+
     match result {
         Ok(command_id) => {
-            let finished_error = app
-                .recent_command_finishes
-                .iter()
-                .position(|(finished_id, _)| *finished_id == command_id)
-                .and_then(|index| app.recent_command_finishes.remove(index))
-                .map(|(_, error)| error);
+            let finished_error = app.recent_command_finishes.remove(&command_id);
             if let Some(finished_error) = finished_error {
                 if let Some(ctx) = pending_ctx {
                     match finished_error {
@@ -82,11 +91,9 @@ pub fn handle_dispatch_completion(result: Result<u64, String>, pending_ctx: Opti
                         None => remove_pending_action(app, &ctx),
                     }
                 }
-            } else {
+            } else if let Some(ctx) = pending_ctx {
                 app.acknowledged_dispatches.insert(command_id);
-                if let Some(ctx) = pending_ctx {
-                    set_pending_status(app, &ctx, PendingStatus::InFlight { command_id });
-                }
+                set_pending_status(app, &ctx, PendingStatus::InFlight { command_id });
             }
         }
         Err(message) => {
@@ -96,6 +103,10 @@ pub fn handle_dispatch_completion(result: Result<u64, String>, pending_ctx: Opti
             reset_loading_mode(app);
             app.model.status_message = Some(message);
         }
+    }
+
+    if app.pending_dispatch_acks == 0 {
+        app.recent_command_finishes.clear();
     }
 }
 
@@ -340,6 +351,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dispatch_rejects_a_second_pending_action_for_the_same_identity() {
+        let execute_gate = Arc::new(Semaphore::new(0));
+        let daemon = Arc::new(StubDaemon::builder().execute_gate(Arc::clone(&execute_gate)).build());
+        let mut app =
+            stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
+        let repo_identity = app.model.repo_order[0].clone();
+        let identity = WorkItemIdentity::Session("session-1".into());
+        let pending_ctx =
+            PendingActionContext { identity: identity.clone(), description: "Refresh".into(), repo_identity: repo_identity.clone() };
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+
+        dispatch(app.command(CommandAction::Refresh { repo: None }), &mut app, Some(pending_ctx.clone()), event_tx.clone());
+        dispatch(app.command(CommandAction::Refresh { repo: None }), &mut app, Some(pending_ctx), event_tx);
+
+        assert_eq!(app.pending_dispatch_acks, 1);
+        assert_eq!(app.model.status_message.as_deref(), Some("An action is already in progress for this item"));
+
+        execute_gate.add_permits(2);
+        let event = event_rx.recv().await.expect("first dispatch completion event");
+        match event {
+            Event::CommandDispatchCompleted { result, pending_ctx } => {
+                handle_dispatch_completion(result, pending_ctx, &mut app);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+        let duplicate_event = tokio::time::timeout(Duration::from_millis(20), event_rx.recv()).await;
+        assert!(!matches!(duplicate_event, Ok(Some(_))), "the duplicate dispatch should not reach the daemon");
+        assert!(matches!(app.screen.repo_pages[&repo_identity].pending_actions[&identity].status, PendingStatus::InFlight {
+            command_id: 1
+        }));
+    }
+
+    #[tokio::test]
     async fn pane_attach_query_hands_the_resolved_command_to_the_event_loop() {
         let mut app = stub_app_with_query_result(Ok(CommandValue::AttachCommandResolved {
             command: "cleat attach terminal-scratch".to_string(),
@@ -406,6 +450,7 @@ mod tests {
             .expect("repo page")
             .pending_actions
             .insert(identity.clone(), PendingAction { status: PendingStatus::Submitting, description: pending_ctx.description.clone() });
+        app.pending_dispatch_acks = 1;
 
         app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandStarted {
             command_id: 42,
@@ -430,6 +475,53 @@ mod tests {
     }
 
     #[test]
+    fn unrelated_finishes_cannot_evict_a_finish_awaiting_its_ack() {
+        let mut app = stub_app();
+        let repo_identity = app.model.repo_order[0].clone();
+        let repo = app.model.repos[&repo_identity].path.clone();
+        let identity = WorkItemIdentity::Session("session-1".into());
+        let pending_ctx = PendingActionContext {
+            identity: identity.clone(),
+            description: "Archive session".into(),
+            repo_identity: repo_identity.clone(),
+        };
+        app.screen
+            .repo_pages
+            .get_mut(&repo_identity)
+            .expect("repo page")
+            .pending_actions
+            .insert(identity.clone(), PendingAction { status: PendingStatus::Submitting, description: pending_ctx.description.clone() });
+        app.pending_dispatch_acks = 1;
+
+        for command_id in std::iter::once(42).chain(100..166) {
+            app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandStarted {
+                command_id,
+                node_id: NodeId::new(HostName::local().as_str()),
+                repo_identity: repo_identity.clone(),
+                repo: Some(repo.clone()),
+                description: format!("command {command_id}"),
+            });
+            app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandFinished {
+                command_id,
+                node_id: NodeId::new(HostName::local().as_str()),
+                repo_identity: repo_identity.clone(),
+                repo: Some(repo.clone()),
+                result: CommandValue::Ok,
+            });
+        }
+
+        assert!(app.recent_command_finishes.contains_key(&42));
+        assert_eq!(app.recent_command_finishes.len(), 67);
+
+        handle_dispatch_completion(Ok(42), Some(pending_ctx), &mut app);
+
+        assert!(!app.screen.repo_pages[&repo_identity].pending_actions.contains_key(&identity));
+        assert_eq!(app.pending_dispatch_acks, 0);
+        assert!(app.recent_command_finishes.is_empty());
+        assert!(app.acknowledged_dispatches.is_empty());
+    }
+
+    #[test]
     fn command_error_before_ack_marks_pending_action_failed() {
         let mut app = stub_app();
         let repo_identity = app.model.repo_order[0].clone();
@@ -446,6 +538,7 @@ mod tests {
             .expect("repo page")
             .pending_actions
             .insert(identity.clone(), PendingAction { status: PendingStatus::Submitting, description: pending_ctx.description.clone() });
+        app.pending_dispatch_acks = 1;
 
         app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandStarted {
             command_id: 42,
@@ -490,6 +583,7 @@ mod tests {
             .expect("repo page")
             .pending_actions
             .insert(identity.clone(), PendingAction { status: PendingStatus::Submitting, description: pending_ctx.description.clone() });
+        app.pending_dispatch_acks = 1;
 
         handle_dispatch_completion(Ok(42), Some(pending_ctx), &mut app);
         app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandStarted {

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -1,11 +1,15 @@
 use flotilla_protocol::{Command, CommandAction, CommandValue};
+use tokio::sync::mpsc;
 use tracing::info;
 
 use super::{
     ui_state::{PendingAction, PendingActionContext, PendingStatus},
     App,
 };
-use crate::widgets::{branch_input::BranchInputWidget, delete_confirm::DeleteConfirmWidget};
+use crate::{
+    event::Event,
+    widgets::{branch_input::BranchInputWidget, delete_confirm::DeleteConfirmWidget},
+};
 
 /// Dispatch a single protocol command through the daemon.
 ///
@@ -13,27 +17,22 @@ use crate::widgets::{branch_input::BranchInputWidget, delete_confirm::DeleteConf
 /// results arrive via the background `issue_update_tx` channel.  Non-query
 /// commands use the regular `execute` path.
 ///
-/// When `pending_ctx` is provided the successful command ID is recorded as a
-/// [`PendingAction`] on the active repo's UI state so the renderer can show
-/// an in-flight indicator on the affected work item row.
-pub async fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionContext>) {
+/// When `pending_ctx` is provided a [`PendingAction`] is recorded before the
+/// request starts so the renderer can show an indicator while the daemon
+/// acknowledgement is outstanding.
+pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionContext>, event_tx: mpsc::UnboundedSender<Event>) {
     app.model.status_message = None;
 
-    // Pane attach is a synchronous query that resolves a command for the TUI
-    // process to run temporarily outside raw mode. It must not go through the
-    // ordinary command lifecycle (`execute` rejects query commands).
+    // Pane attach is a query that resolves a command for the TUI process to
+    // run temporarily outside raw mode. It must not go through the ordinary
+    // command lifecycle (`execute` rejects query commands).
     if matches!(&cmd.action, CommandAction::Attach { .. } | CommandAction::AttachTransient { .. }) {
-        match app.daemon.execute_query(cmd, app.session_id).await {
-            Ok(CommandValue::AttachCommandResolved { command, .. }) => {
-                app.pending_attach_command = Some(command);
-            }
-            Ok(CommandValue::Error { message }) | Err(message) => {
-                app.model.status_message = Some(message);
-            }
-            Ok(other) => {
-                app.model.status_message = Some(format!("unexpected attach response: {other:?}"));
-            }
-        }
+        let daemon = app.daemon.clone();
+        let session_id = app.session_id;
+        tokio::spawn(async move {
+            let result = daemon.execute_query(cmd, session_id).await;
+            let _ = event_tx.send(Event::AttachDispatchCompleted(result));
+        });
         return;
     }
 
@@ -53,27 +52,83 @@ pub async fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingAc
         return;
     }
 
-    match app.daemon.execute(cmd).await {
+    if let Some(ctx) = &pending_ctx {
+        let action = PendingAction { status: PendingStatus::Submitting, description: ctx.description.clone() };
+        if let Some(page) = app.screen.repo_pages.get_mut(&ctx.repo_identity) {
+            page.pending_actions.insert(ctx.identity.clone(), action);
+        }
+    }
+
+    let daemon = app.daemon.clone();
+    tokio::spawn(async move {
+        let result = daemon.execute(cmd).await;
+        let _ = event_tx.send(Event::CommandDispatchCompleted { result, pending_ctx });
+    });
+}
+
+pub fn handle_dispatch_completion(result: Result<u64, String>, pending_ctx: Option<PendingActionContext>, app: &mut App) {
+    match result {
         Ok(command_id) => {
-            if let Some(ctx) = pending_ctx {
-                let action = PendingAction { command_id, status: PendingStatus::InFlight, description: ctx.description };
-                if let Some(page) = app.screen.repo_pages.get_mut(&ctx.repo_identity) {
-                    page.pending_actions.insert(ctx.identity, action);
+            let finished_error = app
+                .recent_command_finishes
+                .iter()
+                .position(|(finished_id, _)| *finished_id == command_id)
+                .and_then(|index| app.recent_command_finishes.remove(index))
+                .map(|(_, error)| error);
+            if let Some(finished_error) = finished_error {
+                if let Some(ctx) = pending_ctx {
+                    match finished_error {
+                        Some(message) => set_pending_status(app, &ctx, PendingStatus::Failed(message)),
+                        None => remove_pending_action(app, &ctx),
+                    }
+                }
+            } else {
+                app.acknowledged_dispatches.insert(command_id);
+                if let Some(ctx) = pending_ctx {
+                    set_pending_status(app, &ctx, PendingStatus::InFlight { command_id });
                 }
             }
         }
-        Err(e) => {
-            // Reset loading modes so the error message is visible.
+        Err(message) => {
+            if let Some(ctx) = pending_ctx {
+                remove_pending_action(app, &ctx);
+            }
             reset_loading_mode(app);
-            app.model.status_message = Some(e);
+            app.model.status_message = Some(message);
         }
+    }
+}
+
+pub fn handle_attach_dispatch_completion(result: Result<CommandValue, String>, app: &mut App) {
+    match result {
+        Ok(CommandValue::AttachCommandResolved { command, .. }) => {
+            app.pending_attach_command = Some(command);
+        }
+        Ok(CommandValue::Error { message }) | Err(message) => {
+            app.model.status_message = Some(message);
+        }
+        Ok(other) => {
+            app.model.status_message = Some(format!("unexpected attach response: {other:?}"));
+        }
+    }
+}
+
+fn set_pending_status(app: &mut App, ctx: &PendingActionContext, status: PendingStatus) {
+    if let Some(action) = app.screen.repo_pages.get_mut(&ctx.repo_identity).and_then(|page| page.pending_actions.get_mut(&ctx.identity)) {
+        action.status = status;
+    }
+}
+
+fn remove_pending_action(app: &mut App, ctx: &PendingActionContext) {
+    if let Some(page) = app.screen.repo_pages.get_mut(&ctx.repo_identity) {
+        page.pending_actions.remove(&ctx.identity);
     }
 }
 
 /// Reset UI modes that are waiting for a command result.
 ///
-/// When a command fails (either synchronously from `dispatch` or
-/// asynchronously via `CommandValue::Error`), loading modes like
+/// When a command fails (either in its dispatch acknowledgement or later via
+/// `CommandValue::Error`), loading modes like
 /// `DeleteConfirm { loading: true }` must be cleared so the user
 /// can see the error message and isn't stuck in a loading state.
 fn reset_loading_mode(app: &mut App) {
@@ -190,19 +245,99 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, sync::Arc, time::Duration};
 
+    use crossterm::event::KeyCode;
     use flotilla_protocol::{
         arg::Arg,
         qualified_path::{HostId, QualifiedPath},
-        CheckoutStatus, NodeId, RepoIdentity, ResolvedPaneCommand, WorkItemIdentity,
+        CheckoutStatus, HostName, NodeId, RepoIdentity, ResolvedPaneCommand, WorkItemIdentity,
     };
+    use ratatui::{backend::TestBackend, Terminal};
+    use tokio::sync::{mpsc, Semaphore};
 
     use super::*;
-    use crate::app::{
-        test_support::{stub_app, stub_app_with_query_result},
-        ui_state::BranchInputKind,
+    use crate::{
+        app::{
+            test_support::{
+                activate_repo_tab, key, repo_info, session_item, setup_selectable_table, stub_app, stub_app_with_daemon,
+                stub_app_with_query_result, StubDaemon,
+            },
+            ui_state::BranchInputKind,
+        },
+        event::EventHandler,
+        widgets::{InteractiveWidget, RenderContext},
     };
+
+    #[tokio::test]
+    async fn dispatch_returns_while_daemon_ack_is_outstanding() {
+        let execute_gate = Arc::new(Semaphore::new(0));
+        let daemon = Arc::new(StubDaemon::builder().execute_gate(Arc::clone(&execute_gate)).build());
+        let mut app =
+            stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
+        let command = app.command(CommandAction::Refresh { repo: None });
+        let repo_identity = app.model.repo_order[0].clone();
+        let identity = WorkItemIdentity::Session("session-1".into());
+        activate_repo_tab(&mut app, 0);
+        setup_selectable_table(&mut app, vec![session_item("session-1")]);
+        let pending_ctx =
+            PendingActionContext { identity: identity.clone(), description: "Refresh".into(), repo_identity: repo_identity.clone() };
+        let mut events = EventHandler::new(Duration::from_secs(60));
+        events.pause_terminal_input().await;
+
+        dispatch(command, &mut app, Some(pending_ctx), events.sender());
+
+        assert!(matches!(app.screen.repo_pages[&repo_identity].pending_actions[&identity].status, PendingStatus::Submitting));
+        assert!(app.needs_animation(), "submitting actions should render their pending indicator");
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                let mut ctx = RenderContext {
+                    model: &app.model,
+                    views: &mut app.views,
+                    ui: &mut app.ui,
+                    theme: &app.theme,
+                    keymap: &app.keymap,
+                    in_flight: &app.in_flight,
+                    namespaces: &app.namespaces,
+                    query_tables: &app.query_tables,
+                };
+                app.screen.render(frame, frame.area(), &mut ctx);
+            })
+            .expect("pending frame should render");
+        let rendered: String = terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect();
+        assert!(
+            rendered.chars().any(|ch| matches!(
+                ch,
+                '\u{280b}' | '\u{2819}' | '\u{2839}' | '\u{2838}' | '\u{283c}' | '\u{2834}' | '\u{2826}' | '\u{2827}'
+            )),
+            "submitting pending action should render a spinner"
+        );
+
+        events.sender().send(Event::Key(key(KeyCode::Char('q')))).expect("event loop should remain open");
+        match events.next().await.expect("queued key event") {
+            Event::Key(key) => app.handle_key(key),
+            other => panic!("unexpected event: {other:?}"),
+        }
+        assert!(app.should_quit, "the app should continue handling keys while the acknowledgement is outstanding");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), events.next()).await.is_err(),
+            "daemon acknowledgement should still be outstanding"
+        );
+
+        execute_gate.add_permits(1);
+        let event = events.next().await.expect("dispatch completion event");
+        match event {
+            Event::CommandDispatchCompleted { result, pending_ctx } => {
+                handle_dispatch_completion(result, pending_ctx, &mut app);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+        assert!(matches!(app.screen.repo_pages[&repo_identity].pending_actions[&identity].status, PendingStatus::InFlight {
+            command_id: 1
+        }));
+    }
 
     #[tokio::test]
     async fn pane_attach_query_hands_the_resolved_command_to_the_event_loop() {
@@ -214,11 +349,167 @@ mod tests {
             reference: "terminal-scratch".to_string(),
             host: Some(flotilla_protocol::HostName::new("kiwi")),
         });
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
 
-        dispatch(command, &mut app, None).await;
+        dispatch(command, &mut app, None, event_tx);
+        let event = event_rx.recv().await.expect("attach completion event");
+        match event {
+            Event::AttachDispatchCompleted(result) => handle_attach_dispatch_completion(result, &mut app),
+            other => panic!("unexpected event: {other:?}"),
+        }
 
         assert_eq!(app.pending_attach_command.as_deref(), Some("cleat attach terminal-scratch"));
         assert!(app.model.status_message.is_none());
+    }
+
+    #[tokio::test]
+    async fn dispatch_error_clears_pending_state_and_resets_loading_modal() {
+        let daemon = Arc::new(StubDaemon::builder().execute_result(Err("request timed out after 30s".into())).build());
+        let mut app =
+            stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
+        let repo_identity = app.model.repo_order[0].clone();
+        let identity = WorkItemIdentity::Session("session-1".into());
+        let pending_ctx =
+            PendingActionContext { identity: identity.clone(), description: "Delete session".into(), repo_identity: repo_identity.clone() };
+        app.screen.modal_stack.push(Box::new(DeleteConfirmWidget::new(identity.clone(), None, None)));
+        let command = app.command(CommandAction::Refresh { repo: None });
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+
+        dispatch(command, &mut app, Some(pending_ctx), event_tx);
+        let event = event_rx.recv().await.expect("dispatch completion event");
+        match event {
+            Event::CommandDispatchCompleted { result, pending_ctx } => {
+                handle_dispatch_completion(result, pending_ctx, &mut app);
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        assert!(!app.screen.repo_pages[&repo_identity].pending_actions.contains_key(&identity));
+        assert!(app.screen.modal_stack.is_empty(), "loading modal should be reset after dispatch error");
+        assert_eq!(app.model.status_message.as_deref(), Some("request timed out after 30s"));
+    }
+
+    #[test]
+    fn command_finish_before_ack_reconciles_pending_action() {
+        let mut app = stub_app();
+        let repo_identity = app.model.repo_order[0].clone();
+        let repo = app.model.repos[&repo_identity].path.clone();
+        let identity = WorkItemIdentity::Session("session-1".into());
+        let pending_ctx = PendingActionContext {
+            identity: identity.clone(),
+            description: "Archive session".into(),
+            repo_identity: repo_identity.clone(),
+        };
+        app.screen
+            .repo_pages
+            .get_mut(&repo_identity)
+            .expect("repo page")
+            .pending_actions
+            .insert(identity.clone(), PendingAction { status: PendingStatus::Submitting, description: pending_ctx.description.clone() });
+
+        app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandStarted {
+            command_id: 42,
+            node_id: NodeId::new(HostName::local().as_str()),
+            repo_identity: repo_identity.clone(),
+            repo: Some(repo.clone()),
+            description: pending_ctx.description.clone(),
+        });
+        app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandFinished {
+            command_id: 42,
+            node_id: NodeId::new(HostName::local().as_str()),
+            repo_identity: repo_identity.clone(),
+            repo: Some(repo),
+            result: CommandValue::Ok,
+        });
+
+        handle_dispatch_completion(Ok(42), Some(pending_ctx), &mut app);
+
+        assert!(!app.screen.repo_pages[&repo_identity].pending_actions.contains_key(&identity));
+        assert!(app.recent_command_finishes.is_empty());
+        assert!(app.acknowledged_dispatches.is_empty());
+    }
+
+    #[test]
+    fn command_error_before_ack_marks_pending_action_failed() {
+        let mut app = stub_app();
+        let repo_identity = app.model.repo_order[0].clone();
+        let repo = app.model.repos[&repo_identity].path.clone();
+        let identity = WorkItemIdentity::Session("session-1".into());
+        let pending_ctx = PendingActionContext {
+            identity: identity.clone(),
+            description: "Archive session".into(),
+            repo_identity: repo_identity.clone(),
+        };
+        app.screen
+            .repo_pages
+            .get_mut(&repo_identity)
+            .expect("repo page")
+            .pending_actions
+            .insert(identity.clone(), PendingAction { status: PendingStatus::Submitting, description: pending_ctx.description.clone() });
+
+        app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandStarted {
+            command_id: 42,
+            node_id: NodeId::new(HostName::local().as_str()),
+            repo_identity: repo_identity.clone(),
+            repo: Some(repo.clone()),
+            description: pending_ctx.description.clone(),
+        });
+        app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandFinished {
+            command_id: 42,
+            node_id: NodeId::new(HostName::local().as_str()),
+            repo_identity: repo_identity.clone(),
+            repo: Some(repo),
+            result: CommandValue::Error { message: "archive failed".into() },
+        });
+
+        handle_dispatch_completion(Ok(42), Some(pending_ctx), &mut app);
+
+        assert!(matches!(
+            app.screen.repo_pages[&repo_identity].pending_actions[&identity].status,
+            PendingStatus::Failed(ref message) if message == "archive failed"
+        ));
+        assert_eq!(app.model.status_message.as_deref(), Some("archive failed"));
+        assert!(app.recent_command_finishes.is_empty());
+        assert!(app.acknowledged_dispatches.is_empty());
+    }
+
+    #[test]
+    fn command_ack_before_finish_reconciles_pending_action() {
+        let mut app = stub_app();
+        let repo_identity = app.model.repo_order[0].clone();
+        let repo = app.model.repos[&repo_identity].path.clone();
+        let identity = WorkItemIdentity::Session("session-1".into());
+        let pending_ctx = PendingActionContext {
+            identity: identity.clone(),
+            description: "Archive session".into(),
+            repo_identity: repo_identity.clone(),
+        };
+        app.screen
+            .repo_pages
+            .get_mut(&repo_identity)
+            .expect("repo page")
+            .pending_actions
+            .insert(identity.clone(), PendingAction { status: PendingStatus::Submitting, description: pending_ctx.description.clone() });
+
+        handle_dispatch_completion(Ok(42), Some(pending_ctx), &mut app);
+        app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandStarted {
+            command_id: 42,
+            node_id: NodeId::new(HostName::local().as_str()),
+            repo_identity: repo_identity.clone(),
+            repo: Some(repo.clone()),
+            description: "Archive session".into(),
+        });
+        app.handle_daemon_event(flotilla_protocol::DaemonEvent::CommandFinished {
+            command_id: 42,
+            node_id: NodeId::new(HostName::local().as_str()),
+            repo_identity: repo_identity.clone(),
+            repo: Some(repo),
+            result: CommandValue::Ok,
+        });
+
+        assert!(!app.screen.repo_pages[&repo_identity].pending_actions.contains_key(&identity));
+        assert!(app.recent_command_finishes.is_empty());
+        assert!(app.acknowledged_dispatches.is_empty());
     }
 
     #[test]

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -1690,8 +1690,9 @@ fn query_issues_command_intercepted_by_executor_dispatch() {
     // a task that will fail (stub daemon). We just need to verify the
     // interception path runs without error.
     let rt = tokio::runtime::Runtime::new().unwrap();
+    let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
     rt.block_on(async {
-        crate::app::executor::dispatch(cmd, &mut app, None).await;
+        crate::app::executor::dispatch(cmd, &mut app, None, event_tx);
     });
 
     // Key assertion: no in-flight command was recorded. If the command had

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -47,6 +47,8 @@ use crate::{
     },
 };
 
+const RECENT_COMMAND_FINISH_LIMIT: usize = 64;
+
 /// Owned version of `SelectedRow` for use when the borrow can't be held.
 pub(super) enum OwnedSelectedRow {
     WorkItem(Box<WorkItem>),
@@ -435,6 +437,13 @@ pub struct App {
     pub keymap: Keymap,
     pub proto_commands: CommandQueue,
     pub in_flight: HashMap<u64, InFlightCommand>,
+    /// Command IDs whose execute acknowledgement has arrived but whose
+    /// CommandFinished event has not yet been handled.
+    pub acknowledged_dispatches: HashSet<u64>,
+    /// Recently finished commands whose execute acknowledgement was not seen
+    /// first. This bounded cache reconciles independent event/response stream
+    /// ordering without retaining commands initiated by other clients.
+    pub recent_command_finishes: VecDeque<(u64, Option<String>)>,
     pub pending_cancel: Option<u64>,
     pub should_quit: bool,
     pub screen: crate::widgets::screen::Screen,
@@ -537,6 +546,8 @@ impl App {
             keymap,
             proto_commands: Default::default(),
             in_flight: HashMap::new(),
+            acknowledged_dispatches: HashSet::new(),
+            recent_command_finishes: VecDeque::new(),
             pending_cancel: None,
             should_quit: false,
             screen,
@@ -593,7 +604,9 @@ impl App {
         if !self.in_flight.is_empty() {
             return true;
         }
-        if self.screen.repo_pages.values().any(|page| page.pending_actions.values().any(|a| matches!(a.status, PendingStatus::InFlight))) {
+        if self.screen.repo_pages.values().any(|page| {
+            page.pending_actions.values().any(|a| matches!(a.status, PendingStatus::Submitting | PendingStatus::InFlight { .. }))
+        }) {
             return true;
         }
         // Check modal stack for loading states
@@ -1250,7 +1263,7 @@ impl App {
                         self.screen.repo_pages.iter().find_map(|(repo_identity, page)| {
                             page.pending_actions
                                 .iter()
-                                .find(|(_, a)| a.command_id == command_id)
+                                .find(|(_, a)| matches!(a.status, PendingStatus::InFlight { command_id: id } if id == command_id))
                                 .map(|(id, _)| (repo_identity.clone(), id.clone()))
                         });
 
@@ -1263,6 +1276,13 @@ impl App {
                             }
                         } else if let Some(page) = self.screen.repo_pages.get_mut(&repo_identity) {
                             page.pending_actions.remove(&identity);
+                        }
+                    }
+
+                    if !self.acknowledged_dispatches.remove(&command_id) {
+                        self.recent_command_finishes.push_back((command_id, error_message));
+                        if self.recent_command_finishes.len() > RECENT_COMMAND_FINISH_LIMIT {
+                            self.recent_command_finishes.pop_front();
                         }
                     }
                 }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -47,8 +47,6 @@ use crate::{
     },
 };
 
-const RECENT_COMMAND_FINISH_LIMIT: usize = 64;
-
 /// Owned version of `SelectedRow` for use when the borrow can't be held.
 pub(super) enum OwnedSelectedRow {
     WorkItem(Box<WorkItem>),
@@ -440,10 +438,14 @@ pub struct App {
     /// Command IDs whose execute acknowledgement has arrived but whose
     /// CommandFinished event has not yet been handled.
     pub acknowledged_dispatches: HashSet<u64>,
-    /// Recently finished commands whose execute acknowledgement was not seen
-    /// first. This bounded cache reconciles independent event/response stream
-    /// ordering without retaining commands initiated by other clients.
-    pub recent_command_finishes: VecDeque<(u64, Option<String>)>,
+    /// Number of this TUI's pending-action dispatches whose execute
+    /// acknowledgement has not arrived yet.
+    pub pending_dispatch_acks: usize,
+    /// Commands that finished while at least one pending-action dispatch was
+    /// awaiting its acknowledgement. Lifecycle events are system-wide, so
+    /// unrelated finishes may appear here temporarily; the map is cleared as
+    /// soon as this TUI has no acknowledgements left to reconcile.
+    pub recent_command_finishes: HashMap<u64, Option<String>>,
     pub pending_cancel: Option<u64>,
     pub should_quit: bool,
     pub screen: crate::widgets::screen::Screen,
@@ -547,7 +549,8 @@ impl App {
             proto_commands: Default::default(),
             in_flight: HashMap::new(),
             acknowledged_dispatches: HashSet::new(),
-            recent_command_finishes: VecDeque::new(),
+            pending_dispatch_acks: 0,
+            recent_command_finishes: HashMap::new(),
             pending_cancel: None,
             should_quit: false,
             screen,
@@ -1279,11 +1282,8 @@ impl App {
                         }
                     }
 
-                    if !self.acknowledged_dispatches.remove(&command_id) {
-                        self.recent_command_finishes.push_back((command_id, error_message));
-                        if self.recent_command_finishes.len() > RECENT_COMMAND_FINISH_LIMIT {
-                            self.recent_command_finishes.pop_front();
-                        }
+                    if !self.acknowledged_dispatches.remove(&command_id) && self.pending_dispatch_acks > 0 {
+                        self.recent_command_finishes.insert(command_id, error_message);
                     }
                 }
             }

--- a/crates/flotilla-tui/src/app/test_support.rs
+++ b/crates/flotilla-tui/src/app/test_support.rs
@@ -14,7 +14,7 @@ use flotilla_protocol::{
     ProviderData, ProviderError, ProvisioningTarget, RepoDelta, RepoInfo, RepoLabels, RepoSnapshot, StatusResponse, StreamKey,
     TopologyResponse, WorkItem,
 };
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Semaphore};
 use tui_input::Input;
 
 // Re-export shared builders so unit tests can use `test_support::checkout_item` etc.
@@ -22,9 +22,15 @@ pub(crate) use super::test_builders::*;
 use super::{App, CommandQueue, DirEntry, InFlightCommand, OpenViews, TuiHostState, TuiModel};
 use crate::{keymap::Keymap, widgets::WidgetContext};
 
+#[derive(bon::Builder)]
 pub(crate) struct StubDaemon {
+    #[builder(default = broadcast::channel(1).0)]
     tx: broadcast::Sender<DaemonEvent>,
+    #[builder(default = Mutex::new(None), with = |result: Result<CommandValue, String>| Mutex::new(Some(result)))]
     query_result: Mutex<Option<Result<CommandValue, String>>>,
+    execute_gate: Option<Arc<Semaphore>>,
+    #[builder(default = Ok(1))]
+    execute_result: Result<u64, String>,
 }
 
 static STUB_APP_CONFIG_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -55,14 +61,7 @@ fn insert_stub_local_host(model: &mut TuiModel) {
 
 impl StubDaemon {
     pub(crate) fn new() -> Self {
-        let (tx, _) = broadcast::channel(1);
-        Self { tx, query_result: Mutex::new(None) }
-    }
-
-    pub(crate) fn with_query_result(result: Result<CommandValue, String>) -> Self {
-        let daemon = Self::new();
-        *daemon.query_result.lock().expect("query result lock") = Some(result);
-        daemon
+        Self::builder().build()
     }
 }
 
@@ -81,7 +80,10 @@ impl DaemonHandle for StubDaemon {
     }
 
     async fn execute(&self, _command: Command) -> Result<u64, String> {
-        Ok(1)
+        if let Some(gate) = &self.execute_gate {
+            gate.acquire().await.expect("execute gate should remain open").forget();
+        }
+        self.execute_result.clone()
     }
 
     async fn execute_query(&self, _command: Command, _session_id: uuid::Uuid) -> Result<flotilla_protocol::CommandValue, String> {
@@ -212,10 +214,10 @@ fn stub_app_with_repo_infos(repos_info: Vec<RepoInfo>) -> App {
 }
 
 pub(crate) fn stub_app_with_query_result(result: Result<CommandValue, String>) -> App {
-    stub_app_with_daemon(Arc::new(StubDaemon::with_query_result(result)), vec![default_repo_info()])
+    stub_app_with_daemon(Arc::new(StubDaemon::builder().query_result(result).build()), vec![default_repo_info()])
 }
 
-fn stub_app_with_daemon(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>) -> App {
+pub(crate) fn stub_app_with_daemon(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>) -> App {
     let config_id = STUB_APP_CONFIG_COUNTER.fetch_add(1, Ordering::Relaxed);
     let config_base = std::env::temp_dir().join(format!("flotilla-test-{config_id}"));
     let _ = std::fs::remove_dir_all(&config_base);

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -420,9 +420,10 @@ async fn manual_refresh_replaces_default_issue_page_when_fresh_results_arrive() 
     let mut daemon_events = daemon.subscribe();
     app.handle_key(key(KeyCode::Char('r')));
     let (command, pending_ctx) = app.proto_commands.take_next().expect("refresh command");
-    executor::dispatch(command, &mut app, pending_ctx).await;
+    let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
+    executor::dispatch(command, &mut app, pending_ctx, event_tx);
 
-    tokio::time::timeout(Duration::from_secs(1), async {
+    tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let event = daemon_events.recv().await.expect("daemon event");
             let refresh_completed = matches!(event, DaemonEvent::RepoRefreshCompleted { .. });
@@ -1140,11 +1141,12 @@ fn command_finished_ok_clears_pending_action() {
     let repo_path = app.model.repos[&repo].path.clone();
     let identity = WorkItemIdentity::Session("s1".into());
 
-    app.screen.repo_pages.get_mut(&repo).unwrap().pending_actions.insert(identity.clone(), PendingAction {
-        command_id: 42,
-        status: PendingStatus::InFlight,
-        description: "test".into(),
-    });
+    app.screen
+        .repo_pages
+        .get_mut(&repo)
+        .unwrap()
+        .pending_actions
+        .insert(identity.clone(), PendingAction { status: PendingStatus::InFlight { command_id: 42 }, description: "test".into() });
     app.in_flight.insert(42, InFlightCommand { repo_identity: repo.clone(), repo: repo_path.clone(), description: "test".into() });
 
     app.handle_daemon_event(DaemonEvent::CommandFinished {
@@ -1167,11 +1169,12 @@ fn command_finished_error_transitions_to_failed() {
     let repo_path = app.model.repos[&repo].path.clone();
     let identity = WorkItemIdentity::Session("s1".into());
 
-    app.screen.repo_pages.get_mut(&repo).unwrap().pending_actions.insert(identity.clone(), PendingAction {
-        command_id: 42,
-        status: PendingStatus::InFlight,
-        description: "test".into(),
-    });
+    app.screen
+        .repo_pages
+        .get_mut(&repo)
+        .unwrap()
+        .pending_actions
+        .insert(identity.clone(), PendingAction { status: PendingStatus::InFlight { command_id: 42 }, description: "test".into() });
     app.in_flight.insert(42, InFlightCommand { repo_identity: repo.clone(), repo: repo_path.clone(), description: "test".into() });
 
     app.handle_daemon_event(DaemonEvent::CommandFinished {
@@ -1195,11 +1198,12 @@ fn command_finished_cancelled_clears_pending_action() {
     let repo_path = app.model.repos[&repo].path.clone();
     let identity = WorkItemIdentity::Session("s1".into());
 
-    app.screen.repo_pages.get_mut(&repo).unwrap().pending_actions.insert(identity.clone(), PendingAction {
-        command_id: 42,
-        status: PendingStatus::InFlight,
-        description: "test".into(),
-    });
+    app.screen
+        .repo_pages
+        .get_mut(&repo)
+        .unwrap()
+        .pending_actions
+        .insert(identity.clone(), PendingAction { status: PendingStatus::InFlight { command_id: 42 }, description: "test".into() });
     app.in_flight.insert(42, InFlightCommand { repo_identity: repo.clone(), repo: repo_path.clone(), description: "test".into() });
 
     app.handle_daemon_event(DaemonEvent::CommandFinished {
@@ -1222,12 +1226,13 @@ fn orphaned_command_finished_harmlessly_ignored() {
     let repo_path = app.model.repos[&repo].path.clone();
     let identity = WorkItemIdentity::Session("s1".into());
 
-    // Insert pending action with command_id 99 (different from finished event)
-    app.screen.repo_pages.get_mut(&repo).unwrap().pending_actions.insert(identity.clone(), PendingAction {
-        command_id: 99,
-        status: PendingStatus::InFlight,
-        description: "test".into(),
-    });
+    // Insert pending action for command 99 (different from finished event)
+    app.screen
+        .repo_pages
+        .get_mut(&repo)
+        .unwrap()
+        .pending_actions
+        .insert(identity.clone(), PendingAction { status: PendingStatus::InFlight { command_id: 99 }, description: "test".into() });
     app.in_flight.insert(42, InFlightCommand { repo_identity: repo.clone(), repo: repo_path.clone(), description: "test".into() });
 
     app.handle_daemon_event(DaemonEvent::CommandFinished {

--- a/crates/flotilla-tui/src/app/ui_state.rs
+++ b/crates/flotilla-tui/src/app/ui_state.rs
@@ -33,13 +33,13 @@ pub enum RepoViewLayout {
 
 #[derive(Clone, Debug)]
 pub enum PendingStatus {
-    InFlight,
+    Submitting,
+    InFlight { command_id: u64 },
     Failed(String),
 }
 
 #[derive(Clone, Debug)]
 pub struct PendingAction {
-    pub command_id: u64,
     pub status: PendingStatus,
     pub description: String,
 }

--- a/crates/flotilla-tui/src/event.rs
+++ b/crates/flotilla-tui/src/event.rs
@@ -1,12 +1,14 @@
 use std::{collections::VecDeque, time::Duration};
 
 use crossterm::event::{EventStream, KeyEventKind};
-use flotilla_protocol::DaemonEvent;
+use flotilla_protocol::{CommandValue, DaemonEvent};
 use futures::{FutureExt, StreamExt};
 use tokio::{
     sync::{broadcast, mpsc},
     task::JoinHandle,
 };
+
+use crate::app::ui_state::PendingActionContext;
 
 #[derive(Clone, Debug)]
 pub enum Event {
@@ -15,6 +17,8 @@ pub enum Event {
     Mouse(crossterm::event::MouseEvent),
     Daemon(Box<DaemonEvent>),
     DaemonDisconnected,
+    CommandDispatchCompleted { result: Result<u64, String>, pending_ctx: Option<PendingActionContext> },
+    AttachDispatchCompleted(Result<CommandValue, String>),
 }
 
 pub struct EventHandler {
@@ -74,14 +78,18 @@ impl EventHandler {
     }
 
     /// Stop polling the controlling terminal while a foreground child owns
-    /// it. Daemon events remain queued; stale terminal input and ticks do not.
+    /// it. Daemon and command completion events remain queued; stale terminal
+    /// input and ticks do not.
     pub async fn pause_terminal_input(&mut self) {
         if let Some(task) = self.terminal_task.take() {
             task.abort();
             let _ = task.await;
         }
         while let Ok(event) = self.rx.try_recv() {
-            if matches!(event, Event::Daemon(_) | Event::DaemonDisconnected) {
+            if matches!(
+                event,
+                Event::Daemon(_) | Event::DaemonDisconnected | Event::CommandDispatchCompleted { .. } | Event::AttachDispatchCompleted(_)
+            ) {
                 self.retained.push_back(event);
             }
         }
@@ -115,6 +123,10 @@ impl EventHandler {
                 }
             }
         });
+    }
+
+    pub fn sender(&self) -> mpsc::UnboundedSender<Event> {
+        self.tx.clone()
     }
 
     pub async fn next(&mut self) -> Option<Event> {
@@ -152,5 +164,21 @@ mod tests {
 
         let event = tokio::time::timeout(Duration::from_secs(1), handler.next()).await.expect("disconnect event");
         assert!(matches!(event, Some(Event::DaemonDisconnected)));
+    }
+
+    #[tokio::test]
+    async fn pause_retains_command_completions_but_discards_terminal_events() {
+        let mut handler = EventHandler::new(Duration::from_secs(60));
+        handler.pause_terminal_input().await;
+        let sender = handler.sender();
+        sender.send(Event::Tick).expect("event handler should remain open");
+        sender.send(Event::CommandDispatchCompleted { result: Ok(42), pending_ctx: None }).expect("event handler should remain open");
+        sender.send(Event::AttachDispatchCompleted(Err("attach failed".into()))).expect("event handler should remain open");
+
+        handler.pause_terminal_input().await;
+
+        assert!(matches!(handler.try_next(), Some(Event::CommandDispatchCompleted { result: Ok(42), pending_ctx: None })));
+        assert!(matches!(handler.try_next(), Some(Event::AttachDispatchCompleted(Err(message))) if message == "attach failed"));
+        assert!(handler.try_next().is_none(), "ticks should not survive a terminal pause");
     }
 }

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -100,6 +100,12 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
                     crate::terminal::restore_terminal();
                     return Ok(EventLoopExit::DaemonDisconnected);
                 }
+                Event::CommandDispatchCompleted { result, pending_ctx } => {
+                    app::executor::handle_dispatch_completion(result, pending_ctx, &mut app);
+                }
+                Event::AttachDispatchCompleted(result) => {
+                    app::executor::handle_attach_dispatch_completion(result, &mut app);
+                }
                 Event::Key(k) => {
                     // Ctrl-Z: suspend/resume (unix only)
                     #[cfg(unix)]
@@ -138,7 +144,7 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
 
         // ── Process queued commands ──
         while let Some((cmd, pending_ctx)) = app.proto_commands.take_next() {
-            app::executor::dispatch(cmd, &mut app, pending_ctx).await;
+            app::executor::dispatch(cmd, &mut app, pending_ctx, events.sender());
         }
         if let Some(command) = app.pending_attach_command.take() {
             events.pause_terminal_input().await;

--- a/crates/flotilla-tui/src/widgets/repo_page/tests.rs
+++ b/crates/flotilla-tui/src/widgets/repo_page/tests.rs
@@ -147,13 +147,11 @@ fn reconcile_prunes_stale_pending_actions() {
     page.reconcile_if_changed();
 
     page.pending_actions.insert(WorkItemIdentity::Issue("1".into()), PendingAction {
-        command_id: 1,
-        status: crate::app::ui_state::PendingStatus::InFlight,
+        status: crate::app::ui_state::PendingStatus::InFlight { command_id: 1 },
         description: "test".into(),
     });
     page.pending_actions.insert(WorkItemIdentity::Issue("2".into()), PendingAction {
-        command_id: 2,
-        status: crate::app::ui_state::PendingStatus::InFlight,
+        status: crate::app::ui_state::PendingStatus::InFlight { command_id: 2 },
         description: "test".into(),
     });
 

--- a/crates/flotilla-tui/src/widgets/split_table.rs
+++ b/crates/flotilla-tui/src/widgets/split_table.rs
@@ -838,7 +838,7 @@ fn render_data_row(
     area_width: u16,
     theme: &Theme,
 ) {
-    let is_in_flight = pending.is_some_and(|p| matches!(p.status, PendingStatus::InFlight));
+    let is_in_flight = pending.is_some_and(|p| matches!(p.status, PendingStatus::Submitting | PendingStatus::InFlight { .. }));
     let is_failed = pending.is_some_and(|p| matches!(p.status, PendingStatus::Failed(_)));
 
     // ── In-flight shimmer rendering ────────────────────────────────────

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -243,8 +243,9 @@ async fn generated_table_action_completes_work() {
 
     // Dispatch the queued command through the daemon.
     let mut took_one = false;
+    let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
     while let Some((cmd, pending_ctx)) = app.proto_commands.take_next() {
-        flotilla_tui::app::executor::dispatch(cmd, &mut app, pending_ctx).await;
+        flotilla_tui::app::executor::dispatch(cmd, &mut app, pending_ctx, event_tx.clone());
         took_one = true;
     }
     assert!(took_one, "expected at least one command to be dispatched after Enter");

--- a/crates/flotilla-tui/tests/snapshots.rs
+++ b/crates/flotilla-tui/tests/snapshots.rs
@@ -688,22 +688,24 @@ fn command_palette_selection() {
 
 // ── Regression tests ─────────────────────────────────────────────────────
 
-/// In-flight pending action replaces the normal icon with a spinner character
+/// Submitting pending action replaces the normal icon with a spinner character
 /// and preserves the rest of the row content.
 #[test]
-fn pending_action_in_flight_shows_spinner() {
+fn pending_action_submitting_shows_spinner() {
     let items = vec![make_work_item_checkout("feat-login", "/test/my-project/feat-login")];
     let providers = ProviderData::default();
     let mut harness = TestHarness::single_repo("my-project").with_provider_data(providers, items);
 
-    // Insert an in-flight pending action for the checkout item.
+    // Insert a pre-ack pending action for the checkout item.
     let identity = WorkItemIdentity::Checkout(HostPath::new(HostName::local(), PathBuf::from("/test/my-project/feat-login")).into());
     let repo = harness.model.repo_order[0].clone();
-    harness.screen.repo_pages.get_mut(&repo).expect("repo page exists").pending_actions.insert(identity, PendingAction {
-        command_id: 1,
-        status: PendingStatus::InFlight,
-        description: "Deleting checkout...".into(),
-    });
+    harness
+        .screen
+        .repo_pages
+        .get_mut(&repo)
+        .expect("repo page exists")
+        .pending_actions
+        .insert(identity, PendingAction { status: PendingStatus::Submitting, description: "Deleting checkout...".into() });
 
     let buffer = harness.render_to_buffer();
 
@@ -726,7 +728,7 @@ fn pending_action_in_flight_shows_spinner() {
             break;
         }
     }
-    assert!(found_spinner, "expected a braille spinner character in the rendered buffer for an in-flight pending action");
+    assert!(found_spinner, "expected a braille spinner character in the rendered buffer for a submitting pending action");
 
     // Verify the row still contains the branch text and description.
     let output = support::buffer_to_string_for_test(&buffer);
@@ -744,7 +746,6 @@ fn pending_action_failed_shows_error_icon() {
     let identity = WorkItemIdentity::Checkout(HostPath::new(HostName::local(), PathBuf::from("/test/my-project/feat-broken")).into());
     let repo = harness.model.repo_order[0].clone();
     harness.screen.repo_pages.get_mut(&repo).expect("repo page exists").pending_actions.insert(identity, PendingAction {
-        command_id: 2,
         status: PendingStatus::Failed("network error".into()),
         description: "Deleting checkout...".into(),
     });

--- a/crates/flotilla-tui/tests/support/high_fidelity.rs
+++ b/crates/flotilla-tui/tests/support/high_fidelity.rs
@@ -28,6 +28,7 @@ use flotilla_daemon::server::test_support::{spawn_in_memory_request_topology, In
 use flotilla_protocol::{test_support::TestCheckout, DaemonEvent, HostName, RepoIdentity, RepoSelector, WorkItemKind};
 use flotilla_tui::{
     app::{self, App},
+    event::Event,
     theme::Theme,
     widgets::{delete_confirm::DeleteConfirmWidget, InteractiveWidget},
 };
@@ -52,6 +53,8 @@ pub struct HighFidelityHarness {
     daemon_rx: tokio::sync::broadcast::Receiver<DaemonEvent>,
     leader_daemon_rx: tokio::sync::broadcast::Receiver<DaemonEvent>,
     follower_daemon_rx: tokio::sync::broadcast::Receiver<DaemonEvent>,
+    command_event_tx: tokio::sync::mpsc::UnboundedSender<Event>,
+    command_event_rx: tokio::sync::mpsc::UnboundedReceiver<Event>,
     recent_events: Vec<String>,
     recent_leader_events: Vec<String>,
     recent_follower_events: Vec<String>,
@@ -130,6 +133,7 @@ impl HighFidelityHarness {
         for event in daemon.replay_since(&HashMap::new()).await? {
             app.handle_daemon_event(event);
         }
+        let (command_event_tx, command_event_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let mut harness = Self {
             _tempdir: tempdir,
@@ -140,6 +144,8 @@ impl HighFidelityHarness {
             daemon_rx,
             leader_daemon_rx,
             follower_daemon_rx,
+            command_event_tx,
+            command_event_rx,
             recent_events: Vec::new(),
             recent_leader_events: Vec::new(),
             recent_follower_events: Vec::new(),
@@ -203,7 +209,7 @@ impl HighFidelityHarness {
         while let Some((command, pending_ctx)) = self.app.proto_commands.take_next() {
             dispatched += 1;
             self.last_dispatched_command = Some(format!("{command:?}"));
-            app::executor::dispatch(command, &mut self.app, pending_ctx).await;
+            app::executor::dispatch(command, &mut self.app, pending_ctx, self.command_event_tx.clone());
             self.drain_events()?;
         }
         self.drain_events()?;
@@ -274,7 +280,7 @@ impl HighFidelityHarness {
         self.drain_events()?;
         while let Some((command, pending_ctx)) = self.app.proto_commands.take_next() {
             self.last_dispatched_command = Some(format!("{command:?}"));
-            app::executor::dispatch(command, &mut self.app, pending_ctx).await;
+            app::executor::dispatch(command, &mut self.app, pending_ctx, self.command_event_tx.clone());
             self.drain_events()?;
         }
         self.drain_events()?;
@@ -284,6 +290,21 @@ impl HighFidelityHarness {
     fn drain_events(&mut self) -> Result<(), String> {
         drain_daemon_events(&mut self.leader_daemon_rx, &mut self.recent_leader_events, "leader", |_| {})?;
         drain_daemon_events(&mut self.follower_daemon_rx, &mut self.recent_follower_events, "follower", |_| {})?;
+        loop {
+            match self.command_event_rx.try_recv() {
+                Ok(Event::CommandDispatchCompleted { result, pending_ctx }) => {
+                    app::executor::handle_dispatch_completion(result, pending_ctx, &mut self.app);
+                }
+                Ok(Event::AttachDispatchCompleted(result)) => {
+                    app::executor::handle_attach_dispatch_completion(result, &mut self.app);
+                }
+                Ok(other) => return Err(format!("unexpected command event: {other:?}")),
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    return Err("command event stream closed".into());
+                }
+            }
+        }
         loop {
             match self.daemon_rx.try_recv() {
                 Ok(event) => {


### PR DESCRIPTION
## Summary

- dispatch daemon commands and attach queries from background tasks instead of awaiting them on the TUI event loop
- represent pre-ack submissions explicitly and reconcile command-finish/ack ordering
- preserve completion events across foreground terminal attaches and reset pending/loading state on errors
- add delayed-ack, rendered-spinner, ordering, timeout, and attach completion regression coverage

## Root cause

The command executor awaited daemon acknowledgements while holding the mutable `App` borrow on the event-loop path. Any delayed acknowledgement therefore stopped input handling and rendering until the daemon responded.

## Impact

The TUI remains responsive and continues rendering pending feedback while daemon acknowledgements are outstanding. Timeout and dispatch failures still surface through the status line and clear loading modals.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-tui --locked`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #783