### PR TITLE
fix: recover peer session establishment

### DIFF
--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -760,7 +760,15 @@ fn build_topology(local_node: &NodeInfo, routes: &[TopologyRoute], configured_pe
         }
         if !routes.iter().any(|r| r.target.node_id == *node_id) {
             let node = NodeInfo::new(node_id.clone(), display_name.clone());
-            all_routes.push(TopologyRoute { target: node.clone(), next_hop: node, direct: true, connected: false, fallbacks: vec![] });
+            all_routes.push(TopologyRoute {
+                target: node.clone(),
+                next_hop: node,
+                direct: true,
+                connected: false,
+                fallbacks: vec![],
+                last_attempt: None,
+                last_error: None,
+            });
         }
     }
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1931,6 +1931,8 @@ async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
             direct: false,
             connected: true,
             fallbacks: vec![],
+            last_attempt: None,
+            last_error: None,
         }])
         .await;
 
@@ -2174,6 +2176,8 @@ async fn attach_query_reports_route_that_points_back_to_local_host() {
             direct: false,
             connected: true,
             fallbacks: vec![],
+            last_attempt: None,
+            last_error: None,
         }])
         .await;
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -2554,6 +2554,8 @@ async fn list_hosts_counts_remote_repo_overlay_and_get_topology_returns_mirrored
             direct: false,
             connected: true,
             fallbacks: vec![test_node("backup-relay")],
+            last_attempt: None,
+            last_error: None,
         }])
         .await;
 
@@ -2597,6 +2599,8 @@ async fn get_topology_includes_configured_but_disconnected_peers() {
             direct: true,
             connected: true,
             fallbacks: vec![],
+            last_attempt: None,
+            last_error: None,
         }])
         .await;
 

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -1332,7 +1332,7 @@ impl PeerManager {
                         .and_then(|active| active.meta.config_label.as_ref())
                         .or_else(|| self.transport_peers.iter().find_map(|(label, node)| (node == target).then_some(label)))
                         .and_then(|label| self.peer_dial_status.get(label))
-                        .and_then(|status| status.last_attempt.clone()),
+                        .and_then(|status| status.last_attempt),
                     last_error: self
                         .active_connections
                         .get(target)

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -1432,7 +1432,8 @@ impl PeerManager {
                                 displaced_generation
                             }
                             ActivationResult::Rejected { .. } => {
-                                self.note_dial_result(&label, Err("connection lost duplicate arbitration"));
+                                let error = format!("connection for {name} lost duplicate arbitration");
+                                self.note_dial_result(&label, Err(&error));
                                 if let Some(target) = self.configured_targets.get_mut(&label) {
                                     let _ = target.transport.disconnect().await;
                                 }

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -6,6 +6,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use chrono::{DateTime, Utc};
 use flotilla_protocol::{
     Command, CommandPeerEvent, CommandValue, ConfigLabel, EnvironmentId, GoodbyeReason, HostName, HostSummary, NodeId, NodeInfo,
     PeerDataKind, PeerDataMessage, PeerWireMessage, ProviderData, RepoIdentity, RepositoryKey, RoutedPeerMessage, Step, StepOutcome,
@@ -172,6 +173,12 @@ struct ConfiguredPeerTarget {
     transport: Box<dyn PeerTransport>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct PeerDialStatus {
+    last_attempt: Option<DateTime<Utc>>,
+    last_error: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConfiguredPeerTargetInfo {
     pub label: ConfigLabel,
@@ -264,6 +271,7 @@ pub struct PerRepoPeerState {
 pub struct PeerManager {
     local_node_id: NodeId,
     configured_targets: HashMap<ConfigLabel, ConfiguredPeerTarget>,
+    peer_dial_status: HashMap<ConfigLabel, PeerDialStatus>,
     senders: HashMap<NodeId, Arc<dyn PeerSender>>,
     active_connections: HashMap<NodeId, ActiveConnection>,
     displaced_senders: HashMap<(NodeId, u64), Arc<dyn PeerSender>>,
@@ -305,6 +313,7 @@ impl PeerManager {
         Self {
             local_node_id,
             configured_targets: HashMap::new(),
+            peer_dial_status: HashMap::new(),
             senders: HashMap::new(),
             active_connections: HashMap::new(),
             displaced_senders: HashMap::new(),
@@ -356,6 +365,15 @@ impl PeerManager {
         info!(target = %label.0, expected_host = %expected_host_name, expected_node_id = ?expected_node_id, "registered configured peer target");
         let connection_address = transport.connection_address();
         self.configured_targets.insert(label, ConfiguredPeerTarget { expected_host_name, expected_node_id, connection_address, transport });
+    }
+
+    pub fn note_dial_attempt(&mut self, label: &ConfigLabel) {
+        self.peer_dial_status.entry(label.clone()).or_default().last_attempt = Some(Utc::now());
+    }
+
+    pub fn note_dial_result(&mut self, label: &ConfigLabel, result: Result<(), &str>) {
+        let status = self.peer_dial_status.entry(label.clone()).or_default();
+        status.last_error = result.err().map(str::to_string);
     }
 
     /// Register or replace a sender for a connected peer.
@@ -1308,6 +1326,20 @@ impl PeerManager {
                     direct: route.primary.next_hop == *target,
                     connected: self.route_hop_is_live(&route.primary),
                     fallbacks: fallbacks.into_iter().map(|hop| self.node_info_for(&hop.next_hop)).collect(),
+                    last_attempt: self
+                        .active_connections
+                        .get(target)
+                        .and_then(|active| active.meta.config_label.as_ref())
+                        .or_else(|| self.transport_peers.iter().find_map(|(label, node)| (node == target).then_some(label)))
+                        .and_then(|label| self.peer_dial_status.get(label))
+                        .and_then(|status| status.last_attempt.clone()),
+                    last_error: self
+                        .active_connections
+                        .get(target)
+                        .and_then(|active| active.meta.config_label.as_ref())
+                        .or_else(|| self.transport_peers.iter().find_map(|(label, node)| (node == target).then_some(label)))
+                        .and_then(|label| self.peer_dial_status.get(label))
+                        .and_then(|status| status.last_error.clone()),
                 }
             })
             .collect();
@@ -1340,6 +1372,7 @@ impl PeerManager {
         let labels: Vec<ConfigLabel> = self.configured_targets.keys().cloned().collect();
         let mut receivers = Vec::new();
         for label in labels {
+            self.note_dial_attempt(&label);
             let connect_result = if let Some(target) = self.configured_targets.get_mut(&label) {
                 let transport = &mut target.transport;
                 match transport.connect().await {
@@ -1360,6 +1393,7 @@ impl PeerManager {
                 Ok((sender, subscribe_result, remote_node, remote_session_id)) => {
                     let Some(remote_node) = remote_node else {
                         warn!(target = %label.0, "peer transport connected without remote node identity");
+                        self.note_dial_result(&label, Err("peer transport connected without remote node identity"));
                         if let Some(target) = self.configured_targets.get_mut(&label) {
                             let _ = target.transport.disconnect().await;
                         }
@@ -1385,6 +1419,7 @@ impl PeerManager {
                                 displaced_generation
                             }
                             ActivationResult::Rejected { .. } => {
+                                self.note_dial_result(&label, Err("connection lost duplicate arbitration"));
                                 if let Some(target) = self.configured_targets.get_mut(&label) {
                                     let _ = target.transport.disconnect().await;
                                 }
@@ -1399,15 +1434,22 @@ impl PeerManager {
                     }
                     match subscribe_result {
                         Ok(rx) => {
+                            self.note_dial_result(&label, Ok(()));
                             receivers.push(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, inbound_rx: rx })
                         }
                         Err(e) => {
                             warn!(peer = %name, target = %label.0, err = %e, "failed to subscribe to peer");
+                            self.note_dial_result(&label, Err(&e));
+                            let _ = self.disconnect_peer(&name, generation);
+                            if let Some(target) = self.configured_targets.get_mut(&label) {
+                                let _ = target.transport.disconnect().await;
+                            }
                         }
                     }
                 }
                 Err(e) => {
                     warn!(target = %label.0, err = %e, "failed to connect peer transport");
+                    self.note_dial_result(&label, Err(&e));
                 }
             }
         }
@@ -1586,7 +1628,8 @@ impl PeerManager {
             }
         }
 
-        let (sender, rx, remote_node, remote_session_id) = {
+        self.note_dial_attempt(label);
+        let result = async {
             let target = self.configured_targets.get_mut(label).ok_or_else(|| format!("unknown configured target: {}", label.0))?;
             let transport = &mut target.transport;
 
@@ -1597,10 +1640,22 @@ impl PeerManager {
             let rx = transport.subscribe().await?;
             let remote_node = transport.remote_node_info();
             let remote_session_id = transport.remote_session_id();
-            (sender, rx, remote_node, remote_session_id)
+            Ok::<_, String>((sender, rx, remote_node, remote_session_id))
+        }
+        .await;
+        let (sender, rx, remote_node, remote_session_id) = match result {
+            Ok(connection) => connection,
+            Err(error) => {
+                self.note_dial_result(label, Err(&error));
+                return Err(error);
+            }
         };
 
-        let remote_node = remote_node.ok_or_else(|| format!("configured target {} connected without remote node identity", label.0))?;
+        let Some(remote_node) = remote_node else {
+            let error = format!("configured target {} connected without remote node identity", label.0);
+            self.note_dial_result(label, Err(&error));
+            return Err(error);
+        };
         let name = remote_node.node_id.clone();
 
         let mut generation = 0;
@@ -1624,7 +1679,9 @@ impl PeerManager {
                     if let Some(target) = self.configured_targets.get_mut(label) {
                         let _ = target.transport.disconnect().await;
                     }
-                    return Err(format!("connection for {name} lost duplicate arbitration"));
+                    let error = format!("connection for {name} lost duplicate arbitration");
+                    self.note_dial_result(label, Err(&error));
+                    return Err(error);
                 }
             };
             if let Some(displaced_generation) = displaced {
@@ -1634,6 +1691,7 @@ impl PeerManager {
             }
         }
 
+        self.note_dial_result(label, Ok(()));
         Ok(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, inbound_rx: rx })
     }
 

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -277,6 +277,10 @@ pub struct PeerManager {
     displaced_senders: HashMap<(NodeId, u64), Arc<dyn PeerSender>>,
     reconnect_suppressed_until: HashMap<NodeId, Instant>,
     transport_peers: HashMap<ConfigLabel, NodeId>,
+    /// Last node identity learned for each configured transport. Unlike
+    /// `transport_peers`, this survives disconnect so topology diagnostics
+    /// remain attributable while retries are failing.
+    learned_transport_peers: HashMap<ConfigLabel, NodeId>,
     generations: HashMap<NodeId, u64>,
     routes: HashMap<NodeId, RouteState>,
     /// TODO: expire abandoned reverse-path entries when routed replies time out
@@ -319,6 +323,7 @@ impl PeerManager {
             displaced_senders: HashMap::new(),
             reconnect_suppressed_until: HashMap::new(),
             transport_peers: HashMap::new(),
+            learned_transport_peers: HashMap::new(),
             generations: HashMap::new(),
             routes: HashMap::new(),
             reverse_paths: HashMap::new(),
@@ -602,7 +607,8 @@ impl PeerManager {
         self.install_direct_route(&host, generation);
 
         if let Some(label) = meta.config_label {
-            self.transport_peers.insert(label, host);
+            self.transport_peers.insert(label.clone(), host.clone());
+            self.learned_transport_peers.insert(label, host);
         }
 
         ActivationResult::Accepted { generation, displaced }
@@ -1327,17 +1333,11 @@ impl PeerManager {
                     connected: self.route_hop_is_live(&route.primary),
                     fallbacks: fallbacks.into_iter().map(|hop| self.node_info_for(&hop.next_hop)).collect(),
                     last_attempt: self
-                        .active_connections
-                        .get(target)
-                        .and_then(|active| active.meta.config_label.as_ref())
-                        .or_else(|| self.transport_peers.iter().find_map(|(label, node)| (node == target).then_some(label)))
+                        .configured_label_for_node(target)
                         .and_then(|label| self.peer_dial_status.get(label))
                         .and_then(|status| status.last_attempt),
                     last_error: self
-                        .active_connections
-                        .get(target)
-                        .and_then(|active| active.meta.config_label.as_ref())
-                        .or_else(|| self.transport_peers.iter().find_map(|(label, node)| (node == target).then_some(label)))
+                        .configured_label_for_node(target)
                         .and_then(|label| self.peer_dial_status.get(label))
                         .and_then(|status| status.last_error.clone()),
                 }
@@ -1345,6 +1345,19 @@ impl PeerManager {
             .collect();
         routes.sort_by(|a, b| a.target.node_id.cmp(&b.target.node_id));
         routes
+    }
+
+    fn configured_label_for_node(&self, node_id: &NodeId) -> Option<&ConfigLabel> {
+        self.active_connections
+            .get(node_id)
+            .and_then(|active| active.meta.config_label.as_ref())
+            .or_else(|| self.transport_peers.iter().find_map(|(label, node)| (node == node_id).then_some(label)))
+            .or_else(|| self.learned_transport_peers.iter().find_map(|(label, node)| (node == node_id).then_some(label)))
+            .or_else(|| {
+                self.configured_targets
+                    .iter()
+                    .find_map(|(label, target)| (target.expected_node_id.as_ref() == Some(node_id)).then_some(label))
+            })
     }
 
     /// Snapshot relay targets without performing any async sends.

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -1356,28 +1356,31 @@ async fn get_sender_if_current_returns_sender_for_matching_generation() {
     assert!(mgr.get_sender_if_current(&NodeId::new("unknown"), 1).is_none());
 }
 
-#[test]
-fn topology_exposes_the_most_recent_dial_error_for_a_configured_peer() {
+#[tokio::test]
+async fn failed_subscription_is_torn_down_diagnosed_and_retried() {
     let mut mgr = PeerManager::new(NodeId::new("local"));
     let label = ConfigLabel("feta".into());
     let peer = NodeId::new("feta");
+    let (transport, _sent) = MockTransport::with_sender();
     mgr.add_configured_target(
         label.clone(),
         HostName::new("feta"),
         Some(peer.clone()),
-        Box::new(MockTransport::new().with_remote_node(NodeInfo::new(peer.clone(), "feta"))),
+        Box::new(transport.with_remote_node(NodeInfo::new(peer.clone(), "feta")).with_subscribe_error("peer closed before sending hello")),
     );
-    let _generation = accepted_generation(mgr.activate_connection(peer.clone(), MockPeerSender::discard(), ConnectionMeta {
-        direction: ConnectionDirection::Outbound,
-        config_label: Some(label.clone()),
-        expected_peer: Some(peer.clone()),
-        config_backed: true,
-    }));
 
-    mgr.note_dial_attempt(&label);
-    mgr.note_dial_result(&label, Err("peer closed before sending hello"));
+    assert!(mgr.connect_all().await.is_empty(), "failed subscription must not produce an owned connection");
+    assert!(mgr.resolve_sender(&peer).is_err(), "failed subscription must tear down the activated sender");
 
     let route = mgr.topology_routes().into_iter().find(|route| route.target.node_id == peer).expect("feta route");
+    assert!(!route.connected);
     assert!(route.last_attempt.is_some());
     assert_eq!(route.last_error.as_deref(), Some("peer closed before sending hello"));
+
+    let connection = mgr.reconnect_target(&label).await.expect("next retry should establish a fully subscribed connection");
+    assert_eq!(connection.node.node_id, peer);
+    assert!(mgr.resolve_sender(&peer).is_ok());
+    let route = mgr.topology_routes().into_iter().find(|route| route.target.node_id == peer).expect("feta route after retry");
+    assert!(route.connected);
+    assert_eq!(route.last_error, None);
 }

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -1355,3 +1355,29 @@ async fn get_sender_if_current_returns_sender_for_matching_generation() {
     assert!(mgr.get_sender_if_current(&NodeId::new("peer"), generation + 1).is_none());
     assert!(mgr.get_sender_if_current(&NodeId::new("unknown"), 1).is_none());
 }
+
+#[test]
+fn topology_exposes_the_most_recent_dial_error_for_a_configured_peer() {
+    let mut mgr = PeerManager::new(NodeId::new("local"));
+    let label = ConfigLabel("feta".into());
+    let peer = NodeId::new("feta");
+    mgr.add_configured_target(
+        label.clone(),
+        HostName::new("feta"),
+        Some(peer.clone()),
+        Box::new(MockTransport::new().with_remote_node(NodeInfo::new(peer.clone(), "feta"))),
+    );
+    let _generation = accepted_generation(mgr.activate_connection(peer.clone(), MockPeerSender::discard(), ConnectionMeta {
+        direction: ConnectionDirection::Outbound,
+        config_label: Some(label.clone()),
+        expected_peer: Some(peer.clone()),
+        config_backed: true,
+    }));
+
+    mgr.note_dial_attempt(&label);
+    mgr.note_dial_result(&label, Err("peer closed before sending hello"));
+
+    let route = mgr.topology_routes().into_iter().find(|route| route.target.node_id == peer).expect("feta route");
+    assert!(route.last_attempt.is_some());
+    assert_eq!(route.last_error.as_deref(), Some("peer closed before sending hello"));
+}

--- a/crates/flotilla-daemon/src/peer/test_support.rs
+++ b/crates/flotilla-daemon/src/peer/test_support.rs
@@ -230,6 +230,7 @@ pub struct MockTransport {
     pub status: PeerConnectionStatus,
     sender: Option<Arc<dyn PeerSender>>,
     remote_node: Option<NodeInfo>,
+    subscribe_error: Option<String>,
 }
 
 impl Default for MockTransport {
@@ -240,17 +241,22 @@ impl Default for MockTransport {
 
 impl MockTransport {
     pub fn new() -> Self {
-        Self { status: PeerConnectionStatus::Connected, sender: None, remote_node: None }
+        Self { status: PeerConnectionStatus::Connected, sender: None, remote_node: None, subscribe_error: None }
     }
 
     pub fn with_sender() -> (Self, Arc<Mutex<Vec<PeerWireMessage>>>) {
         let (mock_sender, sent) = MockPeerSender::new();
         let sender: Arc<dyn PeerSender> = Arc::new(mock_sender);
-        (Self { status: PeerConnectionStatus::Connected, sender: Some(sender), remote_node: None }, sent)
+        (Self { status: PeerConnectionStatus::Connected, sender: Some(sender), remote_node: None, subscribe_error: None }, sent)
     }
 
     pub fn with_remote_node(mut self, node: NodeInfo) -> Self {
         self.remote_node = Some(node);
+        self
+    }
+
+    pub fn with_subscribe_error(mut self, error: impl Into<String>) -> Self {
+        self.subscribe_error = Some(error.into());
         self
     }
 }
@@ -276,6 +282,9 @@ impl PeerTransport for MockTransport {
     }
 
     async fn subscribe(&mut self) -> Result<tokio::sync::mpsc::Receiver<PeerWireMessage>, String> {
+        if let Some(error) = self.subscribe_error.take() {
+            return Err(error);
+        }
         let (_tx, rx) = tokio::sync::mpsc::channel(1);
         Ok(rx)
     }

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -285,6 +285,7 @@ impl PeerRuntime {
                                 }
                                 Err(e) => {
                                     warn!(target = %target_label.0, err = %e, %attempt, "reconnection failed");
+                                    sync_peer_query_state(&pm, &daemon_for_cleanup).await;
                                     attempt = attempt.saturating_add(1);
                                 }
                             }

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -437,6 +437,8 @@ async fn dispatch_host_query_methods_round_trip() {
             direct: false,
             connected: true,
             fallbacks: vec![],
+            last_attempt: None,
+            last_error: None,
         }])
         .await;
 

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -322,6 +322,12 @@ pub struct TopologyRoute {
     pub connected: bool,
     #[serde(default)]
     pub fallbacks: Vec<NodeInfo>,
+    /// Most recent dial attempt for this configured direct peer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_attempt: Option<DateTime<Utc>>,
+    /// Error from the most recent failed dial. Cleared after a successful dial.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 #[cfg(test)]
@@ -488,6 +494,8 @@ mod tests {
                 direct: false,
                 connected: true,
                 fallbacks: vec![NodeInfo::new(NodeId::new("node-backup-relay-1"), "Backup Relay")],
+                last_attempt: None,
+                last_error: None,
             }],
         };
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -269,7 +269,7 @@ fn format_topology_human(response: &TopologyResponse) -> String {
 
     let mut table = Table::new();
     table.load_preset(UTF8_FULL_CONDENSED);
-    table.set_header(vec!["Target", "Via", "Direct", "Connected", "Fallbacks"]);
+    table.set_header(vec!["Target", "Via", "Direct", "Connected", "Last attempt", "Last error", "Fallbacks"]);
     for route in &response.routes {
         let fallbacks = if route.fallbacks.is_empty() {
             "-".to_string()
@@ -281,6 +281,8 @@ fn format_topology_human(response: &TopologyResponse) -> String {
             Cell::new(node_label(&route.next_hop)),
             Cell::new(if route.direct { "yes" } else { "no" }),
             Cell::new(if route.connected { "yes" } else { "no" }),
+            Cell::new(route.last_attempt.map(|attempt| attempt.format("%H:%M:%S").to_string()).unwrap_or_else(|| "-".to_string())),
+            Cell::new(route.last_error.as_deref().unwrap_or("-")),
             Cell::new(fallbacks),
         ]);
     }

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -281,7 +281,9 @@ fn format_topology_human(response: &TopologyResponse) -> String {
             Cell::new(node_label(&route.next_hop)),
             Cell::new(if route.direct { "yes" } else { "no" }),
             Cell::new(if route.connected { "yes" } else { "no" }),
-            Cell::new(route.last_attempt.map(|attempt| attempt.format("%H:%M:%S").to_string()).unwrap_or_else(|| "-".to_string())),
+            Cell::new(
+                route.last_attempt.map(|attempt| attempt.format("%Y-%m-%d %H:%M:%SZ").to_string()).unwrap_or_else(|| "-".to_string()),
+            ),
             Cell::new(route.last_error.as_deref().unwrap_or("-")),
             Cell::new(fallbacks),
         ]);

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -204,8 +204,8 @@ mod status_human {
                 direct: false,
                 connected: true,
                 fallbacks: vec![NodeInfo::new(NodeId::new("backup"), "backup")],
-                last_attempt: None,
-                last_error: None,
+                last_attempt: Some(serde_json::from_str("\"2026-07-23T10:15:30Z\"").expect("valid timestamp")),
+                last_error: Some("peer closed before sending hello".to_string()),
             }],
         };
 
@@ -213,6 +213,8 @@ mod status_human {
         assert!(output.contains("remote"));
         assert!(output.contains("relay"));
         assert!(output.contains("backup"));
+        assert!(output.contains("2026-07-23 10:15:30Z"));
+        assert!(output.contains("peer closed before sending hello"));
     }
 }
 

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -204,6 +204,8 @@ mod status_human {
                 direct: false,
                 connected: true,
                 fallbacks: vec![NodeInfo::new(NodeId::new("backup"), "backup")],
+                last_attempt: None,
+                last_error: None,
             }],
         };
 


### PR DESCRIPTION
Closes #902

Peer dial attempts now retain diagnostic state in topology, failed subscriptions are fully disconnected so the reconnect runtime owns and retries them, and the CLI surfaces the last dial attempt/error.

The root cause was a successful transport connect followed by subscription failure leaving an activated session without an inbound forwarder or retry owner.