### PR TITLE
feat: add PrincipalAttention resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,7 @@ dependencies = [
  "libc",
  "ratatui",
  "serde_json",
+ "serde_yml",
  "tokio",
  "tracing",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,6 @@ color-eyre = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 tracing = { workspace = true }
 serde_json = { workspace = true }
+serde_yml = "0.0.12"
 libc = "0.2"
 uuid = { version = "1", features = ["v4"] }

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -167,7 +167,10 @@ pub async fn build_plan(
     let issue_source = forge_issue_source(&repo.identity);
 
     match action {
-        CommandAction::QueryResourceList { .. } | CommandAction::QueryResourceGet { .. } | CommandAction::ResourceWatch { .. } => {
+        CommandAction::QueryResourceList { .. }
+        | CommandAction::QueryResourceGet { .. }
+        | CommandAction::ResourceApply { .. }
+        | CommandAction::ResourceWatch { .. } => {
             Err(CommandValue::Error { message: "resource commands should be handled by the daemon resource dispatcher".to_string() })
         }
         CommandAction::Checkout { target, issue_ids, .. } => {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -29,10 +29,10 @@ use flotilla_protocol::{
     AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    apply_status_patch as apply_resource_status_patch, apply_status_patch_checked as apply_resource_status_patch_checked,
-    external_patches as convoy_external_patches, get_resource_kind, list_resource_kind, normalize_project_spec,
-    resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, Checkout as ResourceCheckout,
-    CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    apply_resource_document, apply_status_patch as apply_resource_status_patch,
+    apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
+    list_resource_kind, normalize_project_spec, resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind,
+    Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec,
     ConvoyStatusPatch, CrewSource, Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
@@ -5200,6 +5200,21 @@ impl InProcessDaemon {
                 repo: None,
                 result,
             });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ResourceApply { namespace, document } = &command.action {
+            let empty_identity = self.start_context_free_command(id, command.description().to_string());
+            let result = match apply_resource_document(&self.resource_backend, namespace, document.clone()).await {
+                Ok(applied) => flotilla_protocol::CommandValue::ResourceObject(Box::new(ResourceJsonResponse {
+                    kind: applied.kind,
+                    plural: applied.plural,
+                    namespace: applied.namespace,
+                    value: applied.value,
+                })),
+                Err(error) => flotilla_protocol::CommandValue::Error { message: error.to_string() },
+            };
+            self.finish_context_free_command(id, empty_identity, result);
             return Ok(id);
         }
 

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -377,6 +377,10 @@ pub enum CommandAction {
         kind: String,
         name: String,
     },
+    ResourceApply {
+        namespace: String,
+        document: serde_json::Value,
+    },
     ResourceWatch {
         namespace: String,
         kind: String,
@@ -461,6 +465,7 @@ impl Command {
             CommandAction::QueryFleetReplicaSnapshot {} => "query fleet replica snapshot",
             CommandAction::QueryResourceList { .. } => "query resource list",
             CommandAction::QueryResourceGet { .. } => "query resource get",
+            CommandAction::ResourceApply { .. } => "apply resource",
             CommandAction::ResourceWatch { .. } => "watch resources",
         }
     }

--- a/crates/flotilla-resources/src/crds/demand.crd.yaml
+++ b/crates/flotilla-resources/src/crds/demand.crd.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: demands.flotilla.work
+spec:
+  group: flotilla.work
+  scope: Namespaced
+  names:
+    plural: demands
+    singular: demand
+    kind: Demand
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Kind
+          type: string
+          jsonPath: .spec.kind
+        - name: State
+          type: string
+          jsonPath: .status.state
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/crates/flotilla-resources/src/crds/regard.crd.yaml
+++ b/crates/flotilla-resources/src/crds/regard.crd.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: regards.flotilla.work
+spec:
+  group: flotilla.work
+  scope: Namespaced
+  names:
+    plural: regards
+    singular: regard
+    kind: Regard
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Principal
+          type: string
+          jsonPath: .spec.principal_ref
+        - name: Target
+          type: string
+          jsonPath: .spec.target.name
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -11,6 +11,7 @@ mod in_memory;
 mod labels;
 mod placement_policy;
 mod presentation;
+mod principal_attention;
 mod project;
 mod provisioning_identity;
 mod registry;
@@ -52,14 +53,18 @@ pub use placement_policy::{
     PlacementPolicy, PlacementPolicySpec,
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
+pub use principal_attention::{
+    Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, DemandState, DemandStatus, DemandStatusPatch, DemandTransition,
+    PrincipalRef, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RegardStatus, RegardStatusPatch,
+};
 pub use project::{
     normalize_project_spec, resolve_project_issue_sources, IssueSource, IssueSourceResolution, IssueSourceUnavailable, Project,
     ProjectRepositorySpec, ProjectSpec,
 };
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
-    get_resource_kind, list_resource_kind, resource_list_api_version, watch_resource_kind, DynamicResourceList, DynamicResourceObject,
-    DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
+    apply_resource_document, get_resource_kind, list_resource_kind, resource_list_api_version, watch_resource_kind, DynamicResourceList,
+    DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
 };
 pub use repository::{
     ensure_repository, resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity, Repository,

--- a/crates/flotilla-resources/src/principal_attention.rs
+++ b/crates/flotilla-resources/src/principal_attention.rs
@@ -1,0 +1,155 @@
+use chrono::{DateTime, Utc};
+use flotilla_protocol::ResourceRef;
+use serde::{Deserialize, Serialize};
+
+use crate::{resource::define_resource, status_patch::StatusPatch};
+
+define_resource!(Regard, "regards", RegardSpec, RegardStatus, RegardStatusPatch);
+define_resource!(Demand, "demands", DemandSpec, DemandStatus, DemandStatusPatch);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PrincipalRef(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DemandPoolRef(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct RegardSpec {
+    pub principal_ref: PrincipalRef,
+    pub target: ResourceRef,
+    pub source: RegardSource,
+    pub expiry: RegardExpiryPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RegardSource {
+    Expressed,
+    Implicit { policy: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RegardExpiryPolicy {
+    Decaying { expires_after_seconds: u64 },
+    Pin,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegardStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refreshed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegardStatusPatch {
+    Refresh { as_of: DateTime<Utc> },
+}
+
+impl StatusPatch<RegardStatus> for RegardStatusPatch {
+    fn apply(&self, status: &mut RegardStatus) {
+        match self {
+            Self::Refresh { as_of } => {
+                status.created_at.get_or_insert(*as_of);
+                if status.refreshed_at.is_none_or(|current| *as_of > current) {
+                    status.refreshed_at = Some(*as_of);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct DemandSpec {
+    pub originating_work_ref: ResourceRef,
+    pub kind: DemandKind,
+    pub addressee: DemandAddressee,
+}
+
+impl DemandSpec {
+    pub fn for_dispatching_principal(originating_work_ref: ResourceRef, kind: DemandKind, dispatching_principal_ref: PrincipalRef) -> Self {
+        Self { originating_work_ref, kind, addressee: DemandAddressee::Principal { principal_ref: dispatching_principal_ref } }
+    }
+
+    pub fn for_pool(originating_work_ref: ResourceRef, kind: DemandKind, pool_ref: DemandPoolRef) -> Self {
+        Self { originating_work_ref, kind, addressee: DemandAddressee::Pool { pool_ref } }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DemandKind {
+    Permission,
+    HumanGate,
+    Review,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DemandAddressee {
+    Principal { principal_ref: PrincipalRef },
+    Pool { pool_ref: DemandPoolRef },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct DemandStatus {
+    #[serde(default)]
+    pub state: DemandState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raised: Option<DemandTransition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub satisfied: Option<DemandTransition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acknowledged: Option<DemandTransition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct DemandTransition {
+    pub as_of: DateTime<Utc>,
+    pub authority: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DemandState {
+    #[default]
+    Raised,
+    Satisfied,
+    Acknowledged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DemandStatusPatch {
+    Raise { as_of: DateTime<Utc>, authority: String },
+    Satisfy { as_of: DateTime<Utc>, authority: String },
+    Acknowledge { as_of: DateTime<Utc>, authority: String },
+}
+
+impl StatusPatch<DemandStatus> for DemandStatusPatch {
+    fn apply(&self, status: &mut DemandStatus) {
+        match self {
+            Self::Raise { as_of, authority } => {
+                if status.raised.is_none() && status.satisfied.is_none() && status.acknowledged.is_none() {
+                    status.state = DemandState::Raised;
+                    status.raised = Some(DemandTransition { as_of: *as_of, authority: authority.clone() });
+                }
+            }
+            Self::Satisfy { as_of, authority } => {
+                if status.state != DemandState::Acknowledged {
+                    status.state = DemandState::Satisfied;
+                    status.raised.get_or_insert_with(|| DemandTransition { as_of: *as_of, authority: authority.clone() });
+                    status.satisfied.get_or_insert_with(|| DemandTransition { as_of: *as_of, authority: authority.clone() });
+                }
+            }
+            Self::Acknowledge { as_of, authority } => {
+                status.state = DemandState::Acknowledged;
+                status.raised.get_or_insert_with(|| DemandTransition { as_of: *as_of, authority: authority.clone() });
+                status.acknowledged.get_or_insert_with(|| DemandTransition { as_of: *as_of, authority: authority.clone() });
+            }
+        }
+    }
+}

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -1,10 +1,13 @@
+use std::collections::BTreeMap;
+
 use futures::{stream::BoxStream, StreamExt};
+use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::{
-    api_version, Checkout, Clone as CloneResource, Convoy, Environment, Host, K8sListMeta, K8sResourceList, PlacementPolicy, Presentation,
-    Project, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, TerminalSession, Vessel, WatchEvent,
-    WatchStart, WorkflowTemplate,
+    api_version, Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, K8sListMeta, K8sResourceList,
+    OwnerReference, PlacementPolicy, Presentation, Project, Regard, Repository, Resource, ResourceBackend, ResourceError, ResourceList,
+    ResourceObject, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20,11 +23,13 @@ enum RegisteredResource {
     Checkout,
     Clone,
     Convoy,
+    Demand,
     Environment,
     Host,
     PlacementPolicy,
     Presentation,
     Project,
+    Regard,
     Repository,
     TerminalSession,
     Vessel,
@@ -59,6 +64,7 @@ pub const REGISTERED_RESOURCE_KINDS: &[RegisteredResourceKind] = &[
     kind::<Checkout>(RegisteredResource::Checkout, &[]),
     kind::<CloneResource>(RegisteredResource::Clone, &[]),
     kind::<Convoy>(RegisteredResource::Convoy, &[]),
+    kind::<Demand>(RegisteredResource::Demand, &[]),
     kind::<Environment>(RegisteredResource::Environment, &[]),
     kind::<Host>(RegisteredResource::Host, &[]),
     kind::<PlacementPolicy>(RegisteredResource::PlacementPolicy, &[
@@ -70,6 +76,7 @@ pub const REGISTERED_RESOURCE_KINDS: &[RegisteredResourceKind] = &[
     ]),
     kind::<Presentation>(RegisteredResource::Presentation, &[]),
     kind::<Project>(RegisteredResource::Project, &[]),
+    kind::<Regard>(RegisteredResource::Regard, &[]),
     kind::<Repository>(RegisteredResource::Repository, &[]),
     kind::<TerminalSession>(RegisteredResource::TerminalSession, &[
         "terminalsession",
@@ -98,11 +105,13 @@ macro_rules! dispatch_resource_kind {
             RegisteredResource::Checkout => $body::<Checkout>($($arg),*).await,
             RegisteredResource::Clone => $body::<CloneResource>($($arg),*).await,
             RegisteredResource::Convoy => $body::<Convoy>($($arg),*).await,
+            RegisteredResource::Demand => $body::<Demand>($($arg),*).await,
             RegisteredResource::Environment => $body::<Environment>($($arg),*).await,
             RegisteredResource::Host => $body::<Host>($($arg),*).await,
             RegisteredResource::PlacementPolicy => $body::<PlacementPolicy>($($arg),*).await,
             RegisteredResource::Presentation => $body::<Presentation>($($arg),*).await,
             RegisteredResource::Project => $body::<Project>($($arg),*).await,
+            RegisteredResource::Regard => $body::<Regard>($($arg),*).await,
             RegisteredResource::Repository => $body::<Repository>($($arg),*).await,
             RegisteredResource::TerminalSession => $body::<TerminalSession>($($arg),*).await,
             RegisteredResource::Vessel => $body::<Vessel>($($arg),*).await,
@@ -114,11 +123,13 @@ macro_rules! dispatch_resource_kind {
             RegisteredResource::Checkout => $body::<Checkout>(),
             RegisteredResource::Clone => $body::<CloneResource>(),
             RegisteredResource::Convoy => $body::<Convoy>(),
+            RegisteredResource::Demand => $body::<Demand>(),
             RegisteredResource::Environment => $body::<Environment>(),
             RegisteredResource::Host => $body::<Host>(),
             RegisteredResource::PlacementPolicy => $body::<PlacementPolicy>(),
             RegisteredResource::Presentation => $body::<Presentation>(),
             RegisteredResource::Project => $body::<Project>(),
+            RegisteredResource::Regard => $body::<Regard>(),
             RegisteredResource::Repository => $body::<Repository>(),
             RegisteredResource::TerminalSession => $body::<TerminalSession>(),
             RegisteredResource::Vessel => $body::<Vessel>(),
@@ -152,6 +163,20 @@ pub async fn watch_resource_kind(
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, watch_typed(backend, namespace).await)
 }
 
+pub async fn apply_resource_document(
+    backend: &ResourceBackend,
+    default_namespace: &str,
+    document: Value,
+) -> Result<DynamicResourceObject, ResourceError> {
+    let document: DynamicApplyDocument =
+        serde_json::from_value(document).map_err(|error| ResourceError::decode(format!("decode resource document: {error}")))?;
+    let namespace = document.metadata.namespace.clone().unwrap_or_else(|| default_namespace.to_string());
+    dispatch_resource_kind!(
+        lookup_resource_kind(&document.kind)?.resource,
+        apply_typed(backend, &namespace, document.metadata, document.spec).await
+    )
+}
+
 fn lookup_resource_kind(kind: &str) -> Result<&'static RegisteredResourceKind, ResourceError> {
     let normalized = kind.trim();
     REGISTERED_RESOURCE_KINDS
@@ -162,6 +187,40 @@ fn lookup_resource_kind(kind: &str) -> Result<&'static RegisteredResourceKind, R
                 || entry.aliases.iter().any(|alias| normalized.eq_ignore_ascii_case(alias))
         })
         .ok_or_else(|| unknown_kind(kind))
+}
+
+#[derive(Debug, Deserialize)]
+struct DynamicApplyDocument {
+    kind: String,
+    metadata: DynamicApplyMetadata,
+    spec: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct DynamicApplyMetadata {
+    name: String,
+    #[serde(default)]
+    namespace: Option<String>,
+    #[serde(default)]
+    labels: BTreeMap<String, String>,
+    #[serde(default)]
+    annotations: BTreeMap<String, String>,
+    #[serde(default, rename = "ownerReferences")]
+    owner_references: Vec<OwnerReference>,
+    #[serde(default)]
+    finalizers: Vec<String>,
+}
+
+impl DynamicApplyMetadata {
+    fn input_meta(&self) -> InputMeta {
+        InputMeta::builder()
+            .name(self.name.clone())
+            .labels(self.labels.clone())
+            .annotations(self.annotations.clone())
+            .owner_references(self.owner_references.clone())
+            .finalizers(self.finalizers.clone())
+            .build()
+    }
 }
 
 fn unknown_kind(kind: &str) -> ResourceError {
@@ -204,6 +263,29 @@ async fn watch_typed<T: Resource>(backend: &ResourceBackend, namespace: &str) ->
     })
 }
 
+async fn apply_typed<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+    metadata: DynamicApplyMetadata,
+    spec: Value,
+) -> Result<DynamicResourceObject, ResourceError> {
+    let spec = serde_json::from_value::<T::Spec>(spec)
+        .map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", T::API_PATHS.kind)))?;
+    let resolver = backend.using::<T>(namespace);
+    let meta = metadata.input_meta();
+    let object = match resolver.get(&meta.name).await {
+        Ok(existing) => resolver.update(&meta, &existing.metadata.resource_version, &spec).await?,
+        Err(ResourceError::NotFound { .. }) => resolver.create(&meta, &spec).await?,
+        Err(error) => return Err(error),
+    };
+    Ok(DynamicResourceObject {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value: object_value(&object)?,
+    })
+}
+
 fn list_value<T: Resource>(listed: &ResourceList<T>) -> Result<Value, ResourceError> {
     let list = K8sResourceList {
         metadata: K8sListMeta { resource_version: listed.resource_version.clone() },
@@ -241,8 +323,13 @@ fn api_version_typed<T: Resource>() -> String {
 
 #[cfg(test)]
 mod tests {
+    use flotilla_protocol::ResourceRef;
+
     use super::*;
-    use crate::{Convoy, ConvoySpec, InMemoryBackend, InputMeta};
+    use crate::{
+        Convoy, ConvoySpec, Demand, DemandAddressee, DemandKind, DemandSpec, InMemoryBackend, InputMeta, PrincipalRef, Regard,
+        RegardExpiryPolicy, RegardSource, RegardSpec,
+    };
 
     #[tokio::test]
     async fn list_resource_kind_returns_k8s_wire_list() {
@@ -268,5 +355,78 @@ mod tests {
         let message = error.to_string();
         assert!(message.contains("unknown resource kind 'nope'"));
         assert!(message.contains("convoys"));
+    }
+
+    #[tokio::test]
+    async fn attention_resource_kinds_are_registered_for_dynamic_listing() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        backend
+            .using::<Regard>("flotilla")
+            .create(
+                &InputMeta::builder().name("principal-default-convoy-demo".to_string()).build(),
+                &RegardSpec::builder()
+                    .principal_ref(PrincipalRef("principal/default".to_string()))
+                    .target(ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "demo"))
+                    .source(RegardSource::Expressed)
+                    .expiry(RegardExpiryPolicy::Pin)
+                    .build(),
+            )
+            .await
+            .expect("create regard");
+        backend
+            .using::<Demand>("flotilla")
+            .create(
+                &InputMeta::builder().name("demo-permission".to_string()).build(),
+                &DemandSpec::builder()
+                    .originating_work_ref(ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "demo-implement"))
+                    .kind(DemandKind::Permission)
+                    .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) })
+                    .build(),
+            )
+            .await
+            .expect("create demand");
+
+        let regards = list_resource_kind(&backend, "flotilla", "regards").await.expect("list regards dynamically");
+        let demands = list_resource_kind(&backend, "flotilla", "demands").await.expect("list demands dynamically");
+
+        assert_eq!(regards.kind, "Regard");
+        assert_eq!(regards.value["items"][0]["kind"], "Regard");
+        assert_eq!(demands.kind, "Demand");
+        assert_eq!(demands.value["items"][0]["kind"], "Demand");
+    }
+
+    #[tokio::test]
+    async fn apply_resource_document_creates_registered_resources() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let applied = apply_resource_document(
+            &backend,
+            "flotilla",
+            json!({
+                "apiVersion": "flotilla.work/v1",
+                "kind": "Demand",
+                "metadata": {
+                    "name": "demo-review"
+                },
+                "spec": {
+                    "originating_work_ref": {
+                        "api_version": "flotilla.work/v1",
+                        "kind": "Vessel",
+                        "namespace": "flotilla",
+                        "name": "demo-review"
+                    },
+                    "kind": "review",
+                    "addressee": {
+                        "kind": "principal",
+                        "principal_ref": "principal/default"
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("apply demand document");
+
+        assert_eq!(applied.kind, "Demand");
+        assert_eq!(applied.value["metadata"]["name"], "demo-review");
+        assert_eq!(backend.using::<Demand>("flotilla").get("demo-review").await.expect("stored demand").spec.kind, DemandKind::Review);
     }
 }

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -210,8 +209,6 @@ struct DynamicApplyMetadata {
     owner_references: Option<Vec<OwnerReference>>,
     #[serde(default)]
     finalizers: Option<Vec<String>>,
-    #[serde(default, rename = "deletionTimestamp")]
-    deletion_timestamp: Option<Option<DateTime<Utc>>>,
 }
 
 impl DynamicApplyMetadata {
@@ -222,7 +219,7 @@ impl DynamicApplyMetadata {
             annotations: self.annotations.clone().unwrap_or_default(),
             owner_references: self.owner_references.clone().unwrap_or_default(),
             finalizers: self.finalizers.clone().unwrap_or_default(),
-            deletion_timestamp: self.deletion_timestamp.unwrap_or(None),
+            deletion_timestamp: None,
         }
     }
 
@@ -233,7 +230,7 @@ impl DynamicApplyMetadata {
             annotations: self.annotations.clone().unwrap_or_else(|| existing.annotations.clone()),
             owner_references: self.owner_references.clone().unwrap_or_else(|| existing.owner_references.clone()),
             finalizers: self.finalizers.clone().unwrap_or_else(|| existing.finalizers.clone()),
-            deletion_timestamp: self.deletion_timestamp.unwrap_or(existing.deletion_timestamp),
+            deletion_timestamp: existing.deletion_timestamp,
         }
     }
 }
@@ -476,9 +473,7 @@ mod tests {
             .await
             .expect("create demand with metadata");
 
-        apply_resource_document(
-            &backend,
-            "flotilla",
+        let reapply_review_document = || {
             json!({
                 "apiVersion": "flotilla.work/v1",
                 "kind": "Demand",
@@ -498,15 +493,24 @@ mod tests {
                         "principal_ref": "principal/default"
                     }
                 }
-            }),
-        )
-        .await
-        .expect("reapply demand document");
+            })
+        };
+
+        apply_resource_document(&backend, "flotilla", reapply_review_document()).await.expect("reapply demand document");
 
         let updated = resolver.get("demo-review").await.expect("updated demand");
         assert_eq!(updated.spec.kind, DemandKind::Review);
         assert_eq!(updated.metadata.owner_references, vec![owner_reference]);
         assert_eq!(updated.metadata.labels.get("controller").map(String::as_str), Some("attention"));
         assert_eq!(updated.metadata.finalizers, vec!["attention.flotilla.work/finalizer"]);
+
+        resolver.delete("demo-review").await.expect("mark demand for deletion");
+        let deleting = resolver.get("demo-review").await.expect("deleting demand");
+        let deletion_timestamp = deleting.metadata.deletion_timestamp.expect("deletion timestamp should be set");
+
+        apply_resource_document(&backend, "flotilla", reapply_review_document()).await.expect("reapply pending-delete demand document");
+
+        let reapplied = resolver.get("demo-review").await.expect("reapplied pending-delete demand");
+        assert_eq!(reapplied.metadata.deletion_timestamp, Some(deletion_timestamp));
     }
 }

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeMap;
 
+use chrono::{DateTime, Utc};
 use futures::{stream::BoxStream, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::{
-    api_version, Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, K8sListMeta, K8sResourceList,
+    api_version, Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, K8sListMeta, K8sResourceList, ObjectMeta,
     OwnerReference, PlacementPolicy, Presentation, Project, Regard, Repository, Resource, ResourceBackend, ResourceError, ResourceList,
     ResourceObject, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
 };
@@ -202,24 +203,38 @@ struct DynamicApplyMetadata {
     #[serde(default)]
     namespace: Option<String>,
     #[serde(default)]
-    labels: BTreeMap<String, String>,
+    labels: Option<BTreeMap<String, String>>,
     #[serde(default)]
-    annotations: BTreeMap<String, String>,
+    annotations: Option<BTreeMap<String, String>>,
     #[serde(default, rename = "ownerReferences")]
-    owner_references: Vec<OwnerReference>,
+    owner_references: Option<Vec<OwnerReference>>,
     #[serde(default)]
-    finalizers: Vec<String>,
+    finalizers: Option<Vec<String>>,
+    #[serde(default, rename = "deletionTimestamp")]
+    deletion_timestamp: Option<Option<DateTime<Utc>>>,
 }
 
 impl DynamicApplyMetadata {
-    fn input_meta(&self) -> InputMeta {
-        InputMeta::builder()
-            .name(self.name.clone())
-            .labels(self.labels.clone())
-            .annotations(self.annotations.clone())
-            .owner_references(self.owner_references.clone())
-            .finalizers(self.finalizers.clone())
-            .build()
+    fn input_meta_for_create(&self) -> InputMeta {
+        InputMeta {
+            name: self.name.clone(),
+            labels: self.labels.clone().unwrap_or_default(),
+            annotations: self.annotations.clone().unwrap_or_default(),
+            owner_references: self.owner_references.clone().unwrap_or_default(),
+            finalizers: self.finalizers.clone().unwrap_or_default(),
+            deletion_timestamp: self.deletion_timestamp.unwrap_or(None),
+        }
+    }
+
+    fn input_meta_for_update(&self, existing: &ObjectMeta) -> InputMeta {
+        InputMeta {
+            name: self.name.clone(),
+            labels: self.labels.clone().unwrap_or_else(|| existing.labels.clone()),
+            annotations: self.annotations.clone().unwrap_or_else(|| existing.annotations.clone()),
+            owner_references: self.owner_references.clone().unwrap_or_else(|| existing.owner_references.clone()),
+            finalizers: self.finalizers.clone().unwrap_or_else(|| existing.finalizers.clone()),
+            deletion_timestamp: self.deletion_timestamp.unwrap_or(existing.deletion_timestamp),
+        }
     }
 }
 
@@ -272,10 +287,12 @@ async fn apply_typed<T: Resource>(
     let spec = serde_json::from_value::<T::Spec>(spec)
         .map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", T::API_PATHS.kind)))?;
     let resolver = backend.using::<T>(namespace);
-    let meta = metadata.input_meta();
-    let object = match resolver.get(&meta.name).await {
-        Ok(existing) => resolver.update(&meta, &existing.metadata.resource_version, &spec).await?,
-        Err(ResourceError::NotFound { .. }) => resolver.create(&meta, &spec).await?,
+    let object = match resolver.get(&metadata.name).await {
+        Ok(existing) => {
+            let meta = metadata.input_meta_for_update(&existing.metadata);
+            resolver.update(&meta, &existing.metadata.resource_version, &spec).await?
+        }
+        Err(ResourceError::NotFound { .. }) => resolver.create(&metadata.input_meta_for_create(), &spec).await?,
         Err(error) => return Err(error),
     };
     Ok(DynamicResourceObject {
@@ -323,6 +340,8 @@ fn api_version_typed<T: Resource>() -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use flotilla_protocol::ResourceRef;
 
     use super::*;
@@ -428,5 +447,66 @@ mod tests {
         assert_eq!(applied.kind, "Demand");
         assert_eq!(applied.value["metadata"]["name"], "demo-review");
         assert_eq!(backend.using::<Demand>("flotilla").get("demo-review").await.expect("stored demand").spec.kind, DemandKind::Review);
+    }
+
+    #[tokio::test]
+    async fn apply_resource_document_reapply_preserves_existing_metadata_when_omitted() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let resolver = backend.using::<Demand>("flotilla");
+        let owner_reference = OwnerReference {
+            api_version: "flotilla.work/v1".to_string(),
+            kind: "Vessel".to_string(),
+            name: "demo-implement".to_string(),
+            controller: true,
+        };
+        resolver
+            .create(
+                &InputMeta::builder()
+                    .name("demo-review".to_string())
+                    .labels(BTreeMap::from([("controller".to_string(), "attention".to_string())]))
+                    .owner_references(vec![owner_reference.clone()])
+                    .finalizers(vec!["attention.flotilla.work/finalizer".to_string()])
+                    .build(),
+                &DemandSpec::builder()
+                    .originating_work_ref(ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "demo-implement"))
+                    .kind(DemandKind::Permission)
+                    .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) })
+                    .build(),
+            )
+            .await
+            .expect("create demand with metadata");
+
+        apply_resource_document(
+            &backend,
+            "flotilla",
+            json!({
+                "apiVersion": "flotilla.work/v1",
+                "kind": "Demand",
+                "metadata": {
+                    "name": "demo-review"
+                },
+                "spec": {
+                    "originating_work_ref": {
+                        "api_version": "flotilla.work/v1",
+                        "kind": "Vessel",
+                        "namespace": "flotilla",
+                        "name": "demo-implement"
+                    },
+                    "kind": "review",
+                    "addressee": {
+                        "kind": "principal",
+                        "principal_ref": "principal/default"
+                    }
+                }
+            }),
+        )
+        .await
+        .expect("reapply demand document");
+
+        let updated = resolver.get("demo-review").await.expect("updated demand");
+        assert_eq!(updated.spec.kind, DemandKind::Review);
+        assert_eq!(updated.metadata.owner_references, vec![owner_reference]);
+        assert_eq!(updated.metadata.labels.get("controller").map(String::as_str), Some("attention"));
+        assert_eq!(updated.metadata.finalizers, vec!["attention.flotilla.work/finalizer"]);
     }
 }

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
+use flotilla_protocol::ResourceRef;
 use flotilla_resources::{
-    Convoy, InMemoryBackend, InputMeta, OwnerReference, Resource, ResourceBackend, ResourceError, ResourceObject, TypedResolver,
+    Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, OwnerReference, PrincipalRef,
+    Regard, RegardExpiryPolicy, RegardSource, RegardSpec, Resource, ResourceBackend, ResourceError, ResourceObject, TypedResolver,
     WatchEvent, WatchStart, WorkflowTemplate,
 };
 use futures::StreamExt;
@@ -86,6 +88,92 @@ impl ResourceContractFixture for WorkflowTemplateFixture {
             other => panic!("expected tool process, got {other:?}"),
         }
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RegardFixture;
+
+impl ResourceContractFixture for RegardFixture {
+    type Resource = Regard;
+
+    fn label() -> &'static str {
+        "Regard"
+    }
+
+    fn meta(name: &str) -> InputMeta {
+        InputMeta::builder().name(name.to_string()).build()
+    }
+
+    fn spec() -> <Self::Resource as Resource>::Spec {
+        RegardSpec::builder()
+            .principal_ref(PrincipalRef("principal/default".to_string()))
+            .target(resource_ref("Convoy", "alpha"))
+            .source(RegardSource::Expressed)
+            .expiry(RegardExpiryPolicy::Decaying { expires_after_seconds: 300 })
+            .build()
+    }
+
+    fn updated_spec() -> <Self::Resource as Resource>::Spec {
+        RegardSpec::builder()
+            .principal_ref(PrincipalRef("principal/default".to_string()))
+            .target(resource_ref("Convoy", "alpha"))
+            .source(RegardSource::Implicit { policy: "convoy-start".to_string() })
+            .expiry(RegardExpiryPolicy::Pin)
+            .build()
+    }
+
+    fn assert_created(created: &ResourceObject<Self::Resource>) {
+        assert_eq!(created.spec.principal_ref, PrincipalRef("principal/default".to_string()));
+        assert!(created.status.is_none());
+    }
+
+    fn assert_updated(updated: &ResourceObject<Self::Resource>) {
+        assert_eq!(updated.spec.expiry, RegardExpiryPolicy::Pin);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DemandFixture;
+
+impl ResourceContractFixture for DemandFixture {
+    type Resource = Demand;
+
+    fn label() -> &'static str {
+        "Demand"
+    }
+
+    fn meta(name: &str) -> InputMeta {
+        InputMeta::builder().name(name.to_string()).build()
+    }
+
+    fn spec() -> <Self::Resource as Resource>::Spec {
+        DemandSpec::builder()
+            .originating_work_ref(resource_ref("Vessel", "alpha-implement"))
+            .kind(DemandKind::Permission)
+            .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) })
+            .build()
+    }
+
+    fn updated_spec() -> <Self::Resource as Resource>::Spec {
+        DemandSpec::builder()
+            .originating_work_ref(resource_ref("Vessel", "alpha-review"))
+            .kind(DemandKind::Review)
+            .addressee(DemandAddressee::Pool { pool_ref: DemandPoolRef("project/default".to_string()) })
+            .build()
+    }
+
+    fn assert_created(created: &ResourceObject<Self::Resource>) {
+        assert_eq!(created.spec.kind, DemandKind::Permission);
+        assert!(created.status.is_none());
+    }
+
+    fn assert_updated(updated: &ResourceObject<Self::Resource>) {
+        assert_eq!(updated.spec.kind, DemandKind::Review);
+    }
+}
+
+fn resource_ref(kind: &str, name: &str) -> ResourceRef {
+    ResourceRef::new("flotilla.work/v1", kind, "flotilla", name)
 }
 
 pub fn in_memory_backend() -> ResourceBackend {

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -10,128 +10,110 @@ use common::{
         assert_stale_resource_version_conflicts, assert_store_diagnostics_report_retained_events_with_backend,
         assert_watch_from_version_replays, assert_watch_now_semantics,
         assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
-        assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
+        assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture, DemandFixture, RegardFixture,
     },
     convoy_meta, convoy_spec,
 };
 use flotilla_resources::{Convoy, EventRetention, InMemoryBackend, ResourceBackend};
-use rstest::rstest;
 
 fn resolver(namespace: &str) -> flotilla_resources::TypedResolver<Convoy> {
     ResourceBackend::InMemory(InMemoryBackend::default()).using::<Convoy>(namespace)
 }
 
-// Keep the rstest shape even with a single fixture so this suite can grow into
-// shared backend contract coverage without restructuring each test.
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn create_get_list_roundtrip(#[case] _fixture: ConvoyFixture) {
-    assert_create_get_list_roundtrip::<ConvoyFixture>().await;
+macro_rules! resource_contract_tests {
+    ($module:ident, $fixture:ty) => {
+        mod $module {
+            use super::*;
+
+            #[tokio::test]
+            async fn create_get_list_roundtrip() {
+                assert_create_get_list_roundtrip::<$fixture>().await;
+            }
+
+            #[tokio::test]
+            async fn update_requires_current_resource_version() {
+                assert_stale_resource_version_conflicts::<$fixture>().await;
+            }
+
+            #[tokio::test]
+            async fn identical_update_preserves_resource_version_and_emits_no_event() {
+                assert_identical_update_is_noop_with_backend::<$fixture>(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+            }
+
+            #[tokio::test]
+            async fn identical_status_update_preserves_resource_version_and_emits_no_event() {
+                assert_identical_status_update_is_noop_with_backend::<$fixture>(ResourceBackend::InMemory(InMemoryBackend::default()))
+                    .await;
+            }
+
+            #[tokio::test]
+            async fn delete_emits_deleted_event() {
+                assert_delete_emits_event::<$fixture>().await;
+            }
+
+            #[tokio::test]
+            async fn watch_from_version_replays_gaplessly_after_list() {
+                assert_watch_from_version_replays::<$fixture>().await;
+            }
+
+            #[tokio::test]
+            async fn watch_now_only_sees_future_events() {
+                assert_watch_now_semantics::<$fixture>().await;
+            }
+
+            #[tokio::test]
+            async fn watch_below_retention_floor_expires() {
+                let retention = EventRetention::new(2).expect("valid retention");
+                let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
+                assert_watch_retention_expires_only_versions_below_floor_with_backend::<$fixture>(backend).await;
+            }
+
+            #[tokio::test]
+            async fn expired_watch_consumer_relists_and_converges() {
+                let retention = EventRetention::new(2).expect("valid retention");
+                let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
+                assert_consumer_relists_after_expired_watch_and_converges_with_backend::<$fixture>(backend).await;
+            }
+
+            #[tokio::test]
+            async fn diagnostics_report_bounded_event_log() {
+                let retention = EventRetention::new(2).expect("valid retention");
+                let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
+                assert_store_diagnostics_report_retained_events_with_backend::<$fixture>(backend).await;
+            }
+
+            #[tokio::test]
+            async fn watch_only_diagnostics_match_mutation_based_stream_semantics() {
+                assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend::<$fixture>(ResourceBackend::InMemory(
+                    InMemoryBackend::default(),
+                ))
+                .await;
+            }
+
+            #[tokio::test]
+            async fn namespaces_are_isolated() {
+                assert_namespace_isolation::<$fixture>().await;
+            }
+
+            #[tokio::test]
+            async fn owner_references_roundtrip_through_in_memory_backend() {
+                assert_metadata_roundtrip::<$fixture>().await;
+            }
+
+            #[tokio::test]
+            async fn repeated_delete_is_noop_while_finalizers_are_pending() {
+                assert_repeated_delete_with_pending_finalizers_is_noop_with_backend::<$fixture>(ResourceBackend::InMemory(
+                    InMemoryBackend::default(),
+                ))
+                .await;
+            }
+        }
+    };
 }
 
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn update_requires_current_resource_version(#[case] _fixture: ConvoyFixture) {
-    assert_stale_resource_version_conflicts::<ConvoyFixture>().await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn identical_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
-    assert_identical_update_is_noop_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(InMemoryBackend::default())).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn identical_status_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
-    assert_identical_status_update_is_noop_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(InMemoryBackend::default())).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn delete_emits_deleted_event(#[case] _fixture: ConvoyFixture) {
-    assert_delete_emits_event::<ConvoyFixture>().await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_from_version_replays_gaplessly_after_list(#[case] _fixture: ConvoyFixture) {
-    assert_watch_from_version_replays::<ConvoyFixture>().await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_now_only_sees_future_events(#[case] _fixture: ConvoyFixture) {
-    assert_watch_now_semantics::<ConvoyFixture>().await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_below_retention_floor_expires(#[case] _fixture: ConvoyFixture) {
-    let retention = EventRetention::new(2).expect("valid retention");
-    let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
-    assert_watch_retention_expires_only_versions_below_floor_with_backend::<ConvoyFixture>(backend).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn expired_watch_consumer_relists_and_converges(#[case] _fixture: ConvoyFixture) {
-    let retention = EventRetention::new(2).expect("valid retention");
-    let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
-    assert_consumer_relists_after_expired_watch_and_converges_with_backend::<ConvoyFixture>(backend).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn diagnostics_report_bounded_event_log(#[case] _fixture: ConvoyFixture) {
-    let retention = EventRetention::new(2).expect("valid retention");
-    let backend = ResourceBackend::InMemory(InMemoryBackend::with_event_retention(retention));
-    assert_store_diagnostics_report_retained_events_with_backend::<ConvoyFixture>(backend).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_only_diagnostics_match_mutation_based_stream_semantics(#[case] _fixture: ConvoyFixture) {
-    assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(
-        InMemoryBackend::default(),
-    ))
-    .await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn namespaces_are_isolated(#[case] _fixture: ConvoyFixture) {
-    assert_namespace_isolation::<ConvoyFixture>().await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn owner_references_roundtrip_through_in_memory_backend(#[case] _fixture: ConvoyFixture) {
-    assert_metadata_roundtrip::<ConvoyFixture>().await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn repeated_delete_is_noop_while_finalizers_are_pending(#[case] _fixture: ConvoyFixture) {
-    assert_repeated_delete_with_pending_finalizers_is_noop_with_backend::<ConvoyFixture>(ResourceBackend::InMemory(
-        InMemoryBackend::default(),
-    ))
-    .await;
-}
+resource_contract_tests!(convoy_contract, ConvoyFixture);
+resource_contract_tests!(regard_contract, RegardFixture);
+resource_contract_tests!(demand_contract, DemandFixture);
 
 #[tokio::test]
 async fn list_matching_labels_returns_only_exact_matches() {

--- a/crates/flotilla-resources/tests/principal_attention_status_patch.rs
+++ b/crates/flotilla-resources/tests/principal_attention_status_patch.rs
@@ -1,0 +1,74 @@
+mod common;
+
+use common::timestamp;
+use flotilla_protocol::ResourceRef;
+use flotilla_resources::{
+    DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, DemandState, DemandStatus, DemandStatusPatch, PrincipalRef, RegardStatus,
+    RegardStatusPatch, StatusPatch,
+};
+
+#[test]
+fn regard_refresh_records_created_and_latest_refreshed_time() {
+    let mut status = RegardStatus::default();
+
+    RegardStatusPatch::Refresh { as_of: timestamp(10) }.apply(&mut status);
+    RegardStatusPatch::Refresh { as_of: timestamp(8) }.apply(&mut status);
+    RegardStatusPatch::Refresh { as_of: timestamp(20) }.apply(&mut status);
+
+    assert_eq!(status.created_at, Some(timestamp(10)));
+    assert_eq!(status.refreshed_at, Some(timestamp(20)));
+}
+
+#[test]
+fn demand_raise_stamps_lifecycle_authority_once() {
+    let mut status = DemandStatus::default();
+
+    DemandStatusPatch::Raise { as_of: timestamp(10), authority: "dispatch/principal-default".to_string() }.apply(&mut status);
+    DemandStatusPatch::Raise { as_of: timestamp(20), authority: "other".to_string() }.apply(&mut status);
+
+    assert_eq!(status.state, DemandState::Raised);
+    let raised = status.raised.expect("raised transition");
+    assert_eq!(raised.as_of, timestamp(10));
+    assert_eq!(raised.authority, "dispatch/principal-default");
+    assert!(status.satisfied.is_none());
+    assert!(status.acknowledged.is_none());
+}
+
+#[test]
+fn demand_satisfy_and_acknowledge_preserve_transition_timestamps_and_authorities() {
+    let mut status = DemandStatus::default();
+
+    DemandStatusPatch::Raise { as_of: timestamp(10), authority: "dispatch/principal-default".to_string() }.apply(&mut status);
+    DemandStatusPatch::Satisfy { as_of: timestamp(20), authority: "principal/default".to_string() }.apply(&mut status);
+    DemandStatusPatch::Acknowledge { as_of: timestamp(30), authority: "principal/default".to_string() }.apply(&mut status);
+    DemandStatusPatch::Satisfy { as_of: timestamp(40), authority: "late-controller".to_string() }.apply(&mut status);
+
+    assert_eq!(status.state, DemandState::Acknowledged);
+    let raised = status.raised.expect("raised transition");
+    let satisfied = status.satisfied.expect("satisfied transition");
+    let acknowledged = status.acknowledged.expect("acknowledged transition");
+    assert_eq!(raised.as_of, timestamp(10));
+    assert_eq!(raised.authority, "dispatch/principal-default");
+    assert_eq!(satisfied.as_of, timestamp(20));
+    assert_eq!(satisfied.authority, "principal/default");
+    assert_eq!(acknowledged.as_of, timestamp(30));
+    assert_eq!(acknowledged.authority, "principal/default");
+}
+
+#[test]
+fn demand_spec_defaults_to_dispatching_principal_via_constructor() {
+    let work_ref = ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "demo-implement");
+    let spec =
+        DemandSpec::for_dispatching_principal(work_ref.clone(), DemandKind::Permission, PrincipalRef("principal/default".to_string()));
+
+    assert_eq!(spec.originating_work_ref, work_ref);
+    assert_eq!(spec.addressee, DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) });
+}
+
+#[test]
+fn demand_spec_can_route_unroutable_work_to_a_pool() {
+    let work_ref = ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "demo-review");
+    let spec = DemandSpec::for_pool(work_ref, DemandKind::Review, DemandPoolRef("project/default".to_string()));
+
+    assert_eq!(spec.addressee, DemandAddressee::Pool { pool_ref: DemandPoolRef("project/default".to_string()) });
+}

--- a/crates/flotilla-resources/tests/resource_projection.rs
+++ b/crates/flotilla-resources/tests/resource_projection.rs
@@ -70,6 +70,17 @@ fn convoy_crd_allows_omitted_empty_repository_subpaths() {
 }
 
 #[test]
+fn attention_crds_parse_with_expected_names() {
+    let regard: serde_json::Value = serde_yml::from_str(include_str!("../src/crds/regard.crd.yaml")).expect("Regard CRD should parse");
+    let demand: serde_json::Value = serde_yml::from_str(include_str!("../src/crds/demand.crd.yaml")).expect("Demand CRD should parse");
+
+    assert_eq!(regard["metadata"]["name"], "regards.flotilla.work");
+    assert_eq!(regard["spec"]["names"]["kind"], "Regard");
+    assert_eq!(demand["metadata"]["name"], "demands.flotilla.work");
+    assert_eq!(demand["spec"]["names"]["kind"], "Demand");
+}
+
+#[test]
 fn k8s_object_projection_rejects_wrong_resource_identity() {
     let object = convoy_object("alpha", convoy_spec("review"), None);
     let mut projected = object.to_k8s_object();

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -11,7 +11,7 @@ use common::{
         assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_stale_resource_version_conflicts_with_backend,
         assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays_with_backend,
         assert_watch_now_semantics_with_backend, assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
-        assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture,
+        assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture, DemandFixture, RegardFixture,
     },
     convoy_meta, convoy_spec, convoy_status, pending_task_state, resource_meta, TestLoopHarness,
 };
@@ -23,7 +23,6 @@ use flotilla_resources::{
     WorkflowTemplate, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 use futures::StreamExt;
-use rstest::rstest;
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
 use tempfile::tempdir;
 use tokio::time::{timeout, Duration};
@@ -62,112 +61,99 @@ impl Resource for SlowResource {
     const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.test", version: "v1", plural: "slowresources", kind: "SlowResource" };
 }
 
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn create_get_list_roundtrip(#[case] _fixture: ConvoyFixture) {
-    assert_create_get_list_roundtrip_with_backend::<ConvoyFixture>(backend()).await;
+macro_rules! resource_contract_tests {
+    ($module:ident, $fixture:ty) => {
+        mod $module {
+            use super::*;
+
+            #[tokio::test]
+            async fn create_get_list_roundtrip() {
+                assert_create_get_list_roundtrip_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn update_requires_current_resource_version() {
+                assert_stale_resource_version_conflicts_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn identical_update_preserves_resource_version_and_emits_no_event() {
+                assert_identical_update_is_noop_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn identical_status_update_preserves_resource_version_and_emits_no_event() {
+                assert_identical_status_update_is_noop_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn delete_emits_deleted_event() {
+                assert_delete_emits_event_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn repeated_delete_is_noop_while_finalizers_are_pending() {
+                assert_repeated_delete_with_pending_finalizers_is_noop_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn watch_from_version_replays_gaplessly_after_list() {
+                assert_watch_from_version_replays_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn watch_now_only_sees_future_events() {
+                assert_watch_now_semantics_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn watch_below_retention_floor_expires() {
+                let retention = EventRetention::new(2).expect("valid retention");
+                let backend = ResourceBackend::Sqlite(
+                    SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"),
+                );
+                assert_watch_retention_expires_only_versions_below_floor_with_backend::<$fixture>(backend).await;
+            }
+
+            #[tokio::test]
+            async fn expired_watch_consumer_relists_and_converges() {
+                let retention = EventRetention::new(2).expect("valid retention");
+                let backend = ResourceBackend::Sqlite(
+                    SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"),
+                );
+                assert_consumer_relists_after_expired_watch_and_converges_with_backend::<$fixture>(backend).await;
+            }
+
+            #[tokio::test]
+            async fn diagnostics_report_bounded_event_log() {
+                let retention = EventRetention::new(2).expect("valid retention");
+                let backend = ResourceBackend::Sqlite(
+                    SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"),
+                );
+                assert_store_diagnostics_report_retained_events_with_backend::<$fixture>(backend).await;
+            }
+
+            #[tokio::test]
+            async fn watch_only_diagnostics_match_mutation_based_stream_semantics() {
+                assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn namespaces_are_isolated() {
+                assert_namespace_isolation_with_backend::<$fixture>(backend()).await;
+            }
+
+            #[tokio::test]
+            async fn owner_references_roundtrip_through_sqlite_backend() {
+                assert_metadata_roundtrip_with_backend::<$fixture>(backend()).await;
+            }
+        }
+    };
 }
 
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn update_requires_current_resource_version(#[case] _fixture: ConvoyFixture) {
-    assert_stale_resource_version_conflicts_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn identical_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
-    assert_identical_update_is_noop_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn identical_status_update_preserves_resource_version_and_emits_no_event(#[case] _fixture: ConvoyFixture) {
-    assert_identical_status_update_is_noop_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn delete_emits_deleted_event(#[case] _fixture: ConvoyFixture) {
-    assert_delete_emits_event_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn repeated_delete_is_noop_while_finalizers_are_pending(#[case] _fixture: ConvoyFixture) {
-    assert_repeated_delete_with_pending_finalizers_is_noop_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_from_version_replays_gaplessly_after_list(#[case] _fixture: ConvoyFixture) {
-    assert_watch_from_version_replays_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_now_only_sees_future_events(#[case] _fixture: ConvoyFixture) {
-    assert_watch_now_semantics_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_below_retention_floor_expires(#[case] _fixture: ConvoyFixture) {
-    let retention = EventRetention::new(2).expect("valid retention");
-    let backend =
-        ResourceBackend::Sqlite(SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"));
-    assert_watch_retention_expires_only_versions_below_floor_with_backend::<ConvoyFixture>(backend).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn expired_watch_consumer_relists_and_converges(#[case] _fixture: ConvoyFixture) {
-    let retention = EventRetention::new(2).expect("valid retention");
-    let backend =
-        ResourceBackend::Sqlite(SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"));
-    assert_consumer_relists_after_expired_watch_and_converges_with_backend::<ConvoyFixture>(backend).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn diagnostics_report_bounded_event_log(#[case] _fixture: ConvoyFixture) {
-    let retention = EventRetention::new(2).expect("valid retention");
-    let backend =
-        ResourceBackend::Sqlite(SqliteBackend::open_in_memory_with_event_retention(retention).expect("sqlite backend should open"));
-    assert_store_diagnostics_report_retained_events_with_backend::<ConvoyFixture>(backend).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn watch_only_diagnostics_match_mutation_based_stream_semantics(#[case] _fixture: ConvoyFixture) {
-    assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn namespaces_are_isolated(#[case] _fixture: ConvoyFixture) {
-    assert_namespace_isolation_with_backend::<ConvoyFixture>(backend()).await;
-}
-
-#[rstest]
-#[case(ConvoyFixture)]
-#[tokio::test]
-async fn owner_references_roundtrip_through_sqlite_backend(#[case] _fixture: ConvoyFixture) {
-    assert_metadata_roundtrip_with_backend::<ConvoyFixture>(backend()).await;
-}
+resource_contract_tests!(convoy_contract, ConvoyFixture);
+resource_contract_tests!(regard_contract, RegardFixture);
+resource_contract_tests!(demand_contract, DemandFixture);
 
 #[tokio::test]
 async fn objects_and_resource_versions_survive_restart() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,8 @@ enum HooksSubCommand {
 enum ResourceSubCommand {
     /// List resources of a kind
     List(ResourceListArgs),
+    /// Create or update a raw resource document
+    Apply(ResourceApplyArgs),
     /// Get one resource by name
     Get(ResourceGetArgs),
     /// Watch resources of a kind
@@ -251,6 +253,19 @@ struct ResourceGetArgs {
     #[arg(long, default_value = "flotilla")]
     namespace: String,
     /// Route the query to a peer host
+    #[arg(long)]
+    host: Option<String>,
+}
+
+#[derive(clap::Args)]
+struct ResourceApplyArgs {
+    /// Resource document path (JSON or YAML)
+    #[arg(short, long)]
+    file: PathBuf,
+    /// Default namespace when metadata.namespace is omitted
+    #[arg(long, default_value = "flotilla")]
+    namespace: String,
+    /// Route the mutation to a peer host
     #[arg(long)]
     host: Option<String>,
 }
@@ -729,6 +744,24 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
                 .await
                 .map_err(|e| color_eyre::eyre::eyre!(e))?;
             print_resource_query_result(result, format)
+        }
+        ResourceSubCommand::Apply(args) => {
+            let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
+            let raw = std::fs::read_to_string(&args.file)
+                .map_err(|error| color_eyre::eyre::eyre!("read resource document {}: {error}", args.file.display()))?;
+            let document: serde_json::Value = serde_yml::from_str(&raw)
+                .map_err(|error| color_eyre::eyre::eyre!("parse resource document {}: {error}", args.file.display()))?;
+            run_control_command(
+                cli,
+                Command {
+                    node_id,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::ResourceApply { namespace: args.namespace, document },
+                },
+                format,
+            )
+            .await
         }
         ResourceSubCommand::Watch(args) => run_resource_watch(cli, args, format).await,
     }
@@ -1309,7 +1342,7 @@ fn uninstall_claude_code_hooks(path: &std::path::Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use clap::Parser;
     use flotilla_protocol::{
@@ -1317,8 +1350,8 @@ mod tests {
     };
 
     use super::{
-        provisioning_target_for_environment, run_replica_snapshot, select_host_target, select_startup_repo_roots, Cli, ResourceGetArgs,
-        ResourceListArgs, ResourceSubCommand, SubCommand,
+        provisioning_target_for_environment, run_replica_snapshot, select_host_target, select_startup_repo_roots, Cli, ResourceApplyArgs,
+        ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
     };
 
     #[test]
@@ -1383,6 +1416,15 @@ mod tests {
             Some(SubCommand::Resource {
                 command: ResourceSubCommand::Get(ResourceGetArgs { kind, name, namespace, host: None })
             }) if kind == "convoys" && name == "demo" && namespace == "ops"
+        ));
+
+        let apply = Cli::try_parse_from(["flotilla", "resource", "apply", "-f", "demand.yaml", "--namespace", "ops"])
+            .expect("resource apply should parse");
+        assert!(matches!(
+            apply.command,
+            Some(SubCommand::Resource {
+                command: ResourceSubCommand::Apply(ResourceApplyArgs { file, namespace, host: None })
+            }) if file.as_path() == Path::new("demand.yaml") && namespace == "ops"
         ));
 
         let watch =


### PR DESCRIPTION
## Summary

- add mesh-resident `Regard` and `Demand` resources for principal attention state
- register the resources for dynamic list/get/watch support and add CRD projections
- add raw `flotilla resource apply` support so attention resources can be created or updated via CLI/API
- cover backend contracts, status patch transitions, registry apply, and CLI parsing

Closes #860.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`