### PR TITLE
feat: compute central awareness salience

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 use crate::{
     awareness_projection::{project_awareness, AwarenessInput, ScopedIssueRow},
     query_registry::QueryRegistry,
+    salience::SalienceFacts,
     scoped_store::{ScopedCheckoutProjection, ScopedIndependentProjection},
 };
 
@@ -108,6 +109,12 @@ impl<R: QueryRow + PartialEq> QueryProjection<R> {
     }
 }
 
+#[derive(Debug, Default)]
+struct SalienceProjection {
+    facts: SalienceFacts,
+    revision: u64,
+}
+
 #[derive(Debug, Default, Clone, bon::Builder)]
 pub struct AggregatorProjectionState {
     convoys: Arc<RwLock<QueryProjection<ConvoyRow>>>,
@@ -115,6 +122,8 @@ pub struct AggregatorProjectionState {
     independents: Arc<RwLock<ScopedIndependentProjection>>,
     #[builder(skip)]
     checkouts: Arc<RwLock<ScopedCheckoutProjection>>,
+    #[builder(skip)]
+    salience: Arc<RwLock<SalienceProjection>>,
     /// Subscriber ownership and demand-backed materializations belong to the
     /// Aggregator state, shared with the daemon's subscription transport.
     demand_backed: QueryRegistry,
@@ -180,6 +189,18 @@ impl AggregatorProjectionState {
 
     pub async fn replace_checkout_replica_rows(&self, replicas: HashMap<HostName, Vec<CheckoutRow>>) -> Vec<ResultDelta> {
         self.checkouts.write().await.replace_replica_rows(replicas)
+    }
+
+    /// Replace the mesh-side facts used by the central salience join. Returns
+    /// whether any projected salience may have changed.
+    pub async fn replace_salience_facts(&self, facts: SalienceFacts) -> bool {
+        let mut current = self.salience.write().await;
+        if current.facts == facts {
+            return false;
+        }
+        current.facts = facts;
+        current.revision = current.revision.saturating_add(1);
+        true
     }
 
     /// Replace one subscriber's complete demand and return queries whose
@@ -287,12 +308,27 @@ impl AggregatorProjectionState {
             })
             .collect::<Vec<_>>();
         let state = merged_issue_state(&issue_sets);
-        let seq = [self.seq().await, independents_set.seq, checkouts_set.seq, issue_sets.iter().map(|(_, set)| set.seq).max().unwrap_or(0)]
-            .into_iter()
-            .max()
-            .unwrap_or(0);
-        let (rows, state) =
-            project_awareness(AwarenessInput { scope: scope.clone(), grouping, limit, convoys, issues, checkouts, independents, state });
+        let (salience, salience_revision) = {
+            let projection = self.salience.read().await;
+            (projection.facts.clone(), projection.revision)
+        };
+        let base_seq =
+            [self.seq().await, independents_set.seq, checkouts_set.seq, issue_sets.iter().map(|(_, set)| set.seq).max().unwrap_or(0)]
+                .into_iter()
+                .max()
+                .unwrap_or(0);
+        let seq = base_seq.saturating_add(salience_revision);
+        let (rows, state) = project_awareness(AwarenessInput {
+            scope: scope.clone(),
+            grouping,
+            limit,
+            convoys,
+            issues,
+            checkouts,
+            independents,
+            salience,
+            state,
+        });
         ResultSet { seq, rows: Rows::Awareness { scope: scope.clone(), grouping, limit, rows }, state }
     }
 
@@ -345,8 +381,10 @@ mod tests {
     use flotilla_protocol::{
         AwarenessKind, DemandBackedMetadata, Issue, IssueRef, IssueSource, IssueState, QueryCursor, ResultSetState, Rows,
     };
+    use flotilla_resources::PrincipalRef;
 
     use super::*;
+    use crate::salience::RegardFact;
 
     fn scope_in(namespace: &str, name: &str) -> QueryScope {
         QueryScope::new(namespace, name)
@@ -439,5 +477,28 @@ mod tests {
         assert_eq!(rows[0].counts.convoys, 1);
         assert_eq!(rows[0].entries.iter().filter(|entry| entry.kind == AwarenessKind::Convoy).count(), 1);
         assert!(rows[0].refs.contains(&matching.resource));
+    }
+
+    #[tokio::test]
+    async fn salience_only_changes_advance_awareness_sequence() {
+        let state = AggregatorProjectionState::new();
+        let query_scope = Some(scope("roadmap"));
+        let before = state.awareness_result_set(&query_scope, AwarenessGrouping::Project, AwarenessLimit::default()).await;
+
+        assert!(
+            state
+                .replace_salience_facts(SalienceFacts {
+                    regards: vec![RegardFact {
+                        principal: PrincipalRef("flotilla/operator".into()),
+                        target: ResourceRef::new("flotilla.work/v1", "Project", "flotilla", "roadmap"),
+                        as_of: Utc::now(),
+                    }],
+                    ..SalienceFacts::default()
+                })
+                .await
+        );
+
+        let after = state.awareness_result_set(&query_scope, AwarenessGrouping::Project, AwarenessLimit::default()).await;
+        assert!(after.seq > before.seq);
     }
 }

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -7,8 +7,9 @@ use std::collections::BTreeMap;
 
 use chrono::Utc;
 use flotilla_protocol::{
-    AwarenessCounts, AwarenessEntry, AwarenessGrouping, AwarenessKind, AwarenessLimit, AwarenessNode, AwarenessPhase, AwarenessState,
-    CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef, ResultSetState, Salience, WorkPhase,
+    AwarenessCounts, AwarenessEntry, AwarenessFamily, AwarenessFamilySummary, AwarenessGrouping, AwarenessKind, AwarenessLimit,
+    AwarenessNode, AwarenessPhase, AwarenessState, CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef,
+    ResultSetState, Salience, WorkPhase,
 };
 use flotilla_resources::{api_version, Project, Resource};
 
@@ -186,6 +187,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
             group.entries.sort_by(|left, right| entry_rank(left).cmp(&entry_rank(right)).then_with(|| left.label.cmp(&right.label)));
             let salience = group.entries.iter().map(|entry| entry.salience).max().unwrap_or(Salience::None);
             let node_as_of = group.entries.iter().map(|entry| entry.as_of).max().unwrap_or(as_of);
+            let family_summaries = awareness_family_summaries(&group.entries);
             group.entries.truncate(input.limit.entries);
             AwarenessNode::builder()
                 .id(group.id)
@@ -198,10 +200,33 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .counts(group.counts)
                 .refs(group.refs)
                 .entries(group.entries)
+                .family_summaries(family_summaries)
                 .build()
         })
         .collect();
     (rows, input.state)
+}
+
+fn awareness_family_summaries(entries: &[AwarenessEntry]) -> Vec<AwarenessFamilySummary> {
+    [AwarenessFamily::Convoys, AwarenessFamily::Issues, AwarenessFamily::Checkouts, AwarenessFamily::Independents]
+        .into_iter()
+        .filter_map(|family| {
+            let mut matching = entries.iter().filter(|entry| family_contains(family, entry.kind));
+            let first = matching.next()?;
+            let (salience, as_of) = matching
+                .fold((first.salience, first.as_of), |(salience, as_of), entry| (salience.max(entry.salience), as_of.max(entry.as_of)));
+            Some(AwarenessFamilySummary::builder().family(family).salience(salience).as_of(as_of).build())
+        })
+        .collect()
+}
+
+fn family_contains(family: AwarenessFamily, kind: AwarenessKind) -> bool {
+    match family {
+        AwarenessFamily::Convoys => matches!(kind, AwarenessKind::Convoy | AwarenessKind::Vessel),
+        AwarenessFamily::Issues => kind == AwarenessKind::Issue,
+        AwarenessFamily::Checkouts => kind == AwarenessKind::Checkout,
+        AwarenessFamily::Independents => kind == AwarenessKind::Independent,
+    }
 }
 
 fn enrich_salience(mut entry: AwarenessEntry, facts: &SalienceFacts, ancestors: &[ResourceRef]) -> AwarenessEntry {
@@ -494,6 +519,14 @@ mod tests {
         let (nodes, _) = project_awareness(AwarenessInput {
             scope: Some(QueryScope::new("flotilla", "platform")),
             convoys: vec![convoy.clone()],
+            checkouts: vec![CheckoutRow::builder()
+                .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "platform"))
+                .repo(RepositoryKey("repo-a".into()))
+                .path("/work/platform")
+                .branch("main")
+                .host(HostName::new("local"))
+                .authority(flotilla_protocol::LifecycleAuthority::Observed)
+                .build()],
             salience: SalienceFacts {
                 demands: vec![DemandFact {
                     target: vessel.clone(),
@@ -522,5 +555,11 @@ mod tests {
         assert_eq!(vessel.as_of, attention_at);
         assert_eq!(node.salience, Salience::Urgent);
         assert_eq!(node.as_of, attention_at);
+        let convoys = node.family_summary(AwarenessFamily::Convoys).expect("convoy family summary");
+        assert_eq!(convoys.salience, Salience::Urgent);
+        assert_eq!(convoys.as_of, attention_at);
+        let checkouts = node.family_summary(AwarenessFamily::Checkouts).expect("checkout family summary");
+        assert_eq!(checkouts.salience, Salience::Info);
+        assert_eq!(checkouts.as_of, base);
     }
 }

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -8,8 +8,11 @@ use std::collections::BTreeMap;
 use chrono::Utc;
 use flotilla_protocol::{
     AwarenessCounts, AwarenessEntry, AwarenessGrouping, AwarenessKind, AwarenessLimit, AwarenessNode, AwarenessPhase, AwarenessState,
-    CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef, ResultSetState, WorkPhase,
+    CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef, ResultSetState, Salience, WorkPhase,
 };
+use flotilla_resources::{api_version, Project, Resource};
+
+use crate::salience::{evaluate_entry, SalienceFacts};
 
 #[derive(Debug, Clone, Default)]
 pub struct AwarenessInput {
@@ -20,6 +23,7 @@ pub struct AwarenessInput {
     pub issues: Vec<ScopedIssueRow>,
     pub checkouts: Vec<CheckoutRow>,
     pub independents: Vec<IndependentRow>,
+    pub salience: SalienceFacts,
     pub state: ResultSetState,
 }
 
@@ -50,7 +54,13 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
         let kind = group_kind_for_query(input.scope.as_ref(), input.grouping);
         let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, kind));
         group.refs.push(convoy.resource.clone());
-        group.add_entry(
+        let project_ancestors = convoy
+            .project_ref
+            .as_deref()
+            .map(|project| project_resource_ref(&convoy.resource.namespace, project))
+            .into_iter()
+            .collect::<Vec<_>>();
+        group.add_entry(enrich_salience(
             AwarenessEntry::builder()
                 .id(format!("convoy/{}/{}", convoy.resource.namespace, convoy.name))
                 .kind(AwarenessKind::Convoy)
@@ -61,9 +71,15 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .refs(vec![convoy.resource.clone()])
                 .issue_refs(convoy.issues.iter().map(|issue| issue.reference.clone()).collect())
                 .build(),
-        );
+            &input.salience,
+            &project_ancestors,
+        ));
         for vessel in &convoy.vessels {
-            group.add_entry(
+            let mut refs = vec![vessel.resource.clone()];
+            refs.extend(vessel.vessel_resource.clone());
+            let mut ancestors = vec![convoy.resource.clone()];
+            ancestors.extend(project_ancestors.clone());
+            group.add_entry(enrich_salience(
                 AwarenessEntry::builder()
                     .id(format!("vessel/{}/{}/{}", convoy.resource.namespace, convoy.name, vessel.name))
                     .kind(AwarenessKind::Vessel)
@@ -71,9 +87,11 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                     .state(work_state(vessel.phase))
                     .phase(AwarenessPhase::Work(vessel.phase))
                     .as_of(as_of)
-                    .refs(vec![vessel.resource.clone()])
+                    .refs(refs)
                     .build(),
-            );
+                &input.salience,
+                &ancestors,
+            ));
         }
     }
 
@@ -84,7 +102,14 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 GroupKey::new(format!("issue-source/{}", row.reference.source.scope), row.reference.source.scope.clone())
             });
         let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
-        group.add_entry(
+        let project_ancestors = issue
+            .scope
+            .as_ref()
+            .or(input.scope.as_ref())
+            .map(|scope| project_resource_ref(&scope.namespace, &scope.name))
+            .into_iter()
+            .collect::<Vec<_>>();
+        group.add_entry(enrich_salience(
             AwarenessEntry::builder()
                 .id(format!("issue/{}/{}", row.reference.source.scope, row.reference.id))
                 .kind(AwarenessKind::Issue)
@@ -94,7 +119,9 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .as_of(row.issue.as_of)
                 .issue_refs(vec![row.reference.clone()])
                 .build(),
-        );
+            &input.salience,
+            &project_ancestors,
+        ));
     }
 
     for checkout in &input.checkouts {
@@ -104,7 +131,9 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
             .map(group_key_for_scope)
             .unwrap_or_else(|| GroupKey::new(format!("repo/{}", checkout.repo), checkout.repo.to_string()));
         let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
-        group.add_entry(
+        let project_ancestors =
+            input.scope.as_ref().map(|scope| project_resource_ref(&scope.namespace, &scope.name)).into_iter().collect::<Vec<_>>();
+        group.add_entry(enrich_salience(
             AwarenessEntry::builder()
                 .id(format!("checkout/{}/{}", checkout.host, checkout.path))
                 .kind(AwarenessKind::Checkout)
@@ -113,7 +142,9 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .as_of(as_of)
                 .refs(vec![checkout.resource.clone()])
                 .build(),
-        );
+            &input.salience,
+            &project_ancestors,
+        ));
     }
 
     for independent in &input.independents {
@@ -124,7 +155,9 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
             .or_else(|| independent.repository_key.as_ref().map(|repo| GroupKey::new(format!("repo/{repo}"), repo.to_string())))
             .unwrap_or_else(|| GroupKey::new("unparented", "Unparented"));
         let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
-        group.add_entry(
+        let project_ancestors =
+            input.scope.as_ref().map(|scope| project_resource_ref(&scope.namespace, &scope.name)).into_iter().collect::<Vec<_>>();
+        group.add_entry(enrich_salience(
             AwarenessEntry::builder()
                 .id(format!("independent/{}/{}", independent.resource.namespace, independent.name))
                 .kind(AwarenessKind::Independent)
@@ -139,7 +172,9 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .as_of(as_of)
                 .refs(vec![independent.resource.clone()])
                 .build(),
-        );
+            &input.salience,
+            &project_ancestors,
+        ));
     }
 
     let mut nodes = groups.into_values().collect::<Vec<_>>();
@@ -149,6 +184,8 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
         .into_iter()
         .map(|mut group| {
             group.entries.sort_by(|left, right| entry_rank(left).cmp(&entry_rank(right)).then_with(|| left.label.cmp(&right.label)));
+            let salience = group.entries.iter().map(|entry| entry.salience).max().unwrap_or(Salience::None);
+            let node_as_of = group.entries.iter().map(|entry| entry.as_of).max().unwrap_or(as_of);
             group.entries.truncate(input.limit.entries);
             AwarenessNode::builder()
                 .id(group.id)
@@ -156,7 +193,8 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .label(group.label)
                 .maybe_scope(group.scope)
                 .state(group.state)
-                .as_of(as_of)
+                .salience(salience)
+                .as_of(node_as_of)
                 .counts(group.counts)
                 .refs(group.refs)
                 .entries(group.entries)
@@ -164,6 +202,20 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
         })
         .collect();
     (rows, input.state)
+}
+
+fn enrich_salience(mut entry: AwarenessEntry, facts: &SalienceFacts, ancestors: &[ResourceRef]) -> AwarenessEntry {
+    let mut coverage_targets = entry.refs.clone();
+    coverage_targets.extend_from_slice(ancestors);
+    let evaluation = evaluate_entry(&entry.refs, &coverage_targets, facts, entry.as_of);
+    entry.salience = evaluation.salience;
+    entry.as_of = evaluation.as_of;
+    entry
+}
+
+fn project_resource_ref(default_namespace: &str, project_ref: &str) -> ResourceRef {
+    let (namespace, name) = project_ref.split_once('/').unwrap_or((default_namespace, project_ref));
+    ResourceRef::new(api_version(Project::API_PATHS), Project::API_PATHS.kind, namespace, name)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -319,9 +371,12 @@ fn entry_rank(entry: &AwarenessEntry) -> (u8, u8) {
 
 #[cfg(test)]
 mod tests {
+    use chrono::TimeZone;
     use flotilla_protocol::{HostName, Issue, IssueRef, IssueSource, IssueState, RepositoryKey, ResourceRef, SessionPhase};
+    use flotilla_resources::{DemandState, PrincipalRef, TerminalAttentionState};
 
     use super::*;
+    use crate::salience::{AttentionFact, DemandFact, RegardFact};
 
     fn convoy(project_ref: Option<&str>, name: &str, phase: ConvoyPhase) -> ConvoyRow {
         ConvoyRow::builder()
@@ -417,5 +472,55 @@ mod tests {
 
         assert_eq!(project_nodes.len(), 1);
         assert_eq!(convoy_nodes.len(), 2);
+    }
+
+    #[test]
+    fn salience_is_joined_onto_entries_and_aggregated_to_their_node() {
+        let base = Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).single().expect("timestamp");
+        let demand_at = Utc.with_ymd_and_hms(2026, 7, 22, 12, 1, 0).single().expect("timestamp");
+        let attention_at = Utc.with_ymd_and_hms(2026, 7, 22, 12, 2, 0).single().expect("timestamp");
+        let mut convoy = convoy(Some("flotilla/platform"), "ship-it", ConvoyPhase::Active);
+        let vessel = convoy.resource.subresource("vessels/implement");
+        convoy.vessels.push(
+            flotilla_protocol::VesselRow::builder()
+                .resource(vessel.clone())
+                .name("implement")
+                .phase(WorkPhase::Running)
+                .host(HostName::new("local"))
+                .build(),
+        );
+        let principal = PrincipalRef("flotilla/implicit".to_string());
+
+        let (nodes, _) = project_awareness(AwarenessInput {
+            scope: Some(QueryScope::new("flotilla", "platform")),
+            convoys: vec![convoy.clone()],
+            salience: SalienceFacts {
+                demands: vec![DemandFact {
+                    target: vessel.clone(),
+                    addressee: Some(principal.clone()),
+                    state: DemandState::Raised,
+                    as_of: demand_at,
+                }],
+                regards: vec![RegardFact { principal, target: project_resource_ref("flotilla", "flotilla/platform"), as_of: base }],
+                attention: vec![AttentionFact {
+                    target: vessel,
+                    state: TerminalAttentionState::NeedsInput,
+                    work_unsettled: true,
+                    as_of: attention_at,
+                }],
+            },
+            state: ResultSetState {
+                demand: Some(flotilla_protocol::DemandBackedMetadata { as_of: base, has_more: false }),
+                conditions: Vec::new(),
+            },
+            ..AwarenessInput::default()
+        });
+
+        let node = nodes.first().expect("project node");
+        let vessel = node.entries.iter().find(|entry| entry.kind == AwarenessKind::Vessel).expect("vessel entry");
+        assert_eq!(vessel.salience, Salience::Urgent);
+        assert_eq!(vessel.as_of, attention_at);
+        assert_eq!(node.salience, Salience::Urgent);
+        assert_eq!(node.as_of, attention_at);
     }
 }

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod refresh;
 pub(crate) mod repo_state;
 pub mod repository_inspection;
 pub mod resolve;
+pub mod salience;
 mod scoped_store;
 pub mod step;
 pub mod template;

--- a/crates/flotilla-core/src/salience.rs
+++ b/crates/flotilla-core/src/salience.rs
@@ -1,0 +1,231 @@
+//! Central salience policy for the awareness projection.
+
+use chrono::{DateTime, Utc};
+use flotilla_protocol::{ResourceRef, Salience};
+use flotilla_resources::{DemandState, PrincipalRef, TerminalAttentionState};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SalienceFacts {
+    pub demands: Vec<DemandFact>,
+    pub regards: Vec<RegardFact>,
+    pub attention: Vec<AttentionFact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DemandFact {
+    pub target: ResourceRef,
+    pub addressee: Option<PrincipalRef>,
+    pub state: DemandState,
+    pub as_of: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegardFact {
+    pub principal: PrincipalRef,
+    pub target: ResourceRef,
+    pub as_of: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttentionFact {
+    pub target: ResourceRef,
+    pub state: TerminalAttentionState,
+    pub work_unsettled: bool,
+    pub as_of: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SalienceEvaluation {
+    pub salience: Salience,
+    pub as_of: DateTime<Utc>,
+}
+
+/// Compute the surface-independent salience judgment for one projection
+/// entry. `work_unsettled` gives ADR 0017's precise meaning to an `Idle`
+/// observation.
+pub fn compute_salience(
+    demand: Option<DemandState>,
+    regard_covers: bool,
+    attention: Option<TerminalAttentionState>,
+    work_unsettled: bool,
+) -> Salience {
+    let attention_needs_human = matches!(attention, Some(TerminalAttentionState::NeedsInput))
+        || matches!(attention, Some(TerminalAttentionState::Idle)) && work_unsettled;
+    let demand_is_unacknowledged = matches!(demand, Some(DemandState::Raised | DemandState::Satisfied));
+    if demand_is_unacknowledged && regard_covers && attention_needs_human {
+        return Salience::Urgent;
+    }
+
+    let demand_salience = match demand {
+        Some(DemandState::Raised) => Salience::Attention,
+        Some(DemandState::Satisfied) => Salience::Info,
+        Some(DemandState::Acknowledged) | None => Salience::None,
+    };
+    let attention_salience = match attention {
+        Some(TerminalAttentionState::NeedsInput) => Salience::Attention,
+        Some(TerminalAttentionState::Idle) if work_unsettled => Salience::Attention,
+        Some(TerminalAttentionState::Working | TerminalAttentionState::Idle) => Salience::Info,
+        Some(TerminalAttentionState::Unobservable) | None => Salience::None,
+    };
+    let regard_salience = if regard_covers { Salience::Info } else { Salience::None };
+    demand_salience.max(attention_salience).max(regard_salience)
+}
+
+/// Evaluate all facts related to one entry's resource identities. The
+/// timestamp advances only from facts participating in that entry's join.
+pub fn evaluate_entry(
+    targets: &[ResourceRef],
+    coverage_targets: &[ResourceRef],
+    facts: &SalienceFacts,
+    base_as_of: DateTime<Utc>,
+) -> SalienceEvaluation {
+    let demands =
+        facts.demands.iter().filter(|demand| targets.iter().any(|target| references_match(&demand.target, target))).collect::<Vec<_>>();
+    let attention = facts
+        .attention
+        .iter()
+        .filter(|observation| targets.iter().any(|target| references_match(&observation.target, target)))
+        .collect::<Vec<_>>();
+
+    let mut result = SalienceEvaluation { salience: Salience::None, as_of: base_as_of };
+    evaluate_combination(None, None, coverage_targets, facts, &mut result);
+    for &observation in &attention {
+        evaluate_combination(None, Some(observation), coverage_targets, facts, &mut result);
+    }
+    for demand in demands {
+        evaluate_combination(Some(demand), None, coverage_targets, facts, &mut result);
+        for &observation in &attention {
+            evaluate_combination(Some(demand), Some(observation), coverage_targets, facts, &mut result);
+        }
+    }
+    result
+}
+
+fn evaluate_combination(
+    demand: Option<&DemandFact>,
+    attention: Option<&AttentionFact>,
+    targets: &[ResourceRef],
+    facts: &SalienceFacts,
+    result: &mut SalienceEvaluation,
+) {
+    let matching_regards = facts.regards.iter().filter(|regard| {
+        demand.is_none_or(|demand| demand.addressee.as_ref() == Some(&regard.principal))
+            && targets.iter().any(|target| reference_covers(&regard.target, target))
+    });
+    let mut regard_covers = false;
+    for regard in matching_regards {
+        regard_covers = true;
+        result.as_of = result.as_of.max(regard.as_of);
+    }
+    let candidate = compute_salience(
+        demand.map(|demand| demand.state),
+        regard_covers,
+        attention.map(|attention| attention.state),
+        attention.is_some_and(|attention| attention.work_unsettled),
+    );
+    result.salience = result.salience.max(candidate);
+    if let Some(demand) = demand {
+        result.as_of = result.as_of.max(demand.as_of);
+    }
+    if let Some(attention) = attention {
+        result.as_of = result.as_of.max(attention.as_of);
+    }
+}
+
+fn references_match(left: &ResourceRef, right: &ResourceRef) -> bool {
+    left.api_version == right.api_version
+        && left.kind == right.kind
+        && left.namespace == right.namespace
+        && left.name == right.name
+        && left.subresource == right.subresource
+        && left.host.as_ref().zip(right.host.as_ref()).is_none_or(|(left, right)| left == right)
+}
+
+fn reference_covers(ancestor: &ResourceRef, target: &ResourceRef) -> bool {
+    if ancestor.api_version != target.api_version
+        || ancestor.kind != target.kind
+        || ancestor.namespace != target.namespace
+        || ancestor.name != target.name
+        || ancestor.host.as_ref().zip(target.host.as_ref()).is_some_and(|(left, right)| left != right)
+    {
+        return false;
+    }
+    match (&ancestor.subresource, &target.subresource) {
+        (None, _) => true,
+        (Some(ancestor), Some(target)) => target == ancestor || target.strip_prefix(ancestor).is_some_and(|suffix| suffix.starts_with('/')),
+        (Some(_), None) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn demand_regard_attention_join_has_one_central_precedence_table() {
+        let cases = [
+            (None, false, None, true, Salience::None, "no facts"),
+            (None, true, None, true, Salience::Info, "regarded work"),
+            (None, false, Some(TerminalAttentionState::Working), true, Salience::Info, "working observation"),
+            (None, false, Some(TerminalAttentionState::Idle), false, Salience::Info, "settled idle observation"),
+            (None, false, Some(TerminalAttentionState::Idle), true, Salience::Attention, "idle unsettled work"),
+            (None, false, Some(TerminalAttentionState::NeedsInput), true, Salience::Attention, "unrouted input need"),
+            (Some(DemandState::Raised), false, Some(TerminalAttentionState::Working), true, Salience::Attention, "raised demand"),
+            (Some(DemandState::Raised), true, Some(TerminalAttentionState::Working), true, Salience::Attention, "regarded raised demand"),
+            (
+                Some(DemandState::Raised),
+                true,
+                Some(TerminalAttentionState::NeedsInput),
+                true,
+                Salience::Urgent,
+                "in-searchlight input demand",
+            ),
+            (
+                Some(DemandState::Raised),
+                true,
+                Some(TerminalAttentionState::Idle),
+                true,
+                Salience::Urgent,
+                "in-searchlight idle unsettled demand",
+            ),
+            (
+                Some(DemandState::Raised),
+                false,
+                Some(TerminalAttentionState::NeedsInput),
+                true,
+                Salience::Attention,
+                "out-of-searchlight demand",
+            ),
+            (Some(DemandState::Satisfied), false, None, true, Salience::Info, "satisfied demand awaiting acknowledgement"),
+            (
+                Some(DemandState::Satisfied),
+                true,
+                Some(TerminalAttentionState::NeedsInput),
+                true,
+                Salience::Urgent,
+                "satisfied demand remains unacknowledged",
+            ),
+            (Some(DemandState::Acknowledged), false, None, true, Salience::None, "acknowledged demand"),
+            (
+                Some(DemandState::Acknowledged),
+                true,
+                Some(TerminalAttentionState::NeedsInput),
+                true,
+                Salience::Attention,
+                "live input remains visible after acknowledgement",
+            ),
+            (
+                Some(DemandState::Raised),
+                true,
+                Some(TerminalAttentionState::Unobservable),
+                true,
+                Salience::Attention,
+                "unobservable raised demand",
+            ),
+        ];
+
+        for (demand, regard_covers, attention, work_unsettled, expected, description) in cases {
+            assert_eq!(compute_salience(demand, regard_covers, attention, work_unsettled), expected, "{description}");
+        }
+    }
+}

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -6,7 +6,11 @@ use std::{
 };
 
 use async_trait::async_trait;
-use flotilla_core::{aggregator_projection::AggregatorProjectionState, in_process::InProcessDaemon};
+use flotilla_core::{
+    aggregator_projection::AggregatorProjectionState,
+    in_process::InProcessDaemon,
+    salience::{AttentionFact, DemandFact, RegardFact, SalienceFacts},
+};
 use flotilla_protocol::{
     result_set::{
         CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow, CrewMemberSummary, IndependentRow, QueryChanges, QueryId, QueryScope,
@@ -16,10 +20,10 @@ use flotilla_protocol::{
     RepositoryKey, ResourceRef,
 };
 use flotilla_resources::{
-    api_version, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Environment, Presentation,
-    Project, Repository, Resource, ResourceError, ResourceList, ResourceObject, TerminalAttentionState, TerminalSession,
-    TerminalSessionPhase, TypedResolver, VesselRequirement, WatchEvent, WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState,
-    CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, VESSEL_LABEL,
+    api_version, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Demand, DemandAddressee,
+    DemandState, Environment, Presentation, Project, Regard, RegardExpiryPolicy, Repository, Resource, ResourceError, ResourceList,
+    ResourceObject, TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, Vessel, VesselRequirement, WatchEvent,
+    WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::broadcast;
@@ -33,11 +37,13 @@ type ChangeRequestFingerprint = HashMap<String, (String, String)>;
 #[derive(bon::Builder)]
 pub struct AggregatorResolvers {
     durable_convoys: TypedResolver<Convoy>,
+    durable_demands: TypedResolver<Demand>,
     durable_environments: TypedResolver<Environment>,
     durable_presentations: TypedResolver<Presentation>,
     durable_sessions: TypedResolver<TerminalSession>,
     durable_projects: TypedResolver<Project>,
     durable_repositories: TypedResolver<Repository>,
+    durable_regards: TypedResolver<Regard>,
     observed_convoys: TypedResolver<Convoy>,
     observed_presentations: TypedResolver<Presentation>,
     observed_sessions: TypedResolver<TerminalSession>,
@@ -47,11 +53,13 @@ pub struct AggregatorResolvers {
 #[derive(bon::Builder)]
 struct AggregatorSourceRefs<'a> {
     durable_convoys: &'a dyn AggregatorWatchSource<Convoy>,
+    durable_demands: &'a dyn AggregatorWatchSource<Demand>,
     durable_environments: &'a dyn AggregatorWatchSource<Environment>,
     durable_presentations: &'a dyn AggregatorWatchSource<Presentation>,
     durable_sessions: &'a dyn AggregatorWatchSource<TerminalSession>,
     durable_projects: &'a dyn AggregatorWatchSource<Project>,
     durable_repositories: &'a dyn AggregatorWatchSource<Repository>,
+    durable_regards: &'a dyn AggregatorWatchSource<Regard>,
     observed_convoys: &'a dyn AggregatorWatchSource<Convoy>,
     observed_presentations: &'a dyn AggregatorWatchSource<Presentation>,
     observed_sessions: &'a dyn AggregatorWatchSource<TerminalSession>,
@@ -114,6 +122,8 @@ pub struct Aggregator {
     #[builder(skip)]
     convoys_by_source: HashMap<LocalSource, HashMap<ResourceRef, ResourceObject<Convoy>>>,
     #[builder(skip)]
+    demands: HashMap<ResourceRef, ResourceObject<Demand>>,
+    #[builder(skip)]
     presentations_by_source: HashMap<LocalSource, HashMap<ResourceRef, ResourceObject<Presentation>>>,
     #[builder(skip)]
     sessions_by_source: HashMap<LocalSource, HashMap<SessionKey, ResourceObject<TerminalSession>>>,
@@ -122,6 +132,8 @@ pub struct Aggregator {
     attachable_references: HashSet<String>,
     projects: HashMap<(String, String), ResourceObject<Project>>,
     repositories: HashMap<RepositoryKey, ResourceObject<Repository>>,
+    #[builder(skip)]
+    regards: HashMap<ResourceRef, ResourceObject<Regard>>,
     observed_checkouts: HashMap<ResourceRef, ResourceObject<Checkout>>,
     bootstrapping: bool,
     emitted_queries: HashSet<QueryId>,
@@ -146,6 +158,7 @@ impl Aggregator {
             state,
             local_host,
             convoys_by_source: HashMap::new(),
+            demands: HashMap::new(),
             presentations_by_source: HashMap::new(),
             sessions_by_source: HashMap::new(),
             presentation_workspaces: HashMap::new(),
@@ -153,6 +166,7 @@ impl Aggregator {
             attachable_references: HashSet::new(),
             projects: HashMap::new(),
             repositories: HashMap::new(),
+            regards: HashMap::new(),
             observed_checkouts: HashMap::new(),
             bootstrapping: false,
             emitted_queries: HashSet::new(),
@@ -196,11 +210,13 @@ impl Aggregator {
     ) -> Result<(), ResourceError> {
         let AggregatorResolvers {
             durable_convoys,
+            durable_demands,
             durable_environments,
             durable_presentations,
             durable_sessions,
             durable_projects,
             durable_repositories,
+            durable_regards,
             observed_convoys,
             observed_presentations,
             observed_sessions,
@@ -208,11 +224,13 @@ impl Aggregator {
         } = resolvers;
         let sources = AggregatorSourceRefs::builder()
             .durable_convoys(&durable_convoys)
+            .durable_demands(&durable_demands)
             .durable_environments(&durable_environments)
             .durable_presentations(&durable_presentations)
             .durable_sessions(&durable_sessions)
             .durable_projects(&durable_projects)
             .durable_repositories(&durable_repositories)
+            .durable_regards(&durable_regards)
             .observed_convoys(&observed_convoys)
             .observed_presentations(&observed_presentations)
             .observed_sessions(&observed_sessions)
@@ -228,11 +246,13 @@ impl Aggregator {
     ) -> Result<(), ResourceError> {
         let AggregatorSourceRefs {
             durable_convoys,
+            durable_demands,
             durable_environments,
             durable_presentations,
             durable_sessions,
             durable_projects,
             durable_repositories,
+            durable_regards,
             observed_convoys,
             observed_presentations,
             observed_sessions,
@@ -259,11 +279,13 @@ impl Aggregator {
         }
         self.state.replace_local_independent_rows(Vec::new()).await;
         let mut durable_convoy_stream = self.recover_convoy_watch(LocalSource::Durable, durable_convoys).await?;
+        let mut durable_demand_stream = self.recover_demand_watch(durable_demands).await?;
         let mut durable_environment_stream = self.recover_environment_watch(durable_environments).await?;
         let mut durable_presentation_stream = self.recover_presentation_watch(LocalSource::Durable, durable_presentations).await?;
         let mut durable_session_stream = self.recover_session_watch(LocalSource::Durable, durable_sessions).await?;
         let mut durable_project_stream = self.recover_project_watch(durable_projects).await?;
         let mut durable_repository_stream = self.recover_repository_watch(durable_repositories).await?;
+        let mut durable_regard_stream = self.recover_regard_watch(durable_regards).await?;
         let mut observed_convoy_stream = self.recover_convoy_watch(LocalSource::Observed, observed_convoys).await?;
         let mut observed_presentation_stream = self.recover_presentation_watch(LocalSource::Observed, observed_presentations).await?;
         let mut observed_session_stream = self.recover_session_watch(LocalSource::Observed, observed_sessions).await?;
@@ -274,7 +296,21 @@ impl Aggregator {
         let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.independents_result_set(&None).await)));
 
         loop {
+            let regard_expiry_delay = self.next_regard_expiry_delay();
+            let regard_expiry = async move {
+                match regard_expiry_delay {
+                    Some(delay) => tokio::time::sleep(delay).await,
+                    None => futures::future::pending().await,
+                }
+            };
+            tokio::pin!(regard_expiry);
             tokio::select! {
+                () = &mut regard_expiry => {
+                    self.prune_expired_regards(chrono::Utc::now());
+                    if self.rebuild_salience_projection().await {
+                        self.emit_awareness_result_sets().await;
+                    }
+                }
                 demand = demand_rx.changed() => {
                     if demand.is_err() {
                         return Err(ResourceError::other("aggregator demand registry closed"));
@@ -326,6 +362,14 @@ impl Aggregator {
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator durable convoy watch ended")),
                 },
+                event = durable_demand_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_demand_event(event).await,
+                    Some(Err(ResourceError::WatchExpired { .. })) => {
+                        durable_demand_stream = self.recover_demand_watch(durable_demands).await?;
+                    }
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator durable demand watch ended")),
+                },
                 event = durable_environment_stream.next() => match event {
                     Some(Ok(event)) => self.apply_environment_event(event).await,
                     Some(Err(ResourceError::WatchExpired { .. })) => {
@@ -365,6 +409,14 @@ impl Aggregator {
                     }
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator durable repository watch ended")),
+                },
+                event = durable_regard_stream.next() => match event {
+                    Some(Ok(event)) => self.apply_regard_event(event).await,
+                    Some(Err(ResourceError::WatchExpired { .. })) => {
+                        durable_regard_stream = self.recover_regard_watch(durable_regards).await?;
+                    }
+                    Some(Err(err)) => return Err(err),
+                    None => return Err(ResourceError::other("aggregator durable regard watch ended")),
                 },
                 event = observed_convoy_stream.next() => match event {
                     Some(Ok(event)) => self.apply_convoy_event_from(LocalSource::Observed, event).await,
@@ -431,6 +483,24 @@ impl Aggregator {
     ) -> Result<WatchStream<Presentation>, ResourceError> {
         loop {
             match self.list_and_watch_presentations(source, resolver).await {
+                Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
+                result => return result,
+            }
+        }
+    }
+
+    async fn recover_demand_watch(&mut self, resolver: &dyn AggregatorWatchSource<Demand>) -> Result<WatchStream<Demand>, ResourceError> {
+        loop {
+            match self.list_and_watch_demands(resolver).await {
+                Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
+                result => return result,
+            }
+        }
+    }
+
+    async fn recover_regard_watch(&mut self, resolver: &dyn AggregatorWatchSource<Regard>) -> Result<WatchStream<Regard>, ResourceError> {
+        loop {
+            match self.list_and_watch_regards(resolver).await {
                 Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
                 result => return result,
             }
@@ -519,6 +589,28 @@ impl Aggregator {
         let start = WatchStart::resuming_from(&listed);
         let watch = resolver.watch(start).await?;
         self.replace_presentation_source(source, listed.items).await;
+        Ok(watch)
+    }
+
+    async fn list_and_watch_demands(&mut self, resolver: &dyn AggregatorWatchSource<Demand>) -> Result<WatchStream<Demand>, ResourceError> {
+        let listed = resolver.list().await?;
+        let watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
+        self.demands =
+            listed.items.into_iter().map(|demand| (self.demand_ref(&demand.metadata.namespace, &demand.metadata.name), demand)).collect();
+        if self.rebuild_salience_projection().await && !self.bootstrapping {
+            self.emit_awareness_result_sets().await;
+        }
+        Ok(watch)
+    }
+
+    async fn list_and_watch_regards(&mut self, resolver: &dyn AggregatorWatchSource<Regard>) -> Result<WatchStream<Regard>, ResourceError> {
+        let listed = resolver.list().await?;
+        let watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
+        self.regards =
+            listed.items.into_iter().map(|regard| (self.regard_ref(&regard.metadata.namespace, &regard.metadata.name), regard)).collect();
+        if self.rebuild_salience_projection().await && !self.bootstrapping {
+            self.emit_awareness_result_sets().await;
+        }
         Ok(watch)
     }
 
@@ -626,6 +718,38 @@ impl Aggregator {
             }
         }
         self.rebuild_local_projection().await;
+    }
+
+    async fn apply_demand_event(&mut self, event: WatchEvent<Demand>) {
+        match event {
+            WatchEvent::Added(demand) | WatchEvent::Modified(demand) => {
+                let reference = self.demand_ref(&demand.metadata.namespace, &demand.metadata.name);
+                self.demands.insert(reference, demand);
+            }
+            WatchEvent::Deleted(demand) => {
+                let reference = self.demand_ref(&demand.metadata.namespace, &demand.metadata.name);
+                self.demands.remove(&reference);
+            }
+        }
+        if self.rebuild_salience_projection().await && !self.bootstrapping {
+            self.emit_awareness_result_sets().await;
+        }
+    }
+
+    async fn apply_regard_event(&mut self, event: WatchEvent<Regard>) {
+        match event {
+            WatchEvent::Added(regard) | WatchEvent::Modified(regard) => {
+                let reference = self.regard_ref(&regard.metadata.namespace, &regard.metadata.name);
+                self.regards.insert(reference, regard);
+            }
+            WatchEvent::Deleted(regard) => {
+                let reference = self.regard_ref(&regard.metadata.namespace, &regard.metadata.name);
+                self.regards.remove(&reference);
+            }
+        }
+        if self.rebuild_salience_projection().await && !self.bootstrapping {
+            self.emit_awareness_result_sets().await;
+        }
     }
 
     async fn apply_convoy_event_from(&mut self, source: LocalSource, event: WatchEvent<Convoy>) {
@@ -777,6 +901,7 @@ impl Aggregator {
 
     async fn rebuild_local_projection(&mut self) {
         let effective_convoys = self.effective_convoys();
+        let salience_changed = self.rebuild_salience_projection().await;
         let presentation_keys = effective_convoys
             .values()
             .flat_map(|convoy| {
@@ -825,6 +950,10 @@ impl Aggregator {
                 .collect::<Vec<_>>();
             let removed = view.local_rows.keys().filter(|reference| !replacement.contains_key(*reference)).cloned().collect::<Vec<_>>();
             if changed.is_empty() && removed.is_empty() {
+                drop(view);
+                if salience_changed && !self.bootstrapping {
+                    self.emit_awareness_result_sets().await;
+                }
                 return;
             }
             view.local_rows = replacement;
@@ -983,6 +1112,7 @@ impl Aggregator {
             effective_sessions.extend(sessions.iter().map(|(key, session)| (key.clone(), session.clone())));
         }
         self.terminal_sessions = effective_sessions;
+        let salience_changed = self.rebuild_salience_projection().await;
 
         self.attachable_references = match &self.attach_resolver {
             Some(daemon) => {
@@ -998,7 +1128,11 @@ impl Aggregator {
             .filter_map(|session| self.summarize_independent(session, &self.attachable_references))
             .collect();
         let deltas = self.state.replace_local_independent_rows(replacement).await;
+        let store_changed = !deltas.is_empty();
         self.emit_store_deltas(deltas).await;
+        if salience_changed && !store_changed && !self.bootstrapping {
+            self.emit_awareness_result_sets().await;
+        }
     }
 
     pub async fn apply_replica_cache(&mut self, snapshots: Vec<FleetReplicaSnapshot>) {
@@ -1086,6 +1220,91 @@ impl Aggregator {
         self.emit_awareness_result_sets().await;
     }
 
+    async fn rebuild_salience_projection(&self) -> bool {
+        self.state.replace_salience_facts(self.salience_facts()).await
+    }
+
+    fn salience_facts(&self) -> SalienceFacts {
+        self.salience_facts_at(chrono::Utc::now())
+    }
+
+    fn salience_facts_at(&self, now: chrono::DateTime<chrono::Utc>) -> SalienceFacts {
+        let mut demand_resources = self.demands.values().collect::<Vec<_>>();
+        demand_resources
+            .sort_by(|left, right| (&left.metadata.namespace, &left.metadata.name).cmp(&(&right.metadata.namespace, &right.metadata.name)));
+        let demands = demand_resources
+            .into_iter()
+            .map(|demand| {
+                let state = demand.status.as_ref().map_or(DemandState::Raised, |status| status.state);
+                let as_of = demand
+                    .status
+                    .as_ref()
+                    .and_then(|status| match state {
+                        DemandState::Raised => status.raised.as_ref(),
+                        DemandState::Satisfied => status.satisfied.as_ref(),
+                        DemandState::Acknowledged => status.acknowledged.as_ref(),
+                    })
+                    .map_or(demand.metadata.creation_timestamp, |transition| transition.as_of);
+                let addressee = match &demand.spec.addressee {
+                    DemandAddressee::Principal { principal_ref } => Some(principal_ref.clone()),
+                    DemandAddressee::Pool { .. } => None,
+                };
+                DemandFact { target: demand.spec.originating_work_ref.clone(), addressee, state, as_of }
+            })
+            .collect();
+        let mut regard_resources = self.regards.values().collect::<Vec<_>>();
+        regard_resources
+            .sort_by(|left, right| (&left.metadata.namespace, &left.metadata.name).cmp(&(&right.metadata.namespace, &right.metadata.name)));
+        let regards = regard_resources
+            .into_iter()
+            .filter_map(|regard| {
+                let as_of = regard_as_of(regard);
+                let live = regard_expiry_at(regard).is_none_or(|expiry| now < expiry);
+                live.then(|| RegardFact { principal: regard.spec.principal_ref.clone(), target: regard.spec.target.clone(), as_of })
+            })
+            .collect();
+        let mut sessions = self.terminal_sessions.values().collect::<Vec<_>>();
+        sessions
+            .sort_by(|left, right| (&left.metadata.namespace, &left.metadata.name).cmp(&(&right.metadata.namespace, &right.metadata.name)));
+        let attention = sessions
+            .into_iter()
+            .filter_map(|session| {
+                let convoy = session.metadata.labels.get(CONVOY_LABEL)?;
+                let vessel = session.metadata.labels.get(VESSEL_LABEL)?;
+                let status = session.status.as_ref()?;
+                let observation = status.attention.as_ref()?;
+                if status.phase != TerminalSessionPhase::Running || observation.is_stale_at(now) {
+                    return None;
+                }
+                let convoy_ref = self.convoy_ref(&session.metadata.namespace, convoy);
+                let work_unsettled = self
+                    .effective_convoy(&convoy_ref)
+                    .and_then(|convoy| convoy.status.as_ref())
+                    .and_then(|status| status.work.get(vessel))
+                    .is_none_or(|work| !work.phase.is_terminal());
+                Some(AttentionFact {
+                    target: convoy_ref.subresource(format!("vessels/{vessel}")),
+                    state: observation.state,
+                    work_unsettled,
+                    as_of: observation.as_of,
+                })
+            })
+            .collect();
+        SalienceFacts { demands, regards, attention }
+    }
+
+    fn next_regard_expiry_delay(&self) -> Option<std::time::Duration> {
+        self.next_regard_expiry_delay_at(chrono::Utc::now())
+    }
+
+    fn next_regard_expiry_delay_at(&self, now: chrono::DateTime<chrono::Utc>) -> Option<std::time::Duration> {
+        self.regards.values().filter_map(regard_expiry_at).min().map(|expiry| (expiry - now).to_std().unwrap_or_default())
+    }
+
+    fn prune_expired_regards(&mut self, now: chrono::DateTime<chrono::Utc>) {
+        self.regards.retain(|_, regard| regard_expiry_at(regard).is_none_or(|expiry| expiry > now));
+    }
+
     async fn emit_awareness_result_sets(&self) {
         for query in self.state.subscribed_queries() {
             if !matches!(query, QueryId::Awareness { .. }) {
@@ -1104,6 +1323,14 @@ impl Aggregator {
     fn presentation_ref(&self, namespace: &str, name: &str) -> ResourceRef {
         ResourceRef::new(api_version(Presentation::API_PATHS), Presentation::API_PATHS.kind, namespace, name)
             .on_host(self.local_host.clone())
+    }
+
+    fn demand_ref(&self, namespace: &str, name: &str) -> ResourceRef {
+        ResourceRef::new(api_version(Demand::API_PATHS), Demand::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
+    }
+
+    fn regard_ref(&self, namespace: &str, name: &str) -> ResourceRef {
+        ResourceRef::new(api_version(Regard::API_PATHS), Regard::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
     }
 
     fn session_ref(&self, namespace: &str, name: &str) -> ResourceRef {
@@ -1208,6 +1435,14 @@ impl Aggregator {
 
     fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {
         let requested_stance = definition.stance.to_string();
+        let vessel_resource = state
+            .and_then(|state| state.placement.as_ref())
+            .and_then(|placement| placement.fields.get("vessel_ref"))
+            .and_then(serde_json::Value::as_str)
+            .map(|name| {
+                ResourceRef::new(api_version(Vessel::API_PATHS), Vessel::API_PATHS.kind, &convoy_ref.namespace, name)
+                    .on_host(self.local_host.clone())
+            });
         let effective_stance = state
             .and_then(|state| state.placement.as_ref())
             .and_then(|placement| placement.fields.get("effective_stance"))
@@ -1245,6 +1480,7 @@ impl Aggregator {
         });
         VesselRow::builder()
             .resource(convoy_ref.subresource(format!("vessels/{}", definition.name)))
+            .maybe_vessel_resource(vessel_resource)
             .name(&definition.name)
             .phase(work_phase(state.map(|state| state.phase).unwrap_or(ResourceWorkPhase::Pending)))
             .crew(crew)
@@ -1262,6 +1498,19 @@ impl Aggregator {
             .needs_attention(needs_attention)
             .build()
     }
+}
+
+fn regard_as_of(regard: &ResourceObject<Regard>) -> chrono::DateTime<chrono::Utc> {
+    regard.status.as_ref().and_then(|status| status.refreshed_at.or(status.created_at)).unwrap_or(regard.metadata.creation_timestamp)
+}
+
+fn regard_expiry_at(regard: &ResourceObject<Regard>) -> Option<chrono::DateTime<chrono::Utc>> {
+    let RegardExpiryPolicy::Decaying { expires_after_seconds } = &regard.spec.expiry else {
+        return None;
+    };
+    let seconds = i64::try_from(*expires_after_seconds).ok()?;
+    let duration = chrono::TimeDelta::try_seconds(seconds)?;
+    regard_as_of(regard).checked_add_signed(duration)
 }
 
 fn attention_needs_human(state: TerminalAttentionState, work_unsettled: bool) -> bool {
@@ -1289,6 +1538,9 @@ fn set_convoy_row_host(row: &mut ConvoyRow, host: &HostName) {
     row.resource.host = Some(host.clone());
     for vessel in &mut row.vessels {
         vessel.resource.host = Some(host.clone());
+        if let Some(resource) = &mut vessel.vessel_resource {
+            resource.host = Some(host.clone());
+        }
         vessel.host = host.clone();
     }
 }
@@ -1355,12 +1607,15 @@ mod tests {
         PrincipalRef,
     };
     use flotilla_resources::{
-        ConvoyRepositorySpec, ConvoySpec, CrewSpec, EnvironmentSpec, HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta,
-        PlacementStatus, PresentationPhase, PresentationSpec, PresentationStatus, ResourceBackend, Stance, TerminalAttention,
-        TerminalAttentionSource, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
+        ConvoyRepositorySpec, ConvoySpec, CrewSpec, DemandKind, DemandSpec, DemandStatus, DemandTransition, EnvironmentSpec,
+        HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta, PlacementStatus, PresentationPhase, PresentationSpec,
+        PresentationStatus, PrincipalRef as AttentionPrincipalRef, RegardSource, RegardSpec, RegardStatus, ResourceBackend, Stance,
+        TerminalAttention, TerminalAttentionSource, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement,
+        WorkflowSnapshot,
     };
     use futures::stream;
     use tokio::{sync::Mutex, time::timeout};
+    use uuid::Uuid;
 
     use super::*;
 
@@ -1371,6 +1626,45 @@ mod tests {
         assert!(!attention_needs_human(TerminalAttentionState::Idle, false));
         assert!(!attention_needs_human(TerminalAttentionState::Working, true));
         assert!(!attention_needs_human(TerminalAttentionState::Unobservable, true));
+    }
+
+    #[test]
+    fn decaying_regards_schedule_expiry_and_handle_unrepresentable_durations() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(4);
+        let mut aggregator = Aggregator::new(state, HostName::new("local"), event_tx);
+        let now = Utc::now();
+        let principal = AttentionPrincipalRef("flotilla/operator".into());
+        let target = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "convoy-a");
+        let decaying = ResourceObject {
+            metadata: attention_meta("decaying", now),
+            spec: RegardSpec::builder()
+                .principal_ref(principal.clone())
+                .target(target.clone())
+                .source(RegardSource::Expressed)
+                .expiry(RegardExpiryPolicy::Decaying { expires_after_seconds: 5 })
+                .build(),
+            status: Some(RegardStatus { created_at: Some(now), refreshed_at: None }),
+        };
+        let unbounded = ResourceObject {
+            metadata: attention_meta("unbounded", now),
+            spec: RegardSpec::builder()
+                .principal_ref(principal)
+                .target(target)
+                .source(RegardSource::Expressed)
+                .expiry(RegardExpiryPolicy::Decaying { expires_after_seconds: u64::MAX })
+                .build(),
+            status: Some(RegardStatus { created_at: Some(now), refreshed_at: None }),
+        };
+        aggregator.regards.insert(aggregator.regard_ref("flotilla", "decaying"), decaying);
+        aggregator.regards.insert(aggregator.regard_ref("flotilla", "unbounded"), unbounded);
+
+        assert_eq!(aggregator.next_regard_expiry_delay_at(now), Some(Duration::from_secs(5)));
+        assert_eq!(aggregator.salience_facts_at(now).regards.len(), 2);
+        assert_eq!(aggregator.salience_facts_at(now + chrono::Duration::seconds(5)).regards.len(), 1);
+        aggregator.prune_expired_regards(now + chrono::Duration::seconds(5));
+        assert_eq!(aggregator.regards.len(), 1);
+        assert_eq!(aggregator.next_regard_expiry_delay_at(now + chrono::Duration::seconds(5)), None);
     }
 
     #[tokio::test]
@@ -1414,6 +1708,107 @@ mod tests {
         let result_set = state.result_set().await;
         let row = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
         assert_eq!(row.dispatching_principal_ref, principal);
+    }
+
+    #[tokio::test]
+    async fn awareness_salience_recomputes_on_attention_demand_and_regard_changes() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(16);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+        let query = QueryId::Awareness {
+            scope: None,
+            grouping: flotilla_protocol::AwarenessGrouping::Convoy,
+            limit: flotilla_protocol::AwarenessLimit::default(),
+        };
+        state.replace_subscriber(Uuid::new_v4(), &[flotilla_protocol::QueryCursor { query: query.clone(), since: None }]);
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy_with_vessel("convoy-a").await)).await;
+
+        let now = Utc::now();
+        let mut session = session_object("terminal-convoy-a-implement").await;
+        session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        session.status.as_mut().expect("running status").attention =
+            Some(TerminalAttention { state: TerminalAttentionState::NeedsInput, as_of: now, source: TerminalAttentionSource::Hook });
+        aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Added(session.clone())).await;
+        assert_eq!(awareness_vessel_salience(&state, &query).await, flotilla_protocol::Salience::Attention);
+
+        let principal = AttentionPrincipalRef("flotilla/implicit".to_string());
+        let target = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "convoy-a").subresource("vessels/implement");
+        let mut demand = ResourceObject {
+            metadata: attention_meta("input-demand", now),
+            spec: DemandSpec::builder()
+                .originating_work_ref(target)
+                .kind(DemandKind::Permission)
+                .addressee(DemandAddressee::Principal { principal_ref: principal.clone() })
+                .build(),
+            status: Some(
+                DemandStatus::builder()
+                    .state(DemandState::Raised)
+                    .raised(DemandTransition { as_of: now, authority: "hook".to_string() })
+                    .build(),
+            ),
+        };
+        aggregator.apply_demand_event(WatchEvent::Added(demand.clone())).await;
+        assert_eq!(awareness_vessel_salience(&state, &query).await, flotilla_protocol::Salience::Attention);
+
+        let regard = ResourceObject {
+            metadata: attention_meta("convoy-regard", now),
+            spec: RegardSpec::builder()
+                .principal_ref(principal)
+                .target(ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "convoy-a"))
+                .source(RegardSource::Expressed)
+                .expiry(RegardExpiryPolicy::Pin)
+                .build(),
+            status: Some(RegardStatus { created_at: Some(now), refreshed_at: Some(now) }),
+        };
+        aggregator.apply_regard_event(WatchEvent::Added(regard)).await;
+        assert_eq!(awareness_vessel_salience(&state, &query).await, flotilla_protocol::Salience::Urgent);
+
+        let acknowledged_at = now + chrono::Duration::seconds(1);
+        demand.metadata.resource_version = "2".to_string();
+        demand.status.as_mut().expect("demand status").state = DemandState::Acknowledged;
+        demand.status.as_mut().expect("demand status").acknowledged =
+            Some(DemandTransition { as_of: acknowledged_at, authority: "principal".to_string() });
+        aggregator.apply_demand_event(WatchEvent::Modified(demand)).await;
+        let (salience, as_of) = awareness_vessel_salience_and_time(&state, &query).await;
+        assert_eq!(salience, flotilla_protocol::Salience::Attention);
+        assert_eq!(as_of, acknowledged_at);
+
+        let working_at = now + chrono::Duration::seconds(2);
+        session.status.as_mut().expect("running status").attention =
+            Some(TerminalAttention { state: TerminalAttentionState::Working, as_of: working_at, source: TerminalAttentionSource::Hook });
+        aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Modified(session)).await;
+        let (salience, as_of) = awareness_vessel_salience_and_time(&state, &query).await;
+        assert_eq!(salience, flotilla_protocol::Salience::Info);
+        assert_eq!(as_of, working_at);
+    }
+
+    fn attention_meta(name: &str, creation_timestamp: chrono::DateTime<Utc>) -> ObjectMeta {
+        ObjectMeta {
+            name: name.to_string(),
+            namespace: "flotilla".to_string(),
+            resource_version: "1".to_string(),
+            labels: BTreeMap::new(),
+            annotations: BTreeMap::new(),
+            owner_references: Vec::new(),
+            finalizers: Vec::new(),
+            deletion_timestamp: None,
+            creation_timestamp,
+        }
+    }
+
+    async fn awareness_vessel_salience(state: &AggregatorProjectionState, query: &QueryId) -> flotilla_protocol::Salience {
+        awareness_vessel_salience_and_time(state, query).await.0
+    }
+
+    async fn awareness_vessel_salience_and_time(
+        state: &AggregatorProjectionState,
+        query: &QueryId,
+    ) -> (flotilla_protocol::Salience, chrono::DateTime<Utc>) {
+        let result = state.result_set_for(query).await.expect("awareness result set");
+        let node = result.rows.as_awareness().expect("awareness rows").first().expect("convoy node");
+        let vessel = node.entries.iter().find(|entry| entry.kind == flotilla_protocol::AwarenessKind::Vessel).expect("vessel entry");
+        (vessel.salience, vessel.as_of)
     }
 
     struct ScriptedSource<T: Resource> {
@@ -1524,18 +1919,22 @@ mod tests {
         replica_rx: broadcast::Receiver<Vec<FleetReplicaSnapshot>>,
     ) -> Result<(), ResourceError> {
         let durable_environments = ScriptedSource::<Environment>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_demands = ScriptedSource::<Demand>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let durable_sessions = ScriptedSource::<TerminalSession>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let durable_projects = ScriptedSource::<Project>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let durable_repositories = ScriptedSource::<Repository>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_regards = ScriptedSource::<Regard>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let observed_sessions = ScriptedSource::<TerminalSession>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let observed_checkouts = ScriptedSource::<Checkout>::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let sources = AggregatorSourceRefs::builder()
             .durable_convoys(durable_convoys)
+            .durable_demands(&durable_demands)
             .durable_environments(&durable_environments)
             .durable_presentations(durable_presentations)
             .durable_sessions(&durable_sessions)
             .durable_projects(&durable_projects)
             .durable_repositories(&durable_repositories)
+            .durable_regards(&durable_regards)
             .observed_convoys(observed_convoys)
             .observed_presentations(observed_presentations)
             .observed_sessions(&observed_sessions)
@@ -2309,11 +2708,13 @@ mod tests {
             .run(
                 AggregatorResolvers::builder()
                     .durable_convoys(durable.clone().using::<Convoy>("flotilla"))
+                    .durable_demands(durable.clone().using::<Demand>("flotilla"))
                     .durable_environments(durable.clone().using::<Environment>("flotilla"))
                     .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
                     .durable_sessions(durable.using::<TerminalSession>("flotilla"))
                     .durable_projects(durable.using::<Project>("flotilla"))
                     .durable_repositories(durable.using::<Repository>("flotilla"))
+                    .durable_regards(durable.using::<Regard>("flotilla"))
                     .observed_convoys(observed.clone().using::<Convoy>("flotilla"))
                     .observed_presentations(observed.clone().using::<Presentation>("flotilla"))
                     .observed_sessions(observed.using::<TerminalSession>("flotilla"))
@@ -2386,6 +2787,7 @@ mod tests {
         let stale = session_object("deleted-while-watch-expired").await;
         let durable_convoys = Arc::new(ScriptedSource::<Convoy>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let durable_environments = Arc::new(ScriptedSource::<Environment>::new(vec![empty_list()], vec![Ok(pending_watch())]));
+        let durable_demands = Arc::new(ScriptedSource::<Demand>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let durable_presentations = Arc::new(ScriptedSource::<Presentation>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let durable_sessions = Arc::new(ScriptedSource::new(
             vec![ResourceList { items: vec![stale], resource_version: "1".to_string(), generation: None }, empty_list()],
@@ -2393,6 +2795,7 @@ mod tests {
         ));
         let durable_projects = Arc::new(ScriptedSource::<Project>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let durable_repositories = Arc::new(ScriptedSource::<Repository>::new(vec![empty_list()], vec![Ok(pending_watch())]));
+        let durable_regards = Arc::new(ScriptedSource::<Regard>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let observed_convoys = Arc::new(ScriptedSource::<Convoy>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let observed_presentations = Arc::new(ScriptedSource::<Presentation>::new(vec![empty_list()], vec![Ok(pending_watch())]));
         let observed_sessions = Arc::new(ScriptedSource::<TerminalSession>::new(vec![empty_list()], vec![Ok(pending_watch())]));
@@ -2406,11 +2809,13 @@ mod tests {
         let task = tokio::spawn(async move {
             let sources = AggregatorSourceRefs::builder()
                 .durable_convoys(durable_convoys.as_ref())
+                .durable_demands(durable_demands.as_ref())
                 .durable_environments(durable_environments.as_ref())
                 .durable_presentations(durable_presentations.as_ref())
                 .durable_sessions(run_durable_sessions.as_ref())
                 .durable_projects(durable_projects.as_ref())
                 .durable_repositories(durable_repositories.as_ref())
+                .durable_regards(durable_regards.as_ref())
                 .observed_convoys(observed_convoys.as_ref())
                 .observed_presentations(observed_presentations.as_ref())
                 .observed_sessions(observed_sessions.as_ref())

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -33,11 +33,11 @@ use flotilla_core::{
 use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource, TerminalStatus};
 use flotilla_resources::{
     clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, Clone,
-    CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment,
-    EnvironmentSpec, ForgeIdentity, Host, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,
-    HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Repository,
-    ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate,
-    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
+    CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec, Demand, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec,
+    Environment, EnvironmentSpec, ForgeIdentity, Host, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation,
+    Project, Regard, Repository, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement,
+    WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -853,11 +853,13 @@ fn spawn_aggregator_task(
                     .run(
                         AggregatorResolvers::builder()
                             .durable_convoys(durable.clone().using::<Convoy>(&namespace))
+                            .durable_demands(durable.clone().using::<Demand>(&namespace))
                             .durable_environments(durable.clone().using::<Environment>(&namespace))
                             .durable_presentations(durable.using::<Presentation>(&namespace))
                             .durable_sessions(durable.using::<flotilla_resources::TerminalSession>(&namespace))
                             .durable_projects(durable.using::<Project>(&namespace))
                             .durable_repositories(durable.using::<Repository>(&namespace))
+                            .durable_regards(durable.using::<Regard>(&namespace))
                             .observed_convoys(observed.clone().using::<Convoy>(&namespace))
                             .observed_presentations(observed.using::<Presentation>(&namespace))
                             .observed_sessions(observed.using::<flotilla_resources::TerminalSession>(&namespace))

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -126,10 +126,10 @@ pub use query::{
 };
 pub use resource_ref::ResourceRef;
 pub use result_set::{
-    AwarenessCounts, AwarenessEntry, AwarenessGrouping, AwarenessKind, AwarenessLimit, AwarenessLink, AwarenessNode, AwarenessPhase,
-    AwarenessState, CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow, CrewMemberSummary, DemandBackedMetadata, IndependentRow,
-    IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetCondition, ResultSetState, Rows, Salience, SessionPhase,
-    VesselRow, WorkPhase,
+    AwarenessCounts, AwarenessEntry, AwarenessFamily, AwarenessFamilySummary, AwarenessGrouping, AwarenessKind, AwarenessLimit,
+    AwarenessLink, AwarenessNode, AwarenessPhase, AwarenessState, CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow,
+    CrewMemberSummary, DemandBackedMetadata, IndependentRow, IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet,
+    ResultSetCondition, ResultSetState, Rows, Salience, SessionPhase, VesselRow, WorkPhase,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -128,8 +128,8 @@ pub use resource_ref::ResourceRef;
 pub use result_set::{
     AwarenessCounts, AwarenessEntry, AwarenessGrouping, AwarenessKind, AwarenessLimit, AwarenessLink, AwarenessNode, AwarenessPhase,
     AwarenessState, CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow, CrewMemberSummary, DemandBackedMetadata, IndependentRow,
-    IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetCondition, ResultSetState, Rows, SessionPhase, VesselRow,
-    WorkPhase,
+    IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet, ResultSetCondition, ResultSetState, Rows, Salience, SessionPhase,
+    VesselRow, WorkPhase,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -430,6 +430,20 @@ pub enum AwarenessState {
     Cancelled,
 }
 
+/// Centrally-computed urgency of an awareness node or entry.
+///
+/// Surfaces render this value but must not derive it from the underlying
+/// demand, regard, or attention facts themselves.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Salience {
+    #[default]
+    None,
+    Info,
+    Attention,
+    Urgent,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum AwarenessPhase {
@@ -484,6 +498,9 @@ pub struct AwarenessEntry {
     pub kind: AwarenessKind,
     pub label: String,
     pub state: AwarenessState,
+    #[builder(default)]
+    #[serde(default)]
+    pub salience: Salience,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phase: Option<AwarenessPhase>,
     pub as_of: Timestamp,
@@ -509,6 +526,9 @@ pub struct AwarenessNode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<QueryScope>,
     pub state: AwarenessState,
+    #[builder(default)]
+    #[serde(default)]
+    pub salience: Salience,
     pub as_of: Timestamp,
     #[serde(default, skip_serializing_if = "AwarenessCounts::is_empty")]
     #[builder(default)]
@@ -743,6 +763,10 @@ pub struct ConvoyChangeRequest {
 pub struct VesselRow {
     /// `convoy_ref.subresource("vessels/{name}")`.
     pub resource: ResourceRef,
+    /// Concrete Vessel resource realizing this workflow requirement, when it
+    /// has been placed. Demand origins use this control-plane identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vessel_resource: Option<ResourceRef>,
     pub name: String,
     pub phase: WorkPhase,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -417,6 +417,16 @@ pub enum AwarenessKind {
     Checkout,
 }
 
+/// Named-query family represented by one panel of a project awareness view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AwarenessFamily {
+    Convoys,
+    Issues,
+    Checkouts,
+    Independents,
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AwarenessState {
@@ -442,6 +452,16 @@ pub enum Salience {
     Info,
     Attention,
     Urgent,
+}
+
+/// Centrally aggregated salience and freshness for one awareness family.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct AwarenessFamilySummary {
+    pub family: AwarenessFamily,
+    #[builder(default)]
+    #[serde(default)]
+    pub salience: Salience,
+    pub as_of: Timestamp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -548,6 +568,15 @@ pub struct AwarenessNode {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub entries: Vec<AwarenessEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub family_summaries: Vec<AwarenessFamilySummary>,
+}
+
+impl AwarenessNode {
+    pub fn family_summary(&self, family: AwarenessFamily) -> Option<&AwarenessFamilySummary> {
+        self.family_summaries.iter().find(|summary| summary.family == family)
+    }
 }
 
 impl AwarenessCounts {

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -7,9 +7,9 @@
 use std::collections::{HashMap, HashSet};
 
 use flotilla_protocol::{
-    result_set::Timestamp, AwarenessGrouping, AwarenessLimit, AwarenessNode, ChangeRequestStatus, CheckoutRow, HostName, IndependentRow,
-    IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey, ResultSetCondition, ResultSetState, Salience, SessionPhase,
-    ViewAddress,
+    result_set::Timestamp, AwarenessFamily, AwarenessGrouping, AwarenessLimit, AwarenessNode, ChangeRequestStatus, CheckoutRow, HostName,
+    IndependentRow, IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey, ResultSetCondition, ResultSetState, Salience,
+    SessionPhase, ViewAddress,
 };
 
 use crate::{
@@ -597,15 +597,13 @@ pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec
     }
 
     if let Some(awareness) = awareness {
-        for table in [&mut checkouts, &mut issues, &mut independents] {
-            table.meta.salience = awareness.salience;
-            table.meta.as_of = Some(awareness.as_of);
-        }
+        apply_family_summary(&mut checkouts, awareness, AwarenessFamily::Checkouts);
+        apply_family_summary(&mut issues, awareness, AwarenessFamily::Issues);
+        apply_family_summary(&mut independents, awareness, AwarenessFamily::Independents);
     }
     let mut convoys = TableView { title: convoys_title, ..convoys };
     if let Some(awareness) = awareness {
-        convoys.meta.salience = awareness.salience;
-        convoys.meta.as_of = Some(awareness.as_of);
+        apply_family_summary(&mut convoys, awareness, AwarenessFamily::Convoys);
     }
 
     Ok(vec![
@@ -614,6 +612,13 @@ pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec
         ProjectPanel { kind: ProjectPanelKind::Issues, target: issues_address, table: issues },
         ProjectPanel { kind: ProjectPanelKind::Independents, target: independents_address, table: independents },
     ])
+}
+
+fn apply_family_summary(table: &mut TableView, awareness: &AwarenessNode, family: AwarenessFamily) {
+    if let Some(summary) = awareness.family_summary(family) {
+        table.meta.salience = summary.salience;
+        table.meta.as_of = Some(summary.as_of);
+    }
 }
 
 fn awareness_for_project<'a>(namespace: &str, name: &str, data: &'a TableRows<'_>) -> Option<&'a AwarenessNode> {
@@ -1190,8 +1195,8 @@ fn attach_independent(row: &IndependentRow) -> Option<TableIntent> {
 #[cfg(test)]
 mod tests {
     use flotilla_protocol::{
-        test_support::TestIssue, AwarenessCounts, AwarenessKind, AwarenessNode, AwarenessState, DemandBackedMetadata, LifecycleAuthority,
-        QueryId, QueryScope, RepositoryKey, ResourceRef, ResultSetCondition, ResultSetState,
+        test_support::TestIssue, AwarenessCounts, AwarenessFamilySummary, AwarenessKind, AwarenessNode, AwarenessState,
+        DemandBackedMetadata, LifecycleAuthority, QueryId, QueryScope, RepositoryKey, ResourceRef, ResultSetCondition, ResultSetState,
     };
 
     use super::*;
@@ -1439,6 +1444,28 @@ mod tests {
             .salience(Salience::Urgent)
             .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
             .counts(AwarenessCounts::builder().total(4).convoys(1).issues(1).checkouts(1).independents(1).build())
+            .family_summaries(vec![
+                AwarenessFamilySummary::builder()
+                    .family(AwarenessFamily::Convoys)
+                    .salience(Salience::Urgent)
+                    .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+                    .build(),
+                AwarenessFamilySummary::builder()
+                    .family(AwarenessFamily::Checkouts)
+                    .salience(Salience::None)
+                    .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+                    .build(),
+                AwarenessFamilySummary::builder()
+                    .family(AwarenessFamily::Issues)
+                    .salience(Salience::Attention)
+                    .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+                    .build(),
+                AwarenessFamilySummary::builder()
+                    .family(AwarenessFamily::Independents)
+                    .salience(Salience::Info)
+                    .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+                    .build(),
+            ])
             .build();
         let state = ResultSetState::default();
         let address = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
@@ -1471,7 +1498,12 @@ mod tests {
             "Issues (1)",
             "Independents (1)",
         ]);
-        assert!(panels.iter().all(|panel| panel.table.meta.salience == Salience::Urgent));
+        assert_eq!(panels.iter().map(|panel| panel.table.meta.salience).collect::<Vec<_>>(), vec![
+            Salience::Urgent,
+            Salience::None,
+            Salience::Attention,
+            Salience::Info,
+        ]);
         assert!(panels.iter().all(|panel| panel.table.meta.as_of == Some(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)));
         assert_eq!(panels[0].table.rows[0].cells[0].text, "tables");
         assert_eq!(panels[1].table.rows[0].cells[1].text, "/work/flotilla");

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -7,8 +7,8 @@
 use std::collections::{HashMap, HashSet};
 
 use flotilla_protocol::{
-    result_set::Timestamp, AwarenessCounts, AwarenessGrouping, AwarenessLimit, AwarenessNode, ChangeRequestStatus, CheckoutRow, HostName,
-    IndependentRow, IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey, ResultSetCondition, ResultSetState, SessionPhase,
+    result_set::Timestamp, AwarenessGrouping, AwarenessLimit, AwarenessNode, ChangeRequestStatus, CheckoutRow, HostName, IndependentRow,
+    IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey, ResultSetCondition, ResultSetState, Salience, SessionPhase,
     ViewAddress,
 };
 
@@ -383,6 +383,8 @@ pub enum TableAvailability {
 #[derive(Debug, Clone, Default, PartialEq, Eq, bon::Builder)]
 pub struct TableMeta {
     pub as_of: Option<Timestamp>,
+    #[builder(default)]
+    pub salience: Salience,
     pub has_more: bool,
     pub conditions: Vec<String>,
     pub availability: TableAvailability,
@@ -576,11 +578,11 @@ pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec
     let checkouts_address = ViewAddress::Checkouts { scope: Some(scope.clone()) };
     let issues_address = ViewAddress::Issues { scope: scope.clone() };
     let independents_address = ViewAddress::Independents { scope: Some(scope) };
-    let awareness_counts = awareness_counts_for_project(namespace, name, data);
+    let awareness = awareness_for_project(namespace, name, data);
     let mut checkouts = project(&checkouts_address, data).unwrap_or_else(|_| pending_project_table(&checkouts_address));
     let mut issues = project(&issues_address, data).unwrap_or_else(|_| pending_project_table(&issues_address));
     let mut independents = project(&independents_address, data).unwrap_or_else(|_| pending_project_table(&independents_address));
-    if let Some(counts) = awareness_counts {
+    if let Some(counts) = awareness.map(|node| &node.counts) {
         checkouts.title = format!("Checkouts ({})", counts.checkouts);
         issues.title = format!("Issues ({})", counts.issues);
         independents.title = format!("Independents ({})", counts.independents);
@@ -590,23 +592,31 @@ pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec
         independents.title = "Independents".to_string();
     }
     let mut convoys_title = "Convoys".to_string();
-    if let Some(counts) = awareness_counts {
+    if let Some(counts) = awareness.map(|node| &node.counts) {
         convoys_title = format!("Convoys ({})", counts.convoys);
     }
 
+    if let Some(awareness) = awareness {
+        for table in [&mut checkouts, &mut issues, &mut independents] {
+            table.meta.salience = awareness.salience;
+            table.meta.as_of = Some(awareness.as_of);
+        }
+    }
+    let mut convoys = TableView { title: convoys_title, ..convoys };
+    if let Some(awareness) = awareness {
+        convoys.meta.salience = awareness.salience;
+        convoys.meta.as_of = Some(awareness.as_of);
+    }
+
     Ok(vec![
-        ProjectPanel {
-            kind: ProjectPanelKind::Convoys,
-            target: ViewAddress::Convoys { namespace: namespace.clone() },
-            table: TableView { title: convoys_title, ..convoys },
-        },
+        ProjectPanel { kind: ProjectPanelKind::Convoys, target: ViewAddress::Convoys { namespace: namespace.clone() }, table: convoys },
         ProjectPanel { kind: ProjectPanelKind::Checkouts, target: checkouts_address, table: checkouts },
         ProjectPanel { kind: ProjectPanelKind::Issues, target: issues_address, table: issues },
         ProjectPanel { kind: ProjectPanelKind::Independents, target: independents_address, table: independents },
     ])
 }
 
-fn awareness_counts_for_project<'a>(namespace: &str, name: &str, data: &'a TableRows<'_>) -> Option<&'a AwarenessCounts> {
+fn awareness_for_project<'a>(namespace: &str, name: &str, data: &'a TableRows<'_>) -> Option<&'a AwarenessNode> {
     let query = QueryId::Awareness {
         scope: Some(QueryScope::new(namespace, name)),
         grouping: AwarenessGrouping::Project,
@@ -618,7 +628,6 @@ fn awareness_counts_for_project<'a>(namespace: &str, name: &str, data: &'a Table
         .rows
         .iter()
         .find(|node| node.scope.as_ref().is_some_and(|scope| scope.namespace == namespace && scope.name == name))
-        .map(|node| &node.counts)
 }
 
 fn pending_project_table(address: &ViewAddress) -> TableView {
@@ -1427,6 +1436,7 @@ mod tests {
             .label("roadmap".to_string())
             .scope(scope.clone())
             .state(AwarenessState::Active)
+            .salience(Salience::Urgent)
             .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
             .counts(AwarenessCounts::builder().total(4).convoys(1).issues(1).checkouts(1).independents(1).build())
             .build();
@@ -1461,6 +1471,8 @@ mod tests {
             "Issues (1)",
             "Independents (1)",
         ]);
+        assert!(panels.iter().all(|panel| panel.table.meta.salience == Salience::Urgent));
+        assert!(panels.iter().all(|panel| panel.table.meta.as_of == Some(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)));
         assert_eq!(panels[0].table.rows[0].cells[0].text, "tables");
         assert_eq!(panels[1].table.rows[0].cells[1].text, "/work/flotilla");
         assert_eq!(panels[2].table.rows[0].actions[0].intent, TableIntent::StartConvoy {

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
-use flotilla_protocol::{QueryId, ViewAddress};
+use flotilla_protocol::{QueryId, Salience, ViewAddress};
 use ratatui::{layout::Rect, style::Modifier, Frame};
 
 use super::{
@@ -266,6 +266,9 @@ impl ProjectPageWidget {
         for layout in &layouts {
             if let Some(header_area) = self.line_area(layout.header_line, state) {
                 let mut label = format!("{}  › {}", layout.panel.table.title, layout.panel.target.human_label());
+                if let Some(marker) = salience_marker(layout.panel.table.meta.salience) {
+                    label = format!("{marker} {label}");
+                }
                 if let Some(as_of) = layout.panel.table.meta.as_of {
                     label.push_str(&format!(" · as of {}", as_of.format("%Y-%m-%d %H:%M")));
                 }
@@ -279,7 +282,13 @@ impl ProjectPageWidget {
                     label.push_str(&format!(" · ⚠ {}", layout.panel.table.meta.conditions.join("; ")));
                 }
                 let focused = state.active() == layout.panel.kind && state.header_focused();
-                let style = if focused { theme.header_style().add_modifier(Modifier::REVERSED) } else { theme.header_style() };
+                let style = match layout.panel.table.meta.salience {
+                    Salience::None => theme.header_style(),
+                    Salience::Info => theme.header_style().fg(theme.info),
+                    Salience::Attention => theme.header_style().fg(theme.warning),
+                    Salience::Urgent => theme.header_style().fg(theme.error),
+                };
+                let style = if focused { style.add_modifier(Modifier::REVERSED) } else { style };
                 let row_style = if focused { style } else { Default::default() };
                 ui_helpers::render_section_divider(frame, &label, theme, header_area, row_style, style);
             }
@@ -313,6 +322,15 @@ impl ProjectPageWidget {
                 }
             }
         }
+    }
+}
+
+fn salience_marker(salience: Salience) -> Option<&'static str> {
+    match salience {
+        Salience::None => None,
+        Salience::Info => Some("ⓘ"),
+        Salience::Attention => Some("!"),
+        Salience::Urgent => Some("‼"),
     }
 }
 
@@ -598,6 +616,28 @@ mod tests {
         assert!(rendered.contains("as of 2026-07-21 12:30"));
         assert!(rendered.contains("more available"));
         assert!(rendered.contains("⚠ one source stale"));
+    }
+
+    #[test]
+    fn project_headers_render_central_salience_levels_distinctly() {
+        let mut panels = vec![
+            panel(ProjectPanelKind::Convoys, "Convoys", "convoys/flotilla", "convoy-a"),
+            panel(ProjectPanelKind::Checkouts, "Checkouts", "checkouts?project=flotilla%2Froadmap", "checkout-a"),
+            panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "issue-a"),
+        ];
+        panels[0].table.meta.salience = Salience::Info;
+        panels[1].table.meta.salience = Salience::Attention;
+        panels[2].table.meta.salience = Salience::Urgent;
+        let mut terminal = Terminal::new(TestBackend::new(100, 10)).expect("terminal");
+        let mut widget = ProjectPageWidget::default();
+        let mut state = ProjectTableState::default();
+
+        terminal.draw(|frame| widget.render_composite(frame, frame.area(), &Theme::classic(), &panels, &mut state)).expect("render");
+
+        let rendered = terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect::<String>();
+        assert!(rendered.contains("ⓘ Convoys"));
+        assert!(rendered.contains("! Checkouts"));
+        assert!(rendered.contains("‼ Issues"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #864.

## Summary

- add centrally computed `none` / `info` / `attention` / `urgent` salience and `as_of` metadata to every awareness node and entry
- join demand lifecycle, principal regard coverage, and ADR 0017 terminal attention in the mesh-side awareness projection
- model explicit Project → Convoy → Vessel coverage, exact demand/attention targets, salience-only sequence advancement, and decaying-regard expiry wakeups
- render the central salience enum distinctly in the TUI without surface-side policy computation

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- independent Standards and Spec review passes
