### PR TITLE
feat: surface convoy attention signals

### DIFF
--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -64,7 +64,7 @@ impl TerminalActuator {
         let TerminalSessionSource::Tool { command } = &spec.source else {
             return Err("agent sessions require an AgentAdapter-aware runtime".to_string());
         };
-        self.pool.ensure_session(name, command, &ExecutionEnvironmentPath::new(spec.cwd.clone()), &env_vars).await
+        self.pool.ensure_session(name, command, &ExecutionEnvironmentPath::new(spec.cwd.clone()), &env_vars, &[]).await
     }
 }
 

--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -4,8 +4,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     controller::{ReconcileOutcome, Reconciler},
-    Environment, EnvironmentPhase, ResourceBackend, ResourceError, ResourceObject, TerminalSession, TerminalSessionPhase,
-    TerminalSessionStatusPatch, TypedResolver,
+    Environment, EnvironmentPhase, ResourceBackend, ResourceError, ResourceObject, TerminalAttention, TerminalAttentionSource,
+    TerminalAttentionState, TerminalSession, TerminalSessionPhase, TerminalSessionStatusPatch, TerminalSessionTag, TypedResolver,
+    CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
@@ -20,9 +21,21 @@ pub struct TerminalRuntimeState {
 
 #[async_trait]
 pub trait TerminalRuntime: Send + Sync {
-    async fn ensure_session(&self, name: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<TerminalRuntimeState, String>;
+    async fn ensure_session(
+        &self,
+        name: &str,
+        spec: &flotilla_resources::TerminalSessionSpec,
+        tags: &[TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String>;
     async fn session_is_running(&self, _session_id: &str, _spec: &flotilla_resources::TerminalSessionSpec) -> Result<bool, String> {
         Ok(true)
+    }
+    async fn observe_attention(
+        &self,
+        _session_id: &str,
+        _spec: &flotilla_resources::TerminalSessionSpec,
+    ) -> Result<Option<TerminalAttention>, String> {
+        Ok(None)
     }
     async fn deliver_message(
         &self,
@@ -52,6 +65,8 @@ pub enum TerminalDeps {
     Running(TerminalRuntimeState),
     MessageDelivered(String),
     Stopped,
+    Attention(TerminalAttention),
+    AttentionStale,
     Failed(String),
 }
 
@@ -73,6 +88,12 @@ where
             let running = self.runtime.session_is_running(session_id, &obj.spec).await.map_err(ResourceError::other)?;
             if !running {
                 return Ok(TerminalDeps::Stopped);
+            }
+            if let Some(attention) = self.runtime.observe_attention(session_id, &obj.spec).await.map_err(ResourceError::other)? {
+                return Ok(TerminalDeps::Attention(attention));
+            }
+            if obj.status.as_ref().and_then(|status| status.attention.as_ref()).is_some_and(|attention| attention.is_stale_at(Utc::now())) {
+                return Ok(TerminalDeps::AttentionStale);
             }
             if let flotilla_resources::TerminalSessionSource::Agent { message: Some(message), .. } = &obj.spec.source {
                 if obj.status.as_ref().and_then(|status| status.delivered_message_id.as_deref()) != Some(message.id.as_str()) {
@@ -98,7 +119,14 @@ where
             return Ok(TerminalDeps::Waiting);
         }
 
-        Ok(match self.runtime.ensure_session(&obj.metadata.name, &obj.spec).await {
+        let tags = [
+            obj.metadata.labels.get(CONVOY_LABEL).map(|value| TerminalSessionTag::new("convoy", value)),
+            obj.metadata.labels.get(VESSEL_REF_LABEL).map(|value| TerminalSessionTag::new("vessel", value)),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        Ok(match self.runtime.ensure_session(&obj.metadata.name, &obj.spec, &tags).await {
             Ok(state) => TerminalDeps::Running(state),
             Err(err) => TerminalDeps::Failed(err),
         })
@@ -124,7 +152,12 @@ where
                 TerminalDeps::Failed(message) => {
                     Some(TerminalSessionStatusPatch::MarkFailed { message: message.clone(), stopped_at: Some(now) })
                 }
-                TerminalDeps::Waiting | TerminalDeps::None | TerminalDeps::Stopped | TerminalDeps::MessageDelivered(_) => None,
+                TerminalDeps::Waiting
+                | TerminalDeps::None
+                | TerminalDeps::Stopped
+                | TerminalDeps::MessageDelivered(_)
+                | TerminalDeps::Attention(_)
+                | TerminalDeps::AttentionStale => None,
             },
             TerminalSessionPhase::Running if matches!(deps, TerminalDeps::Stopped) => Some(TerminalSessionStatusPatch::MarkStopped {
                 stopped_at: now,
@@ -136,6 +169,27 @@ where
                 TerminalDeps::MessageDelivered(message_id) => {
                     Some(TerminalSessionStatusPatch::MarkMessageDelivered { message_id: message_id.clone() })
                 }
+                TerminalDeps::Attention(attention)
+                    if obj
+                        .status
+                        .as_ref()
+                        .and_then(|status| status.attention.as_ref())
+                        .is_none_or(|current| current.should_replace_with(attention)) =>
+                {
+                    Some(TerminalSessionStatusPatch::ObserveAttention { attention: attention.clone() })
+                }
+                TerminalDeps::AttentionStale => Some(TerminalSessionStatusPatch::ObserveAttention {
+                    attention: TerminalAttention {
+                        state: TerminalAttentionState::Unobservable,
+                        as_of: now,
+                        source: obj
+                            .status
+                            .as_ref()
+                            .and_then(|status| status.attention.as_ref())
+                            .map(|attention| attention.source)
+                            .unwrap_or(TerminalAttentionSource::Screen),
+                    },
+                }),
                 _ => None,
             },
             TerminalSessionPhase::Stopped | TerminalSessionPhase::Failed => None,

--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -92,20 +92,21 @@ where
             if !running {
                 return Ok(TerminalDeps::Stopped);
             }
-            if let Some(attention) = self.runtime.observe_attention(session_id, &obj.spec).await.map_err(ResourceError::other)? {
-                return Ok(TerminalDeps::Attention(attention));
-            }
-            if obj.status.as_ref().and_then(|status| status.attention.as_ref()).is_some_and(|attention| attention.is_stale_at(Utc::now())) {
-                return Ok(TerminalDeps::AttentionStale);
-            }
             if let flotilla_resources::TerminalSessionSource::Agent { message: Some(message), .. } = &obj.spec.source {
                 if obj.status.as_ref().and_then(|status| status.delivered_message_id.as_deref()) != Some(message.id.as_str()) {
+                    // A continuous attention signal must not starve a queued handoff.
                     // Delivery is deliberately at-least-once. A crash after the pool accepts the
                     // message but before MarkMessageDelivered is persisted may redeliver it; losing
                     // a handoff is worse, and exactly-once requires acknowledgement by the agent.
                     self.runtime.deliver_message(session_id, &obj.spec, &message.text).await.map_err(ResourceError::other)?;
                     return Ok(TerminalDeps::MessageDelivered(message.id.clone()));
                 }
+            }
+            if let Some(attention) = self.runtime.observe_attention(session_id, &obj.spec).await.map_err(ResourceError::other)? {
+                return Ok(TerminalDeps::Attention(attention));
+            }
+            if obj.status.as_ref().and_then(|status| status.attention.as_ref()).is_some_and(|attention| attention.is_stale_at(Utc::now())) {
+                return Ok(TerminalDeps::AttentionStale);
             }
             return Ok(TerminalDeps::None);
         }

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -62,6 +62,7 @@ impl TerminalPool for FakeTerminalPool {
         _command: &str,
         _cwd: &ExecutionEnvironmentPath,
         _env_vars: &TerminalEnvVars,
+        _tags: &[flotilla_core::providers::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -345,6 +345,7 @@ pub async fn create_stopped_terminal(
             crew: None,
             launch_command: Some(fixture.command),
             delivered_message_id: None,
+            attention: None,
         })
         .await
         .expect("terminal status update should succeed");

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -83,6 +83,7 @@ impl TerminalPool for FakeTerminalPool {
         _command: &str,
         _cwd: &flotilla_core::path_context::ExecutionEnvironmentPath,
         _env_vars: &TerminalEnvVars,
+        _tags: &[flotilla_core::providers::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -111,7 +111,12 @@ struct FakeTerminalRuntime;
 
 #[async_trait]
 impl TerminalRuntime for FakeTerminalRuntime {
-    async fn ensure_session(&self, name: &str, _spec: &flotilla_resources::TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+    async fn ensure_session(
+        &self,
+        name: &str,
+        _spec: &flotilla_resources::TerminalSessionSpec,
+        _tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
         Ok(TerminalRuntimeState {
             session_id: format!("session-{name}"),
             pid: Some(42),
@@ -176,6 +181,7 @@ impl TerminalPool for FakePresentationTerminalPool {
         _command: &str,
         _cwd: &flotilla_core::path_context::ExecutionEnvironmentPath,
         _env_vars: &TerminalEnvVars,
+        _tags: &[flotilla_core::providers::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -1,11 +1,15 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
 
 use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
 use flotilla_resources::{
-    controller::Reconciler, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, ResourceBackend,
-    StatusPatch, TerminalSessionSpec,
+    controller::Reconciler, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta,
+    ResourceBackend, StatusPatch, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSessionPhase,
+    TerminalSessionSpec, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 
 mod common;
@@ -61,8 +65,82 @@ struct FailingTerminalRuntime;
 
 #[async_trait]
 impl TerminalRuntime for FailingTerminalRuntime {
-    async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+    async fn ensure_session(
+        &self,
+        _name: &str,
+        _spec: &TerminalSessionSpec,
+        _tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
         Err("boom".to_string())
+    }
+
+    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn session_provisioning_passes_convoy_and_vessel_tags_to_runtime() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let environments = backend.clone().using::<flotilla_resources::Environment>("flotilla");
+    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
+    let env = environments
+        .create(&meta("env-a"), &EnvironmentSpec {
+            host_direct: Some(HostDirectEnvironmentSpec { host_ref: "host-a".into(), repo_default_dir: "/repos".into() }),
+            docker: None,
+        })
+        .await
+        .expect("environment");
+    let mut env_status = EnvironmentStatus::default();
+    EnvironmentStatusPatch::MarkReady { docker_container_id: None }.apply(&mut env_status);
+    environments.update_status("env-a", &env.metadata.resource_version, &env_status).await.expect("ready environment");
+    let input = InputMeta::builder()
+        .name("term-a".to_string())
+        .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "demo".to_string()), (VESSEL_REF_LABEL.to_string(), "demo-work".to_string())]))
+        .build();
+    let session = sessions
+        .create(&input, &TerminalSessionSpec {
+            env_ref: "env-a".into(),
+            role: "watcher".into(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: "tail -f log".into() },
+            cwd: "/workspace".into(),
+            pool: "cleat".into(),
+        })
+        .await
+        .expect("terminal");
+    let runtime = Arc::new(TagRecordingRuntime::default());
+    let reconciler = TerminalSessionReconciler::new(Arc::clone(&runtime), backend, "flotilla");
+
+    reconciler.fetch_dependencies(&session).await.expect("provisioning dependencies");
+
+    assert_eq!(runtime.tags.lock().expect("tags mutex").as_slice(), &[
+        flotilla_resources::TerminalSessionTag::new("convoy", "demo"),
+        flotilla_resources::TerminalSessionTag::new("vessel", "demo-work"),
+    ]);
+}
+
+#[derive(Default)]
+struct TagRecordingRuntime {
+    tags: Mutex<Vec<flotilla_resources::TerminalSessionTag>>,
+}
+
+#[async_trait]
+impl TerminalRuntime for TagRecordingRuntime {
+    async fn ensure_session(
+        &self,
+        name: &str,
+        _spec: &TerminalSessionSpec,
+        tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
+        *self.tags.lock().expect("tags mutex") = tags.to_vec();
+        Ok(TerminalRuntimeState {
+            session_id: name.to_string(),
+            pid: None,
+            started_at: Utc::now(),
+            crew: None,
+            launch_command: "tail -f log".into(),
+            delivered_message_id: None,
+        })
     }
 
     async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
@@ -124,7 +202,12 @@ struct MissingTerminalRuntime;
 
 #[async_trait]
 impl TerminalRuntime for MissingTerminalRuntime {
-    async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+    async fn ensure_session(
+        &self,
+        _name: &str,
+        _spec: &TerminalSessionSpec,
+        _tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
         panic!("running sessions should be observed, not ensured")
     }
 
@@ -208,13 +291,77 @@ struct DeliveringTerminalRuntime {
 
 #[async_trait]
 impl TerminalRuntime for DeliveringTerminalRuntime {
-    async fn ensure_session(&self, _name: &str, _spec: &TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+    async fn ensure_session(
+        &self,
+        _name: &str,
+        _spec: &TerminalSessionSpec,
+        _tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
         panic!("running sessions should not be ensured")
     }
 
     async fn deliver_message(&self, session_id: &str, _spec: &TerminalSessionSpec, message: &str) -> Result<(), String> {
         self.delivered.lock().expect("delivered mutex").push((session_id.to_string(), message.to_string()));
         Ok(())
+    }
+
+    async fn kill_session(&self, _session_id: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn stale_hook_attention_decays_to_unobservable_without_changing_phase() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
+    let created = sessions
+        .create(&meta("term-a"), &TerminalSessionSpec {
+            env_ref: "env-a".to_string(),
+            role: "coder".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
+            cwd: "/workspace".to_string(),
+            pool: "hookless".to_string(),
+        })
+        .await
+        .expect("session");
+    let mut status = flotilla_resources::TerminalSessionStatus::default();
+    flotilla_resources::TerminalSessionStatusPatch::MarkRunning {
+        session_id: "session-a".into(),
+        pid: None,
+        started_at: Utc::now(),
+        crew: None,
+        launch_command: "cargo test".into(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
+    status.attention = Some(TerminalAttention {
+        state: TerminalAttentionState::Working,
+        as_of: Utc::now() - chrono::Duration::seconds(31),
+        source: TerminalAttentionSource::Hook,
+    });
+    let session = sessions.update_status("term-a", &created.metadata.resource_version, &status).await.expect("running session");
+    let reconciler = TerminalSessionReconciler::new(Arc::new(HooklessTerminalRuntime), backend, "flotilla");
+
+    let deps = reconciler.fetch_dependencies(&session).await.expect("observe stale attention");
+    let now = Utc::now();
+    let patch = reconciler.reconcile(&session, &deps, now).patch.expect("decay patch");
+    patch.apply(&mut status);
+
+    assert_eq!(status.phase, TerminalSessionPhase::Running);
+    assert_eq!(status.attention.expect("attention").state, TerminalAttentionState::Unobservable);
+}
+
+struct HooklessTerminalRuntime;
+
+#[async_trait]
+impl TerminalRuntime for HooklessTerminalRuntime {
+    async fn ensure_session(
+        &self,
+        _name: &str,
+        _spec: &TerminalSessionSpec,
+        _tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
+        panic!("running sessions should not be ensured")
     }
 
     async fn kill_session(&self, _session_id: &str) -> Result<(), String> {

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -277,7 +277,7 @@ impl TerminalRuntime for MissingTerminalRuntime {
 }
 
 #[tokio::test]
-async fn a_message_queued_during_startup_is_delivered_after_the_session_becomes_running() {
+async fn a_message_queued_during_startup_is_delivered_before_attention_observation() {
     let backend = ResourceBackend::InMemory(Default::default());
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
     let created = sessions
@@ -336,7 +336,7 @@ async fn a_message_queued_during_startup_is_delivered_after_the_session_becomes_
         sessions.update_status("term-a", &session.metadata.resource_version, &acknowledged_status).await.expect("acknowledge message");
 
     let deps = reconciler.fetch_dependencies(&acknowledged).await.expect("observe acknowledged message");
-    assert!(matches!(deps, flotilla_controllers::reconcilers::terminal_session::TerminalDeps::None));
+    assert!(matches!(deps, flotilla_controllers::reconcilers::terminal_session::TerminalDeps::Attention(_)));
     assert_eq!(runtime.delivered.lock().expect("delivered mutex").len(), 1);
 }
 
@@ -436,6 +436,10 @@ impl TerminalRuntime for DeliveringTerminalRuntime {
     async fn deliver_message(&self, session_id: &str, _spec: &TerminalSessionSpec, message: &str) -> Result<(), String> {
         self.delivered.lock().expect("delivered mutex").push((session_id.to_string(), message.to_string()));
         Ok(())
+    }
+
+    async fn observe_attention(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<Option<TerminalAttention>, String> {
+        Ok(Some(TerminalAttention { state: TerminalAttentionState::Working, as_of: Utc::now(), source: TerminalAttentionSource::Screen }))
     }
 
     async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -1723,6 +1723,7 @@ async fn create_running_terminal(
             crew: None,
             launch_command: Some(command.to_string()),
             delivered_message_id: None,
+            attention: None,
         })
         .await
         .expect("terminal status update should succeed");

--- a/crates/flotilla-core/src/agents/hooks.rs
+++ b/crates/flotilla-core/src/agents/hooks.rs
@@ -213,14 +213,15 @@ mod tests {
 
     #[test]
     fn agent_hook_event_serde_roundtrip() {
-        let event = AgentHookEvent {
-            attachable_id: AttachableId::new("att-123"),
-            harness: AgentHarness::ClaudeCode,
-            event_type: AgentEventType::Active,
-            session_id: Some("sess-abc".into()),
-            model: Some("opus-4".into()),
-            cwd: Some("/home/dev".into()),
-        };
+        let event = AgentHookEvent::builder()
+            .attachable_id(AttachableId::new("att-123"))
+            .harness(AgentHarness::ClaudeCode)
+            .event_type(AgentEventType::Active)
+            .session_id("sess-abc".to_string())
+            .model("opus-4".to_string())
+            .cwd("/home/dev".to_string())
+            .terminal(flotilla_protocol::AgentHookTerminalRef { namespace: "flotilla".into(), session_name: "terminal-demo-coder".into() })
+            .build();
         let json = serde_json::to_string(&event).expect("serialize");
         let decoded: AgentHookEvent = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(decoded, event);

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -1378,6 +1378,7 @@ impl TerminalPool for MockTerminalPool {
         _cmd: &str,
         _cwd: &ExecutionEnvironmentPath,
         _env_vars: &crate::providers::terminal::TerminalEnvVars,
+        _tags: &[crate::providers::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/flotilla-core/src/hop_chain/tests.rs
+++ b/crates/flotilla-core/src/hop_chain/tests.rs
@@ -497,6 +497,7 @@ impl TerminalPool for FakeTerminalPool {
         _command: &str,
         _cwd: &ExecutionEnvironmentPath,
         _env_vars: &TerminalEnvVars,
+        _tags: &[crate::providers::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         Ok(())
     }

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -802,6 +802,7 @@ impl TerminalPool for FakeTerminalPool {
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &super::super::terminal::TerminalEnvVars,
+        _tags: &[super::super::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         let mut sessions = self.sessions.lock().await;
         if sessions.iter().any(|s| s.session_name == session_name) {
@@ -818,6 +819,7 @@ impl TerminalPool for FakeTerminalPool {
             status: TerminalStatus::Running,
             command: Some(command.to_string()),
             working_directory: Some(cwd.clone()),
+            screen_activity: None,
         });
         Ok(())
     }

--- a/crates/flotilla-core/src/providers/scan_cache.rs
+++ b/crates/flotilla-core/src/providers/scan_cache.rs
@@ -155,8 +155,9 @@ impl TerminalPool for SharedTerminalPool {
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
+        tags: &[super::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
-        let result = self.inner.ensure_session(session_name, command, cwd, env_vars).await;
+        let result = self.inner.ensure_session(session_name, command, cwd, env_vars, tags).await;
         if result.is_ok() {
             self.sessions.invalidate();
         }

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use flotilla_protocol::arg::Arg;
 use serde::Deserialize;
 
-use super::{TerminalEnvVars, TerminalPool, TerminalSession};
+use super::{ScreenActivity, TerminalEnvVars, TerminalPool, TerminalSession, TerminalSessionTag};
 use crate::{
     path_context::ExecutionEnvironmentPath,
     providers::{run, CommandRunner},
@@ -16,6 +16,7 @@ struct SessionInfo {
     cwd: Option<std::path::PathBuf>,
     cmd: Option<String>,
     status: SessionStatus,
+    screen_activity: Option<ScreenActivityWire>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -23,6 +24,13 @@ struct SessionInfo {
 enum SessionStatus {
     Attached,
     Detached,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScreenActivityWire {
+    Active,
+    Stable,
 }
 
 pub struct CleatTerminalPool {
@@ -67,6 +75,10 @@ impl TerminalPool for CleatTerminalPool {
                     status,
                     command: session.cmd,
                     working_directory: session.cwd.map(ExecutionEnvironmentPath::new),
+                    screen_activity: session.screen_activity.map(|activity| match activity {
+                        ScreenActivityWire::Active => ScreenActivity::Active,
+                        ScreenActivityWire::Stable => ScreenActivity::Stable,
+                    }),
                 }
             })
             .collect())
@@ -78,36 +90,32 @@ impl TerminalPool for CleatTerminalPool {
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
+        tags: &[TerminalSessionTag],
     ) -> Result<(), String> {
-        // If the session already exists, leave it alone.
         let existing = self.list_sessions().await.unwrap_or_default();
-        if existing.iter().any(|s| s.session_name == session_name) {
+        if existing.iter().any(|session| session.session_name == session_name) {
             return Ok(());
         }
 
-        // terminal_env_defaults (from discovery) provide TERM/COLORTERM
-        // fallbacks for daemons started without a TTY (e.g. remote SSH).
         let has_env = !env_vars.is_empty() || !self.terminal_env_defaults.is_empty();
         let effective_cmd = if !has_env {
             command.to_string()
         } else {
             let mut parts = vec!["env".to_string()];
-            for (k, v) in &self.terminal_env_defaults {
-                parts.push(format!("{k}={}", flotilla_protocol::arg::shell_quote(v)));
-            }
-            for (k, v) in env_vars {
-                parts.push(format!("{k}={}", flotilla_protocol::arg::shell_quote(v)));
+            for (key, value) in self.terminal_env_defaults.iter().chain(env_vars) {
+                parts.push(format!("{key}={}", flotilla_protocol::arg::shell_quote(value)));
             }
             parts.push(command.to_string());
             parts.join(" ")
         };
-
-        run!(
-            self.runner,
-            &self.binary,
-            &["create", "--json", session_name, "--cwd", &cwd.as_path().display().to_string(), "--cmd", &effective_cmd],
-            Path::new("/")
-        )?;
+        let cwd = cwd.as_path().display().to_string();
+        let mut args = vec!["create", "--json", session_name, "--cwd", &cwd, "--cmd", &effective_cmd];
+        let encoded_tags = tags.iter().map(|tag| format!("{}={}", tag.key, tag.value)).collect::<Vec<_>>();
+        for tag in &encoded_tags {
+            args.push("--tag");
+            args.push(tag);
+        }
+        run!(self.runner, &self.binary, &args, Path::new("/"))?;
         Ok(())
     }
 
@@ -156,8 +164,8 @@ mod tests {
     #[tokio::test]
     async fn list_sessions_parses_json() {
         let json = r#"[
-            {"id":"sess-1","cwd":"/repo","cmd":"bash","status":"Attached"},
-            {"id":"sess-2","cwd":"/other","cmd":null,"status":"Detached"}
+            {"id":"sess-1","cwd":"/repo","cmd":"bash","status":"Attached","screen_activity":"active"},
+            {"id":"sess-2","cwd":"/other","cmd":null,"status":"Detached","screen_activity":"stable"}
         ]"#;
         let pool = CleatTerminalPool::new(Arc::new(MockRunner::new(vec![Ok(json.into())])), "cleat");
 
@@ -168,10 +176,12 @@ mod tests {
         assert_eq!(sessions[0].status, flotilla_protocol::TerminalStatus::Running);
         assert_eq!(sessions[0].command.as_deref(), Some("bash"));
         assert_eq!(sessions[0].working_directory.as_ref().map(|p| p.as_path()), Some(Path::new("/repo")));
+        assert_eq!(sessions[0].screen_activity, Some(ScreenActivity::Active));
         assert_eq!(sessions[1].session_name, "sess-2");
         assert_eq!(sessions[1].status, flotilla_protocol::TerminalStatus::Disconnected);
         assert!(sessions[1].command.is_none());
         assert_eq!(sessions[1].working_directory.as_ref().map(|p| p.as_path()), Some(Path::new("/other")));
+        assert_eq!(sessions[1].screen_activity, Some(ScreenActivity::Stable));
     }
 
     #[tokio::test]
@@ -183,7 +193,7 @@ mod tests {
         ]));
         let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
 
-        pool.ensure_session("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![]).await.expect("ensure session");
+        pool.ensure_session("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![], &[]).await.expect("ensure session");
 
         let calls = runner.calls();
         assert_eq!(calls.len(), 2);
@@ -201,7 +211,7 @@ mod tests {
         let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
         let env = vec![("FOO".to_string(), "bar".to_string())];
 
-        pool.ensure_session("my-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env).await.expect("ensure session");
+        pool.ensure_session("my-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env, &[]).await.expect("ensure session");
 
         let calls = runner.calls();
         assert_eq!(calls.len(), 2);
@@ -214,6 +224,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ensure_session_tags_convoy_and_vessel() {
+        let runner = Arc::new(MockRunner::new(vec![Ok("[]".into()), Ok("{}".into())]));
+        let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
+
+        pool.ensure_session("terminal-demo-coder", "codex", &ExecutionEnvironmentPath::new("/repo"), &vec![], &[
+            TerminalSessionTag::new("convoy", "demo"),
+            TerminalSessionTag::new("vessel", "demo-work"),
+        ])
+        .await
+        .expect("ensure tagged session");
+
+        assert_eq!(runner.calls()[1].1, vec![
+            "create",
+            "--json",
+            "terminal-demo-coder",
+            "--cwd",
+            "/repo",
+            "--cmd",
+            "codex",
+            "--tag",
+            "convoy=demo",
+            "--tag",
+            "vessel=demo-work",
+        ]);
+    }
+
+    #[tokio::test]
     async fn ensure_session_skips_if_session_exists() {
         let list_json = r#"[{"id":"my-session","cwd":"/repo","cmd":"claude","status":"Detached"}]"#;
         let runner = Arc::new(MockRunner::new(vec![
@@ -222,7 +259,7 @@ mod tests {
         let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
         let env = vec![("FOO".to_string(), "bar".to_string())];
 
-        pool.ensure_session("my-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env).await.expect("ensure session");
+        pool.ensure_session("my-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env, &[]).await.expect("ensure session");
 
         let calls = runner.calls();
         assert_eq!(calls.len(), 1, "should only call list, not create: {calls:?}");
@@ -356,7 +393,7 @@ mod tests {
         let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat").with_terminal_env_defaults(env_defaults);
         let caller_env = vec![("FOO".to_string(), "bar".to_string())];
 
-        pool.ensure_session("sess", "claude", &ExecutionEnvironmentPath::new("/repo"), &caller_env).await.expect("ensure session");
+        pool.ensure_session("sess", "claude", &ExecutionEnvironmentPath::new("/repo"), &caller_env, &[]).await.expect("ensure session");
 
         let calls = runner.calls();
         let cmd_idx = calls[1].1.iter().position(|a| a == "--cmd").expect("--cmd present");

--- a/crates/flotilla-core/src/providers/terminal/mod.rs
+++ b/crates/flotilla-core/src/providers/terminal/mod.rs
@@ -4,6 +4,7 @@ pub mod shpool;
 
 use async_trait::async_trait;
 use flotilla_protocol::{arg::Arg, AttachableId, AttachableSetId, TerminalStatus};
+pub use flotilla_resources::TerminalSessionTag;
 
 use crate::path_context::ExecutionEnvironmentPath;
 
@@ -12,12 +13,19 @@ pub type TerminalEnvVars = Vec<(String, String)>;
 
 /// Raw session data returned by a terminal pool CLI adapter.
 /// No AttachableId — the manager handles identity mapping.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, bon::Builder)]
 pub struct TerminalSession {
     pub session_name: String,
     pub status: TerminalStatus,
     pub command: Option<String>,
     pub working_directory: Option<ExecutionEnvironmentPath>,
+    pub screen_activity: Option<ScreenActivity>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenActivity {
+    Active,
+    Stable,
 }
 
 pub(crate) const MANAGED_SESSION_PREFIX: &str = "flotilla-v2:";
@@ -89,6 +97,7 @@ pub trait TerminalPool: Send + Sync {
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
+        tags: &[TerminalSessionTag],
     ) -> Result<(), String>;
 
     /// Returns a structured `Arg` tree representing the attach command.

--- a/crates/flotilla-core/src/providers/terminal/passthrough.rs
+++ b/crates/flotilla-core/src/providers/terminal/passthrough.rs
@@ -18,6 +18,7 @@ impl TerminalPool for PassthroughTerminalPool {
         _command: &str,
         _cwd: &ExecutionEnvironmentPath,
         _env_vars: &TerminalEnvVars,
+        _tags: &[super::TerminalSessionTag],
     ) -> Result<(), String> {
         Ok(())
     }
@@ -60,7 +61,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_is_noop() {
         let pool = PassthroughTerminalPool;
-        assert!(pool.ensure_session("my-session", "bash", &ExecutionEnvironmentPath::new("/tmp"), &vec![]).await.is_ok());
+        assert!(pool.ensure_session("my-session", "bash", &ExecutionEnvironmentPath::new("/tmp"), &vec![], &[]).await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/providers/terminal/shpool.rs
+++ b/crates/flotilla-core/src/providers/terminal/shpool.rs
@@ -93,7 +93,13 @@ impl ShpoolTerminalPool {
             // V2 names carry discovery metadata and are decoded by the terminal
             // manager. Legacy names retain their historical validation here.
             if name.starts_with(MANAGED_SESSION_PREFIX) {
-                terminals.push(TerminalSession { session_name: name.to_string(), status, command: None, working_directory: None });
+                terminals.push(TerminalSession {
+                    session_name: name.to_string(),
+                    status,
+                    command: None,
+                    working_directory: None,
+                    screen_activity: None,
+                });
                 continue;
             }
 
@@ -117,6 +123,7 @@ impl ShpoolTerminalPool {
                 status,
                 command: None,           // shpool doesn't report the original command
                 working_directory: None, // shpool doesn't report cwd
+                screen_activity: None,
             });
         }
 
@@ -150,6 +157,7 @@ impl TerminalPool for ShpoolTerminalPool {
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
+        _tags: &[super::TerminalSessionTag],
     ) -> Result<(), String> {
         // If the session already exists, leave it alone — don't disrupt a
         // live attach by re-running attach+detach. We can't use list_sessions()

--- a/crates/flotilla-core/src/providers/terminal/shpool/tests.rs
+++ b/crates/flotilla-core/src/providers/terminal/shpool/tests.rs
@@ -237,7 +237,7 @@ async fn ensure_session_creates_via_attach_then_detach() {
     let (pool, _dir) = test_pool(runner.clone());
     let env = vec![("FLOTILLA_ATTACHABLE_ID".to_string(), "test-uuid".to_string())];
 
-    pool.ensure_session("test-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env).await.expect("ensure_session");
+    pool.ensure_session("test-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env, &[]).await.expect("ensure_session");
 
     let calls = runner.calls();
     assert_eq!(calls.len(), 3, "should call list, attach, detach: {calls:?}");
@@ -269,7 +269,7 @@ async fn ensure_session_skips_if_session_exists() {
     let (pool, _dir) = test_pool(runner.clone());
     let env = vec![("FLOTILLA_ATTACHABLE_ID".to_string(), "test-uuid".to_string())];
 
-    pool.ensure_session("test-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env).await.expect("ensure_session");
+    pool.ensure_session("test-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env, &[]).await.expect("ensure_session");
 
     let calls = runner.calls();
     assert_eq!(calls.len(), 1, "should only call list (session_exists), not attach: {calls:?}");
@@ -286,7 +286,7 @@ async fn ensure_session_empty_command_starts_login_shell() {
     ]));
     let (pool, _dir) = test_pool(runner.clone());
 
-    pool.ensure_session("test-session", "", &ExecutionEnvironmentPath::new("/repo"), &vec![]).await.expect("ensure_session");
+    pool.ensure_session("test-session", "", &ExecutionEnvironmentPath::new("/repo"), &vec![], &[]).await.expect("ensure_session");
 
     let calls = runner.calls();
     let cmd_idx = calls[1].1.iter().position(|a| a == "--cmd").expect("--cmd present");
@@ -301,7 +301,7 @@ async fn ensure_session_terminal_env_defaults_appear_before_caller_env() {
     let (pool, _dir) = test_pool_with_env(runner.clone(), env_defaults);
     let caller_env = vec![("FLOTILLA_ATTACHABLE_ID".to_string(), "test-uuid".to_string())];
 
-    pool.ensure_session("sess", "claude", &ExecutionEnvironmentPath::new("/repo"), &caller_env).await.expect("ensure_session");
+    pool.ensure_session("sess", "claude", &ExecutionEnvironmentPath::new("/repo"), &caller_env, &[]).await.expect("ensure_session");
 
     let calls = runner.calls();
     let cmd_idx = calls[1].1.iter().position(|a| a == "--cmd").expect("--cmd present");

--- a/crates/flotilla-core/src/refresh/tests.rs
+++ b/crates/flotilla-core/src/refresh/tests.rs
@@ -254,6 +254,7 @@ impl TerminalPool for MockTerminalPool {
         _command: &str,
         _cwd: &ExecutionEnvironmentPath,
         _env_vars: &crate::providers::terminal::TerminalEnvVars,
+        _tags: &[crate::providers::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         Ok(())
     }
@@ -1134,6 +1135,7 @@ async fn refresh_correlates_discovered_attachable_set_from_member_working_direct
             status: flotilla_protocol::TerminalStatus::Running,
             command: None,
             working_directory: None,
+            screen_activity: None,
         }])),
     );
     let handle = RepoRefreshHandle::spawn(

--- a/crates/flotilla-core/src/terminal_manager.rs
+++ b/crates/flotilla-core/src/terminal_manager.rs
@@ -159,7 +159,7 @@ impl TerminalManager {
         if let Some(socket) = daemon_socket_path {
             env_vars.push(("FLOTILLA_DAEMON_SOCKET".to_string(), socket.to_string()));
         }
-        self.pool.ensure_session(&session_name, &command, &cwd, &env_vars).await
+        self.pool.ensure_session(&session_name, &command, &cwd, &env_vars, &[]).await
     }
 
     /// Returns the command string needed to attach to a terminal session.

--- a/crates/flotilla-core/src/terminal_manager/tests.rs
+++ b/crates/flotilla-core/src/terminal_manager/tests.rs
@@ -53,6 +53,7 @@ impl TerminalPool for MockTerminalPool {
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
+        _tags: &[crate::providers::terminal::TerminalSessionTag],
     ) -> Result<(), String> {
         self.calls.lock().expect("lock calls").push(PoolCall::EnsureSession {
             session_name: session_name.to_string(),
@@ -176,6 +177,7 @@ async fn ensure_running_uses_provider_discovery_session_name() {
             command: &str,
             cwd: &ExecutionEnvironmentPath,
             env_vars: &TerminalEnvVars,
+            _tags: &[crate::providers::terminal::TerminalSessionTag],
         ) -> Result<(), String> {
             self.calls.lock().expect("lock").push(PoolCall::EnsureSession {
                 session_name: session_name.to_string(),
@@ -245,7 +247,14 @@ async fn attach_command_includes_env_vars() {
         async fn list_sessions(&self) -> Result<Vec<TerminalSession>, String> {
             Ok(Vec::new())
         }
-        async fn ensure_session(&self, _: &str, _: &str, _: &ExecutionEnvironmentPath, _: &TerminalEnvVars) -> Result<(), String> {
+        async fn ensure_session(
+            &self,
+            _: &str,
+            _: &str,
+            _: &ExecutionEnvironmentPath,
+            _: &TerminalEnvVars,
+            _: &[crate::providers::terminal::TerminalSessionTag],
+        ) -> Result<(), String> {
             Ok(())
         }
         fn attach_args(
@@ -348,7 +357,14 @@ async fn kill_terminal_delegates_to_pool() {
         async fn list_sessions(&self) -> Result<Vec<TerminalSession>, String> {
             Ok(Vec::new())
         }
-        async fn ensure_session(&self, _: &str, _: &str, _: &ExecutionEnvironmentPath, _: &TerminalEnvVars) -> Result<(), String> {
+        async fn ensure_session(
+            &self,
+            _: &str,
+            _: &str,
+            _: &ExecutionEnvironmentPath,
+            _: &TerminalEnvVars,
+            _: &[crate::providers::terminal::TerminalSessionTag],
+        ) -> Result<(), String> {
             Ok(())
         }
         fn attach_args(
@@ -397,6 +413,7 @@ async fn refresh_updates_statuses() {
         status: TerminalStatus::Running,
         command: Some("bash".to_string()),
         working_directory: Some(ExecutionEnvironmentPath::new("/repo/wt-feat")),
+        screen_activity: None,
     }]);
     let mgr = TerminalManager::new(Arc::new(pool), store.clone(), test_host());
 
@@ -441,7 +458,14 @@ async fn cascade_delete_removes_sets_and_kills_sessions() {
         async fn list_sessions(&self) -> Result<Vec<TerminalSession>, String> {
             Ok(Vec::new())
         }
-        async fn ensure_session(&self, _: &str, _: &str, _: &ExecutionEnvironmentPath, _: &TerminalEnvVars) -> Result<(), String> {
+        async fn ensure_session(
+            &self,
+            _: &str,
+            _: &str,
+            _: &ExecutionEnvironmentPath,
+            _: &TerminalEnvVars,
+            _: &[crate::providers::terminal::TerminalSessionTag],
+        ) -> Result<(), String> {
             Ok(())
         }
         fn attach_args(

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -16,9 +16,9 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     api_version, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Environment, Presentation,
-    Project, Repository, Resource, ResourceError, ResourceList, ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver,
-    VesselRequirement, WatchEvent, WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_KEY_LABEL,
-    REPO_LABEL, VESSEL_LABEL,
+    Project, Repository, Resource, ResourceError, ResourceList, ResourceObject, TerminalAttentionState, TerminalSession,
+    TerminalSessionPhase, TypedResolver, VesselRequirement, WatchEvent, WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState,
+    CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::broadcast;
@@ -801,6 +801,7 @@ impl Aggregator {
             sessions.into_iter().map(|session| ((session.metadata.namespace.clone(), session.metadata.name.clone()), session)).collect();
         self.sessions_by_source.insert(source, replacement);
         self.rebuild_independents_projection().await;
+        self.rebuild_local_projection().await;
     }
 
     async fn apply_session_event_from(&mut self, source: LocalSource, event: WatchEvent<TerminalSession>) {
@@ -819,6 +820,7 @@ impl Aggregator {
             }
         }
         self.rebuild_independents_projection().await;
+        self.rebuild_local_projection().await;
     }
 
     async fn apply_environment_event(&mut self, _event: WatchEvent<Environment>) {
@@ -1061,7 +1063,7 @@ impl Aggregator {
         let change_request = self.convoy_change_requests.get(&resource).cloned();
         let status = convoy.status.as_ref();
         let phase = status.map(|status| status.phase).unwrap_or_default();
-        let vessels = status
+        let vessels: Vec<VesselRow> = status
             .and_then(|status| status.workflow_snapshot.as_ref())
             .map(|snapshot| {
                 snapshot
@@ -1073,6 +1075,7 @@ impl Aggregator {
                     .collect()
             })
             .unwrap_or_default();
+        let needs_attention = vessels.iter().any(|vessel| vessel.needs_attention);
         ConvoyRow::builder()
             .resource(resource)
             .name(name)
@@ -1087,6 +1090,7 @@ impl Aggregator {
             .maybe_project_ref(convoy.spec.project_ref.clone())
             .maybe_change_request(change_request)
             .vessels(vessels)
+            .needs_attention(needs_attention)
             .build()
     }
 
@@ -1113,6 +1117,20 @@ impl Aggregator {
                 }
             })
             .collect();
+        let work_unsettled = !state.is_some_and(|state| state.phase.is_terminal());
+        let now = chrono::Utc::now();
+        let needs_attention = self.terminal_sessions.values().any(|session| {
+            session.metadata.namespace == convoy_ref.namespace
+                && session.metadata.labels.get(CONVOY_LABEL) == Some(&convoy_ref.name)
+                && session.metadata.labels.get(VESSEL_LABEL) == Some(&definition.name)
+                && session.status.as_ref().is_some_and(|status| {
+                    status.phase == TerminalSessionPhase::Running
+                        && status
+                            .attention
+                            .as_ref()
+                            .is_some_and(|attention| !attention.is_stale_at(now) && attention_needs_human(attention.state, work_unsettled))
+                })
+        });
         VesselRow::builder()
             .resource(convoy_ref.subresource(format!("vessels/{}", definition.name)))
             .name(&definition.name)
@@ -1128,8 +1146,13 @@ impl Aggregator {
             .host(self.local_host.clone())
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
             .complete_work(state.is_some_and(|state| !state.phase.is_terminal()))
+            .needs_attention(needs_attention)
             .build()
     }
+}
+
+fn attention_needs_human(state: TerminalAttentionState, work_unsettled: bool) -> bool {
+    state == TerminalAttentionState::NeedsInput || (state == TerminalAttentionState::Idle && work_unsettled)
 }
 
 fn presentation_key(presentation: &ResourceObject<Presentation>) -> Option<PresentationKey> {
@@ -1213,13 +1236,49 @@ mod tests {
     use flotilla_protocol::result_set::{ResultSet, ResultSetState};
     use flotilla_resources::{
         ConvoyRepositorySpec, ConvoySpec, CrewSpec, InMemoryBackend, InputMeta, ObjectMeta, PlacementStatus, PresentationPhase,
-        PresentationSpec, PresentationStatus, ResourceBackend, Stance, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
-        VesselRequirement, WorkflowSnapshot,
+        PresentationSpec, PresentationStatus, ResourceBackend, Stance, TerminalAttention, TerminalAttentionSource, TerminalSessionSource,
+        TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
     };
     use futures::stream;
     use tokio::{sync::Mutex, time::timeout};
 
     use super::*;
+
+    #[test]
+    fn needs_attention_is_needs_input_or_idle_with_unsettled_work() {
+        assert!(attention_needs_human(TerminalAttentionState::NeedsInput, false));
+        assert!(attention_needs_human(TerminalAttentionState::Idle, true));
+        assert!(!attention_needs_human(TerminalAttentionState::Idle, false));
+        assert!(!attention_needs_human(TerminalAttentionState::Working, true));
+        assert!(!attention_needs_human(TerminalAttentionState::Unobservable, true));
+    }
+
+    #[tokio::test]
+    async fn attention_projection_is_namespace_scoped_and_tracks_idle_unsettled_sessions() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(4);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy_with_vessel("convoy-a").await)).await;
+
+        let mut session = session_object("terminal-convoy-a-implement").await;
+        session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        session.status.as_mut().expect("running status").attention =
+            Some(TerminalAttention { state: TerminalAttentionState::Idle, as_of: Utc::now(), source: TerminalAttentionSource::Screen });
+
+        let mut foreign_session = session.clone();
+        foreign_session.metadata.namespace = "other".to_string();
+        aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Added(foreign_session)).await;
+        let result_set = state.result_set().await;
+        assert!(!result_set.rows.as_convoys().expect("convoy rows")[0].needs_attention);
+
+        aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Added(session)).await;
+
+        let result_set = state.result_set().await;
+        let convoy = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
+        assert!(convoy.vessels.first().expect("vessel row").needs_attention);
+        assert!(convoy.needs_attention);
+    }
 
     struct ScriptedSource<T: Resource> {
         lists: Mutex<VecDeque<ResourceList<T>>>,

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -25,7 +25,7 @@ use flotilla_core::{
         discovery::{EnvironmentAssertion, EnvironmentBag},
         environment::{CreateOpts, EnvironmentHandle, ProvisionedMount},
         registry::ProviderRegistry,
-        terminal::TerminalPool,
+        terminal::{ScreenActivity, TerminalPool},
         vcs::{CloneProvisioner, GitCloneProvisioner},
         ChannelLabel, CommandRunner,
     },
@@ -1250,7 +1250,12 @@ struct TerminalControllerRuntime {
 
 #[async_trait]
 impl TerminalRuntime for TerminalControllerRuntime {
-    async fn ensure_session(&self, name: &str, spec: &flotilla_resources::TerminalSessionSpec) -> Result<TerminalRuntimeState, String> {
+    async fn ensure_session(
+        &self,
+        name: &str,
+        spec: &flotilla_resources::TerminalSessionSpec,
+        tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
         let registry = self.registry_for_env(&spec.env_ref)?;
         let pool = registry
             .terminal_pools
@@ -1294,6 +1299,7 @@ impl TerminalRuntime for TerminalControllerRuntime {
                     ("FLOTILLA_VESSEL".to_string(), context.vessel_ref.clone()),
                     ("FLOTILLA_CREW_ROLE".to_string(), spec.role.clone()),
                     ("FLOTILLA_NAMESPACE".to_string(), context.namespace.clone()),
+                    ("FLOTILLA_TERMINAL_SESSION".to_string(), name.to_string()),
                 ]);
                 (plan.command, env, Some(crew), message.clone())
             }
@@ -1305,7 +1311,7 @@ impl TerminalRuntime for TerminalControllerRuntime {
                 pool.kill_session(name).await?;
             }
         }
-        pool.ensure_session(name, &command, &cwd, &env).await?;
+        pool.ensure_session(name, &command, &cwd, &env, tags).await?;
         let delivered_message_id = initial_message.as_ref().map(|message| message.id.clone());
         if let Some(message) = initial_message {
             if let Err(err) = pool.deliver(name, &message.text, true).await {
@@ -1338,6 +1344,27 @@ impl TerminalRuntime for TerminalControllerRuntime {
             self.state.active_sessions.lock().await.remove(session_id);
         }
         Ok(running)
+    }
+
+    async fn observe_attention(
+        &self,
+        session_id: &str,
+        spec: &flotilla_resources::TerminalSessionSpec,
+    ) -> Result<Option<flotilla_resources::TerminalAttention>, String> {
+        let pool = self.pool_for_spec(spec)?;
+        let Some(session) = pool.list_sessions().await?.into_iter().find(|session| session.session_name == session_id) else {
+            return Ok(None);
+        };
+        let Some(activity) = session.screen_activity else { return Ok(None) };
+        let state = match activity {
+            ScreenActivity::Active => flotilla_resources::TerminalAttentionState::Working,
+            ScreenActivity::Stable => flotilla_resources::TerminalAttentionState::Idle,
+        };
+        Ok(Some(flotilla_resources::TerminalAttention {
+            state,
+            as_of: Utc::now(),
+            source: flotilla_resources::TerminalAttentionSource::Screen,
+        }))
     }
 
     async fn deliver_message(&self, session_id: &str, spec: &flotilla_resources::TerminalSessionSpec, message: &str) -> Result<(), String> {
@@ -2402,6 +2429,7 @@ mod tests {
             status: flotilla_protocol::TerminalStatus::Running,
             command: Some("old codex process with stale crew identity".to_string()),
             working_directory: Some(ExecutionEnvironmentPath::new("/repo")),
+            screen_activity: None,
         }])
         .await;
         let runtime = TerminalControllerRuntime { state };
@@ -2430,7 +2458,7 @@ mod tests {
             pool: "fake-terminals".to_string(),
         };
 
-        let launched = runtime.ensure_session(session_name, &spec).await.expect("replace stale session");
+        let launched = runtime.ensure_session(session_name, &spec, &[]).await.expect("replace stale session");
 
         assert_eq!(pool.killed.lock().await.as_slice(), &[session_name.to_string()]);
         assert_eq!(pool.ensured.lock().await.len(), 1, "the fresh agent command must actually be launched");

--- a/crates/flotilla-daemon/src/server/request_dispatch.rs
+++ b/crates/flotilla-daemon/src/server/request_dispatch.rs
@@ -142,7 +142,7 @@ impl<'a> RequestDispatcher<'a> {
                 Err(e) => Message::error_response(id, e),
             },
 
-            Request::AgentHook { event } => match self.handle_agent_hook(event) {
+            Request::AgentHook { event } => match self.handle_agent_hook(event).await {
                 Ok(()) => Message::ok_response(id, Response::AgentHook),
                 Err(e) => {
                     warn!(err = %e, "failed to process agent hook event");
@@ -152,7 +152,7 @@ impl<'a> RequestDispatcher<'a> {
         }
     }
 
-    fn handle_agent_hook(&self, event: AgentHookEvent) -> Result<(), String> {
+    async fn handle_agent_hook(&self, event: AgentHookEvent) -> Result<(), String> {
         use flotilla_protocol::AgentEventType;
 
         tracing::info!(
@@ -163,47 +163,76 @@ impl<'a> RequestDispatcher<'a> {
             "received agent hook event"
         );
 
-        let mut store = self.agent_state_store.lock().map_err(|_| "agent state store lock poisoned".to_string())?;
+        {
+            let mut store = self.agent_state_store.lock().map_err(|_| "agent state store lock poisoned".to_string())?;
 
-        let attachable_id = if let Some(ref sid) = event.session_id {
-            if let Some(existing) = store.lookup_by_session_id(sid) {
-                existing.clone()
+            let attachable_id = if let Some(ref sid) = event.session_id {
+                if let Some(existing) = store.lookup_by_session_id(sid) {
+                    existing.clone()
+                } else {
+                    event.attachable_id.clone()
+                }
             } else {
                 event.attachable_id.clone()
-            }
-        } else {
-            event.attachable_id.clone()
-        };
-
-        let changed = if event.event_type == AgentEventType::Ended {
-            store.remove(&attachable_id);
-            true
-        } else if let Some(status) = event.event_type.to_status() {
-            let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
-            let existing = store.get(&attachable_id);
-            // TODO(#393): persist event.cwd for CliAgentProvider correlation
-            let entry = AgentEntry {
-                harness: event.harness.clone(),
-                status,
-                model: event.model.clone().or_else(|| existing.and_then(|e| e.model.clone())),
-                session_title: existing.and_then(|e| e.session_title.clone()),
-                session_id: event.session_id.clone(),
-                last_event_epoch_secs: now,
             };
-            store.upsert(attachable_id, entry);
-            true
-        } else {
-            false
-        };
 
-        if changed {
-            store.save()
-        } else {
-            Ok(())
+            let changed = if event.event_type == AgentEventType::Ended {
+                store.remove(&attachable_id);
+                true
+            } else if let Some(status) = event.event_type.to_status() {
+                let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs();
+                let existing = store.get(&attachable_id);
+                // TODO(#393): persist event.cwd for CliAgentProvider correlation
+                let entry = AgentEntry {
+                    harness: event.harness.clone(),
+                    status,
+                    model: event.model.clone().or_else(|| existing.and_then(|e| e.model.clone())),
+                    session_title: existing.and_then(|e| e.session_title.clone()),
+                    session_id: event.session_id.clone(),
+                    last_event_epoch_secs: now,
+                };
+                store.upsert(attachable_id, entry);
+                true
+            } else {
+                false
+            };
+
+            if changed {
+                store.save()?;
+            } else {
+                // Keep the legacy observer path a no-op when it has no control-plane identity.
+            }
         }
-        // NOTE: agent state changes are not pushed to the TUI immediately.
-        // They become visible on the next refresh cycle (~10s). A proper fix
-        // requires the log-based architecture (#256) where push events can
-        // trigger targeted view re-materialization without a full provider refresh.
+
+        let Some(terminal) = event.terminal.as_ref() else { return Ok(()) };
+        let state = match event.event_type {
+            AgentEventType::Active => flotilla_resources::TerminalAttentionState::Working,
+            AgentEventType::Idle | AgentEventType::Started => flotilla_resources::TerminalAttentionState::Idle,
+            AgentEventType::WaitingForPermission => flotilla_resources::TerminalAttentionState::NeedsInput,
+            AgentEventType::Ended | AgentEventType::NoChange => return Ok(()),
+        };
+        let sessions = self.daemon.resource_backend().using::<flotilla_resources::TerminalSession>(&terminal.namespace);
+        let session = sessions.get(&terminal.session_name).await.map_err(|error| error.to_string())?;
+        let attention = flotilla_resources::TerminalAttention {
+            state,
+            as_of: chrono::Utc::now(),
+            source: flotilla_resources::TerminalAttentionSource::Hook,
+        };
+        if session
+            .status
+            .as_ref()
+            .and_then(|status| status.attention.as_ref())
+            .is_some_and(|current| !current.should_replace_with(&attention))
+        {
+            return Ok(());
+        }
+        flotilla_resources::apply_status_patch(
+            &sessions,
+            &terminal.session_name,
+            &flotilla_resources::TerminalSessionStatusPatch::ObserveAttention { attention },
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        Ok(())
     }
 }

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -31,7 +31,8 @@ use flotilla_protocol::{
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
     ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectSpec, ResourceBackend, ResourceError, Stance,
-    WorkflowTemplate,
+    StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
+    TerminalSessionStatusPatch, WorkflowTemplate,
 };
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
@@ -464,14 +465,13 @@ async fn dispatch_agent_hook_started_updates_existing_session_entry() {
     }
 
     let response = dispatch_request_with_state(&daemon, &agent_state_store, 5, Request::AgentHook {
-        event: AgentHookEvent {
-            attachable_id: incoming_id.clone(),
-            harness: AgentHarness::ClaudeCode,
-            event_type: AgentEventType::Active,
-            session_id: Some(session_id.clone()),
-            model: Some("new-model".into()),
-            cwd: None,
-        },
+        event: AgentHookEvent::builder()
+            .attachable_id(incoming_id.clone())
+            .harness(AgentHarness::ClaudeCode)
+            .event_type(AgentEventType::Active)
+            .session_id(session_id.clone())
+            .model("new-model".to_string())
+            .build(),
     })
     .await;
 
@@ -482,6 +482,53 @@ async fn dispatch_agent_hook_started_updates_existing_session_entry() {
     assert_eq!(entry.status, AgentStatus::Active);
     assert_eq!(entry.model.as_deref(), Some("new-model"));
     assert!(store.get(&incoming_id).is_none(), "session remap should update the existing attachable id");
+}
+
+#[tokio::test]
+async fn managed_claude_permission_prompt_marks_terminal_as_needing_input() {
+    let (_tmp, daemon) = empty_daemon().await;
+    let sessions = daemon.resource_backend().using::<TerminalSession>("flotilla");
+    let created = sessions
+        .create(&InputMeta::builder().name("terminal-demo-coder".to_string()).build(), &TerminalSessionSpec {
+            env_ref: "host-direct".into(),
+            role: "coder".into(),
+            source: TerminalSessionSource::Tool { command: "claude".into() },
+            cwd: "/repo".into(),
+            pool: "cleat".into(),
+        })
+        .await
+        .expect("terminal create");
+    let mut status = TerminalSessionStatus::default();
+    TerminalSessionStatusPatch::MarkRunning {
+        session_id: "terminal-demo-coder".into(),
+        pid: None,
+        started_at: chrono::Utc::now(),
+        crew: None,
+        launch_command: "claude".into(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
+    sessions.update_status("terminal-demo-coder", &created.metadata.resource_version, &status).await.expect("running status");
+    let agent_state_store = flotilla_core::agents::shared_in_memory_agent_state_store();
+
+    let response = dispatch_request_with_state(&daemon, &agent_state_store, 8, Request::AgentHook {
+        event: AgentHookEvent::builder()
+            .attachable_id(AttachableId::new("att-managed"))
+            .harness(AgentHarness::ClaudeCode)
+            .event_type(AgentEventType::WaitingForPermission)
+            .session_id("claude-native-session".to_string())
+            .cwd("/repo".to_string())
+            .terminal(flotilla_protocol::AgentHookTerminalRef { namespace: "flotilla".into(), session_name: "terminal-demo-coder".into() })
+            .build(),
+    })
+    .await;
+
+    assert!(matches!(ok_response(response, 8), Response::AgentHook));
+    let observed = sessions.get("terminal-demo-coder").await.expect("observed terminal");
+    assert_eq!(
+        observed.status.and_then(|status| status.attention).map(|attention| attention.state),
+        Some(TerminalAttentionState::NeedsInput)
+    );
 }
 
 #[tokio::test]
@@ -504,14 +551,12 @@ async fn dispatch_agent_hook_ended_removes_existing_session_entry() {
     }
 
     let response = dispatch_request_with_state(&daemon, &agent_state_store, 6, Request::AgentHook {
-        event: AgentHookEvent {
-            attachable_id: AttachableId::new("att-ended"),
-            harness: AgentHarness::ClaudeCode,
-            event_type: AgentEventType::Ended,
-            session_id: Some(session_id.clone()),
-            model: None,
-            cwd: None,
-        },
+        event: AgentHookEvent::builder()
+            .attachable_id(AttachableId::new("att-ended"))
+            .harness(AgentHarness::ClaudeCode)
+            .event_type(AgentEventType::Ended)
+            .session_id(session_id.clone())
+            .build(),
     })
     .await;
 
@@ -528,14 +573,12 @@ async fn dispatch_agent_hook_no_change_event_is_ok_without_creating_entry() {
     let attachable_id = AttachableId::new("att-no-change");
 
     let response = dispatch_request_with_state(&daemon, &agent_state_store, 7, Request::AgentHook {
-        event: AgentHookEvent {
-            attachable_id: attachable_id.clone(),
-            harness: AgentHarness::ClaudeCode,
-            event_type: AgentEventType::NoChange,
-            session_id: Some("sess-no-change".into()),
-            model: None,
-            cwd: None,
-        },
+        event: AgentHookEvent::builder()
+            .attachable_id(attachable_id.clone())
+            .harness(AgentHarness::ClaudeCode)
+            .event_type(AgentEventType::NoChange)
+            .session_id("sess-no-change".to_string())
+            .build(),
     })
     .await;
 

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -92,10 +92,10 @@ pub use commands::{
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{
-    Agent, AgentContext, AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AheadBehind, AssociationKey, AttachableId,
-    AttachableSet, AttachableSetId, ChangeRequest, ChangeRequestStatus, Checkout, CloudAgentSession, CommitInfo, CorrelationKey, Issue,
-    IssueChangeset, IssueRef, IssueSource, IssueState, ManagedTerminal, ProviderData, RemoteAccessPoint, RemoteAccessType, SessionStatus,
-    TerminalStatus, WorkingTreeStatus, Workspace,
+    Agent, AgentContext, AgentEventType, AgentHarness, AgentHookEvent, AgentHookTerminalRef, AgentStatus, AheadBehind, AssociationKey,
+    AttachableId, AttachableSet, AttachableSetId, ChangeRequest, ChangeRequestStatus, Checkout, CloudAgentSession, CommitInfo,
+    CorrelationKey, Issue, IssueChangeset, IssueRef, IssueSource, IssueState, ManagedTerminal, ProviderData, RemoteAccessPoint,
+    RemoteAccessType, SessionStatus, TerminalStatus, WorkingTreeStatus, Workspace,
 };
 pub use query::{
     CrewCommandContext, CrewListMember, CrewListResponse, DiscoveryEntry, FleetListResponse, FleetListRow, FleetReplicaSnapshot,

--- a/crates/flotilla-protocol/src/provider_data.rs
+++ b/crates/flotilla-protocol/src/provider_data.rs
@@ -252,7 +252,7 @@ impl AgentEventType {
 }
 
 /// A normalized agent hook event sent from the hook CLI to the daemon.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct AgentHookEvent {
     /// Which terminal this agent lives in (from env or allocated).
     pub attachable_id: AttachableId,
@@ -266,6 +266,16 @@ pub struct AgentHookEvent {
     pub model: Option<String>,
     /// Current working directory (if reported).
     pub cwd: Option<String>,
+    /// Control-plane identity injected into managed crew sessions. Legacy
+    /// observer hooks omit it and continue through their old path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<AgentHookTerminalRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentHookTerminalRef {
+    pub namespace: String,
+    pub session_name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -509,6 +509,8 @@ pub struct ConvoyRow {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub vessels: Vec<VesselRow>,
+    #[builder(default)]
+    pub needs_attention: bool,
 }
 
 /// The external change request currently associated with a convoy branch.
@@ -556,6 +558,9 @@ pub struct VesselRow {
     /// Capability fact: the daemon will accept completing this vessel's work.
     #[builder(default)]
     pub complete_work: bool,
+    /// A live observation requests human attention; it never changes `phase`.
+    #[builder(default)]
+    pub needs_attention: bool,
 }
 
 /// Crew membership summary on a vessel row.

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -74,9 +74,10 @@ pub use retention::{EventRetention, ResourceStoreDiagnostics, ResourceStoreWarni
 pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, apply_status_patch_checked, NoStatusPatch, StatusPatch};
 pub use terminal_session::{
-    terminal_session_attach_target, CrewSessionStatus, InnerCommandStatus, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
-    TerminalSession, TerminalSessionAttachTarget, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource,
-    TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
+    terminal_session_attach_target, CrewSessionStatus, InnerCommandStatus, TerminalAttention, TerminalAttentionSource,
+    TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession, TerminalSessionAttachTarget,
+    TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
+    TerminalSessionStatusPatch, TerminalSessionTag,
 };
 pub use vessel::{Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch};
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -161,6 +161,71 @@ pub struct TerminalSessionStatus {
     pub launch_command: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delivered_message_id: Option<String>,
+    /// A fresh observation of what the terminal's harness appears to be doing.
+    /// This deliberately does not participate in the session lifecycle phase.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention: Option<TerminalAttention>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalAttentionState {
+    Working,
+    NeedsInput,
+    Idle,
+    Unobservable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalAttentionSource {
+    Hook,
+    Screen,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalAttention {
+    pub state: TerminalAttentionState,
+    pub as_of: DateTime<Utc>,
+    pub source: TerminalAttentionSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalSessionTag {
+    pub key: String,
+    pub value: String,
+}
+
+impl TerminalSessionTag {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { key: key.into(), value: value.into() }
+    }
+}
+
+impl TerminalAttention {
+    pub const FRESH_FOR: chrono::Duration = chrono::Duration::seconds(30);
+    pub const DEBOUNCE_FOR: chrono::Duration = chrono::Duration::seconds(5);
+
+    pub fn is_stale_at(&self, now: DateTime<Utc>) -> bool {
+        self.state != TerminalAttentionState::Unobservable && now.signed_duration_since(self.as_of) > Self::FRESH_FOR
+    }
+
+    /// Whether persisting `incoming` would add information. Hook observations
+    /// take precedence while fresh; identical observations are rate-limited.
+    pub fn should_replace_with(&self, incoming: &Self) -> bool {
+        if incoming.as_of <= self.as_of {
+            return false;
+        }
+        if self.source == TerminalAttentionSource::Hook
+            && incoming.source == TerminalAttentionSource::Screen
+            && !self.is_stale_at(incoming.as_of)
+        {
+            return false;
+        }
+        self.state != incoming.state
+            || self.source != incoming.source
+            || incoming.as_of.signed_duration_since(self.as_of) >= Self::DEBOUNCE_FOR
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
@@ -198,6 +263,9 @@ pub enum TerminalSessionStatusPatch {
         message: String,
         stopped_at: Option<DateTime<Utc>>,
     },
+    ObserveAttention {
+        attention: TerminalAttention,
+    },
 }
 
 impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
@@ -224,6 +292,10 @@ impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
                 status.inner_command_status = *inner_command_status;
                 status.inner_exit_code = *inner_exit_code;
                 status.message = message.clone();
+                if let Some(attention) = &mut status.attention {
+                    attention.state = TerminalAttentionState::Unobservable;
+                    attention.as_of = *stopped_at;
+                }
             }
             Self::MarkFailed { message, stopped_at } => {
                 status.phase = TerminalSessionPhase::Failed;
@@ -231,7 +303,87 @@ impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
                     status.stopped_at.get_or_insert(*stopped_at);
                 }
                 status.message = Some(message.clone());
+                if let Some(attention) = &mut status.attention {
+                    attention.state = TerminalAttentionState::Unobservable;
+                    if let Some(stopped_at) = stopped_at {
+                        attention.as_of = *stopped_at;
+                    }
+                }
+            }
+            Self::ObserveAttention { attention } => {
+                let replace = status.attention.as_ref().is_none_or(|previous| previous.should_replace_with(attention));
+                if replace {
+                    status.attention = Some(attention.clone());
+                }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+
+    fn attention(state: TerminalAttentionState, source: TerminalAttentionSource, second: u32) -> TerminalAttention {
+        TerminalAttention { state, source, as_of: Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, second).single().expect("valid timestamp") }
+    }
+
+    #[test]
+    fn attention_observation_never_changes_a_terminal_phase() {
+        let mut status = TerminalSessionStatus { phase: TerminalSessionPhase::Running, ..Default::default() };
+        TerminalSessionStatusPatch::ObserveAttention {
+            attention: TerminalAttention {
+                state: TerminalAttentionState::Idle,
+                as_of: Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).single().expect("valid timestamp"),
+                source: TerminalAttentionSource::Hook,
+            },
+        }
+        .apply(&mut status);
+
+        assert_eq!(status.phase, TerminalSessionPhase::Running);
+        assert_eq!(status.attention.expect("attention").state, TerminalAttentionState::Idle);
+    }
+
+    #[test]
+    fn fresh_hook_observation_wins_over_screen_fallback() {
+        let hook = attention(TerminalAttentionState::NeedsInput, TerminalAttentionSource::Hook, 0);
+        let screen = attention(TerminalAttentionState::Working, TerminalAttentionSource::Screen, 10);
+
+        assert!(!hook.should_replace_with(&screen));
+    }
+
+    #[test]
+    fn stale_hook_observation_yields_to_screen_fallback() {
+        let hook = attention(TerminalAttentionState::Working, TerminalAttentionSource::Hook, 0);
+        let screen = attention(TerminalAttentionState::Idle, TerminalAttentionSource::Screen, 31);
+
+        assert!(hook.should_replace_with(&screen));
+    }
+
+    #[test]
+    fn identical_observations_are_debounced() {
+        let first = attention(TerminalAttentionState::Working, TerminalAttentionSource::Hook, 0);
+        let too_soon = attention(TerminalAttentionState::Working, TerminalAttentionSource::Hook, 1);
+        let refresh = attention(TerminalAttentionState::Working, TerminalAttentionSource::Hook, 5);
+
+        assert!(!first.should_replace_with(&too_soon));
+        assert!(first.should_replace_with(&refresh));
+    }
+
+    #[test]
+    fn stopping_a_session_makes_its_attention_unobservable() {
+        let stopped_at = Utc.with_ymd_and_hms(2026, 7, 22, 12, 1, 0).single().expect("valid timestamp");
+        let mut status = TerminalSessionStatus {
+            phase: TerminalSessionPhase::Running,
+            attention: Some(attention(TerminalAttentionState::NeedsInput, TerminalAttentionSource::Hook, 0)),
+            ..Default::default()
+        };
+
+        TerminalSessionStatusPatch::MarkStopped { stopped_at, inner_command_status: None, inner_exit_code: None, message: None }
+            .apply(&mut status);
+
+        assert_eq!(status.attention.expect("attention").state, TerminalAttentionState::Unobservable);
     }
 }

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -218,6 +218,7 @@ impl TerminalAttention {
         }
         if self.source == TerminalAttentionSource::Hook
             && incoming.source == TerminalAttentionSource::Screen
+            && self.state != TerminalAttentionState::Unobservable
             && !self.is_stale_at(incoming.as_of)
         {
             return false;
@@ -358,6 +359,14 @@ mod tests {
     fn stale_hook_observation_yields_to_screen_fallback() {
         let hook = attention(TerminalAttentionState::Working, TerminalAttentionSource::Hook, 0);
         let screen = attention(TerminalAttentionState::Idle, TerminalAttentionSource::Screen, 31);
+
+        assert!(hook.should_replace_with(&screen));
+    }
+
+    #[test]
+    fn unobservable_hook_observation_yields_to_screen_fallback() {
+        let hook = attention(TerminalAttentionState::Unobservable, TerminalAttentionSource::Hook, 30);
+        let screen = attention(TerminalAttentionState::Working, TerminalAttentionSource::Screen, 31);
 
         assert!(hook.should_replace_with(&screen));
     }

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -67,6 +67,7 @@ define_patch_kinds! {
     TerminalMarkStarting => NEW_ATTEMPT,
     TerminalMarkRunning => DUPLICATE,
     TerminalMarkMessageDelivered => NONE,
+    TerminalObserveAttention => NONE,
     TerminalMarkStopped => DUPLICATE,
     TerminalMarkFailed => DUPLICATE,
     VesselMarkProvisioning => DUPLICATE,
@@ -106,6 +107,7 @@ fn terminal_session_patch_kind(patch: &TerminalSessionStatusPatch) -> PatchKind 
         TerminalSessionStatusPatch::MarkMessageDelivered { .. } => PatchKind::TerminalMarkMessageDelivered,
         TerminalSessionStatusPatch::MarkStopped { .. } => PatchKind::TerminalMarkStopped,
         TerminalSessionStatusPatch::MarkFailed { .. } => PatchKind::TerminalMarkFailed,
+        TerminalSessionStatusPatch::ObserveAttention { .. } => PatchKind::TerminalObserveAttention,
     }
 }
 
@@ -513,6 +515,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                     crew: None,
                     launch_command: Some("bash".to_string()),
                     delivered_message_id: None,
+                    attention: None,
                 };
                 let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
                 let patch = TerminalSessionStatusPatch::MarkRunning {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1736,6 +1736,7 @@ fn test_convoy(
         finished_at: None,
         observed_workflow_ref: None,
         initializing,
+        needs_attention: false,
     }
 }
 

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -161,6 +161,8 @@ pub struct ConvoySummary {
     pub finished_at: Option<Timestamp>,
     pub observed_workflow_ref: Option<String>,
     pub initializing: bool,
+    #[builder(default)]
+    pub needs_attention: bool,
 }
 
 impl From<&wire::ConvoyRow> for ConvoySummary {
@@ -181,6 +183,7 @@ impl From<&wire::ConvoyRow> for ConvoySummary {
             finished_at: row.finished_at,
             observed_workflow_ref: row.observed_workflow_ref.clone(),
             initializing: row.initializing,
+            needs_attention: row.needs_attention,
         }
     }
 }

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -837,6 +837,7 @@ mod tests {
             finished_at: None,
             observed_workflow_ref: None,
             initializing: false,
+            needs_attention: false,
         };
         let mut model = crate::app::NamespaceModel::default();
         model.convoys.insert(convoy.id.clone(), convoy);

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -699,7 +699,7 @@ static CONVOY_COLUMNS: [ColumnSpec<ConvoySummary>; 7] = [
         label: "CONVOY",
         width: WidthHint::Flexible { minimum: 12, weight: 2 },
         alignment: Alignment::Left,
-        extract: |row| CellValue::plain(&row.name),
+        extract: |row| CellValue::plain(if row.needs_attention { format!("⚠ {}", row.name) } else { row.name.clone() }),
     },
     ColumnSpec {
         id: "workflow",
@@ -1138,6 +1138,7 @@ mod tests {
             finished_at: None,
             observed_workflow_ref: None,
             initializing: false,
+            needs_attention: false,
         }
     }
 
@@ -1180,6 +1181,16 @@ mod tests {
 
         assert_eq!(view.rows[0].cells[2], CellValue::toned("completed", CellTone::Success));
         assert_eq!(view.rows[1].cells[2], CellValue::toned("failed", CellTone::Error));
+    }
+
+    #[test]
+    fn project_convoy_row_badges_needs_attention() {
+        let mut row = convoy(vec![vessel("implement", &[], WorkPhase::Running)]);
+        row.needs_attention = true;
+
+        let view = project_convoys("convoys/dev", &[&row]).expect("convoy table");
+
+        assert_eq!(view.rows[0].cells[0].text, "⚠ tables");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -487,10 +487,10 @@ impl InteractiveWidget for Screen {
 
         // 3f. Mode indicators — only for Normal mode (no modals, not config or issue search)
         let mode_indicators = if active_mode == BindingModeId::Normal && self.modal_stack.is_empty() {
-            status_bar_widget::normal_mode_indicators(ctx.ui)
+            status_bar_widget::normal_mode_indicators(ctx.ui, ctx.namespaces)
         } else if active_mode == BindingModeId::CommandPalette {
             // CommandPalette keeps mode indicators
-            status_bar_widget::normal_mode_indicators(ctx.ui)
+            status_bar_widget::normal_mode_indicators(ctx.ui, ctx.namespaces)
         } else {
             vec![]
         };

--- a/crates/flotilla-tui/src/widgets/status_bar_widget.rs
+++ b/crates/flotilla-tui/src/widgets/status_bar_widget.rs
@@ -12,7 +12,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::{AppAction, InteractiveWidget, Outcome, RenderContext, WidgetContext};
 use crate::{
-    app::{InFlightCommand, RepoViewLayout, TuiModel, UiState},
+    app::{InFlightCommand, NamespaceMap, RepoViewLayout, TuiModel, UiState},
     binding_table::{KeyBindingMode, StatusContent, StatusFragment},
     keymap::Action,
     segment_bar::{self, BarStyle, ThemedRibbonStyle},
@@ -269,7 +269,7 @@ pub(crate) fn active_task(model: &TuiModel, in_flight: &HashMap<u64, InFlightCom
 }
 
 /// Build mode indicators for Normal mode (layout and host).
-pub(crate) fn normal_mode_indicators(ui: &UiState) -> Vec<ModeIndicator> {
+pub(crate) fn normal_mode_indicators(ui: &UiState, namespaces: &NamespaceMap) -> Vec<ModeIndicator> {
     let layout_icon = match ui.view_layout {
         RepoViewLayout::Auto => "◫",
         RepoViewLayout::Zoom => "□",
@@ -285,10 +285,16 @@ pub(crate) fn normal_mode_indicators(ui: &UiState) -> Vec<ModeIndicator> {
 
     let host_label = ui.provisioning_target.to_string();
 
-    vec![
+    let attention_count =
+        namespaces.values().flat_map(|namespace| namespace.convoys.values()).filter(|convoy| convoy.needs_attention).count();
+    let mut indicators = vec![
         ModeIndicator::new(layout_icon, layout_label, StatusBarAction::key(KeyCode::Char('l'))),
         ModeIndicator::new("", &host_label, StatusBarAction::None),
-    ]
+    ];
+    if attention_count > 0 {
+        indicators.push(ModeIndicator::new("⚠", &format!("{attention_count} need attention"), StatusBarAction::None));
+    }
+    indicators
 }
 
 /// Build a `StatusSection` from a `StatusFragment`, resolving the fragment's content.
@@ -322,7 +328,38 @@ mod tests {
     use ratatui::layout::Rect;
 
     use super::*;
-    use crate::{app::test_support::repo_info, status_bar::StatusBarAction};
+    use crate::{
+        app::{test_support::repo_info, NamespaceModel},
+        convoy_model::{ConvoyId, ConvoyPhase, ConvoySummary},
+        status_bar::StatusBarAction,
+    };
+
+    fn attention_convoy(name: &str, needs_attention: bool) -> ConvoySummary {
+        ConvoySummary::builder()
+            .id(ConvoyId::new("flotilla", name))
+            .namespace("flotilla".to_string())
+            .name(name.to_string())
+            .workflow_ref("implement".to_string())
+            .phase(ConvoyPhase::Active)
+            .project_ref("flotilla".to_string())
+            .vessels(Vec::new())
+            .initializing(false)
+            .needs_attention(needs_attention)
+            .build()
+    }
+
+    #[test]
+    fn fleet_attention_indicator_counts_attention_convoys() {
+        let mut namespace = NamespaceModel::default();
+        for convoy in [attention_convoy("one", true), attention_convoy("two", false), attention_convoy("three", true)] {
+            namespace.convoys.insert(convoy.id.clone(), convoy);
+        }
+        let namespaces = NamespaceMap::from([("flotilla".to_string(), namespace)]);
+
+        let indicators = normal_mode_indicators(&UiState::new(&[]), &namespaces);
+
+        assert!(indicators.iter().any(|indicator| indicator.icon == "⚠" && indicator.label == "2 need attention"));
+    }
 
     #[test]
     fn handle_click_returns_none_for_miss() {

--- a/docs/adr/0017-convoy-completion-claims-conditions-attention.md
+++ b/docs/adr/0017-convoy-completion-claims-conditions-attention.md
@@ -69,6 +69,14 @@ Attention **never transitions a phase** — idle is not done; the
 (needs-attention = `NeedsInput ∨ (Idle ∧ work unsettled)`), not
 auto-resolved. That inference is what this ADR forbids.
 
+Implementation note (issue #811): Claude Code lifecycle hooks provide the
+v1 hook source, including `permission_prompt` as `NeedsInput`. Codex's
+trust-gated hook event vocabulary is not yet stable enough for a
+Flotilla-side parser, so Codex sessions deliberately use Cleat screen
+stability as their v1 fallback (`Working` / `Idle`). This keeps them visible
+and truthfully observable without claiming that a stable screen is a prompt;
+a Codex parser can take precedence once its hook contract is documented.
+
 ## Phase vocabulary
 
 - **`Abandoned`** joins `WorkPhase` and `ConvoyPhase`: a chosen terminal —

--- a/src/main.rs
+++ b/src/main.rs
@@ -1050,14 +1050,20 @@ async fn run_hook(cli: &Cli, harness: &str, event_type: &str) -> Result<()> {
     };
 
     // 5. Build the event
-    let event = AgentHookEvent {
-        attachable_id,
-        harness: harness_enum,
-        event_type: parsed.event_type,
-        session_id: parsed.session_id,
-        model: parsed.model,
-        cwd: parsed.cwd,
-    };
+    let terminal = std::env::var("FLOTILLA_NAMESPACE")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .zip(std::env::var("FLOTILLA_TERMINAL_SESSION").ok().filter(|value| !value.is_empty()))
+        .map(|(namespace, session_name)| flotilla_protocol::AgentHookTerminalRef { namespace, session_name });
+    let event = AgentHookEvent::builder()
+        .attachable_id(attachable_id)
+        .harness(harness_enum)
+        .event_type(parsed.event_type)
+        .maybe_session_id(parsed.session_id)
+        .maybe_model(parsed.model)
+        .maybe_cwd(parsed.cwd)
+        .maybe_terminal(terminal)
+        .build();
 
     // 6. Send to daemon via socket. The daemon owns agent state as a single
     // actor — no file-level races between concurrent hook processes.


### PR DESCRIPTION
## Summary

- add debounced, source-aware attention observations to terminal session status with hook precedence and stale decay
- consume Claude permission prompts and Cleat screen activity, and tag provisioned Cleat sessions by convoy and vessel
- derive namespace-scoped convoy attention badges and a fleet-level attention count without changing lifecycle phases

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- final standards review: PASS
- final spec review: PASS

Closes #811