### PR TITLE
feat: start batch convoys from issue selections

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -204,11 +204,11 @@ impl ConvoyNoun {
                 if self.subject.is_some() {
                     return Err("convoy start does not take a positional convoy name; use --name".to_string());
                 }
-                let issue = match (issue, issue_service, issue_scope) {
-                    (None, None, None) => None,
-                    (Some(id), None, None) => Some(IssueSelector::Id(id)),
+                let issues = match (issue, issue_service, issue_scope) {
+                    (None, None, None) => Vec::new(),
+                    (Some(id), None, None) => vec![IssueSelector::Id(id)],
                     (Some(id), Some(service), Some(scope)) => {
-                        Some(IssueSelector::Reference(IssueRef { source: IssueSource { service, scope }, id }))
+                        vec![IssueSelector::Reference(IssueRef { source: IssueSource { service, scope }, id })]
                     }
                     (None, Some(_), _) | (None, _, Some(_)) => {
                         return Err("--issue-service and --issue-scope require --issue".to_string());
@@ -226,7 +226,7 @@ impl ConvoyNoun {
                             intent: Box::new(ConvoyStartIntent {
                                 namespace: None,
                                 project_ref: project,
-                                issue,
+                                issues,
                                 name,
                                 branch,
                                 workflow_ref: workflow,
@@ -253,7 +253,7 @@ impl ConvoyNoun {
                                 intent: Box::new(ConvoyStartIntent {
                                     namespace: None,
                                     project_ref: project_ref.clone(),
-                                    issue: None,
+                                    issues: Vec::new(),
                                     name: Some(name),
                                     branch: r#ref,
                                     workflow_ref: Some(template),
@@ -509,10 +509,10 @@ mod tests {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: None,
                         project_ref: "widgets".into(),
-                        issue: Some(IssueSelector::Reference(IssueRef {
+                        issues: vec![IssueSelector::Reference(IssueRef {
                             source: IssueSource { service: "https://linear.app".into(), scope: "WIDGET".into() },
                             id: "WIDGET-732".into(),
-                        })),
+                        })],
                         name: Some("repair-widget-admission".into()),
                         branch: Some("fix/repair-widget-admission".into()),
                         workflow_ref: Some("single-agent-contained".into()),
@@ -541,7 +541,7 @@ mod tests {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: None,
                         project_ref: "flotilla".into(),
-                        issue: Some(IssueSelector::Id("834".into())),
+                        issues: vec![IssueSelector::Id("834".into())],
                         name: None,
                         branch: None,
                         workflow_ref: None,
@@ -642,7 +642,7 @@ mod tests {
             intent: Box::new(ConvoyStartIntent {
                 namespace: None,
                 project_ref: "widgets".into(),
-                issue: None,
+                issues: Vec::new(),
                 name: Some("project-work".into()),
                 branch: Some("fix/widgets".into()),
                 workflow_ref: Some("single-agent-contained".into()),

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -533,11 +533,14 @@ impl Reconciler for VesselReconciler {
             }
         };
         let terminal_cwd = strategy.terminal_cwd(&workspace_root, multi_repository, has_repositories);
+        let issue_repository_refs = convoy.spec.issues.iter().map(|issue| issue.repository_ref.as_ref()).collect::<Vec<_>>();
+        let copy_to_all_repositories = issue_repository_refs.iter().any(|repository_ref| repository_ref.is_none());
         let brief_copies = checkout_paths
             .iter()
             .filter(|(repo_ref, _)| {
-                let relevant_issue_refs = convoy.spec.issues.iter().filter_map(|issue| issue.repository_ref.as_ref()).collect::<Vec<_>>();
-                relevant_issue_refs.is_empty() || relevant_issue_refs.contains(repo_ref)
+                copy_to_all_repositories
+                    || issue_repository_refs.is_empty()
+                    || issue_repository_refs.iter().flatten().any(|relevant| *relevant == *repo_ref)
             })
             .map(|(repo_ref, path)| match &strategy {
                 PlacementStrategy::DockerWorktreeOnHostAndMount { mount_path, .. } => {
@@ -765,7 +768,8 @@ fn append_convoy_work_context(content: &mut String, convoy: &ResourceObject<Conv
         content.push_str(&format!("  - `{}` — {}\n", repository.repo_ref, repository.url));
     }
     if !convoy.spec.issues.is_empty() {
-        content.push_str("\n## Issue snapshots\n\n");
+        let header = if convoy.spec.issues.len() == 1 { "Issue snapshot" } else { "Issue snapshots" };
+        content.push_str(&format!("\n## {header}\n\n"));
     }
     for issue in &convoy.spec.issues {
         content.push_str(&format!(

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -536,7 +536,8 @@ impl Reconciler for VesselReconciler {
         let brief_copies = checkout_paths
             .iter()
             .filter(|(repo_ref, _)| {
-                convoy.spec.issue.as_ref().and_then(|issue| issue.repository_ref.as_ref()).is_none_or(|relevant| relevant == *repo_ref)
+                let relevant_issue_refs = convoy.spec.issues.iter().filter_map(|issue| issue.repository_ref.as_ref()).collect::<Vec<_>>();
+                relevant_issue_refs.is_empty() || relevant_issue_refs.contains(repo_ref)
             })
             .map(|(repo_ref, path)| match &strategy {
                 PlacementStrategy::DockerWorktreeOnHostAndMount { mount_path, .. } => {
@@ -763,8 +764,10 @@ fn append_convoy_work_context(content: &mut String, convoy: &ResourceObject<Conv
     for repository in convoy.spec.repositories.iter().filter(|repository| repository_refs.contains(&repository.repo_ref)) {
         content.push_str(&format!("  - `{}` — {}\n", repository.repo_ref, repository.url));
     }
-    if let Some(issue) = &convoy.spec.issue {
-        content.push_str("\n## Issue snapshot\n\n");
+    if !convoy.spec.issues.is_empty() {
+        content.push_str("\n## Issue snapshots\n\n");
+    }
+    for issue in &convoy.spec.issues {
         content.push_str(&format!(
             "Source-qualified reference: `{}` / `{}` / `{}`\n\n",
             issue.reference.source.service, issue.reference.source.scope, issue.reference.id

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -90,7 +90,7 @@ pub async fn create_convoy_with_single_task(
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -43,7 +43,7 @@ async fn repositoryless_vessel_runs_tools_without_provisioning_a_checkout() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await
@@ -318,7 +318,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
             r#ref: Some("feature/multi".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
-            issue: Some(ConvoyIssue {
+            issues: vec![ConvoyIssue {
                 reference: IssueRef {
                     source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
                     id: "732".into(),
@@ -331,7 +331,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
                     labels: vec!["enhancement".into()],
                     as_of: "2026-07-18T09:30:00Z".parse().expect("timestamp"),
                 },
-            }),
+            }],
             instruction: Some("Keep the public seam stable.".into()),
         })
         .await
@@ -498,7 +498,7 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
             r#ref: Some("feature/multi".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await
@@ -649,7 +649,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
             r#ref: Some("feature/multi".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await
@@ -757,7 +757,7 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
             r#ref: Some("feature/scoped".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await
@@ -1634,7 +1634,7 @@ async fn create_convoy_with_labeled_processes(
             r#ref: Some(git_ref.to_string()),
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -318,20 +318,36 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
             r#ref: Some("feature/multi".to_string()),
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
-            issues: vec![ConvoyIssue {
-                reference: IssueRef {
-                    source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
-                    id: "732".into(),
+            issues: vec![
+                ConvoyIssue {
+                    reference: IssueRef {
+                        source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+                        id: "732".into(),
+                    },
+                    repository_ref: Some(repository_specs[0].key()),
+                    snapshot: IssueSnapshot {
+                        title: "Start convoy from an issue".into(),
+                        body: Some("Persist this exact issue body.".into()),
+                        state: IssueState::Open,
+                        labels: vec!["enhancement".into()],
+                        as_of: "2026-07-18T09:30:00Z".parse().expect("timestamp"),
+                    },
                 },
-                repository_ref: Some(repository_specs[0].key()),
-                snapshot: IssueSnapshot {
-                    title: "Start convoy from an issue".into(),
-                    body: Some("Persist this exact issue body.".into()),
-                    state: IssueState::Open,
-                    labels: vec!["enhancement".into()],
-                    as_of: "2026-07-18T09:30:00Z".parse().expect("timestamp"),
+                ConvoyIssue {
+                    reference: IssueRef {
+                        source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/cleat".into() },
+                        id: "733".into(),
+                    },
+                    repository_ref: None,
+                    snapshot: IssueSnapshot {
+                        title: "Fix shared workflow setup".into(),
+                        body: Some("This issue applies across the checked-out repositories.".into()),
+                        state: IssueState::Open,
+                        labels: vec!["enhancement".into()],
+                        as_of: "2026-07-18T09:31:00Z".parse().expect("timestamp"),
+                    },
                 },
-            }],
+            ],
             instruction: Some("Keep the public seam stable.".into()),
         })
         .await
@@ -432,10 +448,15 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
                 if spec.cwd == "/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi"
                     && matches!(&spec.source, TerminalSessionSource::Agent { brief, .. }
                         if brief.path == ".flotilla/briefs/coder.md"
-                            && brief.copies == ["/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi/flotilla"]
+                            && brief.copies == [
+                                "/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi/cleat",
+                                "/Users/alice/dev/flotilla-repos/convoy-multi/feature-multi/flotilla"
+                            ]
                             && brief.content.contains("https://github.com` / `flotilla-org/flotilla` / `732")
+                            && brief.content.contains("https://github.com` / `flotilla-org/cleat` / `733")
                             && brief.content.contains("Snapshot as of `2026-07-18T09:30:00+00:00`")
                             && brief.content.contains("Persist this exact issue body.")
+                            && brief.content.contains("This issue applies across the checked-out repositories.")
                             && brief.content.contains("Keep the public seam stable."))
         )
     }));

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -107,6 +107,7 @@ pub fn append_convoy_work_context(
             content.push_str(body);
             content.push('\n');
         }
+        content.push('\n');
     }
     if let Some(instruction) = &convoy.spec.instruction {
         content.push_str("\n## Human instruction\n\n");
@@ -292,12 +293,20 @@ impl AgentAdapterRegistry {
 
 #[cfg(test)]
 mod tests {
-    use std::{process::Command as ProcessCommand, sync::Arc};
+    use std::{collections::BTreeMap, process::Command as ProcessCommand, sync::Arc};
 
-    use flotilla_resources::{single_agent_contained_workflow_spec, CrewSource, TerminalCrewContext};
+    use chrono::Utc;
+    use flotilla_protocol::{IssueRef, IssueSource, IssueState};
+    use flotilla_resources::{
+        single_agent_contained_workflow_spec, Convoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, CrewSource, IssueSnapshot, ObjectMeta,
+        RepositoryKey, ResourceObject, TerminalCrewContext,
+    };
 
     use crate::{
-        agent_adapter::{build_crew_brief, AgentAdapterRegistry, AgentLaunchRequest, CapabilityTable, CrewAssignment, CrewBriefMember},
+        agent_adapter::{
+            append_convoy_work_context, build_crew_brief, AgentAdapterRegistry, AgentLaunchRequest, CapabilityTable, CrewAssignment,
+            CrewBriefMember,
+        },
         path_context::ExecutionEnvironmentPath,
         providers::{
             discovery::{EnvironmentAssertion, EnvironmentBag},
@@ -362,6 +371,58 @@ mod tests {
         let content = brief_for(CrewAssignment::CarriedIssue);
         assert!(content.contains("## Assignment\n\nYour assignment is the issue snapshot section below."));
         assert!(!content.contains("No assignment was provided"));
+    }
+
+    #[test]
+    fn convoy_work_context_separates_multiple_issue_snapshots() {
+        let repo_ref = RepositoryKey("repo_widgets".to_string());
+        let source = IssueSource { service: "https://github.com".to_string(), scope: "flotilla-org/flotilla".to_string() };
+        let issue = |id: &str, title: &str, body: &str| ConvoyIssue {
+            reference: IssueRef { source: source.clone(), id: id.to_string() },
+            repository_ref: Some(repo_ref.clone()),
+            snapshot: IssueSnapshot {
+                title: title.to_string(),
+                body: Some(body.to_string()),
+                state: IssueState::Open,
+                labels: Vec::new(),
+                as_of: "2026-07-22T00:00:00Z".parse().expect("timestamp"),
+            },
+        };
+        let convoy = ResourceObject::<Convoy> {
+            metadata: ObjectMeta {
+                name: "batch".to_string(),
+                namespace: "flotilla".to_string(),
+                resource_version: "1".to_string(),
+                labels: BTreeMap::new(),
+                annotations: BTreeMap::new(),
+                owner_references: Vec::new(),
+                finalizers: Vec::new(),
+                deletion_timestamp: None,
+                creation_timestamp: Utc::now(),
+            },
+            spec: ConvoySpec {
+                workflow_ref: "workflow".to_string(),
+                inputs: BTreeMap::new(),
+                placement_policy: None,
+                repositories: vec![ConvoyRepositorySpec {
+                    url: "https://github.com/flotilla-org/flotilla".to_string(),
+                    repo_ref: repo_ref.clone(),
+                    base_ref: "main".to_string(),
+                    workspace_slug: "flotilla".to_string(),
+                    subpaths: Vec::new(),
+                }],
+                r#ref: Some("fix/batch".to_string()),
+                project_ref: None,
+                adopted_checkout_refs: BTreeMap::new(),
+                issues: vec![issue("809", "First issue", "First issue body."), issue("810", "Second issue", "Second issue body.")],
+                instruction: None,
+            },
+            status: None,
+        };
+        let mut content = String::new();
+        append_convoy_work_context(&mut content, &convoy, &[repo_ref]);
+
+        assert!(content.contains("First issue body.\n\nSource-qualified reference: `https://github.com` / `flotilla-org/flotilla` / `810`"));
     }
 
     #[test]

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -10,7 +10,9 @@ use std::{
 };
 
 use flotilla_protocol::{
-    result_set::{CheckoutRow, ConvoyRow, IndependentRow, IssueRow, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetState, Rows},
+    result_set::{
+        CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetState, Rows,
+    },
     HostName, IssueRef, QueryCursor, RepositoryKey, ResourceRef,
 };
 use tokio::sync::{broadcast, watch, RwLock, RwLockWriteGuard};
@@ -223,6 +225,7 @@ impl AggregatorProjectionState {
             .local_rows
             .values()
             .chain(convoys.replica_rows.values().flat_map(|rows| rows.values()))
+            .filter(|convoy| convoy_phase_represents_issues(convoy.phase))
             .flat_map(|convoy| convoy.issues.iter().map(|issue| issue.reference.clone()))
             .collect()
     }
@@ -240,4 +243,8 @@ impl AggregatorProjectionState {
             QueryId::Checkouts { scope } => Some(self.checkouts.write().await.result_set(scope)),
         }
     }
+}
+
+fn convoy_phase_represents_issues(phase: ConvoyPhase) -> bool {
+    matches!(phase, ConvoyPhase::Pending | ConvoyPhase::Active)
 }

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -217,6 +217,20 @@ impl AggregatorProjectionState {
         self.demand_backed.apply_issue_changes(query, generation, changed, removed, state)
     }
 
+    pub async fn represented_issue_refs(&self) -> HashSet<IssueRef> {
+        let convoys = self.convoys.read().await;
+        convoys
+            .local_rows
+            .values()
+            .chain(convoys.replica_rows.values().flat_map(|rows| rows.values()))
+            .flat_map(|convoy| convoy.issues.iter().map(|issue| issue.reference.clone()))
+            .collect()
+    }
+
+    pub fn suppress_issues(&self, represented: &HashSet<IssueRef>) -> Vec<ResultDelta> {
+        self.demand_backed.suppress_issues(represented)
+    }
+
     /// The current fleet-merged result set for one named query.
     pub async fn result_set_for(&self, query: &QueryId) -> Option<ResultSet> {
         match query {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1099,8 +1099,7 @@ struct ConvoyStartKey {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum ConvoyStartSubject {
-    IssueId(String),
-    IssueReference(flotilla_protocol::IssueRef),
+    Issues(Vec<flotilla_protocol::IssueSelector>),
     Name(String),
     Anonymous {
         branch: Option<String>,
@@ -1113,10 +1112,8 @@ enum ConvoyStartSubject {
 
 impl ConvoyStartKey {
     fn new(namespace: String, intent: &flotilla_protocol::ConvoyStartIntent) -> Self {
-        let subject = match &intent.issue {
-            Some(flotilla_protocol::IssueSelector::Id(id)) => ConvoyStartSubject::IssueId(id.clone()),
-            Some(flotilla_protocol::IssueSelector::Reference(reference)) => ConvoyStartSubject::IssueReference(reference.clone()),
-            None => match &intent.name {
+        let subject = if intent.issues.is_empty() {
+            match &intent.name {
                 Some(name) => ConvoyStartSubject::Name(name.clone()),
                 None => ConvoyStartSubject::Anonymous {
                     branch: intent.branch.clone(),
@@ -1125,7 +1122,9 @@ impl ConvoyStartKey {
                     instruction: intent.instruction.clone(),
                     placement_policy: intent.placement_policy.clone(),
                 },
-            },
+            }
+        } else {
+            ConvoyStartSubject::Issues(intent.issues.clone())
         };
         Self { namespace, project_ref: intent.project_ref.clone(), subject }
     }
@@ -2941,6 +2940,21 @@ fn convoy_fallback_slug(title: &str, id: &str) -> String {
     format!("{base}-{suffix}")
 }
 
+fn convoy_issues_fallback_slug(issues: &[ConvoyIssue], project_display_name: &str, project_ref: &str) -> String {
+    match issues {
+        [] => convoy_fallback_slug(project_display_name, project_ref),
+        [issue] => convoy_fallback_slug(&issue.snapshot.title, &issue.reference.id),
+        issues => {
+            let issue_ids = issues.iter().map(|issue| issue.reference.id.as_str()).collect::<Vec<_>>().join("-");
+            convoy_fallback_slug("batch-issues", &issue_ids)
+        }
+    }
+}
+
+fn convoy_issue_name_context(issue: &ConvoyIssue) -> String {
+    format!("Issue {}: {}\n{}", issue.reference.id, issue.snapshot.title, issue.snapshot.body.as_deref().unwrap_or_default())
+}
+
 fn validate_convoy_name(name: &str) -> Result<(), String> {
     if name.len() > 63
         || !name.bytes().all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
@@ -3057,10 +3071,10 @@ impl InProcessDaemon {
             .await
             .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
         let repositories = self.snapshot_project_repositories(namespace, project_ref).await?;
-        let issue = match &intent.issue {
-            Some(selector) => Some(self.resolve_convoy_issue(namespace, &project, selector).await?),
-            None => None,
-        };
+        let mut issues = Vec::with_capacity(intent.issues.len());
+        for selector in &intent.issues {
+            issues.push(self.resolve_convoy_issue(namespace, &project, selector).await?);
+        }
         let workflow_ref = match intent.workflow_ref.as_deref() {
             Some(workflow_ref) => required_admission_value(workflow_ref, "workflow")?.to_string(),
             None => project.spec.default_workflow_ref.clone(),
@@ -3073,14 +3087,9 @@ impl InProcessDaemon {
             .await
             .map_err(|error| format!("workflow template {workflow_ref}: {error}"))?;
 
-        let fallback_slug = issue
-            .as_ref()
-            .map(|issue| convoy_fallback_slug(&issue.snapshot.title, &issue.reference.id))
-            .unwrap_or_else(|| convoy_fallback_slug(&project.spec.display_name, project_ref));
+        let fallback_slug = convoy_issues_fallback_slug(&issues, &project.spec.display_name, project_ref);
         let generated = if intent.name.is_none() || intent.branch.is_none() {
-            let issue_context = issue.as_ref().map(|issue| {
-                format!("Issue {}: {}\n{}", issue.reference.id, issue.snapshot.title, issue.snapshot.body.as_deref().unwrap_or_default())
-            });
+            let issue_context = (!issues.is_empty()).then(|| issues.iter().map(convoy_issue_name_context).collect::<Vec<_>>().join("\n\n"));
             let context = [
                 Some(format!("Project: {}", project.spec.display_name)),
                 issue_context,
@@ -3126,7 +3135,7 @@ impl InProcessDaemon {
             r#ref: Some(branch),
             project_ref: Some(project_ref.to_string()),
             adopted_checkout_refs: BTreeMap::new(),
-            issue,
+            issues,
             instruction: intent.instruction.clone(),
         };
         Ok(ConvoyAdmission::builder()
@@ -5550,7 +5559,7 @@ impl InProcessDaemon {
                 r#ref,
                 project_ref: project_ref.clone(),
                 adopted_checkout_refs,
-                issue: None,
+                issues: Vec::new(),
                 instruction: None,
             };
             let meta = InputMeta::builder().name(name.clone()).build();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3071,9 +3071,12 @@ impl InProcessDaemon {
             .await
             .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
         let repositories = self.snapshot_project_repositories(namespace, project_ref).await?;
+        let mut seen_issue_selectors = HashSet::new();
         let mut issues = Vec::with_capacity(intent.issues.len());
         for selector in &intent.issues {
-            issues.push(self.resolve_convoy_issue(namespace, &project, selector).await?);
+            if seen_issue_selectors.insert(selector.clone()) {
+                issues.push(self.resolve_convoy_issue(namespace, &project, selector).await?);
+            }
         }
         let workflow_ref = match intent.workflow_ref.as_deref() {
             Some(workflow_ref) => required_admission_value(workflow_ref, "workflow")?.to_string(),

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -591,7 +591,7 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await
@@ -2731,7 +2731,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await
@@ -3188,7 +3188,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await

--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -114,6 +114,38 @@ impl QueryRegistry {
         })
     }
 
+    pub fn suppress_issues(&self, represented: &HashSet<IssueRef>) -> Vec<ResultDelta> {
+        if represented.is_empty() {
+            return Vec::new();
+        }
+        let mut registry = self.inner.lock().expect("query registry lock poisoned");
+        let mut deltas = Vec::new();
+        for (query, current) in &mut registry.demand_backed {
+            let QueryId::Issues { scope, search } = query else { continue };
+            let Rows::Issues { rows, .. } = &mut current.rows else { continue };
+            let mut removed = Vec::new();
+            rows.retain(|row| {
+                let suppress = represented.contains(&row.reference);
+                if suppress {
+                    removed.push(row.reference.clone());
+                }
+                !suppress
+            });
+            if removed.is_empty() {
+                continue;
+            }
+            removed.sort();
+            current.seq = current.seq.saturating_add(1);
+            let result_state = current.state.clone();
+            deltas.push(ResultDelta {
+                seq: current.seq,
+                changes: QueryChanges::Issues { scope: scope.clone(), search: search.clone(), changed: Vec::new(), removed },
+                state: Some(result_state.clone()),
+            });
+        }
+        deltas
+    }
+
     pub fn subscribe_demand(&self) -> watch::Receiver<HashMap<QueryId, u64>> {
         self.demand_tx.subscribe()
     }
@@ -191,7 +223,7 @@ fn unavailable_issues_result_set(query: QueryId) -> ResultSet {
 
 #[cfg(test)]
 mod tests {
-    use flotilla_protocol::QueryScope;
+    use flotilla_protocol::{Issue, IssueSource, IssueState, QueryScope};
 
     use super::*;
 
@@ -201,6 +233,25 @@ mod tests {
 
     fn cursor(query: QueryId) -> QueryCursor {
         QueryCursor { query, since: None }
+    }
+
+    fn issue_row(id: &str) -> IssueRow {
+        let reference =
+            IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: id.into() };
+        IssueRow {
+            reference: reference.clone(),
+            issue: Issue {
+                reference,
+                title: format!("Issue {id}"),
+                body: None,
+                state: IssueState::Open,
+                labels: Vec::new(),
+                as_of: Utc::now(),
+                association_keys: Vec::new(),
+                provider_name: "github".into(),
+                provider_display_name: "GitHub".into(),
+            },
+        }
     }
 
     #[test]
@@ -238,6 +289,29 @@ mod tests {
         assert!(result.rows.is_empty());
         assert!(matches!(result.state.conditions.as_slice(), [ResultSetCondition::IssueSourceUnavailable { source: None, .. }]));
         assert!(result.state.demand.is_some());
+    }
+
+    #[test]
+    fn suppress_issues_removes_represented_rows_from_live_issue_sets() {
+        let registry = QueryRegistry::default();
+        let query = issues("represented");
+        registry.replace(Uuid::new_v4(), &[cursor(query.clone())]);
+        let generation = registry.generation(&query);
+        let ready = ResultSetState { demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: true }), conditions: vec![] };
+        registry.replace_issues(&query, generation, vec![issue_row("809"), issue_row("810")], ready).expect("issue window");
+
+        let represented = HashSet::from([IssueRef {
+            source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+            id: "810".into(),
+        }]);
+        let deltas = registry.suppress_issues(&represented);
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].changes.removed_issues().expect("removed issue refs"), represented.iter().cloned().collect::<Vec<_>>());
+        let result = registry.result_set(&query).expect("live issue window");
+        let Rows::Issues { rows, .. } = result.rows else { panic!("expected issue rows") };
+        assert_eq!(rows.iter().map(|row| row.reference.id.as_str()).collect::<Vec<_>>(), vec!["809"]);
+        assert!(result.state.demand.as_ref().expect("demand metadata").has_more, "suppression should preserve demand metadata");
     }
 
     #[test]

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1067,7 +1067,11 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
-                    issues: vec![IssueSelector::Reference(reference.clone()), IssueSelector::Reference(reference_two.clone())],
+                    issues: vec![
+                        IssueSelector::Reference(reference.clone()),
+                        IssueSelector::Reference(reference_two.clone()),
+                        IssueSelector::Reference(reference_two.clone()),
+                    ],
                     name: Some("batch-732-733".into()),
                     branch: Some("fix/batch-732-733".into()),
                     workflow_ref: Some("single-agent-contained".into()),

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -887,7 +887,7 @@ async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
-                    issue: None,
+                    issues: Vec::new(),
                     name: Some("missing-adapter".into()),
                     branch: Some("fix/missing-adapter".into()),
                     workflow_ref: None,
@@ -965,11 +965,16 @@ async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
 async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snapshot() {
     let reference =
         IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/planning".into() }, id: "732".into() };
+    let reference_two =
+        IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/planning".into() }, id: "733".into() };
     let mut issue = TestIssue::new("Start convoy from an issue").id("732").with_labels(vec!["enhancement".into()]).build();
     issue.reference = reference.clone();
     issue.body = Some("Capture the issue at admission time.".into());
+    let mut issue_two = TestIssue::new("Carry a second issue").id("733").with_labels(vec!["quick-win".into()]).build();
+    issue_two.reference = reference_two.clone();
+    issue_two.body = Some("Include this issue in the same convoy.".into());
     let provider = Arc::new(FakeIssueProvider::new());
-    provider.add_issues(vec![(reference.id.clone(), issue.clone())]).await;
+    provider.add_issues(vec![(reference.id.clone(), issue.clone()), (reference_two.id.clone(), issue_two.clone())]).await;
     let utility = Arc::new(CountingConvoyAiUtility { calls: AtomicUsize::new(0), fail: AtomicBool::new(false) });
     let mut discovery = fake_discovery_with_provider_set(
         FakeDiscoveryProviders::new().with_issue_tracker(provider as Arc<dyn flotilla_core::providers::issue_tracker::IssueProvider>),
@@ -1013,7 +1018,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
-                    issue: Some(IssueSelector::Reference(reference.clone())),
+                    issues: vec![IssueSelector::Reference(reference.clone())],
                     name: Some("issue-732".into()),
                     branch: Some("fix/issue-732".into()),
                     workflow_ref: Some("single-agent-contained".into()),
@@ -1046,12 +1051,50 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     assert_eq!(persisted.spec.placement_policy.as_deref(), Some("docker-test"));
     assert_eq!(persisted.spec.repositories.len(), 1);
     assert_eq!(persisted.spec.instruction.as_deref(), Some("Keep the snapshot durable."));
-    let persisted_issue = persisted.spec.issue.expect("issue snapshot");
+    let persisted_issue = persisted.spec.issues.first().expect("issue snapshot");
     assert_eq!(persisted_issue.reference, reference);
     assert_eq!(persisted_issue.repository_ref, Some(repository.key()));
     assert_eq!(persisted_issue.snapshot.title, issue.title);
     assert_eq!(persisted_issue.snapshot.body, issue.body);
     assert_eq!(utility.calls.load(Ordering::SeqCst), 0, "fully specified admission must not call AI");
+
+    let batch_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".into(),
+                    issues: vec![IssueSelector::Reference(reference.clone()), IssueSelector::Reference(reference_two.clone())],
+                    name: Some("batch-732-733".into()),
+                    branch: Some("fix/batch-732-733".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: Vec::new(),
+                    instruction: Some("Fix both issues in one convoy.".into()),
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("batch command accepted");
+    let batch_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == batch_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("batch start should finish");
+    assert_eq!(batch_result, CommandValue::ConvoyStarted { name: "batch-732-733".into(), attach_command: None, binding: None });
+    let batch = backend.using::<ResourceConvoy>("flotilla").get("batch-732-733").await.expect("batch convoy");
+    assert_eq!(batch.spec.issues.iter().map(|issue| &issue.reference).collect::<Vec<_>>(), vec![&reference, &reference_two]);
+    assert_eq!(batch.spec.instruction.as_deref(), Some("Fix both issues in one convoy."));
 
     utility.fail.store(true, Ordering::SeqCst);
     let fallback_id = daemon
@@ -1063,7 +1106,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
-                    issue: Some(IssueSelector::Reference(reference)),
+                    issues: vec![IssueSelector::Reference(reference)],
                     name: None,
                     branch: None,
                     workflow_ref: None,
@@ -1116,7 +1159,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: Some("flotilla".into()),
                     project_ref: "explicit-workflow".into(),
-                    issue: None,
+                    issues: Vec::new(),
                     name: Some("explicit-workflow".into()),
                     branch: Some("fix/explicit-workflow".into()),
                     workflow_ref: Some("single-agent-contained".into()),
@@ -1151,7 +1194,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: Some("other".into()),
                     project_ref: "flotilla".into(),
-                    issue: None,
+                    issues: Vec::new(),
                     name: Some("wrong-namespace".into()),
                     branch: Some("fix/wrong-namespace".into()),
                     workflow_ref: Some("single-agent-contained".into()),
@@ -1190,7 +1233,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
-                    issue: None,
+                    issues: Vec::new(),
                     name: Some("invalid-branch".into()),
                     branch: Some("bad branch".into()),
                     workflow_ref: Some("single-agent-contained".into()),
@@ -1266,7 +1309,7 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
-                    issue: None,
+                    issues: Vec::new(),
                     name: None,
                     branch: None,
                     workflow_ref: None,
@@ -1318,7 +1361,7 @@ async fn convoy_start_acknowledges_while_admission_is_in_flight() {
                         intent: Box::new(ConvoyStartIntent {
                             namespace: None,
                             project_ref: "flotilla".into(),
-                            issue: None,
+                            issues: Vec::new(),
                             name: None,
                             branch: None,
                             workflow_ref: None,
@@ -1382,7 +1425,7 @@ async fn convoy_start_rejects_the_same_project_start_while_admission_is_in_fligh
             intent: Box::new(ConvoyStartIntent {
                 namespace: None,
                 project_ref: "flotilla".into(),
-                issue: Some(IssueSelector::Reference(reference)),
+                issues: vec![IssueSelector::Reference(reference)],
                 name: None,
                 branch: None,
                 workflow_ref: None,
@@ -1469,7 +1512,7 @@ async fn convoy_start_reports_failed_work_without_waiting_for_auto_attach_timeou
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
-                    issue: None,
+                    issues: Vec::new(),
                     name: Some("bootstrap-failure".into()),
                     branch: Some("fix/bootstrap-failure".into()),
                     workflow_ref: Some("single-agent-contained".into()),

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -794,6 +794,10 @@ impl Aggregator {
             self.emitted_queries.insert(QueryId::Convoys);
             let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
         }
+        let represented = self.state.represented_issue_refs().await;
+        for delta in self.state.suppress_issues(&represented) {
+            let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
+        }
     }
 
     async fn replace_session_source(&mut self, source: LocalSource, sessions: Vec<ResourceObject<TerminalSession>>) {
@@ -995,6 +999,10 @@ impl Aggregator {
                 self.emitted_queries.insert(QueryId::Convoys);
                 let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.result_set().await)));
             }
+            let represented = self.state.represented_issue_refs().await;
+            for delta in self.state.suppress_issues(&represented) {
+                let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
+            }
         }
 
         let independent_deltas = self.state.replace_independent_replica_rows(independent_replacements).await;
@@ -1085,6 +1093,18 @@ impl Aggregator {
             .maybe_finished_at(status.and_then(|status| status.finished_at))
             .maybe_observed_workflow_ref(status.and_then(|status| status.observed_workflow_ref.clone()))
             .maybe_project_ref(convoy.spec.project_ref.clone())
+            .issues(
+                convoy
+                    .spec
+                    .issues
+                    .iter()
+                    .map(|issue| flotilla_protocol::result_set::ConvoyIssueRow {
+                        reference: issue.reference.clone(),
+                        title: issue.snapshot.title.clone(),
+                        state: issue.snapshot.state,
+                    })
+                    .collect(),
+            )
             .maybe_change_request(change_request)
             .vessels(vessels)
             .build()

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -799,6 +799,9 @@ impl Aggregator {
             let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
         }
         if let Some(materializer) = &self.issue_materializer {
+            // The direct delta hides represented rows immediately; refiltering
+            // republishes loaded windows so rows can reappear when representation
+            // changes again.
             materializer.refilter_active_queries();
         }
     }
@@ -1007,6 +1010,9 @@ impl Aggregator {
                 let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
             }
             if let Some(materializer) = &self.issue_materializer {
+                // The direct delta hides represented rows immediately; refiltering
+                // republishes loaded windows so rows can reappear when representation
+                // changes again.
                 materializer.refilter_active_queries();
             }
         }

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -798,6 +798,9 @@ impl Aggregator {
         for delta in self.state.suppress_issues(&represented) {
             let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
         }
+        if let Some(materializer) = &self.issue_materializer {
+            materializer.refilter_active_queries();
+        }
     }
 
     async fn replace_session_source(&mut self, source: LocalSource, sessions: Vec<ResourceObject<TerminalSession>>) {
@@ -1002,6 +1005,9 @@ impl Aggregator {
             let represented = self.state.represented_issue_refs().await;
             for delta in self.state.suppress_issues(&represented) {
                 let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
+            }
+            if let Some(materializer) = &self.issue_materializer {
+                materializer.refilter_active_queries();
             }
         }
 

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -48,6 +48,7 @@ impl IssueMaterializationResolver for InProcessDaemon {
 
 enum MaterializationIntent {
     FetchMore,
+    Refilter,
     #[cfg(test)]
     Refresh,
 }
@@ -124,6 +125,14 @@ impl IssueMaterializer {
         }
     }
 
+    pub(crate) fn refilter_active_queries(&self) {
+        for (query, active) in &self.active {
+            if let Err(error) = active.intents.try_send(MaterializationIntent::Refilter) {
+                tracing::warn!(%query, %error, "could not enqueue issue refilter intent");
+            }
+        }
+    }
+
     #[cfg(test)]
     fn refresh(&self, query: &QueryId) {
         self.active.get(query).expect("active materialization").intents.try_send(MaterializationIntent::Refresh).expect("enqueue refresh");
@@ -154,6 +163,16 @@ struct MaterializedWindow {
     conditions: Vec<ResultSetCondition>,
 }
 
+impl MaterializedWindow {
+    fn rows(&self) -> Vec<IssueRow> {
+        self.sources.iter().flat_map(|source| source.rows.values().cloned()).collect()
+    }
+
+    fn has_more(&self) -> bool {
+        self.sources.iter().any(|source| source.has_more)
+    }
+}
+
 async fn run_materialization(
     query: QueryId,
     generation: u64,
@@ -177,6 +196,9 @@ async fn run_materialization(
                         _ = cancel.cancelled() => return,
                         _ = fetch_more(&query, generation, &mut window, &state, &event_tx) => {}
                     }
+                }
+                Some(MaterializationIntent::Refilter) => {
+                    publish_loaded_window(&query, generation, window.rows(), window.has_more(), window.conditions.clone(), &state, &event_tx).await;
                 }
                 #[cfg(test)]
                 Some(MaterializationIntent::Refresh) => {
@@ -262,12 +284,9 @@ async fn load_window(
             Err(condition) => conditions.push(condition),
         }
     }
-    let has_more = windows.iter().any(|window| window.has_more);
-    let mut rows = rows.into_values().collect::<Vec<_>>();
-    suppress_represented_rows(&mut rows, state).await;
-    sort_rows(&mut rows);
+    let rows = rows.into_values().collect::<Vec<_>>();
     let needs_full_reload = !conditions.is_empty();
-    publish_window(query, generation, rows, has_more, conditions.clone(), state, event_tx);
+    publish_loaded_window(query, generation, rows, windows.iter().any(|window| window.has_more), conditions.clone(), state, event_tx).await;
     MaterializedWindow { sources: windows, needs_full_reload, conditions }
 }
 
@@ -445,6 +464,20 @@ fn publish_window(
     }
 }
 
+async fn publish_loaded_window(
+    query: &QueryId,
+    generation: u64,
+    mut rows: Vec<IssueRow>,
+    has_more: bool,
+    conditions: Vec<ResultSetCondition>,
+    state: &AggregatorProjectionState,
+    event_tx: &broadcast::Sender<DaemonEvent>,
+) {
+    suppress_represented_rows(&mut rows, state).await;
+    sort_rows(&mut rows);
+    publish_window(query, generation, rows, has_more, conditions, state, event_tx);
+}
+
 fn demand_state(has_more: bool, conditions: Vec<ResultSetCondition>) -> ResultSetState {
     ResultSetState { demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more }), conditions }
 }
@@ -488,7 +521,12 @@ mod tests {
     use std::collections::VecDeque;
 
     use chrono::Duration as ChronoDuration;
-    use flotilla_protocol::{issue_query::IssueResultPage, test_support::TestIssue, Issue, IssueChangeset, QueryCursor};
+    use flotilla_protocol::{
+        issue_query::IssueResultPage,
+        result_set::{ConvoyIssueRow, ConvoyPhase, ConvoyRow},
+        test_support::TestIssue,
+        Issue, IssueChangeset, QueryCursor, ResourceRef,
+    };
     use tokio::sync::{Mutex, Notify};
     use uuid::Uuid;
 
@@ -742,6 +780,46 @@ mod tests {
         assert_eq!(result.rows.as_issues().expect("issue rows")[0].reference, IssueRef { source, id: "WIDGET-123".into() });
         assert!(!result.state.demand.expect("demand metadata").has_more);
         assert!(result.state.conditions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn refilter_republishes_loaded_issue_rows_when_convoy_representation_changes() {
+        let state = AggregatorProjectionState::new();
+        let query = project_query("repo_widget");
+        let source = IssueSource { service: "https://issues.example".into(), scope: "widgets/api".into() };
+        let represented = IssueRef { source: source.clone(), id: "WIDGET-810".into() };
+        let provider = Arc::new(ScriptedProvider::new(vec![page(&["WIDGET-809", "WIDGET-810"], false)], vec![]));
+        let (materializer, mut events) = manager(&state, &query, vec![source], provider);
+        let _ = next_event(&mut events).await;
+
+        {
+            let mut convoys = state.write().await;
+            let resource = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "batch");
+            convoys.local_rows.insert(
+                resource.clone(),
+                ConvoyRow::builder()
+                    .resource(resource)
+                    .name("batch")
+                    .workflow_ref("workflow")
+                    .phase(ConvoyPhase::Active)
+                    .issues(vec![ConvoyIssueRow { reference: represented, title: "Issue WIDGET-810".into(), state: IssueState::Open }])
+                    .build(),
+            );
+        }
+        materializer.refilter_active_queries();
+        let DaemonEvent::ResultSet(suppressed) = next_event(&mut events).await else { panic!("refilter must emit a result set") };
+        assert_eq!(
+            suppressed.rows.as_issues().expect("suppressed issue rows").iter().map(|row| row.reference.id.as_str()).collect::<Vec<_>>(),
+            vec!["WIDGET-809"]
+        );
+
+        state.write().await.local_rows.clear();
+        materializer.refilter_active_queries();
+        let DaemonEvent::ResultSet(restored) = next_event(&mut events).await else { panic!("refilter must emit a result set") };
+        assert_eq!(
+            restored.rows.as_issues().expect("restored issue rows").iter().map(|row| row.reference.id.as_str()).collect::<Vec<_>>(),
+            vec!["WIDGET-810", "WIDGET-809"]
+        );
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -264,6 +264,7 @@ async fn load_window(
     }
     let has_more = windows.iter().any(|window| window.has_more);
     let mut rows = rows.into_values().collect::<Vec<_>>();
+    suppress_represented_rows(&mut rows, state).await;
     sort_rows(&mut rows);
     let needs_full_reload = !conditions.is_empty();
     publish_window(query, generation, rows, has_more, conditions.clone(), state, event_tx);
@@ -315,6 +316,7 @@ async fn fetch_more(
         }
     }
     window.conditions = conditions.clone();
+    suppress_represented_rows(&mut changed, state).await;
     sort_rows(&mut changed);
     let result_state = demand_state(window.sources.iter().any(|source| source.has_more), conditions);
     // Metadata-only deltas are significant: an empty final page must still
@@ -418,6 +420,7 @@ async fn refresh_window(
     }
 
     let mut changed = changed.into_values().collect::<Vec<_>>();
+    suppress_represented_rows(&mut changed, state).await;
     sort_rows(&mut changed);
     let mut removed = removed.into_iter().collect::<Vec<_>>();
     removed.sort();
@@ -456,6 +459,11 @@ fn issue_row(issue: flotilla_protocol::Issue) -> IssueRow {
 
 fn sort_rows(rows: &mut [IssueRow]) {
     rows.sort_by(|left, right| left.reference.cmp_id_desc(&right.reference));
+}
+
+async fn suppress_represented_rows(rows: &mut Vec<IssueRow>, state: &AggregatorProjectionState) {
+    let represented = state.represented_issue_refs().await;
+    rows.retain(|row| !represented.contains(&row.reference));
 }
 
 async fn query_page(

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -791,18 +791,22 @@ mod tests {
         let provider = Arc::new(ScriptedProvider::new(vec![page(&["WIDGET-809", "WIDGET-810"], false)], vec![]));
         let (materializer, mut events) = manager(&state, &query, vec![source], provider);
         let _ = next_event(&mut events).await;
+        let resource = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "batch");
 
         {
             let mut convoys = state.write().await;
-            let resource = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "batch");
             convoys.local_rows.insert(
                 resource.clone(),
                 ConvoyRow::builder()
-                    .resource(resource)
+                    .resource(resource.clone())
                     .name("batch")
                     .workflow_ref("workflow")
                     .phase(ConvoyPhase::Active)
-                    .issues(vec![ConvoyIssueRow { reference: represented, title: "Issue WIDGET-810".into(), state: IssueState::Open }])
+                    .issues(vec![ConvoyIssueRow {
+                        reference: represented.clone(),
+                        title: "Issue WIDGET-810".into(),
+                        state: IssueState::Open,
+                    }])
                     .build(),
             );
         }
@@ -813,7 +817,7 @@ mod tests {
             vec!["WIDGET-809"]
         );
 
-        state.write().await.local_rows.clear();
+        state.write().await.local_rows.get_mut(&resource).expect("represented convoy row").phase = ConvoyPhase::Completed;
         materializer.refilter_active_queries();
         let DaemonEvent::ResultSet(restored) = next_event(&mut events).await else { panic!("refilter must emit a result set") };
         assert_eq!(

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2073,7 +2073,7 @@ mod tests {
                 r#ref: Some("main".to_string()),
                 project_ref: None,
                 adopted_checkout_refs: BTreeMap::new(),
-                issue: None,
+                issues: Vec::new(),
                 instruction: None,
             })
             .await

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -306,7 +306,7 @@ async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
             r#ref: None,
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
-            issue: None,
+            issues: Vec::new(),
             instruction: None,
         })
         .await

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -57,7 +57,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
-        issue: None,
+        issues: Vec::new(),
         instruction: None,
     }
 }

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -111,7 +111,7 @@ pub struct Command {
 /// An issue supplied to convoy admission either as a fully source-qualified
 /// reference or as an opaque ID whose source must be resolved through the
 /// Project.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum IssueSelector {
     Id(String),
@@ -128,8 +128,9 @@ pub struct ConvoyStartIntent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     pub project_ref: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issue: Option<IssueSelector>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<IssueSelector>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -108,9 +108,9 @@ pub struct Command {
     pub action: CommandAction,
 }
 
-/// An issue supplied to convoy admission either as a fully source-qualified
+/// One issue supplied to convoy admission either as a fully source-qualified
 /// reference or as an opaque ID whose source must be resolved through the
-/// Project.
+/// Project. A start intent may carry several selectors.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum IssueSelector {
@@ -120,6 +120,8 @@ pub enum IssueSelector {
 
 /// Partial intent accepted by the convoy start verb. Admission completes any
 /// omitted fields before persisting a `ConvoySpec`.
+/// `issues` contains zero or more issue selectors to snapshot into the
+/// admitted convoy.
 ///
 /// This type lives in protocol rather than resources because incomplete
 /// intent must never enter the resource store.

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -18,7 +18,7 @@ use crate::{
     provider_data::{ChangeRequestStatus, Issue},
     resource_ref::ResourceRef,
     snapshot::RepoKey,
-    IssueRef, IssueSource, LifecycleAuthority, RepositoryKey,
+    IssueRef, IssueSource, IssueState, LifecycleAuthority, RepositoryKey,
 };
 
 pub type Timestamp = DateTime<Utc>;
@@ -501,6 +501,10 @@ pub struct ConvoyRow {
     /// The Project this convoy belongs to, from `ConvoySpec.project_ref`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_ref: Option<String>,
+    /// Issues represented by this convoy, captured at admission time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub issues: Vec<ConvoyIssueRow>,
     /// Shallow forge lookup for the convoy branch. This is display/reference
     /// data, not a Flotilla-managed resource.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -509,6 +513,13 @@ pub struct ConvoyRow {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub vessels: Vec<VesselRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvoyIssueRow {
+    pub reference: IssueRef,
+    pub title: String,
+    pub state: IssueState,
 }
 
 /// The external change request currently associated with a convoy branch.

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -52,7 +52,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: Default::default(),
-        issue: None,
+        issues: Vec::new(),
         instruction: None,
     }
 }

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -31,8 +31,9 @@ pub struct ConvoySpec {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub adopted_checkout_refs: BTreeMap<RepositoryKey, String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub issue: Option<ConvoyIssue>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<ConvoyIssue>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instruction: Option<String>,
 }

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -205,7 +205,7 @@ pub fn valid_convoy_spec() -> RealConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
-        issue: None,
+        issues: Vec::new(),
         instruction: None,
     }
 }

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -44,7 +44,7 @@ async fn convoy_persists_source_qualified_issue_snapshot_and_instruction() {
     let convoys = backend.using::<Convoy>("flotilla");
     let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository");
     let mut spec = valid_convoy_spec();
-    spec.issue = Some(ConvoyIssue {
+    spec.issues.push(ConvoyIssue {
         reference: IssueRef {
             source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
             id: "WIDGET-732".into(),
@@ -63,7 +63,7 @@ async fn convoy_persists_source_qualified_issue_snapshot_and_instruction() {
     convoys.create(&convoy_meta("issue-work"), &spec).await.expect("convoy create");
     let persisted = convoys.get("issue-work").await.expect("convoy get");
 
-    assert_eq!(persisted.spec.issue, spec.issue);
+    assert_eq!(persisted.spec.issues, spec.issues);
     assert_eq!(persisted.spec.instruction.as_deref(), Some("Preserve the public API."));
 }
 

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -39,7 +39,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: Default::default(),
-        issue: None,
+        issues: Vec::new(),
         instruction: None,
     }
 }

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -440,7 +440,7 @@ impl App {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: Some(namespace),
                         project_ref: project,
-                        issue: Some(IssueSelector::Reference(issue)),
+                        issues: vec![IssueSelector::Reference(issue)],
                         name: None,
                         branch: None,
                         workflow_ref: None,
@@ -460,7 +460,7 @@ impl App {
                         intent: Box::new(ConvoyStartIntent {
                             namespace: Some(namespace.clone()),
                             project_ref: project.clone(),
-                            issue: Some(IssueSelector::Reference(issue.issue.clone())),
+                            issues: vec![IssueSelector::Reference(issue.issue.clone())],
                             name: None,
                             branch: None,
                             workflow_ref: None,
@@ -488,6 +488,31 @@ impl App {
                         view.project_table_state.table_mut(crate::table_view::ProjectPanelKind::Issues).multi_selected.clear();
                     }
                 }
+                return;
+            }
+            TableIntent::StartBatchConvoy { namespace, project, issues } => {
+                let Some(address) = self.views.active_address().cloned() else { return };
+                let issue_count = issues.len();
+                self.proto_commands.push(self.command(CommandAction::ConvoyStart {
+                    intent: Box::new(ConvoyStartIntent {
+                        namespace: Some(namespace),
+                        project_ref: project,
+                        issues: issues.into_iter().map(|issue| IssueSelector::Reference(issue.issue)).collect(),
+                        name: None,
+                        branch: None,
+                        workflow_ref: None,
+                        inputs: Vec::new(),
+                        instruction: None,
+                        placement_policy: None,
+                        auto_attach: true,
+                    }),
+                }));
+                if let Some(index) = self.views.find(&address) {
+                    if let Some(view) = self.views.get_mut(index) {
+                        view.project_table_state.table_mut(crate::table_view::ProjectPanelKind::Issues).multi_selected.clear();
+                    }
+                }
+                self.set_status_message(Some(format!("Starting batch convoy for {issue_count} issues...")));
                 return;
             }
         };

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -57,7 +57,7 @@ fn project_issue_start_preserves_the_selected_namespace() {
     let flotilla_protocol::CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
     assert_eq!(intent.namespace.as_deref(), Some("other-team"));
     assert_eq!(intent.project_ref, "roadmap");
-    assert_eq!(intent.issue, Some(flotilla_protocol::IssueSelector::Reference(issue)));
+    assert_eq!(intent.issues, vec![flotilla_protocol::IssueSelector::Reference(issue)]);
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -16,8 +16,8 @@ use flotilla_protocol::{
     provider_data::Issue,
     qualified_path::{HostId, QualifiedPath},
     test_support::TestIssue,
-    Change, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostSummary, ImageId, IssueChangeset, IssueRef, IssueSource, NodeId,
-    NodeInfo, ProvisioningTarget, RepoIdentity, RepoSelector, ViewAddress, WorkItemIdentity,
+    Change, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostSummary, ImageId, IssueChangeset, IssueRef, IssueSelector, IssueSource,
+    NodeId, NodeInfo, ProvisioningTarget, RepoIdentity, RepoSelector, ViewAddress, WorkItemIdentity,
 };
 use ratatui::{backend::TestBackend, Terminal};
 use tempfile::tempdir;
@@ -1730,6 +1730,7 @@ fn test_convoy(
         message: None,
         repo_hint: None,
         project_ref: None,
+        issues: Vec::new(),
         change_request: None,
         vessels: vec![],
         started_at: None,
@@ -2301,13 +2302,52 @@ fn project_issue_bulk_start_queues_one_convoy_start_per_issue() {
     while let Some((command, ctx)) = app.proto_commands.take_next() {
         let CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
         let Some(project_ctx) = ctx.expect("pending context").project_issue_start else { panic!("expected project context") };
-        queued.push((intent.issue, project_ctx.issue.id, intent.auto_attach));
+        queued.push((intent.issues, project_ctx.issue.id, intent.auto_attach));
     }
 
     assert_eq!(queued.len(), 3);
     assert_eq!(queued.iter().map(|(_, id, _)| id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
     assert!(queued.iter().all(|(_, _, auto_attach)| !auto_attach), "bulk convoy starts should not auto-attach one selected issue");
     assert_eq!(app.model.status_message.as_deref(), Some("Starting 3 convoys..."));
+}
+
+#[test]
+fn project_issue_batch_start_queues_one_convoy_for_all_issues() {
+    let mut app = stub_app();
+    let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+    app.open_view(address);
+    let source = IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() };
+
+    app.execute_table_intent(crate::table_view::TableIntent::StartBatchConvoy {
+        namespace: "flotilla".into(),
+        project: "roadmap".into(),
+        issues: ["809", "810", "811"]
+            .into_iter()
+            .map(|id| crate::table_view::TableIssueStart {
+                row_id: crate::table_view::RowId::new(format!("issue:{id}")),
+                issue: IssueRef { source: source.clone(), id: id.into() },
+            })
+            .collect(),
+    });
+
+    let (command, ctx) = app.proto_commands.take_next().expect("expected command");
+    assert!(app.proto_commands.take_next().is_none(), "batch start should queue exactly one command");
+    assert!(ctx.is_none(), "batch convoy start has one command-level outcome");
+    let CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
+    assert_eq!(intent.issues.len(), 3);
+    assert_eq!(
+        intent
+            .issues
+            .iter()
+            .map(|selector| match selector {
+                IssueSelector::Reference(reference) => reference.id.as_str(),
+                IssueSelector::Id(id) => id.as_str(),
+            })
+            .collect::<Vec<_>>(),
+        vec!["809", "810", "811"]
+    );
+    assert!(intent.auto_attach, "batch convoy start should auto-attach the single created convoy");
+    assert_eq!(app.model.status_message.as_deref(), Some("Starting batch convoy for 3 issues..."));
 }
 
 #[test]

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -155,6 +155,8 @@ pub struct ConvoySummary {
     pub repo_hint: Option<RepoKey>,
     /// The Project this convoy belongs to (`ConvoySpec.project_ref`).
     pub project_ref: Option<String>,
+    #[builder(default)]
+    pub issues: Vec<wire::ConvoyIssueRow>,
     pub change_request: Option<wire::ConvoyChangeRequest>,
     pub vessels: Vec<VesselSummary>,
     pub started_at: Option<Timestamp>,
@@ -175,6 +177,7 @@ impl From<&wire::ConvoyRow> for ConvoySummary {
             message: row.message.clone(),
             repo_hint: row.repo.clone(),
             project_ref: row.project_ref.clone(),
+            issues: row.issues.clone(),
             change_request: row.change_request.clone(),
             vessels: row.vessels.iter().map(|vessel| vessel_summary(row, vessel)).collect(),
             started_at: row.started_at,

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -815,6 +815,7 @@ mod tests {
             message: None,
             repo_hint: None,
             project_ref: None,
+            issues: Vec::new(),
             change_request: None,
             vessels: vessels
                 .iter()

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -318,6 +318,7 @@ pub enum TableIntent {
     ForceCompleteWork { convoy: String, vessel: String, host: HostName },
     StartConvoy { namespace: String, project: String, issue: IssueRef },
     StartConvoys { namespace: String, project: String, issues: Vec<TableIssueStart> },
+    StartBatchConvoy { namespace: String, project: String, issues: Vec<TableIssueStart> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -952,6 +953,12 @@ fn convoy_description(row: &ConvoySummary) -> Vec<DetailField> {
     if let Some(change_request) = &row.change_request {
         fields.push(DetailField { label: "Pull request", value: format!("#{} · {}", change_request.id, change_request.status) });
     }
+    if !row.issues.is_empty() {
+        fields.push(DetailField {
+            label: "Issues",
+            value: row.issues.iter().map(|issue| format!("{}: {}", issue.reference.id, issue.title)).collect::<Vec<_>>().join("\n"),
+        });
+    }
     fields
 }
 
@@ -1132,6 +1139,7 @@ mod tests {
             message: None,
             repo_hint: None,
             project_ref: Some("flotilla".into()),
+            issues: Vec::new(),
             change_request: None,
             vessels,
             started_at: None,

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -240,14 +240,22 @@ impl ProjectPageWidget {
         Some((scope.namespace.clone(), scope.name.clone(), selected))
     }
 
-    fn selected_issue_bulk_action(layouts: &[PanelLayout<'_>], state: &ProjectTableState) -> Option<AvailableAction> {
+    fn selected_issue_bulk_actions(layouts: &[PanelLayout<'_>], state: &ProjectTableState) -> Option<Vec<AvailableAction>> {
         let (namespace, project, issues) = Self::selected_issue_starts(layouts, state)?;
-        Some(AvailableAction {
-            id: "start_convoys",
-            label: "Start convoys",
-            key: 'c',
-            intent: TableIntent::StartConvoys { namespace, project, issues },
-        })
+        Some(vec![
+            AvailableAction {
+                id: "start_convoys",
+                label: "Start convoys",
+                key: 'c',
+                intent: TableIntent::StartConvoys { namespace: namespace.clone(), project: project.clone(), issues: issues.clone() },
+            },
+            AvailableAction {
+                id: "start_batch_convoy",
+                label: "Start batch convoy",
+                key: 'b',
+                intent: TableIntent::StartBatchConvoy { namespace, project, issues },
+            },
+        ])
     }
 
     fn render_composite(&mut self, frame: &mut Frame, area: Rect, theme: &Theme, panels: &[ProjectPanel], state: &mut ProjectTableState) {
@@ -388,8 +396,8 @@ impl InteractiveWidget for ProjectPageWidget {
                 Some((panel, row)) => Outcome::Push(Box::new(DescribeWidget::new(panel.table.title.clone(), row.describe.clone()))),
                 None => Outcome::Consumed,
             },
-            Action::OpenActionMenu => match Self::selected_issue_bulk_action(&layouts, ctx.views.active_project_table_state()) {
-                Some(action) => Outcome::Push(Box::new(TableActionMenuWidget::new(vec![action]))),
+            Action::OpenActionMenu => match Self::selected_issue_bulk_actions(&layouts, ctx.views.active_project_table_state()) {
+                Some(actions) => Outcome::Push(Box::new(TableActionMenuWidget::new(actions))),
                 None => match Self::active_row(&layouts, ctx.views.active_project_table_state()) {
                     Some((_, row)) if !row.actions.is_empty() => Outcome::Push(Box::new(TableActionMenuWidget::new(row.actions.clone()))),
                     Some(_) => {
@@ -616,11 +624,16 @@ mod tests {
         state.table_mut(ProjectPanelKind::Issues).multi_selected.insert(panels[0].table.rows[0].id.clone());
         state.table_mut(ProjectPanelKind::Issues).multi_selected.insert(panels[0].table.rows[1].id.clone());
 
-        let action = ProjectPageWidget::selected_issue_bulk_action(&layouts, &state).expect("bulk action");
+        let actions = ProjectPageWidget::selected_issue_bulk_actions(&layouts, &state).expect("bulk actions");
+        let action = actions.iter().find(|action| action.id == "start_convoys").expect("fan-out action");
+        let batch = actions.iter().find(|action| action.id == "start_batch_convoy").expect("batch action");
 
         assert_eq!(action.label, "Start convoys");
-        let TableIntent::StartConvoys { namespace, project, issues } = action.intent else { panic!("expected bulk start") };
+        assert_eq!(batch.label, "Start batch convoy");
+        let TableIntent::StartConvoys { namespace, project, issues } = &action.intent else { panic!("expected bulk start") };
         assert_eq!((namespace.as_str(), project.as_str()), ("flotilla", "roadmap"));
+        assert_eq!(issues.iter().map(|issue| issue.issue.id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
+        let TableIntent::StartBatchConvoy { issues, .. } = &batch.intent else { panic!("expected batch start") };
         assert_eq!(issues.iter().map(|issue| issue.issue.id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
     }
 
@@ -641,9 +654,10 @@ mod tests {
             description: "Start convoy".into(),
         });
 
-        let action = ProjectPageWidget::selected_issue_bulk_action(&layouts, &state).expect("bulk action");
+        let actions = ProjectPageWidget::selected_issue_bulk_actions(&layouts, &state).expect("bulk actions");
+        let action = actions.iter().find(|action| action.id == "start_convoys").expect("fan-out action");
 
-        let TableIntent::StartConvoys { issues, .. } = action.intent else { panic!("expected bulk start") };
+        let TableIntent::StartConvoys { issues, .. } = &action.intent else { panic!("expected bulk start") };
         assert_eq!(issues.iter().map(|issue| issue.issue.id.as_str()).collect::<Vec<_>>(), vec!["809", "811"]);
     }
 

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -47,7 +47,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         r#ref: None,
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
-        issue: None,
+        issues: Vec::new(),
         instruction: None,
     }
 }


### PR DESCRIPTION
Closes #814.

## Summary
- replace singular convoy issue fields with `issues` vectors across protocol/resource admission
- add the project issue action menu sibling: start convoys vs start batch convoy
- include carried issue summaries in convoy rows/briefs and suppress represented issues from live issue panels

## Verification
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`