### PR TITLE
feat: add convoy delete action

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -23,6 +23,11 @@ pub struct ConvoyNoun {
 pub enum ConvoyVerb {
     /// Manage the work aboard a convoy's vessels
     Work(ConvoyWorkNoun),
+    /// Delete a convoy and tear down its managed resources
+    Delete {
+        /// Convoy resource name
+        name: String,
+    },
     /// Start a convoy through Project-scoped admission completion
     Start {
         /// Project whose definitions and repository set admission snapshots
@@ -139,6 +144,21 @@ impl ConvoyNoun {
                     host: HostResolution::Local,
                 }),
             },
+            ConvoyVerb::Delete { name } => {
+                if self.subject.is_some() {
+                    return Err("convoy delete takes its name after `delete`".to_string());
+                }
+                Ok(Resolved::NeedsContext {
+                    command: Command {
+                        node_id: None,
+                        provisioning_target: None,
+                        context_repo: None,
+                        action: CommandAction::ConvoyDelete { namespace: None, name },
+                    },
+                    repo: RepoContext::None,
+                    host: HostResolution::Local,
+                })
+            }
             ConvoyVerb::Start {
                 project,
                 issue,
@@ -263,6 +283,9 @@ impl std::fmt::Display for ConvoyNoun {
                         }
                     }
                 }
+            }
+            ConvoyVerb::Delete { name } => {
+                write!(f, " delete {}", quote_value(name))?;
             }
             ConvoyVerb::Start {
                 project,
@@ -394,6 +417,26 @@ mod tests {
     #[test]
     fn round_trip_complete() {
         assert_round_trip::<ConvoyNoun>(&["convoy", "convoy-a", "work", "implement", "complete"]);
+    }
+
+    #[test]
+    fn convoy_delete_resolves() {
+        let resolved = parse(&["convoy", "delete", "failed-convoy"]).resolve().expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyDelete { namespace: None, name: "failed-convoy".into() },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn round_trip_delete() {
+        assert_round_trip::<ConvoyNoun>(&["convoy", "delete", "failed-convoy"]);
     }
 
     #[test]

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -333,6 +333,7 @@ pub async fn build_plan(
 
         // Daemon-level commands should not reach build_plan.
         CommandAction::ConvoyWorkForceComplete { .. }
+        | CommandAction::ConvoyDelete { .. }
         | CommandAction::CrewComplete { .. }
         | CommandAction::CrewFail { .. }
         | CommandAction::CrewHandoff { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4438,6 +4438,21 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
+        if let flotilla_protocol::CommandAction::ConvoyDelete { namespace, name } = &command.action {
+            let empty_identity = self.start_context_free_command(id, command.description().to_string());
+            let namespace = match namespace {
+                Some(namespace) => namespace.clone(),
+                None => self.provisioning_namespace().await,
+            };
+            let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
+            let result = match convoys.delete(name).await {
+                Ok(()) => flotilla_protocol::CommandValue::Ok,
+                Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+            };
+            self.finish_context_free_command(id, empty_identity, result);
+            return Ok(id);
+        }
+
         if let flotilla_protocol::CommandAction::ConvoyWorkForceComplete { convoy, work, message } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
             let namespace = self.provisioning_namespace().await;

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2958,6 +2958,50 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
 }
 
 #[tokio::test]
+async fn convoy_delete_command_targets_requested_namespace_or_configured_default() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    daemon.set_provisioning_namespace("custom-ns".to_string()).await;
+    let convoy_spec = ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build();
+    let convoys = daemon.resource_backend().using::<Convoy>("custom-ns");
+    convoys.create(&empty_input_meta("failed-convoy"), &convoy_spec).await.expect("convoy create should succeed");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyDelete { namespace: None, name: "failed-convoy".to_string() },
+        })
+        .await
+        .expect("execute should return a command id");
+
+    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
+    assert!(matches!(convoys.get("failed-convoy").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
+
+    let explicit_convoys = daemon.resource_backend().using::<Convoy>("explicit-ns");
+    explicit_convoys.create(&empty_input_meta("completed-convoy"), &convoy_spec).await.expect("convoy create should succeed");
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyDelete { namespace: Some("explicit-ns".to_string()), name: "completed-convoy".to_string() },
+        })
+        .await
+        .expect("execute should return a command id");
+
+    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
+    assert!(matches!(explicit_convoys.get("completed-convoy").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
+}
+
+#[tokio::test]
 async fn normalize_local_provider_hosts_uses_mount_metadata_for_provisioned_checkouts() {
     struct TestProvisionedEnvironment {
         id: EnvironmentId,

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -202,6 +202,11 @@ pub enum CommandAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
     },
+    ConvoyDelete {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
+        name: String,
+    },
     CrewHandoff {
         context: CrewCommandContext,
         target: String,
@@ -351,6 +356,7 @@ impl Command {
             CommandAction::ArchiveSession { .. } => "Archiving session...",
             CommandAction::GenerateBranchName { .. } => "Generating branch name...",
             CommandAction::ConvoyWorkForceComplete { .. } => "Force-completing work...",
+            CommandAction::ConvoyDelete { .. } => "Deleting convoy...",
             CommandAction::CrewHandoff { .. } => "Handing off to crew member...",
             CommandAction::CrewComplete { .. } => "Completing crew work...",
             CommandAction::CrewFail { .. } => "Failing crew work...",
@@ -677,6 +683,12 @@ mod tests {
                     work: "implement".into(),
                     message: Some("done".into()),
                 },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyDelete { namespace: Some("flotilla".into()), name: "failed-convoy".into() },
             },
             Command {
                 node_id: None,
@@ -1196,6 +1208,12 @@ mod tests {
                 provisioning_target: None,
                 context_repo: Some(RepoSelector::Path(PathBuf::from("/tmp"))),
                 action: CommandAction::GenerateBranchName { issue_keys: vec![] },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyDelete { namespace: Some("flotilla".into()), name: "failed-convoy".into() },
             },
             Command {
                 node_id: None,

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -6,7 +6,7 @@ use crate::{
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
     table_view::TableIntent,
-    widgets::InteractiveWidget,
+    widgets::{convoy_delete_confirm::ConvoyDeleteConfirmWidget, InteractiveWidget},
 };
 
 impl App {
@@ -385,6 +385,22 @@ impl App {
             }
             TableIntent::AttachPane { reference, host } => {
                 self.proto_commands.push(self.command(CommandAction::AttachTransient { reference, host: Some(host) }));
+                return;
+            }
+            TableIntent::DeleteConvoy { namespace, name, host } => {
+                let node_id = match host.as_ref() {
+                    Some(host) => match self.panel_target_node(host) {
+                        Ok(node_id) => node_id,
+                        Err(message) => {
+                            self.set_status_message(Some(message));
+                            return;
+                        }
+                    },
+                    None => None,
+                };
+                let mut command = self.command(CommandAction::ConvoyDelete { namespace: Some(namespace.clone()), name: name.clone() });
+                command.node_id = node_id;
+                self.screen.modal_stack.push(Box::new(ConvoyDeleteConfirmWidget::new(command)));
                 return;
             }
             TableIntent::ForceCompleteWork { convoy, vessel, host } => {

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -60,6 +60,30 @@ fn project_issue_start_preserves_the_selected_namespace() {
     assert_eq!(intent.issue, Some(flotilla_protocol::IssueSelector::Reference(issue)));
 }
 
+#[test]
+fn convoy_delete_table_intent_confirms_then_routes_to_origin_host() {
+    let mut app = stub_app();
+    insert_peer_host(&mut app.model, "remote-host");
+
+    app.execute_table_intent(TableIntent::DeleteConvoy {
+        namespace: "other-team".into(),
+        name: "failed-convoy".into(),
+        host: Some(HostName::new("remote-host")),
+    });
+
+    assert_eq!(
+        app.screen.modal_stack.last().expect("delete confirmation modal").binding_mode(),
+        KeyBindingMode::from(BindingModeId::DeleteConfirm)
+    );
+    assert!(app.proto_commands.take_next().is_none(), "delete must wait for confirmation");
+
+    app.handle_key(key(KeyCode::Enter));
+
+    let (command, _) = app.proto_commands.take_next().expect("confirmed delete command");
+    assert_eq!(command.node_id, Some(NodeId::new("remote-host")));
+    assert_eq!(command.action, CommandAction::ConvoyDelete { namespace: Some("other-team".into()), name: "failed-convoy".into() });
+}
+
 /// Read the active RepoPage's selected flat index.
 fn active_selection(app: &App) -> Option<usize> {
     let identity = app.model.active_repo.as_ref().expect("active tab should be a repo view");

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -25,7 +25,10 @@ use test_support::*;
 use tokio::sync::{watch, Mutex as TokioMutex, Semaphore};
 
 use super::*;
-use crate::widgets::InteractiveWidget;
+use crate::{
+    binding_table::{BindingModeId, KeyBindingMode},
+    widgets::{table_action_menu::TableActionMenuWidget, InteractiveWidget},
+};
 
 fn insert_host(
     model: &mut TuiModel,
@@ -1554,7 +1557,10 @@ fn wire_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_proto
         HostName, ResourceRef,
     };
 
-    let resource = ResourceRef::new("flotilla.work/v1", "Convoy", &convoy.namespace, &convoy.name);
+    let mut resource = ResourceRef::new("flotilla.work/v1", "Convoy", &convoy.namespace, &convoy.name);
+    if let Some(host) = convoy.origin_host {
+        resource = resource.on_host(host);
+    }
     let vessels = convoy
         .vessels
         .into_iter()
@@ -1686,6 +1692,7 @@ fn test_convoy(
         id: crate::convoy_model::ConvoyId::new(namespace, name),
         namespace: namespace.into(),
         name: name.into(),
+        origin_host: None,
         workflow_ref: "wf".into(),
         phase,
         message: None,
@@ -2085,14 +2092,20 @@ fn describe_opens_for_the_selected_table_row() {
 }
 
 #[test]
-fn action_menu_reports_when_the_selected_table_row_has_no_actions() {
+fn convoy_delete_action_menu_opens_confirmation() {
     let mut app = stub_app();
     app.handle_daemon_event(result_set_event(Box::new(make_convoy_fixture_snapshot(&["alpha"]))));
     app.switch_tab(1);
 
     app.handle_key(key(KeyCode::Char('.')));
+    assert!(app.screen.modal_stack.last().is_some_and(|widget| widget.as_any().is::<TableActionMenuWidget>()));
 
-    assert_eq!(app.model.status_message.as_deref(), Some("No actions available for the selected row"));
+    app.handle_key(key(KeyCode::Char('d')));
+
+    assert_eq!(
+        app.screen.modal_stack.last().expect("delete confirmation modal").binding_mode(),
+        KeyBindingMode::from(BindingModeId::DeleteConfirm)
+    );
 }
 
 #[test]

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -143,6 +143,7 @@ pub struct ConvoySummary {
     pub id: ConvoyId,
     pub namespace: String,
     pub name: String,
+    pub origin_host: Option<HostName>,
     pub workflow_ref: String,
     pub phase: ConvoyPhase,
     pub message: Option<String>,
@@ -162,6 +163,7 @@ impl From<&wire::ConvoyRow> for ConvoySummary {
             id: ConvoyId::for_resource(&row.resource),
             namespace: row.resource.namespace.clone(),
             name: row.name.clone(),
+            origin_host: row.resource.host.clone(),
             workflow_ref: row.workflow_ref.clone(),
             phase: row.phase.into(),
             message: row.message.clone(),
@@ -218,4 +220,23 @@ pub struct ConvoyFixtureDelta {
     pub namespace: String,
     pub changed: Vec<ConvoySummary>,
     pub removed: Vec<ConvoyId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convoy_summary_preserves_origin_host_for_action_routing() {
+        let row = wire::ConvoyRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "remote-convoy").on_host(HostName::new("feta")))
+            .name("remote-convoy")
+            .workflow_ref("review-and-fix")
+            .phase(wire::ConvoyPhase::Failed)
+            .build();
+
+        let summary = ConvoySummary::from(&row);
+
+        assert_eq!(summary.origin_host, Some(HostName::new("feta")));
+    }
 }

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -809,6 +809,7 @@ mod tests {
             id: ConvoyId::new("flotilla", name),
             namespace: "flotilla".into(),
             name: name.into(),
+            origin_host: None,
             workflow_ref: "wf".into(),
             phase: ConvoyPhase::Active,
             message: None,

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -291,6 +291,7 @@ pub struct DetailField {
 pub enum TableIntent {
     AttachWorkspace { workspace_ref: String, host: HostName, repo_hint: Option<RepoKey> },
     AttachPane { reference: String, host: HostName },
+    DeleteConvoy { namespace: String, name: String, host: Option<HostName> },
     ForceCompleteWork { convoy: String, vessel: String, host: HostName },
     StartConvoy { namespace: String, project: String, issue: IssueRef },
 }
@@ -619,7 +620,11 @@ fn stable_topological_vessels(vessels: &[VesselSummary]) -> Vec<&VesselSummary> 
 }
 
 fn convoy_spec() -> TableSpec<ConvoySummary> {
-    TableSpec { columns: &CONVOY_COLUMNS, actions: &[], row: RowSpec { id: convoy_id, drill: convoy_drill, describe: convoy_description } }
+    TableSpec {
+        columns: &CONVOY_COLUMNS,
+        actions: &CONVOY_ACTIONS,
+        row: RowSpec { id: convoy_id, drill: convoy_drill, describe: convoy_description },
+    }
 }
 
 fn vessel_spec() -> TableSpec<VesselProjection> {
@@ -686,6 +691,9 @@ static CONVOY_COLUMNS: [ColumnSpec<ConvoySummary>; 6] = [
         extract: |row| CellValue::plain(row.message.as_deref().unwrap_or_default()),
     },
 ];
+
+static CONVOY_ACTIONS: [ActionSpec<ConvoySummary>; 1] =
+    [ActionSpec { id: "delete", label: "Delete convoy", key: 'd', resolve: delete_convoy }];
 
 static VESSEL_COLUMNS: [ColumnSpec<VesselProjection>; 6] = [
     ColumnSpec {
@@ -889,6 +897,10 @@ fn convoy_description(row: &ConvoySummary) -> Vec<DetailField> {
     ]
 }
 
+fn delete_convoy(row: &ConvoySummary) -> Option<TableIntent> {
+    Some(TableIntent::DeleteConvoy { namespace: row.namespace.clone(), name: row.name.clone(), host: row.origin_host.clone() })
+}
+
 fn scoped_issue_id(row: &ScopedIssueProjection) -> RowId {
     RowId::new(format!(
         "issue:{}:{}:{}:{}:{}",
@@ -1046,6 +1058,7 @@ mod tests {
             id: ConvoyId::new("dev", "tables"),
             namespace: "dev".into(),
             name: "tables".into(),
+            origin_host: None,
             workflow_ref: "implement-review".into(),
             phase: ConvoyPhase::Active,
             message: None,
@@ -1083,6 +1096,20 @@ mod tests {
         assert_eq!(view.rows[0].cells[2], CellValue::toned("failed", CellTone::Error));
         assert_eq!(view.rows[0].cells[5].text, "workspace launch failed: disk full");
         assert_eq!(view.rows[0].drill, Some("convoy/dev/tables".parse().expect("valid address")));
+    }
+
+    #[test]
+    fn convoy_projection_exposes_host_routed_delete_action() {
+        let mut row = convoy(vec![]);
+        row.origin_host = Some(HostName::new("kiwi"));
+        let view = project_convoys("convoys/dev", &[&row]).expect("project table");
+
+        assert_eq!(view.rows[0].actions, vec![AvailableAction {
+            id: "delete",
+            label: "Delete convoy",
+            key: 'd',
+            intent: TableIntent::DeleteConvoy { namespace: "dev".into(), name: "tables".into(), host: Some(HostName::new("kiwi")) },
+        }]);
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/convoy_delete_confirm.rs
+++ b/crates/flotilla-tui/src/widgets/convoy_delete_confirm.rs
@@ -1,0 +1,83 @@
+use flotilla_protocol::{Command, CommandAction};
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use super::{InteractiveWidget, Outcome, RenderContext, WidgetContext};
+use crate::{
+    binding_table::{BindingModeId, KeyBindingMode, StatusContent, StatusFragment},
+    keymap::Action,
+    ui_helpers,
+};
+
+pub struct ConvoyDeleteConfirmWidget {
+    command: Command,
+}
+
+impl ConvoyDeleteConfirmWidget {
+    pub fn new(command: Command) -> Self {
+        assert!(
+            matches!(&command.action, CommandAction::ConvoyDelete { namespace: Some(_), .. }),
+            "convoy delete confirmation requires an explicitly namespaced convoy delete command"
+        );
+        Self { command }
+    }
+
+    fn target(&self) -> (&str, &str) {
+        match &self.command.action {
+            CommandAction::ConvoyDelete { namespace: Some(namespace), name } => (namespace, name),
+            _ => unreachable!("constructor validates the command action"),
+        }
+    }
+}
+
+impl InteractiveWidget for ConvoyDeleteConfirmWidget {
+    fn handle_action(&mut self, action: Action, ctx: &mut WidgetContext) -> Outcome {
+        match action {
+            Action::Confirm => {
+                ctx.commands.push(self.command.clone());
+                Outcome::Finished
+            }
+            Action::Dismiss => Outcome::Finished,
+            _ => Outcome::Ignored,
+        }
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: &mut RenderContext) {
+        let (namespace, name) = self.target();
+        let popup = ui_helpers::popup_area(area, 56, 28);
+        frame.render_widget(Clear, popup);
+
+        let lines = vec![
+            Line::from(vec![Span::raw("Convoy: "), Span::styled(format!("{namespace}/{name}"), Style::default().bold())]),
+            Line::from(""),
+            Line::from("Managed vessels, environments, and terminal sessions will be torn down."),
+            Line::from(""),
+            Line::from(Span::styled("y/Enter: confirm    n/Esc: cancel", Style::default().fg(ctx.theme.muted))),
+        ];
+        let paragraph = Paragraph::new(lines)
+            .block(Block::bordered().style(ctx.theme.block_style()).title(" Delete convoy "))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(paragraph, popup);
+    }
+
+    fn binding_mode(&self) -> KeyBindingMode {
+        BindingModeId::DeleteConfirm.into()
+    }
+
+    fn status_fragment(&self) -> StatusFragment {
+        StatusFragment { status: Some(StatusContent::Label("CONFIRM DELETE".into())) }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}

--- a/crates/flotilla-tui/src/widgets/mod.rs
+++ b/crates/flotilla-tui/src/widgets/mod.rs
@@ -3,6 +3,7 @@ pub mod branch_input;
 pub mod close_confirm;
 pub mod columns;
 pub mod command_palette;
+pub mod convoy_delete_confirm;
 pub mod delete_confirm;
 pub mod describe;
 pub mod event_log;


### PR DESCRIPTION
## Summary

- add `flotilla convoy delete <name>` to the CLI and protocol
- route convoy deletion through the resource resolver so existing finalizers clean up managed children
- add a host-aware Convoy row Delete action in the TUI with confirmation before dispatch

## Why

Convoys could be created and completed, but users had no direct CLI or TUI action to delete or gracefully cancel one. Using the existing deletion/finalizer path keeps active and terminal convoy cleanup consistent.

## User impact

Users can delete a convoy from either the CLI or its TUI row. Active convoys follow the same finalizer path, tearing down managed vessels, presentations, checkouts, environments, and terminal sessions.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-tui --locked`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- parallel standards and spec review; all findings addressed

Closes #785
