### PR TITLE
fix: make action failures visible in status bar and event log

### DIFF
--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -21,7 +21,7 @@ use crate::{
 /// request starts so the renderer can show an indicator while the daemon
 /// acknowledgement is outstanding.
 pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionContext>, event_tx: mpsc::UnboundedSender<Event>) {
-    app.model.status_message = None;
+    app.set_status_message(None);
 
     // Pane attach is a query that resolves a command for the TUI process to
     // run temporarily outside raw mode. It must not go through the ordinary
@@ -41,7 +41,7 @@ pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionCo
         let repo_identity = match repo {
             flotilla_protocol::RepoSelector::Identity(id) => id,
             _ => {
-                app.model.status_message = Some("issue query requires RepoSelector::Identity".into());
+                app.set_status_message(Some("issue query requires RepoSelector::Identity".into()));
                 return;
             }
         };
@@ -60,7 +60,7 @@ pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionCo
                 .get(&ctx.identity)
                 .is_some_and(|pending| matches!(pending.status, PendingStatus::Submitting | PendingStatus::InFlight { .. }))
             {
-                app.model.status_message = Some("An action is already in progress for this item".into());
+                app.set_status_message(Some("An action is already in progress for this item".into()));
                 return;
             }
             page.pending_actions.insert(ctx.identity.clone(), action);
@@ -101,7 +101,7 @@ pub fn handle_dispatch_completion(result: Result<u64, String>, pending_ctx: Opti
                 remove_pending_action(app, &ctx);
             }
             reset_loading_mode(app);
-            app.model.status_message = Some(message);
+            app.set_status_message(Some(message));
         }
     }
 
@@ -116,10 +116,10 @@ pub fn handle_attach_dispatch_completion(result: Result<CommandValue, String>, a
             app.pending_attach_command = Some(command);
         }
         Ok(CommandValue::Error { message }) | Err(message) => {
-            app.model.status_message = Some(message);
+            app.set_status_message(Some(message));
         }
         Ok(other) => {
-            app.model.status_message = Some(format!("unexpected attach response: {other:?}"));
+            app.set_status_message(Some(format!("unexpected attach response: {other:?}")));
         }
     }
 }
@@ -200,11 +200,11 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         }
         CommandValue::Error { message } => {
             reset_loading_mode(app);
-            app.model.status_message = Some(message);
+            app.set_status_message(Some(message));
         }
         CommandValue::Cancelled => {
             reset_loading_mode(app);
-            app.model.status_message = Some("Command cancelled".into());
+            app.set_status_message(Some("Command cancelled".into()));
         }
         CommandValue::TerminalPrepared { .. }
         | CommandValue::PreparedWorkspace(_)
@@ -230,26 +230,26 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         CommandValue::IssuePage(_) | CommandValue::IssuesByIds { .. } => {}
         CommandValue::ConvoyCreated { name } => {
             info!(%name, "convoy created");
-            app.model.status_message = Some(format!("Convoy created: {name}"));
+            app.set_status_message(Some(format!("Convoy created: {name}")));
         }
         CommandValue::ConvoyStarted { name, attach_command, .. } => {
             info!(%name, "convoy started");
-            app.model.status_message = Some(format!("Convoy started: {name}"));
+            app.set_status_message(Some(format!("Convoy started: {name}")));
             if let Some(command) = attach_command {
                 app.pending_attach_command = Some(command);
             }
         }
         CommandValue::WorkflowTemplateApplied { name } => {
             info!(%name, "workflow template applied");
-            app.model.status_message = Some(format!("Workflow template applied: {name}"));
+            app.set_status_message(Some(format!("Workflow template applied: {name}")));
         }
         CommandValue::ProjectAdded { name } => {
             info!(%name, "project created");
-            app.model.status_message = Some(format!("Project created: {name}"));
+            app.set_status_message(Some(format!("Project created: {name}")));
         }
         CommandValue::ProjectApplied { name } => {
             info!(%name, "project applied");
-            app.model.status_message = Some(format!("Project applied: {name}"));
+            app.set_status_message(Some(format!("Project applied: {name}")));
         }
     }
 }

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -267,7 +267,7 @@ impl App {
         let my_node_id = self.model.my_node_id().cloned();
         if !intent.is_allowed_for_host(item, &my_node_id) {
             tracing::warn!(?intent, node_id = %item.node_id, "blocked intent on remote item");
-            self.model.status_message = Some("Cannot perform this action on a remote item".to_string());
+            self.set_status_message(Some("Cannot perform this action on a remote item".to_string()));
             return;
         }
 
@@ -323,7 +323,7 @@ impl App {
                             return;
                         }
                         Err(e) => {
-                            self.model.status_message = Some(e);
+                            self.set_status_message(Some(e));
                             return;
                         }
                     }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -799,7 +799,12 @@ impl App {
         self.ui.status_bar.dismissed_status_ids.insert(id);
     }
 
-    fn set_status_message(&mut self, status_message: Option<String>) {
+    /// The only sanctioned way to write `model.status_message`. A dismissed
+    /// error chip stays hidden only while the message is unchanged; any new
+    /// message un-dismisses so it becomes visible. Writing the field directly
+    /// bypasses that and leaves new errors invisible after one dismissal —
+    /// which is how convoy admission errors vanished during the #796 dogfood.
+    pub(crate) fn set_status_message(&mut self, status_message: Option<String>) {
         if self.model.status_message != status_message {
             self.ui.status_bar.dismissed_status_ids.remove(&0);
         }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -617,6 +617,21 @@ fn new_status_message_reappears_after_dismissing_old_one() {
 }
 
 #[test]
+fn command_error_is_visible_after_a_prior_dismissal() {
+    // Regression: command errors used to write `model.status_message`
+    // directly, bypassing `set_status_message`'s un-dismiss — so one
+    // dismissed error chip muted every later error for the session.
+    let mut app = stub_app();
+    app.set_status_message(Some("provider noise".into()));
+    app.dismiss_status_item(0);
+    assert!(app.visible_status_items().is_empty());
+
+    executor::handle_result(CommandValue::Error { message: "admission rejected".into() }, &mut app);
+
+    assert_eq!(app.visible_status_items(), vec![VisibleStatusItem { id: 0, text: "ERROR admission rejected".into() }]);
+}
+
+#[test]
 fn visible_status_items_use_shared_error_and_peer_labels() {
     let mut app = stub_app();
     app.set_status_message(Some("boom".into()));

--- a/crates/flotilla-tui/src/event_log.rs
+++ b/crates/flotilla-tui/src/event_log.rs
@@ -196,10 +196,11 @@ impl<S: tracing::Subscriber> Layer<S> for TuiLayer {
     fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
         let level = *event.metadata().level();
 
-        let mut visitor = MessageVisitor { message: String::new(), provider: None };
+        let mut visitor = MessageVisitor { message: String::new(), provider: None, fields: Vec::new() };
         event.record(&mut visitor);
 
-        let display = format_log_message(&visitor.message, visitor.provider.as_deref());
+        let provider = visitor.provider.clone();
+        let display = format_log_message(&visitor.into_line(), provider.as_deref());
         EVENT_LOG.lock().unwrap().push(level, display);
     }
 }
@@ -215,12 +216,28 @@ fn format_log_message(message: &str, provider: Option<&str>) -> String {
 struct MessageVisitor {
     message: String,
     provider: Option<String>,
+    /// Non-message structured fields, rendered as ` key=value` suffixes so
+    /// the log viewer shows the substance of an event (e.g. the `error` field
+    /// of a "command failed" warning), not just its bare message.
+    fields: Vec<(String, String)>,
+}
+
+impl MessageVisitor {
+    fn into_line(self) -> String {
+        let mut line = self.message;
+        for (key, value) in &self.fields {
+            line.push_str(&format!(" {key}={value}"));
+        }
+        line
+    }
 }
 
 impl tracing::field::Visit for MessageVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         if field.name() == "message" {
             self.message = format!("{:?}", value);
+        } else {
+            self.fields.push((field.name().to_string(), format!("{:?}", value)));
         }
     }
 
@@ -228,7 +245,7 @@ impl tracing::field::Visit for MessageVisitor {
         match field.name() {
             "message" => self.message = value.to_string(),
             "provider" => self.provider = Some(value.to_string()),
-            _ => {}
+            _ => self.fields.push((field.name().to_string(), value.to_string())),
         }
     }
 }

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -152,7 +152,7 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
             terminal = next_terminal;
             events.resume_terminal_input();
             if let Err(message) = result {
-                app.model.status_message = Some(message);
+                app.set_status_message(Some(message));
             }
         }
         app.drain_background_updates();

--- a/crates/flotilla-tui/src/widgets/event_log.rs
+++ b/crates/flotilla-tui/src/widgets/event_log.rs
@@ -91,7 +91,8 @@ impl EventLogWidget {
                     .title(" Event Log ")
                     .title_top(Line::from(Span::styled(filter_label, Style::default().fg(theme.muted))).right_aligned()),
             )
-            .highlight_style(Style::default().bg(theme.multi_select_bg));
+            .highlight_style(Style::default().bg(theme.row_highlight).bold())
+            .highlight_symbol("\u{25b8} ");
 
         let mut state = ListState::default();
         state.select(self.selected);


### PR DESCRIPTION
During the #666 dogfood, starting a convoy from an issue produced a fast, precise admission rejection daemon-side — and zero visible feedback in the TUI. Three independent bugs conspired:

1. **One dismissal muted every future error.** `set_status_message` un-dismisses the error chip when the message changes, but nine call sites — including the `CommandValue::Error` path in `handle_result` — wrote `model.status_message` directly, bypassing it. After dismissing any earlier error chip (e.g. recurring zellij provider noise), all later errors were silently filtered. All writers now go through `set_status_message` (now `pub(crate)`, with a doc comment naming the invariant), and a regression test pins the `handle_result` path: dismiss → command error arrives → chip visible.
2. **Event-log lines dropped every structured field.** `MessageVisitor` recorded only `message` (and `provider`), so a `command failed` WARN rendered with no detail — the actual `error=…` text never reached the viewer. Non-message fields are now appended as ` key=value` suffixes.
3. **The viewer's auto-selected newest line was unreadable.** The list highlight used `multi_select_bg` with no modifier, which in practice made the most important (most recent, auto-selected) entry illegible. Switched to the app-wide selection convention: `row_highlight` bg + bold + `▸` highlight symbol.

Companion PR #806 fixes the underlying codex adapter detection gap that caused the rejection itself.

This is the minimal 'an action can never fail silently' guarantee; the richer subscription-backed action-progress surface (replacing the old bottom-right step progress) is future presentation work.