### PR TITLE
[codex] feat: dispatch selected issues as convoys

### DIFF
--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -427,11 +427,9 @@ fn write_attach_hosts_config(config_base: &Path, hosts: &[(&str, &str, Option<&s
 }
 
 fn non_local_attach_hosts() -> (&'static str, &'static str) {
-    if HostName::local().as_str() == "feta" {
-        ("kiwi", "gouda")
-    } else {
-        ("feta", "gouda")
-    }
+    let local = HostName::local();
+    let mut candidates = ["feta", "gouda", "kiwi"].into_iter().filter(|host| *host != local.as_str());
+    (candidates.next().expect("first non-local host"), candidates.next().expect("second non-local host"))
 }
 
 async fn publish_attach_host_summary(daemon: &InProcessDaemon, node_name: &str, host_name: &str) {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -426,6 +426,14 @@ fn write_attach_hosts_config(config_base: &Path, hosts: &[(&str, &str, Option<&s
     std::fs::write(config_base.join("hosts.toml"), toml).expect("write hosts config");
 }
 
+fn non_local_attach_hosts() -> (&'static str, &'static str) {
+    if HostName::local().as_str() == "feta" {
+        ("kiwi", "gouda")
+    } else {
+        ("feta", "gouda")
+    }
+}
+
 async fn publish_attach_host_summary(daemon: &InProcessDaemon, node_name: &str, host_name: &str) {
     daemon
         .host_registry
@@ -1473,10 +1481,12 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+    let (remote_host, _) = non_local_attach_hosts();
+    let remote_hostname = format!("{remote_host}.local");
+    write_attach_hosts_config(&config_base, &[(remote_host, &remote_hostname, Some("alice"))]);
 
     let daemon = new_attach_test_daemon(&config_base).await;
-    let env_ref = create_remote_attach_environment(&daemon, "feta").await;
+    let env_ref = create_remote_attach_environment(&daemon, remote_host).await;
     create_running_attach_session(
         &daemon,
         &env_ref,
@@ -1504,7 +1514,7 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
     let CommandValue::AttachCommandResolved { command, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "command should target the next host over SSH: {command}");
+    assert!(command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")), "command should target the next host over SSH: {command}");
     assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
     assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach: {command}");
     assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
@@ -1518,16 +1528,18 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+    let (remote_host, _) = non_local_attach_hosts();
+    let remote_hostname = format!("{remote_host}.local");
+    write_attach_hosts_config(&config_base, &[(remote_host, &remote_hostname, Some("alice"))]);
 
     let daemon = new_attach_test_daemon(&config_base).await;
-    daemon.fleet_replica_cache.write().await.insert(HostName::new("feta"), FleetReplicaCacheEntry {
+    daemon.fleet_replica_cache.write().await.insert(HostName::new(remote_host), FleetReplicaCacheEntry {
         rows: vec![FleetListRow::builder()
             .convoy("convoy-a".to_string())
             .vessel("remote-env".to_string())
             .crew("implement/coder".to_string())
             .crew_state("running".to_string())
-            .host(HostName::new("feta"))
+            .host(HostName::new(remote_host))
             .namespace("dev")
             .session("terminal-remote-coder")
             .staleness(FleetStaleness::Stale { last_sync: Utc::now() - chrono::Duration::seconds(FLEET_REPLICA_FRESH_SECS + 1) })
@@ -1555,13 +1567,16 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
         panic!("expected attach command, got {result:?}");
     };
     let binding = binding.expect("replica resolution carries the structured binding");
-    assert_eq!(binding.host.as_str(), "feta");
+    assert_eq!(binding.host.as_str(), remote_host);
     assert_eq!(binding.namespace, "dev");
     assert_eq!(binding.session.as_deref(), Some("terminal-remote-coder"), "cross-host panes stamp the full join key");
     assert_eq!(binding.convoy.as_deref(), Some("convoy-a"));
     assert_eq!(binding.vessel.as_deref(), Some("implement"));
     assert_eq!(binding.role.as_deref(), Some("coder"));
-    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "command should target the replica host over SSH: {command}");
+    assert!(
+        command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")),
+        "command should target the replica host over SSH: {command}"
+    );
     assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
     assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach: {command}");
     assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
@@ -1582,7 +1597,10 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
     let CommandValue::AttachCommandResolved { command, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "bare role should resolve through the replica host: {command}");
+    assert!(
+        command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")),
+        "bare role should resolve through the replica host: {command}"
+    );
     assert!(command.contains("flotilla attach"), "bare role should recursively invoke flotilla attach: {command}");
     assert!(command.contains("coder"), "command should preserve the original bare role reference: {command}");
 
@@ -1602,7 +1620,10 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
     let CommandValue::AttachCommandResolved { command, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "session name should resolve through the replica host: {command}");
+    assert!(
+        command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")),
+        "session name should resolve through the replica host: {command}"
+    );
     assert!(command.contains("terminal-remote-coder"), "command should preserve the independent row's attach reference: {command}");
 }
 
@@ -1612,10 +1633,13 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice")), ("gouda", "gouda.local", None)]);
+    let (selected_host, other_host) = non_local_attach_hosts();
+    let selected_hostname = format!("{selected_host}.local");
+    let other_hostname = format!("{other_host}.local");
+    write_attach_hosts_config(&config_base, &[(selected_host, &selected_hostname, Some("alice")), (other_host, &other_hostname, None)]);
 
     let daemon = new_attach_test_daemon(&config_base).await;
-    for host in ["feta", "gouda"] {
+    for host in [selected_host, other_host] {
         let host_name = HostName::new(host);
         let row = IndependentRow::builder()
             .resource(ResourceRef::new("flotilla.work/v1", "TerminalSession", "dev", "terminal-scratch").on_host(host_name.clone()))
@@ -1624,7 +1648,7 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
             .attach("terminal-scratch")
             .phase(SessionPhase::Running)
             .build();
-        let fleet_rows = (host == "feta")
+        let fleet_rows = (host == selected_host)
             .then(|| {
                 FleetListRow::builder()
                     .convoy("-")
@@ -1654,7 +1678,10 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::AttachTransient { reference: "terminal-scratch".to_string(), host: Some(HostName::new("feta")) },
+                action: CommandAction::AttachTransient {
+                    reference: "terminal-scratch".to_string(),
+                    host: Some(HostName::new(selected_host)),
+                },
             },
             uuid::Uuid::new_v4(),
         )
@@ -1665,14 +1692,17 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
         panic!("expected attach command, got {result:?}");
     };
     let binding = binding.expect("replica resolution carries a structured binding");
-    assert_eq!(binding.host, HostName::new("feta"));
+    assert_eq!(binding.host, HostName::new(selected_host));
     assert_eq!(binding.session.as_deref(), Some("terminal-scratch"));
     assert_eq!(binding.convoy, None);
     assert_eq!(binding.role, None);
-    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "selected row should route through feta: {command}");
+    assert!(
+        command.starts_with(&format!("ssh -t 'alice@{selected_hostname}' ")),
+        "selected row should route through {selected_host}: {command}"
+    );
     assert!(command.contains("--transient"), "recursive attach must preserve the no-stamp mode: {command}");
     assert!(command.contains("--host"), "recursive attach must preserve the owning host: {command}");
-    assert!(!command.contains("gouda.local"), "same-named row on another host must not make selection ambiguous: {command}");
+    assert!(!command.contains(&other_hostname), "same-named row on another host must not make selection ambiguous: {command}");
 }
 
 #[tokio::test]
@@ -1725,22 +1755,25 @@ async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+    let (next_hop_host, target_host) = non_local_attach_hosts();
+    let next_hop_hostname = format!("{next_hop_host}.local");
+    let target_hostname = format!("{target_host}.local");
+    write_attach_hosts_config(&config_base, &[(next_hop_host, &next_hop_hostname, Some("alice"))]);
 
     let daemon = new_attach_test_daemon(&config_base).await;
-    publish_attach_host_summary(&daemon, "feta", "feta").await;
-    publish_attach_host_summary(&daemon, "gouda", "gouda").await;
+    publish_attach_host_summary(&daemon, next_hop_host, next_hop_host).await;
+    publish_attach_host_summary(&daemon, target_host, target_host).await;
     daemon
         .set_topology_routes(vec![TopologyRoute {
-            target: node("gouda"),
-            next_hop: node("feta"),
+            target: node(target_host),
+            next_hop: node(next_hop_host),
             direct: false,
             connected: true,
             fallbacks: vec![],
         }])
         .await;
 
-    let env_ref = create_remote_attach_environment(&daemon, "gouda").await;
+    let env_ref = create_remote_attach_environment(&daemon, target_host).await;
     create_running_attach_session(
         &daemon,
         &env_ref,
@@ -1768,10 +1801,10 @@ async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
     let CommandValue::AttachCommandResolved { command, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert!(command.starts_with("ssh -t 'alice@feta.local' "), "command should target the routed next hop: {command}");
+    assert!(command.starts_with(&format!("ssh -t 'alice@{next_hop_hostname}' ")), "command should target the routed next hop: {command}");
     assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
     assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach on the next hop: {command}");
-    assert!(!command.contains("gouda.local"), "command should not try to jump directly to the final host: {command}");
+    assert!(!command.contains(&target_hostname), "command should not try to jump directly to the final host: {command}");
     assert!(!command.contains("gouda-provider-session"), "command should not embed final terminal-provider attach args: {command}");
 }
 
@@ -1967,13 +2000,15 @@ async fn attach_query_reports_route_that_points_back_to_local_host() {
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+    let (remote_host, _) = non_local_attach_hosts();
+    let remote_hostname = format!("{remote_host}.local");
+    write_attach_hosts_config(&config_base, &[(remote_host, &remote_hostname, Some("alice"))]);
 
     let daemon = new_attach_test_daemon(&config_base).await;
-    publish_attach_host_summary(&daemon, "feta", "feta").await;
+    publish_attach_host_summary(&daemon, remote_host, remote_host).await;
     daemon
         .set_topology_routes(vec![TopologyRoute {
-            target: node("feta"),
+            target: node(remote_host),
             next_hop: NodeInfo::new(daemon.node_id().clone(), "local"),
             direct: false,
             connected: true,
@@ -1981,7 +2016,7 @@ async fn attach_query_reports_route_that_points_back_to_local_host() {
         }])
         .await;
 
-    let env_ref = create_remote_attach_environment(&daemon, "feta").await;
+    let env_ref = create_remote_attach_environment(&daemon, remote_host).await;
     create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
         .await;
 
@@ -1999,7 +2034,7 @@ async fn attach_query_reports_route_that_points_back_to_local_host() {
         .expect("attach query should execute");
 
     assert_eq!(result, CommandValue::Error {
-        message: "unreachable next hop for host 'feta': route points back to local host".to_string()
+        message: format!("unreachable next hop for host '{remote_host}': route points back to local host")
     });
 }
 
@@ -2011,10 +2046,11 @@ async fn attach_query_reports_ambiguous_routed_host_name() {
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
 
     let daemon = new_attach_test_daemon(&config_base).await;
-    publish_attach_host_summary(&daemon, "feta-a", "feta").await;
-    publish_attach_host_summary(&daemon, "feta-b", "feta").await;
+    let (remote_host, _) = non_local_attach_hosts();
+    publish_attach_host_summary(&daemon, &format!("{remote_host}-a"), remote_host).await;
+    publish_attach_host_summary(&daemon, &format!("{remote_host}-b"), remote_host).await;
 
-    let env_ref = create_remote_attach_environment(&daemon, "feta").await;
+    let env_ref = create_remote_attach_environment(&daemon, remote_host).await;
     create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
         .await;
 
@@ -2031,7 +2067,7 @@ async fn attach_query_reports_ambiguous_routed_host_name() {
         .await
         .expect("attach query should execute");
 
-    assert_eq!(result, CommandValue::Error { message: "host name 'feta' matches multiple routed nodes".to_string() });
+    assert_eq!(result, CommandValue::Error { message: format!("host name '{remote_host}' matches multiple routed nodes") });
 }
 
 #[tokio::test]

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -21,7 +21,10 @@ use crate::{
 /// request starts so the renderer can show an indicator while the daemon
 /// acknowledgement is outstanding.
 pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionContext>, event_tx: mpsc::UnboundedSender<Event>) {
-    app.set_status_message(None);
+    let project_issue_start = pending_ctx.as_ref().is_some_and(|ctx| ctx.project_issue_start.is_some());
+    if !project_issue_start {
+        app.set_status_message(None);
+    }
 
     // Pane attach is a query that resolves a command for the TUI process to
     // run temporarily outside raw mode. It must not go through the ordinary
@@ -284,7 +287,7 @@ mod tests {
     use flotilla_protocol::{
         arg::Arg,
         qualified_path::{HostId, QualifiedPath},
-        CheckoutStatus, HostName, NodeId, RepoIdentity, ResolvedPaneCommand, WorkItemIdentity,
+        CheckoutStatus, HostName, IssueRef, IssueSource, NodeId, RepoIdentity, ResolvedPaneCommand, ViewAddress, WorkItemIdentity,
     };
     use ratatui::{backend::TestBackend, Terminal};
     use tokio::sync::{mpsc, Semaphore};
@@ -411,6 +414,37 @@ mod tests {
         assert!(matches!(app.screen.repo_pages[&repo_identity].pending_actions[&identity].status, PendingStatus::InFlight {
             command_id: 1
         }));
+    }
+
+    #[tokio::test]
+    async fn project_issue_dispatch_preserves_batch_start_status() {
+        let execute_gate = Arc::new(Semaphore::new(0));
+        let daemon = Arc::new(StubDaemon::builder().execute_gate(Arc::clone(&execute_gate)).build());
+        let mut app =
+            stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
+        let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+        app.open_view(address.clone());
+        let batch_id = app.begin_project_issue_start_batch(2);
+        let issue = IssueRef {
+            source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+            id: "809".into(),
+        };
+        let pending_ctx = PendingActionContext {
+            identity: WorkItemIdentity::Issue("809".into()),
+            description: "Start convoy".into(),
+            repo_identity: RepoIdentity { authority: "project".into(), path: address.to_string() },
+            project_issue_start: Some(crate::app::ui_state::ProjectIssueStartContext {
+                address,
+                row_id: crate::table_view::RowId::new("issue:809"),
+                issue,
+                batch_id,
+            }),
+        };
+        let (event_tx, _event_rx) = mpsc::unbounded_channel();
+
+        dispatch(app.command(CommandAction::Refresh { repo: None }), &mut app, Some(pending_ctx), event_tx);
+
+        assert_eq!(app.model.status_message.as_deref(), Some("Starting 2 convoys..."));
     }
 
     #[tokio::test]

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -54,7 +54,9 @@ pub fn dispatch(cmd: Command, app: &mut App, pending_ctx: Option<PendingActionCo
 
     if let Some(ctx) = &pending_ctx {
         let action = PendingAction { status: PendingStatus::Submitting, description: ctx.description.clone() };
-        if let Some(page) = app.screen.repo_pages.get_mut(&ctx.repo_identity) {
+        if let Some(project_ctx) = &ctx.project_issue_start {
+            app.set_project_issue_start_pending(project_ctx, PendingStatus::Submitting, ctx.description.clone());
+        } else if let Some(page) = app.screen.repo_pages.get_mut(&ctx.repo_identity) {
             if page
                 .pending_actions
                 .get(&ctx.identity)
@@ -86,22 +88,42 @@ pub fn handle_dispatch_completion(result: Result<u64, String>, pending_ctx: Opti
             let finished_error = app.recent_command_finishes.remove(&command_id);
             if let Some(finished_error) = finished_error {
                 if let Some(ctx) = pending_ctx {
-                    match finished_error {
-                        Some(message) => set_pending_status(app, &ctx, PendingStatus::Failed(message)),
-                        None => remove_pending_action(app, &ctx),
+                    if let Some(project_ctx) = ctx.project_issue_start {
+                        match finished_error {
+                            Some(message) => app.record_project_issue_start_result(project_ctx, Err(message)),
+                            None => app.record_project_issue_start_result(project_ctx, Ok(None)),
+                        }
+                    } else {
+                        match finished_error {
+                            Some(message) => set_pending_status(app, &ctx, PendingStatus::Failed(message)),
+                            None => remove_pending_action(app, &ctx),
+                        }
                     }
                 }
             } else if let Some(ctx) = pending_ctx {
                 app.acknowledged_dispatches.insert(command_id);
-                set_pending_status(app, &ctx, PendingStatus::InFlight { command_id });
+                if let Some(project_ctx) = &ctx.project_issue_start {
+                    app.command_project_issue_starts.insert(command_id, project_ctx.clone());
+                    app.set_project_issue_start_pending(project_ctx, PendingStatus::InFlight { command_id }, ctx.description.clone());
+                } else {
+                    set_pending_status(app, &ctx, PendingStatus::InFlight { command_id });
+                }
             }
         }
         Err(message) => {
+            let mut handled_by_project_batch = false;
             if let Some(ctx) = pending_ctx {
-                remove_pending_action(app, &ctx);
+                if let Some(project_ctx) = ctx.project_issue_start {
+                    app.record_project_issue_start_result(project_ctx, Err(message.clone()));
+                    handled_by_project_batch = true;
+                } else {
+                    remove_pending_action(app, &ctx);
+                }
             }
             reset_loading_mode(app);
-            app.set_status_message(Some(message));
+            if !handled_by_project_batch {
+                app.set_status_message(Some(message));
+            }
         }
     }
 
@@ -291,8 +313,12 @@ mod tests {
         let identity = WorkItemIdentity::Session("session-1".into());
         activate_repo_tab(&mut app, 0);
         setup_selectable_table(&mut app, vec![session_item("session-1")]);
-        let pending_ctx =
-            PendingActionContext { identity: identity.clone(), description: "Refresh".into(), repo_identity: repo_identity.clone() };
+        let pending_ctx = PendingActionContext {
+            identity: identity.clone(),
+            description: "Refresh".into(),
+            repo_identity: repo_identity.clone(),
+            project_issue_start: None,
+        };
         let mut events = EventHandler::new(Duration::from_secs(60));
         events.pause_terminal_input().await;
 
@@ -358,8 +384,12 @@ mod tests {
             stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
         let repo_identity = app.model.repo_order[0].clone();
         let identity = WorkItemIdentity::Session("session-1".into());
-        let pending_ctx =
-            PendingActionContext { identity: identity.clone(), description: "Refresh".into(), repo_identity: repo_identity.clone() };
+        let pending_ctx = PendingActionContext {
+            identity: identity.clone(),
+            description: "Refresh".into(),
+            repo_identity: repo_identity.clone(),
+            project_issue_start: None,
+        };
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
 
         dispatch(app.command(CommandAction::Refresh { repo: None }), &mut app, Some(pending_ctx.clone()), event_tx.clone());
@@ -413,8 +443,12 @@ mod tests {
             stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
         let repo_identity = app.model.repo_order[0].clone();
         let identity = WorkItemIdentity::Session("session-1".into());
-        let pending_ctx =
-            PendingActionContext { identity: identity.clone(), description: "Delete session".into(), repo_identity: repo_identity.clone() };
+        let pending_ctx = PendingActionContext {
+            identity: identity.clone(),
+            description: "Delete session".into(),
+            repo_identity: repo_identity.clone(),
+            project_issue_start: None,
+        };
         app.screen.modal_stack.push(Box::new(DeleteConfirmWidget::new(identity.clone(), None, None)));
         let command = app.command(CommandAction::Refresh { repo: None });
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
@@ -443,6 +477,7 @@ mod tests {
             identity: identity.clone(),
             description: "Archive session".into(),
             repo_identity: repo_identity.clone(),
+            project_issue_start: None,
         };
         app.screen
             .repo_pages
@@ -484,6 +519,7 @@ mod tests {
             identity: identity.clone(),
             description: "Archive session".into(),
             repo_identity: repo_identity.clone(),
+            project_issue_start: None,
         };
         app.screen
             .repo_pages
@@ -531,6 +567,7 @@ mod tests {
             identity: identity.clone(),
             description: "Archive session".into(),
             repo_identity: repo_identity.clone(),
+            project_issue_start: None,
         };
         app.screen
             .repo_pages
@@ -576,6 +613,7 @@ mod tests {
             identity: identity.clone(),
             description: "Archive session".into(),
             repo_identity: repo_identity.clone(),
+            project_issue_start: None,
         };
         app.screen
             .repo_pages

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -1,5 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
-use flotilla_protocol::{Command, CommandAction, ConvoyStartIntent, HostName, IssueSelector, NodeId, RepoIdentity, RepoKey, WorkItem};
+use flotilla_protocol::{
+    Command, CommandAction, ConvoyStartIntent, HostName, IssueSelector, NodeId, RepoIdentity, RepoKey, WorkItem, WorkItemIdentity,
+};
 
 use super::{ui_state::PendingActionContext, App, BranchInputKind, Intent, OwnedSelectedRow};
 use crate::{
@@ -318,6 +320,7 @@ impl App {
                                 identity: item.identity.clone(),
                                 description: intent.label(self.model.active_labels()),
                                 repo_identity: self.model.active_repo_identity().clone(),
+                                project_issue_start: None,
                             };
                             self.proto_commands.push_with_context(cmd, Some(pending_ctx));
                             return;
@@ -369,6 +372,7 @@ impl App {
                 identity: item.identity.clone(),
                 description: intent.label(self.model.active_labels()),
                 repo_identity: self.model.active_repo_identity().clone(),
+                project_issue_start: None,
             };
             self.proto_commands.push_with_context(cmd, Some(pending_ctx));
         }
@@ -445,6 +449,44 @@ impl App {
                         auto_attach: true,
                     }),
                 }));
+                return;
+            }
+            TableIntent::StartConvoys { namespace, project, issues } => {
+                let Some(address) = self.views.active_address().cloned() else { return };
+                let batch_id = self.begin_project_issue_start_batch(issues.len());
+                for issue in issues {
+                    let command = self.command(CommandAction::ConvoyStart {
+                        intent: Box::new(ConvoyStartIntent {
+                            namespace: Some(namespace.clone()),
+                            project_ref: project.clone(),
+                            issue: Some(IssueSelector::Reference(issue.issue.clone())),
+                            name: None,
+                            branch: None,
+                            workflow_ref: None,
+                            inputs: Vec::new(),
+                            instruction: None,
+                            placement_policy: None,
+                            auto_attach: true,
+                        }),
+                    });
+                    let pending_ctx = PendingActionContext {
+                        identity: WorkItemIdentity::Issue(issue.issue.id.clone()),
+                        description: "Start convoy".into(),
+                        repo_identity: RepoIdentity { authority: "project".into(), path: address.to_string() },
+                        project_issue_start: Some(crate::app::ui_state::ProjectIssueStartContext {
+                            address: address.clone(),
+                            row_id: issue.row_id,
+                            issue: issue.issue,
+                            batch_id,
+                        }),
+                    };
+                    self.proto_commands.push_with_context(command, Some(pending_ctx));
+                }
+                if let Some(index) = self.views.find(&address) {
+                    if let Some(view) = self.views.get_mut(index) {
+                        view.project_table_state.table_mut(crate::table_view::ProjectPanelKind::Issues).multi_selected.clear();
+                    }
+                }
                 return;
             }
         };

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -466,7 +466,7 @@ impl App {
                             inputs: Vec::new(),
                             instruction: None,
                             placement_policy: None,
-                            auto_attach: true,
+                            auto_attach: false,
                         }),
                     });
                     let pending_ctx = PendingActionContext {

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -33,7 +33,7 @@ pub use open_views::{OpenView, OpenViews, ViewTarget};
 use tokio::sync::mpsc;
 use tui_input::Input;
 use ui_state::PendingStatus;
-pub use ui_state::{BranchInputKind, DirEntry, RepoViewLayout, TabId, UiState};
+pub use ui_state::{BranchInputKind, DirEntry, ProjectIssueStartContext, RepoViewLayout, TabId, UiState};
 
 use crate::{
     convoy_model::{ConvoyId, ConvoySummary},
@@ -361,6 +361,13 @@ pub struct InFlightCommand {
     pub description: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct ProjectIssueStartBatch {
+    total: usize,
+    started: usize,
+    rejected: Vec<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VisibleStatusItem {
     pub id: usize,
@@ -446,6 +453,9 @@ pub struct App {
     /// unrelated finishes may appear here temporarily; the map is cleared as
     /// soon as this TUI has no acknowledgements left to reconcile.
     pub recent_command_finishes: HashMap<u64, Option<String>>,
+    pub next_project_issue_start_batch_id: u64,
+    pub project_issue_start_batches: HashMap<u64, ProjectIssueStartBatch>,
+    pub command_project_issue_starts: HashMap<u64, ProjectIssueStartContext>,
     pub pending_cancel: Option<u64>,
     pub should_quit: bool,
     pub screen: crate::widgets::screen::Screen,
@@ -551,6 +561,9 @@ impl App {
             acknowledged_dispatches: HashSet::new(),
             pending_dispatch_acks: 0,
             recent_command_finishes: HashMap::new(),
+            next_project_issue_start_batch_id: 1,
+            project_issue_start_batches: HashMap::new(),
+            command_project_issue_starts: HashMap::new(),
             pending_cancel: None,
             should_quit: false,
             screen,
@@ -612,6 +625,13 @@ impl App {
         }) {
             return true;
         }
+        if self.views.iter().any(|view| {
+            view.project_table_state.tables().iter().any(|table| {
+                table.pending_actions.values().any(|a| matches!(a.status, PendingStatus::Submitting | PendingStatus::InFlight { .. }))
+            })
+        }) {
+            return true;
+        }
         // Check modal stack for loading states
         if let Some(widget) = self.screen.modal_stack.last() {
             if let Some(biw) = widget.as_any().downcast_ref::<crate::widgets::branch_input::BranchInputWidget>() {
@@ -626,6 +646,71 @@ impl App {
             }
         }
         false
+    }
+
+    pub(crate) fn begin_project_issue_start_batch(&mut self, total: usize) -> u64 {
+        let batch_id = self.next_project_issue_start_batch_id;
+        self.next_project_issue_start_batch_id += 1;
+        self.project_issue_start_batches.insert(batch_id, ProjectIssueStartBatch { total, started: 0, rejected: Vec::new() });
+        self.set_status_message(Some(format!("Starting {total} convoys...")));
+        batch_id
+    }
+
+    pub(crate) fn set_project_issue_start_pending(&mut self, ctx: &ProjectIssueStartContext, status: PendingStatus, description: String) {
+        let Some(index) = self.views.find(&ctx.address) else { return };
+        let Some(view) = self.views.get_mut(index) else { return };
+        view.project_table_state
+            .table_mut(crate::table_view::ProjectPanelKind::Issues)
+            .pending_actions
+            .insert(ctx.row_id.clone(), ui_state::PendingAction { status, description });
+    }
+
+    pub(crate) fn clear_project_issue_start_pending(&mut self, ctx: &ProjectIssueStartContext) {
+        let Some(index) = self.views.find(&ctx.address) else { return };
+        let Some(view) = self.views.get_mut(index) else { return };
+        view.project_table_state.table_mut(crate::table_view::ProjectPanelKind::Issues).pending_actions.remove(&ctx.row_id);
+    }
+
+    pub(crate) fn record_project_issue_start_result(&mut self, ctx: ProjectIssueStartContext, result: Result<Option<String>, String>) {
+        match result {
+            Ok(_) => {
+                self.clear_project_issue_start_pending(&ctx);
+                if let Some(batch) = self.project_issue_start_batches.get_mut(&ctx.batch_id) {
+                    batch.started += 1;
+                }
+            }
+            Err(message) => {
+                self.set_project_issue_start_pending(&ctx, PendingStatus::Failed(message.clone()), "Start convoy".into());
+                if let Some(batch) = self.project_issue_start_batches.get_mut(&ctx.batch_id) {
+                    batch.rejected.push(format!("{}: {message}", ctx.issue.id));
+                }
+            }
+        }
+        self.update_project_issue_start_status(ctx.batch_id);
+    }
+
+    fn update_project_issue_start_status(&mut self, batch_id: u64) {
+        let Some(batch) = self.project_issue_start_batches.get(&batch_id) else { return };
+        let rejected = batch.rejected.len();
+        let pending = batch.total.saturating_sub(batch.started + rejected);
+        let convoy_word = if batch.started == 1 { "convoy" } else { "convoys" };
+        let mut message = format!("{} {convoy_word} started", batch.started);
+        if pending > 0 {
+            message.push_str(&format!(", {pending} pending"));
+        }
+        if rejected > 0 {
+            message.push_str(&format!(", {rejected} rejected"));
+            if let Some(first) = batch.rejected.first() {
+                message.push_str(&format!(": {first}"));
+                if rejected > 1 {
+                    message.push_str(&format!("; +{} more", rejected - 1));
+                }
+            }
+        }
+        self.set_status_message(Some(message));
+        if pending == 0 {
+            self.project_issue_start_batches.remove(&batch_id);
+        }
     }
 
     pub fn persist_layout(&self) {
@@ -1264,7 +1349,22 @@ impl App {
                             None
                         }
                     };
-                    executor::handle_result(result, self);
+                    let project_issue_start = self.command_project_issue_starts.remove(&command_id);
+                    executor::handle_result(result.clone(), self);
+                    if let Some(ctx) = project_issue_start {
+                        match result {
+                            CommandValue::ConvoyStarted { name, .. } => {
+                                self.record_project_issue_start_result(ctx, Ok(Some(name)));
+                            }
+                            CommandValue::Error { message } => {
+                                self.record_project_issue_start_result(ctx, Err(message));
+                            }
+                            CommandValue::Cancelled => {
+                                self.record_project_issue_start_result(ctx, Err("cancelled".into()));
+                            }
+                            _ => {}
+                        }
+                    }
 
                     // Find which repo+identity has this command_id
                     let found: Option<(RepoIdentity, WorkItemIdentity)> =

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2257,11 +2257,12 @@ fn project_issue_bulk_start_queues_one_convoy_start_per_issue() {
     while let Some((command, ctx)) = app.proto_commands.take_next() {
         let CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
         let Some(project_ctx) = ctx.expect("pending context").project_issue_start else { panic!("expected project context") };
-        queued.push((intent.issue, project_ctx.issue.id));
+        queued.push((intent.issue, project_ctx.issue.id, intent.auto_attach));
     }
 
     assert_eq!(queued.len(), 3);
-    assert_eq!(queued.iter().map(|(_, id)| id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
+    assert_eq!(queued.iter().map(|(_, id, _)| id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
+    assert!(queued.iter().all(|(_, _, auto_attach)| !auto_attach), "bulk convoy starts should not auto-attach one selected issue");
     assert_eq!(app.model.status_message.as_deref(), Some("Starting 3 convoys..."));
 }
 

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -68,6 +68,14 @@ fn insert_peer_host(model: &mut TuiModel, name: &str, status: PeerStatus) {
     insert_host(model, name, environment_id, NodeId::new(format!("node-{name}-peer")), name, false, status);
 }
 
+fn non_local_test_host() -> &'static str {
+    if HostName::local().as_str() == "feta" {
+        "kiwi"
+    } else {
+        "feta"
+    }
+}
+
 #[derive(Clone)]
 struct QueryStep {
     expected_page: u32,
@@ -1129,6 +1137,7 @@ fn command_queue_push_with_context() {
         identity: WorkItemIdentity::Session("s1".into()),
         description: "Archive session".into(),
         repo_identity: RepoIdentity { authority: "local".into(), path: "/tmp/test-repo".into() },
+        project_issue_start: None,
     };
     q.push_with_context(
         Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::Refresh { repo: None } },
@@ -2181,10 +2190,11 @@ fn independent_view_subscribes_and_generates_a_pane_attach_query() {
 fn generated_vessel_actions_route_to_the_vessels_host() {
     let mut app = stub_app();
     let repo_identity = app.model.repo_order[0].clone();
-    insert_peer_host(&mut app.model, "feta", PeerStatus::Connected);
+    let peer = non_local_test_host();
+    insert_peer_host(&mut app.model, peer, PeerStatus::Connected);
     let mut convoy = convoy_with_vessels("alpha", &["implement"]);
-    convoy.vessels[0].host = Some(HostName::new("feta"));
-    convoy.vessels[0].completion_target.as_mut().expect("completion capability").host = HostName::new("feta");
+    convoy.vessels[0].host = Some(HostName::new(peer));
+    convoy.vessels[0].completion_target.as_mut().expect("completion capability").host = HostName::new(peer);
     app.handle_daemon_event(result_set_event(Box::new(snapshot_with(vec![convoy]))));
     app.switch_tab(1);
     app.handle_key(key(KeyCode::Enter));
@@ -2193,7 +2203,7 @@ fn generated_vessel_actions_route_to_the_vessels_host() {
     app.handle_key(key(KeyCode::Enter));
 
     let command = app.proto_commands.take_next().expect("remote attach command").0;
-    assert_eq!(command.node_id, Some(NodeId::new("node-feta-peer")));
+    assert_eq!(command.node_id, Some(NodeId::new(format!("node-{peer}-peer"))));
     assert_eq!(command.context_repo, Some(RepoSelector::Identity(repo_identity)));
 }
 
@@ -2222,6 +2232,71 @@ fn table_action_repo_hint_matches_remote_repo_identity() {
         &identity,
         &flotilla_protocol::RepoKey("github-com-flotilla-org-flotilla".into())
     ));
+}
+
+#[test]
+fn project_issue_bulk_start_queues_one_convoy_start_per_issue() {
+    let mut app = stub_app();
+    let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+    app.open_view(address.clone());
+    let source = IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() };
+
+    app.execute_table_intent(crate::table_view::TableIntent::StartConvoys {
+        namespace: "flotilla".into(),
+        project: "roadmap".into(),
+        issues: ["809", "810", "811"]
+            .into_iter()
+            .map(|id| crate::table_view::TableIssueStart {
+                row_id: crate::table_view::RowId::new(format!("issue:{id}")),
+                issue: IssueRef { source: source.clone(), id: id.into() },
+            })
+            .collect(),
+    });
+
+    let mut queued = Vec::new();
+    while let Some((command, ctx)) = app.proto_commands.take_next() {
+        let CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
+        let Some(project_ctx) = ctx.expect("pending context").project_issue_start else { panic!("expected project context") };
+        queued.push((intent.issue, project_ctx.issue.id));
+    }
+
+    assert_eq!(queued.len(), 3);
+    assert_eq!(queued.iter().map(|(_, id)| id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
+    assert_eq!(app.model.status_message.as_deref(), Some("Starting 3 convoys..."));
+}
+
+#[test]
+fn project_issue_start_batch_keeps_success_and_rejection_visible_individually() {
+    let mut app = stub_app();
+    let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+    app.open_view(address.clone());
+    let source = IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() };
+    let batch_id = app.begin_project_issue_start_batch(2);
+    let started = ProjectIssueStartContext {
+        address: address.clone(),
+        row_id: crate::table_view::RowId::new("issue:809"),
+        issue: IssueRef { source: source.clone(), id: "809".into() },
+        batch_id,
+    };
+    let rejected = ProjectIssueStartContext {
+        address,
+        row_id: crate::table_view::RowId::new("issue:810"),
+        issue: IssueRef { source, id: "810".into() },
+        batch_id,
+    };
+    app.set_project_issue_start_pending(&started, PendingStatus::InFlight { command_id: 1 }, "Start convoy".into());
+    app.set_project_issue_start_pending(&rejected, PendingStatus::InFlight { command_id: 2 }, "Start convoy".into());
+
+    app.record_project_issue_start_result(started.clone(), Ok(Some("issue-809".into())));
+    app.record_project_issue_start_result(rejected.clone(), Err("missing workflow input".into()));
+
+    let issue_state = app.views.active_project_table_state().table(crate::table_view::ProjectPanelKind::Issues);
+    assert!(!issue_state.pending_actions.contains_key(&started.row_id));
+    assert!(matches!(
+        issue_state.pending_actions[&rejected.row_id].status,
+        PendingStatus::Failed(ref message) if message == "missing workflow input"
+    ));
+    assert_eq!(app.model.status_message.as_deref(), Some("1 convoy started, 1 rejected: 810: missing workflow input"));
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/ui_state.rs
+++ b/crates/flotilla-tui/src/app/ui_state.rs
@@ -1,9 +1,9 @@
 use std::collections::{BTreeMap, HashSet};
 
-use flotilla_protocol::{HostName, ProvisioningTarget, RepoIdentity, WorkItemIdentity};
+use flotilla_protocol::{HostName, IssueRef, ProvisioningTarget, RepoIdentity, ViewAddress, WorkItemIdentity};
 use ratatui::layout::Rect;
 
-use crate::status_bar::StatusBarTarget;
+use crate::{status_bar::StatusBarTarget, table_view::RowId};
 
 #[derive(Clone)]
 pub struct DirEntry {
@@ -31,14 +31,14 @@ pub enum RepoViewLayout {
     Below,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PendingStatus {
     Submitting,
     InFlight { command_id: u64 },
     Failed(String),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PendingAction {
     pub status: PendingStatus,
     pub description: String,
@@ -49,6 +49,15 @@ pub struct PendingActionContext {
     pub identity: WorkItemIdentity,
     pub description: String,
     pub repo_identity: RepoIdentity,
+    pub project_issue_start: Option<ProjectIssueStartContext>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProjectIssueStartContext {
+    pub address: ViewAddress,
+    pub row_id: RowId,
+    pub issue: IssueRef,
+    pub batch_id: u64,
 }
 
 /// Identifies a clickable segment in the tab bar.

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -172,6 +172,7 @@ pub static BINDINGS: &[Binding] = &[
     // [, ], q come from TabPage (composed). Keep r here: refresh semantics are tab-specific.
     h(BindingModeId::Convoys, "r", Action::Refresh, "Refresh"),
     h(BindingModeId::DemandTable, "f", Action::FetchMore, "Fetch more"),
+    h(BindingModeId::DemandTable, "space", Action::ToggleMultiSelect, "Select"),
     h(BindingModeId::Project, "tab", Action::NextPanel, "Next panel"),
     b(BindingModeId::Project, "S-tab", Action::PrevPanel),
     b(BindingModeId::Project, "backtab", Action::PrevPanel),

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -11,7 +11,10 @@ use flotilla_protocol::{
     RepositoryKey, ResultSetCondition, ResultSetState, SessionPhase, ViewAddress,
 };
 
-use crate::convoy_model::{ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase};
+use crate::{
+    app::ui_state::PendingAction,
+    convoy_model::{ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RowId(String);
@@ -20,11 +23,17 @@ impl RowId {
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, bon::Builder)]
 pub struct TableState {
     selected: Option<RowId>,
+    pub multi_selected: HashSet<RowId>,
+    pub pending_actions: HashMap<RowId, PendingAction>,
     pub filter: String,
     /// Ephemeral provider-side search for demand-backed issue tables. This is
     /// deliberately View state rather than part of the persisted address.
@@ -51,6 +60,8 @@ impl TableState {
         if !selected_exists {
             self.selected = view.rows.first().map(|row| row.id.clone());
         }
+        self.multi_selected.retain(|selected| view.rows.iter().any(|row| &row.id == selected));
+        self.pending_actions.retain(|selected, _| view.rows.iter().any(|row| &row.id == selected));
         self.scroll_offset = self.scroll_offset.min(view.rows.len().saturating_sub(1));
     }
 
@@ -91,6 +102,17 @@ impl TableState {
     pub fn selected_row<'a>(&self, view: &'a TableView) -> Option<&'a ProjectedRow> {
         let selected = self.selected.as_ref()?;
         view.rows.iter().find(|row| &row.id == selected)
+    }
+
+    pub fn selected_id(&self) -> Option<&RowId> {
+        self.selected.as_ref()
+    }
+
+    pub fn toggle_selected_row(&mut self) {
+        let Some(selected) = self.selected.clone() else { return };
+        if !self.multi_selected.remove(&selected) {
+            self.multi_selected.insert(selected);
+        }
     }
 }
 
@@ -175,6 +197,10 @@ impl ProjectTableState {
 
     pub fn active_table_mut(&mut self) -> &mut TableState {
         self.table_mut(self.active)
+    }
+
+    pub fn tables(&self) -> [&TableState; 4] {
+        [&self.convoys, &self.checkouts, &self.issues, &self.independents]
     }
 
     pub fn issue_source_search(&self) -> Option<&str> {
@@ -295,6 +321,13 @@ pub enum TableIntent {
     OpenChangeRequest { id: String, repository_key: RepositoryKey, host: Option<HostName> },
     ForceCompleteWork { convoy: String, vessel: String, host: HostName },
     StartConvoy { namespace: String, project: String, issue: IssueRef },
+    StartConvoys { namespace: String, project: String, issues: Vec<TableIssueStart> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableIssueStart {
+    pub row_id: RowId,
+    pub issue: IssueRef,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -23,10 +23,6 @@ impl RowId {
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, bon::Builder)]

--- a/crates/flotilla-tui/src/widgets/action_menu.rs
+++ b/crates/flotilla-tui/src/widgets/action_menu.rs
@@ -55,14 +55,22 @@ impl ActionMenuWidget {
                 };
                 let checkout_path = self.item.checkout_key().map(|hp| hp.path.clone());
                 let widget = DeleteConfirmWidget::new(self.item.identity.clone(), remote_node_id, checkout_path);
-                let pending_ctx =
-                    PendingActionContext { identity: self.item.identity.clone(), description: entry.intent.label(labels), repo_identity };
+                let pending_ctx = PendingActionContext {
+                    identity: self.item.identity.clone(),
+                    description: entry.intent.label(labels),
+                    repo_identity,
+                    project_issue_start: None,
+                };
                 ctx.commands.push_with_context(entry.command.clone(), Some(pending_ctx));
                 return Outcome::Swap(Box::new(widget));
             }
             Intent::GenerateBranchName => {
-                let pending_ctx =
-                    PendingActionContext { identity: self.item.identity.clone(), description: entry.intent.label(labels), repo_identity };
+                let pending_ctx = PendingActionContext {
+                    identity: self.item.identity.clone(),
+                    description: entry.intent.label(labels),
+                    repo_identity,
+                    project_issue_start: None,
+                };
                 ctx.commands.push_with_context(entry.command.clone(), Some(pending_ctx));
                 let widget = BranchInputWidget::new(BranchInputKind::Generating);
                 return Outcome::Swap(Box::new(widget));
@@ -77,8 +85,12 @@ impl ActionMenuWidget {
                 return Outcome::Swap(Box::new(widget));
             }
             _ => {
-                let pending_ctx =
-                    PendingActionContext { identity: self.item.identity.clone(), description: entry.intent.label(labels), repo_identity };
+                let pending_ctx = PendingActionContext {
+                    identity: self.item.identity.clone(),
+                    description: entry.intent.label(labels),
+                    repo_identity,
+                    project_issue_start: None,
+                };
                 ctx.commands.push_with_context(entry.command.clone(), Some(pending_ctx));
             }
         }

--- a/crates/flotilla-tui/src/widgets/close_confirm.rs
+++ b/crates/flotilla-tui/src/widgets/close_confirm.rs
@@ -36,6 +36,7 @@ impl InteractiveWidget for CloseConfirmWidget {
                     identity: self.identity.clone(),
                     description: format!("Close {}", self.id),
                     repo_identity: ctx.model.active_repo_identity().clone(),
+                    project_issue_start: None,
                 };
                 ctx.commands.push_with_context(self.command.clone(), Some(pending_ctx));
                 Outcome::Finished

--- a/crates/flotilla-tui/src/widgets/delete_confirm.rs
+++ b/crates/flotilla-tui/src/widgets/delete_confirm.rs
@@ -51,6 +51,7 @@ impl InteractiveWidget for DeleteConfirmWidget {
                         identity: self.identity.clone(),
                         description: format!("Remove {}", info.branch),
                         repo_identity: ctx.model.active_repo_identity().clone(),
+                        project_issue_start: None,
                     };
                     let checkout = match &self.checkout_path {
                         Some(path) => CheckoutSelector::Path(path.clone()),

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -12,7 +12,7 @@ use crate::{
     app::{NamespaceMap, QueryTableCache},
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
-    table_view::{self, ProjectPanel, ProjectPanelKind, ProjectTableState, RowId},
+    table_view::{self, AvailableAction, ProjectPanel, ProjectPanelKind, ProjectTableState, RowId, TableIntent, TableIssueStart},
     theme::Theme,
     ui_helpers,
 };
@@ -215,6 +215,41 @@ impl ProjectPageWidget {
         Self::active_row(layouts, state).and_then(|(_, row)| super::table::TablePanel::row_action(row))
     }
 
+    fn selected_issue_starts(layouts: &[PanelLayout<'_>], state: &ProjectTableState) -> Option<(String, String, Vec<TableIssueStart>)> {
+        let layout = layouts.iter().find(|layout| layout.panel.kind == ProjectPanelKind::Issues)?;
+        let ViewAddress::Issues { scope } = &layout.panel.target else { return None };
+        let table_state = state.table(ProjectPanelKind::Issues);
+        let mut selected = Vec::new();
+        for row in &layout.panel.table.rows {
+            if table_state.multi_selected.contains(&row.id) {
+                if let Some(issue) = issue_start_from_row(row) {
+                    selected.push(issue);
+                }
+            }
+        }
+        if let Some(row) = table_state.selected_row(&layout.panel.table) {
+            if !table_state.multi_selected.contains(&row.id) {
+                if let Some(issue) = issue_start_from_row(row) {
+                    selected.push(issue);
+                }
+            }
+        }
+        if selected.len() <= 1 {
+            return None;
+        }
+        Some((scope.namespace.clone(), scope.name.clone(), selected))
+    }
+
+    fn selected_issue_bulk_action(layouts: &[PanelLayout<'_>], state: &ProjectTableState) -> Option<AvailableAction> {
+        let (namespace, project, issues) = Self::selected_issue_starts(layouts, state)?;
+        Some(AvailableAction {
+            id: "start_convoys",
+            label: "Start convoys",
+            key: 'c',
+            intent: TableIntent::StartConvoys { namespace, project, issues },
+        })
+    }
+
     fn render_composite(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, panels: &[ProjectPanel], state: &mut ProjectTableState) {
         self.area = area;
         let layouts = Self::layouts(panels);
@@ -254,7 +289,19 @@ impl ProjectPageWidget {
                     if state.active() == layout.panel.kind && state.header_focused() {
                         unfocused_state.clear_selection();
                     }
-                    super::table::TablePanel::render_rows(frame, rows_area, theme, &layout.panel.table, &unfocused_state, first, count);
+                    let table_state = state.table(layout.panel.kind);
+                    super::table::TablePanel::render_rows(
+                        frame,
+                        rows_area,
+                        theme,
+                        &layout.panel.table,
+                        &unfocused_state,
+                        super::table::RowDecorations {
+                            multi_selected: &table_state.multi_selected,
+                            pending_actions: &table_state.pending_actions,
+                        },
+                        first..first.saturating_add(count),
+                    );
                 }
             }
         }
@@ -299,6 +346,13 @@ impl InteractiveWidget for ProjectPageWidget {
                 self.ensure_active_visible(&layouts, state);
                 Outcome::Consumed
             }
+            Action::ToggleMultiSelect => {
+                let state = ctx.views.active_project_table_state_mut();
+                if !state.header_focused() {
+                    state.active_table_mut().toggle_selected_row();
+                }
+                Outcome::Consumed
+            }
             Action::NextPanel => {
                 let state = ctx.views.active_project_table_state_mut();
                 Self::select_panel_delta(&layouts, state, 1);
@@ -334,13 +388,16 @@ impl InteractiveWidget for ProjectPageWidget {
                 Some((panel, row)) => Outcome::Push(Box::new(DescribeWidget::new(panel.table.title.clone(), row.describe.clone()))),
                 None => Outcome::Consumed,
             },
-            Action::OpenActionMenu => match Self::active_row(&layouts, ctx.views.active_project_table_state()) {
-                Some((_, row)) if !row.actions.is_empty() => Outcome::Push(Box::new(TableActionMenuWidget::new(row.actions.clone()))),
-                Some(_) => {
-                    ctx.app_actions.push(AppAction::ShowStatus("No actions available for the selected row".into()));
-                    Outcome::Consumed
-                }
-                None => Outcome::Consumed,
+            Action::OpenActionMenu => match Self::selected_issue_bulk_action(&layouts, ctx.views.active_project_table_state()) {
+                Some(action) => Outcome::Push(Box::new(TableActionMenuWidget::new(vec![action]))),
+                None => match Self::active_row(&layouts, ctx.views.active_project_table_state()) {
+                    Some((_, row)) if !row.actions.is_empty() => Outcome::Push(Box::new(TableActionMenuWidget::new(row.actions.clone()))),
+                    Some(_) => {
+                        ctx.app_actions.push(AppAction::ShowStatus("No actions available for the selected row".into()));
+                        Outcome::Consumed
+                    }
+                    None => Outcome::Consumed,
+                },
             },
             _ => Outcome::Ignored,
         }
@@ -425,6 +482,13 @@ impl InteractiveWidget for ProjectPageWidget {
     }
 }
 
+fn issue_start_from_row(row: &table_view::ProjectedRow) -> Option<TableIssueStart> {
+    row.actions.iter().find_map(|action| match &action.intent {
+        TableIntent::StartConvoy { issue, .. } => Some(TableIssueStart { row_id: row.id.clone(), issue: issue.clone() }),
+        _ => None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use ratatui::{backend::TestBackend, Terminal};
@@ -453,6 +517,25 @@ mod tests {
                 }],
                 meta: TableMeta::default(),
             },
+        }
+    }
+
+    fn issue_row(id: &str) -> ProjectedRow {
+        let issue = flotilla_protocol::IssueRef {
+            source: flotilla_protocol::IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+            id: id.into(),
+        };
+        ProjectedRow {
+            id: RowId::new(format!("issue:flotilla:roadmap:https://github.com:flotilla-org/flotilla:{id}")),
+            cells: vec![CellValue { text: id.into(), tone: CellTone::Plain }],
+            drill: None,
+            describe: vec![],
+            actions: vec![AvailableAction {
+                id: "start",
+                label: "Start convoy",
+                key: 'c',
+                intent: TableIntent::StartConvoy { namespace: "flotilla".into(), project: "roadmap".into(), issue },
+            }],
         }
     }
 
@@ -508,6 +591,27 @@ mod tests {
         assert_eq!(state.active(), ProjectPanelKind::Issues);
         assert!(ProjectPageWidget::fetch_more_query(&layouts, &state, crate::widgets::table::FetchTrigger::Explicit).is_some());
         assert!(matches!(ProjectPageWidget::active_action(&layouts, &state), Some(AppAction::DrillView(ViewAddress::Issues { .. }))));
+    }
+
+    #[test]
+    fn selected_issue_rows_expose_one_bulk_start_action() {
+        let mut issues = panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "placeholder");
+        issues.table.rows = vec![issue_row("809"), issue_row("810"), issue_row("811")];
+        let panels = vec![issues];
+        let layouts = ProjectPageWidget::layouts(&panels);
+        let mut state = ProjectTableState::default();
+        state.set_active(ProjectPanelKind::Issues);
+        state.focus_rows();
+        state.table_mut(ProjectPanelKind::Issues).select_index(&panels[0].table, 2);
+        state.table_mut(ProjectPanelKind::Issues).multi_selected.insert(panels[0].table.rows[0].id.clone());
+        state.table_mut(ProjectPanelKind::Issues).multi_selected.insert(panels[0].table.rows[1].id.clone());
+
+        let action = ProjectPageWidget::selected_issue_bulk_action(&layouts, &state).expect("bulk action");
+
+        assert_eq!(action.label, "Start convoys");
+        let TableIntent::StartConvoys { namespace, project, issues } = action.intent else { panic!("expected bulk start") };
+        assert_eq!((namespace.as_str(), project.as_str()), ("flotilla", "roadmap"));
+        assert_eq!(issues.iter().map(|issue| issue.issue.id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -9,7 +9,7 @@ use super::{
     Outcome, RenderContext, WidgetContext,
 };
 use crate::{
-    app::{NamespaceMap, QueryTableCache},
+    app::{ui_state::PendingStatus, NamespaceMap, QueryTableCache},
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
     table_view::{self, AvailableAction, ProjectPanel, ProjectPanelKind, ProjectTableState, RowId, TableIntent, TableIssueStart},
@@ -221,14 +221,14 @@ impl ProjectPageWidget {
         let table_state = state.table(ProjectPanelKind::Issues);
         let mut selected = Vec::new();
         for row in &layout.panel.table.rows {
-            if table_state.multi_selected.contains(&row.id) {
+            if table_state.multi_selected.contains(&row.id) && !issue_start_is_pending(table_state, &row.id) {
                 if let Some(issue) = issue_start_from_row(row) {
                     selected.push(issue);
                 }
             }
         }
         if let Some(row) = table_state.selected_row(&layout.panel.table) {
-            if !table_state.multi_selected.contains(&row.id) {
+            if !table_state.multi_selected.contains(&row.id) && !issue_start_is_pending(table_state, &row.id) {
                 if let Some(issue) = issue_start_from_row(row) {
                     selected.push(issue);
                 }
@@ -489,12 +489,22 @@ fn issue_start_from_row(row: &table_view::ProjectedRow) -> Option<TableIssueStar
     })
 }
 
+fn issue_start_is_pending(table_state: &table_view::TableState, row_id: &RowId) -> bool {
+    table_state
+        .pending_actions
+        .get(row_id)
+        .is_some_and(|pending| matches!(pending.status, PendingStatus::Submitting | PendingStatus::InFlight { .. }))
+}
+
 #[cfg(test)]
 mod tests {
     use ratatui::{backend::TestBackend, Terminal};
 
     use super::*;
-    use crate::table_view::{Alignment, CellTone, CellValue, ProjectedColumn, ProjectedRow, TableMeta, TableView, WidthHint};
+    use crate::{
+        app::ui_state::{PendingAction, PendingStatus},
+        table_view::{Alignment, CellTone, CellValue, ProjectedColumn, ProjectedRow, TableMeta, TableView, WidthHint},
+    };
 
     fn panel(kind: ProjectPanelKind, title: &str, target: &str, row: &str) -> ProjectPanel {
         ProjectPanel {
@@ -612,6 +622,29 @@ mod tests {
         let TableIntent::StartConvoys { namespace, project, issues } = action.intent else { panic!("expected bulk start") };
         assert_eq!((namespace.as_str(), project.as_str()), ("flotilla", "roadmap"));
         assert_eq!(issues.iter().map(|issue| issue.issue.id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
+    }
+
+    #[test]
+    fn selected_issue_bulk_start_skips_rows_already_in_progress() {
+        let mut issues = panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "placeholder");
+        issues.table.rows = vec![issue_row("809"), issue_row("810"), issue_row("811")];
+        let panels = vec![issues];
+        let layouts = ProjectPageWidget::layouts(&panels);
+        let mut state = ProjectTableState::default();
+        state.set_active(ProjectPanelKind::Issues);
+        state.focus_rows();
+        state.table_mut(ProjectPanelKind::Issues).select_index(&panels[0].table, 2);
+        state.table_mut(ProjectPanelKind::Issues).multi_selected.insert(panels[0].table.rows[0].id.clone());
+        state.table_mut(ProjectPanelKind::Issues).multi_selected.insert(panels[0].table.rows[1].id.clone());
+        state.table_mut(ProjectPanelKind::Issues).pending_actions.insert(panels[0].table.rows[1].id.clone(), PendingAction {
+            status: PendingStatus::InFlight { command_id: 9 },
+            description: "Start convoy".into(),
+        });
+
+        let action = ProjectPageWidget::selected_issue_bulk_action(&layouts, &state).expect("bulk action");
+
+        let TableIntent::StartConvoys { issues, .. } = action.intent else { panic!("expected bulk start") };
+        assert_eq!(issues.iter().map(|issue| issue.issue.id.as_str()).collect::<Vec<_>>(), vec!["809", "811"]);
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -85,9 +85,9 @@ impl TablePanel {
             let selected = state.selected() == Some(&row.id);
             let multi = decorations.multi_selected.contains(&row.id);
             let pending = decorations.pending_actions.get(&row.id);
-            let cells = row.cells.iter().zip(&view.columns).map(|(cell, column)| {
+            let cells = row.cells.iter().zip(&view.columns).enumerate().map(|(index, (cell, column))| {
                 let mut text = cell.text.clone();
-                if column.id == view.columns[0].id {
+                if index == 0 {
                     if let Some(pending) = pending {
                         let marker = match pending.status {
                             PendingStatus::Submitting | PendingStatus::InFlight { .. } => "...",

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -1,4 +1,8 @@
-use std::time::{Duration, Instant};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Range,
+    time::{Duration, Instant},
+};
 
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use flotilla_protocol::ViewAddress;
@@ -14,6 +18,7 @@ use super::{
     describe::DescribeWidget, table_action_menu::TableActionMenuWidget, AppAction, InteractiveWidget, Outcome, RenderContext, WidgetContext,
 };
 use crate::{
+    app::ui_state::{PendingAction, PendingStatus},
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
     table_view::{self, Alignment, CellTone, ProjectedColumn, RowId, TableView, WidthHint},
@@ -32,6 +37,11 @@ pub(crate) enum FetchTrigger {
 /// in any surface. `TableWidget` adds its border and breadcrumbs; the Project
 /// page composes several panels into its one scrolling document.
 pub(crate) struct TablePanel;
+
+pub(crate) struct RowDecorations<'a> {
+    pub(crate) multi_selected: &'a HashSet<RowId>,
+    pub(crate) pending_actions: &'a HashMap<RowId, PendingAction>,
+}
 
 impl TablePanel {
     pub(crate) fn row_action(row: &table_view::ProjectedRow) -> Option<AppAction> {
@@ -63,18 +73,40 @@ impl TablePanel {
         theme: &Theme,
         view: &TableView,
         state: &table_view::TableState,
-        first: usize,
-        count: usize,
+        decorations: RowDecorations<'_>,
+        visible: Range<usize>,
     ) {
+        let first = visible.start;
+        let count = visible.end.saturating_sub(visible.start);
         if count == 0 {
             return;
         }
         let rows = view.rows.iter().skip(first).take(count).map(|row| {
             let selected = state.selected() == Some(&row.id);
+            let multi = decorations.multi_selected.contains(&row.id);
+            let pending = decorations.pending_actions.get(&row.id);
             let cells = row.cells.iter().zip(&view.columns).map(|(cell, column)| {
-                Cell::from(Line::from(cell.text.clone()).alignment(ratatui_alignment(column.alignment))).style(cell_style(cell.tone, theme))
+                let mut text = cell.text.clone();
+                if column.id == view.columns[0].id {
+                    if let Some(pending) = pending {
+                        let marker = match pending.status {
+                            PendingStatus::Submitting | PendingStatus::InFlight { .. } => "...",
+                            PendingStatus::Failed(_) => "x",
+                        };
+                        text = format!("{marker} {text}");
+                    } else if multi {
+                        text = format!("* {text}");
+                    }
+                }
+                Cell::from(Line::from(text).alignment(ratatui_alignment(column.alignment))).style(cell_style(cell.tone, theme))
             });
-            let style = if selected { Style::default().bg(theme.row_highlight).add_modifier(Modifier::BOLD) } else { Style::default() };
+            let style = if selected {
+                Style::default().bg(theme.row_highlight).add_modifier(Modifier::BOLD)
+            } else if multi {
+                Style::default().add_modifier(Modifier::REVERSED)
+            } else {
+                Style::default()
+            };
             Row::new(cells).style(style)
         });
         let widths = width_constraints(&view.columns, area.width);
@@ -170,7 +202,15 @@ impl TableWidget {
         state.ensure_selected_visible(view, self.rows_area.height as usize);
 
         TablePanel::render_header(frame, Rect { height: 1, ..table_area }, theme, view);
-        TablePanel::render_rows(frame, self.rows_area, theme, view, state, state.scroll_offset, self.rows_area.height as usize);
+        TablePanel::render_rows(
+            frame,
+            self.rows_area,
+            theme,
+            view,
+            state,
+            RowDecorations { multi_selected: &state.multi_selected, pending_actions: &state.pending_actions },
+            state.scroll_offset..state.scroll_offset.saturating_add(self.rows_area.height as usize),
+        );
     }
 }
 
@@ -244,6 +284,10 @@ impl InteractiveWidget for TableWidget {
             }
             Action::SelectPrev => {
                 ctx.views.active_table_state_mut().select_delta(&view, -1);
+                Outcome::Consumed
+            }
+            Action::ToggleMultiSelect => {
+                ctx.views.active_table_state_mut().toggle_selected_row();
                 Outcome::Consumed
             }
             Action::Confirm => {


### PR DESCRIPTION
## Summary

Closes #809.

- Adds multi-select dispatch from project issue tables, exposing a single `Start convoys` action for selected issue rows.
- Queues one convoy-start admission command per selected issue so one rejection does not block the rest.
- Tracks project issue start batches with row-level pending/failed indicators and a summary status message.
- Makes attach-routing tests avoid colliding with the local machine hostname, so the workspace test gate is host-independent.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-tui --locked`
- `mkdir -p /tmp/flotilla-codex && TMPDIR=/tmp/flotilla-codex cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`