### PR TITLE
feat: run host-direct convoys on remote peers

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -339,6 +339,7 @@ pub async fn build_plan(
         | CommandAction::CrewHandoff { .. }
         | CommandAction::ConvoyCreate { .. }
         | CommandAction::ConvoyStart { .. }
+        | CommandAction::ConvoyStartPrepared { .. }
         | CommandAction::WorkflowTemplateApply { .. }
         | CommandAction::ProjectAdd { .. }
         | CommandAction::ProjectApply { .. }

--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -117,6 +117,10 @@ impl HostRegistry {
         self.node_environments.read().await.get(node_id).cloned()
     }
 
+    pub(crate) async fn node_id_for_environment(&self, environment_id: &EnvironmentId) -> Option<NodeId> {
+        self.hosts.read().await.get(environment_id).filter(|state| !state.removed).map(|state| state.node_id.clone())
+    }
+
     pub(crate) async fn get_host_status(
         &self,
         environment_id: &EnvironmentId,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1778,12 +1778,10 @@ impl InProcessDaemon {
             .get(policy_name)
             .await
             .map_err(|error| format!("placement policy {policy_name}: {error}"))?;
-        let host_ref = policy
-            .spec
-            .host_direct
-            .as_ref()
-            .map(|host_direct| host_direct.host_ref.as_str())
-            .ok_or_else(|| format!("placement policy {policy_name} is not a host-direct policy"))?;
+        let Some(host_direct) = policy.spec.host_direct.as_ref() else {
+            return Ok(None);
+        };
+        let host_ref = host_direct.host_ref.as_str();
         if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_ref) {
             return Ok(None);
         }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1742,25 +1742,26 @@ impl InProcessDaemon {
 
         let policy_name = format!("host-direct-{host_name}");
         let policies = self.resource_backend.clone().using::<PlacementPolicy>(&namespace);
+        let pool = terminal_pools.into_iter().next().unwrap_or_else(|| "passthrough".to_string());
+        let desired = PlacementPolicySpec::builder()
+            .pool(pool)
+            .host_direct(HostDirectPlacementPolicySpec {
+                host_ref: host_name.clone(),
+                checkout: HostDirectPlacementPolicyCheckout::Worktree,
+            })
+            .build();
         match policies.get(&policy_name).await {
-            Ok(_) => Ok(()),
-            Err(ResourceError::NotFound { .. }) => {
-                let pool = terminal_pools.into_iter().next().unwrap_or_else(|| "passthrough".to_string());
-                policies
-                    .create(
-                        &InputMeta::builder().name(policy_name).build(),
-                        &PlacementPolicySpec::builder()
-                            .pool(pool)
-                            .host_direct(HostDirectPlacementPolicySpec {
-                                host_ref: host_name,
-                                checkout: HostDirectPlacementPolicyCheckout::Worktree,
-                            })
-                            .build(),
-                    )
-                    .await
-                    .map(|_| ())
-                    .map_err(|error| error.to_string())
-            }
+            Ok(existing) if existing.spec == desired => Ok(()),
+            Ok(existing) => policies
+                .update(&InputMeta::builder().name(policy_name).build(), &existing.metadata.resource_version, &desired)
+                .await
+                .map(|_| ())
+                .map_err(|error| error.to_string()),
+            Err(ResourceError::NotFound { .. }) => policies
+                .create(&InputMeta::builder().name(policy_name).build(), &desired)
+                .await
+                .map(|_| ())
+                .map_err(|error| error.to_string()),
             Err(error) => Err(error.to_string()),
         }
     }
@@ -1808,13 +1809,15 @@ impl InProcessDaemon {
             return Err(format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"));
         }
         let mut admission = self.prepare_convoy_admission(&namespace, intent).await?;
-        let workflow_name = format!("{}-remote-workflow", admission.name);
+        let workflow_value = serde_json::to_value(&admission.workflow).map_err(|error| error.to_string())?;
+        let workflow_name = prepared_snapshot_name(&admission.name, "workflow", &workflow_value)?;
         admission.spec.workflow_ref.clone_from(&workflow_name);
         let (placement_policy_name, placement_policy_spec) = match admission.placement_policy {
             Some(spec) => {
-                let name = format!("{}-remote-placement", admission.name);
+                let value = serde_json::to_value(spec).map_err(|error| error.to_string())?;
+                let name = prepared_snapshot_name(&admission.name, "placement", &value)?;
                 admission.spec.placement_policy = Some(name.clone());
-                (Some(name), Some(serde_json::to_value(spec).map_err(|error| error.to_string())?))
+                (Some(name), Some(value))
             }
             None => (None, None),
         };
@@ -1823,7 +1826,7 @@ impl InProcessDaemon {
             .name(admission.name)
             .convoy_spec(serde_json::to_value(admission.spec).map_err(|error| error.to_string())?)
             .workflow_name(workflow_name)
-            .workflow_spec(serde_json::to_value(admission.workflow).map_err(|error| error.to_string())?)
+            .workflow_spec(workflow_value)
             .maybe_placement_policy_name(placement_policy_name)
             .maybe_placement_policy_spec(placement_policy_spec)
             .auto_attach(intent.auto_attach)
@@ -2539,6 +2542,13 @@ async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, names
         Ok(_) | Err(ResourceError::Conflict { .. }) => Ok(()),
         Err(error) => Err(error.to_string()),
     }
+}
+
+fn prepared_snapshot_name(convoy_name: &str, kind: &str, spec: &serde_json::Value) -> Result<String, String> {
+    let encoded = serde_json::to_vec(spec).map_err(|error| error.to_string())?;
+    let digest = Sha256::digest(encoded);
+    let suffix = digest[..6].iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    Ok(format!("{convoy_name}-remote-{kind}-{suffix}"))
 }
 
 async fn ensure_prepared_workflow_snapshot(

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,23 +22,24 @@ use flotilla_protocol::{
     result_set::{ConvoyRow, ResultSet, Rows},
     AttachBinding, Command, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId,
     FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
-    HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, ProjectListEntry, ProjectListRepository,
-    ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoInfo, RepoProvidersResponse,
-    RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse, StreamKey, SystemInfo, ToolInventory,
-    TopologyResponse, TopologyRoute, ViewAddress,
+    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, ProjectListEntry,
+    ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoInfo,
+    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, StatusResponse, StreamKey, SystemInfo,
+    ToolInventory, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     apply_status_patch as apply_resource_status_patch, apply_status_patch_checked as apply_resource_status_patch_checked,
     external_patches as convoy_external_patches, normalize_project_spec, resolve_project_issue_sources, terminal_session_attach_target,
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch,
-    CrewSource, Environment as ResourceEnvironment, Host as ResourceHost, InMemoryBackend, InputMeta, InputValue, IssueSnapshot,
-    IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
-    PlacementPolicy, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend,
-    ResourceError, ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
-    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
-    Vessel, WatchEvent, WatchStart, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL,
-    REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    CrewSource, Environment as ResourceEnvironment, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,
+    InMemoryBackend, InputMeta, InputValue, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
+    ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, TerminalBrief,
+    TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
+    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent,
+    WatchStart, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
+    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -991,6 +992,14 @@ struct ConvoyStartTask {
     key: ConvoyStartKey,
 }
 
+#[derive(bon::Builder)]
+struct ConvoyAdmission {
+    name: String,
+    spec: ConvoySpec,
+    workflow: WorkflowTemplateSpec,
+    placement_policy: Option<PlacementPolicySpec>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct ConvoyStartKey {
     namespace: String,
@@ -1110,6 +1119,7 @@ pub struct InProcessDaemon {
     fleet_replica_cache: RwLock<HashMap<HostName, FleetReplicaCacheEntry>>,
     fleet_replica_tx: broadcast::Sender<Vec<FleetReplicaSnapshot>>,
     repository_inspector: RwLock<Option<Arc<dyn RepositoryInspector>>>,
+    local_placement_provider_statuses: RwLock<Vec<HostProviderStatus>>,
 }
 
 /// Default provisioning namespace used until [`InProcessDaemon::set_provisioning_namespace`]
@@ -1272,6 +1282,7 @@ impl InProcessDaemon {
             fleet_replica_cache: RwLock::new(HashMap::new()),
             fleet_replica_tx,
             repository_inspector: RwLock::new(None),
+            local_placement_provider_statuses: RwLock::new(Vec::new()),
         });
 
         // Spawn self-driving poll loop with a Weak reference.
@@ -1311,6 +1322,17 @@ impl InProcessDaemon {
 
     pub async fn local_host_summary(&self) -> HostSummary {
         self.refresh_local_host_summary().await
+    }
+
+    pub async fn set_local_placement_capabilities(&self, agent_adapters: &BTreeSet<String>, terminal_pools: &[String]) {
+        let mut statuses = agent_adapters
+            .iter()
+            .map(|adapter| HostProviderStatus::available(AGENT_ADAPTER_PROVIDER_CATEGORY, adapter))
+            .chain(terminal_pools.iter().map(|pool| HostProviderStatus::available(TERMINAL_POOL_PROVIDER_CATEGORY, pool)))
+            .collect::<Vec<_>>();
+        statuses.sort_by(|left, right| (&left.category, &left.implementation).cmp(&(&right.category, &right.implementation)));
+        *self.local_placement_provider_statuses.write().await = statuses;
+        let _ = self.refresh_local_host_summary().await;
     }
 
     pub fn local_environment_id(&self) -> &EnvironmentId {
@@ -1663,11 +1685,149 @@ impl InProcessDaemon {
     }
 
     pub async fn publish_peer_summary(&self, summary: HostSummary) {
+        if let Err(error) = self.materialize_peer_host_direct_placement(&summary).await {
+            warn!(peer = %summary.node.node_id, %error, "failed to materialize peer host-direct placement");
+        }
         self.host_registry
             .publish_peer_summary(summary, &|e| {
                 let _ = self.event_tx.send(e);
             })
             .await;
+    }
+
+    async fn materialize_peer_host_direct_placement(&self, summary: &HostSummary) -> Result<(), String> {
+        let Some(host_id) = summary.environment_id.host_id() else {
+            return Ok(());
+        };
+        if self.local_host_id().as_ref() == Some(host_id) {
+            return Ok(());
+        }
+
+        let namespace = self.provisioning_namespace().await;
+        let hosts = self.resource_backend.clone().using::<ResourceHost>(&namespace);
+        let host_name = host_id.to_string();
+        let host = match hosts.get(&host_name).await {
+            Ok(host) => host,
+            Err(ResourceError::NotFound { .. }) => hosts
+                .create(&InputMeta::builder().name(host_name.clone()).build(), &flotilla_resources::HostSpec {})
+                .await
+                .map_err(|error| error.to_string())?,
+            Err(error) => return Err(error.to_string()),
+        };
+
+        let agent_adapters = summary
+            .providers
+            .iter()
+            .filter(|provider| provider.healthy && provider.category == AGENT_ADAPTER_PROVIDER_CATEGORY)
+            .map(|provider| provider.implementation.clone())
+            .collect::<BTreeSet<_>>();
+        let terminal_pools = summary
+            .providers
+            .iter()
+            .filter(|provider| provider.healthy && provider.category == TERMINAL_POOL_PROVIDER_CATEGORY)
+            .map(|provider| provider.implementation.clone())
+            .collect::<BTreeSet<_>>();
+        let capabilities = BTreeMap::from([
+            (flotilla_resources::AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(agent_adapters)),
+            (flotilla_resources::TERMINAL_POOLS_CAPABILITY.to_string(), serde_json::json!(terminal_pools)),
+        ]);
+        hosts
+            .update_status(
+                &host_name,
+                &host.metadata.resource_version,
+                &flotilla_resources::HostStatus::builder().capabilities(capabilities).heartbeat_at(Utc::now()).ready(true).build(),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let policy_name = format!("host-direct-{host_name}");
+        let policies = self.resource_backend.clone().using::<PlacementPolicy>(&namespace);
+        match policies.get(&policy_name).await {
+            Ok(_) => Ok(()),
+            Err(ResourceError::NotFound { .. }) => {
+                let pool = terminal_pools.into_iter().next().unwrap_or_else(|| "passthrough".to_string());
+                policies
+                    .create(
+                        &InputMeta::builder().name(policy_name).build(),
+                        &PlacementPolicySpec::builder()
+                            .pool(pool)
+                            .host_direct(HostDirectPlacementPolicySpec {
+                                host_ref: host_name,
+                                checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                            })
+                            .build(),
+                    )
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| error.to_string())
+            }
+            Err(error) => Err(error.to_string()),
+        }
+    }
+
+    pub async fn resolve_convoy_start_target_node(&self, intent: &flotilla_protocol::ConvoyStartIntent) -> Result<Option<NodeId>, String> {
+        let Some(policy_name) = intent.placement_policy.as_deref() else {
+            return Ok(None);
+        };
+        let namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
+        let policy = self
+            .resource_backend
+            .clone()
+            .using::<PlacementPolicy>(&namespace)
+            .get(policy_name)
+            .await
+            .map_err(|error| format!("placement policy {policy_name}: {error}"))?;
+        let host_ref = policy
+            .spec
+            .host_direct
+            .as_ref()
+            .map(|host_direct| host_direct.host_ref.as_str())
+            .ok_or_else(|| format!("placement policy {policy_name} is not a host-direct policy"))?;
+        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_ref) {
+            return Ok(None);
+        }
+        let environment_id = EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new(host_ref));
+        self.host_registry
+            .node_id_for_environment(&environment_id)
+            .await
+            .map(Some)
+            .ok_or_else(|| format!("placement policy {policy_name} targets unavailable host {host_ref}"))
+    }
+
+    /// Admit a convoy against this daemon's authoritative project resources,
+    /// then package immutable workflow and placement snapshots for the remote
+    /// execution host. This prevents a peer from re-resolving names against a
+    /// different daemon-local resource store.
+    pub async fn prepare_remote_convoy_start(
+        &self,
+        intent: &flotilla_protocol::ConvoyStartIntent,
+    ) -> Result<flotilla_protocol::PreparedConvoyStart, String> {
+        let namespace = self.provisioning_namespace().await;
+        let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
+        if requested_namespace != namespace {
+            return Err(format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"));
+        }
+        let mut admission = self.prepare_convoy_admission(&namespace, intent).await?;
+        let workflow_name = format!("{}-remote-workflow", admission.name);
+        admission.spec.workflow_ref.clone_from(&workflow_name);
+        let (placement_policy_name, placement_policy_spec) = match admission.placement_policy {
+            Some(spec) => {
+                let name = format!("{}-remote-placement", admission.name);
+                admission.spec.placement_policy = Some(name.clone());
+                (Some(name), Some(serde_json::to_value(spec).map_err(|error| error.to_string())?))
+            }
+            None => (None, None),
+        };
+        Ok(flotilla_protocol::PreparedConvoyStart::builder()
+            .namespace(namespace)
+            .name(admission.name)
+            .convoy_spec(serde_json::to_value(admission.spec).map_err(|error| error.to_string())?)
+            .workflow_name(workflow_name)
+            .workflow_spec(serde_json::to_value(admission.workflow).map_err(|error| error.to_string())?)
+            .maybe_placement_policy_name(placement_policy_name)
+            .maybe_placement_policy_spec(placement_policy_spec)
+            .auto_attach(intent.auto_attach)
+            .build())
     }
 
     pub async fn set_topology_routes(&self, routes: Vec<TopologyRoute>) {
@@ -2381,6 +2541,42 @@ async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, names
     }
 }
 
+async fn ensure_prepared_workflow_snapshot(
+    backend: &ResourceBackend,
+    namespace: &str,
+    name: &str,
+    spec: &WorkflowTemplateSpec,
+) -> Result<(), String> {
+    let templates = backend.clone().using::<WorkflowTemplate>(namespace);
+    match templates.get(name).await {
+        Ok(existing) if existing.spec == *spec => Ok(()),
+        Ok(_) => Err(format!("prepared workflow snapshot {name} already exists with different contents")),
+        Err(ResourceError::NotFound { .. }) => templates
+            .create(&InputMeta::builder().name(name.to_string()).build(), spec)
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+async fn ensure_prepared_placement_snapshot(
+    backend: &ResourceBackend,
+    namespace: &str,
+    name: &str,
+    spec: &PlacementPolicySpec,
+) -> Result<(), String> {
+    let policies = backend.clone().using::<PlacementPolicy>(namespace);
+    match policies.get(name).await {
+        Ok(existing) if existing.spec == *spec => Ok(()),
+        Ok(_) => Err(format!("prepared placement snapshot {name} already exists with different contents")),
+        Err(ResourceError::NotFound { .. }) => {
+            policies.create(&InputMeta::builder().name(name.to_string()).build(), spec).await.map(|_| ()).map_err(|error| error.to_string())
+        }
+        Err(error) => Err(error.to_string()),
+    }
+}
+
 fn validate_project_name(name: &str) -> Result<(), String> {
     let normalized = normalize_project_name(name)?;
     if normalized != name {
@@ -2500,6 +2696,9 @@ async fn validate_workflow_agent_adapters(
             let status = host
                 .status
                 .ok_or_else(|| format!("placement `{}` host `{}` has no observed status", placement.metadata.name, host_direct.host_ref))?;
+            if !status.ready {
+                return Err(format!("placement `{}` host `{}` is not ready", placement.metadata.name, host_direct.host_ref));
+            }
             let available_adapters = status.agent_adapters().map_err(|error| {
                 format!(
                     "placement `{}` host `{}` has invalid agent adapter capabilities: {error}",
@@ -2651,7 +2850,11 @@ impl InProcessDaemon {
         })
     }
 
-    async fn admit_convoy_start(&self, namespace: &str, intent: &flotilla_protocol::ConvoyStartIntent) -> Result<String, String> {
+    async fn prepare_convoy_admission(
+        &self,
+        namespace: &str,
+        intent: &flotilla_protocol::ConvoyStartIntent,
+    ) -> Result<ConvoyAdmission, String> {
         let project_ref = required_admission_value(&intent.project_ref, "project")?;
         let project = self
             .resource_backend
@@ -2721,7 +2924,7 @@ impl InProcessDaemon {
             Err(error) => return Err(error.to_string()),
         }
         let placement = self.resolve_and_validate_convoy_placement(namespace, &workflow.spec, intent.placement_policy.as_deref()).await?;
-        let placement_policy = placement.map(|placement| placement.metadata.name);
+        let placement_policy = placement.as_ref().map(|placement| placement.metadata.name.clone());
         let spec = ConvoySpec {
             workflow_ref,
             inputs: intent.inputs.iter().map(|(key, value)| (key.clone(), InputValue::String(value.clone()))).collect(),
@@ -2733,8 +2936,23 @@ impl InProcessDaemon {
             issue,
             instruction: intent.instruction.clone(),
         };
-        convoys.create(&InputMeta::builder().name(name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
-        Ok(name)
+        Ok(ConvoyAdmission::builder()
+            .name(name)
+            .spec(spec)
+            .workflow(workflow.spec)
+            .maybe_placement_policy(placement.map(|placement| placement.spec))
+            .build())
+    }
+
+    async fn admit_convoy_start(&self, namespace: &str, intent: &flotilla_protocol::ConvoyStartIntent) -> Result<String, String> {
+        let admission = self.prepare_convoy_admission(namespace, intent).await?;
+        self.resource_backend
+            .clone()
+            .using::<ResourceConvoy>(namespace)
+            .create(&InputMeta::builder().name(admission.name.clone()).build(), &admission.spec)
+            .await
+            .map_err(|error| error.to_string())?;
+        Ok(admission.name)
     }
 
     async fn resolve_and_validate_convoy_placement(
@@ -2801,6 +3019,74 @@ impl InProcessDaemon {
             Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
             Err(message) => flotilla_protocol::CommandValue::Error { message },
         }
+    }
+
+    async fn run_prepared_convoy_start(&self, start: flotilla_protocol::PreparedConvoyStart) -> flotilla_protocol::CommandValue {
+        match self.persist_prepared_convoy_start(&start).await {
+            Ok(()) if start.auto_attach => match self.wait_for_convoy_attach(&start.namespace, &start.name).await {
+                Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
+                    name: start.name,
+                    attach_command: Some(resolved.command),
+                    binding: resolved.binding,
+                },
+                Err(message) => flotilla_protocol::CommandValue::Error { message },
+            },
+            Ok(()) => flotilla_protocol::CommandValue::ConvoyStarted { name: start.name, attach_command: None, binding: None },
+            Err(message) => flotilla_protocol::CommandValue::Error { message },
+        }
+    }
+
+    async fn persist_prepared_convoy_start(&self, start: &flotilla_protocol::PreparedConvoyStart) -> Result<(), String> {
+        let namespace = self.provisioning_namespace().await;
+        if start.namespace != namespace {
+            return Err(format!("namespace `{}` is not served by this daemon (configured namespace: `{namespace}`)", start.namespace));
+        }
+        let convoy_spec: ConvoySpec =
+            serde_json::from_value(start.convoy_spec.clone()).map_err(|error| format!("invalid prepared convoy spec: {error}"))?;
+        let workflow_spec: WorkflowTemplateSpec =
+            serde_json::from_value(start.workflow_spec.clone()).map_err(|error| format!("invalid prepared workflow snapshot: {error}"))?;
+        if convoy_spec.workflow_ref != start.workflow_name {
+            return Err("prepared convoy workflow reference does not match its snapshot name".to_string());
+        }
+        let placement_spec = match (&start.placement_policy_name, &start.placement_policy_spec) {
+            (Some(name), Some(value)) => {
+                if convoy_spec.placement_policy.as_deref() != Some(name) {
+                    return Err("prepared convoy placement reference does not match its snapshot name".to_string());
+                }
+                let spec: PlacementPolicySpec =
+                    serde_json::from_value(value.clone()).map_err(|error| format!("invalid prepared placement snapshot: {error}"))?;
+                let local_host_id = self.local_host_id().ok_or_else(|| "local Host identity is unavailable".to_string())?;
+                let target_host = spec
+                    .host_direct
+                    .as_ref()
+                    .map(|host_direct| host_direct.host_ref.as_str())
+                    .ok_or_else(|| "prepared remote placement is not host-direct".to_string())?;
+                if target_host != local_host_id.as_str() {
+                    return Err(format!(
+                        "prepared remote placement targets host `{target_host}`, but this daemon serves `{local_host_id}`"
+                    ));
+                }
+                Some((name, spec))
+            }
+            (None, None) if convoy_spec.placement_policy.is_none() => None,
+            _ => return Err("prepared convoy placement snapshot is incomplete".to_string()),
+        };
+
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
+        match convoys.get(&start.name).await {
+            Ok(_) => return Err(format!("convoy {} already exists", start.name)),
+            Err(ResourceError::NotFound { .. }) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+        ensure_prepared_workflow_snapshot(&self.resource_backend, &namespace, &start.workflow_name, &workflow_spec).await?;
+        if let Some((name, spec)) = placement_spec {
+            ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, &spec).await?;
+        }
+        convoys
+            .create(&InputMeta::builder().name(start.name.clone()).build(), &convoy_spec)
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
     }
 
     async fn supervise_convoy_start(&self, task: ConvoyStartTask) {
@@ -4257,6 +4543,15 @@ impl InProcessDaemon {
         Ok(flotilla_protocol::arg::flatten(&args, 0))
     }
 
+    pub async fn route_remote_attach_binding(&self, binding: &AttachBinding) -> Result<String, String> {
+        let reference = binding
+            .session
+            .as_deref()
+            .or(binding.convoy.as_deref())
+            .ok_or_else(|| "remote attach binding has neither a session nor convoy reference".to_string())?;
+        self.recursive_attach_command_for_remote(&binding.host, reference, false).await
+    }
+
     async fn local_attach_command_for_session(
         &self,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
@@ -4333,14 +4628,24 @@ impl InProcessDaemon {
     }
 
     async fn refresh_local_host_summary(&self) -> HostSummary {
+        let mut providers = crate::host_summary::provider_statuses_from_registries(
+            self.repos.read().await.values().map(|state| state.preferred_root().model.registry.as_ref()),
+        );
+        for advertised in self.local_placement_provider_statuses.read().await.iter() {
+            if !providers
+                .iter()
+                .any(|provider| provider.category == advertised.category && provider.implementation == advertised.implementation)
+            {
+                providers.push(advertised.clone());
+            }
+        }
+        providers.sort_by(|left, right| (&left.category, &left.name).cmp(&(&right.category, &right.name)));
         let summary = crate::host_summary::build_local_host_summary(
             &self.node_id,
             &self.host_name,
             EnvironmentId::host(self.environment_manager.local_host_id().clone()),
             &self.environment_manager,
-            crate::host_summary::provider_statuses_from_registries(
-                self.repos.read().await.values().map(|state| state.preferred_root().model.registry.as_ref()),
-            ),
+            providers,
             &*self.discovery.env,
         )
         .await;
@@ -4581,6 +4886,25 @@ impl InProcessDaemon {
                 });
             } else {
                 self.pending_convoy_starts.lock().await.remove(&key);
+                self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error {
+                    message: "convoy start worker is unavailable".to_string(),
+                });
+            }
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ConvoyStartPrepared { start } = &command.action {
+            let empty_identity = self.start_context_free_command(id, command.description().to_string());
+            let start = start.as_ref().clone();
+            if let Some(daemon) = self.self_weak.upgrade() {
+                tokio::spawn(async move {
+                    let result = match AssertUnwindSafe(daemon.run_prepared_convoy_start(start)).catch_unwind().await {
+                        Ok(result) => result,
+                        Err(_) => flotilla_protocol::CommandValue::Error { message: "prepared convoy start worker panicked".to_string() },
+                    };
+                    daemon.finish_context_free_command(id, empty_identity, result);
+                });
+            } else {
                 self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error {
                     message: "convoy start worker is unavailable".to_string(),
                 });

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -77,6 +77,17 @@ fn convoy_branch_validation_rejects_refs_that_checkout_cannot_create() {
     validate_convoy_branch("fix/issue-732").expect("normal branch should be accepted");
 }
 
+#[test]
+fn prepared_snapshot_names_are_content_addressed_for_safe_convoy_name_reuse() {
+    let first =
+        prepared_snapshot_name("remote-work", "workflow", &serde_json::json!({ "vessels": ["implement"] })).expect("first snapshot name");
+    let second =
+        prepared_snapshot_name("remote-work", "workflow", &serde_json::json!({ "vessels": ["review"] })).expect("second snapshot name");
+
+    assert_ne!(first, second);
+    assert!(first.starts_with("remote-work-remote-workflow-"));
+}
+
 #[tokio::test]
 async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_required_adapter() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
@@ -161,6 +172,28 @@ async fn peer_summary_materializes_an_admissible_host_direct_placement_and_routi
         daemon.resolve_convoy_start_target_node(&intent).await.expect("placement should route"),
         Some(flotilla_protocol::NodeId::new("feta-node"))
     );
+
+    daemon
+        .publish_peer_summary(
+            HostSummary::builder()
+                .environment_id(EnvironmentId::host(HostId::new("feta-host")))
+                .host_name(HostName::new("feta"))
+                .node(flotilla_protocol::NodeInfo::new(flotilla_protocol::NodeId::new("feta-node"), "feta"))
+                .system(SystemInfo::default())
+                .providers(vec![
+                    HostProviderStatus::available(AGENT_ADAPTER_PROVIDER_CATEGORY, "codex"),
+                    HostProviderStatus::available(TERMINAL_POOL_PROVIDER_CATEGORY, "zellij"),
+                ])
+                .build(),
+        )
+        .await;
+    let refreshed = daemon
+        .resource_backend()
+        .using::<PlacementPolicy>("flotilla")
+        .get("host-direct-feta-host")
+        .await
+        .expect("peer placement policy should update");
+    assert_eq!(refreshed.spec.pool, "zellij");
 }
 
 #[test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -9,9 +9,10 @@ use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
     result_set::{ConvoyPhase as WireConvoyPhase, ConvoyRow, IndependentRow, QueryId, ResultSet, Rows, SessionPhase},
     test_support::TestIssue,
-    AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent,
-    EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostSummary, ImageId, QueryCursor, QueryScope, RepoSelector, ResourceRef,
-    ResultSetCondition, SystemInfo, ToolInventory, TopologyRoute,
+    AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent,
+    CrewCommandContext, DaemonEvent, EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostProviderStatus, HostSummary, ImageId,
+    QueryCursor, QueryScope, RepoSelector, ResourceRef, ResultSetCondition, SystemInfo, ToolInventory, TopologyRoute,
+    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
@@ -113,6 +114,53 @@ async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_requ
         .expect_err("host without codex must be rejected");
 
     assert_eq!(error, "workflow requires agent adapter `codex`, which is not available in placement `host-direct-test` (host `host-test`)");
+}
+
+#[tokio::test]
+async fn peer_summary_materializes_an_admissible_host_direct_placement_and_routing_target() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"kiwi-host\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::new("kiwi")).await;
+    daemon
+        .publish_peer_summary(
+            HostSummary::builder()
+                .environment_id(EnvironmentId::host(HostId::new("feta-host")))
+                .host_name(HostName::new("feta"))
+                .node(flotilla_protocol::NodeInfo::new(flotilla_protocol::NodeId::new("feta-node"), "feta"))
+                .system(SystemInfo::default())
+                .providers(vec![
+                    HostProviderStatus::available(AGENT_ADAPTER_PROVIDER_CATEGORY, "codex"),
+                    HostProviderStatus::available(TERMINAL_POOL_PROVIDER_CATEGORY, "cleat"),
+                ])
+                .build(),
+        )
+        .await;
+
+    let backend = daemon.resource_backend();
+    let host = backend.clone().using::<ResourceHost>("flotilla").get("feta-host").await.expect("peer host should be materialized");
+    assert_eq!(host.status.expect("peer host status").agent_adapters().expect("valid adapters"), BTreeSet::from(["codex".to_string()]));
+    let policy = backend
+        .using::<PlacementPolicy>("flotilla")
+        .get("host-direct-feta-host")
+        .await
+        .expect("peer placement policy should be materialized");
+    assert_eq!(policy.spec.pool, "cleat");
+    assert_eq!(policy.spec.host_direct.as_ref().expect("host-direct policy").host_ref, "feta-host");
+    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
+    workflow.vessels[0].stance = Stance::Trusted;
+    validate_workflow_agent_adapters(&daemon.resource_backend(), "flotilla", &workflow, Some(&policy))
+        .await
+        .expect("peer host capabilities should admit the workflow");
+
+    let intent =
+        ConvoyStartIntent::builder().project_ref("flotilla".to_string()).placement_policy("host-direct-feta-host".to_string()).build();
+    assert_eq!(
+        daemon.resolve_convoy_start_target_node(&intent).await.expect("placement should route"),
+        Some(flotilla_protocol::NodeId::new("feta-node"))
+    );
 }
 
 #[test]
@@ -957,6 +1005,51 @@ async fn fleet_list_reports_store_backed_local_sessions_with_authority() {
     let snapshot = daemon.fleet_replica_snapshot_internal().await.expect("fleet replica snapshot should succeed");
     assert_eq!(snapshot.host, daemon.host_name);
     assert_eq!(snapshot.rows, response.rows);
+}
+
+#[tokio::test]
+async fn fleet_list_shows_simultaneous_convoys_on_kiwi_feta_and_udder() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"kiwi-host\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", None), ("udder", "udder.local", None)]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-kiwi-work-implement-coder",
+        "kiwi-session",
+        "kiwi-work",
+        "implement",
+        "coder",
+    )
+    .await;
+    for (host, convoy) in [("feta", "feta-work"), ("udder", "udder-work")] {
+        daemon.fleet_replica_cache.write().await.insert(HostName::new(host), FleetReplicaCacheEntry {
+            rows: vec![FleetListRow::builder()
+                .convoy(convoy.to_string())
+                .vessel("implement".to_string())
+                .crew("implement/coder".to_string())
+                .crew_state("running".to_string())
+                .host(HostName::new(host))
+                .namespace("flotilla")
+                .staleness(FleetStaleness::Local)
+                .build()],
+            result_sets: vec![],
+            last_sync: Some(Utc::now()),
+            generation: Some(format!("{host}-generation")),
+            last_error: None,
+        });
+    }
+
+    let rows = daemon.fleet_list_internal().await.expect("fleet list should succeed").rows;
+    let placements = rows.into_iter().map(|row| (row.convoy, row.host)).collect::<BTreeMap<_, _>>();
+    assert_eq!(placements.get("kiwi-work"), Some(&daemon.host_name));
+    assert_eq!(placements.get("feta-work"), Some(&HostName::new("feta")));
+    assert_eq!(placements.get("udder-work"), Some(&HostName::new("udder")));
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -194,6 +194,18 @@ async fn peer_summary_materializes_an_admissible_host_direct_placement_and_routi
         .await
         .expect("peer placement policy should update");
     assert_eq!(refreshed.spec.pool, "zellij");
+
+    daemon
+        .resource_backend()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &InputMeta::builder().name("local-pool".to_string()).build(),
+            &PlacementPolicySpec::builder().pool("local".to_string()).build(),
+        )
+        .await
+        .expect("local placement policy create");
+    let local_intent = ConvoyStartIntent::builder().project_ref("flotilla".to_string()).placement_policy("local-pool".to_string()).build();
+    assert_eq!(daemon.resolve_convoy_start_target_node(&local_intent).await.expect("non-host-direct placement should remain local"), None);
 }
 
 #[test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -96,6 +96,7 @@ impl DaemonRuntime {
 
         let local_registry = probe_local_provider_registry(&daemon, &config).await?;
         let profile = build_local_profile(&daemon, &local_registry)?;
+        daemon.set_local_placement_capabilities(&profile.available_agent_adapters, &profile.available_pools).await;
         register_startup_resources(&daemon, &options.namespace, &profile).await?;
         apply_host_heartbeat(&daemon, &options.namespace, &profile).await?;
         if let Err(error) = daemon.reconcile_adopted_checkouts(&options.namespace).await {

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -24,7 +24,7 @@ use tracing::info;
 
 use crate::peer::{PeerManager, PeerSender};
 
-#[derive(Debug)]
+#[derive(Debug, bon::Builder)]
 pub(super) struct PendingRemoteCommand {
     pub(super) command_id: u64,
     pub(super) target_node_id: NodeId,
@@ -126,26 +126,42 @@ impl RemoteCommandRouter {
         }
     }
 
-    pub(super) async fn dispatch_execute(&self, command: Command) -> Result<u64, String> {
+    pub(super) async fn dispatch_execute(&self, mut command: Command) -> Result<u64, String> {
+        if matches!(command.action, CommandAction::ConvoyStartPrepared { .. }) {
+            return Err("prepared convoy starts are reserved for authenticated peer forwarding".to_string());
+        }
+        if let CommandAction::ConvoyStart { intent } = &command.action {
+            let placement_target = self.daemon.resolve_convoy_start_target_node(intent).await?;
+            let intended_target = placement_target.as_ref().unwrap_or_else(|| self.daemon.node_id());
+            if command.node_id.as_ref().is_some_and(|target| target != intended_target) {
+                return Err("convoy command target does not match its host-direct placement policy".to_string());
+            }
+            if intended_target != self.daemon.node_id() {
+                command.node_id = Some(intended_target.clone());
+                let prepared = self.daemon.prepare_remote_convoy_start(intent).await?;
+                command.action = CommandAction::ConvoyStartPrepared { start: Box::new(prepared) };
+            }
+        }
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
         let local = self.daemon.node_id();
         let desc = command.description();
         info!(%target_node_id, %local, %desc, "dispatch_execute");
         if target_node_id != *self.daemon.node_id() {
-            if command.action.is_query() {
+            if command.action.is_query() || matches!(command.action, CommandAction::ConvoyStartPrepared { .. }) {
                 let request_id = {
                     let mut pm = self.peer_manager.lock().await;
                     pm.next_request_id()
                 };
                 let command_id = self.next_remote_command_id.fetch_add(1, Ordering::Relaxed);
-                self.pending_remote_commands.lock().await.insert(request_id, PendingRemoteCommand {
-                    command_id,
-                    target_node_id: target_node_id.clone(),
-                    repo_identity: extract_command_repo_identity(&command),
-                    repo: None,
-                    finished_via_event: false,
-                    query_completion: None,
-                });
+                self.pending_remote_commands.lock().await.insert(
+                    request_id,
+                    PendingRemoteCommand::builder()
+                        .command_id(command_id)
+                        .target_node_id(target_node_id.clone())
+                        .maybe_repo_identity(extract_command_repo_identity(&command))
+                        .finished_via_event(false)
+                        .build(),
+                );
 
                 let routed = RoutedPeerMessage::CommandRequest {
                     request_id,
@@ -194,14 +210,16 @@ impl RemoteCommandRouter {
 
         let (tx, rx) = oneshot::channel();
 
-        self.pending_remote_commands.lock().await.insert(request_id, PendingRemoteCommand {
-            command_id,
-            target_node_id: target_node_id.clone(),
-            repo_identity: extract_command_repo_identity(&command),
-            repo: None,
-            finished_via_event: false,
-            query_completion: Some(tx),
-        });
+        self.pending_remote_commands.lock().await.insert(
+            request_id,
+            PendingRemoteCommand::builder()
+                .command_id(command_id)
+                .target_node_id(target_node_id.clone())
+                .maybe_repo_identity(extract_command_repo_identity(&command))
+                .finished_via_event(false)
+                .query_completion(tx)
+                .build(),
+        );
 
         let routed = RoutedPeerMessage::CommandRequest {
             request_id,
@@ -328,6 +346,12 @@ impl RemoteCommandRouter {
     }
 
     pub(super) async fn emit_remote_command_event(&self, request_id: u64, responder_node_id: NodeId, event: CommandPeerEvent) {
+        let event = match event {
+            CommandPeerEvent::Finished { repo_identity, repo, result } => {
+                CommandPeerEvent::Finished { repo_identity, repo, result: self.route_remote_result(result).await }
+            }
+            event => event,
+        };
         let mut pending = self.pending_remote_commands.lock().await;
         let Some(entry) = pending.get_mut(&request_id) else {
             return;
@@ -375,6 +399,7 @@ impl RemoteCommandRouter {
     }
 
     pub(super) async fn complete_remote_command(&self, request_id: u64, responder_node_id: NodeId, result: CommandValue) {
+        let result = self.route_remote_result(result).await;
         let mut pending = self.pending_remote_commands.lock().await;
         let Some(entry) = pending.remove(&request_id) else {
             return;
@@ -407,6 +432,22 @@ impl RemoteCommandRouter {
             repo: entry.repo,
             result,
         });
+    }
+
+    async fn route_remote_result(&self, result: CommandValue) -> CommandValue {
+        let CommandValue::ConvoyStarted { name, attach_command, binding } = result else {
+            return result;
+        };
+        let Some(binding) = binding else {
+            return CommandValue::ConvoyStarted { name, attach_command, binding: None };
+        };
+        if attach_command.is_none() || binding.host == *self.daemon.host_name() {
+            return CommandValue::ConvoyStarted { name, attach_command, binding: Some(binding) };
+        }
+        match self.daemon.route_remote_attach_binding(&binding).await {
+            Ok(command) => CommandValue::ConvoyStarted { name, attach_command: Some(command), binding: Some(binding) },
+            Err(message) => CommandValue::Error { message: format!("convoy {name} started, but remote attach routing failed: {message}") },
+        }
     }
 
     pub(super) async fn complete_remote_cancel(&self, cancel_id: u64, error: Option<String>) {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -746,7 +746,7 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
     remote_command_router.dispatch_execute(command.clone()).await.expect("remote convoy start should dispatch");
 
     assert_eq!(pending_remote_commands.lock().await.len(), 1);
-    let routed = {
+    let (routed, workflow_snapshot_name, placement_snapshot_name) = {
         let sent = sent.lock().expect("lock sent messages");
         let [PeerWireMessage::Routed(RoutedPeerMessage::CommandRequest { target_node_id, command: routed, .. })] = sent.as_slice() else {
             panic!("expected one routed command request");
@@ -756,11 +756,12 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
         let CommandAction::ConvoyStartPrepared { start } = &routed.action else {
             panic!("remote launch must carry an admitted convoy snapshot");
         };
-        assert_eq!(start.workflow_name, "remote-work-remote-workflow");
-        assert_eq!(start.placement_policy_name.as_deref(), Some("remote-work-remote-placement"));
+        assert!(start.workflow_name.starts_with("remote-work-remote-workflow-"));
+        let placement_snapshot_name = start.placement_policy_name.clone().expect("prepared placement snapshot name");
+        assert!(placement_snapshot_name.starts_with("remote-work-remote-placement-"));
         let mut delivered = routed.as_ref().clone();
         delivered.node_id = None;
-        delivered
+        (delivered, start.workflow_name.clone(), placement_snapshot_name)
     };
 
     assert_eq!(
@@ -774,18 +775,18 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
     assert_eq!(remote_result, CommandValue::ConvoyStarted { name: "remote-work".to_string(), attach_command: None, binding: None });
     let remote_backend = remote_daemon.resource_backend();
     let convoy = remote_backend.clone().using::<Convoy>("flotilla").get("remote-work").await.expect("remote daemon should persist convoy");
-    assert_eq!(convoy.spec.workflow_ref, "remote-work-remote-workflow");
-    assert_eq!(convoy.spec.placement_policy.as_deref(), Some("remote-work-remote-placement"));
+    assert_eq!(convoy.spec.workflow_ref, workflow_snapshot_name);
+    assert_eq!(convoy.spec.placement_policy.as_deref(), Some(placement_snapshot_name.as_str()));
     let remote_workflow = remote_backend
         .clone()
         .using::<WorkflowTemplate>("flotilla")
-        .get("remote-work-remote-workflow")
+        .get(&workflow_snapshot_name)
         .await
         .expect("remote daemon should persist workflow snapshot");
     assert_eq!(remote_workflow.spec.vessels[0].stance, Stance::Trusted);
     let remote_policy = remote_backend
         .using::<PlacementPolicy>("flotilla")
-        .get("remote-work-remote-placement")
+        .get(&placement_snapshot_name)
         .await
         .expect("remote daemon should persist placement snapshot");
     assert_eq!(remote_policy.spec.host_direct.expect("host-direct snapshot").host_ref, remote_host_id);

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -21,15 +21,17 @@ use flotilla_core::{
 use flotilla_protocol::{
     qualified_path::QualifiedPath,
     result_set::{QueryChanges, QueryId, ResultDelta},
-    AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachableId, Checkout, CheckoutTarget, Command, CommandAction,
-    CommandPeerEvent, CommandValue, ConfigLabel, DaemonEvent, EnvironmentId, HostName, HostPath, HostSummary, Message, NodeId, NodeInfo,
-    PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage, PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity,
-    RepoSelector, Request, Response, ResponseResult, RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus,
-    StreamKey, VectorClock, PROTOCOL_VERSION,
+    AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachBinding, AttachableId, Checkout, CheckoutTarget, Command,
+    CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, DaemonEvent, EnvironmentId, HostName, HostPath,
+    HostProviderStatus, HostSummary, Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage,
+    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, Response, ResponseResult, RoutedPeerMessage,
+    StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY, PROTOCOL_VERSION,
+    TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, ResourceBackend, ResourceError,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectSpec, ResourceBackend, ResourceError, Stance,
+    WorkflowTemplate,
 };
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
@@ -667,6 +669,183 @@ async fn dispatch_execute_remote_query_routes_through_peer_manager() {
         }
         other => panic!("expected routed command request, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command() {
+    let (_tmp, daemon) = empty_daemon().await;
+    let (_remote_tmp, remote_daemon) = empty_daemon_named("feta").await;
+    let remote_host_id = remote_daemon.local_host_id().expect("remote host identity").to_string();
+    let remote_policy_name = format!("host-direct-{remote_host_id}");
+    daemon
+        .publish_peer_summary(
+            HostSummary::builder()
+                .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new(&remote_host_id)))
+                .host_name(HostName::new("feta"))
+                .node(node_info("feta"))
+                .system(flotilla_protocol::SystemInfo::default())
+                .providers(vec![
+                    HostProviderStatus::available(AGENT_ADAPTER_PROVIDER_CATEGORY, "codex"),
+                    HostProviderStatus::available(TERMINAL_POOL_PROVIDER_CATEGORY, "cleat"),
+                ])
+                .build(),
+        )
+        .await;
+    let backend = daemon.resource_backend();
+    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
+    workflow.vessels[0].stance = Stance::Trusted;
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("remote-workflow".to_string()).build(), &workflow)
+        .await
+        .expect("create workflow");
+    backend
+        .using::<Project>("flotilla")
+        .create(
+            &InputMeta::builder().name("flotilla".to_string()).build(),
+            &ProjectSpec::builder().display_name("Flotilla".to_string()).default_workflow_ref("remote-workflow".to_string()).build(),
+        )
+        .await
+        .expect("create project");
+    let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
+    let pending_remote_commands = Arc::new(Mutex::new(HashMap::new()));
+    let forwarded_commands = Arc::new(Mutex::new(HashMap::new()));
+    let pending_remote_cancels = Arc::new(Mutex::new(HashMap::new()));
+    let next_remote_command_id = Arc::new(AtomicU64::new(1 << 62));
+    let sent = Arc::new(StdMutex::new(Vec::new()));
+    peer_manager.lock().await.register_sender(NodeId::new("feta"), Arc::new(MockPeerSender { sent: Arc::clone(&sent) }));
+    let remote_command_router = make_remote_command_router(
+        &daemon,
+        &peer_manager,
+        &pending_remote_commands,
+        &forwarded_commands,
+        &pending_remote_cancels,
+        &next_remote_command_id,
+    );
+    let command = Command::builder()
+        .action(CommandAction::ConvoyStart {
+            intent: Box::new(
+                ConvoyStartIntent::builder()
+                    .project_ref("flotilla".to_string())
+                    .name("remote-work".to_string())
+                    .branch("feat/remote-work".to_string())
+                    .placement_policy(remote_policy_name)
+                    .build(),
+            ),
+        })
+        .build();
+
+    let mut mismatched = command.clone();
+    mismatched.node_id = Some(daemon.node_id().clone());
+    assert_eq!(
+        remote_command_router.dispatch_execute(mismatched).await.expect_err("explicit local target must not override remote placement"),
+        "convoy command target does not match its host-direct placement policy"
+    );
+
+    remote_command_router.dispatch_execute(command.clone()).await.expect("remote convoy start should dispatch");
+
+    assert_eq!(pending_remote_commands.lock().await.len(), 1);
+    let routed = {
+        let sent = sent.lock().expect("lock sent messages");
+        let [PeerWireMessage::Routed(RoutedPeerMessage::CommandRequest { target_node_id, command: routed, .. })] = sent.as_slice() else {
+            panic!("expected one routed command request");
+        };
+        assert_eq!(*target_node_id, node("feta"));
+        assert_eq!(routed.node_id.as_ref(), Some(&node("feta")));
+        let CommandAction::ConvoyStartPrepared { start } = &routed.action else {
+            panic!("remote launch must carry an admitted convoy snapshot");
+        };
+        assert_eq!(start.workflow_name, "remote-work-remote-workflow");
+        assert_eq!(start.placement_policy_name.as_deref(), Some("remote-work-remote-placement"));
+        let mut delivered = routed.as_ref().clone();
+        delivered.node_id = None;
+        delivered
+    };
+
+    assert_eq!(
+        remote_command_router.dispatch_execute(routed.clone()).await.expect_err("client-submitted prepared start must be rejected"),
+        "prepared convoy starts are reserved for authenticated peer forwarding"
+    );
+
+    let mut remote_events = remote_daemon.subscribe();
+    let remote_command_id = remote_daemon.execute(routed).await.expect("prepared command should be accepted by remote daemon");
+    let remote_result = wait_for_command_result(&mut remote_events, remote_command_id, StdDuration::from_secs(5)).await;
+    assert_eq!(remote_result, CommandValue::ConvoyStarted { name: "remote-work".to_string(), attach_command: None, binding: None });
+    let remote_backend = remote_daemon.resource_backend();
+    let convoy = remote_backend.clone().using::<Convoy>("flotilla").get("remote-work").await.expect("remote daemon should persist convoy");
+    assert_eq!(convoy.spec.workflow_ref, "remote-work-remote-workflow");
+    assert_eq!(convoy.spec.placement_policy.as_deref(), Some("remote-work-remote-placement"));
+    let remote_workflow = remote_backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .get("remote-work-remote-workflow")
+        .await
+        .expect("remote daemon should persist workflow snapshot");
+    assert_eq!(remote_workflow.spec.vessels[0].stance, Stance::Trusted);
+    let remote_policy = remote_backend
+        .using::<PlacementPolicy>("flotilla")
+        .get("remote-work-remote-placement")
+        .await
+        .expect("remote daemon should persist placement snapshot");
+    assert_eq!(remote_policy.spec.host_direct.expect("host-direct snapshot").host_ref, remote_host_id);
+}
+
+#[tokio::test]
+async fn remote_convoy_started_event_routes_auto_attach_back_through_the_target_host() {
+    let (tmp, daemon) = empty_daemon().await;
+    std::fs::write(
+        tmp.path().join("config/hosts.toml"),
+        r#"[hosts.feta]
+hostname = "feta.example"
+expected_host_name = "feta"
+daemon_socket = "/run/user/1000/flotilla.sock"
+"#,
+    )
+    .expect("write peer config");
+    let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
+    let pending_remote_commands = Arc::new(Mutex::new(HashMap::from([(
+        7,
+        PendingRemoteCommand::builder().command_id(42).target_node_id(node("feta")).finished_via_event(false).build(),
+    )])));
+    let router = make_remote_command_router(
+        &daemon,
+        &peer_manager,
+        &pending_remote_commands,
+        &Arc::new(Mutex::new(HashMap::new())),
+        &Arc::new(Mutex::new(HashMap::new())),
+        &Arc::new(AtomicU64::new(1 << 62)),
+    );
+    let mut events = daemon.subscribe();
+
+    router
+        .emit_remote_command_event(7, node("feta"), CommandPeerEvent::Finished {
+            repo_identity: RepoIdentity { authority: String::new(), path: String::new() },
+            repo: None,
+            result: CommandValue::ConvoyStarted {
+                name: "remote-work".to_string(),
+                attach_command: Some("cleat attach remote-session".to_string()),
+                binding: Some(
+                    AttachBinding::builder()
+                        .host(HostName::new("feta"))
+                        .namespace("flotilla".to_string())
+                        .session("remote-session".to_string())
+                        .build(),
+                ),
+            },
+        })
+        .await;
+
+    let result = match events.recv().await.expect("command event") {
+        DaemonEvent::CommandFinished { command_id: 42, result, .. } => result,
+        event => panic!("expected command finished, got {event:?}"),
+    };
+    let CommandValue::ConvoyStarted { attach_command: Some(command), .. } = result else {
+        panic!("expected routed convoy attach result, got {result:?}");
+    };
+    assert!(command.contains("feta.example"), "attach should route through configured peer: {command}");
+    assert!(command.contains("remote-session"), "attach should preserve the remote session reference: {command}");
+    assert!(!command.starts_with("cleat attach"), "origin must not execute the remote host's local attach command");
 }
 
 #[tokio::test]
@@ -1326,14 +1505,10 @@ async fn dispatch_request_cancel_remote_routes_cancel_and_waits_for_reply() {
     let sent = Arc::new(StdMutex::new(Vec::new()));
     peer_manager.lock().await.register_sender(NodeId::new("feta"), Arc::new(MockPeerSender { sent: Arc::clone(&sent) }));
 
-    pending_remote_commands.lock().await.insert(91, PendingRemoteCommand {
-        command_id: 1u64 << 62,
-        target_node_id: NodeId::new("feta"),
-        repo_identity: None,
-        repo: None,
-        finished_via_event: false,
-        query_completion: None,
-    });
+    pending_remote_commands.lock().await.insert(
+        91,
+        PendingRemoteCommand::builder().command_id(1u64 << 62).target_node_id(NodeId::new("feta")).finished_via_event(false).build(),
+    );
 
     let daemon_for_task = Arc::clone(&daemon);
     let peer_manager_for_task = Arc::clone(&peer_manager);

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -74,7 +74,7 @@ pub struct PreparedWorkspace {
 }
 
 /// Routed command envelope shared by all frontends.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct Command {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_id: Option<crate::NodeId>,
@@ -121,6 +121,28 @@ pub struct ConvoyStartIntent {
     pub instruction: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placement_policy: Option<String>,
+    #[builder(default)]
+    #[serde(default)]
+    pub auto_attach: bool,
+}
+
+/// A convoy launch admitted by the presentation host and ready to be
+/// persisted by the selected execution host.
+///
+/// Resource specs remain opaque at the protocol boundary so the protocol
+/// crate does not depend on the resource model. The execution host validates
+/// and deserializes each snapshot before storing it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct PreparedConvoyStart {
+    pub namespace: String,
+    pub name: String,
+    pub convoy_spec: serde_json::Value,
+    pub workflow_name: String,
+    pub workflow_spec: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_policy_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_policy_spec: Option<serde_json::Value>,
     #[builder(default)]
     #[serde(default)]
     pub auto_attach: bool,
@@ -239,6 +261,11 @@ pub enum CommandAction {
     },
     ConvoyStart {
         intent: Box<ConvoyStartIntent>,
+    },
+    /// Internal peer command carrying the exact resource snapshots admitted
+    /// by the presentation host.
+    ConvoyStartPrepared {
+        start: Box<PreparedConvoyStart>,
     },
     WorkflowTemplateApply {
         name: String,
@@ -362,6 +389,7 @@ impl Command {
             CommandAction::CrewFail { .. } => "Failing crew work...",
             CommandAction::ConvoyCreate { .. } => "Creating convoy...",
             CommandAction::ConvoyStart { .. } => "Starting convoy...",
+            CommandAction::ConvoyStartPrepared { .. } => "Starting convoy...",
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
             CommandAction::ProjectAdd { .. } => "Adding project...",
             CommandAction::ProjectApply { .. } => "Applying project...",

--- a/crates/flotilla-protocol/src/host_summary.rs
+++ b/crates/flotilla-protocol/src/host_summary.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Serialize};
 use crate::qualified_path::HostId;
 use crate::{EnvironmentId, EnvironmentInfo, HostName, NodeId};
 
+pub const AGENT_ADAPTER_PROVIDER_CATEGORY: &str = "agent_adapter";
+pub const TERMINAL_POOL_PROVIDER_CATEGORY: &str = "terminal_pool";
+
 /// Mesh identity plus the human-readable label that should be shown in the UI.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeInfo {
@@ -19,17 +22,20 @@ impl NodeInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct HostSummary {
     pub environment_id: EnvironmentId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host_name: Option<HostName>,
     pub node: NodeInfo,
     pub system: SystemInfo,
+    #[builder(default)]
     #[serde(default)]
     pub inventory: ToolInventory,
+    #[builder(default)]
     #[serde(default)]
     pub providers: Vec<HostProviderStatus>,
+    #[builder(default)]
     #[serde(default)]
     pub environments: Vec<EnvironmentInfo>,
 }
@@ -80,7 +86,7 @@ pub struct DiscoveryFact {
     pub detail: Vec<(String, String)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct HostProviderStatus {
     pub category: String,
     /// Display name for the provider (e.g. "Docker").
@@ -89,6 +95,13 @@ pub struct HostProviderStatus {
     #[serde(default)]
     pub implementation: String,
     pub healthy: bool,
+}
+
+impl HostProviderStatus {
+    pub fn available(category: impl Into<String>, implementation: impl Into<String>) -> Self {
+        let implementation = implementation.into();
+        Self::builder().category(category.into()).name(implementation.clone()).implementation(implementation).healthy(true).build()
+    }
 }
 
 /// Full snapshot of one node's state — system info, inventory, provider health.

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -30,6 +30,7 @@ pub use environment::{EnvironmentId, EnvironmentInfo, EnvironmentKind, Environme
 pub use host::{HostName, HostPath, RepoIdentity};
 pub use host_summary::{
     DiscoveryFact, HostEnvironment, HostProviderStatus, HostSnapshot, HostSummary, NodeInfo, SystemInfo, ToolInventory,
+    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 pub use lifecycle::LifecycleAuthority;
 pub use path_context::{DaemonHostPath, ExecutionEnvironmentPath};
@@ -86,7 +87,7 @@ pub(crate) mod test_helpers {
 
 pub use commands::{
     AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyStartIntent,
-    IssueSelector, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand, StepStatus,
+    IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -8,6 +8,7 @@ use crate::{resource::define_resource, retention::ResourceStoreDiagnostics, stat
 define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch);
 
 pub const AGENT_ADAPTERS_CAPABILITY: &str = "agent_adapters";
+pub const TERMINAL_POOLS_CAPABILITY: &str = "terminal_pools";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostSpec {}

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -39,7 +39,7 @@ pub use environment::{
     EnvironmentStatusPatch, HostDirectEnvironmentSpec,
 };
 pub use error::ResourceError;
-pub use host::{Host, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY};
+pub use host::{Host, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY, TERMINAL_POOLS_CAPABILITY};
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use labels::{


### PR DESCRIPTION
## Summary

- advertise each peer's agent adapters and terminal pools as host capabilities
- materialize ready peer `Host` resources and host-direct placement policies
- admit remote convoy starts on the presentation host, then forward immutable workflow, placement, and convoy snapshots to the selected execution host
- route remote auto-attach results back through the selected host and preserve host attribution in fleet views
- reject placement/target mismatches and prevent clients from bypassing admission with prepared peer commands

## Why

Convoy placement previously assumed that the daemon receiving the user command also owned the checkout and terminal session. A host-direct policy targeting a connected peer therefore could not safely launch there, and remote attach commands were not usable from the presentation host.

This change makes peer capability discovery feed placement admission and gives remote convoy launch an explicit, validated peer boundary without depending on identically named resources in two daemon-local stores.

## Validation

- `cargo +nightly-2026-03-12 fmt --all -- --check`
- focused core tests for peer admission/routing and simultaneous kiwi/feta/udder fleet attribution
- focused daemon tests for remote snapshot persistence and routed auto-attach
- `cargo test -p flotilla-protocol --locked`
- workspace clippy passed before the final review fixes; GitHub CI will run the complete repository gates

Closes #812
