### PR TITLE
fix: reconcile repository identity changes

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1008,6 +1008,8 @@ struct FleetReplicaCacheEntry {
     last_error: Option<String>,
 }
 
+const SUPERSEDED_BY_ANNOTATION: &str = "flotilla.work/superseded-by";
+
 #[derive(bon::Builder)]
 struct ResolvedCrewContext {
     namespace: String,
@@ -2945,8 +2947,11 @@ fn local_repository_matches_checkout(spec: &RepositorySpec, checkout: &crate::re
     }
 }
 
-struct RepositoryProjectReconciliation {
-    identity_change: Option<RepositoryIdentityChange>,
+#[derive(Debug)]
+pub struct AddRepoOutcome {
+    pub tracked_path: PathBuf,
+    pub resolved_from: Option<PathBuf>,
+    pub identity_change: Option<RepositoryIdentityChange>,
 }
 
 fn normalize_workspace_slug(candidate: &str) -> String {
@@ -3677,7 +3682,7 @@ impl InProcessDaemon {
     async fn reconcile_whole_repository_project(
         &self,
         inspection: &crate::repository_inspection::RepositoryInspection,
-    ) -> Result<RepositoryProjectReconciliation, String> {
+    ) -> Result<Option<RepositoryIdentityChange>, String> {
         let namespace = self.provisioning_namespace().await;
         let repository_spec = &inspection.spec;
         let repository_key = repository_spec.key();
@@ -3722,9 +3727,19 @@ impl InProcessDaemon {
             }
         }
 
+        let other_tracked_keys = self
+            .repository_keys_by_path
+            .read()
+            .await
+            .iter()
+            .filter(|(path, _)| *path != &inspection.checkout.path)
+            .map(|(_, key)| key.clone())
+            .collect::<BTreeSet<_>>();
+        let migratable_keys = superseded_keys.difference(&other_tracked_keys).cloned().collect::<BTreeSet<_>>();
+
         let mut project_objects = projects.list().await.map_err(|error| error.to_string())?.items;
         let mut generated_names = whole_repository_project_names(repository_spec)?.into_iter().collect::<BTreeSet<_>>();
-        for key in &superseded_keys {
+        for key in &migratable_keys {
             if let Some(spec) = repository_specs.get(key) {
                 generated_names.extend(whole_repository_project_names(spec)?);
             }
@@ -3733,7 +3748,7 @@ impl InProcessDaemon {
             let mut updated = project.spec.clone();
             let mut changed = false;
             for entry in &mut updated.repositories {
-                if superseded_keys.contains(&entry.repo) {
+                if migratable_keys.contains(&entry.repo) {
                     entry.repo = repository_key.clone();
                     changed = true;
                 }
@@ -3764,22 +3779,14 @@ impl InProcessDaemon {
             }
         }
 
-        let other_tracked_keys = self
-            .repository_keys_by_path
-            .read()
-            .await
-            .iter()
-            .filter(|(path, _)| *path != &inspection.checkout.path)
-            .map(|(_, key)| key.clone())
-            .collect::<BTreeSet<_>>();
         let remaining_projects = projects.list().await.map_err(|error| error.to_string())?.items;
         let durable_checkouts =
             self.resource_backend.clone().using::<ResourceCheckout>(&namespace).list().await.map_err(|error| error.to_string())?.items;
-        for old_key in &superseded_keys {
+        for old_key in &migratable_keys {
             let still_referenced =
                 remaining_projects.iter().any(|project| project.spec.repositories.iter().any(|entry| &entry.repo == old_key));
             let has_durable_checkout = durable_checkouts.iter().any(|checkout| checkout.spec.repo_ref() == old_key);
-            if !still_referenced && !has_durable_checkout && !other_tracked_keys.contains(old_key) {
+            if !still_referenced && !has_durable_checkout {
                 crate::observed_resources::delete_observed_checkouts(&self.observed_resource_backend, &namespace, old_key)
                     .await
                     .map_err(|error| error.to_string())?;
@@ -3787,6 +3794,17 @@ impl InProcessDaemon {
                     Ok(()) | Err(ResourceError::NotFound { .. }) => {}
                     Err(error) => return Err(error.to_string()),
                 }
+            } else if !still_referenced && has_durable_checkout {
+                let old_repository = repository_objects
+                    .iter()
+                    .find(|repository| repository.metadata.name == old_key.to_string())
+                    .expect("superseded key came from the listed repositories");
+                let mut meta = InputMeta::from(&old_repository.metadata);
+                meta.annotations.insert(SUPERSEDED_BY_ANNOTATION.to_string(), repository_key.to_string());
+                repositories
+                    .update(&meta, &old_repository.metadata.resource_version, &old_repository.spec)
+                    .await
+                    .map_err(|error| error.to_string())?;
             }
         }
 
@@ -3795,20 +3813,20 @@ impl InProcessDaemon {
             .and_then(|key| repository_specs.get(key))
             .or_else(|| superseded_keys.iter().find_map(|key| repository_specs.get(key)));
         let identity_change = previous_spec.map(|previous| RepositoryIdentityChange {
-            previous: repository_identity_display(previous),
-            current: repository_identity_display(repository_spec),
+            previous_display: repository_identity_display(previous),
+            current_display: repository_identity_display(repository_spec),
         });
         if primary_name.is_some() {
-            return Ok(RepositoryProjectReconciliation { identity_change });
+            return Ok(identity_change);
         }
 
         for project_name in whole_repository_project_names(repository_spec)? {
             match projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await {
-                Ok(_) => return Ok(RepositoryProjectReconciliation { identity_change }),
+                Ok(_) => return Ok(identity_change),
                 Err(ResourceError::Conflict { .. }) => {
                     let existing = projects.get(&project_name).await.map_err(|error| error.to_string())?;
                     if existing.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()) {
-                        return Ok(RepositoryProjectReconciliation { identity_change });
+                        return Ok(identity_change);
                     }
                 }
                 Err(error) => return Err(error.to_string()),
@@ -3888,11 +3906,29 @@ impl InProcessDaemon {
             .map_err(|error| error.to_string())
     }
 
-    pub async fn refresh(&self, repo: &flotilla_protocol::RepoSelector) -> Result<(), String> {
+    pub async fn refresh(&self, repo: &flotilla_protocol::RepoSelector) -> Result<Option<RepositoryIdentityChange>, String> {
         let repo = self.resolve_repo_selector(repo).await?;
+        let identity = self.tracked_repo_identity_for_path(&repo).await.ok_or_else(|| format!("repo not tracked: {}", repo.display()))?;
+        let identity_change = match self.inspect_repository_path(&repo, None).await {
+            Ok(inspection) if self.repository_keys_by_path.read().await.get(&repo) != Some(&inspection.key()) => {
+                let identity_change = self.reconcile_whole_repository_project(&inspection).await?;
+                {
+                    let _reconciliation = self.observed_checkout_reconciliation.lock().await;
+                    if self.tracked_repo_identity_for_path(&repo).await.as_ref() != Some(&identity) {
+                        return Err(format!("repo not tracked: {}", repo.display()));
+                    }
+                    self.repository_keys_by_path.write().await.insert(repo.clone(), inspection.key());
+                }
+                self.publish_repo_info_update(&identity).await;
+                identity_change
+            }
+            Ok(_) => None,
+            Err(error) => {
+                warn!(repo = %repo.display(), %error, "repository identity is unavailable during refresh");
+                None
+            }
+        };
         {
-            let identity =
-                self.tracked_repo_identity_for_path(&repo).await.ok_or_else(|| format!("repo not tracked: {}", repo.display()))?;
             let repos = self.repos.read().await;
             let state = repos.get(&identity).ok_or_else(|| format!("repo not tracked: {}", repo.display()))?;
             for root in &state.roots {
@@ -3902,7 +3938,7 @@ impl InProcessDaemon {
             }
         };
 
-        Ok(())
+        Ok(identity_change)
     }
 
     /// Resolve a path that might be a git worktree to the main repo root.
@@ -3948,12 +3984,12 @@ impl InProcessDaemon {
         }
     }
 
-    /// Add a repo to tracking, returning `(tracked_path, resolved_from, identity_change)`.
+    /// Add a repo to tracking and report path normalization or identity migration.
     ///
     /// If `path` is a git worktree, the main repo root is resolved via
     /// `git rev-parse --path-format=absolute --git-common-dir` and tracked
     /// instead. `resolved_from` is `Some(original_path)` in that case.
-    pub async fn add_repo(&self, path: &Path) -> Result<(PathBuf, Option<PathBuf>, Option<RepositoryIdentityChange>), String> {
+    pub async fn add_repo(&self, path: &Path) -> Result<AddRepoOutcome, String> {
         let (path, resolved_from) = self.normalize_repo_path(path).await;
 
         // Create the model outside the lock (spawns provider detection and refresh)
@@ -3979,8 +4015,7 @@ impl InProcessDaemon {
             .await
             .map_err(|error| format!("cannot track repository {}: {error}", path.display()))?;
         let repository_key = Some(repository_inspection.key());
-        let project_reconciliation = self.reconcile_whole_repository_project(&repository_inspection).await?;
-        let identity_change = project_reconciliation.identity_change;
+        let identity_change = self.reconcile_whole_repository_project(&repository_inspection).await?;
         if let Some(tracked_identity) = self.tracked_repo_identity_for_path(&path).await {
             if tracked_identity == identity {
                 let key_became_available = {
@@ -3998,7 +4033,7 @@ impl InProcessDaemon {
                     self.publish_repo_info_update(&identity).await;
                 }
                 if self.tracked_repo_identity_for_path(&path).await.as_ref() == Some(&identity) {
-                    return Ok((path, resolved_from, identity_change));
+                    return Ok(AddRepoOutcome { tracked_path: path, resolved_from, identity_change });
                 }
             }
             if let Err(error) = self.remove_repo(&path).await {
@@ -4043,7 +4078,7 @@ impl InProcessDaemon {
         let _reconciliation = self.observed_checkout_reconciliation.lock().await;
         let already_tracked = self.path_identities.read().await.contains_key(&path);
         if already_tracked {
-            return Ok((path, resolved_from, identity_change));
+            return Ok(AddRepoOutcome { tracked_path: path, resolved_from, identity_change });
         }
         {
             let mut repos = self.repos.write().await;
@@ -4072,7 +4107,7 @@ impl InProcessDaemon {
             self.broadcast_snapshot_inner(&path, false).await;
         }
 
-        Ok((path, resolved_from, identity_change))
+        Ok(AddRepoOutcome { tracked_path: path, resolved_from, identity_change })
     }
 
     pub async fn remove_repo(&self, path: &Path) -> Result<(), String> {
@@ -5411,16 +5446,19 @@ impl InProcessDaemon {
                 description,
             });
             let mut refreshed = Vec::new();
+            let mut identity_changes = Vec::new();
             let result = match async {
                 for repo in &repo_paths {
-                    self.refresh(&flotilla_protocol::RepoSelector::Path(repo.clone())).await?;
+                    if let Some(change) = self.refresh(&flotilla_protocol::RepoSelector::Path(repo.clone())).await? {
+                        identity_changes.push(change);
+                    }
                     refreshed.push(repo.clone());
                 }
                 Ok::<(), String>(())
             }
             .await
             {
-                Ok(()) => flotilla_protocol::CommandValue::Refreshed { repos: refreshed },
+                Ok(()) => flotilla_protocol::CommandValue::Refreshed { repos: refreshed, identity_changes },
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {
@@ -5925,9 +5963,11 @@ impl InProcessDaemon {
                 description,
             });
             let result = match self.add_repo(path).await {
-                Ok((tracked_path, resolved_from, identity_change)) => {
-                    flotilla_protocol::CommandValue::RepoTracked { path: tracked_path, resolved_from, identity_change }
-                }
+                Ok(outcome) => flotilla_protocol::CommandValue::RepoTracked {
+                    path: outcome.tracked_path,
+                    resolved_from: outcome.resolved_from,
+                    identity_change: outcome.identity_change,
+                },
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {
@@ -5979,7 +6019,10 @@ impl InProcessDaemon {
                 description,
             });
             let result = match self.refresh(&flotilla_protocol::RepoSelector::Path(repo_path.clone())).await {
-                Ok(()) => flotilla_protocol::CommandValue::Refreshed { repos: vec![repo_path.clone()] },
+                Ok(identity_change) => flotilla_protocol::CommandValue::Refreshed {
+                    repos: vec![repo_path.clone()],
+                    identity_changes: identity_change.into_iter().collect(),
+                },
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3765,12 +3765,11 @@ impl InProcessDaemon {
 
         let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
         let spec = whole_repository_project_spec(repository_key.clone(), display_name)?;
-        let primary_name = whole_repository_project_names(repository_spec)?.into_iter().find(|candidate| {
-            project_objects.iter().any(|project| {
-                project.metadata.name == *candidate
-                    && project.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none())
-            })
-        });
+        let primary_name = project_objects
+            .iter()
+            .filter(|project| project.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()))
+            .min_by_key(|project| (generated_names.contains(&project.metadata.name), project.metadata.name.as_str()))
+            .map(|project| project.metadata.name.clone());
         if let Some(primary_name) = &primary_name {
             for duplicate in project_objects.iter().filter(|project| {
                 project.metadata.name != *primary_name && generated_names.contains(&project.metadata.name) && project.spec == spec

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3738,12 +3738,16 @@ impl InProcessDaemon {
         let migratable_keys = superseded_keys.difference(&other_tracked_keys).cloned().collect::<BTreeSet<_>>();
 
         let mut project_objects = projects.list().await.map_err(|error| error.to_string())?.items;
+        let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
         let mut generated_names = whole_repository_project_names(repository_spec)?.into_iter().collect::<BTreeSet<_>>();
+        let mut generated_display_names = BTreeSet::from([display_name.clone()]);
         for key in &migratable_keys {
             if let Some(spec) = repository_specs.get(key) {
                 generated_names.extend(whole_repository_project_names(spec)?);
+                generated_display_names.insert(normalize_project_name(&spec.leaf_slug())?);
             }
         }
+        let mut migrated_project_names = BTreeSet::new();
         for project in &mut project_objects {
             let mut updated = project.spec.clone();
             let mut changed = false;
@@ -3760,19 +3764,30 @@ impl InProcessDaemon {
                     .await
                     .map_err(|error| error.to_string())?;
                 project.spec = updated;
+                migrated_project_names.insert(project.metadata.name.clone());
             }
         }
 
-        let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
         let spec = whole_repository_project_spec(repository_key.clone(), display_name)?;
         let primary_name = project_objects
             .iter()
             .filter(|project| project.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()))
-            .min_by_key(|project| (generated_names.contains(&project.metadata.name), project.metadata.name.as_str()))
+            .min_by_key(|project| {
+                (
+                    !migrated_project_names.contains(&project.metadata.name),
+                    generated_names.contains(&project.metadata.name),
+                    project.metadata.name.as_str(),
+                )
+            })
             .map(|project| project.metadata.name.clone());
         if let Some(primary_name) = &primary_name {
             for duplicate in project_objects.iter().filter(|project| {
-                project.metadata.name != *primary_name && generated_names.contains(&project.metadata.name) && project.spec == spec
+                project.metadata.name != *primary_name
+                    && generated_names.contains(&project.metadata.name)
+                    && generated_display_names.contains(&project.spec.display_name)
+                    && project.spec.default_workflow_ref == spec.default_workflow_ref
+                    && project.spec.issue_source == spec.issue_source
+                    && project.spec.repositories == spec.repositories
             }) {
                 projects.delete(&duplicate.metadata.name).await.map_err(|error| error.to_string())?;
             }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{
     arg::{flatten, Arg},
+    commands::RepositoryIdentityChange,
     qualified_path::QualifiedPath,
     result_set::{ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
     AttachBinding, Command, CommandValue, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry,
@@ -2489,14 +2490,21 @@ impl InProcessDaemon {
                 }
             };
             let repository_key = inspection.key();
-            if let Err(error) = flotilla_resources::ensure_repository(
-                &self.resource_backend.clone().using::<Repository>(&namespace),
-                &repository_key,
-                &inspection.spec,
-            )
-            .await
-            {
-                warn!(repo = %identity.path, %error, "failed to ensure repository for observed checkouts");
+            let stored_key = self.repository_keys_by_path.read().await.get(&local_root).cloned();
+            let reconcile_result = if stored_key.as_ref() == Some(&repository_key) {
+                flotilla_resources::ensure_repository(
+                    &self.resource_backend.clone().using::<Repository>(&namespace),
+                    &repository_key,
+                    &inspection.spec,
+                )
+                .await
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+            } else {
+                self.reconcile_whole_repository_project(&inspection).await.map(|_| ())
+            };
+            if let Err(error) = reconcile_result {
+                warn!(repo = %identity.path, %error, "failed to reconcile repository identity for observed checkouts");
                 continue;
             }
             let _reconciliation = self.observed_checkout_reconciliation.lock().await;
@@ -2904,6 +2912,41 @@ fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: St
         issue_source: None,
         repositories: vec![ProjectRepositorySpec { repo: repository_key, subpath: None, default_branch: None }],
     })
+}
+
+fn whole_repository_project_names(repository_spec: &RepositorySpec) -> Result<Vec<String>, String> {
+    let repository_key = repository_spec.key();
+    let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
+    let catalog_name = normalize_project_name(&repository_spec.catalog_slug())?;
+    let key_suffix = repository_key.0.chars().take(8).collect::<String>();
+    let disambiguated_name = format!("{catalog_name}-{key_suffix}");
+    let mut candidates = Vec::new();
+    for candidate in [display_name, catalog_name, disambiguated_name] {
+        if !candidates.contains(&candidate) {
+            candidates.push(candidate);
+        }
+    }
+    Ok(candidates)
+}
+
+fn repository_identity_display(spec: &RepositorySpec) -> String {
+    match spec.identity() {
+        flotilla_resources::RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
+        flotilla_resources::RepositoryIdentity::Local { .. } => "local".to_string(),
+    }
+}
+
+fn local_repository_matches_checkout(spec: &RepositorySpec, checkout: &crate::repository_inspection::LocalCheckoutInspection) -> bool {
+    match spec.identity() {
+        flotilla_resources::RepositoryIdentity::Local { host_ref, git_common_dir } => {
+            host_ref == &checkout.host_ref && Path::new(git_common_dir).parent() == Some(checkout.path.as_path())
+        }
+        flotilla_resources::RepositoryIdentity::Remote { .. } => false,
+    }
+}
+
+struct RepositoryProjectReconciliation {
+    identity_change: Option<RepositoryIdentityChange>,
 }
 
 fn normalize_workspace_slug(candidate: &str) -> String {
@@ -3631,42 +3674,141 @@ impl InProcessDaemon {
         Ok(project_name)
     }
 
-    async fn ensure_whole_repository_project(&self, repository_spec: &RepositorySpec) -> Result<String, String> {
+    async fn reconcile_whole_repository_project(
+        &self,
+        inspection: &crate::repository_inspection::RepositoryInspection,
+    ) -> Result<RepositoryProjectReconciliation, String> {
         let namespace = self.provisioning_namespace().await;
+        let repository_spec = &inspection.spec;
         let repository_key = repository_spec.key();
         ensure_repository_and_default_project_workflow(&self.resource_backend, &namespace, &repository_key, repository_spec).await?;
 
         let projects = self.resource_backend.clone().using::<Project>(&namespace);
-        if let Some(existing) = projects
+        let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
+        let repository_objects = repositories.list().await.map_err(|error| error.to_string())?.items;
+        let repository_specs = repository_objects
+            .iter()
+            .map(|repository| (RepositoryKey(repository.metadata.name.clone()), repository.spec.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let mut superseded_keys = BTreeSet::new();
+        let previous_tracked_key = self
+            .repository_keys_by_path
+            .read()
+            .await
+            .get(&inspection.checkout.path)
+            .filter(|previous| *previous != &repository_key)
+            .cloned();
+        if let Some(previous) = &previous_tracked_key {
+            superseded_keys.insert(previous.clone());
+        }
+        for (key, spec) in &repository_specs {
+            if key != &repository_key && local_repository_matches_checkout(spec, &inspection.checkout) {
+                superseded_keys.insert(key.clone());
+            }
+        }
+        for checkout in self
+            .observed_resource_backend
+            .clone()
+            .using::<ResourceCheckout>(&namespace)
             .list()
             .await
             .map_err(|error| error.to_string())?
             .items
-            .into_iter()
-            .find(|project| project.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()))
         {
-            return Ok(existing.metadata.name);
-        }
-
-        let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
-        let catalog_name = normalize_project_name(&repository_spec.catalog_slug())?;
-        let key_suffix = repository_key.0.chars().take(8).collect::<String>();
-        let disambiguated_name = format!("{catalog_name}-{key_suffix}");
-        let mut candidates = Vec::new();
-        for candidate in [display_name.clone(), catalog_name, disambiguated_name] {
-            if !candidates.contains(&candidate) {
-                candidates.push(candidate);
+            if let ResourceCheckoutSpec::Observed(observed) = checkout.spec {
+                if Path::new(&observed.path) == inspection.checkout.path && observed.repo_ref != repository_key {
+                    superseded_keys.insert(observed.repo_ref);
+                }
             }
         }
 
+        let mut project_objects = projects.list().await.map_err(|error| error.to_string())?.items;
+        let mut generated_names = whole_repository_project_names(repository_spec)?.into_iter().collect::<BTreeSet<_>>();
+        for key in &superseded_keys {
+            if let Some(spec) = repository_specs.get(key) {
+                generated_names.extend(whole_repository_project_names(spec)?);
+            }
+        }
+        for project in &mut project_objects {
+            let mut updated = project.spec.clone();
+            let mut changed = false;
+            for entry in &mut updated.repositories {
+                if superseded_keys.contains(&entry.repo) {
+                    entry.repo = repository_key.clone();
+                    changed = true;
+                }
+            }
+            if changed {
+                updated = normalize_project_spec(updated)?;
+                projects
+                    .update(&InputMeta::from(&project.metadata), &project.metadata.resource_version, &updated)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                project.spec = updated;
+            }
+        }
+
+        let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
         let spec = whole_repository_project_spec(repository_key.clone(), display_name)?;
-        for project_name in candidates {
+        let primary_name = whole_repository_project_names(repository_spec)?.into_iter().find(|candidate| {
+            project_objects.iter().any(|project| {
+                project.metadata.name == *candidate
+                    && project.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none())
+            })
+        });
+        if let Some(primary_name) = &primary_name {
+            for duplicate in project_objects.iter().filter(|project| {
+                project.metadata.name != *primary_name && generated_names.contains(&project.metadata.name) && project.spec == spec
+            }) {
+                projects.delete(&duplicate.metadata.name).await.map_err(|error| error.to_string())?;
+            }
+        }
+
+        let other_tracked_keys = self
+            .repository_keys_by_path
+            .read()
+            .await
+            .iter()
+            .filter(|(path, _)| *path != &inspection.checkout.path)
+            .map(|(_, key)| key.clone())
+            .collect::<BTreeSet<_>>();
+        let remaining_projects = projects.list().await.map_err(|error| error.to_string())?.items;
+        let durable_checkouts =
+            self.resource_backend.clone().using::<ResourceCheckout>(&namespace).list().await.map_err(|error| error.to_string())?.items;
+        for old_key in &superseded_keys {
+            let still_referenced =
+                remaining_projects.iter().any(|project| project.spec.repositories.iter().any(|entry| &entry.repo == old_key));
+            let has_durable_checkout = durable_checkouts.iter().any(|checkout| checkout.spec.repo_ref() == old_key);
+            if !still_referenced && !has_durable_checkout && !other_tracked_keys.contains(old_key) {
+                crate::observed_resources::delete_observed_checkouts(&self.observed_resource_backend, &namespace, old_key)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                match repositories.delete(&old_key.to_string()).await {
+                    Ok(()) | Err(ResourceError::NotFound { .. }) => {}
+                    Err(error) => return Err(error.to_string()),
+                }
+            }
+        }
+
+        let previous_spec = previous_tracked_key
+            .as_ref()
+            .and_then(|key| repository_specs.get(key))
+            .or_else(|| superseded_keys.iter().find_map(|key| repository_specs.get(key)));
+        let identity_change = previous_spec.map(|previous| RepositoryIdentityChange {
+            previous: repository_identity_display(previous),
+            current: repository_identity_display(repository_spec),
+        });
+        if primary_name.is_some() {
+            return Ok(RepositoryProjectReconciliation { identity_change });
+        }
+
+        for project_name in whole_repository_project_names(repository_spec)? {
             match projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await {
-                Ok(_) => return Ok(project_name),
+                Ok(_) => return Ok(RepositoryProjectReconciliation { identity_change }),
                 Err(ResourceError::Conflict { .. }) => {
                     let existing = projects.get(&project_name).await.map_err(|error| error.to_string())?;
                     if existing.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()) {
-                        return Ok(project_name);
+                        return Ok(RepositoryProjectReconciliation { identity_change });
                     }
                 }
                 Err(error) => return Err(error.to_string()),
@@ -3684,7 +3826,7 @@ impl InProcessDaemon {
                     continue;
                 }
             };
-            self.ensure_whole_repository_project(&inspection.spec)
+            self.reconcile_whole_repository_project(&inspection)
                 .await
                 .map_err(|error| format!("materialize whole-repository Project for {}: {error}", repo_path.display()))?;
         }
@@ -3806,12 +3948,12 @@ impl InProcessDaemon {
         }
     }
 
-    /// Add a repo to tracking, returning `(tracked_path, resolved_from)`.
+    /// Add a repo to tracking, returning `(tracked_path, resolved_from, identity_change)`.
     ///
     /// If `path` is a git worktree, the main repo root is resolved via
     /// `git rev-parse --path-format=absolute --git-common-dir` and tracked
     /// instead. `resolved_from` is `Some(original_path)` in that case.
-    pub async fn add_repo(&self, path: &Path) -> Result<(PathBuf, Option<PathBuf>), String> {
+    pub async fn add_repo(&self, path: &Path) -> Result<(PathBuf, Option<PathBuf>, Option<RepositoryIdentityChange>), String> {
         let (path, resolved_from) = self.normalize_repo_path(path).await;
 
         // Create the model outside the lock (spawns provider detection and refresh)
@@ -3837,7 +3979,8 @@ impl InProcessDaemon {
             .await
             .map_err(|error| format!("cannot track repository {}: {error}", path.display()))?;
         let repository_key = Some(repository_inspection.key());
-        self.ensure_whole_repository_project(&repository_inspection.spec).await?;
+        let project_reconciliation = self.reconcile_whole_repository_project(&repository_inspection).await?;
+        let identity_change = project_reconciliation.identity_change;
         if let Some(tracked_identity) = self.tracked_repo_identity_for_path(&path).await {
             if tracked_identity == identity {
                 let key_became_available = {
@@ -3855,7 +3998,7 @@ impl InProcessDaemon {
                     self.publish_repo_info_update(&identity).await;
                 }
                 if self.tracked_repo_identity_for_path(&path).await.as_ref() == Some(&identity) {
-                    return Ok((path, resolved_from));
+                    return Ok((path, resolved_from, identity_change));
                 }
             }
             if let Err(error) = self.remove_repo(&path).await {
@@ -3900,7 +4043,7 @@ impl InProcessDaemon {
         let _reconciliation = self.observed_checkout_reconciliation.lock().await;
         let already_tracked = self.path_identities.read().await.contains_key(&path);
         if already_tracked {
-            return Ok((path, resolved_from));
+            return Ok((path, resolved_from, identity_change));
         }
         {
             let mut repos = self.repos.write().await;
@@ -3929,7 +4072,7 @@ impl InProcessDaemon {
             self.broadcast_snapshot_inner(&path, false).await;
         }
 
-        Ok((path, resolved_from))
+        Ok((path, resolved_from, identity_change))
     }
 
     pub async fn remove_repo(&self, path: &Path) -> Result<(), String> {
@@ -5782,7 +5925,9 @@ impl InProcessDaemon {
                 description,
             });
             let result = match self.add_repo(path).await {
-                Ok((tracked_path, resolved_from)) => flotilla_protocol::CommandValue::RepoTracked { path: tracked_path, resolved_from },
+                Ok((tracked_path, resolved_from, identity_change)) => {
+                    flotilla_protocol::CommandValue::RepoTracked { path: tracked_path, resolved_from, identity_change }
+                }
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -4491,7 +4491,7 @@ async fn adding_local_clone_promotes_remote_only_identity_to_local_execution() {
         .add_virtual_repo(identity.clone(), None, PathBuf::from("/remote/desktop/owner/repo"), vec![], 0)
         .await
         .expect("add virtual repo");
-    let (tracked_path, _) = daemon.add_repo(&local_repo).await.expect("add local repo");
+    let (tracked_path, _, _) = daemon.add_repo(&local_repo).await.expect("add local repo");
     // Path may be canonicalized (e.g. /var -> /private/var on macOS)
     let canonical_repo = std::fs::canonicalize(&local_repo).unwrap_or_else(|_| local_repo.clone());
 
@@ -5308,7 +5308,7 @@ async fn add_repo_uses_manager_backed_local_environment_for_repo_identity() {
         )))
         .expect("replace local environment bag");
 
-    let (tracked_path, resolved_from) = daemon.add_repo(&repo).await.expect("add repo");
+    let (tracked_path, resolved_from, _) = daemon.add_repo(&repo).await.expect("add repo");
 
     assert_eq!(tracked_path, repo);
     assert_eq!(resolved_from, None);

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -3081,6 +3081,7 @@ async fn repository_identity_change_reconciles_old_identity_shared_by_another_ro
             fixed_repository_by_path: HashMap::from([(repo_b.clone(), "old-repo".to_string())]),
         }))
         .await;
+    daemon.materialize_tracked_repo_projects().await.expect("materialize projects for the shared identity");
     let observed = daemon.observed_resource_backend().using::<ResourceCheckout>("flotilla");
     let mut events = daemon.subscribe();
 
@@ -3118,6 +3119,13 @@ async fn repository_identity_change_reconciles_old_identity_shared_by_another_ro
         checkout.metadata.labels.get(REPO_LABEL).map(String::as_str) == Some("github-com-owner-new-repo")
             && matches!(&checkout.spec, ResourceCheckoutSpec::Observed(spec) if spec.path == repo_a.to_string_lossy())
     }));
+
+    let projects = daemon.resource_backend().using::<Project>("flotilla").list().await.expect("project list");
+    assert_eq!(projects.items.len(), 2, "the shared old identity must retain its own Project");
+    assert!(projects.items.iter().any(|project| project.spec.repositories[0].repo
+        == RepositorySpec::remote("https://github.com/owner/old-repo").expect("old repository spec").key()));
+    assert!(projects.items.iter().any(|project| project.spec.repositories[0].repo
+        == RepositorySpec::remote("https://github.com/owner/new-repo").expect("new repository spec").key()));
 }
 
 #[tokio::test]
@@ -4491,7 +4499,8 @@ async fn adding_local_clone_promotes_remote_only_identity_to_local_execution() {
         .add_virtual_repo(identity.clone(), None, PathBuf::from("/remote/desktop/owner/repo"), vec![], 0)
         .await
         .expect("add virtual repo");
-    let (tracked_path, _, _) = daemon.add_repo(&local_repo).await.expect("add local repo");
+    let outcome = daemon.add_repo(&local_repo).await.expect("add local repo");
+    let tracked_path = outcome.tracked_path;
     // Path may be canonicalized (e.g. /var -> /private/var on macOS)
     let canonical_repo = std::fs::canonicalize(&local_repo).unwrap_or_else(|_| local_repo.clone());
 
@@ -4957,7 +4966,7 @@ async fn refresh_all_command_refreshes_every_tracked_repo() {
     .await
     .expect("timeout waiting for refresh all CommandFinished");
 
-    assert!(matches!(finished, CommandValue::Refreshed { repos } if repos.len() == 2));
+    assert!(matches!(finished, CommandValue::Refreshed { repos, .. } if repos.len() == 2));
 }
 
 #[tokio::test]
@@ -5308,7 +5317,9 @@ async fn add_repo_uses_manager_backed_local_environment_for_repo_identity() {
         )))
         .expect("replace local environment bag");
 
-    let (tracked_path, resolved_from, _) = daemon.add_repo(&repo).await.expect("add repo");
+    let outcome = daemon.add_repo(&repo).await.expect("add repo");
+    let tracked_path = outcome.tracked_path;
+    let resolved_from = outcome.resolved_from;
 
     assert_eq!(tracked_path, repo);
     assert_eq!(resolved_from, None);

--- a/crates/flotilla-daemon/src/peer/channel_tests.rs
+++ b/crates/flotilla-daemon/src/peer/channel_tests.rs
@@ -321,7 +321,7 @@ async fn routed_command_event_and_response_reach_requester_through_relay() {
                 requester_node_id: node("host-a"),
                 responder_node_id: node("host-c"),
                 remaining_hops: PeerManager::DEFAULT_ROUTED_HOPS,
-                result: Box::new(CommandValue::Refreshed { repos: vec![PathBuf::from("/repo")] }),
+                result: Box::new(CommandValue::Refreshed { repos: vec![PathBuf::from("/repo")], identity_changes: Vec::new() }),
             }),
         )
         .await
@@ -332,7 +332,7 @@ async fn routed_command_event_and_response_reach_requester_through_relay() {
         a_response_results.as_slice(),
         [HandleResult::CommandResponseReceived { request_id: 77, responder_node_id, result }]
             if responder_node_id == &node("host-c")
-                && *result == CommandValue::Refreshed { repos: vec![PathBuf::from("/repo")] }
+                && *result == CommandValue::Refreshed { repos: vec![PathBuf::from("/repo")], identity_changes: Vec::new() }
     ));
 }
 

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -2097,7 +2097,7 @@ async fn execute_forwarded_command_proxies_lifecycle_and_response() {
                         }
                         CommandPeerEvent::Finished { repo: event_repo, result, .. } => {
                             assert_eq!(event_repo.as_deref(), Some(repo.as_path()));
-                            assert_eq!(result, &CommandValue::Refreshed { repos: vec![repo.clone()] });
+                            assert_eq!(result, &CommandValue::Refreshed { repos: vec![repo.clone()], identity_changes: Vec::new() });
                             saw_finished = true;
                         }
                         CommandPeerEvent::StepUpdate { .. } => {}
@@ -2113,7 +2113,7 @@ async fn execute_forwarded_command_proxies_lifecycle_and_response() {
                     assert_eq!(*request_id, 7);
                     assert_eq!(requester_node_id, &NodeId::new("desktop"));
                     assert_eq!(responder_node_id, daemon.node_id());
-                    assert_eq!(result.as_ref(), &CommandValue::Refreshed { repos: vec![repo.clone()] });
+                    assert_eq!(result.as_ref(), &CommandValue::Refreshed { repos: vec![repo.clone()], identity_changes: Vec::new() });
                     saw_response = true;
                 }
                 other => panic!("unexpected proxied message: {other:?}"),

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -2,7 +2,7 @@
 
 use std::{
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, RwLock},
     time::Duration,
 };
 
@@ -15,10 +15,10 @@ use flotilla_core::{
     repository_inspection::{LocalCheckoutInspection, RepositoryInspection, RepositoryInspector},
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
-use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName};
+use flotilla_protocol::{commands::RepositoryIdentityChange, Command, CommandAction, CommandValue, DaemonEvent, HostName};
 use flotilla_resources::{
-    Checkout, Convoy, InMemoryBackend, InputMeta, IssueSource, Project, Repository, RepositoryKey, RepositorySpec, RepositoryStatus,
-    ResourceBackend,
+    Checkout, Convoy, InMemoryBackend, InputMeta, IssueSource, Project, ProjectSpec, Repository, RepositoryKey, RepositorySpec,
+    RepositoryStatus, ResourceBackend,
 };
 
 fn test_config(dir: PathBuf) -> Arc<ConfigStore> {
@@ -54,6 +54,27 @@ async fn start_daemon() -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigSto
 struct FixedInspector {
     spec: RepositorySpec,
     host_ref: String,
+}
+
+#[derive(Clone)]
+struct MutableInspector {
+    spec: Arc<RwLock<RepositorySpec>>,
+}
+
+#[async_trait]
+impl RepositoryInspector for MutableInspector {
+    async fn inspect_path(&self, path: &Path, _remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        Ok(RepositoryInspection {
+            spec: self.spec.read().expect("repository identity lock should not be poisoned").clone(),
+            checkout: LocalCheckoutInspection {
+                path: path.to_path_buf(),
+                host_ref: "host-01".to_string(),
+                git_ref: "main".to_string(),
+                is_main: true,
+            },
+            transport_url: None,
+        })
+    }
 }
 
 #[async_trait]
@@ -142,6 +163,108 @@ async fn tracking_repo_materializes_whole_repo_project() {
         subpath: None,
         default_branch: None,
     }]);
+}
+
+#[tokio::test]
+async fn retracking_path_after_remote_appears_migrates_repository_identity() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+    let checkout_path = tmp.path().join("andamento");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let local_spec = RepositorySpec::local("host-01", checkout_path.join(".git").to_string_lossy()).expect("local repository spec");
+    let local_key = local_spec.key();
+    let inspected_spec = Arc::new(RwLock::new(local_spec));
+    daemon.set_repository_inspector(Arc::new(MutableInspector { spec: Arc::clone(&inspected_spec) })).await;
+
+    let first_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path.clone() },
+        })
+        .await
+        .expect("initial repo add");
+    assert!(matches!(await_command_result(&mut rx, first_id).await, CommandValue::RepoTracked { .. }));
+
+    let remote_spec = RepositorySpec::remote("https://github.com/flotilla-org/andamento").expect("remote repository spec");
+    let remote_key = remote_spec.key();
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(remote_key.to_string()).build(), &remote_spec)
+        .await
+        .expect("stale remote repository generation");
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(
+            &InputMeta::builder().name("github-com-flotilla-org-andamento".to_string()).build(),
+            &ProjectSpec::builder()
+                .display_name("andamento".to_string())
+                .default_workflow_ref("single-agent-contained".to_string())
+                .repositories(vec![flotilla_resources::ProjectRepositorySpec::builder().repo(remote_key.clone()).build()])
+                .build(),
+        )
+        .await
+        .expect("stale disambiguated project twin");
+    *inspected_spec.write().expect("repository identity lock should not be poisoned") = remote_spec;
+    let second_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path.clone() },
+        })
+        .await
+        .expect("repo add after remote appears");
+    assert_eq!(await_command_result(&mut rx, second_id).await, CommandValue::RepoTracked {
+        path: checkout_path.clone(),
+        resolved_from: None,
+        identity_change: Some(RepositoryIdentityChange {
+            previous: "local".to_string(),
+            current: "https://github.com/flotilla-org/andamento".to_string(),
+        }),
+    });
+
+    let projects = backend.using::<Project>("flotilla").list().await.expect("project list");
+    assert_eq!(projects.items.len(), 1, "identity migration must not leave a disambiguated twin");
+    assert_eq!(projects.items[0].metadata.name, "andamento");
+    assert_eq!(projects.items[0].spec.repositories[0].repo, remote_key);
+    let repositories = backend.using::<Repository>("flotilla").list().await.expect("repository list");
+    assert_eq!(repositories.items.len(), 1, "superseded repository identities should be garbage-collected");
+    assert_eq!(repositories.items[0].metadata.name, remote_key.to_string());
+    assert!(backend.using::<Repository>("flotilla").get(&local_key.to_string()).await.is_err());
+
+    let repository = backend.clone().using::<Repository>("flotilla").get(&remote_key.to_string()).await.expect("remote repository");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .update_status(&repository.metadata.name, &repository.metadata.resource_version, &RepositoryStatus {
+            default_branch: Some("main".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("repository status update");
+    let convoy_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "identity-migrated".into(),
+                workflow_ref: "scratch".into(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: Some("andamento".into()),
+                placement_policy: None,
+                adopted_checkout: None,
+            },
+        })
+        .await
+        .expect("convoy create");
+    assert_eq!(await_command_result(&mut rx, convoy_id).await, CommandValue::ConvoyCreated { name: "identity-migrated".into() });
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -311,6 +311,67 @@ async fn tracking_after_custom_project_identity_change_does_not_create_generated
 }
 
 #[tokio::test]
+async fn identity_change_preserves_migrated_project_when_local_and_remote_names_differ() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+    let checkout_path = tmp.path().join("z-local-name");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let local_spec = RepositorySpec::local("host-01", checkout_path.join(".git").to_string_lossy()).expect("local repository spec");
+    let inspected_spec = Arc::new(RwLock::new(local_spec));
+    daemon.set_repository_inspector(Arc::new(MutableInspector { spec: Arc::clone(&inspected_spec) })).await;
+    let add_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path.clone() },
+        })
+        .await
+        .expect("initial repo add");
+    assert!(matches!(await_command_result(&mut rx, add_id).await, CommandValue::RepoTracked { .. }));
+
+    let remote_spec = RepositorySpec::remote("https://github.com/flotilla-org/a-remote-name").expect("remote repository spec");
+    let remote_key = remote_spec.key();
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(remote_key.to_string()).build(), &remote_spec)
+        .await
+        .expect("pre-existing remote repository");
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(
+            &InputMeta::builder().name("a-remote-name".to_string()).build(),
+            &ProjectSpec::builder()
+                .display_name("a-remote-name".to_string())
+                .default_workflow_ref("single-agent-contained".to_string())
+                .repositories(vec![flotilla_resources::ProjectRepositorySpec::builder().repo(remote_key.clone()).build()])
+                .build(),
+        )
+        .await
+        .expect("pre-existing remote project twin");
+
+    *inspected_spec.write().expect("repository identity lock should not be poisoned") = remote_spec;
+    let second_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path },
+        })
+        .await
+        .expect("repo add after remote appears");
+    assert!(matches!(await_command_result(&mut rx, second_id).await, CommandValue::RepoTracked { .. }));
+
+    let projects = backend.using::<Project>("flotilla").list().await.expect("project list");
+    assert_eq!(projects.items.len(), 1, "the pre-existing remote twin should be removed");
+    assert_eq!(projects.items[0].metadata.name, "z-local-name", "the migrated Project should retain its identity");
+    assert_eq!(projects.items[0].spec.display_name, "z-local-name");
+    assert_eq!(projects.items[0].spec.repositories[0].repo, remote_key);
+}
+
+#[tokio::test]
 async fn refresh_surfaces_and_reconciles_repository_identity_change() {
     let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
     let mut rx = daemon.subscribe();

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -15,10 +15,10 @@ use flotilla_core::{
     repository_inspection::{LocalCheckoutInspection, RepositoryInspection, RepositoryInspector},
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
-use flotilla_protocol::{commands::RepositoryIdentityChange, Command, CommandAction, CommandValue, DaemonEvent, HostName};
+use flotilla_protocol::{commands::RepositoryIdentityChange, Command, CommandAction, CommandValue, DaemonEvent, HostName, RepoSelector};
 use flotilla_resources::{
-    Checkout, Convoy, InMemoryBackend, InputMeta, IssueSource, Project, ProjectSpec, Repository, RepositoryKey, RepositorySpec,
-    RepositoryStatus, ResourceBackend,
+    Checkout, CheckoutSpec, Convoy, InMemoryBackend, InputMeta, IssueSource, ObservedCheckoutSpec, Project, ProjectSpec, Repository,
+    RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend,
 };
 
 fn test_config(dir: PathBuf) -> Arc<ConfigStore> {
@@ -222,8 +222,8 @@ async fn retracking_path_after_remote_appears_migrates_repository_identity() {
         path: checkout_path.clone(),
         resolved_from: None,
         identity_change: Some(RepositoryIdentityChange {
-            previous: "local".to_string(),
-            current: "https://github.com/flotilla-org/andamento".to_string(),
+            previous_display: "local".to_string(),
+            current_display: "https://github.com/flotilla-org/andamento".to_string(),
         }),
     });
 
@@ -265,6 +265,105 @@ async fn retracking_path_after_remote_appears_migrates_repository_identity() {
         .await
         .expect("convoy create");
     assert_eq!(await_command_result(&mut rx, convoy_id).await, CommandValue::ConvoyCreated { name: "identity-migrated".into() });
+}
+
+#[tokio::test]
+async fn refresh_surfaces_and_reconciles_repository_identity_change() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+    let checkout_path = tmp.path().join("refreshed");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let inspected_spec = Arc::new(RwLock::new(
+        RepositorySpec::local("host-01", checkout_path.join(".git").to_string_lossy()).expect("local repository spec"),
+    ));
+    daemon.set_repository_inspector(Arc::new(MutableInspector { spec: Arc::clone(&inspected_spec) })).await;
+    let add_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path.clone() },
+        })
+        .await
+        .expect("initial repo add");
+    assert!(matches!(await_command_result(&mut rx, add_id).await, CommandValue::RepoTracked { .. }));
+
+    let remote_spec = RepositorySpec::remote("https://github.com/flotilla-org/refreshed").expect("remote repository spec");
+    let remote_key = remote_spec.key();
+    *inspected_spec.write().expect("repository identity lock should not be poisoned") = remote_spec;
+    let refresh_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::Refresh { repo: Some(RepoSelector::Path(checkout_path.clone())) },
+        })
+        .await
+        .expect("refresh command");
+
+    assert_eq!(await_command_result(&mut rx, refresh_id).await, CommandValue::Refreshed {
+        repos: vec![checkout_path],
+        identity_changes: vec![RepositoryIdentityChange {
+            previous_display: "local".to_string(),
+            current_display: "https://github.com/flotilla-org/refreshed".to_string(),
+        }],
+    });
+    let project = backend.using::<Project>("flotilla").get("refreshed").await.expect("migrated project");
+    assert_eq!(project.spec.repositories[0].repo, remote_key);
+}
+
+#[tokio::test]
+async fn identity_migration_marks_repository_retained_by_durable_checkout() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+    let checkout_path = tmp.path().join("retained");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let local_spec = RepositorySpec::local("host-01", checkout_path.join(".git").to_string_lossy()).expect("local repository spec");
+    let local_key = local_spec.key();
+    let inspected_spec = Arc::new(RwLock::new(local_spec));
+    daemon.set_repository_inspector(Arc::new(MutableInspector { spec: Arc::clone(&inspected_spec) })).await;
+    let add_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path.clone() },
+        })
+        .await
+        .expect("initial repo add");
+    assert!(matches!(await_command_result(&mut rx, add_id).await, CommandValue::RepoTracked { .. }));
+    backend
+        .clone()
+        .using::<Checkout>("flotilla")
+        .create(
+            &InputMeta::builder().name("durable-old-checkout".to_string()).build(),
+            &CheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: "main".to_string(),
+                path: checkout_path.to_string_lossy().into_owned(),
+                repo_ref: local_key.clone(),
+                host_ref: "host-01".to_string(),
+                is_main: true,
+            }),
+        )
+        .await
+        .expect("durable checkout");
+
+    let remote_spec = RepositorySpec::remote("https://github.com/flotilla-org/retained").expect("remote repository spec");
+    let remote_key = remote_spec.key();
+    *inspected_spec.write().expect("repository identity lock should not be poisoned") = remote_spec;
+    let second_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path },
+        })
+        .await
+        .expect("repo add after remote appears");
+    assert!(matches!(await_command_result(&mut rx, second_id).await, CommandValue::RepoTracked { .. }));
+
+    let retained = backend.using::<Repository>("flotilla").get(&local_key.to_string()).await.expect("retained old repository");
+    assert_eq!(retained.metadata.annotations.get("flotilla.work/superseded-by"), Some(&remote_key.to_string()));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -268,6 +268,49 @@ async fn retracking_path_after_remote_appears_migrates_repository_identity() {
 }
 
 #[tokio::test]
+async fn tracking_after_custom_project_identity_change_does_not_create_generated_twin() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let mut rx = daemon.subscribe();
+    let checkout_path = tmp.path().join("custom-repo");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let local_spec = RepositorySpec::local("host-01", checkout_path.join(".git").to_string_lossy()).expect("local repository spec");
+    let inspected_spec = Arc::new(RwLock::new(local_spec));
+    daemon.set_repository_inspector(Arc::new(MutableInspector { spec: Arc::clone(&inspected_spec) })).await;
+
+    assert_eq!(
+        execute_project_add(
+            &daemon,
+            &mut rx,
+            checkout_path.to_string_lossy().into_owned(),
+            Some("my-custom-project"),
+            Some("My Custom Project"),
+        )
+        .await,
+        CommandValue::ProjectAdded { name: "my-custom-project".into() }
+    );
+
+    let remote_spec = RepositorySpec::remote("https://github.com/flotilla-org/custom-repo").expect("remote repository spec");
+    let remote_key = remote_spec.key();
+    *inspected_spec.write().expect("repository identity lock should not be poisoned") = remote_spec;
+    let track_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::TrackRepoPath { path: checkout_path },
+        })
+        .await
+        .expect("track repo after remote appears");
+    assert!(matches!(await_command_result(&mut rx, track_id).await, CommandValue::RepoTracked { .. }));
+
+    let projects = backend.using::<Project>("flotilla").list().await.expect("project list");
+    assert_eq!(projects.items.len(), 1, "identity migration must not create a generated twin for a custom-named project");
+    assert_eq!(projects.items[0].metadata.name, "my-custom-project");
+    assert_eq!(projects.items[0].spec.display_name, "My Custom Project");
+    assert_eq!(projects.items[0].spec.repositories[0].repo, remote_key);
+}
+
+#[tokio::test]
 async fn refresh_surfaces_and_reconciles_repository_identity_change() {
     let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
     let mut rx = daemon.subscribe();

--- a/crates/flotilla-daemon/tests/socket_roundtrip.rs
+++ b/crates/flotilla-daemon/tests/socket_roundtrip.rs
@@ -370,7 +370,7 @@ async fn execute_refresh_all_roundtrip_emits_lifecycle_events() {
     assert_eq!(lifecycle.0, Some(command_id));
     let (finished_id, result) = lifecycle.1.expect("command finished event");
     assert_eq!(finished_id, command_id);
-    assert_eq!(result, CommandValue::Refreshed { repos: vec![repo.clone()] });
+    assert_eq!(result, CommandValue::Refreshed { repos: vec![repo.clone()], identity_changes: Vec::new() });
 
     server_handle.abort();
 }

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -506,6 +506,8 @@ pub enum CommandValue {
     },
     Refreshed {
         repos: Vec<PathBuf>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        identity_changes: Vec<RepositoryIdentityChange>,
     },
     CheckoutCreated {
         branch: String,
@@ -592,8 +594,8 @@ pub enum CommandValue {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryIdentityChange {
-    pub previous: String,
-    pub current: String,
+    pub previous_display: String,
+    pub current_display: String,
 }
 
 /// Status of an individual step within a multi-step command.
@@ -977,12 +979,12 @@ mod tests {
                 path: PathBuf::from("/new/repo"),
                 resolved_from: None,
                 identity_change: Some(RepositoryIdentityChange {
-                    previous: "local".to_string(),
-                    current: "https://github.com/flotilla-org/flotilla".to_string(),
+                    previous_display: "local".to_string(),
+                    current_display: "https://github.com/flotilla-org/flotilla".to_string(),
                 }),
             },
             CommandValue::RepoUntracked { path: PathBuf::from("/old/repo") },
-            CommandValue::Refreshed { repos: vec![PathBuf::from("/repo-a"), PathBuf::from("/repo-b")] },
+            CommandValue::Refreshed { repos: vec![PathBuf::from("/repo-a"), PathBuf::from("/repo-b")], identity_changes: Vec::new() },
             CommandValue::CheckoutCreated {
                 branch: "feat-new".into(),
                 path: QualifiedPath::host(HostId::new("host-a"), "/repos/project/wt-1"),

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -498,6 +498,8 @@ pub enum CommandValue {
         path: PathBuf,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         resolved_from: Option<PathBuf>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        identity_change: Option<RepositoryIdentityChange>,
     },
     RepoUntracked {
         path: PathBuf,
@@ -586,6 +588,12 @@ pub enum CommandValue {
     ProjectApplied {
         name: String,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryIdentityChange {
+    pub previous: String,
+    pub current: String,
 }
 
 /// Status of an individual step within a multi-step command.
@@ -965,7 +973,14 @@ mod tests {
     fn command_value_roundtrip_covers_all_variants() {
         let cases = vec![
             CommandValue::Ok,
-            CommandValue::RepoTracked { path: PathBuf::from("/new/repo"), resolved_from: None },
+            CommandValue::RepoTracked {
+                path: PathBuf::from("/new/repo"),
+                resolved_from: None,
+                identity_change: Some(RepositoryIdentityChange {
+                    previous: "local".to_string(),
+                    current: "https://github.com/flotilla-org/flotilla".to_string(),
+                }),
+            },
             CommandValue::RepoUntracked { path: PathBuf::from("/old/repo") },
             CommandValue::Refreshed { repos: vec![PathBuf::from("/repo-a"), PathBuf::from("/repo-b")] },
             CommandValue::CheckoutCreated {

--- a/crates/flotilla-protocol/src/peer.rs
+++ b/crates/flotilla-protocol/src/peer.rs
@@ -477,7 +477,7 @@ mod tests {
             requester_node_id: NodeId::new("workstation"),
             responder_node_id: NodeId::new("feta"),
             remaining_hops: 7,
-            result: Box::new(CommandValue::RepoTracked { path: PathBuf::from("/srv/repo"), resolved_from: None }),
+            result: Box::new(CommandValue::RepoTracked { path: PathBuf::from("/srv/repo"), resolved_from: None, identity_change: None }),
         };
         let json = serde_json::to_string(&msg).expect("serialize");
         let back: RoutedPeerMessage = serde_json::from_str(&json).expect("deserialize");

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -198,7 +198,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         CommandValue::RepoUntracked { path } => {
             info!(path = %path.display(), "untracked repo");
         }
-        CommandValue::Refreshed { repos } => {
+        CommandValue::Refreshed { repos, .. } => {
             info!(count = repos.len(), "refresh completed");
         }
         CommandValue::CheckoutCreated { branch, .. } => {
@@ -750,7 +750,13 @@ mod tests {
     #[test]
     fn refreshed_does_not_set_status_message() {
         let mut app = stub_app();
-        handle_result(CommandValue::Refreshed { repos: vec![PathBuf::from("/tmp/repo-a"), PathBuf::from("/tmp/repo-b")] }, &mut app);
+        handle_result(
+            CommandValue::Refreshed {
+                repos: vec![PathBuf::from("/tmp/repo-a"), PathBuf::from("/tmp/repo-b")],
+                identity_changes: Vec::new(),
+            },
+            &mut app,
+        );
         assert!(app.model.status_message.is_none());
         assert!(app.proto_commands.take_next().is_none());
     }

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -731,7 +731,10 @@ mod tests {
     #[test]
     fn repo_tracked_does_not_set_status_message() {
         let mut app = stub_app();
-        handle_result(CommandValue::RepoTracked { path: PathBuf::from("/tmp/new-repo"), resolved_from: None }, &mut app);
+        handle_result(
+            CommandValue::RepoTracked { path: PathBuf::from("/tmp/new-repo"), resolved_from: None, identity_change: None },
+            &mut app,
+        );
         assert!(app.model.status_message.is_none());
         assert!(app.proto_commands.take_next().is_none());
     }

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -383,10 +383,16 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
     use flotilla_protocol::commands::CommandValue;
     match result {
         CommandValue::Ok => "ok".to_string(),
-        CommandValue::RepoTracked { path, resolved_from } => match resolved_from {
-            Some(original) => format!("repo tracked: {} (resolved from {})", path.display(), original.display()),
-            None => format!("repo tracked: {}", path.display()),
-        },
+        CommandValue::RepoTracked { path, resolved_from, identity_change } => {
+            let mut output = match resolved_from {
+                Some(original) => format!("repo tracked: {} (resolved from {})", path.display(), original.display()),
+                None => format!("repo tracked: {}", path.display()),
+            };
+            if let Some(change) = identity_change {
+                output.push_str(&format!("\nrepository identity changed: {} → {}", change.previous, change.current));
+            }
+            output
+        }
         CommandValue::RepoUntracked { path } => format!("repo untracked: {}", path.display()),
         CommandValue::Refreshed { repos } => format!("refreshed {} repo(s)", repos.len()),
         CommandValue::CheckoutCreated { branch, .. } => format!("checkout created: {branch}"),

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -389,12 +389,18 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
                 None => format!("repo tracked: {}", path.display()),
             };
             if let Some(change) = identity_change {
-                output.push_str(&format!("\nrepository identity changed: {} → {}", change.previous, change.current));
+                output.push_str(&format!("\nrepository identity changed: {} → {}", change.previous_display, change.current_display));
             }
             output
         }
         CommandValue::RepoUntracked { path } => format!("repo untracked: {}", path.display()),
-        CommandValue::Refreshed { repos } => format!("refreshed {} repo(s)", repos.len()),
+        CommandValue::Refreshed { repos, identity_changes } => {
+            let mut output = format!("refreshed {} repo(s)", repos.len());
+            for change in identity_changes {
+                output.push_str(&format!("\nrepository identity changed: {} → {}", change.previous_display, change.current_display));
+            }
+            output
+        }
         CommandValue::CheckoutCreated { branch, .. } => format!("checkout created: {branch}"),
         CommandValue::CheckoutRemoved { branch } => format!("checkout removed: {branch}"),
         CommandValue::TerminalPrepared { branch, target_node_id, .. } => format!("terminal prepared: {branch} on {target_node_id}"),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -426,7 +426,7 @@ mod command_result_human {
     use std::path::PathBuf;
 
     use flotilla_protocol::{
-        commands::{CheckoutStatus, CommandValue},
+        commands::{CheckoutStatus, CommandValue, RepositoryIdentityChange},
         qualified_path::{HostId, QualifiedPath},
         CrewListMember, CrewListResponse, FleetListResponse, FleetListRow, FleetReplicaStatus, FleetStaleness, HostName, NodeId,
         PreparedWorkspace,
@@ -441,7 +441,7 @@ mod command_result_human {
 
     #[test]
     fn repo_tracked() {
-        let result = CommandValue::RepoTracked { path: PathBuf::from("/tmp/my-repo"), resolved_from: None };
+        let result = CommandValue::RepoTracked { path: PathBuf::from("/tmp/my-repo"), resolved_from: None, identity_change: None };
         let output = format_command_result(&result);
         assert!(output.contains("repo tracked"), "should say repo tracked");
         assert!(output.contains("/tmp/my-repo"), "should include path");
@@ -450,12 +450,32 @@ mod command_result_human {
 
     #[test]
     fn repo_tracked_with_resolved_from() {
-        let result =
-            CommandValue::RepoTracked { path: PathBuf::from("/tmp/my-repo"), resolved_from: Some(PathBuf::from("/tmp/my-repo/wt-feat")) };
+        let result = CommandValue::RepoTracked {
+            path: PathBuf::from("/tmp/my-repo"),
+            resolved_from: Some(PathBuf::from("/tmp/my-repo/wt-feat")),
+            identity_change: None,
+        };
         let output = format_command_result(&result);
         assert!(output.contains("repo tracked"), "should say repo tracked");
         assert!(output.contains("/tmp/my-repo/wt-feat"), "should include original path");
         assert!(output.contains("resolved from"), "should mention resolution");
+    }
+
+    #[test]
+    fn repo_tracked_with_identity_change() {
+        let result = CommandValue::RepoTracked {
+            path: PathBuf::from("/tmp/my-repo"),
+            resolved_from: None,
+            identity_change: Some(RepositoryIdentityChange {
+                previous: "local".to_string(),
+                current: "https://github.com/flotilla-org/my-repo".to_string(),
+            }),
+        };
+
+        assert_eq!(
+            format_command_result(&result),
+            "repo tracked: /tmp/my-repo\nrepository identity changed: local → https://github.com/flotilla-org/my-repo"
+        );
     }
 
     #[test]

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -467,8 +467,8 @@ mod command_result_human {
             path: PathBuf::from("/tmp/my-repo"),
             resolved_from: None,
             identity_change: Some(RepositoryIdentityChange {
-                previous: "local".to_string(),
-                current: "https://github.com/flotilla-org/my-repo".to_string(),
+                previous_display: "local".to_string(),
+                current_display: "https://github.com/flotilla-org/my-repo".to_string(),
             }),
         };
 
@@ -488,14 +488,17 @@ mod command_result_human {
 
     #[test]
     fn refreshed() {
-        let result = CommandValue::Refreshed { repos: vec![PathBuf::from("/a"), PathBuf::from("/b"), PathBuf::from("/c")] };
+        let result = CommandValue::Refreshed {
+            repos: vec![PathBuf::from("/a"), PathBuf::from("/b"), PathBuf::from("/c")],
+            identity_changes: Vec::new(),
+        };
         let output = format_command_result(&result);
         assert!(output.contains("refreshed 3 repo(s)"), "should show count of repos");
     }
 
     #[test]
     fn refreshed_empty() {
-        let result = CommandValue::Refreshed { repos: vec![] };
+        let result = CommandValue::Refreshed { repos: vec![], identity_changes: Vec::new() };
         let output = format_command_result(&result);
         assert!(output.contains("refreshed 0 repo(s)"), "should handle zero repos");
     }


### PR DESCRIPTION
## Summary

- reconcile a tracked repository when its identity changes from local-only to a canonical remote
- migrate the existing whole-repository Project without creating a twin, while preserving identities still tracked elsewhere
- remove superseded Repository resources when safe and annotate retained resources that still have durable checkouts
- surface identity changes from both repo add and refresh commands
- cover the behavior through injected repository inspection and in-memory resource backends

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #881
