### PR TITLE
fix: scope handoff brief repositories

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4536,13 +4536,13 @@ impl InProcessDaemon {
             .enumerate()
             .find(|(_, process)| process.role == target && target != context.caller_role)
             .ok_or_else(|| crew_handoff_address_error(target, &context.vessel))?;
+        let CrewSource::Agent { selector, prompt } = &process.source else {
+            return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
+        };
         let repository_refs = task
             .repository_refs
             .clone()
             .unwrap_or_else(|| convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect());
-        let CrewSource::Agent { selector, prompt } = &process.source else {
-            return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
-        };
         if convoy
             .status
             .as_ref()

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1034,6 +1034,7 @@ fn handoff_crew_brief(
     target: &str,
     prompt: Option<&str>,
     members: &[CrewListMember],
+    repository_refs: &[RepositoryKey],
 ) -> TerminalBrief {
     let assignment = match prompt {
         Some(prompt) => crate::agent_adapter::CrewAssignment::Prompt(prompt),
@@ -1058,8 +1059,7 @@ fn handoff_crew_brief(
             })
             .collect::<Vec<_>>(),
     );
-    let repository_refs = convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<Vec<_>>();
-    crate::agent_adapter::append_convoy_work_context(&mut brief.content, convoy, &repository_refs);
+    crate::agent_adapter::append_convoy_work_context(&mut brief.content, convoy, repository_refs);
     brief
 }
 
@@ -4536,6 +4536,10 @@ impl InProcessDaemon {
             .enumerate()
             .find(|(_, process)| process.role == target && target != context.caller_role)
             .ok_or_else(|| crew_handoff_address_error(target, &context.vessel))?;
+        let repository_refs = task
+            .repository_refs
+            .clone()
+            .unwrap_or_else(|| convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect());
         let CrewSource::Agent { selector, prompt } = &process.source else {
             return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
         };
@@ -4592,7 +4596,7 @@ impl InProcessDaemon {
                         .ok_or_else(|| format!("vessel `{}` has no active session to anchor the handoff", context.vessel_ref))?
                 };
                 let current = self.crew_list_internal(requested).await?;
-                let brief = handoff_crew_brief(&context, &convoy, target, prompt.as_deref(), &current.members);
+                let brief = handoff_crew_brief(&context, &convoy, target, prompt.as_deref(), &current.members, &repository_refs);
                 sessions
                     .create(&identity.input_meta(), &flotilla_resources::TerminalSessionSpec {
                         env_ref: anchor.spec.env_ref,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -16,8 +16,8 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, CrewWorkPhase,
-    CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost,
+    CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec,
+    CrewWorkPhase, CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta,
     LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
     ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, RepositoryStatus, Selector, Stance, TerminalBrief, TerminalCrewContext,
@@ -724,6 +724,70 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
         .expect("run coder session");
 }
 
+async fn handoff_brief_for_demo_repository_scope(repository_refs: Option<Vec<RepositoryKey>>) -> String {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, _) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+
+    let flotilla_repo = RepositoryKey("repo-flotilla".into());
+    let cleat_repo = RepositoryKey("repo-cleat".into());
+    let convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    let convoy = convoys.get("demo").await.expect("convoy");
+    let mut spec = convoy.spec.clone();
+    spec.repositories = vec![
+        ConvoyRepositorySpec::builder()
+            .url("https://github.com/flotilla-org/flotilla".to_string())
+            .repo_ref(flotilla_repo.clone())
+            .base_ref("main".to_string())
+            .workspace_slug("flotilla".to_string())
+            .subpaths(Vec::new())
+            .build(),
+        ConvoyRepositorySpec::builder()
+            .url("https://github.com/flotilla-org/cleat".to_string())
+            .repo_ref(cleat_repo)
+            .base_ref("main".to_string())
+            .workspace_slug("cleat".to_string())
+            .subpaths(Vec::new())
+            .build(),
+    ];
+    let convoy = convoys
+        .update(&input_meta_from_resource(&convoy), &convoy.metadata.resource_version, &spec)
+        .await
+        .expect("convoy spec should update");
+    let mut status = convoy.status.expect("convoy status");
+    status
+        .workflow_snapshot
+        .as_mut()
+        .expect("workflow snapshot")
+        .vessels
+        .iter_mut()
+        .find(|vessel| vessel.name == "implement")
+        .expect("implement vessel")
+        .repository_refs = repository_refs;
+    convoys.update_status("demo", &convoy.metadata.resource_version, &status).await.expect("convoy status should update");
+
+    daemon
+        .crew_handoff_internal(
+            &CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
+            "reviewer",
+            "Review the repo scope",
+        )
+        .await
+        .expect("handoff should create reviewer session");
+    let reviewer = daemon
+        .resource_backend()
+        .using::<ResourceTerminalSession>("flotilla")
+        .get("terminal-demo-implement-reviewer")
+        .await
+        .expect("reviewer session should be defined");
+    let TerminalSessionSource::Agent { brief, .. } = reviewer.spec.source else {
+        panic!("reviewer should be agent-backed");
+    };
+    brief.content
+}
+
 #[tokio::test]
 async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
     let temp = tempfile::tempdir().expect("tempdir");
@@ -865,6 +929,22 @@ async fn handoff_rejects_self_and_unknown_targets_without_delivery() {
     let coder = terminals.get("terminal-demo-implement-coder").await.expect("coder session");
     assert!(matches!(coder.spec.source, TerminalSessionSource::Agent { message: None, .. }));
     assert!(terminals.get("terminal-demo-implement-architect").await.is_err(), "misaddressed handoff must not create a target session");
+}
+
+#[tokio::test]
+async fn handoff_brief_uses_vessel_repository_scope() {
+    let brief = handoff_brief_for_demo_repository_scope(Some(vec![RepositoryKey("repo-flotilla".into())])).await;
+
+    assert!(brief.contains("  - `repo-flotilla` — https://github.com/flotilla-org/flotilla\n"));
+    assert!(!brief.contains("  - `repo-cleat` — https://github.com/flotilla-org/cleat\n"));
+}
+
+#[tokio::test]
+async fn handoff_brief_for_unscoped_vessel_lists_all_repositories() {
+    let brief = handoff_brief_for_demo_repository_scope(None).await;
+
+    assert!(brief.contains("  - `repo-flotilla` — https://github.com/flotilla-org/flotilla\n"));
+    assert!(brief.contains("  - `repo-cleat` — https://github.com/flotilla-org/cleat\n"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- Threaded the workflow vessel repository scope into handoff brief generation.
- Kept the existing fallback-to-all behavior when a vessel has no explicit repository scope.
- Added handoff-path behavior coverage for scoped and unscoped multi-repo convoy briefs.

## Why

Initial dispatch already scopes repository work context to `requirement.repository_refs`, but handoff briefs rebuilt that section from every snapshotted convoy repository. That made briefs for the same repo-scoped vessel disagree after a handoff.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`

Closes #869