### PR TITLE
fix: harden convoy lifecycle edge cases

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use flotilla_resources::{
     controller::{ReconcileOutcome, Reconciler},
-    Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatusPatch, Clone, ClonePhase, ResourceBackend, ResourceError, ResourceObject,
-    TypedResolver,
+    Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatusPatch, Clone, ClonePhase, ResourceBackend,
+    ResourceError, ResourceObject, TypedResolver,
 };
 use tracing::warn;
 
@@ -27,6 +27,12 @@ pub enum CheckoutRemovalOutcome {
     PreservedBranch { branch: String, reason: BranchPreservationReason },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedCheckout {
+    pub commit: Option<String>,
+    pub branch_provenance: CheckoutBranchProvenance,
+}
+
 #[async_trait]
 pub trait CheckoutRuntime: Send + Sync {
     async fn create_worktree(
@@ -35,14 +41,14 @@ pub trait CheckoutRuntime: Send + Sync {
         branch: &str,
         base_ref: Option<&str>,
         target_path: &str,
-    ) -> Result<Option<String>, String>;
+    ) -> Result<PreparedCheckout, String>;
     async fn create_fresh_clone(
         &self,
         repo_url: &str,
         branch: &str,
         base_ref: Option<&str>,
         target_path: &str,
-    ) -> Result<Option<String>, String>;
+    ) -> Result<PreparedCheckout, String>;
     async fn remove_checkout(&self, removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String>;
 }
 
@@ -59,7 +65,7 @@ impl<R> CheckoutReconciler<R> {
 
 pub enum CheckoutDeps {
     None,
-    Ready { commit: Option<String> },
+    Ready { prepared: PreparedCheckout },
     Waiting,
     Failed(String),
 }
@@ -90,13 +96,13 @@ where
                     return Ok(CheckoutDeps::Failed("worktree clone env_ref mismatch".to_string()));
                 }
                 Ok(match self.runtime.create_worktree(&clone.spec.path, &spec.r#ref, spec.base_ref.as_deref(), &spec.target_path).await {
-                    Ok(commit) => CheckoutDeps::Ready { commit },
+                    Ok(prepared) => CheckoutDeps::Ready { prepared },
                     Err(err) => CheckoutDeps::Failed(err),
                 })
             }
             CheckoutSpec::FreshClone(spec) => {
                 Ok(match self.runtime.create_fresh_clone(&spec.url, &spec.r#ref, spec.base_ref.as_deref(), &spec.target_path).await {
-                    Ok(commit) => CheckoutDeps::Ready { commit },
+                    Ok(prepared) => CheckoutDeps::Ready { prepared },
                     Err(err) => CheckoutDeps::Failed(err),
                 })
             }
@@ -114,9 +120,11 @@ where
     ) -> ReconcileOutcome<Self::Resource> {
         let patch = if obj.status.as_ref().map(|status| status.phase).unwrap_or(CheckoutPhase::Pending) == CheckoutPhase::Pending {
             match deps {
-                CheckoutDeps::Ready { commit } => {
-                    obj.spec.target_path().map(|path| CheckoutStatusPatch::MarkReady { path: path.to_string(), commit: commit.clone() })
-                }
+                CheckoutDeps::Ready { prepared } => obj.spec.target_path().map(|path| CheckoutStatusPatch::MarkReady {
+                    path: path.to_string(),
+                    commit: prepared.commit.clone(),
+                    branch_provenance: prepared.branch_provenance,
+                }),
                 CheckoutDeps::Failed(message) => Some(CheckoutStatusPatch::MarkFailed { message: message.clone() }),
                 CheckoutDeps::Waiting | CheckoutDeps::None => None,
             }

--- a/crates/flotilla-controllers/src/reconcilers/mod.rs
+++ b/crates/flotilla-controllers/src/reconcilers/mod.rs
@@ -6,7 +6,9 @@ pub mod repository;
 pub mod terminal_session;
 pub mod vessel;
 
-pub use checkout::{BranchPreservationReason, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime};
+pub use checkout::{
+    BranchPreservationReason, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout,
+};
 pub use clone::{CloneReconciler, CloneRuntime};
 pub use environment::{DockerEnvironmentRuntime, EnvironmentReconciler};
 pub use presentation::{

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use common::{create_ready_clone, meta};
-use flotilla_controllers::reconcilers::{CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime};
+use flotilla_controllers::reconcilers::{CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout};
 use flotilla_resources::{
-    controller::Reconciler, repo_key, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, RepositoryKey,
-    ResourceBackend,
+    controller::Reconciler, repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus,
+    CheckoutWorktreeSpec, RepositoryKey, ResourceBackend,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -29,7 +29,7 @@ impl CheckoutRuntime for RecordingCheckoutRuntime {
         _branch: &str,
         _base_ref: Option<&str>,
         _target_path: &str,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<PreparedCheckout, String> {
         Err("creation is outside this test's scope".to_string())
     }
 
@@ -39,7 +39,7 @@ impl CheckoutRuntime for RecordingCheckoutRuntime {
         _branch: &str,
         _base_ref: Option<&str>,
         _target_path: &str,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<PreparedCheckout, String> {
         Err("creation is outside this test's scope".to_string())
     }
 
@@ -73,6 +73,7 @@ async fn worktree_finalizer_supplies_clone_branch_and_target_to_runtime() {
             phase: CheckoutPhase::Ready,
             path: Some("/checkouts/convoy-a/repo.feature-cleanup".to_string()),
             commit: Some("base-commit".to_string()),
+            branch_provenance: CheckoutBranchProvenance::CreatedForConvoy,
             message: None,
         })
         .await

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -296,6 +296,7 @@ pub async fn create_ready_checkout(
             phase: CheckoutPhase::Ready,
             path: Some(fixture.path.clone()),
             commit: Some("44982740".to_string()),
+            branch_provenance: Default::default(),
             message: None,
         })
         .await

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -14,8 +14,8 @@ use common::{
 };
 use flotilla_controllers::reconcilers::{
     CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime,
-    EnvironmentReconciler, HopChainContext, PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime,
-    TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
+    EnvironmentReconciler, HopChainContext, PreparedCheckout, PresentationPolicyRegistry, PresentationReconciler,
+    ProviderPresentationRuntime, TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
 };
 use flotilla_core::{
     path_context::DaemonHostPath,
@@ -29,11 +29,11 @@ use flotilla_core::{
     HostName,
 };
 use flotilla_resources::{
-    clone_key, controller::ControllerLoop, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec,
-    DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host,
-    HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation, PresentationPhase, PresentationSpec, ResourceBackend, ResourceError,
-    StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL,
-    VESSEL_REF_LABEL,
+    clone_key, controller::ControllerLoop, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone,
+    ClonePhase, CloneSpec, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec,
+    Host, HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation, PresentationPhase, PresentationSpec, ResourceBackend,
+    ResourceError, StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, CONVOY_LABEL, CREW_ORDINAL_LABEL,
+    VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -80,8 +80,8 @@ impl CheckoutRuntime for FakeCheckoutRuntime {
         _branch: &str,
         _base_ref: Option<&str>,
         _target_path: &str,
-    ) -> Result<Option<String>, String> {
-        Ok(Some("44982740".to_string()))
+    ) -> Result<PreparedCheckout, String> {
+        Ok(PreparedCheckout { commit: Some("44982740".to_string()), branch_provenance: CheckoutBranchProvenance::CreatedForConvoy })
     }
 
     async fn create_fresh_clone(
@@ -90,8 +90,8 @@ impl CheckoutRuntime for FakeCheckoutRuntime {
         _branch: &str,
         _base_ref: Option<&str>,
         _target_path: &str,
-    ) -> Result<Option<String>, String> {
-        Ok(Some("44982740".to_string()))
+    ) -> Result<PreparedCheckout, String> {
+        Ok(PreparedCheckout { commit: Some("44982740".to_string()), branch_provenance: CheckoutBranchProvenance::PreExisting })
     }
 
     async fn remove_checkout(&self, _removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -220,6 +220,7 @@ async fn sequential_vessels_share_a_convoy_owned_worktree_checkout() {
             phase: CheckoutPhase::Ready,
             path: checkout_spec.target_path().map(str::to_string),
             commit: None,
+            branch_provenance: Default::default(),
             message: None,
         })
         .await
@@ -412,6 +413,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
                 phase: CheckoutPhase::Ready,
                 path: spec.target_path().map(str::to_string),
                 commit: Some("44982740".to_string()),
+                branch_provenance: Default::default(),
                 message: None,
             })
             .await
@@ -556,6 +558,7 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
                 phase: CheckoutPhase::Ready,
                 path: Some(path),
                 commit: Some("44982740".to_string()),
+                branch_provenance: Default::default(),
                 message: None,
             })
             .await
@@ -823,6 +826,7 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
             phase: CheckoutPhase::Ready,
             path: Some(adopted_path.to_string()),
             commit: Some("abc123".to_string()),
+            branch_provenance: Default::default(),
             message: None,
         })
         .await
@@ -1792,6 +1796,7 @@ async fn create_ready_adopted_checkout(backend: &ResourceBackend, namespace: &st
             phase: CheckoutPhase::Ready,
             path: Some(path.to_string()),
             commit: Some("abc123".to_string()),
+            branch_provenance: Default::default(),
             message: None,
         })
         .await
@@ -1818,6 +1823,7 @@ async fn create_ready_observed_checkout_without_status_path(backend: &ResourceBa
             phase: CheckoutPhase::Ready,
             path: None,
             commit: Some("abc123".to_string()),
+            branch_provenance: Default::default(),
             message: None,
         })
         .await

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3498,6 +3498,7 @@ impl InProcessDaemon {
                     _ => None,
                 }),
                 commit: None,
+                branch_provenance: Default::default(),
                 message: None,
             })
             .await

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -531,6 +531,7 @@ async fn create_adopted_checkout_for_convoy(daemon: &InProcessDaemon, convoy: &s
             phase: ResourceCheckoutPhase::Ready,
             path: Some("/repo".to_string()),
             commit: None,
+            branch_provenance: Default::default(),
             message: None,
         })
         .await

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -10,9 +10,9 @@ use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{
     BranchPreservationReason, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, CloneReconciler, CloneRuntime,
-    DockerEnvironmentRuntime, EnvironmentReconciler, ForgeDefaultBranchResolver, HopChainContext, PresentationPolicyRegistry,
-    PresentationReconciler, ProviderPresentationRuntime, RepositoryReconciler, TerminalRuntime, TerminalRuntimeState,
-    TerminalSessionReconciler, VesselReconciler,
+    DockerEnvironmentRuntime, EnvironmentReconciler, ForgeDefaultBranchResolver, HopChainContext, PreparedCheckout,
+    PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, RepositoryReconciler, TerminalRuntime,
+    TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
 };
 use flotilla_core::{
     agent_adapter::{AgentLaunchRequest, CapabilityTable},
@@ -31,11 +31,12 @@ use flotilla_core::{
 };
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
 use flotilla_resources::{
-    clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, Clone, CloneSpec, Convoy, ConvoyReconciler, CrewSource,
-    CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
-    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
-    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Repository, ResourceBackend, ResourceError, ResourceObject,
-    Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
+    clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance, Clone, CloneSpec, Convoy,
+    ConvoyReconciler, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec,
+    ForgeIdentity, Host, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus,
+    InputDefinition, InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Repository, ResourceBackend, ResourceError,
+    ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    AGENT_ADAPTERS_CAPABILITY,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -981,7 +982,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
         branch: &str,
         base_ref: Option<&str>,
         target_path: &str,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<PreparedCheckout, String> {
         let clone_path = utf8_path(clone_path)?;
         let target_path = utf8_path(target_path)?;
 
@@ -1014,7 +1015,11 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
             .run("git", &["-C", clone_path, "show-ref", "--verify", "--quiet", &remote_ref], Path::new("/"), &ChannelLabel::Noop)
             .await
             .is_ok();
-        let bootstrap_branch_created = !local_exists && !remote_exists && base_ref.is_some();
+        let branch_provenance = if !local_exists && !remote_exists && base_ref.is_some() {
+            CheckoutBranchProvenance::CreatedForConvoy
+        } else {
+            CheckoutBranchProvenance::PreExisting
+        };
 
         if local_exists {
             // Multiple vessels can intentionally share the convoy branch. `--force`
@@ -1066,7 +1071,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
         }
 
         let commit = resolve_head_commit(&*self.runner, target_path).await?;
-        if bootstrap_branch_created {
+        if branch_provenance == CheckoutBranchProvenance::CreatedForConvoy {
             // Ownership belongs to the branch, not one checkout: sibling vessels
             // can share it and may finalize in either order.
             let commit = commit.as_deref().ok_or_else(|| format!("resolve bootstrap commit for {branch}"))?;
@@ -1074,7 +1079,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
                 .run("git", &["-C", clone_path, "update-ref", &bootstrap_branch_ref(branch), commit], Path::new("/"), &ChannelLabel::Noop)
                 .await?;
         }
-        Ok(commit)
+        Ok(PreparedCheckout { commit, branch_provenance })
     }
 
     async fn create_fresh_clone(
@@ -1083,7 +1088,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
         branch: &str,
         base_ref: Option<&str>,
         target_path: &str,
-    ) -> Result<Option<String>, String> {
+    ) -> Result<PreparedCheckout, String> {
         let target_path = utf8_path(target_path)?;
         let clone_ref = base_ref.unwrap_or(branch);
         if clone_ref == "HEAD" {
@@ -1111,7 +1116,10 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
                 self.runner.run("git", &["-C", target_path, "switch", "-c", branch], Path::new("/"), &ChannelLabel::Noop).await?;
             }
         }
-        resolve_head_commit(&*self.runner, target_path).await
+        Ok(PreparedCheckout {
+            commit: resolve_head_commit(&*self.runner, target_path).await?,
+            branch_provenance: CheckoutBranchProvenance::PreExisting,
+        })
     }
 
     async fn remove_checkout(&self, removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {
@@ -1457,7 +1465,7 @@ mod tests {
         let target = convoy_dir.join("flotilla.feature-cleanup");
         let runtime = CheckoutControllerRuntime { runner: Arc::new(ProcessCommandRunner) };
 
-        runtime
+        let prepared = runtime
             .create_worktree(
                 clone.path().to_str().expect("utf-8 clone path"),
                 "feature/cleanup",
@@ -1466,6 +1474,8 @@ mod tests {
             )
             .await
             .expect("worktree should create");
+        assert_eq!(prepared.branch_provenance, CheckoutBranchProvenance::CreatedForConvoy);
+        assert!(prepared.commit.is_some(), "worktree should resolve its initial commit");
         let removal = CheckoutRemoval::Worktree {
             clone_path: clone.path().to_str().expect("utf-8 clone path").to_string(),
             branch: "feature/cleanup".to_string(),
@@ -1496,7 +1506,7 @@ mod tests {
         let target = convoy_dir.join("feature-work/flotilla");
         let runtime = CheckoutControllerRuntime { runner: Arc::new(ProcessCommandRunner) };
 
-        runtime
+        let prepared = runtime
             .create_worktree(
                 clone.path().to_str().expect("utf-8 clone path"),
                 "feature/work",
@@ -1505,6 +1515,8 @@ mod tests {
             )
             .await
             .expect("worktree should create");
+        assert_eq!(prepared.branch_provenance, CheckoutBranchProvenance::CreatedForConvoy);
+        assert!(prepared.commit.is_some(), "worktree should resolve its initial commit");
         fs::write(target.join("work.txt"), "real work\n").expect("work file should be written");
         assert!(ProcessCommand::new("git")
             .args(["-C", target.to_str().expect("utf-8 target path"), "add", "work.txt"])
@@ -1558,8 +1570,8 @@ mod tests {
             let branch = format!("feature/shared-{case}");
             let workspace = temp.path().join(format!("workspace-{case}"));
             let targets = [workspace.join("first"), workspace.join("second")];
-            for target in &targets {
-                runtime
+            for (index, target) in targets.iter().enumerate() {
+                let prepared = runtime
                     .create_worktree(
                         clone.path().to_str().expect("utf-8 clone path"),
                         &branch,
@@ -1568,6 +1580,8 @@ mod tests {
                     )
                     .await
                     .expect("worktree should create");
+                let expected = if index == 0 { CheckoutBranchProvenance::CreatedForConvoy } else { CheckoutBranchProvenance::PreExisting };
+                assert_eq!(prepared.branch_provenance, expected, "only the creating checkout should record convoy provenance");
             }
 
             let removals = targets.each_ref().map(|target| CheckoutRemoval::Worktree {
@@ -1606,7 +1620,7 @@ mod tests {
         let target = temp.path().join("workspace/flotilla");
         let runtime = CheckoutControllerRuntime { runner: Arc::new(ProcessCommandRunner) };
 
-        runtime
+        let prepared = runtime
             .create_worktree(
                 clone.path().to_str().expect("utf-8 clone path"),
                 "main",
@@ -1615,6 +1629,7 @@ mod tests {
             )
             .await
             .expect("local branch should not require its origin");
+        assert_eq!(prepared.branch_provenance, CheckoutBranchProvenance::PreExisting);
 
         let branch = ProcessCommand::new("git")
             .args(["-C", target.to_str().expect("utf-8 target path"), "branch", "--show-current"])

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -90,6 +90,20 @@ pub enum CheckoutPhase {
     Failed,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckoutBranchProvenance {
+    #[default]
+    PreExisting,
+    CreatedForConvoy,
+}
+
+impl CheckoutBranchProvenance {
+    fn is_pre_existing(&self) -> bool {
+        *self == Self::PreExisting
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct CheckoutStatus {
     pub phase: CheckoutPhase,
@@ -97,6 +111,9 @@ pub struct CheckoutStatus {
     pub path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commit: Option<String>,
+    #[serde(default, skip_serializing_if = "CheckoutBranchProvenance::is_pre_existing")]
+    #[builder(default)]
+    pub branch_provenance: CheckoutBranchProvenance,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
@@ -104,7 +121,7 @@ pub struct CheckoutStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckoutStatusPatch {
     MarkPreparing,
-    MarkReady { path: String, commit: Option<String> },
+    MarkReady { path: String, commit: Option<String>, branch_provenance: CheckoutBranchProvenance },
     MarkTerminating,
     MarkFailed { message: String },
 }
@@ -116,10 +133,11 @@ impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
                 status.phase = CheckoutPhase::Preparing;
                 status.message = None;
             }
-            Self::MarkReady { path, commit } => {
+            Self::MarkReady { path, commit, branch_provenance } => {
                 status.phase = CheckoutPhase::Ready;
                 status.path = Some(path.clone());
                 status.commit = commit.clone();
+                status.branch_provenance = *branch_provenance;
                 status.message = None;
             }
             Self::MarkTerminating => {

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -25,8 +25,8 @@ mod workflow_template;
 
 pub use backend::{ResourceBackend, TypedResolver};
 pub use checkout::{
-    Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, CheckoutWorktreeSpec, FreshCloneCheckoutSpec,
-    ObservedCheckoutSpec,
+    Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, CheckoutWorktreeSpec,
+    FreshCloneCheckoutSpec, ObservedCheckoutSpec,
 };
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -1,9 +1,9 @@
 use chrono::{TimeZone, Utc};
 use flotilla_resources::{
-    CheckoutPhase, CheckoutStatus, CheckoutStatusPatch, ClonePhase, CloneStatus, CloneStatusPatch, EnvironmentPhase, EnvironmentStatus,
-    EnvironmentStatusPatch, HostStatus, HostStatusPatch, InnerCommandStatus, PresentationPhase, PresentationStatus,
-    PresentationStatusPatch, Stance, StatusPatch, TerminalSessionPhase, TerminalSessionStatus, TerminalSessionStatusPatch, VesselPhase,
-    VesselStatus, VesselStatusPatch,
+    CheckoutBranchProvenance, CheckoutPhase, CheckoutStatus, CheckoutStatusPatch, ClonePhase, CloneStatus, CloneStatusPatch,
+    EnvironmentPhase, EnvironmentStatus, EnvironmentStatusPatch, HostStatus, HostStatusPatch, InnerCommandStatus, PresentationPhase,
+    PresentationStatus, PresentationStatusPatch, Stance, StatusPatch, TerminalSessionPhase, TerminalSessionStatus,
+    TerminalSessionStatusPatch, VesselPhase, VesselStatus, VesselStatusPatch,
 };
 
 #[test]
@@ -51,10 +51,16 @@ fn checkout_status_patch_marks_ready_and_failed() {
     CheckoutStatusPatch::MarkPreparing.apply(&mut status);
     assert_eq!(status.phase, CheckoutPhase::Preparing);
 
-    CheckoutStatusPatch::MarkReady { path: "/workspace".to_string(), commit: Some("44982740".to_string()) }.apply(&mut status);
+    CheckoutStatusPatch::MarkReady {
+        path: "/workspace".to_string(),
+        commit: Some("44982740".to_string()),
+        branch_provenance: CheckoutBranchProvenance::CreatedForConvoy,
+    }
+    .apply(&mut status);
     assert_eq!(status.phase, CheckoutPhase::Ready);
     assert_eq!(status.path.as_deref(), Some("/workspace"));
     assert_eq!(status.commit.as_deref(), Some("44982740"));
+    assert_eq!(status.branch_provenance, CheckoutBranchProvenance::CreatedForConvoy);
 
     CheckoutStatusPatch::MarkFailed { message: "worktree add failed".to_string() }.apply(&mut status);
     assert_eq!(status.phase, CheckoutPhase::Failed);


### PR DESCRIPTION
Salvages commit `33dae9fb` from the #810 convoy's dead integration branch (see #810's comments for the post-mortem). The original commit was authored on top of pre-merge cherry-picks of #823 and #827; this PR rebases it across the landed forms of both.

## What survives the rebase

- **`CheckoutBranchProvenance` enum** (`pre_existing` | `created_for_convoy`, serde snake_case, skipped when `pre_existing`) replacing the never-landed `bootstrap_branch_created: bool` on `CheckoutStatus`. Recorded at `MarkReady`, this is the status-level provenance record needed by ADR 0017's teardown work — branch fate at teardown depends on whether Flotilla created the branch for the convoy.
- **`PreparedCheckout { commit, branch_provenance }`** as the return of `CheckoutRuntime::create_worktree` / `create_fresh_clone`, so the reconciler can propagate provenance into checkout status.
- Provenance assertions in the runtime and reconciler tests (including creator-vs-follower provenance on a shared convoy branch).

## What defers to main's landed form

- #823 landed teardown as git-native bootstrap refs (`refs/flotilla/bootstrap/<branch>`), which handle shared-branch teardown in either order. The salvage's status-driven removal decisions, `initial_commit`/provenance in `CheckoutRemoval`, and the `transfer_branch_provenance` successor-handoff are superseded by that mechanism and are dropped; `remove_checkout` stays exactly as landed.
- The salvage's aggregator change-request hardening (shadowed-convoy refresh suppression) had already landed in finer-grained form via #827 (`effective_convoy` + association/phase-changed refresh); the aggregator resolves to main unchanged.

Part of #810