### PR TITLE
feat: add awareness projection query

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -315,7 +315,11 @@ fn convoy_phase_represents_issues(phase: ConvoyPhase) -> bool {
 }
 
 fn convoy_matches_scope(row: &ConvoyRow, scope: &QueryScope) -> bool {
-    row.project_ref.as_deref().is_some_and(|project| project == scope.name || project == format!("{}/{}", scope.namespace, scope.name))
+    row.resource.namespace == scope.namespace
+        && row
+            .project_ref
+            .as_deref()
+            .is_some_and(|project| project == scope.name || project == format!("{}/{}", scope.namespace, scope.name))
 }
 
 fn merged_issue_state(issue_sets: &[(QueryScope, ResultSet)]) -> ResultSetState {
@@ -344,8 +348,22 @@ mod tests {
 
     use super::*;
 
+    fn scope_in(namespace: &str, name: &str) -> QueryScope {
+        QueryScope::new(namespace, name)
+    }
+
     fn scope(name: &str) -> QueryScope {
-        QueryScope::new("flotilla", name)
+        scope_in("flotilla", name)
+    }
+
+    fn convoy_row(namespace: &str, name: &str, project_ref: &str) -> ConvoyRow {
+        ConvoyRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Convoy", namespace, name))
+            .name(name)
+            .workflow_ref("implement")
+            .phase(ConvoyPhase::Active)
+            .project_ref(project_ref)
+            .build()
     }
 
     fn issue_row(scope: &str, id: &str) -> IssueRow {
@@ -399,5 +417,27 @@ mod tests {
                 && node.scope.as_ref() == Some(&project)
                 && node.entries.iter().any(|entry| entry.kind == AwarenessKind::Issue)
         }));
+    }
+
+    #[tokio::test]
+    async fn scoped_awareness_filters_convoys_by_project_namespace() {
+        let state = AggregatorProjectionState::new();
+        let project = scope_in("team-a", "roadmap");
+        let matching = convoy_row("team-a", "matching", "roadmap");
+        let other_namespace = convoy_row("team-b", "other-namespace", "roadmap");
+        {
+            let mut convoys = state.write().await;
+            convoys.local_rows = [matching.clone(), other_namespace].into_iter().map(|row| (row.resource.clone(), row)).collect();
+            convoys.seq = 1;
+        }
+
+        let result = state.awareness_result_set(&Some(project.clone()), AwarenessGrouping::Project, AwarenessLimit::default()).await;
+        let Rows::Awareness { rows, .. } = result.rows else { panic!("awareness rows") };
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].scope.as_ref(), Some(&project));
+        assert_eq!(rows[0].counts.convoys, 1);
+        assert_eq!(rows[0].entries.iter().filter(|entry| entry.kind == AwarenessKind::Convoy).count(), 1);
+        assert!(rows[0].refs.contains(&matching.resource));
     }
 }

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -11,7 +11,8 @@ use std::{
 
 use flotilla_protocol::{
     result_set::{
-        CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetState, Rows,
+        AwarenessGrouping, AwarenessLimit, CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryId, QueryScope, ResultDelta,
+        ResultSet, ResultSetState, Rows,
     },
     HostName, IssueRef, QueryCursor, RepositoryKey, ResourceRef,
 };
@@ -19,6 +20,7 @@ use tokio::sync::{broadcast, watch, RwLock, RwLockWriteGuard};
 use uuid::Uuid;
 
 use crate::{
+    awareness_projection::{project_awareness, AwarenessInput, ScopedIssueRow},
     query_registry::QueryRegistry,
     scoped_store::{ScopedCheckoutProjection, ScopedIndependentProjection},
 };
@@ -159,6 +161,8 @@ impl AggregatorProjectionState {
     ) -> Vec<ResultDelta> {
         let mut deltas = self.independents.write().await.replace_catalog(repositories.clone(), projects.clone());
         deltas.extend(self.checkouts.write().await.replace_catalog(repositories, projects));
+        let scopes = self.checkouts.read().await.project_scopes();
+        self.demand_backed.expand_fleet_awareness_demands(&scopes);
         deltas
     }
 
@@ -184,8 +188,25 @@ impl AggregatorProjectionState {
         self.demand_backed.replace(subscriber, cursors)
     }
 
+    pub async fn replace_subscriber_expanding_awareness(&self, subscriber: Uuid, cursors: &[QueryCursor]) -> HashSet<QueryId> {
+        let mut expanded = cursors.to_vec();
+        if cursors.iter().any(|cursor| matches!(cursor.query, QueryId::Awareness { scope: None, .. })) {
+            for scope in self.checkouts.read().await.project_scopes() {
+                let query = QueryId::Issues { scope, search: None };
+                if !expanded.iter().any(|cursor| cursor.query == query) {
+                    expanded.push(QueryCursor { query, since: None });
+                }
+            }
+        }
+        self.replace_subscriber(subscriber, &expanded)
+    }
+
     pub fn remove_subscriber(&self, subscriber: Uuid) {
         self.demand_backed.remove(subscriber);
+    }
+
+    pub fn subscribed_queries(&self) -> HashSet<QueryId> {
+        self.demand_backed.subscribed_queries()
     }
 
     /// Observe the complete set of live demand-backed query identities.
@@ -241,10 +262,142 @@ impl AggregatorProjectionState {
             QueryId::Independents { scope } => Some(self.independents_result_set(scope).await),
             QueryId::Issues { .. } => self.demand_backed.result_set(query),
             QueryId::Checkouts { scope } => Some(self.checkouts.write().await.result_set(scope)),
+            QueryId::Awareness { scope, grouping, limit } => Some(self.awareness_result_set(scope, *grouping, *limit).await),
         }
+    }
+
+    pub async fn awareness_result_set(&self, scope: &Option<QueryScope>, grouping: AwarenessGrouping, limit: AwarenessLimit) -> ResultSet {
+        let convoys = {
+            let set = self.result_set().await;
+            let rows = match set.rows {
+                Rows::Convoys(rows) => rows,
+                _ => Vec::new(),
+            };
+            rows.into_iter().filter(|row| scope.as_ref().is_none_or(|scope| convoy_matches_scope(row, scope))).collect::<Vec<_>>()
+        };
+        let independents_set = self.independents_result_set(scope).await;
+        let independents = independents_set.rows.as_independents().map_or_else(Vec::new, ToOwned::to_owned);
+        let checkouts_set = self.checkouts.write().await.result_set(scope);
+        let checkouts = checkouts_set.rows.as_checkouts().map_or_else(Vec::new, ToOwned::to_owned);
+        let issue_sets = self.issue_sets_for_awareness(scope).await;
+        let issues = issue_sets
+            .iter()
+            .flat_map(|(scope, set)| {
+                set.rows.as_issues().into_iter().flatten().cloned().map(|row| ScopedIssueRow { scope: Some(scope.clone()), row })
+            })
+            .collect::<Vec<_>>();
+        let state = merged_issue_state(&issue_sets);
+        let seq = [self.seq().await, independents_set.seq, checkouts_set.seq, issue_sets.iter().map(|(_, set)| set.seq).max().unwrap_or(0)]
+            .into_iter()
+            .max()
+            .unwrap_or(0);
+        let (rows, state) =
+            project_awareness(AwarenessInput { scope: scope.clone(), grouping, limit, convoys, issues, checkouts, independents, state });
+        ResultSet { seq, rows: Rows::Awareness { scope: scope.clone(), grouping, limit, rows }, state }
+    }
+
+    async fn issue_sets_for_awareness(&self, scope: &Option<QueryScope>) -> Vec<(QueryScope, ResultSet)> {
+        let scopes = match scope {
+            Some(scope) => vec![scope.clone()],
+            None => self.checkouts.read().await.project_scopes(),
+        };
+        scopes
+            .into_iter()
+            .filter_map(|scope| {
+                self.demand_backed.result_set(&QueryId::Issues { scope: scope.clone(), search: None }).map(|set| (scope, set))
+            })
+            .collect()
     }
 }
 
 fn convoy_phase_represents_issues(phase: ConvoyPhase) -> bool {
     matches!(phase, ConvoyPhase::Pending | ConvoyPhase::Active)
+}
+
+fn convoy_matches_scope(row: &ConvoyRow, scope: &QueryScope) -> bool {
+    row.project_ref.as_deref().is_some_and(|project| project == scope.name || project == format!("{}/{}", scope.namespace, scope.name))
+}
+
+fn merged_issue_state(issue_sets: &[(QueryScope, ResultSet)]) -> ResultSetState {
+    let mut state = ResultSetState::default();
+    for (_, set) in issue_sets {
+        state.conditions.extend(set.state.conditions.clone());
+        if let Some(demand) = &set.state.demand {
+            state.demand = Some(match state.demand {
+                Some(existing) => flotilla_protocol::DemandBackedMetadata {
+                    as_of: existing.as_of.max(demand.as_of),
+                    has_more: existing.has_more || demand.has_more,
+                },
+                None => demand.clone(),
+            });
+        }
+    }
+    state
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use flotilla_protocol::{
+        AwarenessKind, DemandBackedMetadata, Issue, IssueRef, IssueSource, IssueState, QueryCursor, ResultSetState, Rows,
+    };
+
+    use super::*;
+
+    fn scope(name: &str) -> QueryScope {
+        QueryScope::new("flotilla", name)
+    }
+
+    fn issue_row(scope: &str, id: &str) -> IssueRow {
+        let reference = IssueRef { source: IssueSource { service: "https://github.com".into(), scope: scope.into() }, id: id.into() };
+        IssueRow {
+            reference: reference.clone(),
+            issue: Issue {
+                reference,
+                title: format!("Issue {id}"),
+                body: None,
+                state: IssueState::Open,
+                labels: vec![],
+                as_of: Utc::now(),
+                association_keys: vec![],
+                provider_name: "github".into(),
+                provider_display_name: "GitHub".into(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn fleet_awareness_subscription_demands_project_issue_windows() {
+        let state = AggregatorProjectionState::new();
+        let project = scope("roadmap");
+        state.replace_store_catalog(HashSet::from([RepositoryKey("repo-a".into())]), HashMap::from([(project.clone(), vec![])])).await;
+
+        let awareness = QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
+        state.replace_subscriber_expanding_awareness(Uuid::new_v4(), &[QueryCursor { query: awareness, since: None }]).await;
+
+        assert!(state.subscribe_demand().borrow().contains_key(&QueryId::Issues { scope: project, search: None }));
+    }
+
+    #[tokio::test]
+    async fn fleet_awareness_groups_loaded_project_issues_under_projects() {
+        let state = AggregatorProjectionState::new();
+        let project = scope("roadmap");
+        state.replace_store_catalog(HashSet::from([RepositoryKey("repo-a".into())]), HashMap::from([(project.clone(), vec![])])).await;
+        let issue_query = QueryId::Issues { scope: project.clone(), search: None };
+        state.replace_subscriber(Uuid::new_v4(), &[QueryCursor { query: issue_query.clone(), since: None }]);
+        let generation = *state.subscribe_demand().borrow().get(&issue_query).expect("issue query generation");
+        state.replace_issues(&issue_query, generation, vec![issue_row("flotilla-org/flotilla", "862")], ResultSetState {
+            demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: false }),
+            conditions: vec![],
+        });
+
+        let result = state.awareness_result_set(&None, AwarenessGrouping::Project, AwarenessLimit::default()).await;
+        let Rows::Awareness { rows, .. } = result.rows else { panic!("awareness rows") };
+
+        assert!(rows.iter().any(|node| {
+            node.kind == AwarenessKind::Project
+                && node.scope.as_ref() == Some(&project)
+                && node.entries.iter().any(|entry| entry.kind == AwarenessKind::Issue)
+        }));
+    }
 }

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -47,10 +47,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
 
     for convoy in &input.convoys {
         let key = input.scope.as_ref().map(group_key_for_scope).unwrap_or_else(|| group_key_for_convoy(input.grouping, convoy));
-        let kind = match input.grouping {
-            AwarenessGrouping::Project => AwarenessKind::Project,
-            AwarenessGrouping::Convoy => AwarenessKind::Convoy,
-        };
+        let kind = group_kind_for_query(input.scope.as_ref(), input.grouping);
         let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, kind));
         group.refs.push(convoy.resource.clone());
         group.add_entry(
@@ -226,6 +223,16 @@ fn group_key_for_scope(scope: &QueryScope) -> GroupKey {
     GroupKey::scoped(scope.clone())
 }
 
+fn group_kind_for_query(scope: Option<&QueryScope>, grouping: AwarenessGrouping) -> AwarenessKind {
+    if scope.is_some() {
+        return AwarenessKind::Project;
+    }
+    match grouping {
+        AwarenessGrouping::Project => AwarenessKind::Project,
+        AwarenessGrouping::Convoy => AwarenessKind::Convoy,
+    }
+}
+
 fn group_key_for_convoy(grouping: AwarenessGrouping, convoy: &ConvoyRow) -> GroupKey {
     match grouping {
         AwarenessGrouping::Project => convoy.project_ref.as_deref().map(project_ref_key).unwrap_or_else(|| {
@@ -377,6 +384,22 @@ mod tests {
         assert_eq!(nodes[0].counts.checkouts, 1);
         assert_eq!(nodes[0].counts.independents, 1);
         assert!(nodes[0].entries.iter().any(|entry| entry.kind == AwarenessKind::Convoy && entry.label == "ship-it"));
+    }
+
+    #[test]
+    fn scoped_awareness_reports_project_kind_even_with_convoy_grouping() {
+        let scope = QueryScope::new("flotilla", "platform");
+        let (nodes, _) = project_awareness(AwarenessInput {
+            scope: Some(scope.clone()),
+            grouping: AwarenessGrouping::Convoy,
+            convoys: vec![convoy(Some("flotilla/platform"), "ship-it", ConvoyPhase::Active)],
+            ..AwarenessInput::default()
+        });
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].kind, AwarenessKind::Project);
+        assert_eq!(nodes[0].scope.as_ref(), Some(&scope));
+        assert_eq!(nodes[0].counts.convoys, 1);
     }
 
     #[test]

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -1,0 +1,398 @@
+//! Awareness-band projection over curated query rows.
+//!
+//! This module is deliberately pure: callers inject the row windows they
+//! already hold and choose the grouping parameter at query time.
+
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use flotilla_protocol::{
+    AwarenessCounts, AwarenessEntry, AwarenessGrouping, AwarenessKind, AwarenessLimit, AwarenessNode, AwarenessPhase, AwarenessState,
+    CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef, ResultSetState, WorkPhase,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct AwarenessInput {
+    pub scope: Option<QueryScope>,
+    pub grouping: AwarenessGrouping,
+    pub limit: AwarenessLimit,
+    pub convoys: Vec<ConvoyRow>,
+    pub issues: Vec<ScopedIssueRow>,
+    pub checkouts: Vec<CheckoutRow>,
+    pub independents: Vec<IndependentRow>,
+    pub state: ResultSetState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopedIssueRow {
+    pub scope: Option<QueryScope>,
+    pub row: IssueRow,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Group {
+    id: String,
+    label: String,
+    scope: Option<QueryScope>,
+    kind: AwarenessKind,
+    refs: Vec<ResourceRef>,
+    entries: Vec<AwarenessEntry>,
+    counts: AwarenessCounts,
+    state: AwarenessState,
+}
+
+pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSetState) {
+    let as_of = input.state.demand.as_ref().map_or_else(Utc::now, |metadata| metadata.as_of);
+    let mut groups = BTreeMap::<String, Group>::new();
+
+    for convoy in &input.convoys {
+        let key = input.scope.as_ref().map(group_key_for_scope).unwrap_or_else(|| group_key_for_convoy(input.grouping, convoy));
+        let kind = match input.grouping {
+            AwarenessGrouping::Project => AwarenessKind::Project,
+            AwarenessGrouping::Convoy => AwarenessKind::Convoy,
+        };
+        let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, kind));
+        group.refs.push(convoy.resource.clone());
+        group.add_entry(
+            AwarenessEntry::builder()
+                .id(format!("convoy/{}/{}", convoy.resource.namespace, convoy.name))
+                .kind(AwarenessKind::Convoy)
+                .label(convoy_label(convoy))
+                .state(convoy_state(convoy.phase, convoy.initializing))
+                .phase(AwarenessPhase::Convoy(convoy.phase))
+                .as_of(as_of)
+                .refs(vec![convoy.resource.clone()])
+                .issue_refs(convoy.issues.iter().map(|issue| issue.reference.clone()).collect())
+                .build(),
+        );
+        for vessel in &convoy.vessels {
+            group.add_entry(
+                AwarenessEntry::builder()
+                    .id(format!("vessel/{}/{}/{}", convoy.resource.namespace, convoy.name, vessel.name))
+                    .kind(AwarenessKind::Vessel)
+                    .label(vessel.name.clone())
+                    .state(work_state(vessel.phase))
+                    .phase(AwarenessPhase::Work(vessel.phase))
+                    .as_of(as_of)
+                    .refs(vec![vessel.resource.clone()])
+                    .build(),
+            );
+        }
+    }
+
+    for issue in &input.issues {
+        let row = &issue.row;
+        let key =
+            issue.scope.as_ref().or(input.scope.as_ref()).map(group_key_for_scope).unwrap_or_else(|| {
+                GroupKey::new(format!("issue-source/{}", row.reference.source.scope), row.reference.source.scope.clone())
+            });
+        let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
+        group.add_entry(
+            AwarenessEntry::builder()
+                .id(format!("issue/{}/{}", row.reference.source.scope, row.reference.id))
+                .kind(AwarenessKind::Issue)
+                .label(format!("#{} {}", row.reference.id, row.issue.title))
+                .state(AwarenessState::Waiting)
+                .phase(AwarenessPhase::Issue(row.issue.state))
+                .as_of(row.issue.as_of)
+                .issue_refs(vec![row.reference.clone()])
+                .build(),
+        );
+    }
+
+    for checkout in &input.checkouts {
+        let key = input
+            .scope
+            .as_ref()
+            .map(group_key_for_scope)
+            .unwrap_or_else(|| GroupKey::new(format!("repo/{}", checkout.repo), checkout.repo.to_string()));
+        let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
+        group.add_entry(
+            AwarenessEntry::builder()
+                .id(format!("checkout/{}/{}", checkout.host, checkout.path))
+                .kind(AwarenessKind::Checkout)
+                .label(format!("{} · {}", checkout.branch, checkout.path))
+                .state(AwarenessState::Active)
+                .as_of(as_of)
+                .refs(vec![checkout.resource.clone()])
+                .build(),
+        );
+    }
+
+    for independent in &input.independents {
+        let key = input
+            .scope
+            .as_ref()
+            .map(group_key_for_scope)
+            .or_else(|| independent.repository_key.as_ref().map(|repo| GroupKey::new(format!("repo/{repo}"), repo.to_string())))
+            .unwrap_or_else(|| GroupKey::new("unparented", "Unparented"));
+        let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
+        group.add_entry(
+            AwarenessEntry::builder()
+                .id(format!("independent/{}/{}", independent.resource.namespace, independent.name))
+                .kind(AwarenessKind::Independent)
+                .label(independent.name.clone())
+                .state(match independent.phase {
+                    flotilla_protocol::SessionPhase::Starting => AwarenessState::Waiting,
+                    flotilla_protocol::SessionPhase::Running => AwarenessState::Active,
+                    flotilla_protocol::SessionPhase::Stopped => AwarenessState::Done,
+                    flotilla_protocol::SessionPhase::Failed => AwarenessState::Failed,
+                })
+                .phase(AwarenessPhase::Session(independent.phase))
+                .as_of(as_of)
+                .refs(vec![independent.resource.clone()])
+                .build(),
+        );
+    }
+
+    let mut nodes = groups.into_values().collect::<Vec<_>>();
+    nodes.sort_by(|left, right| group_rank(left).cmp(&group_rank(right)).then_with(|| left.label.cmp(&right.label)));
+    nodes.truncate(input.limit.groups);
+    let rows = nodes
+        .into_iter()
+        .map(|mut group| {
+            group.entries.sort_by(|left, right| entry_rank(left).cmp(&entry_rank(right)).then_with(|| left.label.cmp(&right.label)));
+            group.entries.truncate(input.limit.entries);
+            AwarenessNode::builder()
+                .id(group.id)
+                .kind(group.kind)
+                .label(group.label)
+                .maybe_scope(group.scope)
+                .state(group.state)
+                .as_of(as_of)
+                .counts(group.counts)
+                .refs(group.refs)
+                .entries(group.entries)
+                .build()
+        })
+        .collect();
+    (rows, input.state)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GroupKey {
+    id: String,
+    label: String,
+    scope: Option<QueryScope>,
+}
+
+impl GroupKey {
+    fn new(id: impl Into<String>, label: impl Into<String>) -> Self {
+        Self { id: id.into(), label: label.into(), scope: None }
+    }
+
+    fn scoped(scope: QueryScope) -> Self {
+        Self { id: format!("project/{}/{}", scope.namespace, scope.name), label: scope.name.clone(), scope: Some(scope) }
+    }
+}
+
+impl Group {
+    fn new(key: GroupKey, kind: AwarenessKind) -> Self {
+        Self {
+            id: key.id,
+            label: key.label,
+            scope: key.scope,
+            kind,
+            refs: Vec::new(),
+            entries: Vec::new(),
+            counts: AwarenessCounts::default(),
+            state: AwarenessState::Unknown,
+        }
+    }
+
+    fn add_entry(&mut self, entry: AwarenessEntry) {
+        self.counts.total += 1;
+        match entry.kind {
+            AwarenessKind::Issue => self.counts.issues += 1,
+            AwarenessKind::Convoy => self.counts.convoys += 1,
+            AwarenessKind::Vessel => self.counts.vessels += 1,
+            AwarenessKind::Checkout => self.counts.checkouts += 1,
+            AwarenessKind::Independent => self.counts.independents += 1,
+            AwarenessKind::Fleet | AwarenessKind::Project => {}
+        }
+        match entry.state {
+            AwarenessState::Waiting => self.counts.waiting += 1,
+            AwarenessState::Active => self.counts.active += 1,
+            AwarenessState::Done => self.counts.done += 1,
+            AwarenessState::Failed => self.counts.failed += 1,
+            AwarenessState::Unknown | AwarenessState::Pending | AwarenessState::Cancelled => {}
+        }
+        self.state = stronger_state(self.state, entry.state);
+        self.entries.push(entry);
+    }
+}
+
+fn group_key_for_scope(scope: &QueryScope) -> GroupKey {
+    GroupKey::scoped(scope.clone())
+}
+
+fn group_key_for_convoy(grouping: AwarenessGrouping, convoy: &ConvoyRow) -> GroupKey {
+    match grouping {
+        AwarenessGrouping::Project => convoy.project_ref.as_deref().map(project_ref_key).unwrap_or_else(|| {
+            convoy
+                .repo
+                .as_ref()
+                .map_or_else(|| GroupKey::new("unparented", "Unparented"), |repo| GroupKey::new(format!("repo/{}", repo.0), repo.0.clone()))
+        }),
+        AwarenessGrouping::Convoy => GroupKey::new(format!("convoy/{}/{}", convoy.resource.namespace, convoy.name), convoy.name.clone()),
+    }
+}
+
+fn project_ref_key(value: &str) -> GroupKey {
+    if let Some((namespace, name)) = value.split_once('/') {
+        return GroupKey::scoped(QueryScope::new(namespace, name));
+    }
+    GroupKey::new(format!("project/{value}"), value.to_string())
+}
+
+fn convoy_label(convoy: &ConvoyRow) -> String {
+    convoy
+        .change_request
+        .as_ref()
+        .map_or_else(|| convoy.name.clone(), |change_request| format!("{} · PR #{}", convoy.name, change_request.id))
+}
+
+fn convoy_state(phase: ConvoyPhase, initializing: bool) -> AwarenessState {
+    if initializing {
+        return AwarenessState::Waiting;
+    }
+    match phase {
+        ConvoyPhase::Pending => AwarenessState::Pending,
+        ConvoyPhase::Active => AwarenessState::Active,
+        ConvoyPhase::Completed => AwarenessState::Done,
+        ConvoyPhase::Failed => AwarenessState::Failed,
+        ConvoyPhase::Cancelled | ConvoyPhase::Abandoned => AwarenessState::Cancelled,
+    }
+}
+
+fn work_state(phase: WorkPhase) -> AwarenessState {
+    match phase {
+        WorkPhase::Pending => AwarenessState::Pending,
+        WorkPhase::Ready => AwarenessState::Waiting,
+        WorkPhase::Launching | WorkPhase::Running => AwarenessState::Active,
+        WorkPhase::Complete => AwarenessState::Done,
+        WorkPhase::Failed => AwarenessState::Failed,
+        WorkPhase::Cancelled | WorkPhase::Abandoned => AwarenessState::Cancelled,
+    }
+}
+
+fn stronger_state(left: AwarenessState, right: AwarenessState) -> AwarenessState {
+    if state_rank(right) > state_rank(left) {
+        right
+    } else {
+        left
+    }
+}
+
+fn state_rank(state: AwarenessState) -> u8 {
+    match state {
+        AwarenessState::Failed => 5,
+        AwarenessState::Waiting => 4,
+        AwarenessState::Active => 3,
+        AwarenessState::Pending => 2,
+        AwarenessState::Unknown => 1,
+        AwarenessState::Done | AwarenessState::Cancelled => 0,
+    }
+}
+
+fn group_rank(group: &Group) -> (u8, std::cmp::Reverse<usize>, String) {
+    (std::cmp::Reverse(state_rank(group.state)).0, std::cmp::Reverse(group.counts.total), group.label.clone())
+}
+
+fn entry_rank(entry: &AwarenessEntry) -> (u8, u8) {
+    (std::cmp::Reverse(state_rank(entry.state)).0, match entry.kind {
+        AwarenessKind::Issue => 0,
+        AwarenessKind::Convoy => 1,
+        AwarenessKind::Vessel => 2,
+        AwarenessKind::Independent => 3,
+        AwarenessKind::Checkout => 4,
+        AwarenessKind::Fleet | AwarenessKind::Project => 5,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use flotilla_protocol::{HostName, Issue, IssueRef, IssueSource, IssueState, RepositoryKey, ResourceRef, SessionPhase};
+
+    use super::*;
+
+    fn convoy(project_ref: Option<&str>, name: &str, phase: ConvoyPhase) -> ConvoyRow {
+        ConvoyRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", name))
+            .name(name.to_string())
+            .workflow_ref("implement")
+            .phase(phase)
+            .maybe_project_ref(project_ref.map(str::to_owned))
+            .build()
+    }
+
+    fn issue(id: &str, title: &str) -> IssueRow {
+        let reference =
+            IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: id.into() };
+        IssueRow {
+            reference: reference.clone(),
+            issue: Issue {
+                reference,
+                title: title.into(),
+                body: None,
+                state: IssueState::Open,
+                labels: vec![],
+                as_of: Utc::now(),
+                association_keys: vec![],
+                provider_name: "github".into(),
+                provider_display_name: "GitHub".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn project_grouping_joins_convoys_issues_checkouts_and_independents() {
+        let scope = QueryScope::new("flotilla", "platform");
+        let (nodes, _) = project_awareness(AwarenessInput {
+            scope: Some(scope.clone()),
+            grouping: AwarenessGrouping::Project,
+            convoys: vec![convoy(Some("flotilla/platform"), "ship-it", ConvoyPhase::Active)],
+            issues: vec![ScopedIssueRow { scope: Some(scope.clone()), row: issue("862", "awareness band") }],
+            checkouts: vec![CheckoutRow::builder()
+                .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout"))
+                .repo(RepositoryKey("repo-a".into()))
+                .path("/work/flotilla")
+                .branch("feat/awareness-band")
+                .host(HostName::new("local"))
+                .authority(flotilla_protocol::LifecycleAuthority::Observed)
+                .build()],
+            independents: vec![IndependentRow::builder()
+                .resource(ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", "scratch"))
+                .name("scratch")
+                .repository_key(RepositoryKey("repo-a".into()))
+                .host(HostName::new("local"))
+                .phase(SessionPhase::Running)
+                .build()],
+            ..AwarenessInput::default()
+        });
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].label, "platform");
+        assert_eq!(nodes[0].counts.issues, 1);
+        assert_eq!(nodes[0].counts.checkouts, 1);
+        assert_eq!(nodes[0].counts.independents, 1);
+        assert!(nodes[0].entries.iter().any(|entry| entry.kind == AwarenessKind::Convoy && entry.label == "ship-it"));
+    }
+
+    #[test]
+    fn grouping_parameter_changes_shape_without_changing_input_facts() {
+        let input = AwarenessInput {
+            grouping: AwarenessGrouping::Project,
+            convoys: vec![
+                convoy(Some("flotilla/platform"), "first", ConvoyPhase::Active),
+                convoy(Some("flotilla/platform"), "second", ConvoyPhase::Pending),
+            ],
+            ..AwarenessInput::default()
+        };
+        let (project_nodes, _) = project_awareness(input.clone());
+        let (convoy_nodes, _) = project_awareness(AwarenessInput { grouping: AwarenessGrouping::Convoy, ..input });
+
+        assert_eq!(project_nodes.len(), 1);
+        assert_eq!(convoy_nodes.len(), 2);
+    }
+}

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6260,7 +6260,7 @@ impl DaemonHandle for InProcessDaemon {
 
     async fn subscribe_queries(&self, subscriber_id: uuid::Uuid, queries: &[QueryCursor]) -> Result<Vec<DaemonEvent>, String> {
         let state = self.aggregator_projection_state().await;
-        let newly_materialized = state.replace_subscriber(subscriber_id, queries);
+        let newly_materialized = state.replace_subscriber_expanding_awareness(subscriber_id, queries).await;
         let mut events = Vec::new();
         for cursor in queries {
             let result_set =

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent_adapter;
 pub mod agents;
 pub mod aggregator_projection;
 pub mod attachable;
+pub mod awareness_projection;
 pub mod checkout_integration;
 pub mod config;
 pub mod convert;

--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -51,6 +51,21 @@ impl QueryRegistry {
         created
     }
 
+    pub fn expand_fleet_awareness_demands(&self, scopes: &[flotilla_protocol::QueryScope]) -> HashSet<QueryId> {
+        let mut state = self.inner.lock().expect("query registry lock poisoned");
+        for queries in state.subscribers.values_mut() {
+            if !queries.iter().any(|query| matches!(query, QueryId::Awareness { scope: None, .. })) {
+                continue;
+            }
+            for scope in scopes {
+                queries.insert(QueryId::Issues { scope: scope.clone(), search: None });
+            }
+        }
+        let created = reconcile_demand(&mut state);
+        self.publish_demand(&state);
+        created
+    }
+
     pub fn remove(&self, subscriber: Uuid) {
         let mut state = self.inner.lock().expect("query registry lock poisoned");
         state.subscribers.remove(&subscriber);
@@ -60,6 +75,10 @@ impl QueryRegistry {
 
     pub fn result_set(&self, query: &QueryId) -> Option<ResultSet> {
         self.inner.lock().expect("query registry lock poisoned").demand_backed.get(query).cloned()
+    }
+
+    pub fn subscribed_queries(&self) -> HashSet<QueryId> {
+        self.inner.lock().expect("query registry lock poisoned").subscribers.values().flat_map(|queries| queries.iter().cloned()).collect()
     }
 
     /// Replace the current window of a live issue materialization. A fetch
@@ -184,13 +203,7 @@ impl QueryRegistry {
 }
 
 fn reconcile_demand(state: &mut RegistryState) -> HashSet<QueryId> {
-    let demanded: HashSet<QueryId> = state
-        .subscribers
-        .values()
-        .flat_map(|queries| queries.iter())
-        .filter(|query| matches!(query, QueryId::Issues { .. }))
-        .cloned()
-        .collect();
+    let demanded: HashSet<QueryId> = state.subscribers.values().flat_map(|queries| queries.iter().filter_map(issue_demand_query)).collect();
     state.demand_backed.retain(|query, _| demanded.contains(query));
     state.generations.retain(|query, _| demanded.contains(query));
     let mut created = HashSet::new();
@@ -204,6 +217,14 @@ fn reconcile_demand(state: &mut RegistryState) -> HashSet<QueryId> {
         }
     }
     created
+}
+
+fn issue_demand_query(query: &QueryId) -> Option<QueryId> {
+    match query {
+        QueryId::Issues { .. } => Some(query.clone()),
+        QueryId::Awareness { scope: Some(scope), .. } => Some(QueryId::Issues { scope: scope.clone(), search: None }),
+        QueryId::Convoys | QueryId::Independents { .. } | QueryId::Checkouts { .. } | QueryId::Awareness { scope: None, .. } => None,
+    }
 }
 
 fn unavailable_issues_result_set(query: QueryId) -> ResultSet {
@@ -229,6 +250,14 @@ mod tests {
 
     fn issues(name: &str) -> QueryId {
         QueryId::Issues { scope: QueryScope::new("flotilla", name), search: None }
+    }
+
+    fn awareness(name: &str) -> QueryId {
+        QueryId::Awareness {
+            scope: Some(QueryScope::new("flotilla", name)),
+            grouping: flotilla_protocol::AwarenessGrouping::Project,
+            limit: flotilla_protocol::AwarenessLimit::default(),
+        }
     }
 
     fn cursor(query: QueryId) -> QueryCursor {
@@ -357,6 +386,16 @@ mod tests {
 
         let mut demand = registry.subscribe_demand();
         assert_eq!(demand.borrow_and_update().keys().cloned().collect::<HashSet<_>>(), HashSet::from([query]));
+    }
+
+    #[test]
+    fn project_awareness_subscription_demands_its_issue_window() {
+        let registry = QueryRegistry::default();
+        let issue_query = issues("roadmap");
+        registry.replace(Uuid::new_v4(), &[cursor(awareness("roadmap"))]);
+
+        assert!(registry.result_set(&issue_query).is_some());
+        assert_eq!(registry.subscribe_demand().borrow().keys().cloned().collect::<HashSet<_>>(), HashSet::from([issue_query]));
     }
 
     #[test]

--- a/crates/flotilla-core/src/scoped_store.rs
+++ b/crates/flotilla-core/src/scoped_store.rs
@@ -165,6 +165,12 @@ impl<R: ScopedStoreRow> ScopedStoreProjection<R> {
         vec![MaterializedSet { seq, rows, state: ResultSetState::default() }.result_set(&scope)]
     }
 
+    pub fn project_scopes(&self) -> Vec<QueryScope> {
+        let mut scopes = self.projects.keys().cloned().collect::<Vec<_>>();
+        scopes.sort_by(|left, right| (&left.namespace, &left.name).cmp(&(&right.namespace, &right.name)));
+        scopes
+    }
+
     fn recompute_all(&mut self) -> Vec<ResultDelta> {
         let mut scopes = self.sets.keys().cloned().collect::<HashSet<_>>();
         scopes.insert(None);

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -932,7 +932,7 @@ impl Aggregator {
             })
             .collect();
         let deltas = self.state.replace_store_catalog(repositories, projects).await;
-        self.emit_store_deltas(deltas);
+        self.emit_store_deltas(deltas).await;
     }
 
     async fn rebuild_checkout_rows(&self) -> Result<(), ResourceError> {
@@ -956,16 +956,20 @@ impl Aggregator {
             })
             .collect::<Result<Vec<_>, ResourceError>>()?;
         let deltas = self.state.replace_local_checkout_rows(rows).await;
-        self.emit_store_deltas(deltas);
+        self.emit_store_deltas(deltas).await;
         Ok(())
     }
 
-    fn emit_store_deltas(&self, deltas: Vec<ResultDelta>) {
+    async fn emit_store_deltas(&self, deltas: Vec<ResultDelta>) {
         if self.bootstrapping {
             return;
         }
+        let changed = !deltas.is_empty();
         for delta in deltas {
             let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
+        }
+        if changed {
+            self.emit_awareness_result_sets().await;
         }
     }
 
@@ -993,7 +997,7 @@ impl Aggregator {
         let replacement =
             self.terminal_sessions.values().filter_map(|session| self.summarize_independent(session, &attachable_references)).collect();
         let deltas = self.state.replace_local_independent_rows(replacement).await;
-        self.emit_store_deltas(deltas);
+        self.emit_store_deltas(deltas).await;
     }
 
     pub async fn apply_replica_cache(&mut self, snapshots: Vec<FleetReplicaSnapshot>) {
@@ -1034,6 +1038,9 @@ impl Aggregator {
                     Rows::Checkouts { scope: Some(_), .. } => {
                         tracing::warn!(host = %host, "ignoring derived project checkout set in fleet replica snapshot");
                     }
+                    Rows::Awareness { .. } => {
+                        tracing::warn!(host = %host, "ignoring derived awareness tree in fleet replica snapshot");
+                    }
                 }
             }
             convoy_replacements.insert(host.clone(), convoy_rows);
@@ -1065,16 +1072,28 @@ impl Aggregator {
         }
 
         let independent_deltas = self.state.replace_independent_replica_rows(independent_replacements).await;
-        self.emit_store_deltas(independent_deltas);
+        self.emit_store_deltas(independent_deltas).await;
 
         let checkout_deltas = self.state.replace_checkout_replica_rows(checkout_replacements).await;
-        self.emit_store_deltas(checkout_deltas);
+        self.emit_store_deltas(checkout_deltas).await;
     }
 
     async fn emit_delta(&self, changed: Vec<ConvoyRow>, removed: Vec<ResourceRef>) {
         let seq = self.state.seq().await;
         let changes = QueryChanges::Convoys { changed, removed };
         let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changes, state: None })));
+        self.emit_awareness_result_sets().await;
+    }
+
+    async fn emit_awareness_result_sets(&self) {
+        for query in self.state.subscribed_queries() {
+            if !matches!(query, QueryId::Awareness { .. }) {
+                continue;
+            }
+            if let Some(result_set) = self.state.result_set_for(&query).await {
+                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
+            }
+        }
     }
 
     fn convoy_ref(&self, namespace: &str, name: &str) -> ResourceRef {

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -232,12 +232,12 @@ async fn load_window(
         Ok(sources) if !sources.is_empty() => sources,
         Ok(_) => {
             let conditions = vec![unavailable(None, "query scope has no issue source")];
-            publish_window(query, generation, Vec::new(), false, conditions.clone(), state, event_tx);
+            publish_window(query, generation, Vec::new(), false, conditions.clone(), state, event_tx).await;
             return MaterializedWindow { sources: Vec::new(), needs_full_reload: true, conditions };
         }
         Err(message) => {
             let conditions = vec![unavailable(None, message)];
-            publish_window(query, generation, Vec::new(), false, conditions.clone(), state, event_tx);
+            publish_window(query, generation, Vec::new(), false, conditions.clone(), state, event_tx).await;
             return MaterializedWindow { sources: Vec::new(), needs_full_reload: true, conditions };
         }
     };
@@ -342,6 +342,7 @@ async fn fetch_more(
     // clear `has_more` for clients.
     if let Some(delta) = state.apply_issue_changes(query, generation, changed, Vec::new(), result_state) {
         let _ = event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
+        publish_awareness_sets(state, event_tx).await;
     }
 }
 
@@ -447,10 +448,11 @@ async fn refresh_window(
     let result_state = demand_state(window.sources.iter().any(|source| source.has_more), conditions);
     if let Some(delta) = state.apply_issue_changes(query, generation, changed, removed, result_state) {
         let _ = event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
+        publish_awareness_sets(state, event_tx).await;
     }
 }
 
-fn publish_window(
+async fn publish_window(
     query: &QueryId,
     generation: u64,
     rows: Vec<IssueRow>,
@@ -461,6 +463,7 @@ fn publish_window(
 ) {
     if let Some(result_set) = state.replace_issues(query, generation, rows, demand_state(has_more, conditions)) {
         let _ = event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
+        publish_awareness_sets(state, event_tx).await;
     }
 }
 
@@ -475,7 +478,18 @@ async fn publish_loaded_window(
 ) {
     suppress_represented_rows(&mut rows, state).await;
     sort_rows(&mut rows);
-    publish_window(query, generation, rows, has_more, conditions, state, event_tx);
+    publish_window(query, generation, rows, has_more, conditions, state, event_tx).await;
+}
+
+async fn publish_awareness_sets(state: &AggregatorProjectionState, event_tx: &broadcast::Sender<DaemonEvent>) {
+    for query in state.subscribed_queries() {
+        if !matches!(query, QueryId::Awareness { .. }) {
+            continue;
+        }
+        if let Some(result_set) = state.result_set_for(&query).await {
+            let _ = event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
+        }
+    }
 }
 
 fn demand_state(has_more: bool, conditions: Vec<ResultSetCondition>) -> ResultSetState {

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -85,3 +85,4 @@ pub const KEY_FACTORY_ID: &str = "factory.id";
 pub const SEGMENT_PROJECT: &str = "git.repo";
 pub const SEGMENT_CONVOY: &str = "flotilla.convoy";
 pub const SEGMENT_VESSEL: &str = "flotilla.vessel";
+pub const SEGMENT_ISSUE: &str = "flotilla.issue";

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -13,13 +13,17 @@
 
 use std::collections::BTreeMap;
 
-use flotilla_protocol::result_set::{ConvoyPhase, ConvoyRow, IndependentRow, SessionPhase, VesselRow, WorkPhase};
+use flotilla_protocol::result_set::{
+    AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessPhase, AwarenessState, ConvoyPhase, ConvoyRow, IndependentRow, SessionPhase,
+    VesselRow, WorkPhase,
+};
 
 use crate::{
     keys::{
         ARCHIPELAGO_ORDINAL, CATALOG_TTL_MS, KEY_CONVOY_MESSAGE, KEY_CONVOY_PHASE, KEY_CONVOY_WORKFLOW, KEY_CREW_ROLES, KEY_FACTORY_ID,
         KEY_MATERIALIZE_RECIPE, KEY_MATERIALIZE_TARGET, KEY_PROJECT_NAME, KEY_SCOPE, KEY_SESSION, KEY_STATUS_ATTENTION, KEY_STATUS_STATE,
-        KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_PROJECT, SEGMENT_VESSEL, SOURCE_CONNECTOR,
+        KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_VESSEL,
+        SOURCE_CONNECTOR,
     },
     recipe::RecipeMint,
     wire::{GroupPath, GroupSegment, MetadataIdentity, MetadataPatch, MetadataTarget, MetadataValue, MetadataValueUpdate},
@@ -27,6 +31,7 @@ use crate::{
 
 /// The rows the catalog is projected from.
 pub struct CatalogInput<'a> {
+    pub awareness: Option<&'a [AwarenessNode]>,
     pub convoys: &'a [ConvoyRow],
     pub independents: &'a [IndependentRow],
 }
@@ -161,6 +166,12 @@ fn patch(target: MetadataTarget, set: BTreeMap<String, MetadataValueUpdate>, uns
 /// Project the fleet-merged rows into the catalog the PM should hold.
 pub fn project_catalog(input: &CatalogInput<'_>, mint: &dyn RecipeMint) -> Catalog {
     let mut catalog = Catalog::default();
+    if let Some(nodes) = input.awareness {
+        for node in nodes {
+            project_awareness_node(&mut catalog, node, mint);
+        }
+        return catalog;
+    }
     for convoy in input.convoys {
         project_convoy(&mut catalog, convoy, mint);
     }
@@ -168,6 +179,64 @@ pub fn project_catalog(input: &CatalogInput<'_>, mint: &dyn RecipeMint) -> Catal
         project_independent(&mut catalog, independent, mint);
     }
     catalog
+}
+
+fn project_awareness_node(catalog: &mut Catalog, node: &AwarenessNode, mint: &dyn RecipeMint) {
+    let project = GroupSegment::text(SEGMENT_PROJECT, node.id.clone()).with_label(node.label.clone());
+    assert_project_group(catalog, &project);
+    let project_path = GroupPath(vec![project.clone()]);
+    catalog.assert_facts(
+        MetadataTarget::Group(project_path),
+        vec![
+            (KEY_STATUS_STATE, MetadataValue::text(awareness_state(node.state))),
+            (KEY_SUMMARY_TEXT, MetadataValue::text(summary_text(&node.counts))),
+            (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:awareness/{}", node.id))),
+        ],
+        None,
+    );
+
+    for entry in &node.entries {
+        project_awareness_entry(catalog, &project, entry, mint);
+    }
+}
+
+fn project_awareness_entry(catalog: &mut Catalog, project: &GroupSegment, entry: &AwarenessEntry, _mint: &dyn RecipeMint) {
+    let segment_key = match entry.kind {
+        AwarenessKind::Convoy => SEGMENT_CONVOY,
+        AwarenessKind::Issue => SEGMENT_ISSUE,
+        AwarenessKind::Vessel | AwarenessKind::Independent | AwarenessKind::Checkout => SEGMENT_VESSEL,
+        AwarenessKind::Fleet | AwarenessKind::Project => return,
+    };
+    let path = GroupPath(vec![project.clone(), GroupSegment::text(segment_key, entry.id.clone()).with_label(entry.label.clone())]);
+    let mut facts = vec![
+        (KEY_STATUS_STATE, MetadataValue::text(awareness_state(entry.state))),
+        (KEY_SUMMARY_TEXT, MetadataValue::text(entry.label.clone())),
+        (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:awareness/{}", entry.id))),
+    ];
+    if let Some(AwarenessPhase::Work(phase)) = entry.phase {
+        facts.push((KEY_WORK_PHASE, MetadataValue::text(phase.as_str())));
+    }
+    if let Some(host) = entry.annotations.get(KEY_VESSEL_HOST) {
+        facts.push((KEY_VESSEL_HOST, MetadataValue::text(host.clone())));
+    }
+    if matches!(entry.state, AwarenessState::Waiting | AwarenessState::Failed) {
+        facts.push((KEY_STATUS_ATTENTION, MetadataValue::Bool(true)));
+    }
+    catalog.assert_facts(MetadataTarget::Group(path), facts, None);
+}
+
+fn awareness_state(state: AwarenessState) -> &'static str {
+    match state {
+        AwarenessState::Unknown | AwarenessState::Pending | AwarenessState::Cancelled => "idle",
+        AwarenessState::Waiting => "waiting",
+        AwarenessState::Active => "active",
+        AwarenessState::Done => "done",
+        AwarenessState::Failed => "failed",
+    }
+}
+
+fn summary_text(counts: &flotilla_protocol::AwarenessCounts) -> String {
+    format!("{} entries · {} issues · {} vessels · {} checkouts", counts.total, counts.issues, counts.vessels, counts.checkouts)
 }
 
 /// The project-level segment: `project_ref` when set (the project→convoy

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -1,4 +1,7 @@
-use flotilla_protocol::{result_set::CrewMemberSummary, HostName, RepoKey, ResourceRef};
+use flotilla_protocol::{
+    result_set::{AwarenessCounts, AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessState, CrewMemberSummary},
+    HostName, RepoKey, ResourceRef,
+};
 
 use super::*;
 use crate::{recipe::AttachOnlyRecipes, wire::MetadataPathValue};
@@ -58,6 +61,56 @@ fn text(patch: &MetadataPatch, key: &str) -> String {
 }
 
 #[test]
+fn awareness_tree_projects_project_issue_and_materializable_entries() {
+    let issue = AwarenessEntry::builder()
+        .id("issue/flotilla-org/flotilla/862".to_string())
+        .kind(AwarenessKind::Issue)
+        .label("#862 awareness band".to_string())
+        .state(AwarenessState::Waiting)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .build();
+    let vessel = AwarenessEntry::builder()
+        .id("vessel/dev/ship-it/coder".to_string())
+        .kind(AwarenessKind::Vessel)
+        .label("coder".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .phase(flotilla_protocol::AwarenessPhase::Work(WorkPhase::Running))
+        .annotations(std::collections::HashMap::from([(KEY_VESSEL_HOST.to_string(), "feta".to_string())]))
+        .build();
+    let node = AwarenessNode::builder()
+        .id("project/dev/platform".to_string())
+        .kind(AwarenessKind::Project)
+        .label("platform".to_string())
+        .state(AwarenessState::Waiting)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .counts(AwarenessCounts::builder().total(2).issues(1).vessels(1).build())
+        .entries(vec![issue, vessel])
+        .build();
+
+    let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint());
+    let patches = catalog.reassert_patches();
+
+    let project = GroupSegment::text(SEGMENT_PROJECT, "project/dev/platform").with_label("platform");
+    let issue_patch = find(
+        &patches,
+        &group(vec![
+            project.clone(),
+            GroupSegment::text(SEGMENT_ISSUE, "issue/flotilla-org/flotilla/862").with_label("#862 awareness band"),
+        ]),
+    );
+    assert_eq!(text(issue_patch, KEY_STATUS_STATE), "waiting");
+    assert_eq!(issue_patch.set[KEY_STATUS_ATTENTION].value, MetadataValue::Bool(true));
+
+    let vessel_patch =
+        find(&patches, &group(vec![project, GroupSegment::text(SEGMENT_VESSEL, "vessel/dev/ship-it/coder").with_label("coder")]));
+    assert_eq!(text(vessel_patch, KEY_WORK_PHASE), "running");
+    assert_eq!(text(vessel_patch, KEY_VESSEL_HOST), "feta");
+    assert!(!vessel_patch.set.contains_key(KEY_MATERIALIZE_TARGET));
+    assert!(!vessel_patch.set.contains_key(KEY_MATERIALIZE_RECIPE));
+}
+
+#[test]
 fn convoy_with_project_ref_projects_the_full_spine() {
     let reference = convoy_ref("dev", "manifest-extraction");
     let convoy = ConvoyRow::builder()
@@ -92,7 +145,7 @@ fn convoy_with_project_ref_projects_the_full_spine() {
             vessel().convoy(&reference).name("review").phase(WorkPhase::Complete).call(),
         ])
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     // project_ref wins over the repo as the project segment value.
@@ -139,7 +192,7 @@ fn failed_convoy_surfaces_attention_and_message() {
         .message("vessel checkout failed: disk full")
         .repo(RepoKey("flotilla-org/flotilla".to_owned()))
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     let project_segment = GroupSegment::text(SEGMENT_PROJECT, "flotilla-org/flotilla");
@@ -159,7 +212,7 @@ fn initializing_convoy_reads_waiting_whatever_its_phase() {
         .phase(ConvoyPhase::Active)
         .initializing(true)
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     let convoy_patch = find(&patches, &group(vec![GroupSegment::text(SEGMENT_CONVOY, "dev/warming-up")]));
@@ -177,7 +230,7 @@ fn ready_vessel_waits_with_attention() {
         .phase(ConvoyPhase::Active)
         .vessels(vec![vessel().convoy(&reference).name("implement").phase(WorkPhase::Ready).call()])
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     let implement =
@@ -195,7 +248,7 @@ fn independent_with_repo_groups_under_project_and_publishes_identity() {
         .repo("flotilla-org/flotilla")
         .attach("terminal-scratch")
         .call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
     let project_segment = GroupSegment::text(SEGMENT_PROJECT, "flotilla-org/flotilla");
@@ -224,7 +277,7 @@ fn independent_with_repo_groups_under_project_and_publishes_identity() {
 #[test]
 fn independent_without_repo_is_archipelago_ordered_first() {
     let independent = independent().namespace("dev").name("yeoman").phase(SessionPhase::Running).attach("yeoman").call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
     let group_patch = find(&patches, &group(vec![GroupSegment::text(SEGMENT_VESSEL, "yeoman")]));
@@ -239,7 +292,7 @@ fn independent_without_repo_is_archipelago_ordered_first() {
 #[test]
 fn independent_without_attach_lists_without_recipe() {
     let independent = independent().namespace("dev").name("wedged").phase(SessionPhase::Failed).repo("flotilla-org/flotilla").call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
     let group_patch = find(
@@ -262,11 +315,11 @@ fn diff_sets_changes_and_unsets_disappearances() {
         .message("boom")
         .build();
     let old_independent = independent().namespace("dev").name("scratch").phase(SessionPhase::Running).attach("scratch").call();
-    let previous = project_catalog(&CatalogInput { convoys: &[failed], independents: &[old_independent] }, &mint());
+    let previous = project_catalog(&CatalogInput { awareness: None, convoys: &[failed], independents: &[old_independent] }, &mint());
 
     let recovered =
         ConvoyRow::builder().resource(reference).name("auth").workflow_ref("implement-review").phase(ConvoyPhase::Active).build();
-    let current = project_catalog(&CatalogInput { convoys: &[recovered], independents: &[] }, &mint());
+    let current = project_catalog(&CatalogInput { awareness: None, convoys: &[recovered], independents: &[] }, &mint());
 
     let patches = current.diff_patches(&previous);
 
@@ -294,7 +347,7 @@ fn diff_sets_changes_and_unsets_disappearances() {
 fn reassert_covers_every_target() {
     let independent =
         independent().namespace("dev").name("scratch").phase(SessionPhase::Running).repo("flotilla-org/flotilla").attach("scratch").call();
-    let catalog = project_catalog(&CatalogInput { convoys: &[], independents: &[independent] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
     assert_eq!(patches.len(), 3, "project group + independent group + independent identity");
     assert!(patches.iter().all(|patch| patch.unset.is_empty()));
@@ -312,7 +365,7 @@ fn shared_spine_helpers_match_the_catalog_targets() {
         .repo(RepoKey("flotilla-org/flotilla".to_owned()))
         .vessels(vec![vessel().convoy(&reference).name("implement").phase(WorkPhase::Running).call()])
         .build();
-    let catalog = project_catalog(&CatalogInput { convoys: &[convoy], independents: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     // The actuator's tab stamp builds its scope with these helpers; they

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -105,8 +105,9 @@ pub use query::{
 };
 pub use resource_ref::ResourceRef;
 pub use result_set::{
-    CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow, CrewMemberSummary, DemandBackedMetadata, IndependentRow, IssueRow,
-    QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetCondition, ResultSetState, Rows, SessionPhase, VesselRow,
+    AwarenessCounts, AwarenessEntry, AwarenessGrouping, AwarenessKind, AwarenessLimit, AwarenessLink, AwarenessNode, AwarenessPhase,
+    AwarenessState, CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow, CrewMemberSummary, DemandBackedMetadata, IndependentRow,
+    IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetCondition, ResultSetState, Rows, SessionPhase, VesselRow,
     WorkPhase,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -8,7 +8,7 @@
 //! (columns, labels, tab composition) are consumer config and never appear
 //! on the wire.
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -44,6 +44,14 @@ pub enum QueryId {
     },
     /// Concrete observed checkouts fleet-wide (`None`) or in one Project.
     Checkouts { scope: Option<QueryScope> },
+    /// Awareness-band enrichment tree, fleet-wide or in one Project.
+    Awareness {
+        scope: Option<QueryScope>,
+        #[serde(default)]
+        grouping: AwarenessGrouping,
+        #[serde(default)]
+        limit: AwarenessLimit,
+    },
 }
 
 /// The Project scope owned by a curated query family. Repository membership
@@ -73,6 +81,7 @@ impl QueryId {
             Self::Independents { .. } => "independents",
             Self::Issues { .. } => "issues",
             Self::Checkouts { .. } => "checkouts",
+            Self::Awareness { .. } => "awareness",
         }
     }
 }
@@ -152,6 +161,14 @@ pub enum QueryChanges {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         removed: Vec<ResourceRef>,
     },
+    Awareness {
+        scope: Option<QueryScope>,
+        grouping: AwarenessGrouping,
+        limit: AwarenessLimit,
+        changed: Vec<AwarenessNode>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        removed: Vec<String>,
+    },
 }
 
 impl QueryChanges {
@@ -161,6 +178,9 @@ impl QueryChanges {
             Self::Independents { scope, .. } => QueryId::Independents { scope: scope.clone() },
             Self::Issues { scope, search, .. } => QueryId::Issues { scope: scope.clone(), search: search.clone() },
             Self::Checkouts { scope, .. } => QueryId::Checkouts { scope: scope.clone() },
+            Self::Awareness { scope, grouping, limit, .. } => {
+                QueryId::Awareness { scope: scope.clone(), grouping: *grouping, limit: *limit }
+            }
         }
     }
 
@@ -170,6 +190,7 @@ impl QueryChanges {
             Self::Independents { changed, .. } => changed.len(),
             Self::Issues { changed, .. } => changed.len(),
             Self::Checkouts { changed, .. } => changed.len(),
+            Self::Awareness { changed, .. } => changed.len(),
         }
     }
 
@@ -177,6 +198,7 @@ impl QueryChanges {
         match self {
             Self::Convoys { removed, .. } | Self::Independents { removed, .. } | Self::Checkouts { removed, .. } => removed.len(),
             Self::Issues { removed, .. } => removed.len(),
+            Self::Awareness { removed, .. } => removed.len(),
         }
     }
 
@@ -212,17 +234,24 @@ impl QueryChanges {
         }
     }
 
+    pub fn as_awareness(&self) -> Option<&[AwarenessNode]> {
+        match self {
+            Self::Awareness { changed, .. } => Some(changed),
+            _ => None,
+        }
+    }
+
     pub fn removed_resources(&self) -> Option<&[ResourceRef]> {
         match self {
             Self::Convoys { removed, .. } | Self::Independents { removed, .. } | Self::Checkouts { removed, .. } => Some(removed),
-            Self::Issues { .. } => None,
+            Self::Issues { .. } | Self::Awareness { .. } => None,
         }
     }
 
     pub fn removed_issues(&self) -> Option<&[IssueRef]> {
         match self {
             Self::Issues { removed, .. } => Some(removed),
-            _ => None,
+            Self::Convoys { .. } | Self::Independents { .. } | Self::Checkouts { .. } | Self::Awareness { .. } => None,
         }
     }
 }
@@ -285,6 +314,12 @@ pub enum Rows {
         scope: Option<QueryScope>,
         rows: Vec<CheckoutRow>,
     },
+    Awareness {
+        scope: Option<QueryScope>,
+        grouping: AwarenessGrouping,
+        limit: AwarenessLimit,
+        rows: Vec<AwarenessNode>,
+    },
 }
 
 impl Rows {
@@ -294,6 +329,9 @@ impl Rows {
             Self::Independents { scope, .. } => QueryId::Independents { scope: scope.clone() },
             Self::Issues { scope, search, .. } => QueryId::Issues { scope: scope.clone(), search: search.clone() },
             Self::Checkouts { scope, .. } => QueryId::Checkouts { scope: scope.clone() },
+            Self::Awareness { scope, grouping, limit, .. } => {
+                QueryId::Awareness { scope: scope.clone(), grouping: *grouping, limit: *limit }
+            }
         }
     }
 
@@ -303,6 +341,7 @@ impl Rows {
             Self::Independents { rows, .. } => rows.len(),
             Self::Issues { rows, .. } => rows.len(),
             Self::Checkouts { rows, .. } => rows.len(),
+            Self::Awareness { rows, .. } => rows.len(),
         }
     }
 
@@ -337,6 +376,168 @@ impl Rows {
             _ => None,
         }
     }
+
+    pub fn as_awareness(&self) -> Option<&[AwarenessNode]> {
+        match self {
+            Self::Awareness { rows, .. } => Some(rows),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AwarenessGrouping {
+    #[default]
+    Project,
+    Convoy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AwarenessLimit {
+    pub groups: usize,
+    pub entries: usize,
+}
+
+impl Default for AwarenessLimit {
+    fn default() -> Self {
+        Self { groups: 32, entries: 32 }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AwarenessKind {
+    Fleet,
+    Project,
+    Convoy,
+    Issue,
+    Vessel,
+    Independent,
+    Checkout,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AwarenessState {
+    #[default]
+    Unknown,
+    Pending,
+    Waiting,
+    Active,
+    Done,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum AwarenessPhase {
+    Convoy(ConvoyPhase),
+    Work(WorkPhase),
+    Session(SessionPhase),
+    Issue(IssueState),
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct AwarenessCounts {
+    #[builder(default)]
+    pub total: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub active: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub waiting: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub done: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub failed: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub issues: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub convoys: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub vessels: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub checkouts: usize,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    #[builder(default)]
+    pub independents: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AwarenessLink {
+    pub rel: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct AwarenessEntry {
+    pub id: String,
+    pub kind: AwarenessKind,
+    pub label: String,
+    pub state: AwarenessState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<AwarenessPhase>,
+    pub as_of: Timestamp,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub refs: Vec<ResourceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub issue_refs: Vec<IssueRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub links: Vec<AwarenessLink>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[builder(default)]
+    pub annotations: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct AwarenessNode {
+    pub id: String,
+    pub kind: AwarenessKind,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<QueryScope>,
+    pub state: AwarenessState,
+    pub as_of: Timestamp,
+    #[serde(default, skip_serializing_if = "AwarenessCounts::is_empty")]
+    #[builder(default)]
+    pub counts: AwarenessCounts,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub refs: Vec<ResourceRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub issue_refs: Vec<IssueRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub links: Vec<AwarenessLink>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[builder(default)]
+    pub annotations: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub entries: Vec<AwarenessEntry>,
+}
+
+impl AwarenessCounts {
+    pub fn is_empty(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 /// One row in an `issues{scope}` result set.

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -290,6 +290,7 @@ pub struct QueryTableCache {
     pub independents: HashMap<flotilla_protocol::QueryId, QueryTableResult<flotilla_protocol::IndependentRow>>,
     pub issues: HashMap<flotilla_protocol::QueryId, QueryTableResult<flotilla_protocol::IssueRow>>,
     pub checkouts: HashMap<flotilla_protocol::QueryId, QueryTableResult<flotilla_protocol::CheckoutRow>>,
+    pub awareness: HashMap<flotilla_protocol::QueryId, QueryTableResult<flotilla_protocol::AwarenessNode>>,
 }
 
 pub struct QueryTableResult<R> {
@@ -347,6 +348,11 @@ pub fn table_rows<'a>(
             .collect(),
         checkout_results: queries
             .checkouts
+            .iter()
+            .map(|(query, result)| crate::table_view::QueryRows { query, rows: &result.rows, state: &result.state })
+            .collect(),
+        awareness_results: queries
+            .awareness
             .iter()
             .map(|(query, result)| crate::table_view::QueryRows { query, rows: &result.rows, state: &result.state })
             .collect(),
@@ -1483,6 +1489,9 @@ impl App {
                     flotilla_protocol::Rows::Checkouts { rows, .. } => {
                         self.query_tables.checkouts.insert(query, QueryTableResult { rows: rows.clone(), state: result_set.state.clone() });
                     }
+                    flotilla_protocol::Rows::Awareness { rows, .. } => {
+                        self.query_tables.awareness.insert(query, QueryTableResult { rows: rows.clone(), state: result_set.state.clone() });
+                    }
                 }
             }
             DaemonEvent::ResultDelta(delta) => {
@@ -1542,6 +1551,16 @@ impl App {
                             |left, right| {
                                 (&left.host, &left.path, &left.resource.name).cmp(&(&right.host, &right.path, &right.resource.name))
                             },
+                        );
+                    }
+                    flotilla_protocol::QueryChanges::Awareness { changed, removed, .. } => {
+                        let result = self.query_tables.awareness.entry(query).or_default();
+                        result.apply_delta(
+                            changed,
+                            removed,
+                            delta.state.as_ref(),
+                            |row| row.id.clone(),
+                            |left, right| (&left.label, &left.id).cmp(&(&right.label, &right.id)),
                         );
                     }
                 }

--- a/crates/flotilla-tui/src/app/view_kind.rs
+++ b/crates/flotilla-tui/src/app/view_kind.rs
@@ -6,7 +6,7 @@
 //! `widgets::screen` (rendering dispatch deliberately stays with the
 //! widgets).
 
-use flotilla_protocol::{QueryId, QueryScope, ViewAddress};
+use flotilla_protocol::{AwarenessGrouping, AwarenessLimit, QueryId, QueryScope, ViewAddress};
 
 use crate::binding_table::{BindingModeId, KeyBindingMode};
 
@@ -17,6 +17,11 @@ pub(crate) fn queries(address: &ViewAddress, source_search: Option<&str>) -> Vec
         ViewAddress::Convoys { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. } => vec![QueryId::Convoys],
         ViewAddress::Project { namespace, name } => {
             vec![
+                QueryId::Awareness {
+                    scope: Some(QueryScope::new(namespace, name)),
+                    grouping: AwarenessGrouping::Project,
+                    limit: AwarenessLimit::default(),
+                },
                 QueryId::Convoys,
                 QueryId::Checkouts { scope: Some(QueryScope::new(namespace, name)) },
                 QueryId::Issues {
@@ -87,6 +92,11 @@ mod tests {
     fn project_view_composes_store_and_demand_backed_queries() {
         let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
         assert_eq!(queries(&address, None), vec![
+            QueryId::Awareness {
+                scope: Some(QueryScope::new("flotilla", "roadmap")),
+                grouping: AwarenessGrouping::Project,
+                limit: AwarenessLimit::default(),
+            },
             QueryId::Convoys,
             QueryId::Checkouts { scope: Some(QueryScope::new("flotilla", "roadmap")) },
             QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None },

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -30,7 +30,7 @@ use flotilla_manifest::{
     wire::MetadataPatch,
 };
 use flotilla_protocol::{
-    result_set::{ConvoyRow, IndependentRow, QueryChanges, ResultDelta, ResultSet, Rows},
+    result_set::{AwarenessGrouping, AwarenessLimit, AwarenessNode, ConvoyRow, IndependentRow, QueryChanges, ResultDelta, ResultSet, Rows},
     DaemonEvent, QueryCursor, QueryId, ResourceRef,
 };
 use tokio::sync::broadcast::error::RecvError;
@@ -138,6 +138,7 @@ pub enum Applied {
 /// The connector's held state: fleet-merged rows per query, per-query
 /// cursors, and the catalog as last published.
 pub struct ConnectorState {
+    awareness: Vec<AwarenessNode>,
     convoys: HashMap<ResourceRef, ConvoyRow>,
     independents: HashMap<ResourceRef, IndependentRow>,
     seqs: HashMap<QueryId, u64>,
@@ -148,6 +149,7 @@ pub struct ConnectorState {
 impl Default for ConnectorState {
     fn default() -> Self {
         Self {
+            awareness: Vec::new(),
             convoys: HashMap::new(),
             independents: HashMap::new(),
             seqs: HashMap::new(),
@@ -177,6 +179,9 @@ impl ConnectorState {
                 self.independents = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect();
             }
             Rows::Independents { scope: Some(_), .. } => return Applied::Ignored,
+            Rows::Awareness { rows, .. } => {
+                self.awareness = rows.clone();
+            }
             Rows::Issues { .. } | Rows::Checkouts { .. } => return Applied::Ignored,
         }
         self.seqs.insert(query, set.seq);
@@ -212,6 +217,17 @@ impl ConnectorState {
                 }
             }
             QueryChanges::Independents { scope: Some(_), .. } => return Applied::Ignored,
+            QueryChanges::Awareness { changed: rows, removed, .. } => {
+                self.awareness.retain(|node| !removed.contains(&node.id));
+                for row in rows {
+                    if let Some(existing) = self.awareness.iter_mut().find(|node| node.id == row.id) {
+                        *existing = row.clone();
+                    } else {
+                        self.awareness.push(row.clone());
+                    }
+                }
+                self.awareness.sort_by(|left, right| (&left.label, &left.id).cmp(&(&right.label, &right.id)));
+            }
             QueryChanges::Issues { .. } | QueryChanges::Checkouts { .. } => {
                 return Applied::Gap(query);
             }
@@ -225,7 +241,8 @@ impl ConnectorState {
     pub fn rebuild(&mut self, mint: &dyn RecipeMint) -> Vec<MetadataPatch> {
         let convoys: Vec<ConvoyRow> = self.convoys.values().cloned().collect();
         let independents: Vec<IndependentRow> = self.independents.values().cloned().collect();
-        let next = project_catalog(&CatalogInput { convoys: &convoys, independents: &independents }, mint);
+        let awareness = (!self.awareness.is_empty()).then_some(self.awareness.as_slice());
+        let next = project_catalog(&CatalogInput { awareness, convoys: &convoys, independents: &independents }, mint);
         let patches = next.diff_patches(&self.catalog);
         self.catalog = next;
         patches
@@ -240,7 +257,12 @@ impl ConnectorState {
     /// stale by construction, so resubscribing with these gets it a full
     /// [`ResultSet`].
     pub fn cursors(&self) -> Vec<QueryCursor> {
-        QueryId::ALWAYS_MATERIALIZED.iter().cloned().map(|query| QueryCursor { since: self.seqs.get(&query).copied(), query }).collect()
+        QueryId::ALWAYS_MATERIALIZED
+            .iter()
+            .cloned()
+            .chain([QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() }])
+            .map(|query| QueryCursor { since: self.seqs.get(&query).copied(), query })
+            .collect()
     }
 }
 

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -5,12 +5,12 @@ use std::sync::{
 
 use async_trait::async_trait;
 use flotilla_manifest::{
-    keys::{KEY_SESSION, KEY_STATUS_STATE, SEGMENT_VESSEL},
+    keys::{KEY_SESSION, KEY_STATUS_STATE, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_VESSEL},
     wire::{GroupPath, GroupSegment, MetadataIdentity, MetadataTarget, MetadataValue},
 };
 use flotilla_protocol::{
-    result_set::SessionPhase, Command, CommandValue, HostName, RepoInfo, RepoSelector, RepoSnapshot, ResourceRef, StatusResponse,
-    StreamKey, TopologyResponse,
+    result_set::{AwarenessCounts, AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessState, SessionPhase},
+    Command, CommandValue, HostName, RepoInfo, RepoSelector, RepoSnapshot, ResourceRef, StatusResponse, StreamKey, TopologyResponse,
 };
 use tokio::sync::broadcast;
 
@@ -40,6 +40,32 @@ fn independents_delta(seq: u64, changed: Vec<IndependentRow>, removed: Vec<Resou
 
 fn convoys_set(seq: u64) -> DaemonEvent {
     DaemonEvent::ResultSet(Box::new(ResultSet { seq, rows: Rows::Convoys(vec![]), state: Default::default() }))
+}
+
+fn awareness_set(seq: u64, rows: Vec<AwarenessNode>) -> DaemonEvent {
+    DaemonEvent::ResultSet(Box::new(ResultSet {
+        seq,
+        rows: Rows::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default(), rows },
+        state: Default::default(),
+    }))
+}
+
+fn awareness_node() -> AwarenessNode {
+    AwarenessNode::builder()
+        .id("project/dev/platform".to_string())
+        .kind(AwarenessKind::Project)
+        .label("platform".to_string())
+        .state(AwarenessState::Waiting)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .counts(AwarenessCounts::builder().total(1).issues(1).build())
+        .entries(vec![AwarenessEntry::builder()
+            .id("issue/flotilla-org/flotilla/862".to_string())
+            .kind(AwarenessKind::Issue)
+            .label("#862 awareness band".to_string())
+            .state(AwarenessState::Waiting)
+            .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+            .build()])
+        .build()
 }
 
 fn mint() -> AttachOnlyRecipes {
@@ -87,6 +113,10 @@ fn gaps_and_unseeded_deltas_request_resubscription() {
     assert_eq!(independents.since, Some(1));
     let convoys = cursors.iter().find(|cursor| cursor.query == QueryId::Convoys).expect("convoys cursor");
     assert_eq!(convoys.since, None, "never-seen queries subscribe from scratch");
+    assert!(
+        cursors.iter().any(|cursor| matches!(cursor.query, QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, .. })),
+        "pm connector subscribes to awareness transport"
+    );
 }
 
 #[test]
@@ -107,6 +137,27 @@ fn rebuild_publishes_diffs_not_repeats() {
         after_removal.iter().find(|patch| patch.target == independent_group("scratch")).expect("unset patch for removed independent");
     assert!(group_patch.set.is_empty());
     assert!(group_patch.unset.contains(&KEY_STATUS_STATE.to_owned()));
+}
+
+#[test]
+fn rebuild_prefers_awareness_transport_when_available() {
+    let mut state = ConnectorState::default();
+    state.apply_event(&independents_set(1, vec![independent_row("scratch", SessionPhase::Running)]));
+    assert_eq!(state.apply_event(&awareness_set(1, vec![awareness_node()])), Applied::Updated);
+
+    let patches = state.rebuild(&mint());
+
+    assert!(patches.iter().any(|patch| {
+        patch.target
+            == MetadataTarget::Group(GroupPath(vec![
+                GroupSegment::text(SEGMENT_PROJECT, "project/dev/platform").with_label("platform"),
+                GroupSegment::text(SEGMENT_ISSUE, "issue/flotilla-org/flotilla/862").with_label("#862 awareness band"),
+            ]))
+    }));
+    assert!(
+        !patches.iter().any(|patch| patch.target == independent_group("scratch")),
+        "raw independent fallback is not projected once awareness is available"
+    );
 }
 
 struct RecordingSink {

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -7,8 +7,9 @@
 use std::collections::{HashMap, HashSet};
 
 use flotilla_protocol::{
-    result_set::Timestamp, ChangeRequestStatus, CheckoutRow, HostName, IndependentRow, IssueRef, IssueRow, QueryId, QueryScope, RepoKey,
-    RepositoryKey, ResultSetCondition, ResultSetState, SessionPhase, ViewAddress,
+    result_set::Timestamp, AwarenessCounts, AwarenessGrouping, AwarenessLimit, AwarenessNode, ChangeRequestStatus, CheckoutRow, HostName,
+    IndependentRow, IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey, ResultSetCondition, ResultSetState, SessionPhase,
+    ViewAddress,
 };
 
 use crate::{
@@ -432,6 +433,7 @@ pub struct TableRows<'a> {
     pub independent_results: Vec<QueryRows<'a, IndependentRow>>,
     pub issue_results: Vec<QueryRows<'a, IssueRow>>,
     pub checkout_results: Vec<QueryRows<'a, CheckoutRow>>,
+    pub awareness_results: Vec<QueryRows<'a, AwarenessNode>>,
     pub source_search: Option<&'a str>,
 }
 
@@ -563,19 +565,49 @@ pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec
     let checkouts_address = ViewAddress::Checkouts { scope: Some(scope.clone()) };
     let issues_address = ViewAddress::Issues { scope: scope.clone() };
     let independents_address = ViewAddress::Independents { scope: Some(scope) };
+    let awareness_counts = awareness_counts_for_project(namespace, name, data);
     let mut checkouts = project(&checkouts_address, data).unwrap_or_else(|_| pending_project_table(&checkouts_address));
     let mut issues = project(&issues_address, data).unwrap_or_else(|_| pending_project_table(&issues_address));
     let mut independents = project(&independents_address, data).unwrap_or_else(|_| pending_project_table(&independents_address));
-    checkouts.title = "Checkouts".to_string();
-    issues.title = "Issues".to_string();
-    independents.title = "Independents".to_string();
+    if let Some(counts) = awareness_counts {
+        checkouts.title = format!("Checkouts ({})", counts.checkouts);
+        issues.title = format!("Issues ({})", counts.issues);
+        independents.title = format!("Independents ({})", counts.independents);
+    } else {
+        checkouts.title = "Checkouts".to_string();
+        issues.title = "Issues".to_string();
+        independents.title = "Independents".to_string();
+    }
+    let mut convoys_title = "Convoys".to_string();
+    if let Some(counts) = awareness_counts {
+        convoys_title = format!("Convoys ({})", counts.convoys);
+    }
 
     Ok(vec![
-        ProjectPanel { kind: ProjectPanelKind::Convoys, target: ViewAddress::Convoys { namespace: namespace.clone() }, table: convoys },
+        ProjectPanel {
+            kind: ProjectPanelKind::Convoys,
+            target: ViewAddress::Convoys { namespace: namespace.clone() },
+            table: TableView { title: convoys_title, ..convoys },
+        },
         ProjectPanel { kind: ProjectPanelKind::Checkouts, target: checkouts_address, table: checkouts },
         ProjectPanel { kind: ProjectPanelKind::Issues, target: issues_address, table: issues },
         ProjectPanel { kind: ProjectPanelKind::Independents, target: independents_address, table: independents },
     ])
+}
+
+fn awareness_counts_for_project<'a>(namespace: &str, name: &str, data: &'a TableRows<'_>) -> Option<&'a AwarenessCounts> {
+    let query = QueryId::Awareness {
+        scope: Some(QueryScope::new(namespace, name)),
+        grouping: AwarenessGrouping::Project,
+        limit: AwarenessLimit::default(),
+    };
+    data.awareness_results
+        .iter()
+        .find(|result| *result.query == query)?
+        .rows
+        .iter()
+        .find(|node| node.scope.as_ref().is_some_and(|scope| scope.namespace == namespace && scope.name == name))
+        .map(|node| &node.counts)
 }
 
 fn pending_project_table(address: &ViewAddress) -> TableView {
@@ -1100,8 +1132,8 @@ fn attach_independent(row: &IndependentRow) -> Option<TableIntent> {
 #[cfg(test)]
 mod tests {
     use flotilla_protocol::{
-        test_support::TestIssue, DemandBackedMetadata, LifecycleAuthority, QueryId, QueryScope, RepositoryKey, ResourceRef,
-        ResultSetCondition, ResultSetState,
+        test_support::TestIssue, AwarenessCounts, AwarenessKind, AwarenessNode, AwarenessState, DemandBackedMetadata, LifecycleAuthority,
+        QueryId, QueryScope, RepositoryKey, ResourceRef, ResultSetCondition, ResultSetState,
     };
 
     use super::*;
@@ -1331,6 +1363,17 @@ mod tests {
         let issue_query = QueryId::Issues { scope: scope.clone(), search: None };
         let checkout_query = QueryId::Checkouts { scope: Some(scope.clone()) };
         let independent_query = QueryId::Independents { scope: Some(scope.clone()) };
+        let awareness_query =
+            QueryId::Awareness { scope: Some(scope.clone()), grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
+        let awareness = AwarenessNode::builder()
+            .id("project/flotilla/roadmap".to_string())
+            .kind(AwarenessKind::Project)
+            .label("roadmap".to_string())
+            .scope(scope.clone())
+            .state(AwarenessState::Active)
+            .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+            .counts(AwarenessCounts::builder().total(4).convoys(1).issues(1).checkouts(1).independents(1).build())
+            .build();
         let state = ResultSetState::default();
         let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
 
@@ -1339,6 +1382,7 @@ mod tests {
             issue_results: vec![QueryRows { query: &issue_query, rows: std::slice::from_ref(&issue_row), state: &state }],
             checkout_results: vec![QueryRows { query: &checkout_query, rows: std::slice::from_ref(&checkout), state: &state }],
             independent_results: vec![QueryRows { query: &independent_query, rows: std::slice::from_ref(&independent), state: &state }],
+            awareness_results: vec![QueryRows { query: &awareness_query, rows: std::slice::from_ref(&awareness), state: &state }],
             ..TableRows::default()
         })
         .expect("project panels");
@@ -1354,6 +1398,12 @@ mod tests {
             "checkouts?project=flotilla%2Froadmap",
             "issues?project=flotilla%2Froadmap",
             "independents?project=flotilla%2Froadmap",
+        ]);
+        assert_eq!(panels.iter().map(|panel| panel.table.title.as_str()).collect::<Vec<_>>(), vec![
+            "Convoys (1)",
+            "Checkouts (1)",
+            "Issues (1)",
+            "Independents (1)",
         ]);
         assert_eq!(panels[0].table.rows[0].cells[0].text, "tables");
         assert_eq!(panels[1].table.rows[0].cells[1].text, "/work/flotilla");


### PR DESCRIPTION
Closes #862.

## Summary
- add the awareness query/result/delta protocol family and shared projection types
- project awareness nodes from convoys, issues, checkouts, and independents, including scoped fleet/project grouping
- wire awareness through aggregator, daemon issue materialization, PM connector catalog projection, and TUI project panels

## Verification
- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked