### PR TITLE
fix: sort project issues by id

### DIFF
--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -104,7 +104,7 @@ impl QueryRegistry {
             by_reference.insert(row.reference.clone(), row.clone());
         }
         *rows = by_reference.into_values().collect();
-        rows.sort_by(|left, right| right.issue.as_of.cmp(&left.issue.as_of).then_with(|| left.reference.cmp(&right.reference)));
+        rows.sort_by(|left, right| left.reference.cmp_id_desc(&right.reference));
         current.seq = current.seq.saturating_add(1);
         current.state = result_state.clone();
         Some(ResultDelta {

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -928,12 +928,12 @@ mod tests {
         materializer.refresh(&query);
 
         let DaemonEvent::ResultDelta(delta) = next_event(&mut events).await else { panic!("refresh must emit a delta") };
-        assert_eq!(delta.changes.removed_issues().expect("boundary eviction"), &[IssueRef { source, id: "ISSUE-49".into() }]);
+        assert_eq!(delta.changes.removed_issues().expect("boundary eviction"), &[IssueRef { source, id: "ISSUE-00".into() }]);
         let result = state.result_set_for(&query).await.expect("bounded window");
         let rows = result.rows.as_issues().expect("issue rows");
         assert_eq!(rows.len(), PAGE_SIZE);
         assert_eq!(rows[0].reference.id, "NEWEST");
-        assert!(rows.iter().all(|row| row.reference.id != "ISSUE-49"));
+        assert!(rows.iter().all(|row| row.reference.id != "ISSUE-00"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -890,31 +890,17 @@ mod tests {
         }]));
         let (materializer, mut events) = manager(&state, &query, vec![source], provider);
         let _ = next_event(&mut events).await;
-        let initial_ids = state
-            .result_set_for(&query)
-            .await
-            .expect("initial window")
-            .rows
-            .as_issues()
-            .expect("issue rows")
-            .iter()
-            .map(|row| row.reference.id.as_str())
-            .collect::<Vec<_>>();
+        let initial_window = state.result_set_for(&query).await.expect("initial window");
+        let initial_ids =
+            initial_window.rows.as_issues().expect("issue rows").iter().map(|row| row.reference.id.as_str()).collect::<Vec<_>>();
         assert_eq!(initial_ids, vec!["10", "1"]);
 
         materializer.refresh(&query);
 
         let _ = next_event(&mut events).await;
-        let refreshed_ids = state
-            .result_set_for(&query)
-            .await
-            .expect("refreshed window")
-            .rows
-            .as_issues()
-            .expect("issue rows")
-            .iter()
-            .map(|row| row.reference.id.as_str())
-            .collect::<Vec<_>>();
+        let refreshed_window = state.result_set_for(&query).await.expect("refreshed window");
+        let refreshed_ids =
+            refreshed_window.rows.as_issues().expect("issue rows").iter().map(|row| row.reference.id.as_str()).collect::<Vec<_>>();
         assert_eq!(refreshed_ids, vec!["10", "1"], "an update timestamp must not move issue rows");
     }
 

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -455,7 +455,7 @@ fn issue_row(issue: flotilla_protocol::Issue) -> IssueRow {
 }
 
 fn sort_rows(rows: &mut [IssueRow]) {
-    rows.sort_by(|left, right| right.issue.as_of.cmp(&left.issue.as_of).then_with(|| left.reference.cmp(&right.reference)));
+    rows.sort_by(|left, right| left.reference.cmp_id_desc(&right.reference));
 }
 
 async fn query_page(
@@ -874,6 +874,48 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["NEW-10"]
         );
+    }
+
+    #[tokio::test]
+    async fn incremental_refresh_keeps_rows_in_descending_id_order() {
+        let state = AggregatorProjectionState::new();
+        let query = project_query("repo_stable_order");
+        let source = IssueSource { service: "https://issues.example".into(), scope: "stable/order".into() };
+        let mut refreshed_low_id = issue("1");
+        refreshed_low_id.as_of = Utc::now();
+        let provider = Arc::new(ScriptedProvider::new(vec![page(&["10", "1"], false)], vec![IssueChangeset {
+            updated: vec![refreshed_low_id],
+            closed: vec![],
+            has_more: false,
+        }]));
+        let (materializer, mut events) = manager(&state, &query, vec![source], provider);
+        let _ = next_event(&mut events).await;
+        let initial_ids = state
+            .result_set_for(&query)
+            .await
+            .expect("initial window")
+            .rows
+            .as_issues()
+            .expect("issue rows")
+            .iter()
+            .map(|row| row.reference.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(initial_ids, vec!["10", "1"]);
+
+        materializer.refresh(&query);
+
+        let _ = next_event(&mut events).await;
+        let refreshed_ids = state
+            .result_set_for(&query)
+            .await
+            .expect("refreshed window")
+            .rows
+            .as_issues()
+            .expect("issue rows")
+            .iter()
+            .map(|row| row.reference.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(refreshed_ids, vec!["10", "1"], "an update timestamp must not move issue rows");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -404,7 +404,7 @@ async fn project_issue_subscription_materializes_window_and_ephemeral_search() {
     .expect("materialized issue window");
     let rows = result.rows.as_issues().expect("issue rows");
     assert_eq!(rows.len(), 50);
-    assert_eq!(rows[0].reference.id, "WIDGET-000");
+    assert_eq!(rows[0].reference.id, "WIDGET-049");
     assert!(result.state.demand.as_ref().expect("demand metadata").has_more);
     assert!(result.state.conditions.is_empty());
 

--- a/crates/flotilla-protocol/src/provider_data.rs
+++ b/crates/flotilla-protocol/src/provider_data.rs
@@ -110,6 +110,19 @@ pub struct IssueRef {
     pub id: String,
 }
 
+impl IssueRef {
+    /// Compare issue references for the default issue-panel order: newest ID
+    /// first. Numeric IDs use numeric ordering; opaque IDs fall back to
+    /// descending lexical order. The source is a deterministic tie-breaker.
+    pub fn cmp_id_desc(&self, other: &Self) -> std::cmp::Ordering {
+        let by_id = match (self.id.parse::<u64>(), other.id.parse::<u64>()) {
+            (Ok(left), Ok(right)) => right.cmp(&left),
+            _ => other.id.cmp(&self.id),
+        };
+        by_id.then_with(|| self.source.cmp(&other.source))
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IssueState {
@@ -509,6 +522,17 @@ mod tests {
         assert_eq!(json["source"]["service"], "https://github.com");
         assert_eq!(json["source"]["scope"], "flotilla-org/flotilla");
         assert_eq!(json["id"], "WIDGET-123");
+    }
+
+    #[test]
+    fn issue_reference_default_order_is_descending_by_id() {
+        let source = IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() };
+        let newer = IssueRef { source: source.clone(), id: "10".into() };
+        let older = IssueRef { source: source.clone(), id: "9".into() };
+        let opaque = IssueRef { source, id: "WIDGET-123".into() };
+
+        assert!(newer.cmp_id_desc(&older).is_lt(), "numeric IDs sort numerically");
+        assert!(opaque.cmp_id_desc(&newer).is_lt(), "opaque IDs retain a deterministic lexical order");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -1426,7 +1426,7 @@ impl App {
                             removed,
                             delta.state.as_ref(),
                             |row| row.reference.clone(),
-                            |left, right| right.issue.as_of.cmp(&left.issue.as_of).then_with(|| left.reference.cmp(&right.reference)),
+                            |left, right| left.reference.cmp_id_desc(&right.reference),
                         );
                     }
                     flotilla_protocol::QueryChanges::Checkouts { changed, removed, .. } => {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1885,6 +1885,48 @@ fn app_applies_materialized_issue_sets_and_deltas_to_the_typed_query_cache() {
 }
 
 #[test]
+fn app_keeps_issue_rows_in_id_order_when_an_existing_issue_is_updated() {
+    let mut app = stub_app();
+    let scope = flotilla_protocol::QueryScope::new("flotilla", "roadmap");
+    let query = flotilla_protocol::QueryId::Issues { scope: scope.clone(), search: None };
+    let mut high_id = TestIssue::new("High ID").id("10").build();
+    high_id.as_of = "2026-07-15T12:00:00Z".parse().expect("timestamp");
+    let mut low_id = TestIssue::new("Low ID").id("1").build();
+    low_id.as_of = "2026-07-15T12:00:00Z".parse().expect("timestamp");
+
+    app.handle_daemon_event(DaemonEvent::ResultSet(Box::new(flotilla_protocol::ResultSet {
+        seq: 1,
+        rows: flotilla_protocol::Rows::Issues {
+            scope: scope.clone(),
+            search: None,
+            rows: vec![flotilla_protocol::IssueRow { reference: high_id.reference.clone(), issue: high_id }, flotilla_protocol::IssueRow {
+                reference: low_id.reference.clone(),
+                issue: low_id.clone(),
+            }],
+        },
+        state: Default::default(),
+    })));
+
+    low_id.as_of = "2026-07-15T12:01:00Z".parse().expect("timestamp");
+    app.handle_daemon_event(DaemonEvent::ResultDelta(Box::new(flotilla_protocol::ResultDelta {
+        seq: 2,
+        changes: flotilla_protocol::QueryChanges::Issues {
+            scope,
+            search: None,
+            changed: vec![flotilla_protocol::IssueRow { reference: low_id.reference.clone(), issue: low_id }],
+            removed: vec![],
+        },
+        state: None,
+    })));
+
+    assert_eq!(
+        app.query_tables.issues[&query].rows.iter().map(|row| row.reference.id.as_str()).collect::<Vec<_>>(),
+        vec!["10", "1"],
+        "a newer timestamp must not change the issue-panel row order"
+    );
+}
+
+#[test]
 fn app_applies_checkout_sets_and_removal_deltas_to_the_typed_query_cache() {
     let mut app = stub_app();
     let query = flotilla_protocol::QueryId::Checkouts { scope: None };


### PR DESCRIPTION
Closes #824.

Project issue rows now use a stable descending ID order across initial materialization, refreshes, and client-side deltas. Numeric IDs sort numerically; opaque IDs have a deterministic fallback order.