### PR TITLE
fix: isolate attach-routing test environments

### DIFF
--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -48,6 +48,8 @@ use crate::{
     },
 };
 
+const TEST_LOCAL_ATTACH_HOST: &str = "local";
+
 #[test]
 fn workspace_slugs_are_dns_safe_bounded_and_disambiguatable() {
     let normalized = normalize_workspace_slug("My_repo...with spaces");
@@ -380,7 +382,8 @@ async fn new_attach_test_daemon_with_pool(config_base: &Path) -> (Arc<InProcessD
     let discovery = fake_discovery_with_provider_set(
         FakeDiscoveryProviders::new().with_terminal_pool(Arc::clone(&terminal_pool) as Arc<dyn crate::providers::terminal::TerminalPool>),
     );
-    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), discovery, HostName::local()).await;
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), discovery, HostName::new(TEST_LOCAL_ATTACH_HOST)).await;
     (daemon, terminal_pool)
 }
 
@@ -427,8 +430,7 @@ fn write_attach_hosts_config(config_base: &Path, hosts: &[(&str, &str, Option<&s
 }
 
 fn non_local_attach_hosts() -> (&'static str, &'static str) {
-    let local = HostName::local();
-    let mut candidates = ["feta", "gouda", "kiwi"].into_iter().filter(|host| *host != local.as_str());
+    let mut candidates = ["feta", "gouda", "kiwi"].into_iter().filter(|host| *host != TEST_LOCAL_ATTACH_HOST);
     (candidates.next().expect("first non-local host"), candidates.next().expect("second non-local host"))
 }
 

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -555,7 +555,7 @@ async fn running_convoyless_session_emits_attachable_independent_row() {
                 ]))
                 .build(),
             &TerminalSessionSpec {
-                env_ref: "host-direct-local".to_string(),
+                env_ref: environment_name.clone(),
                 role: "coder".to_string(),
                 source: TerminalSessionSource::Tool { command: "bash".to_string() },
                 cwd: "/repo".to_string(),


### PR DESCRIPTION
## Summary

Fixes attach-routing test fixtures that depended on ambient host identity.

- Make the core attach-routing test daemon use a fixed test-local host name instead of `HostName::local()`.
- Keep remote attach host selection deterministic and independent of the machine running the suite.
- Use the actual host-direct environment name created by the daemon under test in the aggregator fixture instead of hard-coding `host-direct-local`.

## Root Cause

Some attach-routing tests mixed injected resource fixtures with real host-derived identity. On hosts where the daemon's local host id or hostname differed from the hard-coded fixture names, a terminal session could point at an environment resource that did not exist, producing errors such as `environment not found: host-direct-feta`.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" RUSTC_WRAPPER= cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" RUSTC_WRAPPER= cargo test -p flotilla-core --locked --features test-support attach_query_`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" RUSTC_WRAPPER= cargo test -p flotilla-daemon --locked --features skip-no-sandbox-tests --test aggregator running_convoyless_session_emits_attachable_independent_row`

Closes #837