### PR TITLE
fix: exclude generated crew briefs

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -33,6 +33,9 @@ pub trait TerminalRuntime: Send + Sync {
         Err("terminal runtime does not support crew message delivery".to_string())
     }
     async fn kill_session(&self, session_id: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<(), String>;
+    async fn cleanup_session_artifacts(&self, _spec: &flotilla_resources::TerminalSessionSpec) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 pub struct TerminalSessionReconciler<R> {
@@ -145,10 +148,20 @@ where
     }
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
+        let mut errors = Vec::new();
         if let Some(session_id) = obj.status.as_ref().and_then(|status| status.session_id.as_deref()) {
-            self.runtime.kill_session(session_id, &obj.spec).await.map_err(ResourceError::other)?;
+            if let Err(error) = self.runtime.kill_session(session_id, &obj.spec).await {
+                errors.push(error);
+            }
         }
-        Ok(())
+        if let Err(error) = self.runtime.cleanup_session_artifacts(&obj.spec).await {
+            errors.push(error);
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ResourceError::other(errors.join("; ")))
+        }
     }
 
     fn finalizer_name(&self) -> Option<&'static str> {

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -252,9 +252,81 @@ async fn a_message_queued_during_startup_is_delivered_after_the_session_becomes_
     assert_eq!(runtime.delivered.lock().expect("delivered mutex").len(), 1);
 }
 
+#[tokio::test]
+async fn terminal_finalizer_cleans_agent_artifacts() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
+    let created = sessions
+        .create(&meta("term-a"), &TerminalSessionSpec {
+            env_ref: "env-a".to_string(),
+            role: "coder".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Agent {
+                selector: flotilla_resources::Selector { capability: "coding".to_string() },
+                brief: flotilla_resources::TerminalBrief {
+                    path: ".flotilla/briefs/coder.md".into(),
+                    content: "brief".into(),
+                    copies: vec!["/workspace/repo-a".into()],
+                },
+                context: flotilla_resources::TerminalCrewContext {
+                    namespace: "flotilla".into(),
+                    convoy: "demo".into(),
+                    vessel_ref: "demo-implement".into(),
+                },
+                message: None,
+            },
+            cwd: "/workspace".to_string(),
+            pool: "cleat".to_string(),
+        })
+        .await
+        .expect("session");
+    let mut status = flotilla_resources::TerminalSessionStatus::default();
+    flotilla_resources::TerminalSessionStatusPatch::MarkRunning {
+        session_id: "cleat-session".into(),
+        pid: None,
+        started_at: Utc::now(),
+        crew: None,
+        launch_command: "codex".into(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
+    let session = sessions.update_status("term-a", &created.metadata.resource_version, &status).await.expect("running session");
+    let runtime = Arc::new(CleanupRecordingTerminalRuntime::default());
+    let reconciler = TerminalSessionReconciler::new(Arc::clone(&runtime), backend, "flotilla");
+
+    reconciler.run_finalizer(&session).await.expect("finalizer");
+
+    assert_eq!(runtime.killed.lock().expect("killed mutex").as_slice(), &["cleat-session".to_string()]);
+    assert_eq!(runtime.cleaned.lock().expect("cleaned mutex").as_slice(), &[".flotilla/briefs/coder.md".to_string()]);
+}
+
 #[derive(Default)]
 struct DeliveringTerminalRuntime {
     delivered: Mutex<Vec<(String, String)>>,
+}
+
+#[derive(Default)]
+struct CleanupRecordingTerminalRuntime {
+    killed: Mutex<Vec<String>>,
+    cleaned: Mutex<Vec<String>>,
+}
+
+#[async_trait]
+impl TerminalRuntime for CleanupRecordingTerminalRuntime {
+    async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+        panic!("finalizer should not ensure sessions")
+    }
+
+    async fn kill_session(&self, session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
+        self.killed.lock().expect("killed mutex").push(session_id.to_string());
+        Ok(())
+    }
+
+    async fn cleanup_session_artifacts(&self, spec: &TerminalSessionSpec) -> Result<(), String> {
+        if let flotilla_resources::TerminalSessionSource::Agent { brief, .. } = &spec.source {
+            self.cleaned.lock().expect("cleaned mutex").push(brief.path.clone());
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 use async_trait::async_trait;
 use flotilla_protocol::arg::{flatten, Arg};
@@ -6,7 +6,7 @@ use flotilla_resources::TerminalBrief;
 
 use crate::{
     path_context::ExecutionEnvironmentPath,
-    providers::{discovery::EnvironmentBag, CommandRunner},
+    providers::{discovery::EnvironmentBag, ChannelLabel, CommandRunner},
 };
 
 pub const TRUSTED_IMPLICIT_STANCE: &str = "trusted-implicit";
@@ -102,6 +102,9 @@ impl Default for CapabilityTable {
 pub trait AgentAdapter: Send + Sync {
     fn id(&self) -> &'static str;
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String>;
+    async fn cleanup(&self, _cwd: &ExecutionEnvironmentPath, _brief: &TerminalBrief) -> Result<(), String> {
+        Ok(())
+    }
     fn deliver_brief(&self, brief: &TerminalBrief) -> String {
         format!("Read your crew brief at {} and follow it.", brief.path)
     }
@@ -134,12 +137,53 @@ impl AgentAdapter for CliAgentAdapter {
     }
 
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
-        self.runner.write_file(&cwd.as_path().join(&brief.path), &brief.content).await
+        self.runner.write_file(&cwd.as_path().join(&brief.path), &brief.content).await?;
+        ensure_flotilla_git_exclude(&*self.runner, cwd.as_path()).await
+    }
+
+    async fn cleanup(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
+        remove_agent_brief(&*self.runner, cwd.as_path(), brief).await
     }
 
     fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String> {
         Ok(AgentLaunchPlan { command: self.command(request), env: Vec::new(), stance: TRUSTED_IMPLICIT_STANCE.into() })
     }
+}
+
+async fn ensure_flotilla_git_exclude(runner: &dyn CommandRunner, cwd: &Path) -> Result<(), String> {
+    let Ok(output) = runner.run_output("git", &["rev-parse", "--git-path", "info/exclude"], cwd, &ChannelLabel::Noop).await else {
+        return Ok(());
+    };
+    if !output.success {
+        return Ok(());
+    }
+    let exclude_path = output.stdout.trim();
+    if exclude_path.is_empty() {
+        return Ok(());
+    }
+
+    let script = format!(
+        "set -eu; exclude={}; mkdir -p \"$(dirname \"$exclude\")\"; touch \"$exclude\"; grep -qxF '.flotilla/' \"$exclude\" || printf '%s\\n' '.flotilla/' >> \"$exclude\"",
+        flotilla_protocol::arg::shell_quote(exclude_path),
+    );
+    let _ = runner.run("sh", &["-lc", &script], cwd, &ChannelLabel::Noop).await;
+    Ok(())
+}
+
+async fn remove_agent_brief(runner: &dyn CommandRunner, cwd: &Path, brief: &TerminalBrief) -> Result<(), String> {
+    let path = cwd.join(&brief.path);
+    let path_str = path.to_str().ok_or_else(|| format!("brief path is not valid UTF-8: {}", path.display()))?;
+    runner.run("rm", &["-f", path_str], Path::new("/"), &ChannelLabel::Noop).await?;
+
+    for parent in [path.parent(), path.parent().and_then(Path::parent)].into_iter().flatten() {
+        if parent != cwd {
+            let Some(parent) = parent.to_str() else {
+                continue;
+            };
+            let _ = runner.run("rmdir", &[parent], Path::new("/"), &ChannelLabel::Noop).await;
+        }
+    }
+    Ok(())
 }
 
 #[derive(Default)]
@@ -184,7 +228,7 @@ impl AgentAdapterRegistry {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{process::Command as ProcessCommand, sync::Arc};
 
     use flotilla_resources::{single_agent_contained_workflow_spec, CrewSource, TerminalCrewContext};
 
@@ -194,6 +238,7 @@ mod tests {
         providers::{
             discovery::{EnvironmentAssertion, EnvironmentBag},
             testing::MockRunner,
+            ProcessCommandRunner,
         },
     };
 
@@ -201,7 +246,7 @@ mod tests {
         let env = EnvironmentBag::new()
             .with(EnvironmentAssertion::binary("claude", "/tools/claude"))
             .with(EnvironmentAssertion::binary("codex", "/tools/codex"));
-        AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(vec![])))
+        AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(vec![Ok(".git/info/exclude\n".into()), Ok(String::new())])))
     }
 
     #[test]
@@ -279,5 +324,68 @@ mod tests {
             "/tools/claude --dangerously-skip-permissions --model opus 'Read your crew brief at .flotilla/briefs/coder.md and follow it.'"
         );
         assert!(!plan.command.contains("Implement the issue"));
+    }
+
+    #[tokio::test]
+    async fn prepare_excludes_flotilla_brief_from_git_status() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        assert!(ProcessCommand::new("git")
+            .args(["init", "-q", repo.to_str().expect("utf-8 repo path")])
+            .status()
+            .expect("git init")
+            .success());
+        assert!(ProcessCommand::new("git")
+            .args(["-C", repo.to_str().expect("utf-8 repo path"), "config", "user.email", "test@example.com"])
+            .status()
+            .expect("git config email")
+            .success());
+        assert!(ProcessCommand::new("git")
+            .args(["-C", repo.to_str().expect("utf-8 repo path"), "config", "user.name", "Test"])
+            .status()
+            .expect("git config name")
+            .success());
+        std::fs::write(repo.join("README.md"), "hello\n").expect("write readme");
+        assert!(ProcessCommand::new("git")
+            .args(["-C", repo.to_str().expect("utf-8 repo path"), "add", "README.md"])
+            .status()
+            .expect("git add")
+            .success());
+        assert!(ProcessCommand::new("git")
+            .args(["-C", repo.to_str().expect("utf-8 repo path"), "commit", "-q", "-m", "init"])
+            .status()
+            .expect("git commit")
+            .success());
+
+        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("codex", "/tools/codex"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
+        let brief = flotilla_resources::TerminalBrief {
+            path: ".flotilla/briefs/coder.md".into(),
+            content: "secret assignment".into(),
+            copies: Vec::new(),
+        };
+        registry
+            .get("codex")
+            .expect("codex adapter")
+            .prepare(&ExecutionEnvironmentPath::new(repo.to_str().expect("utf-8 repo path")), &brief)
+            .await
+            .expect("prepare brief");
+
+        let status = ProcessCommand::new("git")
+            .args(["-C", repo.to_str().expect("utf-8 repo path"), "status", "--short"])
+            .output()
+            .expect("git status");
+        assert!(status.status.success());
+        assert_eq!(String::from_utf8(status.stdout).expect("utf-8 status"), "");
+        assert_eq!(std::fs::read_to_string(repo.join(".git/info/exclude")).expect("read exclude").matches(".flotilla/").count(), 1);
+
+        registry
+            .get("codex")
+            .expect("codex adapter")
+            .cleanup(&ExecutionEnvironmentPath::new(repo.to_str().expect("utf-8 repo path")), &brief)
+            .await
+            .expect("cleanup brief");
+        assert!(!repo.join(".flotilla/briefs/coder.md").exists(), "brief file should be removed");
+        assert!(!repo.join(".flotilla/briefs").exists(), "empty briefs directory should be removed");
     }
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1349,6 +1349,25 @@ impl TerminalRuntime for TerminalControllerRuntime {
         }
         pool.kill_session(session_id).await
     }
+
+    async fn cleanup_session_artifacts(&self, spec: &flotilla_resources::TerminalSessionSpec) -> Result<(), String> {
+        let TerminalSessionSource::Agent { selector, brief, .. } = &spec.source else {
+            return Ok(());
+        };
+        let registry = self.registry_for_env(&spec.env_ref)?;
+        let requirement = CapabilityTable::seeded().resolve(&selector.capability)?.clone();
+        let adapter = registry
+            .agent_adapters
+            .get(&requirement.adapter)
+            .ok_or_else(|| format!("agent adapter {} unavailable for environment {}", requirement.adapter, spec.env_ref))?;
+
+        let mut roots = BTreeSet::from([spec.cwd.clone()]);
+        roots.extend(brief.copies.iter().cloned());
+        for root in roots {
+            adapter.cleanup(&ExecutionEnvironmentPath::new(root), brief).await?;
+        }
+        Ok(())
+    }
 }
 
 impl TerminalControllerRuntime {
@@ -2431,6 +2450,11 @@ mod tests {
             std::fs::read_to_string(durable_checkout.join(".flotilla/briefs/coder.md")).expect("durable brief copy"),
             "Implement the issue."
         );
+
+        runtime.cleanup_session_artifacts(&spec).await.expect("cleanup generated briefs");
+        assert!(!session_cwd.join(".flotilla/briefs/coder.md").exists(), "session brief should be removed");
+        assert!(!durable_checkout.join(".flotilla/briefs/coder.md").exists(), "durable brief copy should be removed");
+        assert!(!durable_checkout.join(".flotilla/briefs").exists(), "empty durable brief directory should be removed");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- append .flotilla/ to the checkout-local Git exclude when agent crew briefs are written
- remove generated agent brief files from terminal session cleanup, covering adopted checkouts that are preserved after release
- add regressions for clean git status after brief provisioning and terminal finalizer artifact cleanup

## Validation
- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked

Closes #825