### PR TITLE
fix: harden convoy-start cleanup against worker panics

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    panic::AssertUnwindSafe,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -39,7 +40,7 @@ use flotilla_resources::{
     Vessel, WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL,
     REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -2780,30 +2781,39 @@ impl InProcessDaemon {
         Ok(placement)
     }
 
-    async fn run_convoy_start(&self, task: ConvoyStartTask) {
-        let ConvoyStartTask { command_id, intent, key } = task;
+    async fn run_convoy_start(&self, intent: flotilla_protocol::ConvoyStartIntent) -> flotilla_protocol::CommandValue {
         let namespace = self.provisioning_namespace().await;
         let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
-        let result = if requested_namespace != namespace {
-            flotilla_protocol::CommandValue::Error {
+        if requested_namespace != namespace {
+            return flotilla_protocol::CommandValue::Error {
                 message: format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"),
-            }
-        } else {
-            match self.admit_convoy_start(&namespace, &intent).await {
-                Ok(name) if intent.auto_attach => match self.wait_for_convoy_attach(&namespace, &name).await {
-                    Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
-                        name,
-                        attach_command: Some(resolved.command),
-                        binding: resolved.binding,
-                    },
-                    Err(message) => flotilla_protocol::CommandValue::Error { message },
+            };
+        }
+        match self.admit_convoy_start(&namespace, &intent).await {
+            Ok(name) if intent.auto_attach => match self.wait_for_convoy_attach(&namespace, &name).await {
+                Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
+                    name,
+                    attach_command: Some(resolved.command),
+                    binding: resolved.binding,
                 },
-                Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
+            },
+            Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
+            Err(message) => flotilla_protocol::CommandValue::Error { message },
+        }
+    }
+
+    async fn supervise_convoy_start(&self, task: ConvoyStartTask) {
+        let ConvoyStartTask { command_id, intent, key } = task;
+        let result = match AssertUnwindSafe(self.run_convoy_start(intent)).catch_unwind().await {
+            Ok(result) => result,
+            Err(_) => {
+                warn!(command_id, "convoy start worker panicked");
+                flotilla_protocol::CommandValue::Error { message: "convoy start worker panicked".to_string() }
             }
         };
-        self.finish_context_free_command(command_id, empty_repo_identity(), result);
         self.pending_convoy_starts.lock().await.remove(&key);
+        self.finish_context_free_command(command_id, empty_repo_identity(), result);
     }
 
     async fn wait_for_convoy_attach(&self, namespace: &str, name: &str) -> Result<ResolvedAttach, String> {
@@ -4567,7 +4577,7 @@ impl InProcessDaemon {
             let task = ConvoyStartTask { command_id: id, intent: intent.as_ref().clone(), key: key.clone() };
             if let Some(daemon) = self.self_weak.upgrade() {
                 tokio::spawn(async move {
-                    daemon.run_convoy_start(task).await;
+                    daemon.supervise_convoy_start(task).await;
                 });
             } else {
                 self.pending_convoy_starts.lock().await.remove(&key);

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -329,6 +329,48 @@ fn slow_ai_discovery(utility: Arc<SlowAiUtility>) -> DiscoveryRuntime {
     runtime
 }
 
+struct PanicOnceAiUtility {
+    panicked: AtomicBool,
+}
+
+#[async_trait]
+impl AiUtility for PanicOnceAiUtility {
+    async fn generate_branch_name(&self, _: &str) -> Result<String, String> {
+        Ok("fix/retried-convoy".into())
+    }
+
+    async fn generate_convoy_names(&self, _: &str) -> Result<ConvoyNames, String> {
+        if !self.panicked.swap(true, Ordering::SeqCst) {
+            panic!("injected convoy start worker panic");
+        }
+        Ok(ConvoyNames { name: "retried-convoy".into(), branch: "fix/retried-convoy".into() })
+    }
+}
+
+struct PanicOnceAiUtilityFactory {
+    utility: Arc<PanicOnceAiUtility>,
+}
+
+#[async_trait]
+impl Factory for PanicOnceAiUtilityFactory {
+    type Descriptor = ProviderDescriptor;
+    type Output = dyn AiUtility;
+
+    fn descriptor(&self) -> ProviderDescriptor {
+        ProviderDescriptor::named(ProviderCategory::AiUtility, "panic-once-ai")
+    }
+
+    async fn probe(
+        &self,
+        _: &EnvironmentBag,
+        _: &ConfigStore,
+        _: &ExecutionEnvironmentPath,
+        _: Arc<dyn flotilla_core::providers::CommandRunner>,
+    ) -> Result<Arc<Self::Output>, Vec<UnmetRequirement>> {
+        Ok(Arc::clone(&self.utility) as Arc<dyn AiUtility>)
+    }
+}
+
 struct CountingConvoyAiUtility {
     calls: AtomicUsize,
     fail: AtomicBool,
@@ -1286,6 +1328,65 @@ async fn convoy_start_rejects_the_same_project_start_while_admission_is_in_fligh
     .await
     .expect("first convoy start should finish after admission is released");
     assert!(matches!(first_result, CommandValue::ConvoyStarted { .. }));
+
+    drop(temp);
+}
+
+#[tokio::test]
+async fn convoy_start_worker_panic_finishes_the_command_and_allows_retry() {
+    let utility = Arc::new(PanicOnceAiUtility { panicked: AtomicBool::new(false) });
+    let mut discovery = fake_discovery(false);
+    discovery.factories.ai_utilities.push(Box::new(PanicOnceAiUtilityFactory { utility }));
+    let (temp, _repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    create_test_convoy_project(&daemon.resource_backend(), None).await;
+    let command = Command {
+        node_id: None,
+        provisioning_target: None,
+        context_repo: None,
+        action: CommandAction::ConvoyStart {
+            intent: Box::new(ConvoyStartIntent {
+                namespace: None,
+                project_ref: "flotilla".into(),
+                issue: None,
+                name: None,
+                branch: None,
+                workflow_ref: None,
+                inputs: Vec::new(),
+                instruction: None,
+                placement_policy: None,
+                auto_attach: false,
+            }),
+        },
+    };
+    let mut events = daemon.subscribe();
+
+    let first_id = daemon.execute(command.clone()).await.expect("first convoy start should be accepted");
+    let first_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == first_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("panicked convoy start should finish");
+    assert!(matches!(first_result, CommandValue::Error { message } if message.contains("worker panicked")));
+
+    let retry_id = daemon.execute(command).await.expect("matching convoy start retry should be accepted");
+    let retry_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == retry_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("matching convoy start retry should finish");
+    assert_eq!(retry_result, CommandValue::ConvoyStarted { name: "retried-convoy".into(), attach_command: None, binding: None });
 
     drop(temp);
 }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1343,49 +1343,16 @@ async fn convoy_start_worker_panic_finishes_the_command_and_allows_retry() {
         node_id: None,
         provisioning_target: None,
         context_repo: None,
-        action: CommandAction::ConvoyStart {
-            intent: Box::new(ConvoyStartIntent {
-                namespace: None,
-                project_ref: "flotilla".into(),
-                issue: None,
-                name: None,
-                branch: None,
-                workflow_ref: None,
-                inputs: Vec::new(),
-                instruction: None,
-                placement_policy: None,
-                auto_attach: false,
-            }),
-        },
+        action: CommandAction::ConvoyStart { intent: Box::new(ConvoyStartIntent::builder().project_ref("flotilla".to_string()).build()) },
     };
     let mut events = daemon.subscribe();
 
     let first_id = daemon.execute(command.clone()).await.expect("first convoy start should be accepted");
-    let first_result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            match events.recv().await {
-                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == first_id => break result,
-                Ok(_) => {}
-                Err(error) => panic!("command event receive failed: {error:?}"),
-            }
-        }
-    })
-    .await
-    .expect("panicked convoy start should finish");
+    let first_result = recv_command_finished(&mut events, first_id).await;
     assert!(matches!(first_result, CommandValue::Error { message } if message.contains("worker panicked")));
 
     let retry_id = daemon.execute(command).await.expect("matching convoy start retry should be accepted");
-    let retry_result = tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            match events.recv().await {
-                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == retry_id => break result,
-                Ok(_) => {}
-                Err(error) => panic!("command event receive failed: {error:?}"),
-            }
-        }
-    })
-    .await
-    .expect("matching convoy start retry should finish");
+    let retry_result = recv_command_finished(&mut events, retry_id).await;
     assert_eq!(retry_result, CommandValue::ConvoyStarted { name: "retried-convoy".into(), attach_command: None, binding: None });
 
     drop(temp);
@@ -3154,6 +3121,15 @@ async fn provisioned_repo_refresh_stamps_discovered_checkout_environment_id() {
 
 async fn recv_event(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>) -> DaemonEvent {
     tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv()).await.expect("timeout waiting for event").expect("recv error")
+}
+
+async fn recv_command_finished(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
+    loop {
+        match recv_event(rx).await {
+            DaemonEvent::CommandFinished { command_id: finished_id, result, .. } if finished_id == command_id => return result,
+            _ => {}
+        }
+    }
 }
 
 async fn trigger_refresh_and_recv(


### PR DESCRIPTION
## Summary

- supervise asynchronous convoy-start workers with an unwind boundary
- clear the pending deduplication key before publishing command completion
- turn unexpected worker panics into a visible `CommandFinished` error
- add regression coverage proving an identical start can retry after a panic

Closes #796

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon convoy_start_`
- `cargo test --workspace --locked -- --skip server::tests::dispatch_add_list_remove_repo_round_trip`

The unfiltered workspace suite has one unrelated deterministic macOS temp-path assertion mismatch (`/private/var/...` versus `/var/...`) in `dispatch_add_list_remove_repo_round_trip`; the isolated test fails identically on `main`-equivalent code.
