### PR TITLE
fix: route convoy operations to home host

### DIFF
--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -121,6 +121,29 @@ impl HostRegistry {
         self.hosts.read().await.get(environment_id).filter(|state| !state.removed).map(|state| state.node_id.clone())
     }
 
+    pub(crate) async fn node_id_for_host_name(&self, host: &HostName) -> Result<Option<NodeId>, String> {
+        let hosts = self.hosts.read().await;
+        let mut matches = hosts
+            .values()
+            .filter(|state| !state.removed)
+            .filter_map(|state| {
+                state
+                    .summary
+                    .as_ref()
+                    .and_then(|summary| summary.host_name.as_ref())
+                    .filter(|name| *name == host)
+                    .map(|_| state.node_id.clone())
+            })
+            .collect::<Vec<_>>();
+        matches.sort();
+        matches.dedup();
+        match matches.as_slice() {
+            [] => Ok(None),
+            [node_id] => Ok(Some(node_id.clone())),
+            _ => Err(format!("host name '{host}' matches multiple routed nodes")),
+        }
+    }
+
     pub(crate) async fn get_host_status(
         &self,
         environment_id: &EnvironmentId,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1928,6 +1928,48 @@ impl InProcessDaemon {
             .ok_or_else(|| format!("placement policy {policy_name} targets unavailable host {host_ref}"))
     }
 
+    pub async fn resolve_existing_convoy_target_node(&self, action: &flotilla_protocol::CommandAction) -> Result<Option<NodeId>, String> {
+        let (namespace, name) = match action {
+            flotilla_protocol::CommandAction::ConvoyDelete { namespace, name, .. }
+            | flotilla_protocol::CommandAction::ConvoyAbandon { namespace, name, .. } => {
+                (namespace.clone().unwrap_or(self.provisioning_namespace().await), name.as_str())
+            }
+            flotilla_protocol::CommandAction::ConvoyWorkForceComplete { convoy, .. } => {
+                (self.provisioning_namespace().await, convoy.as_str())
+            }
+            _ => return Ok(None),
+        };
+
+        let result_set = self.aggregator_projection_state().await.result_set().await;
+        let Rows::Convoys(rows) = result_set.rows else {
+            return Ok(None);
+        };
+        let mut hosts = rows
+            .into_iter()
+            .filter(|row| row.resource.namespace == namespace && row.resource.name == name)
+            .filter_map(|row| row.resource.host)
+            .collect::<Vec<_>>();
+        hosts.sort();
+        hosts.dedup();
+
+        let home = match hosts.as_slice() {
+            [] => return Ok(None),
+            [host] if host == &self.host_name => return Ok(Some(self.node_id.clone())),
+            [host] => host.clone(),
+            _ => {
+                let homes = hosts.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
+                return Err(format!("convoy {name} is present on multiple home hosts: {homes}"));
+            }
+        };
+
+        match self.host_registry.node_id_for_host_name(&home).await? {
+            Some(node_id) if self.host_registry.peer_connection_status(&node_id).await == PeerConnectionState::Connected => {
+                Ok(Some(node_id))
+            }
+            Some(_) | None => Err(format!("convoy {name} is homed on {home}, which is unreachable")),
+        }
+    }
+
     /// Admit a convoy against this daemon's authoritative project resources,
     /// then package immutable workflow and placement snapshots for the remote
     /// execution host. This prevents a peer from re-resolving names against a

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -130,6 +130,9 @@ impl RemoteCommandRouter {
         if matches!(command.action, CommandAction::ConvoyStartPrepared { .. }) {
             return Err("prepared convoy starts are reserved for authenticated peer forwarding".to_string());
         }
+        if let Some(target_node_id) = self.daemon.resolve_existing_convoy_target_node(&command.action).await? {
+            command.node_id = Some(target_node_id);
+        }
         if let CommandAction::ConvoyStart { intent } = &command.action {
             let placement_target = self.daemon.resolve_convoy_start_target_node(intent).await?;
             let intended_target = placement_target.as_ref().unwrap_or_else(|| self.daemon.node_id());
@@ -148,7 +151,14 @@ impl RemoteCommandRouter {
         info!(%target_node_id, %local, %desc, "dispatch_execute");
         if target_node_id != *self.daemon.node_id() {
             if command.action.is_query()
-                || matches!(command.action, CommandAction::ConvoyStartPrepared { .. } | CommandAction::ResourceWatch { .. })
+                || matches!(
+                    command.action,
+                    CommandAction::ConvoyStartPrepared { .. }
+                        | CommandAction::ConvoyDelete { .. }
+                        | CommandAction::ConvoyAbandon { .. }
+                        | CommandAction::ConvoyWorkForceComplete { .. }
+                        | CommandAction::ResourceWatch { .. }
+                )
             {
                 let request_id = {
                     let mut pm = self.peer_manager.lock().await;

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -1,4 +1,8 @@
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use flotilla_core::{
@@ -13,8 +17,14 @@ use flotilla_core::{
 use flotilla_daemon::server::test_support::{spawn_in_memory_request_topology, spawn_in_memory_request_topology_stateful};
 use flotilla_protocol::{
     issue_query::{IssueQuery, IssueResultPage},
+    result_set::{ConvoyPhase as RowConvoyPhase, ConvoyRow},
     test_support::TestIssue,
-    Command, CommandAction, CommandValue, HostName, Issue, IssueChangeset, IssueRef, IssueSource, RepoSelector,
+    Command, CommandAction, CommandValue, DaemonEvent, HostName, Issue, IssueChangeset, IssueRef, IssueSource, NodeInfo,
+    PeerConnectionState, RepoSelector, ResourceRef,
+};
+use flotilla_resources::{
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, Resource, ResourceError,
+    WorkPhase as ResourceWorkPhase, WorkState,
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -27,6 +37,39 @@ async fn empty_daemon_named(host_name: &str) -> Arc<InProcessDaemon> {
     let tmp = tempfile::tempdir().expect("tempdir");
     let config = test_config_store(tmp.keep());
     InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::new(host_name)).await
+}
+
+fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
+    ConvoySpec::builder().workflow_ref(workflow_ref.to_string()).build()
+}
+
+fn convoy_ref(namespace: &str, name: &str, host: HostName) -> ResourceRef {
+    ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, namespace, name).on_host(host)
+}
+
+async fn seed_convoy_projection(daemon: &InProcessDaemon, namespace: &str, name: &str, home: HostName) {
+    let resource = convoy_ref(namespace, name, home.clone());
+    let row = ConvoyRow::builder().resource(resource.clone()).name(name).workflow_ref("scratch").phase(RowConvoyPhase::Pending).build();
+    daemon
+        .aggregator_projection_state()
+        .await
+        .write()
+        .await
+        .replace_replica_rows(HashMap::from([(home, HashMap::from([(resource, row)]))]));
+}
+
+async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let DaemonEvent::CommandFinished { command_id: id, result, .. } = rx.recv().await.expect("daemon event") {
+                if id == command_id {
+                    return result;
+                }
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for command result")
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +134,223 @@ async fn in_memory_request_client_routes_remote_command_result() {
         }
         other => panic!("expected HostStatus result, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn hostless_convoy_delete_routes_to_remote_home() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let convoy_name = "remote-only";
+
+    let follower_convoys = topology.follower.resource_backend().using::<Convoy>(namespace);
+    follower_convoys
+        .create(&InputMeta::builder().name(convoy_name.to_string()).build(), &convoy_spec("scratch"))
+        .await
+        .expect("create remote-homed convoy");
+
+    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+
+    let mut rx = topology.leader.subscribe();
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyDelete { namespace: Some(namespace.to_string()), name: convoy_name.to_string(), force: true },
+        })
+        .await
+        .expect("dispatch hostless convoy delete");
+
+    assert_eq!(await_command_result(&mut rx, command_id).await, CommandValue::Ok);
+    assert!(
+        matches!(follower_convoys.get(convoy_name).await, Err(ResourceError::NotFound { .. })),
+        "remote-homed convoy should be deleted from follower store"
+    );
+    assert!(
+        matches!(topology.leader.resource_backend().using::<Convoy>(namespace).get(convoy_name).await, Err(ResourceError::NotFound { .. })),
+        "dispatch host should not create or own the convoy"
+    );
+}
+
+#[tokio::test]
+async fn mistargeted_convoy_delete_routes_to_remote_home() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let convoy_name = "mistargeted";
+
+    let follower_convoys = topology.follower.resource_backend().using::<Convoy>(namespace);
+    follower_convoys
+        .create(&InputMeta::builder().name(convoy_name.to_string()).build(), &convoy_spec("scratch"))
+        .await
+        .expect("create remote-homed convoy");
+    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+
+    let mut rx = topology.leader.subscribe();
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: Some(topology.leader.node_id().clone()),
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyDelete { namespace: Some(namespace.to_string()), name: convoy_name.to_string(), force: true },
+        })
+        .await
+        .expect("dispatch mistargeted convoy delete");
+
+    assert_eq!(await_command_result(&mut rx, command_id).await, CommandValue::Ok);
+    assert!(
+        matches!(follower_convoys.get(convoy_name).await, Err(ResourceError::NotFound { .. })),
+        "convoy operation should be rerouted to the row's home even when the incoming command has a stale node target"
+    );
+}
+
+#[tokio::test]
+async fn hostless_convoy_abandon_routes_to_remote_home() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let convoy_name = "remote-abandon";
+
+    let follower_convoys = topology.follower.resource_backend().using::<Convoy>(namespace);
+    follower_convoys
+        .create(&InputMeta::builder().name(convoy_name.to_string()).build(), &convoy_spec("scratch"))
+        .await
+        .expect("create remote-homed convoy");
+    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+
+    let mut rx = topology.leader.subscribe();
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyAbandon {
+                namespace: Some(namespace.to_string()),
+                name: convoy_name.to_string(),
+                reason: "accepted loss".to_string(),
+            },
+        })
+        .await
+        .expect("dispatch hostless convoy abandon");
+
+    assert_eq!(await_command_result(&mut rx, command_id).await, CommandValue::Ok);
+    assert!(
+        matches!(follower_convoys.get(convoy_name).await, Err(ResourceError::NotFound { .. })),
+        "remote-homed convoy should be abandoned and deleted from follower store"
+    );
+}
+
+#[tokio::test]
+async fn hostless_convoy_work_complete_routes_to_remote_home() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let convoy_name = "remote-work";
+    let work_name = "implement";
+
+    let follower_convoys = topology.follower.resource_backend().using::<Convoy>(namespace);
+    let created = follower_convoys
+        .create(&InputMeta::builder().name(convoy_name.to_string()).build(), &convoy_spec("scratch"))
+        .await
+        .expect("create remote-homed convoy");
+    follower_convoys
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &ConvoyStatus {
+            phase: ResourceConvoyPhase::Active,
+            work: BTreeMap::from([(work_name.to_string(), WorkState::builder().phase(ResourceWorkPhase::Running).build())]),
+            ..Default::default()
+        })
+        .await
+        .expect("seed remote work status");
+    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+
+    let mut rx = topology.leader.subscribe();
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyWorkForceComplete {
+                convoy: convoy_name.to_string(),
+                work: work_name.to_string(),
+                message: Some("done".to_string()),
+            },
+        })
+        .await
+        .expect("dispatch hostless work completion");
+
+    assert_eq!(await_command_result(&mut rx, command_id).await, CommandValue::Ok);
+    let status = follower_convoys.get(convoy_name).await.expect("remote convoy").status.expect("remote convoy status");
+    let work = status.work.get(work_name).expect("work status");
+    assert_eq!(work.phase, ResourceWorkPhase::Complete);
+    assert_eq!(work.message.as_deref(), Some("done"));
+}
+
+#[tokio::test]
+async fn hostless_convoy_command_names_unreachable_home() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let convoy_name = "stranded";
+
+    seed_convoy_projection(&topology.leader, namespace, convoy_name, HostName::new("feta")).await;
+
+    let message = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyAbandon {
+                namespace: Some(namespace.to_string()),
+                name: convoy_name.to_string(),
+                reason: "lost host".to_string(),
+            },
+        })
+        .await
+        .expect_err("unreachable convoy home should reject dispatch");
+
+    assert_eq!(message, "convoy stranded is homed on feta, which is unreachable");
+}
+
+#[tokio::test]
+async fn hostless_convoy_command_names_disconnected_home() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let convoy_name = "offline-home";
+
+    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+    topology
+        .leader
+        .publish_peer_connection_status(
+            &NodeInfo::new(topology.follower.node_id().clone(), topology.follower_host.to_string()),
+            PeerConnectionState::Disconnected,
+        )
+        .await;
+
+    let message = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyDelete { namespace: Some(namespace.to_string()), name: convoy_name.to_string(), force: true },
+        })
+        .await
+        .expect_err("disconnected convoy home should reject dispatch");
+
+    assert_eq!(message, "convoy offline-home is homed on follower, which is unreachable");
 }
 
 /// A stateless remote issue query should return results end-to-end.


### PR DESCRIPTION
## Summary
- resolve convoy delete/abandon/work completion targets from the aggregated convoy row home
- forward existing-convoy mutations directly to the resolved home daemon
- report `convoy X is homed on HOST, which is unreachable` for unknown or disconnected homes

## Tests
- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked

Closes #850