### PR TITLE
Open convoy rows in presentation manager

### DIFF
--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -119,6 +119,7 @@ pub struct Aggregator {
     sessions_by_source: HashMap<LocalSource, HashMap<SessionKey, ResourceObject<TerminalSession>>>,
     presentation_workspaces: HashMap<PresentationKey, String>,
     terminal_sessions: HashMap<SessionKey, ResourceObject<TerminalSession>>,
+    attachable_references: HashSet<String>,
     projects: HashMap<(String, String), ResourceObject<Project>>,
     repositories: HashMap<RepositoryKey, ResourceObject<Repository>>,
     observed_checkouts: HashMap<ResourceRef, ResourceObject<Checkout>>,
@@ -149,6 +150,7 @@ impl Aggregator {
             sessions_by_source: HashMap::new(),
             presentation_workspaces: HashMap::new(),
             terminal_sessions: HashMap::new(),
+            attachable_references: HashSet::new(),
             projects: HashMap::new(),
             repositories: HashMap::new(),
             observed_checkouts: HashMap::new(),
@@ -977,21 +979,19 @@ impl Aggregator {
         }
         self.terminal_sessions = effective_sessions;
 
-        let attachable_references = match &self.attach_resolver {
+        self.attachable_references = match &self.attach_resolver {
             Some(daemon) => {
-                let references = self
-                    .terminal_sessions
-                    .values()
-                    .filter(|session| is_independent_session(session))
-                    .map(|session| session.metadata.name.clone())
-                    .collect::<Vec<_>>();
+                let references = self.terminal_sessions.values().map(|session| session.metadata.name.clone()).collect::<Vec<_>>();
                 daemon.resolvable_attach_references(&references).await.unwrap_or_default()
             }
             None => HashSet::new(),
         };
 
-        let replacement =
-            self.terminal_sessions.values().filter_map(|session| self.summarize_independent(session, &attachable_references)).collect();
+        let replacement = self
+            .terminal_sessions
+            .values()
+            .filter_map(|session| self.summarize_independent(session, &self.attachable_references))
+            .collect();
         let deltas = self.state.replace_local_independent_rows(replacement).await;
         self.emit_store_deltas(deltas);
     }
@@ -1121,6 +1121,20 @@ impl Aggregator {
         self.presentation_workspaces.get(&(namespace.to_string(), convoy.to_string(), vessel.to_string())).cloned()
     }
 
+    fn vessel_materialize(&self, namespace: &str, convoy: &str, vessel: &str) -> Option<String> {
+        self.terminal_sessions
+            .values()
+            .filter(|session| {
+                session.metadata.namespace == namespace
+                    && session.metadata.labels.get(CONVOY_LABEL).is_some_and(|value| value == convoy)
+                    && session.metadata.labels.get(VESSEL_LABEL).is_some_and(|value| value == vessel)
+                    && session.status.as_ref().is_some_and(|status| status.phase == TerminalSessionPhase::Running)
+                    && self.attachable_references.contains(&session.metadata.name)
+            })
+            .min_by_key(|session| &session.metadata.name)
+            .map(|session| session.metadata.name.clone())
+    }
+
     fn summarize(&self, convoy: &ResourceObject<Convoy>) -> ConvoyRow {
         let namespace = &convoy.metadata.namespace;
         let name = &convoy.metadata.name;
@@ -1222,6 +1236,7 @@ impl Aggregator {
             .depends_on(definition.depends_on.clone())
             .host(self.local_host.clone())
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
+            .maybe_materialize(self.vessel_materialize(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
             .complete_work(state.is_some_and(|state| !state.phase.is_terminal()))
             .needs_attention(needs_attention)
             .build()

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -882,6 +882,7 @@ impl Aggregator {
 
     async fn apply_environment_event(&mut self, _event: WatchEvent<Environment>) {
         self.rebuild_independents_projection().await;
+        self.rebuild_local_projection().await;
     }
 
     async fn apply_project_event(&mut self, event: WatchEvent<Project>) {
@@ -1331,9 +1332,9 @@ mod tests {
     use chrono::Utc;
     use flotilla_protocol::result_set::{ResultSet, ResultSetState};
     use flotilla_resources::{
-        ConvoyRepositorySpec, ConvoySpec, CrewSpec, InMemoryBackend, InputMeta, ObjectMeta, PlacementStatus, PresentationPhase,
-        PresentationSpec, PresentationStatus, ResourceBackend, Stance, TerminalAttention, TerminalAttentionSource, TerminalSessionSource,
-        TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
+        ConvoyRepositorySpec, ConvoySpec, CrewSpec, EnvironmentSpec, HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta,
+        PlacementStatus, PresentationPhase, PresentationSpec, PresentationStatus, ResourceBackend, Stance, TerminalAttention,
+        TerminalAttentionSource, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
     };
     use futures::stream;
     use tokio::{sync::Mutex, time::timeout};
@@ -1411,6 +1412,10 @@ mod tests {
         calls: AtomicUsize,
     }
 
+    struct FlippingAttachResolver {
+        calls: AtomicUsize,
+    }
+
     struct ScriptedChangeRequestResolver {
         results: Mutex<VecDeque<Result<Option<flotilla_protocol::ConvoyChangeRequest>, String>>>,
         branches: Mutex<Vec<String>>,
@@ -1436,6 +1441,14 @@ mod tests {
         async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(references.iter().cloned().collect())
+        }
+    }
+
+    #[async_trait]
+    impl AttachCapabilityResolver for FlippingAttachResolver {
+        async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(if call == 0 { HashSet::new() } else { references.iter().cloned().collect() })
         }
     }
 
@@ -1603,6 +1616,18 @@ mod tests {
             .expect("set scripted terminal session status")
     }
 
+    async fn environment_object(name: &str) -> ResourceObject<Environment> {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        backend
+            .using::<Environment>("flotilla")
+            .create(&InputMeta::builder().name(name.to_string()).build(), &EnvironmentSpec {
+                host_direct: Some(HostDirectEnvironmentSpec { host_ref: "local".to_string(), repo_default_dir: "/repo".to_string() }),
+                docker: None,
+            })
+            .await
+            .expect("create scripted environment")
+    }
+
     #[tokio::test]
     async fn independents_projection_resolves_attach_capabilities_once_per_rebuild() {
         let state = AggregatorProjectionState::new();
@@ -1619,6 +1644,28 @@ mod tests {
         let rows = result_set.rows.as_independents().expect("session rows");
         assert_eq!(rows.len(), 2);
         assert!(rows.iter().all(|row| row.attach.as_deref() == Some(row.name.as_str())));
+    }
+
+    #[tokio::test]
+    async fn environment_event_refreshes_convoy_vessel_materialization_capability() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(4);
+        let resolver = Arc::new(FlippingAttachResolver { calls: AtomicUsize::new(0) });
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx).with_attach_resolver(resolver);
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy_with_vessel("convoy-a").await)).await;
+
+        let mut session = session_object("terminal-convoy-a-implement").await;
+        session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        aggregator.replace_session_source(LocalSource::Durable, vec![session]).await;
+
+        let before = state.result_set().await;
+        assert_eq!(before.rows.as_convoys().expect("convoy rows")[0].vessels[0].materialize, None);
+
+        aggregator.apply_environment_event(WatchEvent::Modified(environment_object("local").await)).await;
+
+        let after = state.result_set().await;
+        assert_eq!(after.rows.as_convoys().expect("convoy rows")[0].vessels[0].materialize.as_deref(), Some("terminal-convoy-a-implement"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -679,7 +679,9 @@ async fn running_convoyless_session_emits_attachable_independent_row() {
         })
         .expect("convoys replay result set");
     let convoy = convoy_rows.iter().find(|row| row.name == "convoy-a").expect("convoy row for bound terminal session");
-    assert!(convoy.vessels.iter().any(|vessel| vessel.name == "coder"), "convoy-bound terminal session surfaces on its vessel row");
+    let vessel = convoy.vessels.iter().find(|vessel| vessel.name == "coder").expect("convoy-bound session vessel row");
+    assert_eq!(vessel.materialize.as_deref(), Some("terminal-convoy-coder"));
+    assert_eq!(vessel.attach, None, "materialization must not pretend an observed PM workspace already exists");
 
     let row = rows.iter().find(|row| row.name == "terminal-yeoman").expect("attachable session row");
     assert_eq!(row.repo.as_ref().map(|repo| repo.0.as_str()), Some("flotilla-org/flotilla"));

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -284,7 +284,7 @@ fn project_vessel(
     }
     // Vessels materialise at workspace granularity (ADR 0012); the recipe
     // exists iff the daemon can resolve the attach — a capability fact.
-    if let Some(recipe) = vessel.attach.as_deref().and_then(|attach_ref| mint.attach(attach_ref)) {
+    if let Some(recipe) = vessel.materialize.as_deref().and_then(|attach_ref| mint.attach(attach_ref)) {
         facts.push((KEY_MATERIALIZE_TARGET, MetadataValue::text("workspace")));
         facts.push((KEY_MATERIALIZE_RECIPE, MetadataValue::text(recipe.command())));
     }

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -16,13 +16,13 @@ fn session_ref(namespace: &str, name: &str) -> ResourceRef {
 }
 
 #[bon::builder]
-fn vessel(convoy: &ResourceRef, name: &str, phase: WorkPhase, attach: Option<&str>) -> VesselRow {
+fn vessel(convoy: &ResourceRef, name: &str, phase: WorkPhase, materialize: Option<&str>) -> VesselRow {
     VesselRow::builder()
         .resource(convoy.subresource(format!("vessels/{name}")))
         .name(name)
         .phase(phase)
         .host(HostName::new("feta"))
-        .maybe_attach(attach.map(str::to_owned))
+        .maybe_materialize(materialize.map(str::to_owned))
         .build()
 }
 
@@ -87,7 +87,7 @@ fn convoy_with_project_ref_projects_the_full_spine() {
                     },
                 ])
                 .host(HostName::new("feta"))
-                .attach("workspace-1")
+                .materialize("terminal-implement")
                 .build(),
             vessel().convoy(&reference).name("review").phase(WorkPhase::Complete).call(),
         ])
@@ -118,7 +118,7 @@ fn convoy_with_project_ref_projects_the_full_spine() {
     assert_eq!(text(implement, KEY_STATUS_STATE), "active");
     assert_eq!(text(implement, KEY_VESSEL_HOST), "feta");
     assert_eq!(text(implement, KEY_MATERIALIZE_TARGET), "workspace");
-    assert_eq!(text(implement, KEY_MATERIALIZE_RECIPE), "flotilla attach workspace-1");
+    assert_eq!(text(implement, KEY_MATERIALIZE_RECIPE), "flotilla attach terminal-implement");
     assert_eq!(text(implement, KEY_FACTORY_ID), "flotilla:convoys/dev/manifest-extraction/implement");
     assert_eq!(implement.set[KEY_CREW_ROLES].value, MetadataValue::StringList(vec!["coder".to_owned(), "reviewer".to_owned()]));
 

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -123,7 +123,7 @@ pub use snapshot::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 15;
+pub const PROTOCOL_VERSION: u32 = 16;
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -577,6 +577,7 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
         }])
         .host(HostName::new("local"))
         .attach("ws-1".to_string())
+        .materialize("terminal-implement".to_string())
         .complete_work(true)
         .build();
     let review = VesselRow::builder()
@@ -608,6 +609,7 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
     let rows = result_set.rows.as_convoys().expect("convoy rows");
     assert_eq!(rows[0].vessels[1].depends_on, vec![rows[0].vessels[0].name.clone()]);
     assert!(rows[0].vessels[0].attach.is_some(), "presentation join surfaces as attach capability");
+    assert_eq!(rows[0].vessels[0].materialize.as_deref(), Some("terminal-implement"));
     assert!(rows[0].vessels[1].attach.is_none());
     assert!(rows[0].vessels[0].complete_work);
     assert!(!rows[0].vessels[1].complete_work, "capabilities default closed");

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -566,6 +566,11 @@ pub struct VesselRow {
     /// an attach on this row.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attach: Option<String>,
+    /// Terminal-session reference from which a presentation manager can
+    /// materialize this vessel's workspace. This is deliberately distinct
+    /// from `attach`, which names an already-observed PM workspace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialize: Option<String>,
     /// Capability fact: the daemon will accept completing this vessel's work.
     #[builder(default)]
     pub complete_work: bool,

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -393,6 +393,34 @@ impl App {
 
     pub(super) fn execute_table_intent(&mut self, intent: TableIntent) {
         let (mut command, host) = match intent {
+            TableIntent::OpenInPm(target) => {
+                let locally_homed = target
+                    .host
+                    .as_ref()
+                    .is_some_and(|home| home == &HostName::local() || self.model.my_host().is_some_and(|local| home == local));
+                if !locally_homed {
+                    let home = target.host.as_ref().map_or_else(|| "unknown host".to_string(), ToString::to_string);
+                    self.set_status_message(Some(format!("{} is not reachable from this PM yet (homed on {home})", target.label)));
+                    return;
+                }
+                let Some(connector) = self.pm_connector.clone() else {
+                    self.set_status_message(Some("No presentation manager is connected".to_string()));
+                    return;
+                };
+                let working_directory = self
+                    .table_action_repo(target.repo_hint.as_ref())
+                    .and_then(|identity| self.model.repos.get(&identity).map(|repo| repo.path.clone()))
+                    .or_else(|| std::env::current_dir().ok())
+                    .unwrap_or_else(|| std::path::PathBuf::from("."));
+                let tx = self.pm_update_tx.clone();
+                let label = target.label.clone();
+                self.set_status_message(Some(format!("Opening {label} in PM...")));
+                tokio::spawn(async move {
+                    let result = connector.open(&target, &working_directory).await;
+                    let _ = tx.send(super::PmOpenUpdate { label, result });
+                });
+                return;
+            }
             TableIntent::AttachWorkspace { workspace_ref, host, repo_hint } => {
                 let Some(repo_identity) = self.table_action_repo(repo_hint.as_ref()) else {
                     self.set_status_message(Some("Cannot attach workspace: the convoy does not identify a tracked repository".to_string()));

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use flotilla_protocol::{
@@ -18,9 +21,73 @@ use crate::{
         },
         PeerStatus, TuiHostState,
     },
+    pm_open::{OpenInPmTarget, PmConnector},
     status_bar::{StatusBarAction, StatusBarTarget},
     widgets::section_table::IssueRow,
 };
+
+#[derive(Default)]
+struct RecordingPmConnector {
+    calls: Mutex<Vec<OpenInPmTarget>>,
+}
+
+#[async_trait::async_trait]
+impl PmConnector for RecordingPmConnector {
+    async fn open(&self, target: &OpenInPmTarget, _working_directory: &Path) -> Result<(), String> {
+        self.calls.lock().expect("recording connector lock").push(target.clone());
+        Ok(())
+    }
+}
+
+fn pm_target(host: HostName) -> OpenInPmTarget {
+    OpenInPmTarget {
+        namespace: "dev".into(),
+        convoy: "tables".into(),
+        vessel: Some("implement".into()),
+        label: "tables".into(),
+        host: Some(host),
+        project_ref: Some("flotilla".into()),
+        repo_hint: None,
+        workspace_ref: None,
+        materialize_ref: Some("terminal-implement".into()),
+    }
+}
+
+#[tokio::test]
+async fn open_in_pm_intent_dispatches_only_local_targets_to_the_injected_connector() {
+    let mut app = stub_app();
+    let local = app.model.my_host().expect("stub local host").clone();
+    let connector = Arc::new(RecordingPmConnector::default());
+    app.pm_connector = Some(connector.clone());
+
+    let local_target = pm_target(local);
+    app.execute_table_intent(TableIntent::OpenInPm(local_target.clone()));
+    tokio::task::yield_now().await;
+    app.drain_background_updates();
+
+    assert_eq!(*connector.calls.lock().expect("recorded calls"), vec![local_target]);
+    assert_eq!(app.model.status_message.as_deref(), Some("Opened tables in PM"));
+
+    let remote_target = pm_target(HostName::new("feta"));
+    app.execute_table_intent(TableIntent::OpenInPm(remote_target));
+    assert_eq!(connector.calls.lock().expect("recorded calls").len(), 1, "remote targets must not dispatch");
+    assert!(app.model.status_message.as_deref().is_some_and(|message| message.contains("not reachable from this PM yet")));
+
+    app.model.hosts.clear();
+    app.execute_table_intent(TableIntent::OpenInPm(pm_target(HostName::new("unknown-without-model"))));
+    assert_eq!(connector.calls.lock().expect("recorded calls").len(), 1, "unknown locality must fail closed");
+    assert!(app.model.status_message.as_deref().is_some_and(|message| message.contains("not reachable from this PM yet")));
+}
+
+#[test]
+fn open_in_pm_without_a_connector_reports_that_no_pm_is_connected() {
+    let mut app = stub_app();
+    let local = app.model.my_host().expect("stub local host").clone();
+
+    app.execute_table_intent(TableIntent::OpenInPm(pm_target(local)));
+
+    assert_eq!(app.model.status_message.as_deref(), Some("No presentation manager is connected"));
+}
 
 fn hp(path: &str) -> HostPath {
     HostPath::new(HostName::local(), PathBuf::from(path))

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -38,6 +38,7 @@ pub use ui_state::{BranchInputKind, DirEntry, ProjectIssueStartContext, RepoView
 use crate::{
     convoy_model::{ConvoyId, ConvoySummary},
     keymap::Keymap,
+    pm_open::PmConnector,
     shared::Shared,
     theme::Theme,
     widgets::{
@@ -368,6 +369,11 @@ pub struct ProjectIssueStartBatch {
     rejected: Vec<String>,
 }
 
+struct PmOpenUpdate {
+    label: String,
+    result: Result<(), String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VisibleStatusItem {
     pub id: usize,
@@ -473,6 +479,11 @@ pub struct App {
     pub issue_update_tx: mpsc::UnboundedSender<issue_view::IssueQueryUpdate>,
     /// Receiver half, drained each event-loop iteration.
     pub issue_update_rx: mpsc::UnboundedReceiver<issue_view::IssueQueryUpdate>,
+    /// Connected presentation-manager realization path, when this TUI is
+    /// running inside a supported PM.
+    pub pm_connector: Option<Arc<dyn PmConnector>>,
+    pm_update_tx: mpsc::UnboundedSender<PmOpenUpdate>,
+    pm_update_rx: mpsc::UnboundedReceiver<PmOpenUpdate>,
     /// Client session ID. Passed to `execute_query` for query dispatch.
     pub session_id: uuid::Uuid,
     /// Drop guard that gives in-process subscribers the same teardown
@@ -545,6 +556,7 @@ impl App {
         }
 
         let (issue_update_tx, issue_update_rx) = mpsc::unbounded_channel();
+        let (pm_update_tx, pm_update_rx) = mpsc::unbounded_channel();
         let session_id = uuid::Uuid::new_v4();
         let query_subscription = daemon.query_subscription(session_id);
 
@@ -573,6 +585,9 @@ impl App {
             pending_fetch_more: HashSet::new(),
             issue_update_tx,
             issue_update_rx,
+            pm_connector: None,
+            pm_update_tx,
+            pm_update_rx,
             session_id,
             _query_subscription: query_subscription,
             namespaces: HashMap::new(),
@@ -581,6 +596,11 @@ impl App {
             subscriptions_dirty: true,
             pending_attach_command: None,
         }
+    }
+
+    pub fn with_pm_connector(mut self, connector: Option<Arc<dyn PmConnector>>) -> Self {
+        self.pm_connector = connector;
+        self
     }
 
     /// Construct an `App` in scoped mode: exactly the one View at `address`,
@@ -943,6 +963,13 @@ impl App {
                         self.spawn_query_page(repo, params, 1, 50);
                     }
                 }
+            }
+        }
+
+        while let Ok(update) = self.pm_update_rx.try_recv() {
+            match update.result {
+                Ok(()) => self.set_status_message(Some(format!("Opened {} in PM", update.label))),
+                Err(error) => self.set_status_message(Some(format!("Could not open {} in PM: {error}", update.label))),
             }
         }
     }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1618,6 +1618,7 @@ fn wire_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_proto
                 .depends_on(vessel.depends_on)
                 .host(vessel.host.unwrap_or_else(HostName::local))
                 .maybe_attach(vessel.workspace_ref)
+                .maybe_materialize(vessel.materialize_ref)
                 .complete_work(vessel.completion_target.is_some())
                 .build()
         })
@@ -2107,6 +2108,7 @@ fn convoy_with_vessels(name: &str, vessel_names: &[&str]) -> crate::convoy_model
             host: Some(HostName::local()),
             checkout: None,
             workspace_ref: Some(format!("ws://{vessel_name}")),
+            materialize_ref: Some(format!("terminal-{vessel_name}")),
             completion_target: Some(crate::convoy_model::WorkCompletionTarget {
                 convoy: name.to_string(),
                 vessel: (*vessel_name).to_string(),

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -169,6 +169,7 @@ pub static BINDINGS: &[Binding] = &[
     h(BindingModeId::Convoys, "y", Action::Describe, "Describe"),
     h(BindingModeId::Convoys, "l", Action::Confirm, "Drill"),
     b(BindingModeId::Convoys, "right", Action::Confirm),
+    h(BindingModeId::Convoys, "o", Action::OpenInPm, "Open in PM"),
     // [, ], q come from TabPage (composed). Keep r here: refresh semantics are tab-specific.
     h(BindingModeId::Convoys, "r", Action::Refresh, "Refresh"),
     h(BindingModeId::DemandTable, "f", Action::FetchMore, "Fetch more"),

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -136,6 +136,7 @@ pub struct VesselSummary {
     pub host: Option<HostName>,
     pub checkout: Option<CheckoutRef>,
     pub workspace_ref: Option<String>,
+    pub materialize_ref: Option<String>,
     pub completion_target: Option<WorkCompletionTarget>,
     pub ready_at: Option<Timestamp>,
     pub started_at: Option<Timestamp>,
@@ -206,6 +207,7 @@ fn vessel_summary(row: &wire::ConvoyRow, vessel: &wire::VesselRow) -> VesselSumm
         // The convoys query does not yet expose checkout allocation.
         checkout: None,
         workspace_ref: vessel.attach.clone(),
+        materialize_ref: vessel.materialize.clone(),
         completion_target: vessel.complete_work.then(|| WorkCompletionTarget {
             convoy: row.name.clone(),
             vessel: vessel.name.clone(),

--- a/crates/flotilla-tui/src/keymap.rs
+++ b/crates/flotilla-tui/src/keymap.rs
@@ -52,6 +52,8 @@ pub enum Action {
     CompleteConvoyWork,
     /// Attach the active workspace manager to the selected convoy vessel's workspace.
     AttachConvoyVessel,
+    /// Materialize or focus the selected convoy/vessel in the connected PM.
+    OpenInPm,
     Dispatch(Intent),
 }
 
@@ -126,6 +128,7 @@ impl Action {
             "fill_selected" => Action::FillSelected,
             "complete_convoy_work" => Action::CompleteConvoyWork,
             "attach_convoy_vessel" => Action::AttachConvoyVessel,
+            "open_in_pm" => Action::OpenInPm,
             // Intent-wrapping actions
             "switch_to_workspace" => Action::Dispatch(Intent::SwitchToWorkspace),
             "create_workspace" => Action::Dispatch(Intent::CreateWorkspace),
@@ -181,6 +184,7 @@ impl Action {
             Action::FillSelected => "fill_selected",
             Action::CompleteConvoyWork => "complete_convoy_work",
             Action::AttachConvoyVessel => "attach_convoy_vessel",
+            Action::OpenInPm => "open_in_pm",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "switch_to_workspace",
                 Intent::CreateWorkspace => "create_workspace",
@@ -233,6 +237,7 @@ impl Action {
             Action::FillSelected => "Fill selected item",
             Action::CompleteConvoyWork => "Force complete work",
             Action::AttachConvoyVessel => "Attach to vessel workspace",
+            Action::OpenInPm => "Open in presentation manager",
             Action::Dispatch(intent) => match intent {
                 Intent::SwitchToWorkspace => "Switch to workspace",
                 Intent::CreateWorkspace => "Create workspace",

--- a/crates/flotilla-tui/src/keymap/tests.rs
+++ b/crates/flotilla-tui/src/keymap/tests.rs
@@ -41,6 +41,7 @@ fn round_trip_non_dispatch_actions() {
         Action::OpenCommandPalette,
         Action::OpenContextualPalette,
         Action::FillSelected,
+        Action::OpenInPm,
     ];
     for action in actions {
         let s = action.as_config_str();
@@ -113,6 +114,7 @@ fn all_actions_have_descriptions() {
         Action::OpenCommandPalette,
         Action::OpenContextualPalette,
         Action::FillSelected,
+        Action::OpenInPm,
         Action::Dispatch(Intent::SwitchToWorkspace),
         Action::Dispatch(Intent::CreateWorkspace),
         Action::Dispatch(Intent::RemoveCheckout),
@@ -159,6 +161,12 @@ fn defaults_resolve_project_panel_navigation() {
     assert_eq!(km.resolve(&mode, kc(KeyCode::Tab, KeyModifiers::SHIFT)), Some(Action::PrevPanel));
     assert_eq!(km.resolve(&mode, kc(KeyCode::BackTab, KeyModifiers::NONE)), Some(Action::PrevPanel));
     assert_eq!(km.resolve(&mode, kc(KeyCode::BackTab, KeyModifiers::SHIFT)), Some(Action::PrevPanel));
+}
+
+#[test]
+fn convoy_rows_bind_o_to_open_in_pm() {
+    let km = Keymap::defaults();
+    assert_eq!(km.resolve(&KeyBindingMode::from(BindingModeId::Convoys), crokey::key!(o)), Some(Action::OpenInPm));
 }
 
 #[test]

--- a/crates/flotilla-tui/src/lib.rs
+++ b/crates/flotilla-tui/src/lib.rs
@@ -8,6 +8,7 @@ pub mod interaction;
 pub mod keymap;
 pub mod palette;
 pub mod pm_connect;
+pub mod pm_open;
 pub mod run;
 pub use flotilla_client as socket;
 pub mod segment_bar;

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -827,6 +827,7 @@ mod tests {
                     host: None,
                     checkout: None,
                     workspace_ref: None,
+                    materialize_ref: None,
                     completion_target: None,
                     ready_at: None,
                     started_at: None,

--- a/crates/flotilla-tui/src/pm_open.rs
+++ b/crates/flotilla-tui/src/pm_open.rs
@@ -1,0 +1,267 @@
+//! Direct v0 realization of the row-level "open in PM" Regard.
+//!
+//! The TUI supplies semantic identity and capability facts. The connector
+//! owns presentation-manager effects and preserves focus-not-duplicate.
+
+use std::{collections::HashMap, path::Path, sync::Arc};
+
+use async_trait::async_trait;
+use flotilla_core::{
+    path_context::ExecutionEnvironmentPath,
+    providers::{
+        presentation::{zellij::ZellijPresentationManager, PresentationManager},
+        types::WorkspaceAttachRequest,
+        ProcessCommandRunner,
+    },
+};
+use flotilla_manifest::{
+    projection::{convoy_group_path, project_segment, vessel_factory_id, vessel_group_path},
+    stamp::WorkspaceStamp,
+};
+use flotilla_protocol::{arg::shell_quote, HostName, RepoKey};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenInPmTarget {
+    pub namespace: String,
+    pub convoy: String,
+    pub vessel: Option<String>,
+    pub label: String,
+    pub host: Option<HostName>,
+    pub project_ref: Option<String>,
+    pub repo_hint: Option<RepoKey>,
+    pub workspace_ref: Option<String>,
+    pub materialize_ref: Option<String>,
+}
+
+#[async_trait]
+pub trait PmConnector: Send + Sync {
+    async fn open(&self, target: &OpenInPmTarget, working_directory: &Path) -> Result<(), String>;
+}
+
+pub struct PresentationPmConnector {
+    manager: Arc<dyn PresentationManager>,
+    flotilla_bin: String,
+    /// Direct v0 realization predates PM→daemon convergence (#835), so keep
+    /// the stable workspace refs created by this connector. The mutex covers
+    /// the complete focus-or-create transaction and prevents double-open
+    /// races from creating duplicate tabs.
+    realized: tokio::sync::Mutex<HashMap<String, String>>,
+}
+
+impl PresentationPmConnector {
+    pub fn new(manager: Arc<dyn PresentationManager>, flotilla_bin: impl Into<String>) -> Self {
+        Self { manager, flotilla_bin: flotilla_bin.into(), realized: tokio::sync::Mutex::new(HashMap::new()) }
+    }
+
+    fn stamp(target: &OpenInPmTarget) -> WorkspaceStamp {
+        let project = project_segment(target.project_ref.as_deref(), target.repo_hint.as_ref().map(|repo| repo.0.as_str()));
+        match &target.vessel {
+            Some(vessel) => WorkspaceStamp {
+                kind: "flotilla-vessel".to_owned(),
+                factory_id: vessel_factory_id(&target.namespace, &target.convoy, vessel),
+                scope: Some(vessel_group_path(project, &target.namespace, &target.convoy, vessel)),
+            },
+            None => WorkspaceStamp {
+                kind: "flotilla-convoy".to_owned(),
+                factory_id: format!("flotilla:convoys/{}/{}", target.namespace, target.convoy),
+                scope: Some(convoy_group_path(project, &target.namespace, &target.convoy)),
+            },
+        }
+    }
+
+    /// Stable, PM-visible fallback identity for direct v0 realizations. This
+    /// remains unique across namespaces and does not change with display
+    /// labels or vessel-count presentation rules.
+    fn workspace_name(target: &OpenInPmTarget) -> String {
+        match &target.vessel {
+            Some(vessel) => format!("{}/{}/{}", target.namespace, target.convoy, vessel),
+            None => format!("{}/{}", target.namespace, target.convoy),
+        }
+    }
+
+    fn workspace_ref_belongs_to_manager(&self, workspace_ref: &str) -> bool {
+        let prefix = self.manager.binding_scope_prefix();
+        prefix.is_empty() || workspace_ref.starts_with(&prefix)
+    }
+}
+
+#[async_trait]
+impl PmConnector for PresentationPmConnector {
+    async fn open(&self, target: &OpenInPmTarget, working_directory: &Path) -> Result<(), String> {
+        let stamp = Self::stamp(target);
+        let workspace_name = Self::workspace_name(target);
+        let mut realized = self.realized.lock().await;
+        if let Some(workspace_ref) = target.workspace_ref.as_deref().filter(|reference| self.workspace_ref_belongs_to_manager(reference)) {
+            if self.manager.select_workspace(workspace_ref).await.is_ok() {
+                realized.insert(stamp.factory_id, workspace_ref.to_owned());
+                return Ok(());
+            }
+        }
+
+        if let Some(workspace_ref) = realized.get(&stamp.factory_id).cloned() {
+            if self.manager.select_workspace(&workspace_ref).await.is_ok() {
+                return Ok(());
+            }
+            realized.remove(&stamp.factory_id);
+        }
+
+        if let Some((workspace_ref, _)) =
+            self.manager.list_workspaces().await?.into_iter().find(|(_, workspace)| workspace.name == workspace_name)
+        {
+            self.manager.select_workspace(&workspace_ref).await?;
+            realized.insert(stamp.factory_id, workspace_ref);
+            return Ok(());
+        }
+
+        let materialize_ref =
+            target.materialize_ref.as_deref().ok_or_else(|| format!("{} has no running session to open in the PM", target.label))?;
+        let command = format!("{} attach {}", shell_quote(&self.flotilla_bin), shell_quote(materialize_ref));
+        let request = WorkspaceAttachRequest::builder()
+            .name(workspace_name)
+            .working_directory(ExecutionEnvironmentPath::new(working_directory))
+            .attach_commands(vec![(target.vessel.clone().unwrap_or_else(|| "session".to_owned()), command)])
+            .stamp(stamp.clone())
+            .build();
+        let (workspace_ref, _) = self.manager.create_workspace(&request).await?;
+        realized.insert(stamp.factory_id, workspace_ref);
+        Ok(())
+    }
+}
+
+/// Detect the PM enclosing this TUI. In v0 only Zellij/andamento supports
+/// direct realization; absence is represented honestly as `None`.
+pub fn detect_connector() -> Option<Arc<dyn PmConnector>> {
+    std::env::var_os("ZELLIJ")?;
+    let session = std::env::var("ZELLIJ_SESSION_NAME").ok()?;
+    let runner = Arc::new(ProcessCommandRunner);
+    let manager: Arc<dyn PresentationManager> = Arc::new(ZellijPresentationManager::with_session_name(runner, session));
+    let flotilla_bin = std::env::current_exe().ok()?.to_string_lossy().into_owned();
+    Some(Arc::new(PresentationPmConnector::new(manager, flotilla_bin)))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use flotilla_core::providers::types::Workspace;
+
+    use super::*;
+
+    type CreatedWorkspace = (String, Vec<(String, String)>, Option<WorkspaceStamp>);
+
+    #[derive(Default)]
+    struct FakeManager {
+        workspaces: Mutex<Vec<(String, Workspace)>>,
+        selected: Mutex<Vec<String>>,
+        created: Mutex<Vec<CreatedWorkspace>>,
+    }
+
+    #[async_trait]
+    impl PresentationManager for FakeManager {
+        async fn list_workspaces(&self) -> Result<Vec<(String, Workspace)>, String> {
+            let workspaces = self.workspaces.lock().expect("workspaces lock").clone();
+            // Force concurrent opens to interleave at the list/create seam;
+            // without the connector's transaction mutex both would observe
+            // the same empty snapshot and create duplicate workspaces.
+            tokio::task::yield_now().await;
+            Ok(workspaces)
+        }
+
+        async fn create_workspace(&self, request: &WorkspaceAttachRequest) -> Result<(String, Workspace), String> {
+            self.created.lock().expect("created lock").push((request.name.clone(), request.attach_commands.clone(), request.stamp.clone()));
+            let workspace = Workspace { name: request.name.clone(), correlation_keys: vec![], attachable_set_id: None };
+            self.workspaces.lock().expect("workspaces lock").push(("session:7".into(), workspace.clone()));
+            Ok(("session:7".into(), workspace))
+        }
+
+        async fn select_workspace(&self, workspace_ref: &str) -> Result<(), String> {
+            self.selected.lock().expect("selected lock").push(workspace_ref.to_owned());
+            Ok(())
+        }
+
+        async fn delete_workspace(&self, _workspace_ref: &str) -> Result<(), String> {
+            Ok(())
+        }
+
+        fn binding_scope_prefix(&self) -> String {
+            "session:".into()
+        }
+    }
+
+    fn target() -> OpenInPmTarget {
+        OpenInPmTarget {
+            namespace: "dev".into(),
+            convoy: "tables".into(),
+            vessel: Some("implement".into()),
+            label: "tables".into(),
+            host: Some(HostName::new("kiwi")),
+            project_ref: Some("flotilla".into()),
+            repo_hint: Some(RepoKey("flotilla-org/flotilla".into())),
+            workspace_ref: None,
+            materialize_ref: Some("terminal-implement".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn focuses_a_realized_semantic_identity_instead_of_duplicating_it() {
+        let manager = Arc::new(FakeManager::default());
+        let connector = PresentationPmConnector::new(manager.clone(), "flotilla");
+
+        connector.open(&target(), Path::new("/repo")).await.expect("materialize workspace");
+        let mut repeated = target();
+        repeated.label = "a changed display label".into();
+        repeated.materialize_ref = None;
+        connector.open(&repeated, Path::new("/repo")).await.expect("focus realized workspace");
+
+        assert_eq!(*manager.selected.lock().expect("selected lock"), vec!["session:7"]);
+        assert_eq!(manager.created.lock().expect("created lock").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_opens_create_one_workspace_for_the_semantic_identity() {
+        let manager = Arc::new(FakeManager::default());
+        let connector = PresentationPmConnector::new(manager.clone(), "flotilla");
+        let first = target();
+        let second = first.clone();
+
+        let (left, right) = tokio::join!(connector.open(&first, Path::new("/repo")), connector.open(&second, Path::new("/repo")));
+
+        left.expect("first open");
+        right.expect("second open");
+        assert_eq!(manager.created.lock().expect("created lock").len(), 1);
+        assert_eq!(*manager.selected.lock().expect("selected lock"), vec!["session:7"]);
+    }
+
+    #[tokio::test]
+    async fn materializes_a_stamped_workspace_from_the_session_capability() {
+        let manager = Arc::new(FakeManager::default());
+        let connector = PresentationPmConnector::new(manager.clone(), "/opt/flotilla");
+
+        connector.open(&target(), Path::new("/repo")).await.expect("materialize workspace");
+
+        let created = manager.created.lock().expect("created lock");
+        assert_eq!(created.len(), 1);
+        assert_eq!(created[0].0, "dev/tables/implement");
+        assert_eq!(created[0].1, vec![("implement".into(), "'/opt/flotilla' attach 'terminal-implement'".into())]);
+        assert_eq!(created[0].2.as_ref().expect("workspace stamp").factory_id, "flotilla:convoys/dev/tables/implement");
+    }
+
+    #[tokio::test]
+    async fn a_new_connector_rediscovers_the_stable_direct_workspace_name() {
+        let manager = Arc::new(FakeManager::default());
+        PresentationPmConnector::new(manager.clone(), "flotilla")
+            .open(&target(), Path::new("/repo"))
+            .await
+            .expect("initial materialization");
+        let mut rediscovered = target();
+        rediscovered.materialize_ref = None;
+
+        PresentationPmConnector::new(manager.clone(), "flotilla")
+            .open(&rediscovered, Path::new("/repo"))
+            .await
+            .expect("rediscover workspace after connector restart");
+
+        assert_eq!(manager.created.lock().expect("created lock").len(), 1);
+        assert_eq!(*manager.selected.lock().expect("selected lock"), vec!["session:7"]);
+    }
+}

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -14,6 +14,7 @@ use flotilla_protocol::{
 use crate::{
     app::ui_state::PendingAction,
     convoy_model::{ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase},
+    pm_open::OpenInPmTarget,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -311,6 +312,7 @@ pub struct DetailField {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TableIntent {
+    OpenInPm(OpenInPmTarget),
     AttachWorkspace { workspace_ref: String, host: HostName, repo_hint: Option<RepoKey> },
     AttachPane { reference: String, host: HostName },
     DeleteConvoy { namespace: String, name: String, host: Option<HostName> },
@@ -413,7 +415,10 @@ fn fuzzy_matches(value: &str, pattern: &str) -> bool {
 struct VesselProjection {
     namespace: String,
     convoy: String,
+    origin_host: Option<HostName>,
+    project_ref: Option<String>,
     repo_hint: Option<RepoKey>,
+    vessel_count: usize,
     vessel: VesselSummary,
 }
 
@@ -489,7 +494,10 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
             let rows = stable_topological_vessels(&convoy.vessels).into_iter().map(|vessel| VesselProjection {
                 namespace: namespace.clone(),
                 convoy: name.clone(),
+                origin_host: convoy.origin_host.clone(),
+                project_ref: convoy.project_ref.clone(),
                 repo_hint: convoy.repo_hint.clone(),
+                vessel_count: convoy.vessels.len(),
                 vessel: vessel.clone(),
             });
             let title = convoy.change_request.as_ref().map_or_else(
@@ -508,7 +516,10 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
             Ok(vessel_spec().project(format!("Vessel · {vessel}"), [VesselProjection {
                 namespace: namespace.clone(),
                 convoy: convoy.clone(),
+                origin_host: convoy_row.origin_host.clone(),
+                project_ref: convoy_row.project_ref.clone(),
                 repo_hint: convoy_row.repo_hint.clone(),
+                vessel_count: convoy_row.vessels.len(),
                 vessel: vessel_row.clone(),
             }]))
         }
@@ -728,13 +739,11 @@ static CONVOY_COLUMNS: [ColumnSpec<ConvoySummary>; 7] = [
     },
 ];
 
-static CONVOY_ACTIONS: [ActionSpec<ConvoySummary>; 2] =
-    [ActionSpec { id: "open_pr", label: "Open PR", key: 'p', resolve: open_convoy_change_request }, ActionSpec {
-        id: "delete",
-        label: "Delete convoy",
-        key: 'd',
-        resolve: delete_convoy,
-    }];
+static CONVOY_ACTIONS: [ActionSpec<ConvoySummary>; 3] = [
+    ActionSpec { id: "open_pr", label: "Open PR", key: 'p', resolve: open_convoy_change_request },
+    ActionSpec { id: "delete", label: "Delete convoy", key: 'd', resolve: delete_convoy },
+    ActionSpec { id: "open_in_pm", label: "Open in PM", key: 'o', resolve: open_convoy_in_pm },
+];
 
 static VESSEL_COLUMNS: [ColumnSpec<VesselProjection>; 6] = [
     ColumnSpec {
@@ -775,13 +784,11 @@ static VESSEL_COLUMNS: [ColumnSpec<VesselProjection>; 6] = [
     },
 ];
 
-static VESSEL_ACTIONS: [ActionSpec<VesselProjection>; 2] =
-    [ActionSpec { id: "attach", label: "Attach workspace", key: 'a', resolve: attach_vessel }, ActionSpec {
-        id: "force_complete",
-        label: "Force-complete work",
-        key: 'x',
-        resolve: force_complete_vessel,
-    }];
+static VESSEL_ACTIONS: [ActionSpec<VesselProjection>; 3] = [
+    ActionSpec { id: "attach", label: "Attach workspace", key: 'a', resolve: attach_vessel },
+    ActionSpec { id: "force_complete", label: "Force-complete work", key: 'x', resolve: force_complete_vessel },
+    ActionSpec { id: "open_in_pm", label: "Open in PM", key: 'o', resolve: open_vessel_in_pm },
+];
 
 static INDEPENDENT_COLUMNS: [ColumnSpec<IndependentRow>; 5] = [
     ColumnSpec {
@@ -971,6 +978,30 @@ fn open_convoy_change_request(row: &ConvoySummary) -> Option<TableIntent> {
     })
 }
 
+fn open_convoy_in_pm(row: &ConvoySummary) -> Option<TableIntent> {
+    let vessel = row
+        .vessels
+        .iter()
+        .find(|vessel| vessel.workspace_ref.is_some())
+        .or_else(|| row.vessels.iter().find(|vessel| vessel.materialize_ref.is_some()))
+        .or_else(|| row.vessels.first());
+    let label = vessel.map_or_else(
+        || row.name.clone(),
+        |vessel| if row.vessels.len() == 1 { row.name.clone() } else { format!("{}:{}", row.name, vessel.name) },
+    );
+    Some(TableIntent::OpenInPm(OpenInPmTarget {
+        namespace: row.namespace.clone(),
+        convoy: row.name.clone(),
+        vessel: vessel.map(|vessel| vessel.name.clone()),
+        label,
+        host: row.origin_host.clone().or_else(|| vessel.and_then(|vessel| vessel.host.clone())),
+        project_ref: row.project_ref.clone(),
+        repo_hint: row.repo_hint.clone(),
+        workspace_ref: vessel.and_then(|vessel| vessel.workspace_ref.clone()),
+        materialize_ref: vessel.and_then(|vessel| vessel.materialize_ref.clone()),
+    }))
+}
+
 fn delete_convoy(row: &ConvoySummary) -> Option<TableIntent> {
     Some(TableIntent::DeleteConvoy { namespace: row.namespace.clone(), name: row.name.clone(), host: row.origin_host.clone() })
 }
@@ -1063,6 +1094,20 @@ fn attach_vessel(row: &VesselProjection) -> Option<TableIntent> {
     })
 }
 
+fn open_vessel_in_pm(row: &VesselProjection) -> Option<TableIntent> {
+    Some(TableIntent::OpenInPm(OpenInPmTarget {
+        namespace: row.namespace.clone(),
+        convoy: row.convoy.clone(),
+        vessel: Some(row.vessel.name.clone()),
+        label: if row.vessel_count == 1 { row.convoy.clone() } else { format!("{}:{}", row.convoy, row.vessel.name) },
+        host: row.origin_host.clone().or_else(|| row.vessel.host.clone()),
+        project_ref: row.project_ref.clone(),
+        repo_hint: row.repo_hint.clone(),
+        workspace_ref: row.vessel.workspace_ref.clone(),
+        materialize_ref: row.vessel.materialize_ref.clone(),
+    }))
+}
+
 fn force_complete_vessel(row: &VesselProjection) -> Option<TableIntent> {
     let target = row.vessel.completion_target.as_ref()?;
     Some(TableIntent::ForceCompleteWork { convoy: target.convoy.clone(), vessel: target.vessel.clone(), host: target.host.clone() })
@@ -1120,6 +1165,7 @@ mod tests {
             host: Some(HostName::new("kiwi")),
             checkout: None,
             workspace_ref: None,
+            materialize_ref: None,
             completion_target: None,
             ready_at: None,
             started_at: None,
@@ -1238,12 +1284,16 @@ mod tests {
         row.origin_host = Some(HostName::new("kiwi"));
         let view = project_convoys("convoys/dev", &[&row]).expect("project table");
 
-        assert_eq!(view.rows[0].actions, vec![AvailableAction {
-            id: "delete",
-            label: "Delete convoy",
-            key: 'd',
-            intent: TableIntent::DeleteConvoy { namespace: "dev".into(), name: "tables".into(), host: Some(HostName::new("kiwi")) },
-        }]);
+        assert!(view.rows[0].actions.iter().any(|action| action.id == "open_in_pm" && action.label == "Open in PM" && action.key == 'o'));
+        assert!(view.rows[0].actions.iter().any(|action| {
+            action
+                == &AvailableAction {
+                    id: "delete",
+                    label: "Delete convoy",
+                    key: 'd',
+                    intent: TableIntent::DeleteConvoy { namespace: "dev".into(), name: "tables".into(), host: Some(HostName::new("kiwi")) },
+                }
+        }));
     }
 
     #[test]
@@ -1283,8 +1333,8 @@ mod tests {
         let row = convoy(vec![actionable, vessel("review", &["implement"], WorkPhase::Pending)]);
         let view = project_convoys("convoy/dev/tables", &[&row]).expect("project table");
 
-        assert_eq!(view.rows[0].actions.iter().map(|action| action.id).collect::<Vec<_>>(), vec!["attach", "force_complete"]);
-        assert!(view.rows[1].actions.is_empty(), "unavailable actions must not render");
+        assert_eq!(view.rows[0].actions.iter().map(|action| action.id).collect::<Vec<_>>(), vec!["attach", "force_complete", "open_in_pm"]);
+        assert_eq!(view.rows[1].actions.iter().map(|action| action.id).collect::<Vec<_>>(), vec!["open_in_pm"]);
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -407,6 +407,15 @@ impl InteractiveWidget for ProjectPageWidget {
                     None => Outcome::Consumed,
                 },
             },
+            Action::OpenInPm => {
+                if let Some(intent) = Self::active_row(&layouts, ctx.views.active_project_table_state())
+                    .and_then(|(_, row)| row.actions.iter().find(|action| action.id == "open_in_pm"))
+                    .map(|action| action.intent.clone())
+                {
+                    ctx.app_actions.push(AppAction::ExecuteTableIntent(intent));
+                }
+                Outcome::Consumed
+            }
             _ => Outcome::Ignored,
         }
     }

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -319,6 +319,18 @@ impl InteractiveWidget for TableWidget {
                     Outcome::Consumed
                 }
             },
+            Action::OpenInPm => {
+                if let Some(intent) = ctx
+                    .views
+                    .active_table_state()
+                    .selected_row(&view)
+                    .and_then(|row| row.actions.iter().find(|action| action.id == "open_in_pm"))
+                    .map(|action| action.intent.clone())
+                {
+                    ctx.app_actions.push(AppAction::ExecuteTableIntent(intent));
+                }
+                Outcome::Consumed
+            }
             _ => Outcome::Ignored,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,12 +451,14 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
         tracing::warn!(requested = %theme_name, using = %initial_theme.name, "unknown theme, falling back");
     }
 
+    let pm_connector = flotilla_tui::pm_open::detect_connector();
     loop {
         let repos_info = daemon.list_repos().await.unwrap_or_default();
         let app = match scoped_view.clone() {
             Some(address) => app::App::new_scoped(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone(), address),
             None => app::App::new(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone()),
-        };
+        }
+        .with_pm_connector(pm_connector.clone());
 
         match flotilla_tui::run::run_event_loop(terminal, app).await? {
             flotilla_tui::run::EventLoopExit::Quit => return Ok(()),


### PR DESCRIPTION
## Summary
- add an Open in PM row intent, action-menu entry, and `o` keybinding for convoys and vessels
- expose terminal materialization separately from an existing PM attachment
- focus or create local Zellij tabs using stable semantic identity, with honest remote-host and no-PM feedback

## Testing
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests --quiet`

Closes #878