### PR TITLE
fix: make project panels directly navigable

### DIFF
--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -133,6 +133,8 @@ pub struct KeysConfig {
     #[serde(default)]
     pub convoys: HashMap<String, String>,
     #[serde(default)]
+    pub project: HashMap<String, String>,
+    #[serde(default)]
     pub convoy_vessels: HashMap<String, String>,
     #[serde(default)]
     pub action_menu: HashMap<String, String>,

--- a/crates/flotilla-tui/src/app/view_kind.rs
+++ b/crates/flotilla-tui/src/app/view_kind.rs
@@ -67,7 +67,7 @@ pub(crate) fn kind_modes(address: Option<&ViewAddress>) -> Vec<BindingModeId> {
         ) => {
             vec![BindingModeId::Convoys]
         }
-        Some(ViewAddress::Project { .. }) => vec![BindingModeId::Convoys, BindingModeId::DemandTable],
+        Some(ViewAddress::Project { .. }) => vec![BindingModeId::Convoys, BindingModeId::DemandTable, BindingModeId::Project],
         Some(ViewAddress::Issues { .. }) => vec![BindingModeId::Convoys, BindingModeId::DemandTable],
         Some(ViewAddress::Repo { .. }) => vec![BindingModeId::Normal],
         None => vec![],
@@ -92,6 +92,7 @@ mod tests {
             QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None },
             QueryId::Independents { scope: Some(QueryScope::new("flotilla", "roadmap")) },
         ]);
+        assert_eq!(kind_modes(Some(&address)), vec![BindingModeId::Convoys, BindingModeId::DemandTable, BindingModeId::Project]);
     }
 
     #[test]

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -31,6 +31,8 @@ pub enum BindingModeId {
     /// shell and therefore no tab bindings (ADR 0013).
     TabShell,
     Convoys,
+    /// Navigation between panels on the composite Project page.
+    Project,
     /// Capabilities present only on demand-backed table families.
     DemandTable,
     /// Inner focus on the Convoys tab — the vessel tree on the right pane.
@@ -170,6 +172,10 @@ pub static BINDINGS: &[Binding] = &[
     // [, ], q come from TabPage (composed). Keep r here: refresh semantics are tab-specific.
     h(BindingModeId::Convoys, "r", Action::Refresh, "Refresh"),
     h(BindingModeId::DemandTable, "f", Action::FetchMore, "Fetch more"),
+    h(BindingModeId::Project, "tab", Action::NextPanel, "Next panel"),
+    b(BindingModeId::Project, "S-tab", Action::PrevPanel),
+    b(BindingModeId::Project, "backtab", Action::PrevPanel),
+    b(BindingModeId::Project, "S-backtab", Action::PrevPanel),
     // Legacy mode retained only so existing user keybinding files still parse
     // while the table slices land; no View selects it after #733.
     // j/k/up/down come from Shared. h/left/esc mirror the vim and arrow navigation used to
@@ -468,6 +474,7 @@ fn parse_key_string(s: &str) -> KeyCombination {
         "esc" => KeyCode::Esc,
         "space" => KeyCode::Char(' '),
         "tab" => KeyCode::Tab,
+        "backtab" => KeyCode::BackTab,
         "up" => KeyCode::Up,
         "down" => KeyCode::Down,
         "left" => KeyCode::Left,
@@ -501,6 +508,7 @@ fn display_for_combo(combo: &KeyCombination) -> (String, KeyCode, KeyModifiers) 
         KeyCode::Enter => "ENT".into(),
         KeyCode::Esc => "ESC".into(),
         KeyCode::Tab => "TAB".into(),
+        KeyCode::BackTab => "BACKTAB".into(),
         KeyCode::Up => "UP".into(),
         KeyCode::Down => "DOWN".into(),
         KeyCode::Left => "LEFT".into(),

--- a/crates/flotilla-tui/src/keymap.rs
+++ b/crates/flotilla-tui/src/keymap.rs
@@ -19,6 +19,8 @@ use crate::{
 pub enum Action {
     SelectNext,
     SelectPrev,
+    NextPanel,
+    PrevPanel,
     Confirm,
     Dismiss,
     Quit,
@@ -93,6 +95,8 @@ impl Action {
         let action = match s {
             "select_next" => Action::SelectNext,
             "select_prev" => Action::SelectPrev,
+            "next_panel" => Action::NextPanel,
+            "prev_panel" => Action::PrevPanel,
             "confirm" => Action::Confirm,
             "dismiss" => Action::Dismiss,
             "quit" => Action::Quit,
@@ -146,6 +150,8 @@ impl Action {
         match self {
             Action::SelectNext => "select_next",
             Action::SelectPrev => "select_prev",
+            Action::NextPanel => "next_panel",
+            Action::PrevPanel => "prev_panel",
             Action::Confirm => "confirm",
             Action::Dismiss => "dismiss",
             Action::Quit => "quit",
@@ -196,6 +202,8 @@ impl Action {
         match self {
             Action::SelectNext => "Move selection down",
             Action::SelectPrev => "Move selection up",
+            Action::NextPanel => "Move to next panel",
+            Action::PrevPanel => "Move to previous panel",
             Action::Confirm => "Confirm / execute",
             Action::Dismiss => "Dismiss / go back",
             Action::Quit => "Quit the application",
@@ -296,6 +304,7 @@ impl Keymap {
             (&config.help, BindingModeId::Help),
             (&config.config, BindingModeId::Overview),
             (&config.convoys, BindingModeId::Convoys),
+            (&config.project, BindingModeId::Project),
             (&config.convoy_vessels, BindingModeId::ConvoyVessels),
             (&config.action_menu, BindingModeId::ActionMenu),
             (&config.delete_confirm, BindingModeId::DeleteConfirm),
@@ -384,7 +393,7 @@ impl Keymap {
 
         // Define sections and their actions in display order.
         let section_defs: &[(&str, &[Action])] = &[
-            ("Navigation", &[Action::SelectNext, Action::SelectPrev]),
+            ("Navigation", &[Action::SelectNext, Action::SelectPrev, Action::NextPanel, Action::PrevPanel]),
             ("Actions", &[
                 Action::Confirm,
                 Action::OpenCommandPalette,

--- a/crates/flotilla-tui/src/keymap/tests.rs
+++ b/crates/flotilla-tui/src/keymap/tests.rs
@@ -15,6 +15,8 @@ fn round_trip_non_dispatch_actions() {
     let actions = [
         Action::SelectNext,
         Action::SelectPrev,
+        Action::NextPanel,
+        Action::PrevPanel,
         Action::Confirm,
         Action::Dismiss,
         Action::Quit,
@@ -85,6 +87,8 @@ fn all_actions_have_descriptions() {
     let all_actions: Vec<Action> = vec![
         Action::SelectNext,
         Action::SelectPrev,
+        Action::NextPanel,
+        Action::PrevPanel,
         Action::Confirm,
         Action::Dismiss,
         Action::Quit,
@@ -144,6 +148,17 @@ fn defaults_resolve_shared_navigation() {
     assert_eq!(km.resolve(&KeyBindingMode::from(BindingModeId::Normal), crokey::key!(up)), Some(Action::SelectPrev));
     assert_eq!(km.resolve(&KeyBindingMode::from(BindingModeId::Normal), crokey::key!(enter)), Some(Action::Confirm));
     assert_eq!(km.resolve(&KeyBindingMode::from(BindingModeId::Normal), crokey::key!(esc)), Some(Action::Dismiss));
+}
+
+#[test]
+fn defaults_resolve_project_panel_navigation() {
+    let km = Keymap::defaults();
+    let mode = KeyBindingMode::from(BindingModeId::Project);
+
+    assert_eq!(km.resolve(&mode, kc(KeyCode::Tab, KeyModifiers::NONE)), Some(Action::NextPanel));
+    assert_eq!(km.resolve(&mode, kc(KeyCode::Tab, KeyModifiers::SHIFT)), Some(Action::PrevPanel));
+    assert_eq!(km.resolve(&mode, kc(KeyCode::BackTab, KeyModifiers::NONE)), Some(Action::PrevPanel));
+    assert_eq!(km.resolve(&mode, kc(KeyCode::BackTab, KeyModifiers::SHIFT)), Some(Action::PrevPanel));
 }
 
 #[test]

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -163,6 +163,22 @@ impl ProjectPageWidget {
         }
     }
 
+    fn select_panel_delta(layouts: &[PanelLayout<'_>], state: &mut ProjectTableState, delta: isize) {
+        let Some(index) = layouts.iter().position(|layout| layout.panel.kind == state.active()) else { return };
+        let candidate = if delta > 0 {
+            index.checked_add(1).filter(|candidate| *candidate < layouts.len())
+        } else if delta < 0 {
+            index.checked_sub(1)
+        } else {
+            None
+        };
+        let Some(candidate) = candidate else { return };
+        let next = &layouts[candidate];
+        state.set_active(next.panel.kind);
+        state.table_mut(next.panel.kind).reconcile(&next.panel.table);
+        state.focus_header();
+    }
+
     fn fetch_more_query(layouts: &[PanelLayout<'_>], state: &ProjectTableState, trigger: super::table::FetchTrigger) -> Option<QueryId> {
         let layout = layouts.iter().find(|layout| layout.panel.kind == state.active())?;
         if layout.panel.kind != ProjectPanelKind::Issues
@@ -286,6 +302,18 @@ impl InteractiveWidget for ProjectPageWidget {
                 self.ensure_active_visible(&layouts, state);
                 Outcome::Consumed
             }
+            Action::NextPanel => {
+                let state = ctx.views.active_project_table_state_mut();
+                Self::select_panel_delta(&layouts, state, 1);
+                self.ensure_active_visible(&layouts, state);
+                Outcome::Consumed
+            }
+            Action::PrevPanel => {
+                let state = ctx.views.active_project_table_state_mut();
+                Self::select_panel_delta(&layouts, state, -1);
+                self.ensure_active_visible(&layouts, state);
+                Outcome::Consumed
+            }
             Action::Confirm => {
                 let action = Self::active_action(&layouts, ctx.views.active_project_table_state());
                 if let Some(action) = action {
@@ -388,7 +416,7 @@ impl InteractiveWidget for ProjectPageWidget {
     }
 
     fn binding_mode(&self) -> KeyBindingMode {
-        BindingModeId::Convoys.into()
+        BindingModeId::Project.into()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -491,6 +519,42 @@ mod tests {
 
         assert!(state.header_focused());
         assert!(matches!(ProjectPageWidget::active_action(&layouts, &state), Some(AppAction::DrillView(ViewAddress::Convoys { .. }))));
+    }
+
+    #[test]
+    fn panel_navigation_crosses_a_growing_issue_window_without_disabling_fetch_on_scroll() {
+        let mut panels = vec![
+            panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "issue-0"),
+            panel(ProjectPanelKind::Independents, "Independents", "independents?project=flotilla%2Froadmap", "governor"),
+        ];
+        for index in 1..8 {
+            let mut row = panels[0].table.rows[0].clone();
+            row.id = RowId::new(format!("issue-{index}"));
+            panels[0].table.rows.push(row);
+        }
+        panels[0].table.meta.has_more = true;
+
+        let mut state = ProjectTableState::default();
+        state.set_active(ProjectPanelKind::Issues);
+        state.focus_rows();
+        state.table_mut(ProjectPanelKind::Issues).select_index(&panels[0].table, 0);
+
+        for keypress in 0..20 {
+            let layouts = ProjectPageWidget::layouts(&panels);
+            ProjectPageWidget::select_delta(&layouts, &mut state, 1);
+            if ProjectPageWidget::fetch_more_query(&layouts, &state, crate::widgets::table::FetchTrigger::NearBottom).is_some() {
+                let mut row = panels[0].table.rows[0].clone();
+                row.id = RowId::new(format!("fetched-{keypress}"));
+                panels[0].table.rows.push(row);
+            }
+            ProjectPageWidget::reconcile(&ProjectPageWidget::layouts(&panels), &mut state);
+        }
+
+        assert!(panels[0].table.rows.len() > 8, "near-bottom row navigation should still fetch more issues");
+        assert_eq!(state.active(), ProjectPanelKind::Issues, "the growing issue window should reproduce the row-navigation trap");
+        ProjectPageWidget::select_panel_delta(&ProjectPageWidget::layouts(&panels), &mut state, 1);
+        assert_eq!(state.active(), ProjectPanelKind::Independents);
+        assert!(state.header_focused());
     }
 
     #[test]

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -5,6 +5,7 @@
 | Key | Action |
 |-----|--------|
 | `j` / `k` / `↑` / `↓` | Navigate list |
+| Tab / Shift+Tab | Move between panels on a Project page |
 | `[` / `]` | Switch tabs |
 | `{` / `}` | Reorder tabs |
 | Click | Select item |


### PR DESCRIPTION
## Summary

- add direct Tab / Shift+Tab navigation between panels on Project pages
- keep `j`/`k` row browsing and near-bottom issue fetches unchanged
- expose configurable `next_panel` / `prev_panel` actions and document the new navigation
- add a regression test that simulates a fast-growing issue window

## Root cause

The Issues panel prefetches within five rows of the loaded window's end. When each fetch completes before the next downward keypress, the last loaded row recedes at the same rate as selection, so row navigation never reaches the crossing point into Independents.

Panel navigation is now orthogonal to row exhaustion and network timing: Tab and Shift+Tab move directly to the adjacent panel header.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy -p flotilla-core -p flotilla-tui --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-tui --locked` (938 unit, 2 E2E, 1 high-fidelity, 50 snapshot tests)
- `TMPDIR="$PWD/.codex-tmp" cargo test -p flotilla-core --locked config` (49 tests)

Closes #788