### PR TITLE
fix: resolve convoy PR refs from peer data

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -115,6 +115,10 @@ fn host_name_for_provider_environment(providers: &ProviderData, environment_id: 
     candidates.into_iter().next()
 }
 
+fn cached_change_request_by_branch(providers: &ProviderData, branch: &str) -> Option<(String, flotilla_protocol::ChangeRequest)> {
+    providers.change_requests.iter().find(|(_, request)| request.branch == branch).map(|(id, request)| (id.clone(), request.clone()))
+}
+
 fn static_ssh_environment_id(config_key: &str) -> EnvironmentId {
     let mut encoded = String::with_capacity(config_key.len() * 2);
     for byte in config_key.as_bytes() {
@@ -2188,30 +2192,59 @@ impl InProcessDaemon {
         repository_keys: &[RepositoryKey],
         branch: &str,
     ) -> Result<Option<ConvoyChangeRequest>, String> {
-        let candidates = {
+        let (live_candidates, cached_candidates) = {
             let keys_by_path = self.repository_keys_by_path.read().await;
             let repos = self.repos.read().await;
             let order = self.repo_order.read().await;
-            let mut by_key = order
-                .iter()
-                .filter_map(|identity| {
-                    let state = repos.get(identity)?;
-                    let repository = keys_by_path.get(state.preferred_path())?;
-                    if !repository_keys.contains(repository) {
-                        return None;
+            let mut live_by_key = HashMap::new();
+            let mut cached_by_key = HashMap::new();
+
+            for identity in order.iter() {
+                let Some(state) = repos.get(identity) else { continue };
+                let Some(repository) = state
+                    .roots
+                    .iter()
+                    .filter_map(|root| keys_by_path.get(&root.path))
+                    .find(|repository| repository_keys.contains(repository))
+                    .cloned()
+                else {
+                    continue;
+                };
+
+                if !live_by_key.contains_key(&repository) {
+                    for root in &state.roots {
+                        if keys_by_path.get(&root.path) != Some(&repository) {
+                            continue;
+                        }
+                        let providers =
+                            root.model.registry.change_requests.iter().map(|(_, provider)| Arc::clone(provider)).collect::<Vec<_>>();
+                        if !providers.is_empty() {
+                            live_by_key.insert(repository.clone(), (root.path.clone(), providers));
+                            break;
+                        }
                     }
-                    let providers = state.registry().change_requests.iter().map(|(_, provider)| Arc::clone(provider)).collect::<Vec<_>>();
-                    Some((repository.clone(), (state.preferred_path().to_path_buf(), providers)))
-                })
-                .collect::<HashMap<_, _>>();
-            repository_keys
+                }
+
+                if let Some((id, request)) =
+                    state.cached_snapshot().and_then(|snapshot| cached_change_request_by_branch(&snapshot.providers, branch))
+                {
+                    cached_by_key.entry(repository).or_insert((id, request));
+                }
+            }
+
+            let live_candidates = repository_keys
                 .iter()
-                .filter_map(|repository| by_key.remove(repository).map(|(path, providers)| (repository.clone(), path, providers)))
-                .collect::<Vec<_>>()
+                .filter_map(|repository| live_by_key.remove(repository).map(|(path, providers)| (repository.clone(), path, providers)))
+                .collect::<Vec<_>>();
+            let cached_candidates = repository_keys
+                .iter()
+                .filter_map(|repository| cached_by_key.remove(repository).map(|(id, request)| (repository.clone(), id, request)))
+                .collect::<Vec<_>>();
+            (live_candidates, cached_candidates)
         };
 
         let mut first_error = None;
-        for (repository, path, providers) in candidates {
+        for (repository, path, providers) in live_candidates {
             for provider in providers {
                 match provider.find_change_request_by_branch(&path, branch).await {
                     Ok(Some((id, request))) => {
@@ -2223,6 +2256,9 @@ impl InProcessDaemon {
                     }
                 }
             }
+        }
+        if let Some((repository, id, request)) = cached_candidates.into_iter().next() {
+            return Ok(Some(ConvoyChangeRequest { id, status: request.status, repository_key: repository }));
         }
 
         match first_error {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -11,7 +11,7 @@ use flotilla_protocol::{
     test_support::TestIssue,
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent,
     CrewCommandContext, DaemonEvent, EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostProviderStatus, HostSummary, ImageId,
-    QueryCursor, QueryScope, RepoSelector, ResourceRef, ResultSetCondition, SystemInfo, ToolInventory, TopologyRoute,
+    QueryCursor, QueryScope, RepoSelector, RepositoryKey, ResourceRef, ResultSetCondition, SystemInfo, ToolInventory, TopologyRoute,
     AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
@@ -2539,6 +2539,50 @@ fn collect_linked_issue_ids_from_checkouts() {
 
     let ids = collect_linked_issue_ids(&providers);
     assert_eq!(ids, vec!["7"]);
+}
+
+#[tokio::test]
+async fn convoy_change_request_resolves_from_peer_data_for_virtual_repo() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"feta-host\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::new("feta")).await;
+    let identity = RepoIdentity { authority: "github.com".into(), path: "flotilla-org/flotilla".into() };
+    let repository_key = RepositoryKey("repo_flotilla".into());
+    let mut peer_data = ProviderData::default();
+    peer_data.change_requests.insert("846".into(), ChangeRequest {
+        title: "Fix remote convoy PR refs".into(),
+        branch: "fix/remote-pr-ref".into(),
+        status: ChangeRequestStatus::Open,
+        body: None,
+        correlation_keys: vec![CorrelationKey::ChangeRequestRef("github".into(), "846".into())],
+        association_keys: vec![],
+        provider_name: "github".into(),
+        provider_display_name: "GitHub".into(),
+    });
+
+    daemon
+        .add_virtual_repo(
+            identity,
+            Some(repository_key.clone()),
+            PathBuf::from("/virtual/kiwi/flotilla"),
+            vec![(node("kiwi"), peer_data)],
+            1,
+        )
+        .await
+        .expect("add virtual repo");
+
+    let resolved = daemon
+        .resolve_convoy_change_request(std::slice::from_ref(&repository_key), "fix/remote-pr-ref")
+        .await
+        .expect("resolve change request")
+        .expect("peer-backed change request");
+
+    assert_eq!(resolved.id, "846");
+    assert_eq!(resolved.status, ChangeRequestStatus::Open);
+    assert_eq!(resolved.repository_key, repository_key);
 }
 
 #[test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -12,7 +12,8 @@ use flotilla_protocol::{
         CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow, CrewMemberSummary, IndependentRow, QueryChanges, QueryId, QueryScope,
         ResultDelta, Rows, SessionPhase, VesselRow, WorkPhase,
     },
-    DaemonEvent, FleetReplicaSnapshot, HostName, LifecycleAuthority, RepositoryKey, ResourceRef,
+    Change, DaemonEvent, EntryOp, FleetReplicaSnapshot, HostName, LifecycleAuthority, ProviderData, RepoDelta, RepoIdentity, RepoSnapshot,
+    RepositoryKey, ResourceRef,
 };
 use flotilla_resources::{
     api_version, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Environment, Presentation,
@@ -27,6 +28,7 @@ use crate::issue_materializer::{IssueMaterializationResolver, IssueMaterializer}
 
 type PresentationKey = (String, String, String);
 type SessionKey = (String, String);
+type ChangeRequestFingerprint = HashMap<String, (String, String)>;
 
 #[derive(bon::Builder)]
 pub struct AggregatorResolvers {
@@ -129,6 +131,8 @@ pub struct Aggregator {
     #[builder(skip)]
     convoy_change_requests: HashMap<ResourceRef, ConvoyChangeRequest>,
     #[builder(skip)]
+    repo_change_requests: HashMap<RepoIdentity, ChangeRequestFingerprint>,
+    #[builder(skip)]
     issue_materializer: Option<IssueMaterializer>,
     event_tx: broadcast::Sender<DaemonEvent>,
 }
@@ -153,6 +157,7 @@ impl Aggregator {
             attach_resolver: None,
             change_request_resolver: None,
             convoy_change_requests: HashMap::new(),
+            repo_change_requests: HashMap::new(),
             issue_materializer: None,
             event_tx,
         }
@@ -291,8 +296,16 @@ impl Aggregator {
                     }
                 },
                 event = daemon_event_rx.recv() => match event {
-                    Ok(DaemonEvent::RepoRefreshCompleted { .. } | DaemonEvent::RepoSnapshot(_) | DaemonEvent::RepoDelta(_)) => {
-                        self.refresh_all_change_requests().await;
+                    Ok(DaemonEvent::RepoRefreshCompleted { .. }) => self.refresh_all_change_requests().await,
+                    Ok(DaemonEvent::RepoSnapshot(snapshot)) => {
+                        if self.repo_snapshot_changed_change_requests(&snapshot) {
+                            self.refresh_all_change_requests().await;
+                        }
+                    }
+                    Ok(DaemonEvent::RepoDelta(delta)) => {
+                        if self.repo_delta_changed_change_requests(&delta) {
+                            self.refresh_all_change_requests().await;
+                        }
                     }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
@@ -717,6 +730,36 @@ impl Aggregator {
         self.rebuild_local_projection().await;
     }
 
+    fn repo_snapshot_changed_change_requests(&mut self, snapshot: &RepoSnapshot) -> bool {
+        let current = change_request_fingerprint(&snapshot.providers);
+        match self.repo_change_requests.get(&snapshot.repo_identity) {
+            Some(previous) if previous == &current => false,
+            None if current.is_empty() => false,
+            _ => {
+                self.repo_change_requests.insert(snapshot.repo_identity.clone(), current);
+                true
+            }
+        }
+    }
+
+    fn repo_delta_changed_change_requests(&mut self, delta: &RepoDelta) -> bool {
+        let mut changed = false;
+        let fingerprint = self.repo_change_requests.entry(delta.repo_identity.clone()).or_default();
+        for change in &delta.changes {
+            let Change::ChangeRequest { key, op } = change else { continue };
+            changed = true;
+            match op {
+                EntryOp::Added(request) | EntryOp::Updated(request) => {
+                    fingerprint.insert(key.clone(), (request.branch.clone(), request.status.to_string()));
+                }
+                EntryOp::Removed => {
+                    fingerprint.remove(key);
+                }
+            }
+        }
+        changed
+    }
+
     fn effective_convoys(&self) -> HashMap<ResourceRef, ResourceObject<Convoy>> {
         let mut effective_convoys = HashMap::new();
         for source in LOCAL_SOURCE_PRECEDENCE {
@@ -1132,6 +1175,10 @@ impl Aggregator {
             .complete_work(state.is_some_and(|state| !state.phase.is_terminal()))
             .build()
     }
+}
+
+fn change_request_fingerprint(providers: &ProviderData) -> ChangeRequestFingerprint {
+    providers.change_requests.iter().map(|(key, request)| (key.clone(), (request.branch.clone(), request.status.to_string()))).collect()
 }
 
 fn presentation_key(presentation: &ResourceObject<Presentation>) -> Option<PresentationKey> {
@@ -1702,6 +1749,17 @@ mod tests {
             () = async {
                 let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy result set").await;
                 assert!(matches!(initial, DaemonEvent::ResultSet(_)));
+                let mut providers = flotilla_protocol::ProviderData::default();
+                providers.change_requests.insert("815".into(), flotilla_protocol::ChangeRequest {
+                    title: "Fix convoy PR refs".into(),
+                    branch: "feat/convoy".into(),
+                    status: flotilla_protocol::ChangeRequestStatus::Open,
+                    body: None,
+                    correlation_keys: Vec::new(),
+                    association_keys: Vec::new(),
+                    provider_name: "github".into(),
+                    provider_display_name: "GitHub".into(),
+                });
                 event_tx
                     .send(DaemonEvent::RepoSnapshot(Box::new(flotilla_protocol::RepoSnapshot {
                         seq: 1,
@@ -1712,7 +1770,7 @@ mod tests {
                         repo: Some(std::path::PathBuf::from("/virtual/kiwi/flotilla")),
                         node_id: flotilla_protocol::NodeId::new("kiwi"),
                         work_items: Vec::new(),
-                        providers: flotilla_protocol::ProviderData::default(),
+                        providers,
                         provider_health: HashMap::new(),
                         errors: Vec::new(),
                     })))
@@ -1731,6 +1789,40 @@ mod tests {
             } => {}
         }
         assert_eq!(resolver.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn unchanged_repo_snapshot_does_not_refresh_convoy_change_requests() {
+        let (event_tx, _event_rx) = broadcast::channel(1);
+        let mut aggregator = Aggregator::new(AggregatorProjectionState::new(), HostName::new("local"), event_tx);
+        let repo_identity = flotilla_protocol::RepoIdentity { authority: "github.com".into(), path: "flotilla-org/flotilla".into() };
+        let empty = flotilla_protocol::RepoSnapshot {
+            seq: 1,
+            repo_identity: repo_identity.clone(),
+            repo: Some(std::path::PathBuf::from("/repo")),
+            node_id: flotilla_protocol::NodeId::new("kiwi"),
+            work_items: Vec::new(),
+            providers: flotilla_protocol::ProviderData::default(),
+            provider_health: HashMap::new(),
+            errors: Vec::new(),
+        };
+        assert!(!aggregator.repo_snapshot_changed_change_requests(&empty));
+
+        let mut providers = flotilla_protocol::ProviderData::default();
+        providers.change_requests.insert("815".into(), flotilla_protocol::ChangeRequest {
+            title: "Fix convoy PR refs".into(),
+            branch: "feat/convoy".into(),
+            status: flotilla_protocol::ChangeRequestStatus::Open,
+            body: None,
+            correlation_keys: Vec::new(),
+            association_keys: Vec::new(),
+            provider_name: "github".into(),
+            provider_display_name: "GitHub".into(),
+        });
+        let with_change_request = flotilla_protocol::RepoSnapshot { providers, seq: 2, ..empty };
+
+        assert!(aggregator.repo_snapshot_changed_change_requests(&with_change_request));
+        assert!(!aggregator.repo_snapshot_changed_change_requests(&with_change_request));
     }
 
     fn remote_snapshot(host: &str, generation: &str, name: &str) -> FleetReplicaSnapshot {

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -291,7 +291,9 @@ impl Aggregator {
                     }
                 },
                 event = daemon_event_rx.recv() => match event {
-                    Ok(DaemonEvent::RepoRefreshCompleted { .. }) => self.refresh_all_change_requests().await,
+                    Ok(DaemonEvent::RepoRefreshCompleted { .. } | DaemonEvent::RepoSnapshot(_) | DaemonEvent::RepoDelta(_)) => {
+                        self.refresh_all_change_requests().await;
+                    }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
                         tracing::warn!(skipped, "aggregator lagged behind daemon refresh events");
@@ -1642,6 +1644,79 @@ mod tests {
                         repo: Some(std::path::PathBuf::from("/repo")),
                     })
                     .expect("publish provider refresh");
+
+                let refreshed = recv_query_event(&mut event_rx, QueryId::Convoys, "refreshed convoy delta").await;
+                let DaemonEvent::ResultDelta(delta) = refreshed else { panic!("expected refreshed result delta") };
+                assert_eq!(
+                    delta.changes.as_convoys().expect("convoy changes")[0]
+                        .change_request
+                        .as_ref()
+                        .expect("change request")
+                        .status,
+                    flotilla_protocol::ChangeRequestStatus::Closed
+                );
+            } => {}
+        }
+        assert_eq!(resolver.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn repo_snapshot_refreshes_convoy_change_requests() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, mut event_rx) = broadcast::channel(16);
+        let resolver = Arc::new(ScriptedChangeRequestResolver {
+            results: Mutex::new(VecDeque::from([
+                Ok(Some(ConvoyChangeRequest {
+                    id: "815".into(),
+                    status: flotilla_protocol::ChangeRequestStatus::Open,
+                    repository_key: RepositoryKey("repo_flotilla".into()),
+                })),
+                Ok(Some(ConvoyChangeRequest {
+                    id: "815".into(),
+                    status: flotilla_protocol::ChangeRequestStatus::Closed,
+                    repository_key: RepositoryKey("repo_flotilla".into()),
+                })),
+            ])),
+            branches: Mutex::new(Vec::new()),
+            calls: AtomicUsize::new(0),
+        });
+        let durable_convoys = ScriptedSource::new(
+            vec![ResourceList { items: vec![convoy_with_branch("convoy-a").await], resource_version: "1".into(), generation: None }],
+            vec![Ok(pending_watch())],
+        );
+        let durable_presentations = ScriptedSource::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let observed_convoys = ScriptedSource::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let observed_presentations = ScriptedSource::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let (_replica_tx, replica_rx) = broadcast::channel(1);
+        let run = run_with_test_sources(
+            Aggregator::new(state, HostName::new("local"), event_tx.clone()).with_change_request_resolver(Arc::clone(&resolver)),
+            &durable_convoys,
+            &durable_presentations,
+            &observed_convoys,
+            &observed_presentations,
+            replica_rx,
+        );
+        tokio::pin!(run);
+        tokio::select! {
+            result = &mut run => panic!("aggregator stopped before repo snapshot: {result:?}"),
+            () = async {
+                let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy result set").await;
+                assert!(matches!(initial, DaemonEvent::ResultSet(_)));
+                event_tx
+                    .send(DaemonEvent::RepoSnapshot(Box::new(flotilla_protocol::RepoSnapshot {
+                        seq: 1,
+                        repo_identity: flotilla_protocol::RepoIdentity {
+                            authority: "github.com".into(),
+                            path: "flotilla-org/flotilla".into(),
+                        },
+                        repo: Some(std::path::PathBuf::from("/virtual/kiwi/flotilla")),
+                        node_id: flotilla_protocol::NodeId::new("kiwi"),
+                        work_items: Vec::new(),
+                        providers: flotilla_protocol::ProviderData::default(),
+                        provider_health: HashMap::new(),
+                        errors: Vec::new(),
+                    })))
+                    .expect("publish repo snapshot");
 
                 let refreshed = recv_query_event(&mut event_rx, QueryId::Convoys, "refreshed convoy delta").await;
                 let DaemonEvent::ResultDelta(delta) = refreshed else { panic!("expected refreshed result delta") };


### PR DESCRIPTION
## What changed

- Resolve convoy change-request refs from cached merged provider data when the repo is virtual or peer-backed, while preserving live provider lookup for local tracked roots.
- Retry convoy PR resolution when repo snapshots or deltas arrive, not only on `RepoRefreshCompleted`.
- Add regression coverage for a virtual remote repo with peer PR data and for the aggregator snapshot refresh trigger.

## Why

Remote-placed convoys can be persisted on the target daemon where the matching repository is represented as a virtual/peer-backed repo. The previous resolver only looked at the preferred local root's change-request providers, so those convoys could resolve to `None` even though peer provider data already contained the open PR.

Closes #846

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`