### PR TITLE
fix: align placement admission with live peer routes

### DIFF
--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -117,10 +117,6 @@ impl HostRegistry {
         self.node_environments.read().await.get(node_id).cloned()
     }
 
-    pub(crate) async fn node_id_for_environment(&self, environment_id: &EnvironmentId) -> Option<NodeId> {
-        self.hosts.read().await.get(environment_id).filter(|state| !state.removed).map(|state| state.node_id.clone())
-    }
-
     pub(crate) async fn node_id_for_host_name(&self, host: &HostName) -> Result<Option<NodeId>, String> {
         let hosts = self.hosts.read().await;
         let mut matches = hosts

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, Utc};
 use flotilla_protocol::{
     arg::{flatten, Arg},
     commands::RepositoryIdentityChange,
-    qualified_path::QualifiedPath,
+    qualified_path::{HostId, QualifiedPath},
     result_set::{ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
     AttachBinding, Command, CommandValue, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry,
     EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
@@ -1223,6 +1223,12 @@ pub struct ExistingConvoyTarget {
     pub node_id: NodeId,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConvoyStartTarget {
+    pub policy_name: String,
+    pub host_id: HostId,
+}
+
 pub struct InProcessDaemon {
     repos: RwLock<HashMap<flotilla_protocol::RepoIdentity, RepoState>>,
     repo_order: RwLock<Vec<flotilla_protocol::RepoIdentity>>,
@@ -1973,7 +1979,10 @@ impl InProcessDaemon {
         }
     }
 
-    pub async fn resolve_convoy_start_target_node(&self, intent: &flotilla_protocol::ConvoyStartIntent) -> Result<Option<NodeId>, String> {
+    pub async fn resolve_convoy_start_target(
+        &self,
+        intent: &flotilla_protocol::ConvoyStartIntent,
+    ) -> Result<Option<ConvoyStartTarget>, String> {
         let Some(policy_name) = intent.placement_policy.as_deref() else {
             return Ok(None);
         };
@@ -1992,12 +2001,7 @@ impl InProcessDaemon {
         if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_ref) {
             return Ok(None);
         }
-        let environment_id = EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new(host_ref));
-        self.host_registry
-            .node_id_for_environment(&environment_id)
-            .await
-            .map(Some)
-            .ok_or_else(|| format!("placement policy {policy_name} targets unavailable host {host_ref}"))
+        Ok(Some(ConvoyStartTarget { policy_name: policy_name.to_string(), host_id: HostId::new(host_ref) }))
     }
 
     pub async fn resolve_existing_convoy_target(

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -130,7 +130,7 @@ async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_requ
 }
 
 #[tokio::test]
-async fn peer_summary_materializes_an_admissible_host_direct_placement_and_routing_target() {
+async fn peer_summary_materializes_an_admissible_host_direct_placement_target() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -171,8 +171,8 @@ async fn peer_summary_materializes_an_admissible_host_direct_placement_and_routi
     let intent =
         ConvoyStartIntent::builder().project_ref("flotilla".to_string()).placement_policy("host-direct-feta-host".to_string()).build();
     assert_eq!(
-        daemon.resolve_convoy_start_target_node(&intent).await.expect("placement should route"),
-        Some(flotilla_protocol::NodeId::new("feta-node"))
+        daemon.resolve_convoy_start_target(&intent).await.expect("placement should resolve"),
+        Some(ConvoyStartTarget { policy_name: "host-direct-feta-host".to_string(), host_id: HostId::new("feta-host") })
     );
 
     daemon
@@ -207,7 +207,7 @@ async fn peer_summary_materializes_an_admissible_host_direct_placement_and_routi
         .await
         .expect("local placement policy create");
     let local_intent = ConvoyStartIntent::builder().project_ref("flotilla".to_string()).placement_policy("local-pool".to_string()).build();
-    assert_eq!(daemon.resolve_convoy_start_target_node(&local_intent).await.expect("non-host-direct placement should remain local"), None);
+    assert_eq!(daemon.resolve_convoy_start_target(&local_intent).await.expect("non-host-direct placement should remain local"), None);
 }
 
 #[test]

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -1288,6 +1288,13 @@ impl PeerManager {
         &self.peer_host_summaries
     }
 
+    pub fn node_for_host_environment(&self, environment_id: &EnvironmentId) -> Result<(NodeId, HostName), String> {
+        let summary =
+            self.peer_host_summaries.get(environment_id).ok_or_else(|| format!("no peer summary for host environment {environment_id}"))?;
+        let host_name = summary.host_name.clone().unwrap_or_else(|| HostName::new(summary.node.display_name.clone()));
+        Ok((summary.node.node_id.clone(), host_name))
+    }
+
     pub fn topology_routes(&self) -> Vec<TopologyRoute> {
         let mut routes: Vec<_> = self
             .routes

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -11,12 +11,12 @@ use std::{
 use async_trait::async_trait;
 use flotilla_core::{
     daemon::DaemonHandle,
-    in_process::InProcessDaemon,
+    in_process::{ConvoyStartTarget, InProcessDaemon},
     step::{RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, RemoteStepProgressUpdate, StepOutcome},
 };
 use flotilla_protocol::{
-    Command, CommandAction, CommandPeerEvent, CommandValue, DaemonEvent, NodeId, PeerWireMessage, RepoIdentity, RepoSelector,
-    RoutedPeerMessage, Step, StepStatus,
+    Command, CommandAction, CommandPeerEvent, CommandValue, DaemonEvent, EnvironmentId, HostName, NodeId, PeerWireMessage, RepoIdentity,
+    RepoSelector, RoutedPeerMessage, Step, StepStatus,
 };
 use tokio::sync::{oneshot, Mutex, Notify};
 use tokio_util::sync::CancellationToken;
@@ -103,6 +103,15 @@ pub(super) struct RemoteCommandRouter {
     next_remote_command_id: Arc<AtomicU64>,
 }
 
+#[derive(bon::Builder)]
+struct PlacementRoute {
+    target: ConvoyStartTarget,
+    host_name: HostName,
+    node_id: NodeId,
+    address: String,
+    sender: Arc<dyn PeerSender>,
+}
+
 impl RemoteCommandRouter {
     pub(super) fn new(
         daemon: Arc<InProcessDaemon>,
@@ -143,9 +152,13 @@ impl RemoteCommandRouter {
         if let Some(target) = existing_convoy_target.as_ref() {
             command.node_id = Some(target.node_id.clone());
         }
-        if let CommandAction::ConvoyStart { intent } = &command.action {
-            let placement_target = self.daemon.resolve_convoy_start_target_node(intent).await?;
-            let intended_target = placement_target.as_ref().unwrap_or_else(|| self.daemon.node_id());
+        let placement_route = if let CommandAction::ConvoyStart { intent } = &command.action {
+            let placement_target = self.daemon.resolve_convoy_start_target(intent).await?;
+            let placement_route = match placement_target {
+                Some(target) => Some(self.resolve_placement_route(target).await?),
+                None => None,
+            };
+            let intended_target = placement_route.as_ref().map(|route| &route.node_id).unwrap_or_else(|| self.daemon.node_id());
             if command.node_id.as_ref().is_some_and(|target| target != intended_target) {
                 return Err("convoy command target does not match its host-direct placement policy".to_string());
             }
@@ -154,7 +167,10 @@ impl RemoteCommandRouter {
                 let prepared = self.daemon.prepare_remote_convoy_start(intent, dispatching_principal_ref.as_ref()).await?;
                 command.action = CommandAction::ConvoyStartPrepared { start: Box::new(prepared) };
             }
-        }
+            placement_route
+        } else {
+            None
+        };
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
         let local = self.daemon.node_id();
         let desc = command.description();
@@ -195,7 +211,15 @@ impl RemoteCommandRouter {
                 };
                 let send_result = match &existing_convoy_target {
                     Some(target) => self.send_routed_to_convoy_home(&target.home, &target.node_id, routed).await,
-                    None => self.send_routed_to(&target_node_id, routed).await,
+                    None => match &placement_route {
+                        Some(route) => route.sender.send(PeerWireMessage::Routed(routed)).await.map_err(|cause| {
+                            format!(
+                                "connect to {} at {} for placement policy {} (host {}): {cause}",
+                                route.host_name, route.address, route.target.policy_name, route.target.host_id
+                            )
+                        }),
+                        None => self.send_routed_to(&target_node_id, routed).await,
+                    },
                 };
 
                 match send_result {
@@ -834,6 +858,25 @@ impl RemoteStepExecutor for RemoteCommandRouter {
 }
 
 impl RemoteCommandRouter {
+    async fn resolve_placement_route(&self, target: ConvoyStartTarget) -> Result<PlacementRoute, String> {
+        let environment_id = EnvironmentId::host(target.host_id.clone());
+        let (host_name, node_id, address, sender) = {
+            let pm = self.peer_manager.lock().await;
+            let (node_id, host_name) = pm
+                .node_for_host_environment(&environment_id)
+                .map_err(|cause| format!("resolve placement policy {} target host {}: {cause}", target.policy_name, target.host_id))?;
+            let address = pm.connection_address_for(&node_id, &host_name);
+            let sender = pm.resolve_sender(&node_id).map_err(|cause| {
+                format!(
+                    "connect to {host_name} at {address} for placement policy {} (host {}): {cause}",
+                    target.policy_name, target.host_id
+                )
+            })?;
+            (host_name, node_id, address, sender)
+        };
+        Ok(PlacementRoute::builder().target(target).host_name(host_name).node_id(node_id).address(address).sender(sender).build())
+    }
+
     async fn send_routed_to_convoy_home(
         &self,
         home: &flotilla_protocol::HostName,

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -6,7 +6,7 @@ use flotilla_protocol::{
     result_set::{ConvoyPhase, ConvoyRow, ResultSet, Rows},
     FleetReplicaSnapshot, HostName, NodeInfo, ResourceRef, SurfaceDeclaration,
 };
-use flotilla_resources::{api_version, Convoy, Resource};
+use flotilla_resources::{api_version, Convoy, InputMeta, Project, ProjectSpec, Resource, Stance, WorkflowTemplate};
 use tokio::sync::{mpsc, watch, Mutex, Notify};
 
 use super::{build_remote_command_router, handle_client_session, spawn_peer_networking_runtime};
@@ -27,6 +27,26 @@ pub async fn apply_convoy_replica_feed(daemon: &InProcessDaemon, namespace: &str
     };
     let mut aggregator = Aggregator::new(daemon.aggregator_projection_state().await, daemon.host_name().clone(), daemon.event_sender());
     aggregator.apply_replica_cache(vec![snapshot]).await;
+}
+
+pub async fn seed_trusted_remote_convoy_project(daemon: &InProcessDaemon, namespace: &str) {
+    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
+    workflow.vessels[0].stance = Stance::Trusted;
+    let backend = daemon.resource_backend();
+    backend
+        .clone()
+        .using::<WorkflowTemplate>(namespace)
+        .create(&InputMeta::builder().name("remote-workflow".to_string()).build(), &workflow)
+        .await
+        .expect("create workflow");
+    backend
+        .using::<Project>(namespace)
+        .create(
+            &InputMeta::builder().name("flotilla".to_string()).build(),
+            &ProjectSpec::builder().display_name("Flotilla".to_string()).default_workflow_ref("remote-workflow".to_string()).build(),
+        )
+        .await
+        .expect("create project");
 }
 
 pub struct InMemoryRequestTopology {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -30,9 +30,9 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, Project, ProjectSpec, ResourceBackend, ResourceError, Stance,
-    StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
-    TerminalSessionStatusPatch, WorkflowTemplate,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend, ResourceError, Stance, StatusPatch,
+    TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
+    WorkflowTemplate,
 };
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
@@ -56,7 +56,7 @@ use super::{
     },
     request_dispatch::RequestDispatcher,
     shared::{sync_peer_query_state, write_message, SocketPeerSender},
-    test_support::apply_convoy_replica_feed,
+    test_support::{apply_convoy_replica_feed, seed_trusted_remote_convoy_project},
     DaemonServer, PeerConnectedNotice,
 };
 use crate::peer::{
@@ -855,44 +855,25 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
     let (_remote_tmp, remote_daemon) = empty_daemon_named("feta").await;
     let remote_host_id = remote_daemon.local_host_id().expect("remote host identity").to_string();
     let remote_policy_name = format!("host-direct-{remote_host_id}");
-    daemon
-        .publish_peer_summary(
-            HostSummary::builder()
-                .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new(&remote_host_id)))
-                .host_name(HostName::new("feta"))
-                .node(node_info("feta"))
-                .system(flotilla_protocol::SystemInfo::default())
-                .providers(vec![
-                    HostProviderStatus::available(AGENT_ADAPTER_PROVIDER_CATEGORY, "codex"),
-                    HostProviderStatus::available(TERMINAL_POOL_PROVIDER_CATEGORY, "cleat"),
-                ])
-                .build(),
-        )
-        .await;
-    let backend = daemon.resource_backend();
-    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
-    workflow.vessels[0].stance = Stance::Trusted;
-    backend
-        .clone()
-        .using::<WorkflowTemplate>("flotilla")
-        .create(&InputMeta::builder().name("remote-workflow".to_string()).build(), &workflow)
-        .await
-        .expect("create workflow");
-    backend
-        .using::<Project>("flotilla")
-        .create(
-            &InputMeta::builder().name("flotilla".to_string()).build(),
-            &ProjectSpec::builder().display_name("Flotilla".to_string()).default_workflow_ref("remote-workflow".to_string()).build(),
-        )
-        .await
-        .expect("create project");
+    let remote_summary = HostSummary::builder()
+        .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new(&remote_host_id)))
+        .host_name(HostName::new("feta"))
+        .node(node_info("feta"))
+        .system(flotilla_protocol::SystemInfo::default())
+        .providers(vec![
+            HostProviderStatus::available(AGENT_ADAPTER_PROVIDER_CATEGORY, "codex"),
+            HostProviderStatus::available(TERMINAL_POOL_PROVIDER_CATEGORY, "cleat"),
+        ])
+        .build();
+    daemon.publish_peer_summary(remote_summary.clone()).await;
+    seed_trusted_remote_convoy_project(&daemon, "flotilla").await;
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let pending_remote_commands = Arc::new(Mutex::new(HashMap::new()));
     let forwarded_commands = Arc::new(Mutex::new(HashMap::new()));
     let pending_remote_cancels = Arc::new(Mutex::new(HashMap::new()));
     let next_remote_command_id = Arc::new(AtomicU64::new(1 << 62));
     let sent = Arc::new(StdMutex::new(Vec::new()));
-    peer_manager.lock().await.register_sender(NodeId::new("feta"), Arc::new(MockPeerSender { sent: Arc::clone(&sent) }));
+    peer_manager.lock().await.store_host_summary(remote_summary);
     let remote_command_router = make_remote_command_router(
         &daemon,
         &peer_manager,
@@ -908,11 +889,18 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
                     .project_ref("flotilla".to_string())
                     .name("remote-work".to_string())
                     .branch("feat/remote-work".to_string())
-                    .placement_policy(remote_policy_name)
+                    .placement_policy(remote_policy_name.clone())
                     .build(),
             ),
         })
         .build();
+
+    assert_eq!(
+        remote_command_router.dispatch_execute(command.clone()).await.expect_err("missing live route must reject remote placement"),
+        format!("connect to feta at peer://feta for placement policy {remote_policy_name} (host {remote_host_id}): unknown peer: feta")
+    );
+
+    peer_manager.lock().await.register_sender(NodeId::new("feta"), Arc::new(MockPeerSender { sent: Arc::clone(&sent) }));
 
     let mut mismatched = command.clone();
     mismatched.node_id = Some(daemon.node_id().clone());

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use flotilla_core::{
@@ -11,18 +15,18 @@ use flotilla_core::{
     },
 };
 use flotilla_daemon::server::test_support::{
-    apply_convoy_replica_feed, spawn_in_memory_request_topology, spawn_in_memory_request_topology_stateful,
-    spawn_in_memory_request_topology_stateful_with_surface,
+    apply_convoy_replica_feed, seed_trusted_remote_convoy_project, spawn_in_memory_request_topology,
+    spawn_in_memory_request_topology_stateful, spawn_in_memory_request_topology_stateful_with_surface,
 };
 use flotilla_protocol::{
     issue_query::{IssueQuery, IssueResultPage},
     test_support::TestIssue,
-    Command, CommandAction, CommandValue, DaemonEvent, HostName, Issue, IssueChangeset, IssueRef, IssueSource, NodeInfo,
+    Command, CommandAction, CommandValue, ConvoyStartIntent, DaemonEvent, HostName, Issue, IssueChangeset, IssueRef, IssueSource, NodeInfo,
     PeerConnectionState, PrincipalRef, RepoSelector, ResourceRef, SurfaceCharacter, SurfaceDeclaration,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, Regard, Resource, ResourceError,
-    WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, PlacementPolicy, Regard, Resource,
+    ResourceError, WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -440,6 +444,86 @@ async fn hostless_convoy_delete_uses_live_peer_route_when_connection_status_is_s
         matches!(follower_convoys.get(convoy_name).await, Err(ResourceError::NotFound { .. })),
         "remote-homed convoy should be deleted through the live peer route"
     );
+}
+
+#[tokio::test]
+async fn convoy_start_uses_live_peer_route_when_presentation_membership_is_stale() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    follower.set_local_placement_capabilities(&BTreeSet::from(["codex".to_string()]), &["cleat".to_string()]).await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let remote_host_id = topology.follower.local_host_id().expect("follower host identity").to_string();
+    let placement_policy = format!("host-direct-{remote_host_id}");
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if topology.leader.resource_backend().using::<PlacementPolicy>(namespace).get(&placement_policy).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("peer host summary should materialize placement policy");
+
+    seed_trusted_remote_convoy_project(&topology.leader, namespace).await;
+
+    apply_convoy_replica_feed(&topology.leader, namespace, "fresh-feed", topology.follower_host.clone()).await;
+    topology
+        .leader
+        .publish_peer_connection_status(
+            &NodeInfo::new(topology.follower.node_id().clone(), topology.follower_host.to_string()),
+            PeerConnectionState::Disconnected,
+        )
+        .await;
+    topology.leader.set_peer_host_summaries(HashMap::new()).await;
+    assert_eq!(topology.leader.peer_connection_status(topology.follower.node_id()).await, PeerConnectionState::Disconnected);
+    assert!(
+        topology
+            .leader
+            .get_topology()
+            .await
+            .expect("leader topology")
+            .routes
+            .iter()
+            .any(|route| route.target.node_id == *topology.follower.node_id() && route.connected),
+        "peer manager route should remain live"
+    );
+
+    let mut events = topology.leader.subscribe();
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(
+                    ConvoyStartIntent::builder()
+                        .project_ref("flotilla".to_string())
+                        .name("remote-work".to_string())
+                        .branch("fix/remote-work".to_string())
+                        .placement_policy(placement_policy)
+                        .build(),
+                ),
+            },
+        })
+        .await
+        .expect("live peer route should admit remote placement despite stale presentation membership");
+
+    assert_eq!(await_command_result(&mut events, command_id).await, CommandValue::ConvoyStarted {
+        name: "remote-work".to_string(),
+        attach_command: None,
+        binding: None
+    });
+    topology
+        .follower
+        .resource_backend()
+        .using::<Convoy>(namespace)
+        .get("remote-work")
+        .await
+        .expect("convoy should be created on live placement host");
 }
 
 /// A stateless remote issue query should return results end-to-end.


### PR DESCRIPTION
## Summary

- keep placement-policy selection semantic by resolving host-direct targets to stable host IDs
- admit remote convoy starts through the peer manager's current host summary and routed sender instead of presentation connection state
- report the target policy, host, address, and underlying route failure when placement is genuinely unreachable
- cover stale presentation membership alongside a fresh aggregation feed and live routed sender at the daemon contract boundary

## Root cause

Convoy-start admission converted the selected host-direct policy into a node through `HostRegistry`, whose presentation membership can be stale after a peer bounce. Existing convoy routing already trusted `PeerManager`'s live topology and sender, so the two paths could disagree about the same peer.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-daemon --test request_session_pair --locked`
- `cargo test -p flotilla-core peer_summary_materializes_an_admissible_host_direct_placement_target --locked`
- `cargo test -p flotilla-daemon --lib server::tests::dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command --locked`
- sandbox-safe workspace suite passed before the final review-only cleanup: `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #887
