### PR TITLE
fix: serialize bare convoy issue selectors

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -494,6 +494,35 @@ mod tests {
     }
 
     #[test]
+    fn convoy_start_bare_issue_resolves_to_project_defaulted_selector() {
+        let resolved = parse(&["convoy", "start", "--project", "flotilla", "--issue", "834"]).resolve().expect("resolve");
+
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyStart {
+                    intent: Box::new(ConvoyStartIntent {
+                        namespace: None,
+                        project_ref: "flotilla".into(),
+                        issue: Some(IssueSelector::Id("834".into())),
+                        name: None,
+                        branch: None,
+                        workflow_ref: None,
+                        inputs: vec![],
+                        instruction: None,
+                        placement_policy: None,
+                        auto_attach: true,
+                    }),
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
     fn convoy_create_resolves() {
         let resolved = parse(&[
             "convoy",

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -90,7 +90,7 @@ pub struct Command {
 /// reference or as an opaque ID whose source must be resolved through the
 /// Project.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum IssueSelector {
     Id(String),
     Reference(IssueRef),
@@ -557,6 +557,8 @@ pub struct CheckoutStatus {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::{
         arg::Arg,
@@ -1106,6 +1108,31 @@ mod tests {
     #[test]
     fn repo_selector_identity_roundtrip() {
         assert_json_roundtrip(&RepoSelector::Identity(repo_identity()));
+    }
+
+    #[test]
+    fn issue_selector_json_is_stable_and_roundtrips_all_variants() {
+        let cases = [
+            (IssueSelector::Id("834".into()), json!({"kind": "id", "value": "834"})),
+            (
+                IssueSelector::Reference(IssueRef {
+                    source: crate::IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+                    id: "834".into(),
+                }),
+                json!({
+                    "kind": "reference",
+                    "value": {
+                        "source": {"service": "https://github.com", "scope": "flotilla-org/flotilla"},
+                        "id": "834"
+                    }
+                }),
+            ),
+        ];
+
+        for (selector, expected_json) in cases {
+            assert_eq!(serde_json::to_value(&selector).expect("serialize"), expected_json);
+            assert_json_roundtrip(&selector);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- serialize `IssueSelector` with an adjacent `kind` and `value` wire shape
- make bare `convoy start --issue <id>` requests cross the client/daemon boundary
- pin JSON encoding and round-trip coverage for each selector variant

## Root cause

Serde cannot serialize an internally tagged newtype variant whose payload is a primitive. `IssueSelector::Id(String)` was therefore rejected client-side before project-default issue-source resolution could run.

Closes #834

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTC_WRAPPER= TMPDIR="$(mktemp -d /private/tmp/flotilla-834.XXXXXX)" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests --quiet`
