### PR TITLE
feat: record convoy dispatch principal

### DIFF
--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -78,6 +78,7 @@ pub async fn create_convoy_with_single_task(
     let convoy = convoys
         .create(&meta(name), &ConvoySpec {
             workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: Default::default(),
             placement_policy: None,
             repositories: vec![ConvoyRepositorySpec {

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -37,6 +37,7 @@ async fn repositoryless_vessel_runs_tools_without_provisioning_a_checkout() {
         .using::<Convoy>(NAMESPACE)
         .create(&meta("convoy-scratch"), &ConvoySpec {
             workflow_ref: "scratch".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: None,
             repositories: Vec::new(),
@@ -297,6 +298,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         .using::<Convoy>(NAMESPACE)
         .create(&meta("convoy-multi"), &ConvoySpec {
             workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: None,
             repositories: vec![
@@ -498,6 +500,7 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
         .using::<Convoy>(NAMESPACE)
         .create(&meta("convoy-multi-docker"), &ConvoySpec {
             workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: None,
             repositories: vec![
@@ -649,6 +652,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
         .using::<Convoy>(NAMESPACE)
         .create(&meta("convoy-multi-fresh"), &ConvoySpec {
             workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: None,
             repositories: vec![
@@ -757,6 +761,7 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
         .using::<Convoy>(NAMESPACE)
         .create(&meta("convoy-scoped"), &ConvoySpec {
             workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: None,
             repositories: vec![
@@ -1318,6 +1323,7 @@ async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
         .using::<Convoy>(NAMESPACE)
         .create(&meta("convoy-issue-brief"), &ConvoySpec {
             workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: None,
             repositories: vec![ConvoyRepositorySpec {
@@ -1735,6 +1741,7 @@ async fn create_convoy_with_labeled_processes(
     let convoy = convoys
         .create(&meta(name), &ConvoySpec {
             workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: Default::default(),
             placement_policy: None,
             repositories: vec![ConvoyRepositorySpec {

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -402,6 +402,7 @@ mod tests {
             },
             spec: ConvoySpec {
                 workflow_ref: "workflow".to_string(),
+                dispatching_principal_ref: Default::default(),
                 inputs: BTreeMap::new(),
                 placement_policy: None,
                 repositories: vec![ConvoyRepositorySpec {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,9 +22,9 @@ use flotilla_protocol::{
     result_set::{ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
     AttachBinding, Command, CommandValue, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry,
     EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
-    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, ProjectListEntry,
-    ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity,
-    RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, ResourceJsonResponse,
+    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PrincipalRef,
+    ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse,
+    RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, ResourceJsonResponse,
     ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
     AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
@@ -3224,6 +3224,7 @@ impl InProcessDaemon {
         let placement_policy = placement.as_ref().map(|placement| placement.metadata.name.clone());
         let spec = ConvoySpec {
             workflow_ref,
+            dispatching_principal_ref: PrincipalRef::implicit_for_namespace(namespace),
             inputs: intent.inputs.iter().map(|(key, value)| (key.clone(), InputValue::String(value.clone()))).collect(),
             placement_policy,
             repositories,
@@ -5648,6 +5649,7 @@ impl InProcessDaemon {
             }
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),
+                dispatching_principal_ref: PrincipalRef::implicit_for_namespace(&namespace),
                 inputs: inputs.iter().map(|(k, v)| (k.clone(), InputValue::String(v.clone()))).collect(),
                 placement_policy,
                 repositories,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -587,6 +587,7 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
     let convoy = convoys
         .create(&empty_input_meta("demo"), &ConvoySpec {
             workflow_ref: "coding-review".into(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: None,
             repositories: Vec::new(),
@@ -2771,6 +2772,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
     let created = convoys
         .create(&empty_input_meta("convoy-a"), &ConvoySpec {
             workflow_ref: "review-and-fix".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: Some("laptop-docker".to_string()),
             repositories: Vec::new(),
@@ -3228,6 +3230,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
     let created = convoys
         .create(&empty_input_meta("convoy-a"), &ConvoySpec {
             workflow_ref: "review-and-fix".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: BTreeMap::new(),
             placement_policy: Some("laptop-docker".to_string()),
             repositories: Vec::new(),

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1047,6 +1047,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     let persisted = backend.using::<ResourceConvoy>("flotilla").get("issue-732").await.expect("persisted convoy");
     assert_eq!(persisted.spec.project_ref.as_deref(), Some("flotilla"));
     assert_eq!(persisted.spec.workflow_ref, "single-agent-contained");
+    assert_eq!(persisted.spec.dispatching_principal_ref, flotilla_protocol::PrincipalRef::implicit_for_namespace("flotilla"));
     assert_eq!(persisted.spec.r#ref.as_deref(), Some("fix/issue-732"));
     assert_eq!(persisted.spec.placement_policy.as_deref(), Some("docker-test"));
     assert_eq!(persisted.spec.repositories.len(), 1);

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1145,6 +1145,7 @@ impl Aggregator {
             .resource(resource)
             .name(name)
             .workflow_ref(&convoy.spec.workflow_ref)
+            .dispatching_principal_ref(convoy.spec.dispatching_principal_ref.clone())
             .phase(convoy_phase(phase))
             .initializing(convoy_is_initializing(status))
             .maybe_message(status.and_then(|status| status.message.clone()))
@@ -1314,7 +1315,10 @@ mod tests {
     };
 
     use chrono::Utc;
-    use flotilla_protocol::result_set::{ResultSet, ResultSetState};
+    use flotilla_protocol::{
+        result_set::{ResultSet, ResultSetState},
+        PrincipalRef,
+    };
     use flotilla_resources::{
         ConvoyRepositorySpec, ConvoySpec, CrewSpec, InMemoryBackend, InputMeta, ObjectMeta, PlacementStatus, PresentationPhase,
         PresentationSpec, PresentationStatus, ResourceBackend, Stance, TerminalAttention, TerminalAttentionSource, TerminalSessionSource,
@@ -1359,6 +1363,22 @@ mod tests {
         let convoy = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
         assert!(convoy.vessels.first().expect("vessel row").needs_attention);
         assert!(convoy.needs_attention);
+    }
+
+    #[tokio::test]
+    async fn convoy_projection_carries_dispatching_principal_ref() {
+        let principal = PrincipalRef::implicit_for_namespace("people");
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(4);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+        let mut convoy = convoy_with_vessel("convoy-a").await;
+        convoy.spec.dispatching_principal_ref = principal.clone();
+
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy)).await;
+
+        let result_set = state.result_set().await;
+        let row = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
+        assert_eq!(row.dispatching_principal_ref, principal);
     }
 
     struct ScriptedSource<T: Resource> {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2099,6 +2099,7 @@ mod tests {
             .using::<Convoy>(NAMESPACE)
             .create(&empty_meta("convoy-a"), &ConvoySpec {
                 workflow_ref: "wf-a".to_string(),
+                dispatching_principal_ref: Default::default(),
                 inputs: BTreeMap::new(),
                 placement_policy: Some(format!("host-direct-{host_id}")),
                 repositories: vec![ConvoyRepositorySpec {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -301,6 +301,7 @@ async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
         .using::<Convoy>("flotilla")
         .create(&InputMeta::builder().name("persisted".to_string()).build(), &ConvoySpec {
             workflow_ref: "scratch".to_string(),
+            dispatching_principal_ref: Default::default(),
             inputs: Default::default(),
             placement_policy: None,
             repositories: Vec::new(),

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -51,6 +51,7 @@ fn convoy_meta(name: &str) -> InputMeta {
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
     ConvoySpec {
         workflow_ref: workflow_ref.to_string(),
+        dispatching_principal_ref: Default::default(),
         inputs: BTreeMap::new(),
         placement_policy: None,
         repositories: Vec::new(),

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -7,7 +7,7 @@ use flotilla_core::{
     config::ConfigStore, daemon::DaemonHandle, in_process::InProcessDaemon, providers::discovery::test_support::fake_discovery,
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
-use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName};
+use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName, PrincipalRef};
 use flotilla_resources::{Convoy, ConvoyPhase, CrewSource, InMemoryBackend, ResourceBackend, SqliteBackend, Stance, WorkflowTemplate};
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -127,6 +127,7 @@ async fn convoy_create_command_creates_convoy_resource() {
     let convoys = backend.using::<Convoy>("flotilla");
     let convoy = convoys.get("my-scratch").await.expect("convoy should exist");
     assert_eq!(convoy.spec.workflow_ref, "scratch");
+    assert_eq!(convoy.spec.dispatching_principal_ref, PrincipalRef::implicit_for_namespace("flotilla"));
     assert_eq!(convoy.spec.inputs.len(), 1);
     assert!(convoy.spec.repositories.is_empty());
     assert!(

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -65,6 +65,27 @@ impl fmt::Display for NodeId {
     }
 }
 
+/// Stable reference to the human principal whose attention Flotilla may route.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PrincipalRef {
+    pub namespace: String,
+    pub name: String,
+}
+
+impl PrincipalRef {
+    pub const IMPLICIT_NAME: &'static str = "implicit";
+
+    pub fn implicit_for_namespace(namespace: impl Into<String>) -> Self {
+        Self { namespace: namespace.into(), name: Self::IMPLICIT_NAME.to_string() }
+    }
+}
+
+impl Default for PrincipalRef {
+    fn default() -> Self {
+        Self::implicit_for_namespace("flotilla")
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod test_helpers {
     use serde::{de::DeserializeOwned, Serialize};

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -18,7 +18,7 @@ use crate::{
     provider_data::{ChangeRequestStatus, Issue},
     resource_ref::ResourceRef,
     snapshot::RepoKey,
-    IssueRef, IssueSource, IssueState, LifecycleAuthority, RepositoryKey,
+    IssueRef, IssueSource, IssueState, LifecycleAuthority, PrincipalRef, RepositoryKey,
 };
 
 pub type Timestamp = DateTime<Utc>;
@@ -484,6 +484,10 @@ pub struct ConvoyRow {
     pub resource: ResourceRef,
     pub name: String,
     pub workflow_ref: String,
+    /// Human principal that dispatched the convoy.
+    #[builder(default)]
+    #[serde(default)]
+    pub dispatching_principal_ref: PrincipalRef,
     pub phase: ConvoyPhase,
     /// The convoy has no workflow snapshot yet and is not terminal.
     #[builder(default)]

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -41,6 +41,7 @@ fn updated_workflow_spec() -> WorkflowTemplateSpec {
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
     ConvoySpec {
         workflow_ref: workflow_ref.to_string(),
+        dispatching_principal_ref: Default::default(),
         inputs: [
             ("feature".to_string(), InputValue::String("Retry logic for the poller".to_string())),
             ("branch".to_string(), InputValue::String("fix-bug-123".to_string())),

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
-use flotilla_protocol::{IssueRef, IssueState};
+use flotilla_protocol::{IssueRef, IssueState, PrincipalRef};
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement, RepositoryKey};
@@ -15,6 +15,9 @@ define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoySpec {
     pub workflow_ref: String,
+    #[builder(default)]
+    #[serde(default)]
+    pub dispatching_principal_ref: PrincipalRef,
     #[builder(default)]
     #[serde(default)]
     pub inputs: BTreeMap<String, InputValue>,

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -194,6 +194,7 @@ pub fn object_meta(name: &str, namespace: &str, resource_version: &str) -> Objec
 pub fn valid_convoy_spec() -> RealConvoySpec {
     RealConvoySpec {
         workflow_ref: "review-and-fix".to_string(),
+        dispatching_principal_ref: Default::default(),
         inputs: [
             ("feature".to_string(), flotilla_resources::InputValue::String("Retry logic".to_string())),
             ("branch".to_string(), flotilla_resources::InputValue::String("fix-retry-logic".to_string())),

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -28,6 +28,7 @@ fn workflow_template_spec() -> WorkflowTemplateSpec {
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
     ConvoySpec {
         workflow_ref: workflow_ref.to_string(),
+        dispatching_principal_ref: Default::default(),
         inputs: [
             ("feature".to_string(), InputValue::String("Retry logic".to_string())),
             ("branch".to_string(), InputValue::String("fix-retry".to_string())),

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1726,6 +1726,7 @@ fn test_convoy(
         name: name.into(),
         origin_host: None,
         workflow_ref: "wf".into(),
+        dispatching_principal_ref: Default::default(),
         phase,
         message: None,
         repo_hint: None,

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -4,7 +4,7 @@
 //! ([`flotilla_protocol::result_set`]). This adapter model is intentionally
 //! surface-owned and may evolve with consumer-side view requirements.
 
-use flotilla_protocol::{result_set as wire, CheckoutRef, HostName, RepoKey, ResourceRef};
+use flotilla_protocol::{result_set as wire, CheckoutRef, HostName, PrincipalRef, RepoKey, ResourceRef};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConvoyId(String);
@@ -150,6 +150,8 @@ pub struct ConvoySummary {
     pub name: String,
     pub origin_host: Option<HostName>,
     pub workflow_ref: String,
+    #[builder(default)]
+    pub dispatching_principal_ref: PrincipalRef,
     pub phase: ConvoyPhase,
     pub message: Option<String>,
     pub repo_hint: Option<RepoKey>,
@@ -175,6 +177,7 @@ impl From<&wire::ConvoyRow> for ConvoySummary {
             name: row.name.clone(),
             origin_host: row.resource.host.clone(),
             workflow_ref: row.workflow_ref.clone(),
+            dispatching_principal_ref: row.dispatching_principal_ref.clone(),
             phase: row.phase.into(),
             message: row.message.clone(),
             repo_hint: row.repo.clone(),

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -811,6 +811,7 @@ mod tests {
             name: name.into(),
             origin_host: None,
             workflow_ref: "wf".into(),
+            dispatching_principal_ref: Default::default(),
             phase: ConvoyPhase::Active,
             message: None,
             repo_hint: None,

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -946,6 +946,10 @@ fn convoy_description(row: &ConvoySummary) -> Vec<DetailField> {
         DetailField { label: "Namespace", value: row.namespace.clone() },
         DetailField { label: "Convoy", value: row.name.clone() },
         DetailField { label: "Workflow", value: row.workflow_ref.clone() },
+        DetailField {
+            label: "Dispatcher",
+            value: format!("{}/{}", row.dispatching_principal_ref.namespace, row.dispatching_principal_ref.name),
+        },
         DetailField { label: "Phase", value: convoy_phase(row).text },
         DetailField { label: "Message", value: row.message.clone().unwrap_or_default() },
         DetailField { label: "Vessels", value: convoy_progress(row).text },
@@ -1135,6 +1139,7 @@ mod tests {
             name: "tables".into(),
             origin_host: None,
             workflow_ref: "implement-review".into(),
+            dispatching_principal_ref: Default::default(),
             phase: ConvoyPhase::Active,
             message: None,
             repo_hint: None,
@@ -1215,6 +1220,7 @@ mod tests {
 
         let pr_index = view.columns.iter().position(|column| column.id == "pr").expect("PR column");
         assert_eq!(view.rows[0].cells[pr_index], CellValue::toned("#815 open", CellTone::Success));
+        assert!(view.rows[0].describe.contains(&DetailField { label: "Dispatcher", value: "flotilla/implicit".into() }));
         assert!(view.rows[0].describe.contains(&DetailField { label: "Pull request", value: "#815 · open".into() }));
         assert_eq!(
             view.rows[0].actions.iter().find(|action| action.id == "open_pr"),

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -41,6 +41,7 @@ fn convoy_meta(name: &str) -> InputMeta {
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
     ConvoySpec {
         workflow_ref: workflow_ref.to_string(),
+        dispatching_principal_ref: Default::default(),
         inputs: BTreeMap::new(),
         placement_policy: None,
         repositories: Vec::new(),


### PR DESCRIPTION
Closes #861

## Summary
- add a protocol-level `PrincipalRef` and persist `dispatching_principal_ref` on `ConvoySpec`
- stamp the implicit v1 principal during both project-scoped convoy admission and direct convoy create
- project the dispatching principal into convoy rows and TUI convoy detail fields

## Verification
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- focused: `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snapshot`