### PR TITLE
fix: state the assignment in crew briefs instead of disclaiming it

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use chrono::{DateTime, Utc};
-use flotilla_core::agent_adapter::{build_crew_brief, CrewBriefMember};
+use flotilla_core::agent_adapter::{build_crew_brief, CrewAssignment, CrewBriefMember};
 use flotilla_resources::{
     clone_key,
     controller::{
@@ -612,7 +612,12 @@ impl Reconciler for VesselReconciler {
                                     is_agent: matches!(member.source, CrewSource::Agent { .. }),
                                 })
                                 .collect::<Vec<_>>();
-                            let mut brief = build_crew_brief(&context, &obj.spec.vessel_name, &process.role, prompt.as_deref(), &members);
+                            let assignment = match prompt.as_deref() {
+                                Some(prompt) => CrewAssignment::Prompt(prompt),
+                                None if convoy.spec.issue.is_some() => CrewAssignment::CarriedIssue,
+                                None => CrewAssignment::Unassigned,
+                            };
+                            let mut brief = build_crew_brief(&context, &obj.spec.vessel_name, &process.role, assignment, &members);
                             append_convoy_work_context(&mut brief.content, &convoy, &repository_refs);
                             brief.copies = brief_copies.clone();
                             flotilla_resources::TerminalSessionSource::Agent { selector: selector.clone(), brief, context, message: None }
@@ -764,7 +769,7 @@ fn append_convoy_work_context(content: &mut String, convoy: &ResourceObject<Conv
         content.push_str(&format!("  - `{}` — {}\n", repository.repo_ref, repository.url));
     }
     if let Some(issue) = &convoy.spec.issue {
-        content.push_str("\n## Issue snapshot\n\n");
+        content.push_str("\n## Assigned issue\n\n");
         content.push_str(&format!(
             "Source-qualified reference: `{}` / `{}` / `{}`\n\n",
             issue.reference.source.service, issue.reference.source.scope, issue.reference.id

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
 use chrono::{DateTime, Utc};
-use flotilla_core::agent_adapter::{build_crew_brief, CrewAssignment, CrewBriefMember};
+use flotilla_core::agent_adapter::{append_convoy_work_context, build_crew_brief, CrewAssignment, CrewBriefMember};
 use flotilla_resources::{
     clone_key,
     controller::{
@@ -757,37 +757,6 @@ fn checkout_path_component(branch: &str) -> String {
 
 fn checkout_target_path(repo_default_dir: &str, convoy_slug: &str, repo_slug: &str, branch_slug: &str) -> String {
     format!("{}/{}/{}.{}", repo_default_dir.trim_end_matches('/'), convoy_slug, repo_slug, branch_slug)
-}
-
-fn append_convoy_work_context(content: &mut String, convoy: &ResourceObject<Convoy>, repository_refs: &[RepositoryKey]) {
-    content.push_str("\n\n## Work context\n\n");
-    if let Some(branch) = &convoy.spec.r#ref {
-        content.push_str(&format!("- Branch: `{branch}`\n"));
-    }
-    content.push_str("- Repositories:\n");
-    for repository in convoy.spec.repositories.iter().filter(|repository| repository_refs.contains(&repository.repo_ref)) {
-        content.push_str(&format!("  - `{}` — {}\n", repository.repo_ref, repository.url));
-    }
-    if let Some(issue) = &convoy.spec.issue {
-        content.push_str("\n## Assigned issue\n\n");
-        content.push_str(&format!(
-            "Source-qualified reference: `{}` / `{}` / `{}`\n\n",
-            issue.reference.source.service, issue.reference.source.scope, issue.reference.id
-        ));
-        content.push_str(&format!("Snapshot as of `{}`.\n\n", issue.snapshot.as_of.to_rfc3339()));
-        content.push_str(&format!("### {}\n\n", issue.snapshot.title));
-        content.push_str(&format!("State: `{:?}`\n\n", issue.snapshot.state).to_lowercase());
-        content.push_str(&format!("Labels: {}\n\n", issue.snapshot.labels.join(", ")));
-        if let Some(body) = &issue.snapshot.body {
-            content.push_str(body);
-            content.push('\n');
-        }
-    }
-    if let Some(instruction) = &convoy.spec.instruction {
-        content.push_str("\n## Human instruction\n\n");
-        content.push_str(instruction);
-        content.push('\n');
-    }
 }
 
 fn owned_child_meta(name: &str, workspace: &ResourceObject<Vessel>, mut extra_labels: BTreeMap<String, String>) -> InputMeta {

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -1287,6 +1287,98 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
 }
 
 #[tokio::test]
+async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository");
+    let repository_key = repository_spec.key();
+    ensure_repository(&backend.clone().using::<Repository>(NAMESPACE), &repository_key, &repository_spec).await.expect("repository create");
+    let convoy = backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .create(&meta("convoy-issue-brief"), &ConvoySpec {
+            workflow_ref: "wf".to_string(),
+            inputs: BTreeMap::new(),
+            placement_policy: None,
+            repositories: vec![ConvoyRepositorySpec {
+                url: "https://github.com/flotilla-org/flotilla".to_string(),
+                repo_ref: repository_key.clone(),
+                base_ref: "main".to_string(),
+                workspace_slug: "flotilla".to_string(),
+                subpaths: Vec::new(),
+            }],
+            r#ref: Some("feat/issue-brief".to_string()),
+            project_ref: None,
+            adopted_checkout_refs: BTreeMap::new(),
+            issue: Some(ConvoyIssue {
+                reference: IssueRef {
+                    source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+                    id: "811".into(),
+                },
+                repository_ref: Some(repository_key.clone()),
+                snapshot: IssueSnapshot {
+                    title: "Attention signal".into(),
+                    body: Some("The issue body is the contract.".into()),
+                    state: IssueState::Open,
+                    labels: vec!["enhancement".into()],
+                    as_of: "2026-07-22T09:30:00Z".parse().expect("timestamp"),
+                },
+            }),
+            instruction: None,
+        })
+        .await
+        .expect("convoy create");
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .update_status("convoy-issue-brief", &convoy.metadata.resource_version, &ConvoyStatus {
+            workflow_snapshot: Some(WorkflowSnapshot {
+                vessels: vec![VesselRequirement {
+                    name: "implement".to_string(),
+                    stance: Stance::Trusted,
+                    depends_on: Vec::new(),
+                    repository_refs: None,
+                    crew: vec![CrewSpec::builder()
+                        .role("coder".to_string())
+                        .source(CrewSource::Agent { selector: Selector { capability: "coding".to_string() }, prompt: None })
+                        .build()],
+                }],
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect("convoy status update");
+    create_host_direct_policy(&backend, NAMESPACE, "policy-issue-brief", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    create_ready_adopted_checkout(&backend, NAMESPACE, "adopted-checkout-issue-brief", "/Users/alice/dev/flotilla-existing").await;
+    let workspace = backend
+        .clone()
+        .using::<Vessel>(NAMESPACE)
+        .create(&vessel_meta("workspace-issue-brief", "https://github.com/flotilla-org/flotilla"), &VesselSpec {
+            convoy_ref: "convoy-issue-brief".to_string(),
+            vessel_name: "implement".to_string(),
+            placement_policy_ref: "policy-issue-brief".to_string(),
+            adopted_checkout_refs: BTreeMap::from([(repository_key, "adopted-checkout-issue-brief".to_string())]),
+        })
+        .await
+        .expect("workspace create");
+
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps");
+    let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
+
+    let Actuation::CreateTerminalSession { spec, .. } = outcome.actuations.first().expect("coder session actuation") else {
+        panic!("expected terminal session actuation");
+    };
+    let TerminalSessionSource::Agent { brief, .. } = &spec.source else {
+        panic!("expected structured agent launch");
+    };
+    assert!(brief.content.contains("## Assignment\n\nYour assignment is the issue in the `## Assigned issue` section below."));
+    assert!(brief.content.contains("## Assigned issue"));
+    assert!(brief.content.contains("The issue body is the contract."));
+    assert!(!brief.content.contains("No assignment was provided"));
+}
+
+#[tokio::test]
 async fn observed_checkout_at_managed_name_marks_workspace_failed() {
     let backend = ResourceBackend::InMemory(Default::default());
     create_convoy_with_single_task(&backend, NAMESPACE, "convoy-observed", "implement", REPO_URL, GIT_REF).await;

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -72,6 +72,45 @@ pub fn build_crew_brief(
     flotilla_resources::TerminalBrief { path: crew_brief_path(role), content, copies: Vec::new() }
 }
 
+/// Appends the convoy's work context (branch, repositories, assigned issue, human
+/// instruction) to a crew brief. Every brief whose assignment is
+/// [`CrewAssignment::CarriedIssue`] must pass through here — the assignment text
+/// points at the `## Assigned issue` section this writes.
+pub fn append_convoy_work_context(
+    content: &mut String,
+    convoy: &flotilla_resources::ResourceObject<flotilla_resources::Convoy>,
+    repository_refs: &[flotilla_resources::RepositoryKey],
+) {
+    content.push_str("\n\n## Work context\n\n");
+    if let Some(branch) = &convoy.spec.r#ref {
+        content.push_str(&format!("- Branch: `{branch}`\n"));
+    }
+    content.push_str("- Repositories:\n");
+    for repository in convoy.spec.repositories.iter().filter(|repository| repository_refs.contains(&repository.repo_ref)) {
+        content.push_str(&format!("  - `{}` — {}\n", repository.repo_ref, repository.url));
+    }
+    if let Some(issue) = &convoy.spec.issue {
+        content.push_str("\n## Assigned issue\n\n");
+        content.push_str(&format!(
+            "Source-qualified reference: `{}` / `{}` / `{}`\n\n",
+            issue.reference.source.service, issue.reference.source.scope, issue.reference.id
+        ));
+        content.push_str(&format!("Snapshot as of `{}`.\n\n", issue.snapshot.as_of.to_rfc3339()));
+        content.push_str(&format!("### {}\n\n", issue.snapshot.title));
+        content.push_str(&format!("State: `{:?}`\n\n", issue.snapshot.state).to_lowercase());
+        content.push_str(&format!("Labels: {}\n\n", issue.snapshot.labels.join(", ")));
+        if let Some(body) = &issue.snapshot.body {
+            content.push_str(body);
+            content.push('\n');
+        }
+    }
+    if let Some(instruction) = &convoy.spec.instruction {
+        content.push_str("\n## Human instruction\n\n");
+        content.push_str(instruction);
+        content.push('\n');
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentLaunchRequest {
     pub role: String,

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -26,11 +26,26 @@ pub struct CrewBriefMember {
     pub is_agent: bool,
 }
 
+/// What the `## Assignment` section of a crew brief should say. Distinct from
+/// `Option<&str>` because "no ad-hoc prompt" splits into two very different
+/// situations: the convoy carries an issue (the issue *is* the assignment) or
+/// nothing was provided at all. Conflating them taught a crew to read "no
+/// additional assignment" as overriding the issue contract below it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrewAssignment<'a> {
+    /// An explicit dispatch or handoff prompt.
+    Prompt(&'a str),
+    /// The convoy carries an issue, appended below the brief; that issue is the assignment.
+    CarriedIssue,
+    /// Nothing was provided.
+    Unassigned,
+}
+
 pub fn build_crew_brief(
     context: &flotilla_resources::TerminalCrewContext,
     vessel: &str,
     role: &str,
-    prompt: Option<&str>,
+    assignment: CrewAssignment<'_>,
     members: &[CrewBriefMember],
 ) -> flotilla_resources::TerminalBrief {
     let mut content = format!(
@@ -46,7 +61,13 @@ pub fn build_crew_brief(
     }
     content.push_str(&format!(
         "For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue, and shepherd the pull request until all checks pass. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`. For other assignments, complete with `flotilla crew complete --message '...'`. If the assignment cannot be completed, report the failure with `flotilla crew fail --message '...'`.\n\n## Assignment\n\n{}\n",
-        prompt.unwrap_or("No additional assignment was provided.")
+        match assignment {
+            CrewAssignment::Prompt(prompt) => prompt,
+            CrewAssignment::CarriedIssue =>
+                "Your assignment is the issue in the `## Assigned issue` section below. Its body is the contract: work it to completion and deliver as described above.",
+            CrewAssignment::Unassigned =>
+                "No assignment was provided with this dispatch. Check `## Human instruction` below if present; otherwise report via `flotilla crew fail` rather than inventing work.",
+        }
     ));
     flotilla_resources::TerminalBrief { path: crew_brief_path(role), content, copies: Vec::new() }
 }
@@ -189,7 +210,7 @@ mod tests {
     use flotilla_resources::{single_agent_contained_workflow_spec, CrewSource, TerminalCrewContext};
 
     use crate::{
-        agent_adapter::{build_crew_brief, AgentAdapterRegistry, AgentLaunchRequest, CapabilityTable, CrewBriefMember},
+        agent_adapter::{build_crew_brief, AgentAdapterRegistry, AgentLaunchRequest, CapabilityTable, CrewAssignment, CrewBriefMember},
         path_context::ExecutionEnvironmentPath,
         providers::{
             discovery::{EnvironmentAssertion, EnvironmentBag},
@@ -224,13 +245,48 @@ mod tests {
             },
             "work",
             "coder",
-            prompt.as_deref(),
+            prompt.as_deref().map_or(CrewAssignment::Unassigned, CrewAssignment::Prompt),
             &[CrewBriefMember { role: "coder".to_string(), state: "active".to_string(), is_agent: true }],
         );
 
         assert!(brief.content.contains(
             "For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue, and shepherd the pull request until all checks pass. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`."
         ));
+    }
+
+    fn brief_for(assignment: CrewAssignment<'_>) -> String {
+        build_crew_brief(
+            &TerminalCrewContext {
+                namespace: "flotilla".to_string(),
+                convoy: "fix-delivery".to_string(),
+                vessel_ref: "vessel-fix-delivery-work".to_string(),
+            },
+            "work",
+            "coder",
+            assignment,
+            &[CrewBriefMember { role: "coder".to_string(), state: "active".to_string(), is_agent: true }],
+        )
+        .content
+    }
+
+    #[test]
+    fn carried_issue_assignment_points_at_the_issue_section_instead_of_disclaiming() {
+        let content = brief_for(CrewAssignment::CarriedIssue);
+        assert!(content.contains("## Assignment\n\nYour assignment is the issue in the `## Assigned issue` section below."));
+        assert!(!content.contains("No assignment was provided"));
+    }
+
+    #[test]
+    fn unassigned_brief_says_so_and_forbids_inventing_work() {
+        let content = brief_for(CrewAssignment::Unassigned);
+        assert!(content.contains("No assignment was provided with this dispatch."));
+        assert!(content.contains("rather than inventing work"));
+    }
+
+    #[test]
+    fn prompt_assignment_is_verbatim() {
+        let content = brief_for(CrewAssignment::Prompt("Fix the flux capacitor."));
+        assert!(content.contains("## Assignment\n\nFix the flux capacitor.\n"));
     }
 
     #[test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1037,7 +1037,7 @@ fn handoff_crew_brief(context: &ResolvedCrewContext, target: &str, prompt: Optio
         },
         &context.vessel,
         target,
-        prompt,
+        prompt.map_or(crate::agent_adapter::CrewAssignment::Unassigned, crate::agent_adapter::CrewAssignment::Prompt),
         &members
             .iter()
             .map(|member| crate::agent_adapter::CrewBriefMember {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1028,8 +1028,19 @@ fn input_meta_from_resource<T: Resource>(resource: &flotilla_resources::Resource
         .build()
 }
 
-fn handoff_crew_brief(context: &ResolvedCrewContext, target: &str, prompt: Option<&str>, members: &[CrewListMember]) -> TerminalBrief {
-    crate::agent_adapter::build_crew_brief(
+fn handoff_crew_brief(
+    context: &ResolvedCrewContext,
+    convoy: &flotilla_resources::ResourceObject<ResourceConvoy>,
+    target: &str,
+    prompt: Option<&str>,
+    members: &[CrewListMember],
+) -> TerminalBrief {
+    let assignment = match prompt {
+        Some(prompt) => crate::agent_adapter::CrewAssignment::Prompt(prompt),
+        None if convoy.spec.issue.is_some() => crate::agent_adapter::CrewAssignment::CarriedIssue,
+        None => crate::agent_adapter::CrewAssignment::Unassigned,
+    };
+    let mut brief = crate::agent_adapter::build_crew_brief(
         &TerminalCrewContext {
             namespace: context.namespace.clone(),
             convoy: context.convoy.clone(),
@@ -1037,7 +1048,7 @@ fn handoff_crew_brief(context: &ResolvedCrewContext, target: &str, prompt: Optio
         },
         &context.vessel,
         target,
-        prompt.map_or(crate::agent_adapter::CrewAssignment::Unassigned, crate::agent_adapter::CrewAssignment::Prompt),
+        assignment,
         &members
             .iter()
             .map(|member| crate::agent_adapter::CrewBriefMember {
@@ -1046,7 +1057,10 @@ fn handoff_crew_brief(context: &ResolvedCrewContext, target: &str, prompt: Optio
                 is_agent: member.kind == "agent",
             })
             .collect::<Vec<_>>(),
-    )
+    );
+    let repository_refs = convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<Vec<_>>();
+    crate::agent_adapter::append_convoy_work_context(&mut brief.content, convoy, &repository_refs);
+    brief
 }
 
 fn pending_crew_message(text: &str) -> TerminalCrewMessage {
@@ -4566,7 +4580,7 @@ impl InProcessDaemon {
                         .ok_or_else(|| format!("vessel `{}` has no active session to anchor the handoff", context.vessel_ref))?
                 };
                 let current = self.crew_list_internal(requested).await?;
-                let brief = handoff_crew_brief(&context, target, prompt.as_deref(), &current.members);
+                let brief = handoff_crew_brief(&context, &convoy, target, prompt.as_deref(), &current.members);
                 sessions
                     .create(&identity.input_meta(), &flotilla_resources::TerminalSessionSpec {
                         env_ref: anchor.spec.env_ref,


### PR DESCRIPTION
Observed live (wave 4, convoy-attention-signal): a crew brief for an issue-carrying convoy said `## Assignment` → "No additional assignment was provided." followed by the issue under `## Issue snapshot` — and the codex crew rationally read the disclaimer as overriding the contract below it, deciding it had nothing to do until cajoled.

- `build_crew_brief` now takes a `CrewAssignment` enum (`Prompt` / `CarriedIssue` / `Unassigned`) instead of `Option<&str>`: 'no ad-hoc prompt' splits into two very different situations and the old signature conflated them.
- `CarriedIssue` briefs state: your assignment is the issue below, its body is the contract.
- `Unassigned` briefs say so and forbid inventing work.
- `## Issue snapshot` renamed `## Assigned issue` (snapshot-as-of line retained inside) — the old header read as informational context.

Tests cover all three variants. Note: `server::tests::dispatch_add_list_remove_repo_round_trip` fails on macOS locally (`/private/var` vs `/var` canonicalization) on clean main too — pre-existing, unrelated, filed separately.