### PR TITLE
fix: guard crew handoff provenance

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -969,6 +969,16 @@ fn pending_crew_message(text: &str) -> TerminalCrewMessage {
     TerminalCrewMessage { id: uuid::Uuid::new_v4().to_string(), text: text.to_string() }
 }
 
+fn crew_handoff_address_error(target: &str, vessel: &str) -> String {
+    format!(
+        "no such crew member in your vessel; crew messaging is intra-vessel and requires a different crew member (target `{target}`, vessel `{vessel}`)"
+    )
+}
+
+fn crew_handoff_message(context: &ResolvedCrewContext, message: &str) -> String {
+    format!("handoff from {}@{}\n\n{message}", context.caller_role, context.vessel)
+}
+
 async fn queue_pending_crew_message(
     sessions: &flotilla_resources::TypedResolver<ResourceTerminalSession>,
     existing: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
@@ -4147,7 +4157,10 @@ impl InProcessDaemon {
             .iter()
             .enumerate()
             .find(|(_, process)| process.role == target)
-            .ok_or_else(|| format!("crew target `{target}` is not defined for vessel `{}`", context.vessel))?;
+            .ok_or_else(|| crew_handoff_address_error(target, &context.vessel))?;
+        if target == context.caller_role {
+            return Err(crew_handoff_address_error(target, &context.vessel));
+        }
         let CrewSource::Agent { selector, prompt } = &process.source else {
             return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
         };
@@ -4161,6 +4174,7 @@ impl InProcessDaemon {
             return Err(format!("crew target `{target}` has failed work and cannot receive a handoff"));
         }
 
+        let delivered_message = crew_handoff_message(&context, message);
         let sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(&context.namespace);
         let identity = TerminalSessionIdentity::builder()
             .vessel_ref(context.vessel_ref.clone())
@@ -4174,9 +4188,9 @@ impl InProcessDaemon {
         let terminal_name = identity.name();
         let handoff_result = match sessions.get(&terminal_name).await {
             Ok(existing) => match existing.status.as_ref().map(|status| status.phase) {
-                Some(ResourceTerminalSessionPhase::Running) => self.deliver_to_crew_session(&existing, message).await,
+                Some(ResourceTerminalSessionPhase::Running) => self.deliver_to_crew_session(&existing, &delivered_message).await,
                 Some(ResourceTerminalSessionPhase::Stopped) => {
-                    queue_pending_crew_message(&sessions, &existing, message).await?;
+                    queue_pending_crew_message(&sessions, &existing, &delivered_message).await?;
                     apply_resource_status_patch(&sessions, &terminal_name, &TerminalSessionStatusPatch::MarkStarting)
                         .await
                         .map(|_| ())
@@ -4185,7 +4199,9 @@ impl InProcessDaemon {
                 Some(ResourceTerminalSessionPhase::Failed) => {
                     Err(format!("crew target `{target}` failed provisioning and cannot be revived"))
                 }
-                Some(ResourceTerminalSessionPhase::Starting) | None => queue_pending_crew_message(&sessions, &existing, message).await,
+                Some(ResourceTerminalSessionPhase::Starting) | None => {
+                    queue_pending_crew_message(&sessions, &existing, &delivered_message).await
+                }
             },
             Err(ResourceError::NotFound { .. }) => {
                 let anchor = if let Some(caller) = context.caller_session.as_ref() {
@@ -4214,7 +4230,7 @@ impl InProcessDaemon {
                                 convoy: context.convoy.clone(),
                                 vessel_ref: context.vessel_ref.clone(),
                             },
-                            message: Some(pending_crew_message(message)),
+                            message: Some(pending_crew_message(&delivered_message)),
                         },
                         cwd: anchor.spec.cwd,
                         pool: anchor.spec.pool,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4156,11 +4156,8 @@ impl InProcessDaemon {
             .crew
             .iter()
             .enumerate()
-            .find(|(_, process)| process.role == target)
+            .find(|(_, process)| process.role == target && target != context.caller_role)
             .ok_or_else(|| crew_handoff_address_error(target, &context.vessel))?;
-        if target == context.caller_role {
-            return Err(crew_handoff_address_error(target, &context.vessel));
-        }
         let CrewSource::Agent { selector, prompt } = &process.source else {
             return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
         };

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -792,6 +792,38 @@ async fn handoff_rejects_failed_target_instead_of_succeeding_without_state_chang
 }
 
 #[tokio::test]
+async fn handoff_rejects_self_and_unknown_targets_without_delivery() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+    let context = CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() };
+
+    let self_error =
+        daemon.crew_handoff_internal(&context, "coder", "This should not echo back").await.expect_err("self handoff should be rejected");
+    assert_eq!(
+        self_error,
+        "no such crew member in your vessel; crew messaging is intra-vessel and requires a different crew member (target `coder`, vessel `implement`)"
+    );
+
+    let missing_error = daemon
+        .crew_handoff_internal(&context, "architect", "This should not be delivered")
+        .await
+        .expect_err("unknown target should be rejected");
+    assert_eq!(
+        missing_error,
+        "no such crew member in your vessel; crew messaging is intra-vessel and requires a different crew member (target `architect`, vessel `implement`)"
+    );
+    assert!(terminal_pool.delivered.lock().await.is_empty());
+
+    let terminals = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let coder = terminals.get("terminal-demo-implement-coder").await.expect("coder session");
+    assert!(matches!(coder.spec.source, TerminalSessionSource::Agent { message: None, .. }));
+    assert!(terminals.get("terminal-demo-implement-architect").await.is_err(), "misaddressed handoff must not create a target session");
+}
+
+#[tokio::test]
 async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
     let temp = tempfile::tempdir().expect("tempdir");
     std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
@@ -847,9 +879,11 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
         .get("terminal-demo-implement-reviewer")
         .await
         .expect("reviewer session should be defined");
-    assert!(
-        matches!(reviewer.spec.source, TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Review commit abc123")
-    );
+    assert!(matches!(
+        reviewer.spec.source,
+        TerminalSessionSource::Agent { message: Some(ref message), .. }
+            if message.text == "handoff from coder@implement\n\nReview commit abc123"
+    ));
     assert_eq!(reviewer.metadata.labels.get(VESSEL_ORDINAL_LABEL).map(String::as_str), Some("001"));
     assert_eq!(reviewer.metadata.labels.get(CREW_ORDINAL_LABEL).map(String::as_str), Some("001"));
 
@@ -876,7 +910,8 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
         .expect("reviewer session should still exist");
     assert!(matches!(
         reviewer.spec.source,
-        TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Use the amended commit"
+        TerminalSessionSource::Agent { message: Some(ref message), .. }
+            if message.text == "handoff from coder@implement\n\nUse the amended commit"
     ));
 
     let explicit_context = CrewCommandContext {
@@ -903,7 +938,7 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
     assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
     assert_eq!(terminal_pool.delivered.lock().await.as_slice(), &[(
         "session-coder".to_string(),
-        "Address the review findings".to_string(),
+        "handoff from reviewer@implement\n\nAddress the review findings".to_string(),
         true
     )]);
     let convoy = daemon.resource_backend().using::<Convoy>("flotilla").get("demo").await.expect("convoy");
@@ -935,9 +970,11 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
     assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
     let coder = terminals.get("terminal-demo-implement-coder").await.expect("restarting coder");
     assert_eq!(coder.status.expect("coder status").phase, ResourceTerminalSessionPhase::Starting);
-    assert!(
-        matches!(coder.spec.source, TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Resume after review")
-    );
+    assert!(matches!(
+        coder.spec.source,
+        TerminalSessionSource::Agent { message: Some(ref message), .. }
+            if message.text == "handoff from reviewer@implement\n\nResume after review"
+    ));
 }
 
 #[test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2626,12 +2626,11 @@ mod tests {
             .expect("reviewer session");
         let reviewer_id = reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).expect("reviewer identity").id.clone();
         assert_eq!(reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).map(|crew| crew.adapter.as_str()), Some("claude-code"));
-        assert!(pool
-            .delivered
-            .lock()
-            .await
-            .iter()
-            .any(|(session, text, submit)| session.ends_with("-reviewer") && text == "Review commit abc123" && *submit));
+        let delivered = pool.delivered.lock().await;
+        assert!(delivered.iter().any(|(session, text, submit)| {
+            session.ends_with("-reviewer") && text == "handoff from coder@implement\n\nReview commit abc123" && *submit
+        }));
+        drop(delivered);
 
         let mut rx = daemon.subscribe();
         let reviewer_complete_id = daemon
@@ -2675,12 +2674,11 @@ mod tests {
             .await
             .expect("hand back to coder");
         assert_eq!(wait_for_command_result(&mut rx, hand_back_id).await, CommandValue::Ok);
-        assert!(pool
-            .delivered
-            .lock()
-            .await
-            .iter()
-            .any(|(session, text, submit)| session.ends_with("-coder") && text == "Address the review findings" && *submit));
+        let delivered = pool.delivered.lock().await;
+        assert!(delivered.iter().any(|(session, text, submit)| {
+            session.ends_with("-coder") && text == "handoff from reviewer@implement\n\nAddress the review findings" && *submit
+        }));
+        drop(delivered);
         wait_until(|| {
             let convoys = convoys.clone();
             async move {


### PR DESCRIPTION
## What changed

- Reject crew handoffs to the sender or to an unknown role before creating sessions or delivering text.
- Wrap delivered and queued crew handoff messages with `handoff from <role>@<vessel>` provenance.
- Extend core and daemon coverage for misaddressed handoffs, pending handoffs, live deliveries, and runtime provisioning.

## Why

Crew handoff addressing is intra-vessel. A misaddressed handoff could previously route back into the sender session as unattributed text, making an outbound message look like inbound operator instruction.

Closes #831

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-core --locked handoff_ --features test-support`
- `TMPDIR=/tmp/flotilla-codex-tests cargo test -p flotilla-daemon --locked runtime::tests::crew_provisioning_runs_coder_reviewer_handoffs_and_rejects_unknown_capabilities`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`
- `TMPDIR=/tmp/flotilla-codex-tests cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests -- --skip in_process::tests::attach_query_reports_ambiguous_routed_host_name --skip in_process::tests::attach_query_reports_route_that_points_back_to_local_host --skip in_process::tests::attach_query_resolves_fleet_replica_session_as_one_recursive_hop --skip in_process::tests::attach_query_resolves_remote_session_as_one_recursive_hop --skip in_process::tests::attach_query_uses_topology_next_hop_for_multi_hop_route_shape --skip in_process::tests::transient_attach_selects_the_displayed_host_for_result_set_only_independents --skip app::tests::generated_vessel_actions_route_to_the_vessels_host`

Note: the exact workspace test command fails on this machine because the local hostname is `feta`, which collides with existing remote-host test fixtures named `feta`; the skipped run excludes only those local hostname collision cases.