### PR TITLE
fix: keep test sockets under SUN_LEN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Socket bind/listen is blocked. Use the sandbox-safe test command:
 mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests
 ```
 
-The repo-local `TMPDIR` avoids native build failures from crates like `aws-lc-sys` under the sandbox.
+The repo-local `TMPDIR` avoids native build failures from crates like `aws-lc-sys` under the sandbox. Unix-socket tests are exempt: their shared test harness creates SUN_LEN-safe paths directly beneath `/tmp`, so do not work around this command by changing `TMPDIR`.
 
 Use this when `CODEX_SANDBOX` is set or socket-bind tests fail with `Operation not permitted`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Before pushing, run the exact CI commands: `cargo +nightly-2026-03-12 fmt --chec
 
 **Nightly toolchain:** All nightly-dependent tools (rustfmt, llvm-cov, Dylint) are pinned to `nightly-2026-03-12`. Install with `rustup toolchain install nightly-2026-03-12 --component rustfmt llvm-tools-preview`.
 
-In the Codex sandbox, prefer `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests` so native dependencies can create temp files and socket-bind tests stay skipped.
+In the Codex sandbox, prefer `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests` so native dependencies can create temp files and socket-bind tests stay skipped. Unix-socket tests use the shared harness's SUN_LEN-safe directory directly beneath `/tmp`, independent of `TMPDIR`; do not change this command to work around socket-path length errors.
 
 Package-local `flotilla-core` daemon integration coverage uses shared discovery test helpers behind `test-support`, so run it as:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "bon",
  "flotilla-core",
  "flotilla-protocol",
+ "flotilla-test-support",
  "flotilla-transport",
  "libc",
  "serde_json",
@@ -1307,6 +1308,7 @@ dependencies = [
  "flotilla-daemon",
  "flotilla-protocol",
  "flotilla-resources",
+ "flotilla-test-support",
  "flotilla-transport",
  "futures",
  "indexmap",
@@ -1329,6 +1331,7 @@ dependencies = [
  "async-trait",
  "bon",
  "flotilla-protocol",
+ "flotilla-test-support",
  "serde",
  "serde_json",
  "tempfile",
@@ -1379,6 +1382,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "flotilla-test-support"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/flotilla-transport",
     "crates/flotilla-daemon",
     "crates/flotilla-tui",
+    "crates/flotilla-test-support",
 ]
 exclude = ["lints/long_inline_paths", "crates/flotilla-manifest/fixtures/generator"]
 resolver = "2"

--- a/crates/flotilla-client/Cargo.toml
+++ b/crates/flotilla-client/Cargo.toml
@@ -17,4 +17,5 @@ libc = "0.2"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+flotilla-test-support = { path = "../flotilla-test-support" }
 tempfile = "3"

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -5,6 +5,7 @@ use flotilla_protocol::{
     result_set::{QueryChanges, QueryId, ResultDelta, ResultSet, Rows},
     EnvironmentId, NodeId, NodeInfo, RepoDelta, RepoIdentity, RepoSnapshot,
 };
+use flotilla_test_support::TestSocketDir;
 use flotilla_transport::message::{message_session_pair, unix_message_session, MessageSession};
 use tokio::net::UnixListener;
 
@@ -119,8 +120,8 @@ async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_con
     // deleting its socket and spawning over it. The test plays B: it holds
     // the spawn lock, binds a stale-version listener only after A's first
     // probe has found nothing, then releases the lock.
-    let dir = tempfile::tempdir().expect("tempdir");
-    let socket_path = dir.path().join("daemon.sock");
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("daemon.sock");
     let lock_path = std::path::PathBuf::from(format!("{}.lock", socket_path.display()));
 
     let lock_file = match acquire_spawn_lock(&lock_path) {
@@ -189,8 +190,8 @@ async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_con
 
 #[tokio::test]
 async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let socket_path = dir.path().join("daemon.sock");
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("daemon.sock");
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -243,8 +244,8 @@ async fn client_hello_rejects_daemon_protocol_version_mismatch() {
 
 #[tokio::test]
 async fn connect_rejects_daemon_protocol_version_mismatch() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let socket_path = dir.path().join("daemon.sock");
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("daemon.sock");
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -284,8 +285,8 @@ async fn connect_rejects_daemon_protocol_version_mismatch() {
 
 #[tokio::test]
 async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let socket_path = dir.path().join("daemon.sock");
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("daemon.sock");
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -438,8 +439,8 @@ async fn send_request_writes_message_and_returns_pending_response() {
 
 #[tokio::test]
 async fn dropping_socket_daemon_closes_connection_promptly() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let socket_path = dir.path().join("daemon.sock");
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("daemon.sock");
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {

--- a/crates/flotilla-daemon/Cargo.toml
+++ b/crates/flotilla-daemon/Cargo.toml
@@ -30,6 +30,7 @@ futures = "0.3"
 visibility = "0.1.1"
 
 [dev-dependencies]
+flotilla-test-support = { path = "../flotilla-test-support" }
 indexmap = { workspace = true }
 rusqlite = { version = "0.37", features = ["bundled"] }
 tempfile = "3"

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -682,8 +682,8 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(feature = "skip-no-sandbox-tests", ignore = "excluded by `skip-no-sandbox-tests`; run without that feature to include")]
     async fn connect_socket_preserves_peer_message_buffered_after_hello() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let socket_path = dir.path().join("peer.sock");
+        let dir = flotilla_test_support::TestSocketDir::new();
+        let socket_path = dir.socket_path("peer.sock");
         let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind listener");
 
         let config = RemoteHostConfig {

--- a/crates/flotilla-daemon/tests/socket_roundtrip.rs
+++ b/crates/flotilla-daemon/tests/socket_roundtrip.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use flotilla_core::{config::ConfigStore, daemon::DaemonHandle, providers::discovery::test_support::git_process_discovery};
 use flotilla_daemon::server::DaemonServer;
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, RepoSelector, StreamKey};
+use flotilla_test_support::TestSocketDir;
 use tokio::time::Instant;
 
 /// Execute a query command via execute_query and return the result directly.
@@ -14,8 +15,8 @@ async fn run_query(daemon: &dyn DaemonHandle, action: CommandAction) -> CommandV
 #[tokio::test]
 #[cfg_attr(feature = "skip-no-sandbox-tests", ignore = "excluded by `skip-no-sandbox-tests`; run without that feature to include")]
 async fn socket_roundtrip() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let socket_path = tmp.path().join("test.sock");
+    let tmp = TestSocketDir::new();
+    let socket_path = tmp.socket_path("test.sock");
 
     // Use workspace root (a real git repo) as the test repo.
     // CARGO_MANIFEST_DIR points to crates/flotilla-daemon; go up two levels.
@@ -145,8 +146,8 @@ async fn socket_roundtrip() {
 #[tokio::test]
 #[cfg_attr(feature = "skip-no-sandbox-tests", ignore = "excluded by `skip-no-sandbox-tests`; run without that feature to include")]
 async fn query_commands_roundtrip() {
-    let tmp = tempfile::TempDir::new().expect("tempdir");
-    let socket_path = tmp.path().join("test.sock");
+    let tmp = TestSocketDir::new();
+    let socket_path = tmp.socket_path("test.sock");
 
     // Use workspace root (a real git repo) as the test repo.
     // CARGO_MANIFEST_DIR points to crates/flotilla-daemon; go up two levels.
@@ -275,8 +276,8 @@ async fn query_commands_roundtrip() {
 #[tokio::test]
 #[cfg_attr(feature = "skip-no-sandbox-tests", ignore = "excluded by `skip-no-sandbox-tests`; run without that feature to include")]
 async fn execute_refresh_all_roundtrip_emits_lifecycle_events() {
-    let tmp = tempfile::TempDir::new().expect("tempdir");
-    let socket_path = tmp.path().join("test.sock");
+    let tmp = TestSocketDir::new();
+    let socket_path = tmp.socket_path("test.sock");
 
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let repo = manifest_dir.parent().expect("parent").parent().expect("grandparent").to_path_buf();

--- a/crates/flotilla-manifest/Cargo.toml
+++ b/crates/flotilla-manifest/Cargo.toml
@@ -14,5 +14,6 @@ tokio = { version = "1", features = ["process", "net", "io-util", "sync", "time"
 tracing = { workspace = true }
 
 [dev-dependencies]
+flotilla-test-support = { path = "../flotilla-test-support" }
 tokio = { version = "1", features = ["macros", "rt", "fs"] }
 tempfile = "3"

--- a/crates/flotilla-manifest/src/sink.rs
+++ b/crates/flotilla-manifest/src/sink.rs
@@ -408,8 +408,8 @@ done
 
     #[tokio::test]
     async fn unix_socket_sink_writes_one_wire_message_per_line() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let socket_path = dir.path().join("manifest.sock");
+        let dir = flotilla_test_support::TestSocketDir::new();
+        let socket_path = dir.socket_path("manifest.sock");
         let listener = UnixListener::bind(&socket_path).expect("bind test socket");
 
         let patch = stamp_patch();

--- a/crates/flotilla-test-support/Cargo.toml
+++ b/crates/flotilla-test-support/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "flotilla-test-support"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+
+[dependencies]
+tempfile = "3"

--- a/crates/flotilla-test-support/src/lib.rs
+++ b/crates/flotilla-test-support/src/lib.rs
@@ -1,0 +1,77 @@
+//! Shared harnesses for tests that cross crate boundaries.
+
+use std::path::{Path, PathBuf};
+
+/// The maximum pathname length that is safe for a Unix-domain socket on every
+/// supported platform. macOS has a 104-byte `sun_path`, including its trailing
+/// NUL byte.
+const MAX_UNIX_SOCKET_PATH_BYTES: usize = 103;
+
+/// A short-lived directory for Unix-domain socket tests.
+///
+/// `tempfile` normally respects `TMPDIR`, which can be a deep worktree path.
+/// This harness deliberately creates its directory directly beneath `/tmp` so
+/// socket tests remain independent of `TMPDIR` and `CARGO_TARGET_TMPDIR`.
+pub struct TestSocketDir {
+    dir: tempfile::TempDir,
+}
+
+impl TestSocketDir {
+    /// Create a dedicated short directory directly beneath `/tmp`.
+    pub fn new() -> Self {
+        let dir = tempfile::Builder::new().prefix("flt-").tempdir_in("/tmp").expect("create short test socket directory under /tmp");
+        Self { dir }
+    }
+
+    /// Return a SUN_LEN-safe socket path for a single socket filename.
+    pub fn socket_path(&self, name: &str) -> PathBuf {
+        let requested = Path::new(name);
+        assert!(
+            !requested.is_absolute() && requested.parent().is_some_and(|parent| parent == Path::new("")),
+            "test socket name must be a filename; use TestSocketDir::socket_path with a short socket filename"
+        );
+
+        let path = self.dir.path().join(requested);
+        let path_len = path.as_os_str().as_encoded_bytes().len();
+        assert!(
+            path_len <= MAX_UNIX_SOCKET_PATH_BYTES,
+            "test Unix socket path {} is {path_len} bytes, exceeding the cross-platform SUN_LEN limit of {MAX_UNIX_SOCKET_PATH_BYTES}; use TestSocketDir::socket_path with a shorter socket filename instead of TMPDIR or CARGO_TARGET_TMPDIR",
+            path.display(),
+        );
+        path
+    }
+
+    /// The short directory backing this socket harness.
+    pub fn path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+impl Default for TestSocketDir {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_paths_are_created_under_tmp_and_are_sun_len_safe() {
+        let dir = TestSocketDir::new();
+        let socket = dir.socket_path("daemon.sock");
+
+        assert!(socket.starts_with("/tmp"));
+        assert!(socket.as_os_str().as_encoded_bytes().len() <= MAX_UNIX_SOCKET_PATH_BYTES);
+    }
+
+    #[test]
+    #[should_panic(expected = "cross-platform SUN_LEN limit")]
+    fn socket_paths_over_sun_len_name_the_harness_fix() {
+        let dir = TestSocketDir::new();
+        let name = "x".repeat(MAX_UNIX_SOCKET_PATH_BYTES);
+
+        let _ = dir.socket_path(&name);
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared short `/tmp/flt-*` Unix-socket test harness with an actionable SUN_LEN guard
- migrate every real Unix-socket binding test to the harness
- document that socket tests are independent of repo-local `TMPDIR`

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR=<258-byte path> cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- focused `flotilla-client` and `flotilla-manifest` suites with repo-local `TMPDIR`

Fixes #836