### PR TITLE
fix: decode view labels and restore panel dividers

### DIFF
--- a/crates/flotilla-protocol/src/view_address.rs
+++ b/crates/flotilla-protocol/src/view_address.rs
@@ -76,6 +76,35 @@ impl ViewAddress {
             Self::Repo { .. } => "repo",
         }
     }
+
+    /// A decoded address-shaped label for human-facing surfaces.
+    ///
+    /// Unlike [`fmt::Display`], this form is not a persistence or parsing
+    /// contract: reserved characters remain readable instead of being
+    /// percent-encoded.
+    pub fn human_label(&self) -> String {
+        match self {
+            Self::Overview => "overview".to_string(),
+            Self::Convoys { namespace } => format!("convoys/{namespace}"),
+            Self::Independents { scope: Some(scope) } => {
+                format!("independents?project={}/{}", scope.namespace, scope.name)
+            }
+            Self::Independents { scope: None } => "independents".to_string(),
+            Self::Convoy { namespace, name } => format!("convoy/{namespace}/{name}"),
+            Self::Vessel { namespace, convoy, vessel } => format!("vessel/{namespace}/{convoy}/{vessel}"),
+            Self::Project { namespace, name } => format!("project/{namespace}/{name}"),
+            Self::Issues { scope } => format!("issues?project={}/{}", scope.namespace, scope.name),
+            Self::Checkouts { scope: Some(scope) } => format!("checkouts?project={}/{}", scope.namespace, scope.name),
+            Self::Checkouts { scope: None } => "checkouts".to_string(),
+            Self::Repo { identity, repository_key } => {
+                let mut label = format!("repo/{}/{}", identity.authority, identity.path);
+                if let Some(key) = repository_key {
+                    label.push_str(&format!("?key={}", key.0));
+                }
+                label
+            }
+        }
+    }
 }
 
 fn encode(segment: &str) -> impl fmt::Display + '_ {
@@ -302,6 +331,21 @@ mod tests {
         let reserved = ViewAddress::Issues { scope: QueryScope::new("flotilla+platform", "road map") };
         assert_eq!(reserved.to_string(), "issues?project=flotilla%2Bplatform%2Froad%20map");
         assert_eq!(reserved.to_string().parse::<ViewAddress>().expect("parse reserved characters"), reserved);
+    }
+
+    #[test]
+    fn human_labels_show_decoded_address_components_without_changing_the_canonical_form() {
+        let address = ViewAddress::Issues { scope: QueryScope::new("flotilla+platform", "road map") };
+
+        assert_eq!(address.human_label(), "issues?project=flotilla+platform/road map");
+        assert_eq!(address.to_string(), "issues?project=flotilla%2Bplatform%2Froad%20map");
+
+        let repo = ViewAddress::Repo {
+            identity: RepoIdentity { authority: "local".into(), path: "/tmp/repo 0".into() },
+            repository_key: Some(RepositoryKey("repo/key with space".into())),
+        };
+        assert_eq!(repo.human_label(), "repo/local//tmp/repo 0?key=repo/key with space");
+        assert_eq!(repo.to_string(), "repo/local/%2Ftmp%2Frepo%200?key=repo%2Fkey%20with%20space");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/app/open_views.rs
+++ b/crates/flotilla-tui/src/app/open_views.rs
@@ -95,14 +95,14 @@ impl OpenView {
         }
     }
 
-    pub fn breadcrumb_addresses(&self) -> Vec<&ViewAddress> {
+    pub fn breadcrumb_addresses(&self) -> Vec<ViewAddress> {
         self.history
             .iter()
             .filter_map(|frame| match &frame.target {
-                ViewTarget::View(address) => Some(address),
+                ViewTarget::View(address) => Some(address.clone()),
                 ViewTarget::Broken { .. } => None,
             })
-            .chain(self.address())
+            .chain(self.address().cloned())
             .collect()
     }
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -181,7 +181,7 @@ fn format_project_list_human(response: &ProjectListResponse) -> String {
             Cell::new(repositories),
             Cell::new(issue_source),
             Cell::new(&project.default_workflow_ref),
-            Cell::new(project.address.to_string()),
+            Cell::new(project.address.human_label()),
         ]);
     }
     format!("{table}\n")

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -231,10 +231,10 @@ mod project_list_human {
     #[test]
     fn project_list_shows_addresses_slugs_and_configuration() {
         let few = ProjectListEntry::builder()
-            .namespace("flotilla".to_string())
+            .namespace("flotilla platform".to_string())
             .name("suite".to_string())
             .display_name("Flotilla Suite".to_string())
-            .address(ViewAddress::Project { namespace: "flotilla".into(), name: "suite".into() })
+            .address(ViewAddress::Project { namespace: "flotilla platform".into(), name: "suite".into() })
             .repositories(vec![repository("flotilla-org/cleat"), repository("flotilla-org/flotilla")])
             .maybe_issue_source(Some(IssueSource { service: "https://linear.app".into(), scope: "FLOT".into() }))
             .default_workflow_ref("review-and-fix".to_string())
@@ -250,8 +250,9 @@ mod project_list_human {
             .build();
 
         let output = format_project_list_human(&ProjectListResponse { projects: vec![few, many] });
-        assert!(output.contains("flotilla/suite"));
-        assert!(output.contains("project/flotilla/suite"));
+        assert!(output.contains("flotilla platform/suite"));
+        assert!(output.contains("project/flotilla platform/suite"));
+        assert!(!output.contains("%20"));
         assert!(output.contains("flotilla-org/cleat, flotilla-org/flotilla"));
         assert!(output.contains("https://linear.app / FLOT"));
         assert!(output.contains("review-and-fix"));

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -452,7 +452,7 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
             view.meta = result_set_meta(result.state);
             Ok(view)
         }
-        ViewAddress::Project { .. } => Err(format!("project views are composite: {address}")),
+        ViewAddress::Project { .. } => Err(format!("project views are composite: {}", address.human_label())),
         ViewAddress::Convoy { namespace, name } => {
             let convoy = find_convoy(&data.convoys, namespace, name)?;
             let rows = stable_topological_vessels(&convoy.vessels).into_iter().map(|vessel| VesselProjection {
@@ -505,7 +505,7 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
             view.meta = result_set_meta(result.state);
             Ok(view)
         }
-        ViewAddress::Overview | ViewAddress::Repo { .. } => Err(format!("view is not table-backed: {address}")),
+        ViewAddress::Overview | ViewAddress::Repo { .. } => Err(format!("view is not table-backed: {}", address.human_label())),
     }
 }
 
@@ -514,7 +514,7 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
 /// and future registry changes stay identical in the embedded panel.
 pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec<ProjectPanel>, String> {
     let ViewAddress::Project { namespace, name } = address else {
-        return Err(format!("view is not project-backed: {address}"));
+        return Err(format!("view is not project-backed: {}", address.human_label()));
     };
     let scope = QueryScope::new(namespace, name);
     let convoys = convoy_spec().project(

--- a/crates/flotilla-tui/src/ui_helpers.rs
+++ b/crates/flotilla-tui/src/ui_helpers.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 use flotilla_protocol::{ChangeRequestStatus, Checkout, SessionStatus, WorkItemKind};
 use ratatui::{
     layout::{Constraint, Flex, Layout, Rect},
-    style::Color,
+    style::{Color, Style},
+    text::{Line, Span},
     widgets::Block,
 };
 
@@ -64,6 +65,20 @@ pub fn render_popup_frame(
     let inner = block.inner(area);
     frame.render_widget(block, area);
     (area, inner)
+}
+
+/// Render a full-width section divider: "── Label ──".
+pub fn render_section_divider(frame: &mut ratatui::Frame, label: &str, theme: &Theme, area: Rect, label_style: Style) {
+    let dashes_left = 2;
+    let left = "\u{2500}".repeat(dashes_left);
+    let right_width = area.width.saturating_sub(dashes_left as u16 + label.chars().count() as u16 + 4);
+    let right = "\u{2500}".repeat(right_width as usize);
+    let header_line = Line::from(vec![
+        Span::styled(format!("{left} "), Style::default().fg(theme.muted)),
+        Span::styled(label.to_string(), label_style),
+        Span::styled(format!(" {right}"), Style::default().fg(theme.muted)),
+    ]);
+    frame.render_widget(header_line, area);
 }
 
 pub fn bottom_anchored_overlay(frame_area: Rect, reserved_top_rows: u16, requested_body_rows: u16) -> BottomAnchoredOverlayLayout {

--- a/crates/flotilla-tui/src/ui_helpers.rs
+++ b/crates/flotilla-tui/src/ui_helpers.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Constraint, Flex, Layout, Rect},
     style::{Color, Style},
     text::{Line, Span},
-    widgets::Block,
+    widgets::{Block, Paragraph},
 };
 
 use crate::theme::Theme;
@@ -68,7 +68,7 @@ pub fn render_popup_frame(
 }
 
 /// Render a full-width section divider: "── Label ──".
-pub fn render_section_divider(frame: &mut ratatui::Frame, label: &str, theme: &Theme, area: Rect, label_style: Style) {
+pub fn render_section_divider(frame: &mut ratatui::Frame, label: &str, theme: &Theme, area: Rect, row_style: Style, label_style: Style) {
     let dashes_left = 2;
     let left = "\u{2500}".repeat(dashes_left);
     let right_width = area.width.saturating_sub(dashes_left as u16 + label.chars().count() as u16 + 4);
@@ -78,7 +78,7 @@ pub fn render_section_divider(frame: &mut ratatui::Frame, label: &str, theme: &T
         Span::styled(label.to_string(), label_style),
         Span::styled(format!(" {right}"), Style::default().fg(theme.muted)),
     ]);
-    frame.render_widget(header_line, area);
+    frame.render_widget(Paragraph::new(header_line).style(row_style), area);
 }
 
 pub fn bottom_anchored_overlay(frame_area: Rect, reserved_top_rows: u16, requested_body_rows: u16) -> BottomAnchoredOverlayLayout {

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -235,12 +235,10 @@ impl ProjectPageWidget {
                 if !layout.panel.table.meta.conditions.is_empty() {
                     label.push_str(&format!(" · ⚠ {}", layout.panel.table.meta.conditions.join("; ")));
                 }
-                let style = if state.active() == layout.panel.kind && state.header_focused() {
-                    theme.header_style().add_modifier(Modifier::REVERSED)
-                } else {
-                    theme.header_style()
-                };
-                ui_helpers::render_section_divider(frame, &label, theme, header_area, style);
+                let focused = state.active() == layout.panel.kind && state.header_focused();
+                let style = if focused { theme.header_style().add_modifier(Modifier::REVERSED) } else { theme.header_style() };
+                let row_style = if focused { style } else { Default::default() };
+                ui_helpers::render_section_divider(frame, &label, theme, header_area, row_style, style);
             }
             if let Some(columns_area) = self.line_area(layout.columns_line, state) {
                 super::table::TablePanel::render_header(frame, columns_area, theme, &layout.panel.table);
@@ -563,6 +561,21 @@ mod tests {
         ProjectPageWidget::select_panel_delta(&ProjectPageWidget::layouts(&panels), &mut state, 1);
         assert_eq!(state.active(), ProjectPanelKind::Independents);
         assert!(state.header_focused());
+    }
+
+    #[test]
+    fn focused_panel_header_reverses_the_full_divider_row() {
+        let panels = vec![panel(ProjectPanelKind::Convoys, "Convoys", "convoys/flotilla", "convoy-a")];
+        let mut terminal = Terminal::new(TestBackend::new(80, 3)).expect("terminal");
+        let mut widget = ProjectPageWidget::default();
+        let mut state = ProjectTableState::default();
+        state.focus_header();
+
+        terminal.draw(|frame| widget.render_composite(frame, frame.area(), &Theme::classic(), &panels, &mut state)).expect("render");
+
+        let buffer = terminal.backend().buffer();
+        assert!(buffer[(0, 0)].modifier.contains(Modifier::REVERSED));
+        assert!(buffer[(79, 0)].modifier.contains(Modifier::REVERSED));
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use flotilla_protocol::{QueryId, ViewAddress};
-use ratatui::{layout::Rect, style::Modifier, widgets::Paragraph, Frame};
+use ratatui::{layout::Rect, style::Modifier, Frame};
 
 use super::{
     describe::DescribeWidget, table_action_menu::TableActionMenuWidget, table_search::TableSearchWidget, AppAction, InteractiveWidget,
@@ -14,6 +14,7 @@ use crate::{
     keymap::Action,
     table_view::{self, ProjectPanel, ProjectPanelKind, ProjectTableState, RowId},
     theme::Theme,
+    ui_helpers,
 };
 
 const DOUBLE_CLICK_WINDOW: Duration = Duration::from_millis(500);
@@ -221,7 +222,7 @@ impl ProjectPageWidget {
         self.ensure_active_visible(&layouts, state);
         for layout in &layouts {
             if let Some(header_area) = self.line_area(layout.header_line, state) {
-                let mut label = format!(" {}  › {}", layout.panel.table.title, layout.panel.target);
+                let mut label = format!("{}  › {}", layout.panel.table.title, layout.panel.target.human_label());
                 if let Some(as_of) = layout.panel.table.meta.as_of {
                     label.push_str(&format!(" · as of {}", as_of.format("%Y-%m-%d %H:%M")));
                 }
@@ -235,13 +236,11 @@ impl ProjectPageWidget {
                     label.push_str(&format!(" · ⚠ {}", layout.panel.table.meta.conditions.join("; ")));
                 }
                 let style = if state.active() == layout.panel.kind && state.header_focused() {
-                    theme.header_style().add_modifier(Modifier::BOLD | Modifier::REVERSED)
-                } else if state.active() == layout.panel.kind {
-                    theme.header_style().add_modifier(Modifier::BOLD)
+                    theme.header_style().add_modifier(Modifier::REVERSED)
                 } else {
                     theme.header_style()
                 };
-                frame.render_widget(Paragraph::new(label).style(style), header_area);
+                ui_helpers::render_section_divider(frame, &label, theme, header_area, style);
             }
             if let Some(columns_area) = self.line_area(layout.columns_line, state) {
                 super::table::TablePanel::render_header(frame, columns_area, theme, &layout.panel.table);
@@ -461,13 +460,16 @@ mod tests {
 
     #[test]
     fn composite_renders_the_four_panels_as_one_stacked_page() {
-        let panels = vec![
+        let mut panels = vec![
             panel(ProjectPanelKind::Convoys, "Convoys", "convoys/flotilla", "convoy-a"),
             panel(ProjectPanelKind::Checkouts, "Checkouts", "checkouts?project=flotilla%2Froadmap", "checkout-a"),
             panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "issue-a"),
             panel(ProjectPanelKind::Independents, "Independents", "independents?project=flotilla%2Froadmap", "governor"),
         ];
-        let mut terminal = Terminal::new(TestBackend::new(80, 16)).expect("terminal");
+        panels[2].table.meta.as_of = Some("2026-07-21T12:30:00Z".parse().expect("timestamp"));
+        panels[2].table.meta.has_more = true;
+        panels[2].table.meta.conditions = vec!["one source stale".into()];
+        let mut terminal = Terminal::new(TestBackend::new(140, 16)).expect("terminal");
         let mut widget = ProjectPageWidget::default();
         let mut state = ProjectTableState::default();
         terminal.draw(|frame| widget.render_composite(frame, frame.area(), &Theme::classic(), &panels, &mut state)).expect("render");
@@ -478,10 +480,16 @@ mod tests {
         let issue = rendered.find("Issues").expect("issues header");
         let independents = rendered.find("Independents").expect("independents header");
         assert!(convoy < checkout && checkout < issue && issue < independents, "panels should retain the fixed v1 order");
+        assert!(rendered.contains("── Issues"), "panel headers should use section-divider chrome");
         assert!(rendered.contains("convoy-a"));
         assert!(rendered.contains("checkout-a"));
         assert!(rendered.contains("issue-a"));
         assert!(rendered.contains("governor"));
+        assert!(rendered.contains("issues?project=flotilla/roadmap"));
+        assert!(!rendered.contains("%2F"));
+        assert!(rendered.contains("as of 2026-07-21 12:30"));
+        assert!(rendered.contains("more available"));
+        assert!(rendered.contains("⚠ one source stale"));
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -136,7 +136,7 @@ impl Screen {
                 } else {
                     ActivePage::Error {
                         title: format!("repo not tracked: {}/{}", identity.authority, identity.path),
-                        detail: format!("view address: {}", ViewAddress::repo(identity.clone())),
+                        detail: format!("view address: {}", ViewAddress::repo(identity.clone()).human_label()),
                     }
                 }
             }
@@ -389,8 +389,7 @@ impl InteractiveWidget for Screen {
                 let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
                 match crate::table_view::project(&address, &rows).map(|view| view.filtered(&filter)) {
                     Ok(view) => {
-                        let breadcrumbs =
-                            ctx.views.active().breadcrumb_addresses().into_iter().map(ToString::to_string).collect::<Vec<_>>();
+                        let breadcrumbs = ctx.views.active().breadcrumb_addresses();
                         self.table.render_table(frame, chunks[1], ctx.theme, &view, ctx.views.active_table_state_mut(), &breadcrumbs);
                     }
                     Err(detail) => Self::render_error_page(frame, chunks[1], ctx.theme, "table view unavailable", &detail),

--- a/crates/flotilla-tui/src/widgets/snapshots/flotilla_tui__widgets__table__tests__scoped_issue_metadata_and_condition_snapshot.snap
+++ b/crates/flotilla-tui/src/widgets/snapshots/flotilla_tui__widgets__table__tests__scoped_issue_metadata_and_condition_snapshot.snap
@@ -3,7 +3,7 @@ source: crates/flotilla-tui/src/widgets/table.rs
 expression: terminal.backend()
 ---
 "┌ Issues · flotilla/roadmap · as of 2026-07-20 12:00 · more available · ⚠ one source unavailable ────────────┐"
-"│issues?project=flotilla%2Froadmap                                                                           │"
+"│issues?project=flotilla/roadmap                                                                             │"
 "│ISSUE          TITLE                                           SOURCE                  UPDATED              │"
 "│ENG-42         Fix pagination                                  test / owner/repo       2026-07-15 09:30     │"
 "│                                                                                                            │"

--- a/crates/flotilla-tui/src/widgets/split_table.rs
+++ b/crates/flotilla-tui/src/widgets/split_table.rs
@@ -652,6 +652,7 @@ impl SplitTable {
                     section.header_label(),
                     theme,
                     row_rect,
+                    Style::default(),
                     Style::default().fg(theme.section_header),
                 );
             }

--- a/crates/flotilla-tui/src/widgets/split_table.rs
+++ b/crates/flotilla-tui/src/widgets/split_table.rs
@@ -647,7 +647,13 @@ impl SplitTable {
             if flat_row >= self.scroll_offset && flat_row < self.scroll_offset + viewport_height {
                 let y = area.y + (flat_row - self.scroll_offset) as u16;
                 let row_rect = Rect::new(area.x, y, area.width, 1);
-                render_divider(frame, section.header_label(), theme, row_rect);
+                ui_helpers::render_section_divider(
+                    frame,
+                    section.header_label(),
+                    theme,
+                    row_rect,
+                    Style::default().fg(theme.section_header),
+                );
             }
             flat_row += 1;
 
@@ -784,20 +790,6 @@ impl SplitTable {
 }
 
 // ── Row rendering helpers ──────────────────────────────────────────────────
-
-/// Render a section divider: "── Label ──"
-fn render_divider(frame: &mut Frame, label: &str, theme: &Theme, area: Rect) {
-    let dashes_left = 2;
-    let left = "\u{2500}".repeat(dashes_left);
-    let right_width = area.width.saturating_sub(dashes_left as u16 + label.chars().count() as u16 + 4);
-    let right = "\u{2500}".repeat(right_width as usize);
-    let header_line = Line::from(vec![
-        Span::styled(format!("{left} "), Style::default().fg(theme.muted)),
-        Span::styled(label.to_string(), Style::default().fg(theme.section_header)),
-        Span::styled(format!(" {right}"), Style::default().fg(theme.muted)),
-    ]);
-    frame.render_widget(header_line, area);
-}
 
 /// Render column headers for a section.
 fn render_column_headers(

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use flotilla_protocol::ViewAddress;
 use ratatui::{
     layout::{Alignment as RatatuiAlignment, Constraint, Rect},
     style::{Color, Modifier, Style},
@@ -134,7 +135,7 @@ impl TableWidget {
         theme: &Theme,
         view: &TableView,
         state: &mut table_view::TableState,
-        breadcrumbs: &[String],
+        breadcrumbs: &[ViewAddress],
     ) {
         state.reconcile(view);
         let mut title = view.title.clone();
@@ -160,7 +161,8 @@ impl TableWidget {
         let breadcrumb_height = u16::from(!breadcrumbs.is_empty());
         if breadcrumb_height == 1 {
             let breadcrumb_area = Rect { height: 1, ..inner };
-            frame.render_widget(Line::styled(breadcrumbs.join("  ›  "), Style::default().fg(theme.muted)), breadcrumb_area);
+            let labels = breadcrumbs.iter().map(ViewAddress::human_label).collect::<Vec<_>>();
+            frame.render_widget(Line::styled(labels.join("  ›  "), Style::default().fg(theme.muted)), breadcrumb_area);
         }
         let table_area =
             Rect { y: inner.y.saturating_add(breadcrumb_height), height: inner.height.saturating_sub(breadcrumb_height), ..inner };
@@ -339,7 +341,7 @@ impl InteractiveWidget for TableWidget {
         let source_search = ctx.views.active_table_state().source_search.as_deref();
         let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
         let Ok(view) = table_view::project(&address, &rows).map(|view| view.filtered(&filter)) else { return };
-        let breadcrumbs = ctx.views.active().breadcrumb_addresses().into_iter().map(ToString::to_string).collect::<Vec<_>>();
+        let breadcrumbs = ctx.views.active().breadcrumb_addresses();
         self.render_table(frame, area, ctx.theme, &view, ctx.views.active_table_state_mut(), &breadcrumbs);
     }
 
@@ -448,9 +450,10 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(60, 8)).expect("terminal");
         let mut widget = TableWidget::default();
         let mut state = TableState::default();
+        let address: ViewAddress = "convoys/dev".parse().expect("address");
         terminal
             .draw(|frame| {
-                widget.render_table(frame, frame.area(), &Theme::classic(), &view(), &mut state, &["convoys/dev".into()]);
+                widget.render_table(frame, frame.area(), &Theme::classic(), &view(), &mut state, &[address]);
             })
             .expect("draw");
         let rendered = terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect::<String>();
@@ -478,9 +481,10 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(120, 12)).expect("terminal");
         let mut widget = TableWidget::default();
         let mut state = TableState::default();
+        let address: ViewAddress = "convoys/dev".parse().expect("address");
         terminal
             .draw(|frame| {
-                widget.render_table(frame, frame.area(), &Theme::classic(), &snapshot_view(), &mut state, &["convoys/dev".into()]);
+                widget.render_table(frame, frame.area(), &Theme::classic(), &snapshot_view(), &mut state, &[address]);
             })
             .expect("draw");
         insta::assert_snapshot!(terminal.backend());
@@ -510,14 +514,16 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(110, 7)).expect("terminal");
         let mut widget = TableWidget::default();
         let mut table_state = TableState::default();
+        let address: ViewAddress = "issues?project=flotilla%2Froadmap".parse().expect("address");
         terminal
             .draw(|frame| {
-                widget.render_table(frame, frame.area(), &Theme::classic(), &view, &mut table_state, &[
-                    "issues?project=flotilla%2Froadmap".into(),
-                ]);
+                widget.render_table(frame, frame.area(), &Theme::classic(), &view, &mut table_state, &[address]);
             })
             .expect("draw");
 
+        let rendered = terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect::<String>();
+        assert!(rendered.contains("issues?project=flotilla/roadmap"));
+        assert!(!rendered.contains("%2F"));
         insta::assert_snapshot!(terminal.backend());
     }
 }


### PR DESCRIPTION
Closes #790

## What changed

- added a decoded, human-facing `ViewAddress::human_label()` while preserving canonical `Display`/`FromStr` behavior
- used decoded labels in project headers, breadcrumbs, human CLI output, and user-visible address errors
- extracted the repo-page divider renderer and reused it for project-panel headers
- retained panel metadata and focused-header styling

## Root cause

Human-facing TUI surfaces formatted `ViewAddress` through its canonical persistence/wire `Display` implementation, which correctly percent-encodes reserved characters. Project panels also used plain paragraph headers instead of the established section-divider chrome.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- focused protocol and TUI render tests after rebasing onto current `main`