### PR TITLE
fix: retire crew sessions during convoy teardown

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -32,7 +32,7 @@ pub trait TerminalRuntime: Send + Sync {
     ) -> Result<(), String> {
         Err("terminal runtime does not support crew message delivery".to_string())
     }
-    async fn kill_session(&self, session_id: &str) -> Result<(), String>;
+    async fn kill_session(&self, session_id: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<(), String>;
 }
 
 pub struct TerminalSessionReconciler<R> {
@@ -146,7 +146,7 @@ where
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
         if let Some(session_id) = obj.status.as_ref().and_then(|status| status.session_id.as_deref()) {
-            self.runtime.kill_session(session_id).await.map_err(ResourceError::other)?;
+            self.runtime.kill_session(session_id, &obj.spec).await.map_err(ResourceError::other)?;
         }
         Ok(())
     }

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -122,7 +122,7 @@ impl TerminalRuntime for FakeTerminalRuntime {
         })
     }
 
-    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+    async fn kill_session(&self, _session_id: &str, _spec: &flotilla_resources::TerminalSessionSpec) -> Result<(), String> {
         Ok(())
     }
 }

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -65,7 +65,58 @@ impl TerminalRuntime for FailingTerminalRuntime {
         Err("boom".to_string())
     }
 
-    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+    async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn terminal_finalizer_kills_the_persisted_session_using_its_spec() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
+    let spec = TerminalSessionSpec {
+        env_ref: "host-direct-feta".to_string(),
+        role: "coder".to_string(),
+        source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
+        cwd: "/workspace".to_string(),
+        pool: "cleat".to_string(),
+    };
+    let created = sessions.create(&meta("terminal-convoy-work-coder"), &spec).await.expect("session create");
+    let mut status = flotilla_resources::TerminalSessionStatus::default();
+    flotilla_resources::TerminalSessionStatusPatch::MarkRunning {
+        session_id: "terminal-convoy-work-coder".to_string(),
+        pid: None,
+        started_at: Utc::now(),
+        crew: None,
+        launch_command: "codex".to_string(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
+    let session = sessions
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &status)
+        .await
+        .expect("session should be running");
+    let runtime = Arc::new(RecordingTerminalRuntime::default());
+    let reconciler = TerminalSessionReconciler::new(Arc::clone(&runtime), backend, "flotilla");
+
+    reconciler.run_finalizer(&session).await.expect("terminal finalizer should kill the session");
+
+    assert_eq!(runtime.killed.lock().expect("killed mutex").as_slice(), &[("terminal-convoy-work-coder".to_string(), spec)]);
+}
+
+#[derive(Default)]
+struct RecordingTerminalRuntime {
+    killed: Mutex<Vec<(String, TerminalSessionSpec)>>,
+}
+
+#[async_trait]
+impl TerminalRuntime for RecordingTerminalRuntime {
+    async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+        panic!("terminal finalization must not ensure a new session")
+    }
+
+    async fn kill_session(&self, session_id: &str, spec: &TerminalSessionSpec) -> Result<(), String> {
+        self.killed.lock().expect("killed mutex").push((session_id.to_string(), spec.clone()));
         Ok(())
     }
 }
@@ -132,7 +183,7 @@ impl TerminalRuntime for MissingTerminalRuntime {
         Ok(false)
     }
 
-    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+    async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
         Ok(())
     }
 }
@@ -217,7 +268,7 @@ impl TerminalRuntime for DeliveringTerminalRuntime {
         Ok(())
     }
 
-    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+    async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
         Ok(())
     }
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1330,17 +1330,21 @@ impl TerminalRuntime for TerminalControllerRuntime {
 
     async fn kill_session(&self, session_id: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<(), String> {
         let pool = self.pool_for_spec(spec)?;
-        if pool.tracks_session_liveness()
-            && pool
-                .list_sessions()
-                .await?
-                .iter()
-                .any(|session| session.session_name == session_id && session.status == TerminalStatus::Running)
-        {
-            if let TerminalSessionSource::Agent { context, .. } = &spec.source {
-                warn!(%session_id, convoy = %context.convoy, vessel = %context.vessel_ref, "convoy teardown is terminating an attached terminal session");
-            } else {
-                warn!(%session_id, "convoy teardown is terminating an attached terminal session");
+        if pool.tracks_session_liveness() {
+            match pool.list_sessions().await {
+                Ok(sessions) => {
+                    let Some(session) = sessions.iter().find(|session| session.session_name == session_id) else {
+                        return Ok(());
+                    };
+                    if session.status == TerminalStatus::Running {
+                        if let TerminalSessionSource::Agent { context, .. } = &spec.source {
+                            warn!(%session_id, convoy = %context.convoy, vessel = %context.vessel_ref, "convoy teardown is terminating an attached terminal session");
+                        } else {
+                            warn!(%session_id, "convoy teardown is terminating an attached terminal session");
+                        }
+                    }
+                }
+                Err(error) => warn!(%session_id, %error, "could not inspect terminal session before teardown; attempting kill"),
             }
         }
         pool.kill_session(session_id).await
@@ -2469,6 +2473,40 @@ mod tests {
         runtime.kill_session(session_name, &spec).await.expect("teardown should resolve the persisted session pool");
 
         assert_eq!(pool.killed.lock().await.as_slice(), &[session_name.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn terminal_teardown_skips_a_session_absent_from_the_pool() {
+        let temp = TempDir::new().expect("tempdir");
+        let config_path = temp.path().join("config");
+        std::fs::create_dir_all(&config_path).expect("config dir");
+        std::fs::write(config_path.join("daemon.toml"), "machine_id = \"dinghy-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_path));
+        let (daemon, pool) = crew_daemon_with_process_runner(Arc::clone(&config)).await;
+        let local_registry = probe_local_provider_registry(&daemon, &config).await.expect("crew provider registry");
+        let profile = build_local_profile(&daemon, &local_registry).expect("local profile");
+        let runtime = TerminalControllerRuntime {
+            state: Arc::new(ControllerRuntimeState::new(
+                Arc::clone(&daemon),
+                config,
+                local_registry,
+                None,
+                profile.host_id.clone(),
+                None,
+                profile.host_direct_environment_name(),
+            )),
+        };
+        let spec = flotilla_resources::TerminalSessionSpec {
+            env_ref: profile.host_direct_environment_name(),
+            role: "coder".to_string(),
+            source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
+            cwd: "/repo".to_string(),
+            pool: "fake-terminals".to_string(),
+        };
+
+        runtime.kill_session("terminal-demo-implement-coder", &spec).await.expect("missing sessions should be idempotent");
+
+        assert!(pool.killed.lock().await.is_empty(), "teardown must not invoke the pool for an already-gone session");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -30,7 +30,7 @@ use flotilla_core::{
         ChannelLabel, CommandRunner,
     },
 };
-use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource};
+use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource, TerminalStatus};
 use flotilla_resources::{
     clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, Clone,
     CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment,
@@ -183,7 +183,6 @@ struct ControllerRuntimeState {
     local_repo_root: Option<ExecutionEnvironmentPath>,
     host_direct_environment_name: String,
     provisioned_environments: Mutex<HashMap<String, ActiveProvisionedEnvironment>>,
-    active_sessions: Mutex<HashMap<String, ActiveSession>>,
 }
 
 struct GhForgeDefaultBranchResolver {
@@ -222,7 +221,6 @@ impl ControllerRuntimeState {
             local_repo_root,
             host_direct_environment_name,
             provisioned_environments: Mutex::new(HashMap::new()),
-            active_sessions: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -230,11 +228,6 @@ impl ControllerRuntimeState {
 struct ActiveProvisionedEnvironment {
     env_id: EnvironmentId,
     handle: EnvironmentHandle,
-}
-
-struct ActiveSession {
-    env_ref: String,
-    pool: String,
 }
 
 async fn probe_local_provider_registry(daemon: &Arc<InProcessDaemon>, config: &ConfigStore) -> Result<Arc<ProviderRegistry>, String> {
@@ -1299,11 +1292,10 @@ impl TerminalRuntime for TerminalControllerRuntime {
             }
         };
 
-        if matches!(spec.source, TerminalSessionSource::Agent { .. }) {
-            self.state.active_sessions.lock().await.remove(name);
-            if pool.list_sessions().await?.iter().any(|session| session.session_name == name) {
-                pool.kill_session(name).await?;
-            }
+        if matches!(spec.source, TerminalSessionSource::Agent { .. })
+            && pool.list_sessions().await?.iter().any(|session| session.session_name == name)
+        {
+            pool.kill_session(name).await?;
         }
         pool.ensure_session(name, &command, &cwd, &env).await?;
         let delivered_message_id = initial_message.as_ref().map(|message| message.id.clone());
@@ -1313,11 +1305,6 @@ impl TerminalRuntime for TerminalControllerRuntime {
                 return Err(format!("deliver initial crew message: {err}"));
             }
         }
-        self.state
-            .active_sessions
-            .lock()
-            .await
-            .insert(name.to_string(), ActiveSession { env_ref: spec.env_ref.clone(), pool: spec.pool.clone() });
         Ok(TerminalRuntimeState::builder()
             .session_id(name.to_string())
             .maybe_pid(None)
@@ -1334,9 +1321,6 @@ impl TerminalRuntime for TerminalControllerRuntime {
             return Ok(true);
         }
         let running = pool.list_sessions().await?.iter().any(|session| session.session_name == session_id);
-        if !running {
-            self.state.active_sessions.lock().await.remove(session_id);
-        }
         Ok(running)
     }
 
@@ -1344,17 +1328,21 @@ impl TerminalRuntime for TerminalControllerRuntime {
         self.pool_for_spec(spec)?.deliver(session_id, message, true).await
     }
 
-    async fn kill_session(&self, session_id: &str) -> Result<(), String> {
-        let Some(active) = self.state.active_sessions.lock().await.remove(session_id) else {
-            return Ok(());
-        };
-        let registry = self.registry_for_env(&active.env_ref)?;
-        let pool = registry
-            .terminal_pools
-            .get(&active.pool)
-            .map(|(_, pool)| Arc::clone(pool))
-            .or_else(|| registry.terminal_pools.preferred().cloned())
-            .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", active.pool, active.env_ref))?;
+    async fn kill_session(&self, session_id: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<(), String> {
+        let pool = self.pool_for_spec(spec)?;
+        if pool.tracks_session_liveness()
+            && pool
+                .list_sessions()
+                .await?
+                .iter()
+                .any(|session| session.session_name == session_id && session.status == TerminalStatus::Running)
+        {
+            if let TerminalSessionSource::Agent { context, .. } = &spec.source {
+                warn!(%session_id, convoy = %context.convoy, vessel = %context.vessel_ref, "convoy teardown is terminating an attached terminal session");
+            } else {
+                warn!(%session_id, "convoy teardown is terminating an attached terminal session");
+            }
+        }
         pool.kill_session(session_id).await
     }
 }
@@ -2439,6 +2427,48 @@ mod tests {
             std::fs::read_to_string(durable_checkout.join(".flotilla/briefs/coder.md")).expect("durable brief copy"),
             "Implement the issue."
         );
+    }
+
+    #[tokio::test]
+    async fn terminal_teardown_kills_a_persisted_session_after_runtime_restart() {
+        let temp = TempDir::new().expect("tempdir");
+        let config_path = temp.path().join("config");
+        std::fs::create_dir_all(&config_path).expect("config dir");
+        std::fs::write(config_path.join("daemon.toml"), "machine_id = \"dinghy-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_path));
+        let (daemon, pool) = crew_daemon_with_process_runner(Arc::clone(&config)).await;
+        let local_registry = probe_local_provider_registry(&daemon, &config).await.expect("crew provider registry");
+        let profile = build_local_profile(&daemon, &local_registry).expect("local profile");
+        let runtime = TerminalControllerRuntime {
+            state: Arc::new(ControllerRuntimeState::new(
+                Arc::clone(&daemon),
+                config,
+                local_registry,
+                None,
+                profile.host_id.clone(),
+                None,
+                profile.host_direct_environment_name(),
+            )),
+        };
+        let session_name = "terminal-demo-implement-coder";
+        let spec = flotilla_resources::TerminalSessionSpec {
+            env_ref: profile.host_direct_environment_name(),
+            role: "coder".to_string(),
+            source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
+            cwd: "/repo".to_string(),
+            pool: "fake-terminals".to_string(),
+        };
+        pool.add_sessions(vec![flotilla_core::providers::terminal::TerminalSession {
+            session_name: session_name.to_string(),
+            status: TerminalStatus::Running,
+            command: Some("codex".to_string()),
+            working_directory: Some(ExecutionEnvironmentPath::new("/repo")),
+        }])
+        .await;
+
+        runtime.kill_session(session_name, &spec).await.expect("teardown should resolve the persisted session pool");
+
+        assert_eq!(pool.killed.lock().await.as_slice(), &[session_name.to_string()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- resolve terminal teardown from the persisted `TerminalSession` pool and environment instead of daemon-local runtime state
- retire the Cleat session through `cleat kill`, preserving its recording
- warn with convoy/vessel context before retiring an attached agent session
- cover both finalizer delegation and post-restart teardown with injected collaborators

## Why

After a daemon restart, the previous in-memory session registry was empty, causing terminal finalization to skip `cleat kill` and leave crew processes in deleted worktrees.

Closes #852.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`