### PR TITLE
fix: align convoy routing with live peer routes

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1211,6 +1211,12 @@ fn checkout_integration_summary(checkout: &ResourceObject<ResourceCheckout>, int
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExistingConvoyTarget {
+    pub home: HostName,
+    pub node_id: NodeId,
+}
+
 pub struct InProcessDaemon {
     repos: RwLock<HashMap<flotilla_protocol::RepoIdentity, RepoState>>,
     repo_order: RwLock<Vec<flotilla_protocol::RepoIdentity>>,
@@ -1945,7 +1951,10 @@ impl InProcessDaemon {
             .ok_or_else(|| format!("placement policy {policy_name} targets unavailable host {host_ref}"))
     }
 
-    pub async fn resolve_existing_convoy_target_node(&self, action: &flotilla_protocol::CommandAction) -> Result<Option<NodeId>, String> {
+    pub async fn resolve_existing_convoy_target(
+        &self,
+        action: &flotilla_protocol::CommandAction,
+    ) -> Result<Option<ExistingConvoyTarget>, String> {
         let (namespace, name) = match action {
             flotilla_protocol::CommandAction::ConvoyDelete { namespace, name, .. }
             | flotilla_protocol::CommandAction::ConvoyAbandon { namespace, name, .. } => {
@@ -1971,7 +1980,9 @@ impl InProcessDaemon {
 
         let home = match hosts.as_slice() {
             [] => return Ok(None),
-            [host] if host == &self.host_name => return Ok(Some(self.node_id.clone())),
+            [host] if host == &self.host_name => {
+                return Ok(Some(ExistingConvoyTarget { home: host.clone(), node_id: self.node_id.clone() }));
+            }
             [host] => host.clone(),
             _ => {
                 let homes = hosts.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
@@ -1979,12 +1990,12 @@ impl InProcessDaemon {
             }
         };
 
-        match self.host_registry.node_id_for_host_name(&home).await? {
-            Some(node_id) if self.host_registry.peer_connection_status(&node_id).await == PeerConnectionState::Connected => {
-                Ok(Some(node_id))
-            }
-            Some(_) | None => Err(format!("convoy {name} is homed on {home}, which is unreachable")),
-        }
+        let node_id = self
+            .host_registry
+            .node_id_for_host_name(&home)
+            .await?
+            .ok_or_else(|| format!("connect to {home} for convoy {name}: no routed node address found for host"))?;
+        Ok(Some(ExistingConvoyTarget { home, node_id }))
     }
 
     /// Admit a convoy against this daemon's authoritative project resources,

--- a/crates/flotilla-daemon/src/peer/channel_transport.rs
+++ b/crates/flotilla-daemon/src/peer/channel_transport.rs
@@ -233,6 +233,10 @@ impl PeerTransport for ChannelTransport {
         self.status.lock().expect("status lock").clone()
     }
 
+    fn connection_address(&self) -> String {
+        format!("channel://{}", self.remote_name)
+    }
+
     async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String> {
         {
             let status = self.status.lock().expect("status lock");

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -168,6 +168,7 @@ pub struct PendingPeerSend {
 struct ConfiguredPeerTarget {
     expected_host_name: HostName,
     expected_node_id: Option<NodeId>,
+    connection_address: String,
     transport: Box<dyn PeerTransport>,
 }
 
@@ -353,7 +354,8 @@ impl PeerManager {
         transport: Box<dyn PeerTransport>,
     ) {
         info!(target = %label.0, expected_host = %expected_host_name, expected_node_id = ?expected_node_id, "registered configured peer target");
-        self.configured_targets.insert(label, ConfiguredPeerTarget { expected_host_name, expected_node_id, transport });
+        let connection_address = transport.connection_address();
+        self.configured_targets.insert(label, ConfiguredPeerTarget { expected_host_name, expected_node_id, connection_address, transport });
     }
 
     /// Register or replace a sender for a connected peer.
@@ -1489,6 +1491,33 @@ impl PeerManager {
 
         let route = self.routes.get(name).ok_or_else(|| format!("unknown peer: {name}"))?;
         self.senders.get(&route.primary.next_hop).cloned().ok_or_else(|| format!("missing next hop sender: {}", route.primary.next_hop))
+    }
+
+    pub fn connection_address_for(&self, target: &NodeId, host: &HostName) -> String {
+        let next_hop = if self.senders.contains_key(target) {
+            target
+        } else {
+            self.routes.get(target).map(|route| &route.primary.next_hop).unwrap_or(target)
+        };
+        if let Some(configured) = self
+            .active_connections
+            .get(next_hop)
+            .and_then(|active| active.meta.config_label.as_ref())
+            .and_then(|label| self.configured_targets.get(label))
+        {
+            return configured.connection_address.clone();
+        }
+        if let Some(configured) = self
+            .configured_targets
+            .iter()
+            .find_map(|(_, configured)| (configured.expected_node_id.as_ref() == Some(next_hop)).then_some(configured))
+        {
+            return configured.connection_address.clone();
+        }
+        self.configured_targets
+            .values()
+            .find_map(|configured| (configured.expected_host_name == *host).then(|| configured.connection_address.clone()))
+            .unwrap_or_else(|| format!("peer://{next_hop}"))
     }
 
     pub fn take_displaced_sender(&mut self, name: &NodeId, generation: u64) -> Option<Arc<dyn PeerSender>> {

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -426,6 +426,13 @@ impl PeerTransport for SshTransport {
         self.status.clone()
     }
 
+    fn connection_address(&self) -> String {
+        match &self.config.user {
+            Some(user) => format!("ssh://{user}@{}", self.config.hostname),
+            None => format!("ssh://{}", self.config.hostname),
+        }
+    }
+
     async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String> {
         if self.status != PeerConnectionStatus::Connected {
             return Err("not connected".to_string());

--- a/crates/flotilla-daemon/src/peer/test_support.rs
+++ b/crates/flotilla-daemon/src/peer/test_support.rs
@@ -271,6 +271,10 @@ impl PeerTransport for MockTransport {
         self.status.clone()
     }
 
+    fn connection_address(&self) -> String {
+        self.remote_node.as_ref().map(|node| format!("mock://{}", node.node_id)).unwrap_or_else(|| "mock://unknown".to_string())
+    }
+
     async fn subscribe(&mut self) -> Result<tokio::sync::mpsc::Receiver<PeerWireMessage>, String> {
         let (_tx, rx) = tokio::sync::mpsc::channel(1);
         Ok(rx)

--- a/crates/flotilla-daemon/src/peer/transport.rs
+++ b/crates/flotilla-daemon/src/peer/transport.rs
@@ -24,6 +24,9 @@ pub trait PeerTransport: Send + Sync {
     async fn disconnect(&mut self) -> Result<(), String>;
     fn status(&self) -> PeerConnectionStatus;
 
+    /// Human-readable address used for connection attempts and diagnostics.
+    fn connection_address(&self) -> String;
+
     /// Subscribe to inbound peer wire messages.
     async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String>;
 

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -184,10 +184,10 @@ impl RemoteCommandRouter {
                     command: Box::new(command),
                     session_id: None,
                 };
-                let send_result = self.send_routed_to(&target_node_id, routed).await.map_err(|cause| match &existing_convoy_target {
-                    Some(target) => format!("connect to {} at peer node {}: {cause}", target.home, target.node_id),
-                    None => cause,
-                });
+                let send_result = match &existing_convoy_target {
+                    Some(target) => self.send_routed_to_convoy_home(&target.home, &target.node_id, routed).await,
+                    None => self.send_routed_to(&target_node_id, routed).await,
+                };
 
                 match send_result {
                     Ok(()) => Ok(command_id),
@@ -825,6 +825,21 @@ impl RemoteStepExecutor for RemoteCommandRouter {
 }
 
 impl RemoteCommandRouter {
+    async fn send_routed_to_convoy_home(
+        &self,
+        home: &flotilla_protocol::HostName,
+        node_id: &NodeId,
+        msg: RoutedPeerMessage,
+    ) -> Result<(), String> {
+        let (sender, address) = {
+            let pm = self.peer_manager.lock().await;
+            let address = pm.connection_address_for(node_id, home);
+            let sender = pm.resolve_sender(node_id).map_err(|cause| format!("connect to {home} at {address}: {cause}"))?;
+            (sender, address)
+        };
+        sender.send(PeerWireMessage::Routed(msg)).await.map_err(|cause| format!("connect to {home} at {address}: {cause}"))
+    }
+
     async fn resolve_sender(&self, node_id: &NodeId) -> Result<Arc<dyn PeerSender>, String> {
         let pm = self.peer_manager.lock().await;
         pm.resolve_sender(node_id)

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -130,8 +130,9 @@ impl RemoteCommandRouter {
         if matches!(command.action, CommandAction::ConvoyStartPrepared { .. }) {
             return Err("prepared convoy starts are reserved for authenticated peer forwarding".to_string());
         }
-        if let Some(target_node_id) = self.daemon.resolve_existing_convoy_target_node(&command.action).await? {
-            command.node_id = Some(target_node_id);
+        let existing_convoy_target = self.daemon.resolve_existing_convoy_target(&command.action).await?;
+        if let Some(target) = existing_convoy_target.as_ref() {
+            command.node_id = Some(target.node_id.clone());
         }
         if let CommandAction::ConvoyStart { intent } = &command.action {
             let placement_target = self.daemon.resolve_convoy_start_target_node(intent).await?;
@@ -183,7 +184,10 @@ impl RemoteCommandRouter {
                     command: Box::new(command),
                     session_id: None,
                 };
-                let send_result = self.send_routed_to(&target_node_id, routed).await;
+                let send_result = self.send_routed_to(&target_node_id, routed).await.map_err(|cause| match &existing_convoy_target {
+                    Some(target) => format!("connect to {} at peer node {}: {cause}", target.home, target.node_id),
+                    None => cause,
+                });
 
                 match send_result {
                     Ok(()) => Ok(command_id),

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -2,14 +2,32 @@ use std::{sync::Arc, time::Duration};
 
 use flotilla_client::SocketDaemon;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
-use flotilla_protocol::{HostName, NodeInfo};
+use flotilla_protocol::{
+    result_set::{ConvoyPhase, ConvoyRow, ResultSet, Rows},
+    FleetReplicaSnapshot, HostName, NodeInfo, ResourceRef,
+};
+use flotilla_resources::{api_version, Convoy, Resource};
 use tokio::sync::{mpsc, watch, Mutex, Notify};
 
 use super::{build_remote_command_router, handle_client_session, spawn_peer_networking_runtime};
 use crate::{
+    aggregator::Aggregator,
     peer::{channel_transport::channel_transport_pair_with_nodes, PeerManager},
     server::PeerConnectedNotice,
 };
+
+pub async fn apply_convoy_replica_feed(daemon: &InProcessDaemon, namespace: &str, name: &str, home: HostName) {
+    let resource = ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, namespace, name).on_host(home.clone());
+    let row = ConvoyRow::builder().resource(resource).name(name).workflow_ref("scratch").phase(ConvoyPhase::Pending).build();
+    let snapshot = FleetReplicaSnapshot {
+        host: home,
+        generation: Some("test-generation".to_string()),
+        rows: vec![],
+        result_sets: vec![ResultSet { seq: 1, rows: Rows::Convoys(vec![row]), state: Default::default() }],
+    };
+    let mut aggregator = Aggregator::new(daemon.aggregator_projection_state().await, daemon.host_name().clone(), daemon.event_sender());
+    aggregator.apply_replica_cache(vec![snapshot]).await;
+}
 
 pub struct InMemoryRequestTopology {
     pub leader: Arc<InProcessDaemon>,

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -20,18 +20,18 @@ use flotilla_core::{
 };
 use flotilla_protocol::{
     qualified_path::QualifiedPath,
-    result_set::{QueryChanges, QueryId, ResultDelta},
+    result_set::{ConvoyPhase as RowConvoyPhase, ConvoyRow, QueryChanges, QueryId, ResultDelta},
     AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachBinding, AttachableId, Checkout, CheckoutTarget, Command,
     CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, DaemonEvent, EnvironmentId, HostName, HostPath,
     HostProviderStatus, HostSummary, Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage,
-    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, Response, ResponseResult, RoutedPeerMessage,
-    StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY, PROTOCOL_VERSION,
-    TERMINAL_POOL_PROVIDER_CATEGORY,
+    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, ResourceRef, Response, ResponseResult,
+    RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY,
+    PROTOCOL_VERSION, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectSpec, ResourceBackend, ResourceError, Stance,
-    StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
+    api_version, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectSpec, Resource, ResourceBackend, ResourceError,
+    Stance, StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
     TerminalSessionStatusPatch, WorkflowTemplate,
 };
 use flotilla_transport::message::{message_session_pair, MessageSession};
@@ -152,6 +152,19 @@ fn make_remote_command_router(
         Arc::clone(pending_remote_cancels),
         Arc::clone(next_remote_command_id),
     )
+}
+
+struct FailingPeerSender;
+
+#[async_trait::async_trait]
+impl PeerSender for FailingPeerSender {
+    async fn send(&self, _msg: PeerWireMessage) -> Result<(), String> {
+        Err("outbound channel closed".to_string())
+    }
+
+    async fn retire(&self, _reason: flotilla_protocol::GoodbyeReason) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 fn empty_remote_command_router(daemon: &Arc<InProcessDaemon>, peer_manager: &Arc<Mutex<PeerManager>>) -> RemoteCommandRouter {
@@ -761,6 +774,48 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
         }
         other => panic!("expected routed command request, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn dispatch_execute_remote_convoy_failure_names_transport_target_and_cause() {
+    let (_tmp, daemon) = empty_daemon().await;
+    let home = HostName::new("feta");
+    let resource = ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, "flotilla", "stranded").on_host(home.clone());
+    let row =
+        ConvoyRow::builder().resource(resource.clone()).name("stranded").workflow_ref("scratch").phase(RowConvoyPhase::Pending).build();
+    daemon
+        .aggregator_projection_state()
+        .await
+        .write()
+        .await
+        .replace_replica_rows(HashMap::from([(home.clone(), HashMap::from([(resource, row)]))]));
+    daemon
+        .publish_peer_summary(
+            HostSummary::builder()
+                .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new("feta-host")))
+                .host_name(home)
+                .node(node_info("feta"))
+                .system(flotilla_protocol::SystemInfo::default())
+                .providers(vec![])
+                .build(),
+        )
+        .await;
+
+    let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
+    peer_manager.lock().await.register_sender(node("feta"), Arc::new(FailingPeerSender));
+    let remote_command_router = empty_remote_command_router(&daemon, &peer_manager);
+
+    let message = remote_command_router
+        .dispatch_execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyDelete { namespace: Some("flotilla".to_string()), name: "stranded".to_string(), force: true },
+        })
+        .await
+        .expect_err("failed peer send should reject dispatch");
+
+    assert_eq!(message, "connect to feta at peer node feta: outbound channel closed");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -20,18 +20,18 @@ use flotilla_core::{
 };
 use flotilla_protocol::{
     qualified_path::QualifiedPath,
-    result_set::{ConvoyPhase as RowConvoyPhase, ConvoyRow, QueryChanges, QueryId, ResultDelta},
+    result_set::{QueryChanges, QueryId, ResultDelta},
     AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachBinding, AttachableId, Checkout, CheckoutTarget, Command,
     CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, DaemonEvent, EnvironmentId, HostName, HostPath,
     HostProviderStatus, HostSummary, Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage,
-    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, ResourceRef, Response, ResponseResult,
-    RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY,
-    PROTOCOL_VERSION, TERMINAL_POOL_PROVIDER_CATEGORY,
+    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, Response, ResponseResult, RoutedPeerMessage,
+    StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY, PROTOCOL_VERSION,
+    TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    api_version, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectSpec, Resource, ResourceBackend, ResourceError,
-    Stance, StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
+    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectSpec, ResourceBackend, ResourceError, Stance,
+    StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
     TerminalSessionStatusPatch, WorkflowTemplate,
 };
 use flotilla_transport::message::{message_session_pair, MessageSession};
@@ -56,11 +56,12 @@ use super::{
     },
     request_dispatch::RequestDispatcher,
     shared::{sync_peer_query_state, write_message, SocketPeerSender},
+    test_support::apply_convoy_replica_feed,
     DaemonServer, PeerConnectedNotice,
 };
 use crate::peer::{
     test_support::{ensure_test_connection_generation, handle_test_peer_data, wait_for_command_result, BlockingPeerSender, MockPeerSender},
-    InboundPeerEnvelope, PeerManager, PeerSender,
+    InboundPeerEnvelope, PeerConnectionStatus, PeerManager, PeerSender, PeerTransport,
 };
 
 fn ok_response(msg: Message, expected_id: u64) -> Response {
@@ -164,6 +165,36 @@ impl PeerSender for FailingPeerSender {
 
     async fn retire(&self, _reason: flotilla_protocol::GoodbyeReason) -> Result<(), String> {
         Ok(())
+    }
+}
+
+struct FailingPeerTransport;
+
+#[async_trait::async_trait]
+impl PeerTransport for FailingPeerTransport {
+    async fn connect(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn status(&self) -> PeerConnectionStatus {
+        PeerConnectionStatus::Connected
+    }
+
+    fn connection_address(&self) -> String {
+        "ssh://feta.example".to_string()
+    }
+
+    async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String> {
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+
+    fn sender(&self) -> Option<Arc<dyn PeerSender>> {
+        Some(Arc::new(FailingPeerSender))
     }
 }
 
@@ -780,20 +811,12 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
 async fn dispatch_execute_remote_convoy_failure_names_transport_target_and_cause() {
     let (_tmp, daemon) = empty_daemon().await;
     let home = HostName::new("feta");
-    let resource = ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, "flotilla", "stranded").on_host(home.clone());
-    let row =
-        ConvoyRow::builder().resource(resource.clone()).name("stranded").workflow_ref("scratch").phase(RowConvoyPhase::Pending).build();
-    daemon
-        .aggregator_projection_state()
-        .await
-        .write()
-        .await
-        .replace_replica_rows(HashMap::from([(home.clone(), HashMap::from([(resource, row)]))]));
+    apply_convoy_replica_feed(&daemon, "flotilla", "stranded", home.clone()).await;
     daemon
         .publish_peer_summary(
             HostSummary::builder()
                 .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new("feta-host")))
-                .host_name(home)
+                .host_name(home.clone())
                 .node(node_info("feta"))
                 .system(flotilla_protocol::SystemInfo::default())
                 .providers(vec![])
@@ -802,7 +825,11 @@ async fn dispatch_execute_remote_convoy_failure_names_transport_target_and_cause
         .await;
 
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
-    peer_manager.lock().await.register_sender(node("feta"), Arc::new(FailingPeerSender));
+    {
+        let mut manager = peer_manager.lock().await;
+        manager.add_configured_target(ConfigLabel("feta".to_string()), home, Some(node("feta")), Box::new(FailingPeerTransport));
+        manager.register_sender(node("feta"), Arc::new(FailingPeerSender));
+    }
     let remote_command_router = empty_remote_command_router(&daemon, &peer_manager);
 
     let message = remote_command_router
@@ -815,7 +842,7 @@ async fn dispatch_execute_remote_convoy_failure_names_transport_target_and_cause
         .await
         .expect_err("failed peer send should reject dispatch");
 
-    assert_eq!(message, "connect to feta at peer node feta: outbound channel closed");
+    assert_eq!(message, "connect to feta at ssh://feta.example: outbound channel closed");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -295,7 +295,7 @@ async fn hostless_convoy_work_complete_routes_to_remote_home() {
 }
 
 #[tokio::test]
-async fn hostless_convoy_command_names_unreachable_home() {
+async fn hostless_convoy_command_explains_missing_home_route() {
     let leader = empty_daemon_named("leader").await;
     let follower = empty_daemon_named("follower").await;
     let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
@@ -319,11 +319,11 @@ async fn hostless_convoy_command_names_unreachable_home() {
         .await
         .expect_err("unreachable convoy home should reject dispatch");
 
-    assert_eq!(message, "convoy stranded is homed on feta, which is unreachable");
+    assert_eq!(message, "connect to feta for convoy stranded: no routed node address found for host");
 }
 
 #[tokio::test]
-async fn hostless_convoy_command_names_disconnected_home() {
+async fn hostless_convoy_delete_uses_live_peer_route_when_connection_status_is_stale() {
     let leader = empty_daemon_named("leader").await;
     let follower = empty_daemon_named("follower").await;
     let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
@@ -339,7 +339,14 @@ async fn hostless_convoy_command_names_disconnected_home() {
         )
         .await;
 
-    let message = topology
+    let follower_convoys = topology.follower.resource_backend().using::<Convoy>(namespace);
+    follower_convoys
+        .create(&InputMeta::builder().name(convoy_name.to_string()).build(), &convoy_spec("scratch"))
+        .await
+        .expect("create remote-homed convoy");
+
+    let mut rx = topology.leader.subscribe();
+    let command_id = topology
         .client
         .execute(Command {
             node_id: None,
@@ -348,9 +355,13 @@ async fn hostless_convoy_command_names_disconnected_home() {
             action: CommandAction::ConvoyDelete { namespace: Some(namespace.to_string()), name: convoy_name.to_string(), force: true },
         })
         .await
-        .expect_err("disconnected convoy home should reject dispatch");
+        .expect("live peer route should take precedence over stale connection status");
 
-    assert_eq!(message, "convoy offline-home is homed on follower, which is unreachable");
+    assert_eq!(await_command_result(&mut rx, command_id).await, CommandValue::Ok);
+    assert!(
+        matches!(follower_convoys.get(convoy_name).await, Err(ResourceError::NotFound { .. })),
+        "remote-homed convoy should be deleted through the live peer route"
+    );
 }
 
 /// A stateless remote issue query should return results end-to-end.

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use flotilla_core::{
@@ -14,17 +10,18 @@ use flotilla_core::{
         issue_tracker::IssueProvider,
     },
 };
-use flotilla_daemon::server::test_support::{spawn_in_memory_request_topology, spawn_in_memory_request_topology_stateful};
+use flotilla_daemon::server::test_support::{
+    apply_convoy_replica_feed, spawn_in_memory_request_topology, spawn_in_memory_request_topology_stateful,
+};
 use flotilla_protocol::{
     issue_query::{IssueQuery, IssueResultPage},
-    result_set::{ConvoyPhase as RowConvoyPhase, ConvoyRow},
     test_support::TestIssue,
     Command, CommandAction, CommandValue, DaemonEvent, HostName, Issue, IssueChangeset, IssueRef, IssueSource, NodeInfo,
-    PeerConnectionState, RepoSelector, ResourceRef,
+    PeerConnectionState, RepoSelector,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, Resource, ResourceError,
-    WorkPhase as ResourceWorkPhase, WorkState,
+    Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, ResourceError, WorkPhase as ResourceWorkPhase,
+    WorkState,
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -41,21 +38,6 @@ async fn empty_daemon_named(host_name: &str) -> Arc<InProcessDaemon> {
 
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
     ConvoySpec::builder().workflow_ref(workflow_ref.to_string()).build()
-}
-
-fn convoy_ref(namespace: &str, name: &str, host: HostName) -> ResourceRef {
-    ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, namespace, name).on_host(host)
-}
-
-async fn seed_convoy_projection(daemon: &InProcessDaemon, namespace: &str, name: &str, home: HostName) {
-    let resource = convoy_ref(namespace, name, home.clone());
-    let row = ConvoyRow::builder().resource(resource.clone()).name(name).workflow_ref("scratch").phase(RowConvoyPhase::Pending).build();
-    daemon
-        .aggregator_projection_state()
-        .await
-        .write()
-        .await
-        .replace_replica_rows(HashMap::from([(home, HashMap::from([(resource, row)]))]));
 }
 
 async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
@@ -150,7 +132,7 @@ async fn hostless_convoy_delete_routes_to_remote_home() {
         .await
         .expect("create remote-homed convoy");
 
-    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+    apply_convoy_replica_feed(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
 
     let mut rx = topology.leader.subscribe();
     let command_id = topology
@@ -188,7 +170,7 @@ async fn mistargeted_convoy_delete_routes_to_remote_home() {
         .create(&InputMeta::builder().name(convoy_name.to_string()).build(), &convoy_spec("scratch"))
         .await
         .expect("create remote-homed convoy");
-    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+    apply_convoy_replica_feed(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
 
     let mut rx = topology.leader.subscribe();
     let command_id = topology
@@ -222,7 +204,7 @@ async fn hostless_convoy_abandon_routes_to_remote_home() {
         .create(&InputMeta::builder().name(convoy_name.to_string()).build(), &convoy_spec("scratch"))
         .await
         .expect("create remote-homed convoy");
-    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+    apply_convoy_replica_feed(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
 
     let mut rx = topology.leader.subscribe();
     let command_id = topology
@@ -269,7 +251,7 @@ async fn hostless_convoy_work_complete_routes_to_remote_home() {
         })
         .await
         .expect("seed remote work status");
-    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+    apply_convoy_replica_feed(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
 
     let mut rx = topology.leader.subscribe();
     let command_id = topology
@@ -302,7 +284,7 @@ async fn hostless_convoy_command_explains_missing_home_route() {
     let namespace = "flotilla";
     let convoy_name = "stranded";
 
-    seed_convoy_projection(&topology.leader, namespace, convoy_name, HostName::new("feta")).await;
+    apply_convoy_replica_feed(&topology.leader, namespace, convoy_name, HostName::new("feta")).await;
 
     let message = topology
         .client
@@ -330,7 +312,7 @@ async fn hostless_convoy_delete_uses_live_peer_route_when_connection_status_is_s
     let namespace = "flotilla";
     let convoy_name = "offline-home";
 
-    seed_convoy_projection(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
+    apply_convoy_replica_feed(&topology.leader, namespace, convoy_name, topology.follower_host.clone()).await;
     topology
         .leader
         .publish_peer_connection_status(


### PR DESCRIPTION
## Summary

- route existing-convoy commands using the peer manager's live sender/route instead of the presentation-level connection-status cache
- preserve home-host context and report the configured transport address plus the underlying routing or send failure
- exercise routing-vs-feed agreement through an aggregation replica feed and an in-memory two-daemon request session

## Root cause

Home resolution used the aggregator projection correctly, but then rejected the command from `HostRegistry::peer_connection_status`. Actual peer delivery uses `PeerManager::resolve_sender`, so a stale presentation status could say disconnected while the live peer stream and routed sender were healthy.

## Validation

- `cargo +nightly-2026-03-12 fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --locked -p flotilla-daemon --test request_session_pair`
- `RUSTC_WRAPPER= TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #883
