### PR TITLE
feat: wire regard lifecycle emissions

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use flotilla_core::daemon::DaemonHandle;
 use flotilla_protocol::{
     Command, ConnectionRole, DaemonEvent, Message, NodeId, QueryCursor, QueryId, ReplayCursor, RepoIdentity, RepoInfo, RepoSnapshot,
-    Request, Response, ResponseResult, StatusResponse, StreamKey, TopologyResponse, PROTOCOL_VERSION,
+    Request, Response, ResponseResult, StatusResponse, StreamKey, SurfaceDeclaration, TopologyResponse, PROTOCOL_VERSION,
 };
 use flotilla_transport::message::{connect_unix_message_session, MessageSession};
 use tokio::sync::{broadcast, oneshot, Mutex};
@@ -61,6 +61,14 @@ impl Drop for SpawnLockGuard {
 /// Sends a `Hello` with `ConnectionRole::Client` and a fresh `session_id`,
 /// then waits for the server's Hello reply.
 async fn do_client_hello(session: &MessageSession) -> Result<(), String> {
+    do_client_hello_with_surface(session, None).await
+}
+
+async fn do_client_hello_with_declared_surface(session: &MessageSession, surface: SurfaceDeclaration) -> Result<(), String> {
+    do_client_hello_with_surface(session, Some(surface)).await
+}
+
+async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<SurfaceDeclaration>) -> Result<(), String> {
     let session_id = uuid::Uuid::new_v4();
     session
         .write(Message::Hello {
@@ -69,6 +77,7 @@ async fn do_client_hello(session: &MessageSession) -> Result<(), String> {
             display_name: "client".into(),
             session_id,
             connection_role: Some(ConnectionRole::Client),
+            surface,
         })
         .await
         .map_err(|e| format!("failed to send Hello: {e}"))?;
@@ -105,7 +114,12 @@ impl SocketDaemon {
     /// call-site choice.
     pub async fn connect(socket_path: &Path) -> Result<Arc<Self>, String> {
         let session = connect_unix_message_session(socket_path).await?;
-        from_session_stateful_bounded(socket_path, session).await
+        from_session_stateful_bounded(socket_path, session, None).await
+    }
+
+    pub async fn connect_with_surface(socket_path: &Path, surface: SurfaceDeclaration) -> Result<Arc<Self>, String> {
+        let session = connect_unix_message_session(socket_path).await?;
+        from_session_stateful_bounded(socket_path, session, Some(&surface)).await
     }
 
     /// Build a client from an existing `MessageSession`, performing a Hello
@@ -113,6 +127,11 @@ impl SocketDaemon {
     /// ownership to our `session_id`.
     pub async fn from_session_stateful(session: MessageSession) -> Result<Arc<Self>, String> {
         do_client_hello(&session).await?;
+        Self::from_session(session)
+    }
+
+    pub async fn from_session_stateful_with_surface(session: MessageSession, surface: SurfaceDeclaration) -> Result<Arc<Self>, String> {
+        do_client_hello_with_declared_surface(&session, surface).await?;
         Self::from_session(session)
     }
 
@@ -313,6 +332,26 @@ pub async fn connect_or_spawn(
     config_dir_override: Option<&Path>,
     socket_override: Option<&Path>,
 ) -> Result<Arc<SocketDaemon>, String> {
+    connect_or_spawn_with_optional_surface(socket_path, config_dir, config_dir_override, socket_override, None).await
+}
+
+pub async fn connect_or_spawn_with_surface(
+    socket_path: &Path,
+    config_dir: &Path,
+    config_dir_override: Option<&Path>,
+    socket_override: Option<&Path>,
+    surface: SurfaceDeclaration,
+) -> Result<Arc<SocketDaemon>, String> {
+    connect_or_spawn_with_optional_surface(socket_path, config_dir, config_dir_override, socket_override, Some(surface)).await
+}
+
+async fn connect_or_spawn_with_optional_surface(
+    socket_path: &Path,
+    config_dir: &Path,
+    config_dir_override: Option<&Path>,
+    socket_override: Option<&Path>,
+    surface: Option<SurfaceDeclaration>,
+) -> Result<Arc<SocketDaemon>, String> {
     // An existing socket must complete the stateful Hello handshake. A
     // handshake failure means a daemon is listening but is incompatible or
     // malformed; surface that error instead of treating the socket as stale
@@ -324,7 +363,7 @@ pub async fn connect_or_spawn(
     // 5s-bounded handshake is a condition the caller should hear about
     // immediately — this is the interactive path, and retries would only
     // delay an error the user has to act on anyway.
-    if let Some(daemon) = connect_existing_stateful(socket_path).await? {
+    if let Some(daemon) = connect_existing_stateful(socket_path, surface.as_ref()).await? {
         return Ok(daemon);
     }
 
@@ -351,7 +390,7 @@ pub async fn connect_or_spawn(
                 // attempt rather than aborting; but it must never fall
                 // through to the spawn path, which would delete the socket of
                 // a live (if unwell or incompatible) daemon.
-                let last_probe_error = match connect_existing_stateful(socket_path).await {
+                let last_probe_error = match connect_existing_stateful(socket_path, surface.as_ref()).await {
                     Ok(Some(daemon)) => return Ok(daemon),
                     Ok(None) => None,
                     Err(e) => {
@@ -385,7 +424,7 @@ pub async fn connect_or_spawn(
                     }
                     Ok(None) => {
                         // Someone else spawned while we waited — one last connect attempt.
-                        if let Some(daemon) = connect_existing_stateful(socket_path).await? {
+                        if let Some(daemon) = connect_existing_stateful(socket_path, surface.as_ref()).await? {
                             return Ok(daemon);
                         }
                         return Err("daemon spawn failed: all lock attempts exhausted and connect still failing".into());
@@ -407,7 +446,7 @@ pub async fn connect_or_spawn(
     // lock acquisition, which the releasing winner has left uncontended, so
     // winning the lock says nothing about the socket being free. The lock
     // makes this check race-free: nothing else may spawn while we hold it.
-    match connect_existing_stateful(socket_path).await {
+    match connect_existing_stateful(socket_path, surface.as_ref()).await {
         Ok(Some(daemon)) => return Ok(daemon),
         Ok(None) => {}
         Err(e) => {
@@ -436,7 +475,7 @@ pub async fn connect_or_spawn(
     let mut last_handshake_error: Option<String> = None;
     loop {
         tokio::time::sleep(Duration::from_millis(50)).await;
-        match connect_existing_stateful(socket_path).await {
+        match connect_existing_stateful(socket_path, surface.as_ref()).await {
             Ok(Some(daemon)) => return Ok(daemon),
             Ok(None) => {}
             Err(e) => last_handshake_error = Some(e),
@@ -462,16 +501,26 @@ const HELLO_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 /// a stale socket. The handshake is bounded — a daemon that accepts the
 /// connection but never replies is reported as an error rather than hanging
 /// the caller (or, worse, being treated as absent and spawned over).
-async fn connect_existing_stateful(socket_path: &Path) -> Result<Option<Arc<SocketDaemon>>, String> {
+async fn connect_existing_stateful(socket_path: &Path, surface: Option<&SurfaceDeclaration>) -> Result<Option<Arc<SocketDaemon>>, String> {
     let session = match connect_unix_message_session(socket_path).await {
         Ok(session) => session,
         Err(_) => return Ok(None),
     };
-    from_session_stateful_bounded(socket_path, session).await.map(Some)
+    from_session_stateful_bounded(socket_path, session, surface).await.map(Some)
 }
 
-async fn from_session_stateful_bounded(socket_path: &Path, session: MessageSession) -> Result<Arc<SocketDaemon>, String> {
-    match tokio::time::timeout(HELLO_HANDSHAKE_TIMEOUT, SocketDaemon::from_session_stateful(session)).await {
+async fn from_session_stateful_bounded(
+    socket_path: &Path,
+    session: MessageSession,
+    surface: Option<&SurfaceDeclaration>,
+) -> Result<Arc<SocketDaemon>, String> {
+    let result = match surface {
+        Some(surface) => {
+            tokio::time::timeout(HELLO_HANDSHAKE_TIMEOUT, SocketDaemon::from_session_stateful_with_surface(session, surface.clone())).await
+        }
+        None => tokio::time::timeout(HELLO_HANDSHAKE_TIMEOUT, SocketDaemon::from_session_stateful(session)).await,
+    };
+    match result {
         Ok(result) => result,
         Err(_) => Err(format!(
             "daemon at {} accepted the connection but did not complete the Hello handshake within {}s — it may be wedged; check or restart it",
@@ -896,6 +945,13 @@ impl DaemonHandle for SocketDaemon {
         match into_success_response(self.request(Request::Execute { command }).await?)? {
             Response::Execute { command_id } => Ok(command_id),
             other => Err(format!("unexpected response for execute: {other:?}")),
+        }
+    }
+
+    async fn observe_focus(&self, _surface_id: uuid::Uuid, targets: Vec<flotilla_protocol::ResourceRef>) -> Result<(), String> {
+        match into_success_response(self.request(Request::ObserveFocus { targets }).await?)? {
+            Response::ObserveFocus => Ok(()),
+            other => Err(format!("unexpected response for focus observation: {other:?}")),
         }
     }
 

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -168,6 +168,7 @@ async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_con
                     display_name: "stale daemon".into(),
                     session_id: uuid::Uuid::new_v4(),
                     connection_role: Some(ConnectionRole::Client),
+                    surface: None,
                 })
                 .await;
         }
@@ -231,6 +232,7 @@ async fn client_hello_rejects_daemon_protocol_version_mismatch() {
                 display_name: "stale daemon".into(),
                 session_id: uuid::Uuid::new_v4(),
                 connection_role: Some(ConnectionRole::Client),
+                surface: None,
             })
             .await
             .expect("write stale daemon hello");
@@ -267,6 +269,7 @@ async fn connect_rejects_daemon_protocol_version_mismatch() {
                 display_name: "stale daemon".into(),
                 session_id: uuid::Uuid::new_v4(),
                 connection_role: Some(ConnectionRole::Client),
+                surface: None,
             })
             .await
             .expect("write stale daemon hello");
@@ -306,6 +309,7 @@ async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
                 display_name: "stale daemon".into(),
                 session_id: uuid::Uuid::new_v4(),
                 connection_role: Some(ConnectionRole::Client),
+                surface: None,
             })
             .await
             .expect("write stale daemon hello");
@@ -335,6 +339,7 @@ async fn stateful_handshake_rejects_daemon_with_version_mismatch() {
                 display_name: "daemon".into(),
                 session_id: uuid::Uuid::nil(),
                 connection_role: Some(ConnectionRole::Client),
+                surface: None,
             })
             .await
             .expect("write mismatched hello");
@@ -464,6 +469,7 @@ async fn dropping_socket_daemon_closes_connection_promptly() {
                 display_name: "daemon".into(),
                 session_id: uuid::Uuid::new_v4(),
                 connection_role: Some(ConnectionRole::Client),
+                surface: None,
             })
             .await
             .expect("write daemon hello");

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -489,7 +489,7 @@ mod tests {
             state
                 .replace_salience_facts(SalienceFacts {
                     regards: vec![RegardFact {
-                        principal: PrincipalRef("flotilla/operator".into()),
+                        principal: PrincipalRef { namespace: "flotilla".into(), name: "operator".into() },
                         target: ResourceRef::new("flotilla.work/v1", "Project", "flotilla", "roadmap"),
                         as_of: Utc::now(),
                     }],

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -514,7 +514,7 @@ mod tests {
                 .host(HostName::new("local"))
                 .build(),
         );
-        let principal = PrincipalRef("flotilla/implicit".to_string());
+        let principal = PrincipalRef::implicit_for_namespace("flotilla");
 
         let (nodes, _) = project_awareness(AwarenessInput {
             scope: Some(QueryScope::new("flotilla", "platform")),

--- a/crates/flotilla-core/src/daemon.rs
+++ b/crates/flotilla-core/src/daemon.rs
@@ -92,6 +92,11 @@ pub trait DaemonHandle: Send + Sync {
         Err("fetch-more is unsupported by this daemon".to_string())
     }
 
+    /// Replace the calling surface's current focal resource set.
+    async fn observe_focus(&self, _surface_id: Uuid, _targets: Vec<flotilla_protocol::ResourceRef>) -> Result<(), String> {
+        Ok(())
+    }
+
     /// Execute a query command synchronously. Returns the result directly
     /// without broadcasting. Only valid for commands where `action.is_query()`.
     /// The `session_id` ties cursor ownership to the calling client session.

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -26,11 +26,11 @@ use flotilla_protocol::{
     HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PrincipalRef,
     ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse,
     RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, ResourceJsonResponse,
-    ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
-    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory,
+    TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    apply_resource_document, apply_status_patch as apply_resource_status_patch,
+    api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
     apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
     list_resource_kind, normalize_project_spec, resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind,
     Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
@@ -80,6 +80,7 @@ use crate::{
         ChannelLabel, CommandRunner,
     },
     refresh::RefreshSnapshot,
+    regard_lifecycle::{RegardLifecycle, SurfaceGestureOutcome, DEFAULT_REGARD_REFRESH_SECONDS},
     repo_state::{RepoRootState, RepoState, SnapshotBuildContext},
     repository_inspection::{GitRepositoryInspector, RepositoryInspection, RepositoryInspector},
     step::{
@@ -1097,10 +1098,12 @@ async fn queue_pending_crew_message(
         .map_err(|err| err.to_string())
 }
 
+#[derive(bon::Builder)]
 struct ConvoyStartTask {
     command_id: u64,
     intent: flotilla_protocol::ConvoyStartIntent,
     key: ConvoyStartKey,
+    dispatching_principal_ref: PrincipalRef,
 }
 
 #[derive(bon::Builder)]
@@ -1268,6 +1271,7 @@ pub struct InProcessDaemon {
     /// Used to inject FLOTILLA_DAEMON_SOCKET into managed terminal sessions.
     daemon_socket_path: RwLock<Option<PathBuf>>,
     resource_backend: ResourceBackend,
+    regard_lifecycle: RegardLifecycle,
     observed_resource_backend: ResourceBackend,
     /// Serializes observed Checkout publication with repository removal so a
     /// refresh captured before untracking cannot recreate deleted resources.
@@ -1276,7 +1280,7 @@ pub struct InProcessDaemon {
     /// Provisioning namespace used by daemon-side resource operations (e.g.
     /// looking up the Convoy whose task is being marked complete). Set by the
     /// daemon runtime at startup; defaults to [`DEFAULT_PROVISIONING_NAMESPACE`].
-    provisioning_namespace: RwLock<String>,
+    provisioning_namespace: std::sync::RwLock<String>,
     fleet_replica_cache: RwLock<HashMap<HostName, FleetReplicaCacheEntry>>,
     fleet_replica_tx: broadcast::Sender<Vec<FleetReplicaSnapshot>>,
     repository_inspector: RwLock<Option<Arc<dyn RepositoryInspector>>>,
@@ -1435,11 +1439,12 @@ impl InProcessDaemon {
             session_id: uuid::Uuid::new_v4(),
             agent_state_store,
             daemon_socket_path: RwLock::new(None),
+            regard_lifecycle: RegardLifecycle::with_system_clock(resource_backend.clone()),
             resource_backend,
             observed_resource_backend: ResourceBackend::InMemory(InMemoryBackend::observed()),
             observed_checkout_reconciliation: Mutex::new(()),
             aggregator_projection_state: AggregatorProjectionState::new(),
-            provisioning_namespace: RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
+            provisioning_namespace: std::sync::RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
             fleet_replica_cache: RwLock::new(HashMap::new()),
             fleet_replica_tx,
             repository_inspector: RwLock::new(None),
@@ -1457,6 +1462,31 @@ impl InProcessDaemon {
                 match weak.upgrade() {
                     Some(d) => d.poll_snapshots().await,
                     None => break,
+                }
+            }
+        });
+
+        let weak = Arc::downgrade(&daemon);
+        tokio::spawn(async move {
+            let mut expiry = tokio::time::interval(Duration::from_secs(1));
+            expiry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut refresh = tokio::time::interval(Duration::from_secs(DEFAULT_REGARD_REFRESH_SECONDS));
+            refresh.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    _ = expiry.tick() => {
+                        let Some(daemon) = weak.upgrade() else { break };
+                        let namespace = daemon.provisioning_namespace().await;
+                        if let Err(error) = daemon.regard_lifecycle.expire_due(&namespace).await {
+                            warn!(%error, "failed to expire due regards");
+                        }
+                    }
+                    _ = refresh.tick() => {
+                        let Some(daemon) = weak.upgrade() else { break };
+                        if let Err(error) = daemon.regard_lifecycle.refresh_focused().await {
+                            warn!(%error, "failed to refresh focused regards");
+                        }
+                    }
                 }
             }
         });
@@ -1672,11 +1702,11 @@ impl InProcessDaemon {
     /// (e.g. `ConvoyWorkForceComplete`). Called by the daemon runtime at startup with
     /// `RuntimeOptions::namespace`.
     pub async fn set_provisioning_namespace(&self, namespace: String) {
-        *self.provisioning_namespace.write().await = namespace;
+        *self.provisioning_namespace.write().expect("provisioning namespace lock poisoned") = namespace;
     }
 
     pub async fn provisioning_namespace(&self) -> String {
-        self.provisioning_namespace.read().await.clone()
+        self.provisioning_namespace.read().expect("provisioning namespace lock poisoned").clone()
     }
 
     fn start_context_free_command(&self, command_id: u64, description: String) -> flotilla_protocol::RepoIdentity {
@@ -1730,6 +1760,22 @@ impl InProcessDaemon {
 
     pub fn resource_backend(&self) -> ResourceBackend {
         self.resource_backend.clone()
+    }
+
+    pub fn connect_surface(&self, surface_id: uuid::Uuid, declaration: SurfaceDeclaration) {
+        self.regard_lifecycle.connect_surface(surface_id, declaration);
+    }
+
+    pub fn principal_for_surface(&self, surface_id: uuid::Uuid) -> Result<Option<PrincipalRef>, String> {
+        self.regard_lifecycle.principal_for_surface(surface_id)
+    }
+
+    pub async fn disconnect_surface(&self, surface_id: uuid::Uuid) -> Result<(), String> {
+        self.regard_lifecycle.disconnect_surface(surface_id).await
+    }
+
+    pub async fn observe_surface_focus(&self, surface_id: uuid::Uuid, targets: Vec<ResourceRef>) -> Result<(), String> {
+        self.regard_lifecycle.observe_focus(surface_id, targets).await
     }
 
     pub fn observed_resource_backend(&self) -> ResourceBackend {
@@ -2008,13 +2054,16 @@ impl InProcessDaemon {
     pub async fn prepare_remote_convoy_start(
         &self,
         intent: &flotilla_protocol::ConvoyStartIntent,
+        dispatching_principal_ref: Option<&PrincipalRef>,
     ) -> Result<flotilla_protocol::PreparedConvoyStart, String> {
         let namespace = self.provisioning_namespace().await;
         let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
         if requested_namespace != namespace {
             return Err(format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"));
         }
-        let mut admission = self.prepare_convoy_admission(&namespace, intent).await?;
+        let fallback_principal = PrincipalRef::implicit_for_namespace(&namespace);
+        let mut admission =
+            self.prepare_convoy_admission(&namespace, intent, dispatching_principal_ref.unwrap_or(&fallback_principal)).await?;
         let workflow_value = serde_json::to_value(&admission.workflow).map_err(|error| error.to_string())?;
         let workflow_name = prepared_snapshot_name(&admission.name, "workflow", &workflow_value)?;
         admission.spec.workflow_ref.clone_from(&workflow_name);
@@ -3212,6 +3261,7 @@ impl InProcessDaemon {
         &self,
         namespace: &str,
         intent: &flotilla_protocol::ConvoyStartIntent,
+        dispatching_principal_ref: &PrincipalRef,
     ) -> Result<ConvoyAdmission, String> {
         let project_ref = required_admission_value(&intent.project_ref, "project")?;
         let project = self
@@ -3283,7 +3333,7 @@ impl InProcessDaemon {
         let placement_policy = placement.as_ref().map(|placement| placement.metadata.name.clone());
         let spec = ConvoySpec {
             workflow_ref,
-            dispatching_principal_ref: PrincipalRef::implicit_for_namespace(namespace),
+            dispatching_principal_ref: dispatching_principal_ref.clone(),
             inputs: intent.inputs.iter().map(|(key, value)| (key.clone(), InputValue::String(value.clone()))).collect(),
             placement_policy,
             repositories,
@@ -3301,15 +3351,39 @@ impl InProcessDaemon {
             .build())
     }
 
-    async fn admit_convoy_start(&self, namespace: &str, intent: &flotilla_protocol::ConvoyStartIntent) -> Result<String, String> {
-        let admission = self.prepare_convoy_admission(namespace, intent).await?;
-        self.resource_backend
-            .clone()
-            .using::<ResourceConvoy>(namespace)
-            .create(&InputMeta::builder().name(admission.name.clone()).build(), &admission.spec)
-            .await
-            .map_err(|error| error.to_string())?;
+    async fn admit_convoy_start(
+        &self,
+        namespace: &str,
+        intent: &flotilla_protocol::ConvoyStartIntent,
+        dispatching_principal_ref: &PrincipalRef,
+    ) -> Result<String, String> {
+        let admission = self.prepare_convoy_admission(namespace, intent, dispatching_principal_ref).await?;
+        self.create_convoy_with_regard(namespace, &admission.name, &admission.spec).await?;
         Ok(admission.name)
+    }
+
+    async fn create_convoy_with_regard(&self, namespace: &str, name: &str, spec: &ConvoySpec) -> Result<(), String> {
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
+        convoys.create(&InputMeta::builder().name(name.to_string()).build(), spec).await.map_err(|error| error.to_string())?;
+        if let Err(error) = self.emit_implicit_convoy_regard(namespace, name, &spec.dispatching_principal_ref).await {
+            warn!(%error, %namespace, %name, "failed to emit convoy dispatch regard");
+        }
+        Ok(())
+    }
+
+    async fn emit_implicit_convoy_regard(&self, namespace: &str, name: &str, principal_ref: &PrincipalRef) -> Result<(), String> {
+        let target = ResourceRef::new(api_version(ResourceConvoy::API_PATHS), ResourceConvoy::API_PATHS.kind, namespace, name);
+        self.regard_lifecycle.emit_implicit(principal_ref, &target, "convoy-dispatch").await
+    }
+
+    async fn emit_attach_regard(&self, binding: &AttachBinding, surface_id: uuid::Uuid) -> Result<(), String> {
+        let target = binding.resource_ref().ok_or_else(|| "resolved attach target has no resource identity".to_string())?;
+        match self.regard_lifecycle.emit_expressed_for_surface(surface_id, &target).await? {
+            SurfaceGestureOutcome::Handled => Ok(()),
+            SurfaceGestureOutcome::UnknownSurface => {
+                self.regard_lifecycle.emit_expressed(&PrincipalRef::implicit_for_namespace(&binding.namespace), &target).await
+            }
+        }
     }
 
     async fn resolve_and_validate_convoy_placement(
@@ -3356,7 +3430,11 @@ impl InProcessDaemon {
         Ok(placement)
     }
 
-    async fn run_convoy_start(&self, intent: flotilla_protocol::ConvoyStartIntent) -> flotilla_protocol::CommandValue {
+    async fn run_convoy_start(
+        &self,
+        intent: flotilla_protocol::ConvoyStartIntent,
+        dispatching_principal_ref: PrincipalRef,
+    ) -> flotilla_protocol::CommandValue {
         let namespace = self.provisioning_namespace().await;
         let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
         if requested_namespace != namespace {
@@ -3364,7 +3442,7 @@ impl InProcessDaemon {
                 message: format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"),
             };
         }
-        match self.admit_convoy_start(&namespace, &intent).await {
+        match self.admit_convoy_start(&namespace, &intent, &dispatching_principal_ref).await {
             Ok(name) if intent.auto_attach => match self.wait_for_convoy_attach(&namespace, &name).await {
                 Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
                     name,
@@ -3439,16 +3517,12 @@ impl InProcessDaemon {
         if let Some((name, spec)) = placement_spec {
             ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, &spec).await?;
         }
-        convoys
-            .create(&InputMeta::builder().name(start.name.clone()).build(), &convoy_spec)
-            .await
-            .map(|_| ())
-            .map_err(|error| error.to_string())
+        self.create_convoy_with_regard(&namespace, &start.name, &convoy_spec).await
     }
 
     async fn supervise_convoy_start(&self, task: ConvoyStartTask) {
-        let ConvoyStartTask { command_id, intent, key } = task;
-        let result = match AssertUnwindSafe(self.run_convoy_start(intent)).catch_unwind().await {
+        let ConvoyStartTask { command_id, intent, key, dispatching_principal_ref } = task;
+        let result = match AssertUnwindSafe(self.run_convoy_start(intent, dispatching_principal_ref)).catch_unwind().await {
             Ok(result) => result,
             Err(_) => {
                 warn!(command_id, "convoy start worker panicked");
@@ -5328,7 +5402,11 @@ impl InProcessDaemon {
         command: Command,
         remote_executor: Arc<dyn RemoteStepExecutor>,
     ) -> Result<u64, String> {
-        self.execute_impl(command, remote_executor, true).await
+        self.execute_impl(command, remote_executor, true, None).await
+    }
+
+    pub async fn execute_for_principal(&self, command: Command, principal_ref: Option<PrincipalRef>) -> Result<u64, String> {
+        self.execute_impl(command, Arc::new(crate::step::UnsupportedRemoteStepExecutor), false, principal_ref).await
     }
 
     pub async fn execute_remote_step_batch(
@@ -5377,6 +5455,7 @@ impl InProcessDaemon {
         command: Command,
         remote_executor: Arc<dyn RemoteStepExecutor>,
         allow_remote_host: bool,
+        dispatching_principal_ref: Option<PrincipalRef>,
     ) -> Result<u64, String> {
         let command_node_id = command.node_id.clone().unwrap_or_else(|| self.node_id.clone());
         debug!(
@@ -5610,6 +5689,8 @@ impl InProcessDaemon {
         if let flotilla_protocol::CommandAction::ConvoyStart { intent } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
             let namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
+            let dispatching_principal_ref =
+                dispatching_principal_ref.clone().unwrap_or_else(|| PrincipalRef::implicit_for_namespace(&namespace));
             let key = ConvoyStartKey::new(namespace, intent);
             if !self.pending_convoy_starts.lock().await.insert(key.clone()) {
                 self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error {
@@ -5617,7 +5698,12 @@ impl InProcessDaemon {
                 });
                 return Ok(id);
             }
-            let task = ConvoyStartTask { command_id: id, intent: intent.as_ref().clone(), key: key.clone() };
+            let task = ConvoyStartTask::builder()
+                .command_id(id)
+                .intent(intent.as_ref().clone())
+                .key(key.clone())
+                .dispatching_principal_ref(dispatching_principal_ref)
+                .build();
             if let Some(daemon) = self.self_weak.upgrade() {
                 tokio::spawn(async move {
                     daemon.supervise_convoy_start(task).await;
@@ -5874,7 +5960,9 @@ impl InProcessDaemon {
             }
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),
-                dispatching_principal_ref: PrincipalRef::implicit_for_namespace(&namespace),
+                dispatching_principal_ref: dispatching_principal_ref
+                    .clone()
+                    .unwrap_or_else(|| PrincipalRef::implicit_for_namespace(&namespace)),
                 inputs: inputs.iter().map(|(k, v)| (k.clone(), InputValue::String(v.clone()))).collect(),
                 placement_policy,
                 repositories,
@@ -5884,10 +5972,9 @@ impl InProcessDaemon {
                 issues: Vec::new(),
                 instruction: None,
             };
-            let meta = InputMeta::builder().name(name.clone()).build();
-            let result = match convoys.create(&meta, &spec).await {
-                Ok(_) => flotilla_protocol::CommandValue::ConvoyCreated { name: name.clone() },
-                Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+            let result = match self.create_convoy_with_regard(&namespace, name, &spec).await {
+                Ok(()) => flotilla_protocol::CommandValue::ConvoyCreated { name: name.clone() },
+                Err(message) => flotilla_protocol::CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {
                 command_id: id,
@@ -6288,7 +6375,19 @@ impl DaemonHandle for InProcessDaemon {
 
     fn query_subscription(&self, subscriber_id: uuid::Uuid) -> QuerySubscription {
         let state = self.aggregator_projection_state.clone();
-        QuerySubscription::new(move || state.remove_subscriber(subscriber_id))
+        let namespace = self.provisioning_namespace.read().expect("provisioning namespace lock poisoned").clone();
+        self.connect_surface(subscriber_id, SurfaceDeclaration::focal_for_namespace(namespace));
+        let daemon = self.self_weak.clone();
+        QuerySubscription::new(move || {
+            state.remove_subscriber(subscriber_id);
+            if let Some(daemon) = daemon.upgrade() {
+                tokio::spawn(async move {
+                    if let Err(error) = daemon.disconnect_surface(subscriber_id).await {
+                        warn!(%error, "failed to disconnect in-process surface");
+                    }
+                });
+            }
+        })
     }
 
     async fn get_state(&self, repo: &flotilla_protocol::RepoSelector) -> Result<RepoSnapshot, String> {
@@ -6331,10 +6430,10 @@ impl DaemonHandle for InProcessDaemon {
     }
 
     async fn execute(&self, command: Command) -> Result<u64, String> {
-        self.execute_impl(command, Arc::new(crate::step::UnsupportedRemoteStepExecutor), false).await
+        self.execute_impl(command, Arc::new(crate::step::UnsupportedRemoteStepExecutor), false, None).await
     }
 
-    async fn execute_query(&self, command: Command, _session_id: uuid::Uuid) -> Result<flotilla_protocol::CommandValue, String> {
+    async fn execute_query(&self, command: Command, session_id: uuid::Uuid) -> Result<flotilla_protocol::CommandValue, String> {
         use flotilla_protocol::CommandAction;
         match &command.action {
             CommandAction::QueryRepoDetail { repo } => match self.get_repo_detail_internal(repo).await {
@@ -6402,6 +6501,11 @@ impl DaemonHandle for InProcessDaemon {
             }
             CommandAction::Attach { reference } => match self.resolve_attach_command_internal(reference).await {
                 Ok(resolved) => {
+                    if let Some(binding) = &resolved.binding {
+                        if let Err(error) = self.emit_attach_regard(binding, session_id).await {
+                            warn!(%error, "failed to emit attach regard");
+                        }
+                    }
                     Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command: resolved.command, binding: resolved.binding })
                 }
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
@@ -6434,6 +6538,10 @@ impl DaemonHandle for InProcessDaemon {
             }
             other => Err(format!("execute_query not implemented for this command type: {:?}", std::mem::discriminant(other))),
         }
+    }
+
+    async fn observe_focus(&self, surface_id: uuid::Uuid, targets: Vec<ResourceRef>) -> Result<(), String> {
+        self.observe_surface_focus(surface_id, targets).await
     }
 
     async fn cancel(&self, command_id: u64) -> Result<(), String> {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -20,12 +20,12 @@ use flotilla_resources::{
     CrewWorkPhase, CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta,
     LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
-    ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, RepositoryStatus, Selector, Stance, TerminalBrief, TerminalCrewContext,
-    TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource,
-    TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus, Vessel, VesselPhase,
-    VesselRequirement, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
-    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL,
-    VESSEL_REF_LABEL,
+    ProjectRepositorySpec, ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus, Selector, Stance,
+    TerminalBrief, TerminalCrewContext, TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus,
+    Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL,
+    VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 use super::*;
@@ -1560,6 +1560,13 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
     assert_eq!(binding.convoy.as_deref(), Some("convoy-a"));
     assert_eq!(binding.vessel.as_deref(), Some("implement"));
     assert_eq!(binding.role.as_deref(), Some("coder"));
+    let regards = daemon.resource_backend().using::<Regard>("flotilla").list().await.expect("list attach regards");
+    assert_eq!(regards.items.len(), 1);
+    assert_eq!(regards.items[0].spec.source, RegardSource::Expressed);
+    assert_eq!(
+        regards.items[0].spec.target,
+        ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "convoy-a").subresource("vessels/implement")
+    );
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod provider_data;
 pub mod providers;
 pub mod query_registry;
 pub mod refresh;
+pub mod regard_lifecycle;
 pub(crate) mod repo_state;
 pub mod repository_inspection;
 pub mod resolve;

--- a/crates/flotilla-core/src/regard_lifecycle.rs
+++ b/crates/flotilla-core/src/regard_lifecycle.rs
@@ -1,0 +1,252 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
+
+use chrono::{DateTime, Duration, Utc};
+use flotilla_protocol::{PrincipalRef, ResourceRef, SurfaceCharacter, SurfaceDeclaration};
+use flotilla_resources::{
+    apply_status_patch, InputMeta, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RegardStatusPatch, ResourceBackend, ResourceError,
+};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+pub const DEFAULT_REGARD_DECAY_SECONDS: i64 = 300;
+pub const DEFAULT_REGARD_REFRESH_SECONDS: u64 = 60;
+
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SurfaceState {
+    declaration: SurfaceDeclaration,
+    focused: HashSet<ResourceRef>,
+}
+
+#[derive(bon::Builder)]
+pub struct RegardLifecycle {
+    backend: ResourceBackend,
+    clock: Arc<dyn Clock>,
+    decay_window: Duration,
+    #[builder(skip)]
+    surfaces: Mutex<HashMap<Uuid, SurfaceState>>,
+    #[builder(skip)]
+    tracked_namespaces: Mutex<HashSet<String>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SurfaceGestureOutcome {
+    Handled,
+    UnknownSurface,
+}
+
+impl RegardLifecycle {
+    pub fn new(backend: ResourceBackend, clock: Arc<dyn Clock>, decay_window: Duration) -> Self {
+        Self::builder().backend(backend).clock(clock).decay_window(decay_window).build()
+    }
+
+    pub fn with_system_clock(backend: ResourceBackend) -> Self {
+        Self::new(backend, Arc::new(SystemClock), Duration::seconds(DEFAULT_REGARD_DECAY_SECONDS))
+    }
+
+    pub fn connect_surface(&self, surface_id: Uuid, declaration: SurfaceDeclaration) {
+        self.surfaces
+            .lock()
+            .expect("regard surfaces lock poisoned")
+            .insert(surface_id, SurfaceState { declaration, focused: HashSet::new() });
+    }
+
+    pub fn principal_for_surface(&self, surface_id: Uuid) -> Result<Option<PrincipalRef>, String> {
+        Ok(self
+            .surfaces
+            .lock()
+            .map_err(|_| "regard surfaces lock poisoned".to_string())?
+            .get(&surface_id)
+            .map(|surface| surface.declaration.principal_ref.clone()))
+    }
+
+    pub async fn emit_expressed(&self, principal: &PrincipalRef, target: &ResourceRef) -> Result<(), String> {
+        self.record_regard(principal, target, RegardSource::Expressed).await
+    }
+
+    /// Emit an explicit gesture for a connected surface. Returns
+    /// [`SurfaceGestureOutcome::UnknownSurface`] when the ID does not name a
+    /// local surface, allowing forwarded and direct callers to supply their
+    /// known principal.
+    pub async fn emit_expressed_for_surface(&self, surface_id: Uuid, target: &ResourceRef) -> Result<SurfaceGestureOutcome, String> {
+        let connected = self.surfaces.lock().map_err(|_| "regard surfaces lock poisoned".to_string())?.contains_key(&surface_id);
+        if !connected {
+            return Ok(SurfaceGestureOutcome::UnknownSurface);
+        }
+        self.observe_focus(surface_id, vec![target.clone()]).await?;
+        Ok(SurfaceGestureOutcome::Handled)
+    }
+
+    pub async fn emit_implicit(&self, principal: &PrincipalRef, target: &ResourceRef, policy: &str) -> Result<(), String> {
+        self.record_regard(principal, target, RegardSource::Implicit { policy: policy.to_string() }).await
+    }
+
+    pub async fn disconnect_surface(&self, surface_id: Uuid) -> Result<(), String> {
+        let surface = self.surfaces.lock().map_err(|_| "regard surfaces lock poisoned".to_string())?.remove(&surface_id);
+        let Some(surface) = surface else {
+            return Ok(());
+        };
+        if surface.declaration.character == SurfaceCharacter::Ambient {
+            return Ok(());
+        }
+        for target in surface.focused {
+            self.record_regard(&surface.declaration.principal_ref, &target, RegardSource::Expressed).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn observe_focus(&self, surface_id: Uuid, targets: Vec<ResourceRef>) -> Result<(), String> {
+        let (declaration, previous, current) = {
+            let mut surfaces = self.surfaces.lock().map_err(|_| "regard surfaces lock poisoned".to_string())?;
+            let surface = surfaces.get_mut(&surface_id).ok_or_else(|| format!("surface {surface_id} is not connected"))?;
+            if surface.declaration.character == SurfaceCharacter::Ambient {
+                return Ok(());
+            }
+            let previous = surface.focused.clone();
+            let current = targets.into_iter().collect::<HashSet<_>>();
+            surface.focused = current.clone();
+            (surface.declaration.clone(), previous, current)
+        };
+
+        // Refresh targets at both edges: current focus expresses regard, and
+        // the departure edge starts a full decay window rather than expiring
+        // immediately after a long uninterrupted focus spell.
+        for target in previous.union(&current) {
+            self.record_regard(&declaration.principal_ref, target, RegardSource::Expressed).await?;
+        }
+        Ok(())
+    }
+
+    /// Persist a heartbeat for every target currently focused on this daemon.
+    /// Because Regard status is mesh-resident, heartbeats from every daemon
+    /// make expiry conservative across the principal's whole surface set.
+    pub async fn refresh_focused(&self) -> Result<(), String> {
+        for (principal, target) in self.focused_targets()? {
+            self.record_regard(&principal, &target, RegardSource::Expressed).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn expire_due(&self, namespace: &str) -> Result<(), String> {
+        let now = self.clock.now();
+        let focused = self.focused_targets()?;
+        let mut namespaces = {
+            let mut tracked = self.tracked_namespaces.lock().map_err(|_| "regard namespaces lock poisoned".to_string())?;
+            tracked.insert(namespace.to_string());
+            tracked.iter().cloned().collect::<Vec<_>>()
+        };
+        namespaces.sort();
+
+        for namespace in namespaces {
+            let resolver = self.backend.using::<Regard>(&namespace);
+            let regards = resolver.list().await.map_err(|error| error.to_string())?;
+            for regard in regards.items {
+                let RegardExpiryPolicy::Decaying { expires_after_seconds } = regard.spec.expiry else {
+                    continue;
+                };
+                if focused.contains(&(regard.spec.principal_ref.clone(), regard.spec.target.clone())) {
+                    continue;
+                }
+                let refreshed_at = regard.status.as_ref().and_then(|status| status.refreshed_at.or(status.created_at));
+                let Some(refreshed_at) = refreshed_at else {
+                    continue;
+                };
+                if now.signed_duration_since(refreshed_at) >= Duration::seconds(expires_after_seconds as i64) {
+                    resolver.delete(&regard.metadata.name).await.map_err(|error| error.to_string())?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn focused_targets(&self) -> Result<HashSet<(PrincipalRef, ResourceRef)>, String> {
+        Ok(self
+            .surfaces
+            .lock()
+            .map_err(|_| "regard surfaces lock poisoned".to_string())?
+            .values()
+            .filter(|surface| surface.declaration.character == SurfaceCharacter::Focal)
+            .flat_map(|surface| {
+                surface.focused.iter().cloned().map(|target| (surface.declaration.principal_ref.clone(), target)).collect::<Vec<_>>()
+            })
+            .collect())
+    }
+
+    async fn record_regard(&self, principal: &PrincipalRef, target: &ResourceRef, source: RegardSource) -> Result<(), String> {
+        self.tracked_namespaces.lock().map_err(|_| "regard namespaces lock poisoned".to_string())?.insert(target.namespace.clone());
+        let resolver = self.backend.using::<Regard>(&target.namespace);
+        let name = regard_name(principal, target);
+        let spec = RegardSpec::builder()
+            .principal_ref(principal.clone())
+            .target(target.clone())
+            .source(source.clone())
+            .expiry(RegardExpiryPolicy::Decaying { expires_after_seconds: self.decay_window.num_seconds() as u64 })
+            .build();
+        let mut existing = match resolver.get(&name).await {
+            Ok(existing) => Some(existing),
+            Err(ResourceError::NotFound { .. }) => match resolver.create(&InputMeta::builder().name(name.clone()).build(), &spec).await {
+                Ok(_) => None,
+                Err(ResourceError::Conflict { .. }) => Some(resolver.get(&name).await.map_err(|error| error.to_string())?),
+                Err(error) => return Err(error.to_string()),
+            },
+            Err(error) => return Err(error.to_string()),
+        };
+        for _ in 0..5 {
+            let Some(current) = existing.take() else { break };
+            if source != RegardSource::Expressed || matches!(current.spec.source, RegardSource::Expressed) {
+                break;
+            }
+            let mut promoted = current.spec.clone();
+            promoted.source = RegardSource::Expressed;
+            let meta = InputMeta::builder()
+                .name(current.metadata.name)
+                .labels(current.metadata.labels)
+                .annotations(current.metadata.annotations)
+                .owner_references(current.metadata.owner_references)
+                .finalizers(current.metadata.finalizers)
+                .maybe_deletion_timestamp(current.metadata.deletion_timestamp)
+                .build();
+            match resolver.update(&meta, &current.metadata.resource_version, &promoted).await {
+                Ok(_) => break,
+                Err(ResourceError::Conflict { .. }) => {
+                    existing = Some(resolver.get(&name).await.map_err(|error| error.to_string())?);
+                }
+                Err(error) => return Err(error.to_string()),
+            }
+        }
+        if existing.is_some() {
+            return Err(format!("regard {name} remained conflicted after retries"));
+        }
+        apply_status_patch(&resolver, &name, &RegardStatusPatch::Refresh { as_of: self.clock.now() })
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+}
+
+fn regard_name(principal: &PrincipalRef, target: &ResourceRef) -> String {
+    let mut digest = Sha256::new();
+    digest.update(principal.namespace.as_bytes());
+    digest.update([0]);
+    digest.update(principal.name.as_bytes());
+    digest.update([0]);
+    digest.update(serde_json::to_vec(target).expect("resource ref serialization"));
+    let digest = digest.finalize();
+    let suffix = digest[..8].iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    format!("regard-{suffix}")
+}

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -50,8 +50,8 @@ use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
     DockerPerVesselPlacementPolicySpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
-    ProjectRepositorySpec, ProjectSpec, Repository, RepositorySpec, TypedResolver, WorkPhase, WorkState, WorkflowSnapshot,
-    WorkflowTemplate, REPO_KEY_LABEL, REPO_LABEL,
+    ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositorySpec, TypedResolver, WorkPhase,
+    WorkState, WorkflowSnapshot, WorkflowTemplate, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -1052,6 +1052,11 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     assert_eq!(persisted.spec.placement_policy.as_deref(), Some("docker-test"));
     assert_eq!(persisted.spec.repositories.len(), 1);
     assert_eq!(persisted.spec.instruction.as_deref(), Some("Keep the snapshot durable."));
+    let regards = backend.using::<Regard>("flotilla").list().await.expect("list dispatcher regards");
+    let regard = regards.items.iter().find(|regard| regard.spec.target.name == "issue-732").expect("implicit dispatcher regard");
+    assert_eq!(regard.spec.principal_ref, persisted.spec.dispatching_principal_ref);
+    assert_eq!(regard.spec.source, RegardSource::Implicit { policy: "convoy-dispatch".to_string() });
+    assert_eq!(regard.spec.expiry, RegardExpiryPolicy::Decaying { expires_after_seconds: 300 });
     let persisted_issue = persisted.spec.issues.first().expect("issue snapshot");
     assert_eq!(persisted_issue.reference, reference);
     assert_eq!(persisted_issue.repository_ref, Some(repository.key()));

--- a/crates/flotilla-core/tests/regard_lifecycle.rs
+++ b/crates/flotilla-core/tests/regard_lifecycle.rs
@@ -1,0 +1,196 @@
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use flotilla_core::regard_lifecycle::{Clock, RegardLifecycle, SurfaceGestureOutcome};
+use flotilla_protocol::{PrincipalRef, ResourceRef, SurfaceCharacter, SurfaceDeclaration};
+use flotilla_resources::{
+    apply_status_patch, InMemoryBackend, InputMeta, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RegardStatusPatch,
+    ResourceBackend,
+};
+
+#[derive(Debug)]
+struct ManualClock {
+    now: Mutex<DateTime<Utc>>,
+}
+
+impl ManualClock {
+    fn new(now: DateTime<Utc>) -> Self {
+        Self { now: Mutex::new(now) }
+    }
+
+    fn advance(&self, duration: Duration) {
+        let mut now = self.now.lock().expect("manual clock lock");
+        *now += duration;
+    }
+}
+
+impl Clock for ManualClock {
+    fn now(&self) -> DateTime<Utc> {
+        *self.now.lock().expect("manual clock lock")
+    }
+}
+
+fn principal() -> PrincipalRef {
+    PrincipalRef::implicit_for_namespace("flotilla")
+}
+
+fn target() -> ResourceRef {
+    ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "demo")
+}
+
+#[tokio::test]
+async fn focal_observation_decays_only_after_the_target_has_left_every_surface() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let clock = Arc::new(ManualClock::new(Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap()));
+    let lifecycle = RegardLifecycle::new(backend.clone(), clock.clone(), Duration::seconds(30));
+    let surface_id = uuid::Uuid::new_v4();
+
+    lifecycle.connect_surface(surface_id, SurfaceDeclaration { principal_ref: principal(), character: SurfaceCharacter::Focal });
+    lifecycle.observe_focus(surface_id, vec![target()]).await.expect("observe focused convoy");
+
+    let regards = backend.using::<Regard>("flotilla");
+    let created = regards.list().await.expect("list created regard");
+    assert_eq!(created.items.len(), 1);
+    assert_eq!(created.items[0].spec.target, target());
+    assert_eq!(created.items[0].status.as_ref().and_then(|status| status.refreshed_at), Some(clock.now()));
+
+    clock.advance(Duration::seconds(5));
+    lifecycle.observe_focus(surface_id, Vec::new()).await.expect("leave convoy focus");
+    clock.advance(Duration::seconds(29));
+    lifecycle.expire_due("flotilla").await.expect("sweep before deadline");
+    assert_eq!(regards.list().await.expect("list live regard").items.len(), 1);
+
+    clock.advance(Duration::seconds(2));
+    lifecycle.expire_due("flotilla").await.expect("sweep after deadline");
+    assert!(regards.list().await.expect("list expired regards").items.is_empty());
+}
+
+#[tokio::test]
+async fn disconnecting_the_last_focal_surface_starts_the_decay_window() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let clock = Arc::new(ManualClock::new(Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap()));
+    let lifecycle = RegardLifecycle::new(backend.clone(), clock.clone(), Duration::seconds(30));
+    let first = uuid::Uuid::new_v4();
+    let second = uuid::Uuid::new_v4();
+    let declaration = SurfaceDeclaration { principal_ref: principal(), character: SurfaceCharacter::Focal };
+
+    lifecycle.connect_surface(first, declaration.clone());
+    lifecycle.connect_surface(second, declaration);
+    assert_eq!(lifecycle.emit_expressed_for_surface(first, &target()).await.expect("first surface focus"), SurfaceGestureOutcome::Handled);
+    lifecycle.observe_focus(second, vec![target()]).await.expect("second surface focus");
+
+    lifecycle.disconnect_surface(first).await.expect("disconnect first surface");
+    clock.advance(Duration::seconds(31));
+    lifecycle.expire_due("flotilla").await.expect("sweep while second surface remains focused");
+    assert_eq!(backend.using::<Regard>("flotilla").list().await.expect("list live regard").items.len(), 1);
+
+    lifecycle.disconnect_surface(second).await.expect("disconnect last surface");
+    clock.advance(Duration::seconds(29));
+    lifecycle.expire_due("flotilla").await.expect("sweep before disconnect deadline");
+    assert_eq!(backend.using::<Regard>("flotilla").list().await.expect("list before deadline").items.len(), 1);
+
+    clock.advance(Duration::seconds(2));
+    lifecycle.expire_due("flotilla").await.expect("sweep after disconnect deadline");
+    assert!(backend.using::<Regard>("flotilla").list().await.expect("list expired regards").items.is_empty());
+}
+
+#[tokio::test]
+async fn implicit_emission_records_its_policy_and_visible_decay_window() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let clock = Arc::new(ManualClock::new(Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap()));
+    let lifecycle = RegardLifecycle::new(backend.clone(), clock, Duration::seconds(45));
+
+    lifecycle.emit_implicit(&principal(), &target(), "convoy-dispatch").await.expect("emit implicit regard");
+
+    let regards = backend.using::<Regard>("flotilla").list().await.expect("list implicit regard");
+    assert_eq!(regards.items.len(), 1);
+    assert_eq!(regards.items[0].spec.source, RegardSource::Implicit { policy: "convoy-dispatch".to_string() });
+    assert_eq!(regards.items[0].spec.expiry, RegardExpiryPolicy::Decaying { expires_after_seconds: 45 });
+}
+
+#[tokio::test]
+async fn ambient_observations_emit_nothing_and_pins_never_expire() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let clock = Arc::new(ManualClock::new(Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap()));
+    let lifecycle = RegardLifecycle::new(backend.clone(), clock.clone(), Duration::seconds(30));
+    let ambient = uuid::Uuid::new_v4();
+    lifecycle.connect_surface(ambient, SurfaceDeclaration { principal_ref: principal(), character: SurfaceCharacter::Ambient });
+
+    lifecycle.observe_focus(ambient, vec![target()]).await.expect("ambient observation");
+    assert_eq!(
+        lifecycle.emit_expressed_for_surface(ambient, &target()).await.expect("ambient explicit gesture"),
+        SurfaceGestureOutcome::Handled
+    );
+    let resolver = backend.using::<Regard>("flotilla");
+    assert!(resolver.list().await.expect("list after ambient observation").items.is_empty());
+
+    let pinned = resolver
+        .create(
+            &InputMeta::builder().name("pinned-demo".to_string()).build(),
+            &RegardSpec::builder()
+                .principal_ref(principal())
+                .target(target())
+                .source(RegardSource::Expressed)
+                .expiry(RegardExpiryPolicy::Pin)
+                .build(),
+        )
+        .await
+        .expect("create pin");
+    apply_status_patch(&resolver, &pinned.metadata.name, &RegardStatusPatch::Refresh { as_of: clock.now() }).await.expect("stamp pin");
+
+    clock.advance(Duration::days(365));
+    lifecycle.expire_due("flotilla").await.expect("sweep pins");
+    assert_eq!(resolver.list().await.expect("list pins").items.len(), 1);
+}
+
+#[tokio::test]
+async fn expressed_focus_promotes_an_existing_implicit_regard_without_duplication() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let clock = Arc::new(ManualClock::new(Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap()));
+    let lifecycle = RegardLifecycle::new(backend.clone(), clock.clone(), Duration::seconds(30));
+
+    lifecycle.emit_implicit(&principal(), &target(), "convoy-dispatch").await.expect("implicit regard");
+    clock.advance(Duration::seconds(10));
+    lifecycle.emit_expressed(&principal(), &target()).await.expect("express regard");
+
+    let regards = backend.using::<Regard>("flotilla").list().await.expect("list promoted regard");
+    assert_eq!(regards.items.len(), 1);
+    assert_eq!(regards.items[0].spec.source, RegardSource::Expressed);
+    assert_eq!(regards.items[0].status.as_ref().and_then(|status| status.refreshed_at), Some(clock.now()));
+}
+
+#[tokio::test]
+async fn mesh_resident_heartbeats_prevent_another_daemon_from_expiring_remote_focus() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let clock = Arc::new(ManualClock::new(Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap()));
+    let sweeper = RegardLifecycle::new(backend.clone(), clock.clone(), Duration::seconds(30));
+    let observer = RegardLifecycle::new(backend.clone(), clock.clone(), Duration::seconds(30));
+    let surface = uuid::Uuid::new_v4();
+    observer.connect_surface(surface, SurfaceDeclaration { principal_ref: principal(), character: SurfaceCharacter::Focal });
+    observer.observe_focus(surface, vec![target()]).await.expect("remote focus");
+
+    clock.advance(Duration::seconds(29));
+    observer.refresh_focused().await.expect("remote heartbeat");
+    clock.advance(Duration::seconds(2));
+    sweeper.expire_due("flotilla").await.expect("sweep after original deadline");
+    assert_eq!(backend.using::<Regard>("flotilla").list().await.expect("live regard").items.len(), 1);
+
+    observer.disconnect_surface(surface).await.expect("remote detach");
+    clock.advance(Duration::seconds(31));
+    sweeper.expire_due("flotilla").await.expect("sweep after detach deadline");
+    assert!(backend.using::<Regard>("flotilla").list().await.expect("expired regard").items.is_empty());
+}
+
+#[tokio::test]
+async fn expiry_sweeps_target_namespaces_observed_by_cross_host_gestures() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let clock = Arc::new(ManualClock::new(Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap()));
+    let lifecycle = RegardLifecycle::new(backend.clone(), clock.clone(), Duration::seconds(30));
+    let remote_target = ResourceRef::new("flotilla.work/v1", "Convoy", "remote-host", "demo");
+
+    lifecycle.emit_expressed(&principal(), &remote_target).await.expect("emit cross-host regard");
+    clock.advance(Duration::seconds(31));
+    lifecycle.expire_due("flotilla").await.expect("sweep every observed namespace");
+
+    assert!(backend.using::<Regard>("remote-host").list().await.expect("list remote regards").items.is_empty());
+}

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1634,7 +1634,7 @@ mod tests {
         let (event_tx, _) = broadcast::channel(4);
         let mut aggregator = Aggregator::new(state, HostName::new("local"), event_tx);
         let now = Utc::now();
-        let principal = AttentionPrincipalRef("flotilla/operator".into());
+        let principal = AttentionPrincipalRef { namespace: "flotilla".into(), name: "operator".into() };
         let target = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "convoy-a");
         let decaying = ResourceObject {
             metadata: attention_meta("decaying", now),
@@ -1732,7 +1732,7 @@ mod tests {
         aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Added(session.clone())).await;
         assert_eq!(awareness_vessel_salience(&state, &query).await, flotilla_protocol::Salience::Attention);
 
-        let principal = AttentionPrincipalRef("flotilla/implicit".to_string());
+        let principal = AttentionPrincipalRef::implicit_for_namespace("flotilla");
         let target = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "convoy-a").subresource("vessels/implement");
         let mut demand = ResourceObject {
             metadata: attention_meta("input-demand", now),

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -217,6 +217,7 @@ impl SshTransport {
             display_name: self.local_display_name.clone(),
             session_id: self.local_session_id,
             connection_role: None,
+            surface: None,
         })
         .await?;
 
@@ -569,6 +570,7 @@ mod tests {
             display_name: "remote-host".into(),
             session_id: uuid::Uuid::nil(),
             connection_role: None,
+            surface: None,
         };
 
         let (node, session_id) =
@@ -585,6 +587,7 @@ mod tests {
             display_name: "remote".into(),
             session_id: uuid::Uuid::nil(),
             connection_role: None,
+            surface: None,
         };
 
         let err = SshTransport::validate_remote_hello(&HostName::new("expected-host"), None, hello)
@@ -600,6 +603,7 @@ mod tests {
             display_name: "different-display".into(),
             session_id: uuid::Uuid::nil(),
             connection_role: None,
+            surface: None,
         };
 
         let (node, _) = SshTransport::validate_remote_hello(&HostName::new("expected-host"), Some(&NodeId::new("expected-node")), hello)
@@ -615,6 +619,7 @@ mod tests {
             display_name: "different-display".into(),
             session_id: uuid::Uuid::nil(),
             connection_role: None,
+            surface: None,
         };
 
         let err = SshTransport::validate_remote_hello(&HostName::new("expected-host"), Some(&NodeId::new("expected-node")), hello)
@@ -630,6 +635,7 @@ mod tests {
             display_name: "different-display".into(),
             session_id: uuid::Uuid::nil(),
             connection_role: None,
+            surface: None,
         };
 
         let (node, _) =
@@ -724,6 +730,7 @@ mod tests {
                 display_name: "remote".into(),
                 session_id: uuid::Uuid::nil(),
                 connection_role: None,
+                surface: None,
             })
             .expect("serialize hello");
             let peer = serde_json::to_string(&Message::Peer(Box::new(PeerWireMessage::Data(PeerDataMessage {

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -468,7 +468,7 @@ async fn handle_client_session(
                 .run(Arc::clone(&session), id, request)
                 .await;
         }
-        Message::Hello { protocol_version, node_id, display_name, session_id, connection_role } => {
+        Message::Hello { protocol_version, node_id, display_name, session_id, connection_role, surface } => {
             if environment_context.is_some() {
                 warn!("peer/client hello on per-environment socket is unsupported");
                 return;
@@ -486,6 +486,7 @@ async fn handle_client_session(
                         display_name: daemon.host_name().to_string(),
                         session_id: daemon.session_id(),
                         connection_role: Some(ConnectionRole::Client),
+                        surface: None,
                     })
                     .await
                     .is_err()
@@ -496,8 +497,12 @@ async fn handle_client_session(
                     warn!(expected = PROTOCOL_VERSION, got = protocol_version, %node_id, "rejecting client with protocol version mismatch");
                     return;
                 }
+                let surface = match surface {
+                    Some(surface) => surface,
+                    None => flotilla_protocol::SurfaceDeclaration::focal_for_namespace(daemon.provisioning_namespace().await),
+                };
                 ClientConnection::new(daemon, shutdown_rx, remote_command_router, client_count, client_notify, agent_state_store)
-                    .run_stateful(Arc::clone(&session), session_id)
+                    .run_stateful(Arc::clone(&session), session_id, surface)
                     .await;
             } else {
                 // Peer path (ConnectionRole::Peer or None) — existing behavior.

--- a/crates/flotilla-daemon/src/server/client_connection.rs
+++ b/crates/flotilla-daemon/src/server/client_connection.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use flotilla_core::{agents::SharedAgentStateStore, daemon::DaemonHandle, in_process::InProcessDaemon};
-use flotilla_protocol::{DaemonEvent, Message, QueryId, Request};
+use flotilla_protocol::{DaemonEvent, Message, QueryId, Request, SurfaceDeclaration};
 use flotilla_transport::message::MessageSession;
 use tokio::sync::{watch, Notify};
 use tracing::{error, info, warn};
@@ -37,6 +37,10 @@ pub(super) struct ClientConnection {
 }
 
 impl ClientConnection {
+    async fn default_surface(&self) -> SurfaceDeclaration {
+        SurfaceDeclaration::focal_for_namespace(self.daemon.provisioning_namespace().await)
+    }
+
     pub(super) fn new(
         daemon: Arc<InProcessDaemon>,
         shutdown_rx: watch::Receiver<bool>,
@@ -51,7 +55,8 @@ impl ClientConnection {
     pub(super) async fn run(self, session: Arc<MessageSession>, first_id: u64, first_request: Request) {
         // Legacy clients without Hello handshake get a random session ID.
         let session_id = uuid::Uuid::new_v4();
-        let (event_task, request_dispatcher, mut shutdown_rx) = self.start_session(&session, session_id);
+        let surface = self.default_surface().await;
+        let (event_task, request_dispatcher, mut shutdown_rx) = self.start_session(&session, session_id, surface);
 
         let first_response = request_dispatcher.dispatch(first_id, first_request).await;
         if session.write(first_response).await.is_ok() {
@@ -65,8 +70,8 @@ impl ClientConnection {
     ///
     /// Unlike `run`, the first message (Hello) has already been consumed and
     /// replied to, so the loop starts by awaiting the next message.
-    pub(super) async fn run_stateful(self, session: Arc<MessageSession>, client_session_id: uuid::Uuid) {
-        let (event_task, request_dispatcher, mut shutdown_rx) = self.start_session(&session, client_session_id);
+    pub(super) async fn run_stateful(self, session: Arc<MessageSession>, client_session_id: uuid::Uuid, surface: SurfaceDeclaration) {
+        let (event_task, request_dispatcher, mut shutdown_rx) = self.start_session(&session, client_session_id, surface);
         request_loop(&session, &request_dispatcher, &mut shutdown_rx).await;
         self.finish_session(event_task, client_session_id).await;
     }
@@ -80,10 +85,12 @@ impl ClientConnection {
         &self,
         session: &Arc<MessageSession>,
         session_id: uuid::Uuid,
+        surface: SurfaceDeclaration,
     ) -> (tokio::task::JoinHandle<()>, RequestDispatcher<'_>, watch::Receiver<bool>) {
         let count = self.client_count.fetch_add(1, Ordering::SeqCst) + 1;
         info!(%count, "client connected");
         self.client_notify.notify_one();
+        self.daemon.connect_surface(session_id, surface);
 
         let event_session = Arc::clone(session);
         let mut event_rx = self.daemon.subscribe();
@@ -118,6 +125,9 @@ impl ClientConnection {
     async fn finish_session(&self, event_task: tokio::task::JoinHandle<()>, session_id: uuid::Uuid) {
         event_task.abort();
         self.daemon.unsubscribe_queries(session_id).await;
+        if let Err(error) = self.daemon.disconnect_surface(session_id).await {
+            warn!(%error, "failed to disconnect client surface");
+        }
 
         let count = self.client_count.fetch_sub(1, Ordering::SeqCst) - 1;
         info!(%count, "client disconnected");

--- a/crates/flotilla-daemon/src/server/peer_connection.rs
+++ b/crates/flotilla-daemon/src/server/peer_connection.rs
@@ -63,6 +63,7 @@ impl PeerConnection {
                 display_name: self.daemon.host_name().to_string(),
                 session_id: self.daemon.session_id(),
                 connection_role: None,
+                surface: None,
             })
             .await
             .is_err()

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -126,7 +126,16 @@ impl RemoteCommandRouter {
         }
     }
 
-    pub(super) async fn dispatch_execute(&self, mut command: Command) -> Result<u64, String> {
+    #[cfg(test)]
+    pub(super) async fn dispatch_execute(&self, command: Command) -> Result<u64, String> {
+        self.dispatch_execute_for_principal(command, None).await
+    }
+
+    pub(super) async fn dispatch_execute_for_principal(
+        &self,
+        mut command: Command,
+        dispatching_principal_ref: Option<flotilla_protocol::PrincipalRef>,
+    ) -> Result<u64, String> {
         if matches!(command.action, CommandAction::ConvoyStartPrepared { .. }) {
             return Err("prepared convoy starts are reserved for authenticated peer forwarding".to_string());
         }
@@ -142,7 +151,7 @@ impl RemoteCommandRouter {
             }
             if intended_target != self.daemon.node_id() {
                 command.node_id = Some(intended_target.clone());
-                let prepared = self.daemon.prepare_remote_convoy_start(intent).await?;
+                let prepared = self.daemon.prepare_remote_convoy_start(intent, dispatching_principal_ref.as_ref()).await?;
                 command.action = CommandAction::ConvoyStartPrepared { start: Box::new(prepared) };
             }
         }
@@ -201,7 +210,7 @@ impl RemoteCommandRouter {
                 self.daemon.execute_with_remote_executor(command, remote_executor).await
             }
         } else {
-            self.daemon.execute(command).await
+            self.daemon.execute_for_principal(command, dispatching_principal_ref).await
         }
     }
 

--- a/crates/flotilla-daemon/src/server/request_dispatch.rs
+++ b/crates/flotilla-daemon/src/server/request_dispatch.rs
@@ -51,8 +51,13 @@ impl<'a> RequestDispatcher<'a> {
                     }
                 } else {
                     // Non-query commands: existing dispatch path
-                    match self.remote_command_router.dispatch_execute(command).await {
-                        Ok(command_id) => Message::ok_response(id, Response::Execute { command_id }),
+                    match self.daemon.principal_for_surface(self.session_id) {
+                        Ok(principal_ref) => {
+                            match self.remote_command_router.dispatch_execute_for_principal(command, principal_ref).await {
+                                Ok(command_id) => Message::ok_response(id, Response::Execute { command_id }),
+                                Err(e) => Message::error_response(id, e),
+                            }
+                        }
                         Err(e) => Message::error_response(id, e),
                     }
                 }
@@ -131,6 +136,11 @@ impl<'a> RequestDispatcher<'a> {
                     }
                 }
             }
+
+            Request::ObserveFocus { targets } => match self.daemon.observe_surface_focus(self.session_id, targets).await {
+                Ok(()) => Message::ok_response(id, Response::ObserveFocus),
+                Err(error) => Message::error_response(id, error),
+            },
 
             Request::GetStatus => match self.daemon.get_status().await {
                 Ok(status) => Message::ok_response(id, Response::GetStatus(status)),

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -4,7 +4,7 @@ use flotilla_client::SocketDaemon;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
 use flotilla_protocol::{
     result_set::{ConvoyPhase, ConvoyRow, ResultSet, Rows},
-    FleetReplicaSnapshot, HostName, NodeInfo, ResourceRef,
+    FleetReplicaSnapshot, HostName, NodeInfo, ResourceRef, SurfaceDeclaration,
 };
 use flotilla_resources::{api_version, Convoy, Resource};
 use tokio::sync::{mpsc, watch, Mutex, Notify};
@@ -121,6 +121,24 @@ pub async fn spawn_in_memory_request_topology_stateful(
     leader: Arc<InProcessDaemon>,
     follower: Arc<InProcessDaemon>,
 ) -> Result<InMemoryRequestTopology, String> {
+    spawn_in_memory_request_topology_stateful_with_optional_surface(leader, follower, None).await
+}
+
+/// Stateful in-memory topology whose client declares an explicit attention
+/// character during the Hello handshake.
+pub async fn spawn_in_memory_request_topology_stateful_with_surface(
+    leader: Arc<InProcessDaemon>,
+    follower: Arc<InProcessDaemon>,
+    surface: SurfaceDeclaration,
+) -> Result<InMemoryRequestTopology, String> {
+    spawn_in_memory_request_topology_stateful_with_optional_surface(leader, follower, Some(surface)).await
+}
+
+async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
+    leader: Arc<InProcessDaemon>,
+    follower: Arc<InProcessDaemon>,
+    surface: Option<SurfaceDeclaration>,
+) -> Result<InMemoryRequestTopology, String> {
     let leader_host = leader.host_name().clone();
     let follower_host = follower.host_name().clone();
 
@@ -198,7 +216,10 @@ pub async fn spawn_in_memory_request_topology_stateful(
     });
 
     // Now the server is listening — the handshake can proceed.
-    let client = SocketDaemon::from_session_stateful(client_session).await?;
+    let client = match surface {
+        Some(surface) => SocketDaemon::from_session_stateful_with_surface(client_session, surface).await?,
+        None => SocketDaemon::from_session_stateful(client_session).await?,
+    };
 
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -319,7 +319,10 @@ async fn dispatch_add_list_remove_repo_round_trip() {
         other => panic!("expected list repos response, got {:?}", other),
     };
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].path.as_deref(), Some(repo_path.as_path()));
+    assert_eq!(
+        listed[0].path.as_ref().map(|path| path.canonicalize().expect("canonical listed repo path")),
+        Some(repo_path.canonicalize().expect("canonical requested repo path"))
+    );
 
     let remove = dispatch_request_test(&daemon, 12, Request::RemoveRepo {
         path: listed[0].path.clone().expect("tracked repo should have local path"),
@@ -2543,6 +2546,7 @@ async fn handle_client_forwards_peer_data_and_registers_peer() {
         display_name: "remote-host".into(),
         session_id: uuid::Uuid::nil(),
         connection_role: None,
+        surface: None,
     };
     flotilla_protocol::framing::write_message_line(&mut writer, &hello).await.expect("write hello");
 
@@ -2876,6 +2880,7 @@ async fn handle_client_rejects_client_hello_with_version_mismatch() {
         display_name: "client".into(),
         session_id: uuid::Uuid::nil(),
         connection_role: Some(flotilla_protocol::ConnectionRole::Client),
+        surface: None,
     };
     flotilla_protocol::framing::write_message_line(&mut writer, &hello).await.expect("write hello");
 
@@ -3348,6 +3353,7 @@ async fn handle_client_relays_outbound_peer_messages() {
         display_name: "remote-host".into(),
         session_id: uuid::Uuid::nil(),
         connection_role: None,
+        surface: None,
     };
     flotilla_protocol::framing::write_message_line(&mut writer, &hello).await.expect("write hello");
     let _ = reader.next_line().await.expect("read hello").expect("line");
@@ -3461,6 +3467,7 @@ async fn duplicate_inbound_peer_receives_goodbye_on_rejection() {
             display_name: "peer".into(),
             session_id: uuid::Uuid::nil(),
             connection_role: None,
+            surface: None,
         };
         flotilla_protocol::framing::write_message_line(&mut writer, &hello).await.expect("write hello");
 

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -12,16 +12,17 @@ use flotilla_core::{
 };
 use flotilla_daemon::server::test_support::{
     apply_convoy_replica_feed, spawn_in_memory_request_topology, spawn_in_memory_request_topology_stateful,
+    spawn_in_memory_request_topology_stateful_with_surface,
 };
 use flotilla_protocol::{
     issue_query::{IssueQuery, IssueResultPage},
     test_support::TestIssue,
     Command, CommandAction, CommandValue, DaemonEvent, HostName, Issue, IssueChangeset, IssueRef, IssueSource, NodeInfo,
-    PeerConnectionState, RepoSelector,
+    PeerConnectionState, PrincipalRef, RepoSelector, ResourceRef, SurfaceCharacter, SurfaceDeclaration,
 };
 use flotilla_resources::{
-    Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, ResourceError, WorkPhase as ResourceWorkPhase,
-    WorkState,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, Regard, Resource, ResourceError,
+    WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -52,6 +53,101 @@ async fn await_command_result(rx: &mut tokio::sync::broadcast::Receiver<DaemonEv
     })
     .await
     .expect("timed out waiting for command result")
+}
+
+#[tokio::test]
+async fn ambient_surface_observations_do_not_create_regards_over_the_client_protocol() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful_with_surface(Arc::clone(&leader), follower, SurfaceDeclaration {
+        principal_ref: PrincipalRef::implicit_for_namespace("flotilla"),
+        character: SurfaceCharacter::Ambient,
+    })
+    .await
+    .expect("spawn ambient client topology");
+
+    topology
+        .client
+        .observe_focus(uuid::Uuid::nil(), vec![ResourceRef::new(
+            api_version(Convoy::API_PATHS),
+            Convoy::API_PATHS.kind,
+            "flotilla",
+            "ambient-demo",
+        )])
+        .await
+        .expect("report ambient focus");
+
+    assert!(leader.resource_backend().using::<Regard>("flotilla").list().await.expect("list regards").items.is_empty());
+}
+
+#[tokio::test]
+async fn default_focal_surface_uses_the_daemons_provisioning_principal() {
+    let leader = empty_daemon_named("leader").await;
+    leader.set_provisioning_namespace("dev".to_string()).await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(Arc::clone(&leader), follower).await.expect("spawn default client topology");
+
+    topology
+        .client
+        .observe_focus(uuid::Uuid::nil(), vec![ResourceRef::new(
+            api_version(Convoy::API_PATHS),
+            Convoy::API_PATHS.kind,
+            "dev",
+            "focused-demo",
+        )])
+        .await
+        .expect("report focal focus");
+
+    let regards = leader.resource_backend().using::<Regard>("dev").list().await.expect("list regards");
+    assert_eq!(regards.items.len(), 1);
+    assert_eq!(regards.items[0].spec.principal_ref, PrincipalRef::implicit_for_namespace("dev"));
+}
+
+#[tokio::test]
+async fn convoy_creation_attributes_provenance_and_regard_to_the_surface_principal() {
+    let leader = empty_daemon_named("leader").await;
+    leader
+        .resource_backend()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("empty".to_string()).build(), &WorkflowTemplateSpec::builder().vessels(Vec::new()).build())
+        .await
+        .expect("create workflow");
+    let follower = empty_daemon_named("follower").await;
+    let principal_ref = PrincipalRef { namespace: "flotilla".to_string(), name: "alice".to_string() };
+    let topology = spawn_in_memory_request_topology_stateful_with_surface(Arc::clone(&leader), follower, SurfaceDeclaration {
+        principal_ref: principal_ref.clone(),
+        character: SurfaceCharacter::Focal,
+    })
+    .await
+    .expect("spawn named focal client topology");
+    let mut events = leader.subscribe();
+
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "alice-dispatch".to_string(),
+                workflow_ref: "empty".to_string(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: None,
+                adopted_checkout: None,
+            },
+        })
+        .await
+        .expect("dispatch convoy creation");
+    assert_eq!(await_command_result(&mut events, command_id).await, CommandValue::ConvoyCreated { name: "alice-dispatch".to_string() });
+
+    let convoy = leader.resource_backend().using::<Convoy>("flotilla").get("alice-dispatch").await.expect("created convoy");
+    assert_eq!(convoy.spec.dispatching_principal_ref, principal_ref);
+    let regards = leader.resource_backend().using::<Regard>("flotilla").list().await.expect("list regards");
+    assert_eq!(regards.items.len(), 1);
+    assert_eq!(regards.items[0].spec.principal_ref, convoy.spec.dispatching_principal_ref);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -13,9 +13,12 @@
 
 use std::collections::BTreeMap;
 
-use flotilla_protocol::result_set::{
-    AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessPhase, AwarenessState, ConvoyPhase, ConvoyRow, IndependentRow, SessionPhase,
-    VesselRow, WorkPhase,
+use flotilla_protocol::{
+    result_set::{
+        AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessPhase, AwarenessState, ConvoyPhase, ConvoyRow, IndependentRow, SessionPhase,
+        VesselRow, WorkPhase,
+    },
+    ViewAddress,
 };
 
 use crate::{
@@ -200,7 +203,7 @@ fn project_awareness_node(catalog: &mut Catalog, node: &AwarenessNode, mint: &dy
     }
 }
 
-fn project_awareness_entry(catalog: &mut Catalog, project: &GroupSegment, entry: &AwarenessEntry, _mint: &dyn RecipeMint) {
+fn project_awareness_entry(catalog: &mut Catalog, project: &GroupSegment, entry: &AwarenessEntry, mint: &dyn RecipeMint) {
     let segment_key = match entry.kind {
         AwarenessKind::Convoy => SEGMENT_CONVOY,
         AwarenessKind::Issue => SEGMENT_ISSUE,
@@ -222,7 +225,18 @@ fn project_awareness_entry(catalog: &mut Catalog, project: &GroupSegment, entry:
     if matches!(entry.state, AwarenessState::Waiting | AwarenessState::Failed) {
         facts.push((KEY_STATUS_ATTENTION, MetadataValue::Bool(true)));
     }
+    if let Some(recipe) = awareness_view_target(&entry.id).and_then(|target| mint.scoped_view(&target)) {
+        facts.push((KEY_MATERIALIZE_TARGET, MetadataValue::text("workspace")));
+        facts.push((KEY_MATERIALIZE_RECIPE, MetadataValue::text(recipe.command())));
+    }
     catalog.assert_facts(MetadataTarget::Group(path), facts, None);
+}
+
+fn awareness_view_target(id: &str) -> Option<ViewAddress> {
+    match id.parse().ok()? {
+        address @ (ViewAddress::Project { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. }) => Some(address),
+        _ => None,
+    }
 }
 
 fn awareness_state(state: AwarenessState) -> &'static str {

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -4,10 +4,10 @@ use flotilla_protocol::{
 };
 
 use super::*;
-use crate::{recipe::AttachOnlyRecipes, wire::MetadataPathValue};
+use crate::{recipe::FlotillaRecipes, wire::MetadataPathValue};
 
-fn mint() -> AttachOnlyRecipes {
-    AttachOnlyRecipes::new("flotilla")
+fn mint() -> FlotillaRecipes {
+    FlotillaRecipes::new("flotilla")
 }
 
 fn convoy_ref(namespace: &str, name: &str) -> ResourceRef {
@@ -106,8 +106,8 @@ fn awareness_tree_projects_project_issue_and_materializable_entries() {
         find(&patches, &group(vec![project, GroupSegment::text(SEGMENT_VESSEL, "vessel/dev/ship-it/coder").with_label("coder")]));
     assert_eq!(text(vessel_patch, KEY_WORK_PHASE), "running");
     assert_eq!(text(vessel_patch, KEY_VESSEL_HOST), "feta");
-    assert!(!vessel_patch.set.contains_key(KEY_MATERIALIZE_TARGET));
-    assert!(!vessel_patch.set.contains_key(KEY_MATERIALIZE_RECIPE));
+    assert_eq!(text(vessel_patch, KEY_MATERIALIZE_TARGET), "workspace");
+    assert_eq!(text(vessel_patch, KEY_MATERIALIZE_RECIPE), "flotilla view 'vessel/dev/ship-it/coder'");
 }
 
 #[test]

--- a/crates/flotilla-manifest/src/recipe.rs
+++ b/crates/flotilla-manifest/src/recipe.rs
@@ -22,44 +22,34 @@ impl Recipe {
     }
 }
 
-/// A scoped-view target, mirroring ADR 0013's kind-rooted, host-free
-/// addresses without depending on the (unlanded) address type itself.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ViewTarget {
-    Project { namespace: String, name: String },
-    Convoy { namespace: String, name: String },
-    Vessel { namespace: String, convoy: String, vessel: String },
-}
-
 pub trait RecipeMint: Send + Sync {
     /// Recipe attaching a live entity — a session into a pane, or a vessel's
     /// running session into a workspace; `attach_ref` is any reference the
     /// daemon accepts (rows expose it as a capability fact).
     fn attach(&self, attach_ref: &str) -> Option<Recipe>;
     /// Recipe materialising a scoped view of an entity with no live session.
-    fn scoped_view(&self, target: &ViewTarget) -> Option<Recipe>;
+    fn scoped_view(&self, target: &flotilla_protocol::ViewAddress) -> Option<Recipe>;
 }
 
-/// v0 mint: attach recipes only. Scoped views return `None` — the entry
-/// lists truthfully unmaterialisable — until #589 lands and a view-capable
-/// mint replaces this one.
-pub struct AttachOnlyRecipes {
+/// Recipes implemented by the Flotilla CLI: attach a live entity or open a
+/// scoped focal view for an awareness-band latent.
+pub struct FlotillaRecipes {
     flotilla_bin: String,
 }
 
-impl AttachOnlyRecipes {
+impl FlotillaRecipes {
     pub fn new(flotilla_bin: impl Into<String>) -> Self {
-        AttachOnlyRecipes { flotilla_bin: flotilla_bin.into() }
+        Self { flotilla_bin: flotilla_bin.into() }
     }
 }
 
-impl RecipeMint for AttachOnlyRecipes {
+impl RecipeMint for FlotillaRecipes {
     fn attach(&self, attach_ref: &str) -> Option<Recipe> {
         Some(Recipe::Command(format!("{} attach {attach_ref}", self.flotilla_bin)))
     }
 
-    fn scoped_view(&self, _target: &ViewTarget) -> Option<Recipe> {
-        None
+    fn scoped_view(&self, target: &flotilla_protocol::ViewAddress) -> Option<Recipe> {
+        Some(Recipe::Command(format!("{} view {}", self.flotilla_bin, flotilla_protocol::arg::shell_quote(&target.to_string()))))
     }
 }
 
@@ -68,16 +58,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn attach_only_mint_formats_attach_and_declines_views() {
-        let mint = AttachOnlyRecipes::new("flotilla");
+    fn flotilla_mint_formats_attach_and_scoped_view_recipes() {
+        let mint = FlotillaRecipes::new("flotilla");
         assert_eq!(mint.attach("implement"), Some(Recipe::Command("flotilla attach implement".to_owned())));
         assert_eq!(
-            mint.scoped_view(&ViewTarget::Vessel {
+            mint.scoped_view(&flotilla_protocol::ViewAddress::Vessel {
                 namespace: "dev".to_owned(),
                 convoy: "manifest-extraction".to_owned(),
                 vessel: "implement".to_owned(),
             }),
-            None
+            Some(Recipe::Command("flotilla view 'vessel/dev/manifest-extraction/implement'".to_owned()))
         );
     }
 }

--- a/crates/flotilla-manifest/src/sink.rs
+++ b/crates/flotilla-manifest/src/sink.rs
@@ -312,7 +312,7 @@ done
     }
 
     async fn wait_for_line_count(path: &Path, expected: usize) -> Vec<String> {
-        tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 let lines = std::fs::read_to_string(path).unwrap_or_default().lines().map(str::to_owned).collect::<Vec<_>>();
                 if lines.len() >= expected {
@@ -326,7 +326,7 @@ done
     }
 
     async fn wait_for_path(path: &Path) {
-        tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::time::timeout(Duration::from_secs(5), async {
             while !path.exists() {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -494,6 +494,19 @@ pub struct AttachBinding {
     pub role: Option<String>,
 }
 
+impl AttachBinding {
+    pub fn resource_ref(&self) -> Option<crate::ResourceRef> {
+        match (&self.convoy, &self.vessel, &self.session) {
+            (Some(convoy), Some(vessel), _) => Some(
+                crate::ResourceRef::new("flotilla.work/v1", "Convoy", &self.namespace, convoy).subresource(format!("vessels/{vessel}")),
+            ),
+            (Some(convoy), None, _) => Some(crate::ResourceRef::new("flotilla.work/v1", "Convoy", &self.namespace, convoy)),
+            (None, _, Some(session)) => Some(crate::ResourceRef::new("flotilla.work/v1", "TerminalSession", &self.namespace, session)),
+            (None, _, None) => None,
+        }
+    }
+}
+
 /// Result returned from command execution, or inter-step data passed between steps.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/crates/flotilla-protocol/src/framing.rs
+++ b/crates/flotilla-protocol/src/framing.rs
@@ -30,6 +30,7 @@ mod tests {
             display_name: "test".into(),
             session_id: uuid::Uuid::nil(),
             connection_role: None,
+            surface: None,
         };
         let mut buf = Vec::new();
         write_message_line(&mut buf, &msg).await.expect("write should succeed");

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -138,6 +138,35 @@ pub enum ConnectionRole {
     Client,
     Peer,
 }
+
+/// Whether a connected presentation surface represents a person's active
+/// attention or is only an overview/projection consumer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SurfaceCharacter {
+    #[default]
+    Focal,
+    Ambient,
+}
+
+/// Attention identity declared by a client surface when it connects.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SurfaceDeclaration {
+    pub principal_ref: PrincipalRef,
+    #[serde(default)]
+    pub character: SurfaceCharacter,
+}
+
+impl SurfaceDeclaration {
+    pub fn focal_for_namespace(namespace: impl Into<String>) -> Self {
+        Self { principal_ref: PrincipalRef::implicit_for_namespace(namespace), character: SurfaceCharacter::Focal }
+    }
+
+    pub fn ambient_for_namespace(namespace: impl Into<String>) -> Self {
+        Self { principal_ref: PrincipalRef::implicit_for_namespace(namespace), character: SurfaceCharacter::Ambient }
+    }
+}
+
 pub use snapshot::{
     CategoryLabels, CheckoutRef, ProviderError, RepoInfo, RepoKey, RepoLabels, RepoSnapshot, WorkItem, WorkItemIdentity, WorkItemKind,
 };
@@ -145,7 +174,7 @@ pub use snapshot::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 16;
+pub const PROTOCOL_VERSION: u32 = 17;
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.
@@ -216,6 +245,10 @@ pub enum Request {
     FetchMore {
         query: QueryId,
     },
+    /// Replace this connection's current set of focused resource targets.
+    ObserveFocus {
+        targets: Vec<ResourceRef>,
+    },
     GetStatus,
     GetTopology,
     AgentHook {
@@ -244,6 +277,7 @@ pub enum Response {
     /// per query whose cursor was absent or stale.
     SubscribeQueries(Vec<DaemonEvent>),
     FetchMore,
+    ObserveFocus,
     GetStatus(StatusResponse),
     GetTopology(TopologyResponse),
     AgentHook,
@@ -280,6 +314,8 @@ pub enum Message {
         session_id: uuid::Uuid,
         #[serde(default)]
         connection_role: Option<ConnectionRole>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        surface: Option<SurfaceDeclaration>,
     },
     #[serde(rename = "peer")]
     Peer(Box<PeerWireMessage>),

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -441,9 +441,22 @@ fn message_hello_roundtrip() {
         display_name: "Desktop Workstation".into(),
         session_id: uuid::Uuid::nil(),
         connection_role: None,
+        surface: Some(SurfaceDeclaration {
+            principal_ref: PrincipalRef::implicit_for_namespace("flotilla"),
+            character: SurfaceCharacter::Ambient,
+        }),
     };
 
     test_helpers::assert_json_roundtrip(&msg);
+}
+
+#[test]
+fn observe_focus_request_round_trips_typed_resource_targets() {
+    let request = Request::ObserveFocus {
+        targets: vec![ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "demo").subresource("vessels/implement")],
+    };
+
+    test_helpers::assert_roundtrip(&request);
 }
 
 #[test]

--- a/crates/flotilla-resources/src/crds/regard.crd.yaml
+++ b/crates/flotilla-resources/src/crds/regard.crd.yaml
@@ -18,7 +18,7 @@ spec:
       additionalPrinterColumns:
         - name: Principal
           type: string
-          jsonPath: .spec.principal_ref
+          jsonPath: .spec.principal_ref.name
         - name: Target
           type: string
           jsonPath: .spec.target.name

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -41,6 +41,7 @@ pub use environment::{
     EnvironmentStatusPatch, HostDirectEnvironmentSpec,
 };
 pub use error::ResourceError;
+pub use flotilla_protocol::PrincipalRef;
 pub use host::{Host, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY, TERMINAL_POOLS_CAPABILITY};
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
@@ -54,8 +55,8 @@ pub use placement_policy::{
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
 pub use principal_attention::{
-    Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, DemandState, DemandStatus, DemandStatusPatch, DemandTransition,
-    PrincipalRef, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RegardStatus, RegardStatusPatch,
+    Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, DemandState, DemandStatus, DemandStatusPatch, DemandTransition, Regard,
+    RegardExpiryPolicy, RegardSource, RegardSpec, RegardStatus, RegardStatusPatch,
 };
 pub use project::{
     normalize_project_spec, resolve_project_issue_sources, IssueSource, IssueSourceResolution, IssueSourceUnavailable, Project,

--- a/crates/flotilla-resources/src/principal_attention.rs
+++ b/crates/flotilla-resources/src/principal_attention.rs
@@ -1,15 +1,11 @@
 use chrono::{DateTime, Utc};
-use flotilla_protocol::ResourceRef;
+use flotilla_protocol::{PrincipalRef, ResourceRef};
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::StatusPatch};
 
 define_resource!(Regard, "regards", RegardSpec, RegardStatus, RegardStatusPatch);
 define_resource!(Demand, "demands", DemandSpec, DemandStatus, DemandStatusPatch);
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct PrincipalRef(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -381,7 +381,7 @@ mod tests {
             .create(
                 &InputMeta::builder().name("principal-default-convoy-demo".to_string()).build(),
                 &RegardSpec::builder()
-                    .principal_ref(PrincipalRef("principal/default".to_string()))
+                    .principal_ref(PrincipalRef::implicit_for_namespace("flotilla"))
                     .target(ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "demo"))
                     .source(RegardSource::Expressed)
                     .expiry(RegardExpiryPolicy::Pin)
@@ -396,7 +396,7 @@ mod tests {
                 &DemandSpec::builder()
                     .originating_work_ref(ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "demo-implement"))
                     .kind(DemandKind::Permission)
-                    .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) })
+                    .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef::implicit_for_namespace("flotilla") })
                     .build(),
             )
             .await
@@ -433,7 +433,7 @@ mod tests {
                     "kind": "review",
                     "addressee": {
                         "kind": "principal",
-                        "principal_ref": "principal/default"
+                        "principal_ref": { "namespace": "flotilla", "name": "implicit" }
                     }
                 }
             }),
@@ -467,7 +467,7 @@ mod tests {
                 &DemandSpec::builder()
                     .originating_work_ref(ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "demo-implement"))
                     .kind(DemandKind::Permission)
-                    .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) })
+                    .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef::implicit_for_namespace("flotilla") })
                     .build(),
             )
             .await
@@ -490,7 +490,7 @@ mod tests {
                     "kind": "review",
                     "addressee": {
                         "kind": "principal",
-                        "principal_ref": "principal/default"
+                        "principal_ref": { "namespace": "flotilla", "name": "implicit" }
                     }
                 }
             })

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -106,7 +106,7 @@ impl ResourceContractFixture for RegardFixture {
 
     fn spec() -> <Self::Resource as Resource>::Spec {
         RegardSpec::builder()
-            .principal_ref(PrincipalRef("principal/default".to_string()))
+            .principal_ref(PrincipalRef::implicit_for_namespace("flotilla"))
             .target(resource_ref("Convoy", "alpha"))
             .source(RegardSource::Expressed)
             .expiry(RegardExpiryPolicy::Decaying { expires_after_seconds: 300 })
@@ -115,7 +115,7 @@ impl ResourceContractFixture for RegardFixture {
 
     fn updated_spec() -> <Self::Resource as Resource>::Spec {
         RegardSpec::builder()
-            .principal_ref(PrincipalRef("principal/default".to_string()))
+            .principal_ref(PrincipalRef::implicit_for_namespace("flotilla"))
             .target(resource_ref("Convoy", "alpha"))
             .source(RegardSource::Implicit { policy: "convoy-start".to_string() })
             .expiry(RegardExpiryPolicy::Pin)
@@ -123,7 +123,7 @@ impl ResourceContractFixture for RegardFixture {
     }
 
     fn assert_created(created: &ResourceObject<Self::Resource>) {
-        assert_eq!(created.spec.principal_ref, PrincipalRef("principal/default".to_string()));
+        assert_eq!(created.spec.principal_ref, PrincipalRef::implicit_for_namespace("flotilla"));
         assert!(created.status.is_none());
     }
 
@@ -150,7 +150,7 @@ impl ResourceContractFixture for DemandFixture {
         DemandSpec::builder()
             .originating_work_ref(resource_ref("Vessel", "alpha-implement"))
             .kind(DemandKind::Permission)
-            .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) })
+            .addressee(DemandAddressee::Principal { principal_ref: PrincipalRef::implicit_for_namespace("flotilla") })
             .build()
     }
 

--- a/crates/flotilla-resources/tests/principal_attention_status_patch.rs
+++ b/crates/flotilla-resources/tests/principal_attention_status_patch.rs
@@ -58,11 +58,11 @@ fn demand_satisfy_and_acknowledge_preserve_transition_timestamps_and_authorities
 #[test]
 fn demand_spec_defaults_to_dispatching_principal_via_constructor() {
     let work_ref = ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "demo-implement");
-    let spec =
-        DemandSpec::for_dispatching_principal(work_ref.clone(), DemandKind::Permission, PrincipalRef("principal/default".to_string()));
+    let principal_ref = PrincipalRef::implicit_for_namespace("flotilla");
+    let spec = DemandSpec::for_dispatching_principal(work_ref.clone(), DemandKind::Permission, principal_ref.clone());
 
     assert_eq!(spec.originating_work_ref, work_ref);
-    assert_eq!(spec.addressee, DemandAddressee::Principal { principal_ref: PrincipalRef("principal/default".to_string()) });
+    assert_eq!(spec.addressee, DemandAddressee::Principal { principal_ref });
 }
 
 #[test]

--- a/crates/flotilla-transport/tests/memory_session.rs
+++ b/crates/flotilla-transport/tests/memory_session.rs
@@ -36,6 +36,7 @@ async fn message_session_pair_transfers_protocol_messages() {
             display_name: "remote".into(),
             session_id: Default::default(),
             connection_role: None,
+            surface: None,
         })
         .await
         .expect("write hello");

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -414,6 +414,7 @@ impl App {
                     .unwrap_or_else(|| std::path::PathBuf::from("."));
                 let tx = self.pm_update_tx.clone();
                 let label = target.label.clone();
+                self.report_focus(vec![target.resource_ref()]);
                 self.set_status_message(Some(format!("Opening {label} in PM...")));
                 tokio::spawn(async move {
                     let result = connector.open(&target, &working_directory).await;

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -24,8 +24,8 @@ use flotilla_core::{
 };
 use flotilla_protocol::{
     Command, CommandAction, CommandValue, DaemonEvent, EnvironmentId, HostName, HostSummary, NodeId, PeerConnectionState, ProviderData,
-    ProviderError, ProvisioningTarget, RepoDelta, RepoIdentity, RepoInfo, RepoLabels, RepoSelector, RepoSnapshot, StepStatus, ViewAddress,
-    WorkItem, WorkItemIdentity,
+    ProviderError, ProvisioningTarget, RepoDelta, RepoIdentity, RepoInfo, RepoLabels, RepoSelector, RepoSnapshot, ResourceRef, StepStatus,
+    ViewAddress, WorkItem, WorkItemIdentity,
 };
 use indexmap::IndexMap;
 pub use intent::Intent;
@@ -513,6 +513,12 @@ pub struct App {
 
 impl App {
     pub fn new(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>, config: Arc<ConfigStore>, theme: Theme) -> Self {
+        let app = Self::new_unreported(daemon, repos_info, config, theme);
+        app.report_active_view_focus();
+        app
+    }
+
+    fn new_unreported(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>, config: Arc<ConfigStore>, theme: Theme) -> Self {
         let mut model = TuiModel::from_repo_info(repos_info);
         // Open-view set: persisted if present, else seeded to match the
         // pre-View tab bar (overview + convoys + one tab per tracked repo).
@@ -618,7 +624,7 @@ impl App {
         theme: Theme,
         address: ViewAddress,
     ) -> Self {
-        let mut app = Self::new(daemon, repos_info, config, theme);
+        let mut app = Self::new_unreported(daemon, repos_info, config, theme);
         app.views = OpenViews::scoped(address);
         app.subscriptions_dirty = true;
         app.sync_active_view();
@@ -904,6 +910,25 @@ impl App {
                 self.ui.view_layout = page.layout;
             }
         }
+        self.report_active_view_focus();
+    }
+
+    fn report_active_view_focus(&self) {
+        let targets = self.views.active_address().and_then(view_regard_target).into_iter().collect();
+        self.report_focus(targets);
+    }
+
+    pub(super) fn report_focus(&self, targets: Vec<ResourceRef>) {
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let daemon = Arc::clone(&self.daemon);
+        let surface_id = self.session_id;
+        runtime.spawn(async move {
+            if let Err(error) = daemon.observe_focus(surface_id, targets).await {
+                tracing::warn!(%error, "failed to report TUI focus");
+            }
+        });
     }
 
     pub fn dismiss_status_item(&mut self, id: usize) {
@@ -1855,6 +1880,25 @@ impl App {
         let input = Input::from(format!("{}/", start_dir.display()).as_str());
         let dir_entries = crate::widgets::command_palette::refresh_dir_listing_standalone(input.value(), &self.model);
         self.screen.modal_stack.push(Box::new(crate::widgets::file_picker::FilePickerWidget::new(input, dir_entries)));
+    }
+}
+
+fn view_regard_target(address: &ViewAddress) -> Option<ResourceRef> {
+    match address {
+        ViewAddress::Convoy { namespace, name } => Some(ResourceRef::new("flotilla.work/v1", "Convoy", namespace, name)),
+        ViewAddress::Vessel { namespace, convoy, vessel } => {
+            Some(ResourceRef::new("flotilla.work/v1", "Convoy", namespace, convoy).subresource(format!("vessels/{vessel}")))
+        }
+        ViewAddress::Project { namespace, name } => Some(ResourceRef::new("flotilla.work/v1", "Project", namespace, name)),
+        ViewAddress::Issues { scope } | ViewAddress::Checkouts { scope: Some(scope) } => {
+            Some(ResourceRef::new("flotilla.work/v1", "Project", &scope.namespace, &scope.name))
+        }
+        ViewAddress::Repo { repository_key: Some(key), .. } => Some(ResourceRef::new("flotilla.work/v1", "Repository", "flotilla", &key.0)),
+        ViewAddress::Overview
+        | ViewAddress::Convoys { .. }
+        | ViewAddress::Independents { .. }
+        | ViewAddress::Checkouts { scope: None }
+        | ViewAddress::Repo { repository_key: None, .. } => None,
     }
 }
 

--- a/crates/flotilla-tui/src/app/navigation/tests.rs
+++ b/crates/flotilla-tui/src/app/navigation/tests.rs
@@ -1,7 +1,9 @@
-use flotilla_protocol::ViewAddress;
+use std::sync::Arc;
+
+use flotilla_protocol::{ResourceRef, ViewAddress};
 
 use crate::app::{
-    test_support::{activate_repo_tab, issue_item, set_active_table_items, stub_app_with_repos},
+    test_support::{activate_repo_tab, issue_item, set_active_table_items, stub_app_with_daemon, stub_app_with_repos, StubDaemon},
     App,
 };
 
@@ -18,6 +20,22 @@ fn active_address(app: &App) -> ViewAddress {
 
 fn convoys_address() -> ViewAddress {
     ViewAddress::Convoys { namespace: "flotilla".to_string() }
+}
+
+#[tokio::test]
+async fn opening_a_convoy_view_reports_it_as_the_focal_resource() {
+    let daemon = Arc::new(StubDaemon::new());
+    let daemon_handle = Arc::clone(&daemon) as Arc<dyn flotilla_core::daemon::DaemonHandle>;
+    let mut app = stub_app_with_daemon(daemon_handle, Vec::new());
+
+    app.open_view("convoy/flotilla/demo".parse().expect("convoy address"));
+    tokio::task::yield_now().await;
+
+    let observations = daemon.observations();
+    assert_eq!(
+        observations.last().map(|(_, targets)| targets.as_slice()),
+        Some(&[ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "demo"),][..])
+    );
 }
 
 // Seeded tab layout for `stub_app_with_repos(n)` is

--- a/crates/flotilla-tui/src/app/test_support.rs
+++ b/crates/flotilla-tui/src/app/test_support.rs
@@ -22,6 +22,8 @@ pub(crate) use super::test_builders::*;
 use super::{App, CommandQueue, DirEntry, InFlightCommand, OpenViews, TuiHostState, TuiModel};
 use crate::{keymap::Keymap, widgets::WidgetContext};
 
+type FocusObservations = Arc<Mutex<Vec<(uuid::Uuid, Vec<flotilla_protocol::ResourceRef>)>>>;
+
 #[derive(bon::Builder)]
 pub(crate) struct StubDaemon {
     #[builder(default = broadcast::channel(1).0)]
@@ -31,6 +33,8 @@ pub(crate) struct StubDaemon {
     execute_gate: Option<Arc<Semaphore>>,
     #[builder(default = Ok(1))]
     execute_result: Result<u64, String>,
+    #[builder(default = Arc::new(Mutex::new(Vec::new())))]
+    observations: FocusObservations,
 }
 
 static STUB_APP_CONFIG_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -62,6 +66,10 @@ fn insert_stub_local_host(model: &mut TuiModel) {
 impl StubDaemon {
     pub(crate) fn new() -> Self {
         Self::builder().build()
+    }
+
+    pub(crate) fn observations(&self) -> Vec<(uuid::Uuid, Vec<flotilla_protocol::ResourceRef>)> {
+        self.observations.lock().expect("observations lock").clone()
     }
 }
 
@@ -112,6 +120,11 @@ impl DaemonHandle for StubDaemon {
 
     async fn get_topology(&self) -> Result<TopologyResponse, String> {
         Err("stub".into())
+    }
+
+    async fn observe_focus(&self, surface_id: uuid::Uuid, targets: Vec<flotilla_protocol::ResourceRef>) -> Result<(), String> {
+        self.observations.lock().expect("observations lock").push((surface_id, targets));
+        Ok(())
     }
 }
 

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -25,7 +25,7 @@ use flotilla_manifest::{
     keys::REASSERT_INTERVAL_MS,
     pm::PmInstance,
     projection::{project_catalog, Catalog, CatalogInput},
-    recipe::{AttachOnlyRecipes, RecipeMint},
+    recipe::{FlotillaRecipes, RecipeMint},
     sink::PatchSink,
     wire::MetadataPatch,
 };
@@ -355,12 +355,18 @@ pub async fn run(
         .with_writer(std::io::stderr)
         .try_init();
     let sink = resolve_pm(&options, &|key| std::env::var(key).ok())?.sink();
-    let mint: Arc<dyn RecipeMint> = Arc::new(AttachOnlyRecipes::new(options.flotilla_bin.clone()));
+    let mint: Arc<dyn RecipeMint> = Arc::new(FlotillaRecipes::new(options.flotilla_bin.clone()));
     run_reconnecting(
         || async {
-            crate::socket::connect_or_spawn(socket_path, config_dir, config_dir_override, socket_override)
-                .await
-                .map(|daemon| daemon as Arc<dyn DaemonHandle>)
+            crate::socket::connect_or_spawn_with_surface(
+                socket_path,
+                config_dir,
+                config_dir_override,
+                socket_override,
+                flotilla_protocol::SurfaceDeclaration::ambient_for_namespace("flotilla"),
+            )
+            .await
+            .map(|daemon| daemon as Arc<dyn DaemonHandle>)
         },
         |daemon| run_connector(daemon, sink.clone(), mint.clone(), Duration::from_millis(REASSERT_INTERVAL_MS)),
         ReconnectBackoff::default(),

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -68,8 +68,8 @@ fn awareness_node() -> AwarenessNode {
         .build()
 }
 
-fn mint() -> AttachOnlyRecipes {
-    AttachOnlyRecipes::new("flotilla")
+fn mint() -> FlotillaRecipes {
+    FlotillaRecipes::new("flotilla")
 }
 
 fn independent_group(name: &str) -> MetadataTarget {

--- a/crates/flotilla-tui/src/pm_open.rs
+++ b/crates/flotilla-tui/src/pm_open.rs
@@ -18,7 +18,7 @@ use flotilla_manifest::{
     projection::{convoy_group_path, project_segment, vessel_factory_id, vessel_group_path},
     stamp::WorkspaceStamp,
 };
-use flotilla_protocol::{arg::shell_quote, HostName, RepoKey};
+use flotilla_protocol::{arg::shell_quote, HostName, RepoKey, ResourceRef};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpenInPmTarget {
@@ -31,6 +31,13 @@ pub struct OpenInPmTarget {
     pub repo_hint: Option<RepoKey>,
     pub workspace_ref: Option<String>,
     pub materialize_ref: Option<String>,
+}
+
+impl OpenInPmTarget {
+    pub fn resource_ref(&self) -> ResourceRef {
+        let convoy = ResourceRef::new("flotilla.work/v1", "Convoy", &self.namespace, &self.convoy);
+        self.vessel.as_ref().map_or_else(|| convoy.clone(), |vessel| convoy.subresource(format!("vessels/{vessel}")))
+    }
 }
 
 #[async_trait]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, process::ExitStatus, sync::Arc};
 
 use clap::Parser;
 use color_eyre::Result;
@@ -608,7 +608,7 @@ async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) 
     if let CommandValue::ConvoyStarted { name, attach_command: Some(command), binding } = result {
         if matches!(format, OutputFormat::Human) {
             stamp_pane_identity(&name, binding.as_ref()).await;
-            return exec_attach_command(&command);
+            return run_attach_command(&command);
         }
     }
     Ok(())
@@ -644,7 +644,7 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
                 if !transient {
                     stamp_pane_identity(reference, binding.as_ref()).await;
                 }
-                exec_attach_command(&command)
+                run_attach_command(&command)
             }
         },
         CommandValue::Error { message } => match format {
@@ -662,7 +662,7 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
 }
 
 /// Publish pane ≙ identity into the enclosing PM's metadata plane before
-/// exec'ing the attach command — the one moment a process knows the binding
+/// launching the attach command — the one moment a process knows the binding
 /// (flotilla-org/flotilla#708, half 1). Best-effort: a PM-less or failed
 /// stamp never blocks the attach.
 async fn stamp_pane_identity(reference: &str, binding: Option<&flotilla_protocol::AttachBinding>) {
@@ -854,23 +854,42 @@ fn print_resource_watch_event(response: &flotilla_protocol::ResourceWatchRespons
     }
 }
 
-#[cfg(unix)]
-fn exec_attach_command(command: &str) -> Result<()> {
-    use std::os::unix::process::CommandExt;
-
-    Err(std::process::Command::new("sh").arg("-lc").arg(command).exec().into())
+fn run_attach_command(command: &str) -> Result<()> {
+    let status = std::process::Command::new("sh").arg("-lc").arg(command).status()?;
+    terminate_with_attach_status(status)
 }
 
-#[cfg(not(unix))]
-fn exec_attach_command(command: &str) -> Result<()> {
-    let status = std::process::Command::new("sh").arg("-lc").arg(command).status()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(color_eyre::eyre::eyre!(
-            "attach command exited with status {}",
-            status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
-        ))
+#[derive(Debug, PartialEq, Eq)]
+enum AttachExitDisposition {
+    Code(i32),
+    #[cfg(unix)]
+    Signal(i32),
+}
+
+fn attach_exit_disposition(status: ExitStatus) -> AttachExitDisposition {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return AttachExitDisposition::Signal(signal);
+        }
+    }
+    AttachExitDisposition::Code(status.code().unwrap_or(1))
+}
+
+fn terminate_with_attach_status(status: ExitStatus) -> ! {
+    match attach_exit_disposition(status) {
+        AttachExitDisposition::Code(code) => std::process::exit(code),
+        #[cfg(unix)]
+        AttachExitDisposition::Signal(signal) => {
+            // Match the old `exec` path: callers should observe the attach
+            // process's terminating signal, not a generic Flotilla error.
+            unsafe {
+                libc::signal(signal, libc::SIG_DFL);
+                libc::raise(signal);
+            }
+            std::process::exit(128 + signal)
+        }
     }
 }
 
@@ -1344,7 +1363,10 @@ fn uninstall_claude_code_hooks(path: &std::path::Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::{
+        path::{Path, PathBuf},
+        process::Command,
+    };
 
     use clap::Parser;
     use flotilla_protocol::{
@@ -1352,9 +1374,22 @@ mod tests {
     };
 
     use super::{
-        provisioning_target_for_environment, run_replica_snapshot, select_host_target, select_startup_repo_roots, Cli, ResourceApplyArgs,
-        ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
+        attach_exit_disposition, provisioning_target_for_environment, run_replica_snapshot, select_host_target, select_startup_repo_roots,
+        AttachExitDisposition, Cli, ResourceApplyArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
     };
+
+    #[test]
+    fn attach_exit_disposition_preserves_child_exit_code() {
+        let status = Command::new("sh").args(["-c", "exit 42"]).status().expect("run child");
+        assert_eq!(attach_exit_disposition(status), AttachExitDisposition::Code(42));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn attach_exit_disposition_preserves_child_signal() {
+        let status = Command::new("sh").args(["-c", "kill -TERM $$"]).status().expect("run child");
+        assert_eq!(attach_exit_disposition(status), AttachExitDisposition::Signal(libc::SIGTERM));
+    }
 
     #[test]
     fn explicit_repo_roots_take_precedence_over_cwd_detection() {


### PR DESCRIPTION
Closes #863.

## What changed

- add an injected-clock Regard lifecycle that records expressed and implicit attention, promotes implicit Regards, refreshes focus edges and heartbeats, expires decaying Regards, and preserves pins
- declare focal or ambient surface character during the client handshake; ambient surfaces never emit or sustain Regards
- emit expressed Regards from attach, TUI focus/open navigation, and PM latent materialization through scoped focal views
- attribute convoy provenance and its implicit decaying Regard to the connected dispatching principal, including prepared remote starts
- expose structured principal identity consistently through the protocol and resource model
- keep lifecycle state at the resource-store seam, preserving the repository's resource federation boundary

## User impact

Attach sessions, focused TUI views, and opened PM latents now populate the principal searchlight. Leaving focus or detaching starts the decay window, while active focal surfaces refresh it. Convoy dispatch creates a visibly decaying implicit Regard for the dispatcher. Ambient views remain observation-only.

## Validation

- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- parallel Standards and issue-spec reviews, with no remaining findings

The full workspace run also exposed two pre-existing macOS test flakes. The touched assertions now compare canonical repo paths, and fake-Zellij test waits allow five seconds under workspace load.
