### PR TITLE
fix: qualify presentation tabs with convoy identity

### DIFF
--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -730,6 +730,17 @@ fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, vessel: &str, _now: Da
 }
 
 fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, vessel: &str) -> Actuation {
+    let presentation_name = if convoy
+        .status
+        .as_ref()
+        .and_then(|status| status.workflow_snapshot.as_ref())
+        .is_some_and(|snapshot| snapshot.vessels.len() == 1)
+    {
+        convoy.metadata.name.clone()
+    } else {
+        format!("{}:{vessel}", convoy.metadata.name)
+    };
+
     Actuation::CreatePresentation {
         meta: InputMeta::builder()
             .name(vessel_resource_name(&convoy.metadata.name, vessel))
@@ -749,7 +760,7 @@ fn create_presentation_actuation(convoy: &ResourceObject<Convoy>, vessel: &str) 
             // Stage 4a always uses the built-in default policy. Threading a policy ref through
             // ConvoySpec remains follow-up work once convoys can choose among multiple layouts.
             presentation_policy_ref: "default".to_string(),
-            name: vessel.to_string(),
+            name: presentation_name,
             process_selector: BTreeMap::from([
                 (CONVOY_LABEL.to_string(), convoy.metadata.name.clone()),
                 (VESSEL_LABEL.to_string(), vessel.to_string()),

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -558,12 +558,12 @@ async fn controller_loop_creates_one_presentation_per_active_task() {
     })
     .await
     .map(|(implement, review)| {
-        assert_eq!(implement.spec.name, "implement");
+        assert_eq!(implement.spec.name, "convoy-multi:implement");
         assert_eq!(implement.spec.process_selector.get(CONVOY_LABEL).map(String::as_str), Some("convoy-multi"));
         assert_eq!(implement.spec.process_selector.get(VESSEL_LABEL).map(String::as_str), Some("implement"));
         assert_eq!(implement.metadata.labels.get(VESSEL_LABEL).map(String::as_str), Some("implement"));
 
-        assert_eq!(review.spec.name, "review");
+        assert_eq!(review.spec.name, "convoy-multi:review");
         assert_eq!(review.spec.process_selector.get(CONVOY_LABEL).map(String::as_str), Some("convoy-multi"));
         assert_eq!(review.spec.process_selector.get(VESSEL_LABEL).map(String::as_str), Some("review"));
         assert_eq!(review.metadata.labels.get(VESSEL_LABEL).map(String::as_str), Some("review"));

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -892,7 +892,7 @@ async fn active_convoy_creates_presentation_when_missing() {
                     && meta.owner_references[0].name == "convoy-a"
                     && spec.convoy_ref == "convoy-a"
                     && spec.presentation_policy_ref == "default"
-                    && spec.name == "implement"
+                    && spec.name == "convoy-a:implement"
                     && spec.process_selector == BTreeMap::from([
                         (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
                         (VESSEL_LABEL.to_string(), "implement".to_string()),
@@ -1072,11 +1072,41 @@ async fn multi_task_convoy_creates_presentations_only_for_active_tasks() {
             _ => None,
         })
         .collect();
-    assert_eq!(creates, vec![("convoy-a-implement".to_string(), "implement".to_string())]);
+    assert_eq!(creates, vec![("convoy-a-implement".to_string(), "convoy-a:implement".to_string())]);
     assert!(!outcome
         .actuations
         .iter()
         .any(|actuation| matches!(actuation, Actuation::CreatePresentation { meta, .. } if meta.name == "convoy-a-review")));
+}
+
+#[tokio::test]
+async fn single_vessel_convoys_name_presentations_after_the_convoy() {
+    let mut presentation_names = Vec::new();
+
+    for convoy_name in ["convoy-a", "convoy-b"] {
+        let mut status = bootstrapped_tool_only_convoy_status();
+        status.phase = ConvoyPhase::Active;
+        status.started_at = Some(timestamp(18));
+        status.workflow_snapshot.as_mut().expect("workflow snapshot").vessels.retain(|vessel| vessel.name == "implement");
+        status.work.retain(|vessel, _| vessel == "implement");
+        status.crew_work.retain(|vessel, _| vessel == "implement");
+        status.work.get_mut("implement").expect("implement work").phase = WorkPhase::Running;
+        status.work.get_mut("implement").expect("implement work").started_at = Some(timestamp(18));
+        let convoy = convoy_object(convoy_name, task_provisioning_convoy_spec(), Some(status));
+
+        let outcome = reconcile_once_with_resources(&convoy, None, Vec::new(), Vec::new(), timestamp(20)).await;
+        let presentation_name = outcome
+            .actuations
+            .iter()
+            .find_map(|actuation| match actuation {
+                Actuation::CreatePresentation { spec, .. } => Some(spec.name.clone()),
+                _ => None,
+            })
+            .expect("presentation creation");
+        presentation_names.push(presentation_name);
+    }
+
+    assert_eq!(presentation_names, vec!["convoy-a".to_string(), "convoy-b".to_string()]);
 }
 
 #[tokio::test]
@@ -1127,7 +1157,7 @@ async fn launching_task_creates_presentation_when_missing() {
         actuation,
         Actuation::CreatePresentation { meta, spec }
             if meta.name == "convoy-a-implement"
-                && spec.name == "implement"
+                && spec.name == "convoy-a:implement"
                 && spec.process_selector.get(VESSEL_LABEL).map(String::as_str) == Some("implement")
     )));
 }


### PR DESCRIPTION
## Summary

- name single-vessel presentation tabs after the convoy
- name multi-vessel tabs as `<convoy>:<vessel>`
- cover distinct concurrent convoys and persisted multi-vessel presentations

## Root cause

Presentation creation used the bare vessel name as `PresentationSpec.name`. The default workflow calls its only vessel `work`, so every convoy launched from that workflow produced an indistinguishable `work` tab even though convoy identity was already present in selectors and labels.

## Impact

Presentation tabs now carry convoy identity while retaining the vessel qualifier only when it is needed to distinguish multiple vessels in the same convoy.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR=/private/tmp cargo test --workspace --locked`

Fixes #808