### PR TITLE
feat: resolve convoy issue snapshots store-first

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -415,6 +415,7 @@ mod tests {
                 state: IssueState::Open,
                 labels: vec![],
                 as_of: Utc::now(),
+                observed_at: None,
                 association_keys: vec![],
                 provider_name: "github".into(),
                 provider_display_name: "GitHub".into(),

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -425,6 +425,7 @@ mod tests {
                 state: IssueState::Open,
                 labels: vec![],
                 as_of: Utc::now(),
+                observed_at: None,
                 association_keys: vec![],
                 provider_name: "github".into(),
                 provider_display_name: "GitHub".into(),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use flotilla_protocol::{
     arg::{flatten, Arg},
     commands::RepositoryIdentityChange,
@@ -1114,6 +1114,16 @@ struct ConvoyAdmission {
     placement_policy: Option<PlacementPolicySpec>,
 }
 
+/// An issue body is the crew's contract, so admission may only reuse a
+/// recently observed snapshot. Keep this deliberately fixed until an
+/// operational need establishes that it should be configurable.
+const ISSUE_SNAPSHOT_FRESHNESS: ChronoDuration = ChronoDuration::minutes(5);
+
+fn issue_snapshot_is_fresh(issue: &flotilla_protocol::Issue) -> bool {
+    let age = Utc::now().signed_duration_since(issue.as_of);
+    (ChronoDuration::zero()..=ISSUE_SNAPSHOT_FRESHNESS).contains(&age)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct ConvoyStartKey {
     namespace: String,
@@ -1301,6 +1311,30 @@ const FLEET_REPLICA_FRESH_SECS: i64 = 90;
 const FLEET_REPLICA_REFRESH_TIMEOUT: Duration = Duration::from_secs(2);
 
 impl InProcessDaemon {
+    async fn fresh_cached_issue(&self, reference: &flotilla_protocol::IssueRef) -> Option<flotilla_protocol::Issue> {
+        self.repos
+            .read()
+            .await
+            .values()
+            .flat_map(|state| state.last_local_providers.issues.values())
+            .filter(|issue| issue.reference == *reference)
+            .filter(|issue| issue_snapshot_is_fresh(issue))
+            .max_by_key(|issue| issue.as_of)
+            .cloned()
+    }
+
+    async fn resolve_convoy_issue_snapshot(&self, reference: &flotilla_protocol::IssueRef) -> Result<flotilla_protocol::Issue, String> {
+        let issue = match self.fresh_cached_issue(reference).await {
+            Some(issue) => issue,
+            None => self.fetch_issue_by_ref(reference).await?,
+        };
+        if issue_snapshot_is_fresh(&issue) {
+            Ok(issue)
+        } else {
+            Err(format!("issue {} snapshot is too stale to admit", reference.id))
+        }
+    }
+
     async fn admission_ai_utility(&self) -> Option<Arc<dyn AiUtility>> {
         let environment = self.environment_manager.environment_bag(&self.local_environment_id)?;
         let runner = self.environment_manager.environment_runner(&self.local_environment_id)?;
@@ -3215,14 +3249,14 @@ impl InProcessDaemon {
                         reference.source.service, reference.source.scope, project.metadata.name
                     ));
                 }
-                self.fetch_issue_by_ref(reference).await?
+                self.resolve_convoy_issue_snapshot(reference).await?
             }
             flotilla_protocol::IssueSelector::Id(id) => {
                 let mut matches = Vec::new();
                 let mut failures = Vec::new();
                 for source in sources {
                     let reference = flotilla_protocol::IssueRef { source, id: id.clone() };
-                    match self.fetch_issue_by_ref(&reference).await {
+                    match self.resolve_convoy_issue_snapshot(&reference).await {
                         Ok(issue) => matches.push(issue),
                         Err(error) => failures.push(error),
                     }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1120,7 +1120,8 @@ struct ConvoyAdmission {
 const ISSUE_SNAPSHOT_FRESHNESS: ChronoDuration = ChronoDuration::minutes(5);
 
 fn issue_snapshot_is_fresh(issue: &flotilla_protocol::Issue) -> bool {
-    let age = Utc::now().signed_duration_since(issue.as_of);
+    let Some(observed_at) = issue.observed_at else { return false };
+    let age = Utc::now().signed_duration_since(observed_at);
     (ChronoDuration::zero()..=ISSUE_SNAPSHOT_FRESHNESS).contains(&age)
 }
 
@@ -1319,7 +1320,7 @@ impl InProcessDaemon {
             .flat_map(|state| state.last_local_providers.issues.values())
             .filter(|issue| issue.reference == *reference)
             .filter(|issue| issue_snapshot_is_fresh(issue))
-            .max_by_key(|issue| issue.as_of)
+            .max_by_key(|issue| issue.observed_at)
             .cloned()
     }
 
@@ -3291,7 +3292,13 @@ impl InProcessDaemon {
         Ok(ConvoyIssue {
             reference: issue.reference,
             repository_ref,
-            snapshot: IssueSnapshot { title: issue.title, body: issue.body, state: issue.state, labels: issue.labels, as_of: issue.as_of },
+            snapshot: IssueSnapshot {
+                title: issue.title,
+                body: issue.body,
+                state: issue.state,
+                labels: issue.labels,
+                as_of: issue.observed_at.expect("admission only accepts observed issue snapshots"),
+            },
         })
     }
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -11,8 +11,8 @@ use flotilla_protocol::{
     test_support::TestIssue,
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent,
     CrewCommandContext, DaemonEvent, EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostProviderStatus, HostSummary, ImageId,
-    QueryCursor, QueryScope, RepoSelector, RepositoryKey, ResourceRef, ResultSetCondition, SystemInfo, ToolInventory, TopologyRoute,
-    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    IssueRef, IssueSource, QueryCursor, QueryScope, RepoSelector, RepositoryKey, ResourceRef, ResultSetCondition, SystemInfo,
+    ToolInventory, TopologyRoute, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
@@ -77,6 +77,62 @@ fn convoy_branch_validation_rejects_refs_that_checkout_cannot_create() {
         assert!(validate_convoy_branch(branch).is_err(), "{branch} should be rejected");
     }
     validate_convoy_branch("fix/issue-732").expect("normal branch should be accepted");
+}
+
+#[tokio::test]
+async fn convoy_admission_uses_only_fresh_cached_issue_snapshots() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), fake_discovery(false), HostName::local()).await;
+    let identity = fallback_repo_identity(Path::new("/remote/issues"));
+    daemon.add_virtual_repo(identity.clone(), None, PathBuf::from("/remote/issues"), vec![], 0).await.expect("add virtual repo");
+    let reference =
+        IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "897".into() };
+    let mut issue = TestIssue::new("Store-first admission").id("897").build();
+    issue.reference = reference.clone();
+    issue.as_of = Utc::now();
+    daemon
+        .repos
+        .write()
+        .await
+        .get_mut(&identity)
+        .expect("virtual repo state")
+        .last_local_providers
+        .issues
+        .insert(reference.id.clone(), issue.clone());
+
+    assert_eq!(daemon.resolve_convoy_issue_snapshot(&reference).await.expect("fresh cache resolves"), issue.clone());
+
+    daemon
+        .repos
+        .write()
+        .await
+        .get_mut(&identity)
+        .expect("virtual repo state")
+        .last_local_providers
+        .issues
+        .get_mut(&reference.id)
+        .expect("cached issue")
+        .as_of = Utc::now() - ISSUE_SNAPSHOT_FRESHNESS - ChronoDuration::seconds(1);
+
+    assert!(daemon.resolve_convoy_issue_snapshot(&reference).await.is_err(), "stale cache must fetch instead of dispatching its body");
+
+    daemon
+        .repos
+        .write()
+        .await
+        .get_mut(&identity)
+        .expect("virtual repo state")
+        .last_local_providers
+        .issues
+        .get_mut(&reference.id)
+        .expect("cached issue")
+        .as_of = Utc::now() + ChronoDuration::seconds(1);
+
+    assert!(daemon.resolve_convoy_issue_snapshot(&reference).await.is_err(), "future cache entry must not dispatch");
 }
 
 #[test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -93,7 +93,7 @@ async fn convoy_admission_uses_only_fresh_cached_issue_snapshots() {
         IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "897".into() };
     let mut issue = TestIssue::new("Store-first admission").id("897").build();
     issue.reference = reference.clone();
-    issue.as_of = Utc::now();
+    issue.observed_at = Some(Utc::now());
     daemon
         .repos
         .write()
@@ -116,7 +116,7 @@ async fn convoy_admission_uses_only_fresh_cached_issue_snapshots() {
         .issues
         .get_mut(&reference.id)
         .expect("cached issue")
-        .as_of = Utc::now() - ISSUE_SNAPSHOT_FRESHNESS - ChronoDuration::seconds(1);
+        .observed_at = Some(Utc::now() - ISSUE_SNAPSHOT_FRESHNESS - ChronoDuration::seconds(1));
 
     assert!(daemon.resolve_convoy_issue_snapshot(&reference).await.is_err(), "stale cache must fetch instead of dispatching its body");
 
@@ -130,7 +130,7 @@ async fn convoy_admission_uses_only_fresh_cached_issue_snapshots() {
         .issues
         .get_mut(&reference.id)
         .expect("cached issue")
-        .as_of = Utc::now() + ChronoDuration::seconds(1);
+        .observed_at = Some(Utc::now() + ChronoDuration::seconds(1));
 
     assert!(daemon.resolve_convoy_issue_snapshot(&reference).await.is_err(), "future cache entry must not dispatch");
 }

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -361,6 +361,7 @@ impl IssueProvider for FakeIssueProvider {
             .map(|(id, issue)| {
                 let mut issue = issue.clone();
                 issue.reference = IssueRef { source: source.clone(), id: id.clone() };
+                issue.observed_at = Some(Utc::now());
                 issue
             })
             .collect();
@@ -377,6 +378,7 @@ impl IssueProvider for FakeIssueProvider {
             .map(|(id, issue)| {
                 let mut issue = issue.clone();
                 issue.reference = IssueRef { source: reference.source.clone(), id: id.clone() };
+                issue.observed_at = Some(Utc::now());
                 issue
             })
             .ok_or_else(|| format!("issue {} not found", reference.id))
@@ -391,6 +393,7 @@ impl IssueProvider for FakeIssueProvider {
             .map(|(id, issue)| {
                 let mut issue = issue.clone();
                 issue.reference = IssueRef { source: source.clone(), id: id.clone() };
+                issue.observed_at = Some(Utc::now());
                 issue
             })
             .collect())
@@ -409,6 +412,7 @@ impl IssueProvider for FakeIssueProvider {
             let reference = IssueRef { source: source.clone(), id };
             if issue.state == IssueState::Open {
                 issue.reference = reference;
+                issue.observed_at = Some(Utc::now());
                 updated.push(issue);
             } else {
                 closed.push(reference);

--- a/crates/flotilla-core/src/providers/github_api.rs
+++ b/crates/flotilla-core/src/providers/github_api.rs
@@ -71,7 +71,17 @@ pub fn parse_gh_api_response(raw: &str) -> GhApiResponse {
     GhApiResponse { status, etag, body, has_next_page, total_count: None }
 }
 
-fn rate_limit_error(raw: &str, _stderr: &str) -> Option<String> {
+pub(crate) fn rate_limit_error(reset: &str) -> String {
+    let reset = reset
+        .parse::<i64>()
+        .ok()
+        .and_then(|seconds| Utc.timestamp_opt(seconds, 0).single())
+        .map(|time| time.to_rfc3339())
+        .unwrap_or_else(|| reset.to_string());
+    format!("{RATE_LIMIT_RESET_PREFIX}{reset}")
+}
+
+fn rate_limit_error_from_response(raw: &str) -> Option<String> {
     let response = parse_gh_api_response(raw);
     if response.status != 403 {
         return None;
@@ -79,10 +89,9 @@ fn rate_limit_error(raw: &str, _stderr: &str) -> Option<String> {
 
     let reset = raw.lines().find_map(|line| {
         let (name, value) = line.split_once(':')?;
-        name.eq_ignore_ascii_case("x-ratelimit-reset").then(|| value.trim().parse::<i64>().ok()).flatten()
+        name.eq_ignore_ascii_case("x-ratelimit-reset").then_some(value.trim())
     })?;
-    let reset = Utc.timestamp_opt(reset, 0).single()?;
-    Some(format!("{RATE_LIMIT_RESET_PREFIX}{}", reset.to_rfc3339()))
+    Some(rate_limit_error(reset))
 }
 
 #[async_trait]
@@ -154,7 +163,7 @@ impl GhApi for GhApiClient {
         }
 
         if !output.success {
-            if let Some(error) = rate_limit_error(&output.stdout, &output.stderr) {
+            if let Some(error) = rate_limit_error_from_response(&output.stdout) {
                 return Err(error);
             }
             return Err(output.stderr);
@@ -238,7 +247,7 @@ mod tests {
     #[test]
     fn extracts_rate_limit_reset_from_403_response() {
         let raw = "HTTP/2 403 Forbidden\r\nX-RateLimit-Reset: 1784736000\r\n\r\n{\"message\":\"API rate limit exceeded\"}";
-        let error = rate_limit_error(raw, "gh: API rate limit exceeded").expect("rate limit error");
+        let error = rate_limit_error_from_response(raw).expect("rate limit error");
         assert_eq!(rate_limit_reset(&error).expect("reset timestamp"), Utc.timestamp_opt(1784736000, 0).single().expect("valid timestamp"));
     }
 }

--- a/crates/flotilla-core/src/providers/issue_tracker/github.rs
+++ b/crates/flotilla-core/src/providers/issue_tracker/github.rs
@@ -45,10 +45,7 @@ fn parse_issue(source: &IssueSource, v: &serde_json::Value, fetched_at: DateTime
         .map(|arr| arr.iter().filter_map(|l| l["name"].as_str().map(|s| s.to_string())).collect())
         .unwrap_or_default();
     let id = number.to_string();
-    // `as_of` is the time Flotilla observed this snapshot, not GitHub's last
-    // mutation time. Admission uses it as a hard freshness bound for the
-    // issue body it passes to a crew.
-    let as_of = fetched_at;
+    let as_of = v["updated_at"].as_str().and_then(|value| value.parse::<DateTime<Utc>>().ok()).unwrap_or(fetched_at);
     let reference = IssueRef { source: source.clone(), id: id.clone() };
     let association_keys = vec![AssociationKey::IssueRef("github".to_string(), id)];
     Some(
@@ -59,6 +56,7 @@ fn parse_issue(source: &IssueSource, v: &serde_json::Value, fetched_at: DateTime
             .state(state)
             .labels(labels)
             .as_of(as_of)
+            .observed_at(fetched_at)
             .association_keys(association_keys)
             .provider_name("github".into())
             .provider_display_name("GitHub".into())
@@ -223,7 +221,7 @@ mod tests {
     async fn fetch_by_id_uses_source_identity_without_a_checkout() {
         let before = Utc::now();
         let api = Arc::new(MockGhApi::new(vec![ok_response(
-            r#"{"number":42,"title":"The answer","body":"Details","state":"closed","labels":[{"name":"bug"}]}"#,
+            r#"{"number":42,"title":"The answer","body":"Details","state":"closed","labels":[{"name":"bug"}],"updated_at":"2026-07-20T12:34:56Z"}"#,
             false,
         )]));
         let provider = GitHubIssueProvider::new(api.clone(), Arc::new(MockRunner::new(vec![])), Path::new("/host-capability"));
@@ -234,7 +232,8 @@ mod tests {
         assert_eq!(issue.reference, reference);
         assert_eq!(issue.body.as_deref(), Some("Details"));
         assert_eq!(issue.state, IssueState::Closed);
-        assert!(issue.as_of >= before && issue.as_of <= Utc::now());
+        assert_eq!(issue.as_of, "2026-07-20T12:34:56Z".parse::<DateTime<Utc>>().expect("timestamp"));
+        assert!(issue.observed_at.is_some_and(|observed_at| observed_at >= before && observed_at <= Utc::now()));
         assert_eq!(api.requests(), vec![("repos/owner/repo/issues/42".into(), PathBuf::from("/host-capability"))]);
     }
 

--- a/crates/flotilla-core/src/providers/issue_tracker/github.rs
+++ b/crates/flotilla-core/src/providers/issue_tracker/github.rs
@@ -45,7 +45,10 @@ fn parse_issue(source: &IssueSource, v: &serde_json::Value, fetched_at: DateTime
         .map(|arr| arr.iter().filter_map(|l| l["name"].as_str().map(|s| s.to_string())).collect())
         .unwrap_or_default();
     let id = number.to_string();
-    let as_of = v["updated_at"].as_str().and_then(|value| value.parse::<DateTime<Utc>>().ok()).unwrap_or(fetched_at);
+    // `as_of` is the time Flotilla observed this snapshot, not GitHub's last
+    // mutation time. Admission uses it as a hard freshness bound for the
+    // issue body it passes to a crew.
+    let as_of = fetched_at;
     let reference = IssueRef { source: source.clone(), id: id.clone() };
     let association_keys = vec![AssociationKey::IssueRef("github".to_string(), id)];
     Some(

--- a/crates/flotilla-core/src/providers/replay.rs
+++ b/crates/flotilla-core/src/providers/replay.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use super::{
-    github_api::{GhApi, GhApiResponse},
+    github_api::{rate_limit_error, rate_limit_reset, GhApi, GhApiResponse},
     ChannelLabel, ChannelLabeler, ChannelRequest, CommandOutput, CommandRunner, DefaultLabeler,
 };
 
@@ -516,6 +516,22 @@ impl ReplayGhApi {
     }
 }
 
+fn replay_gh_error(status: u16, body: &str, headers: &HashMap<String, String>) -> String {
+    if status == 403 {
+        if let Some(reset) = headers.iter().find_map(|(name, value)| name.eq_ignore_ascii_case("x-ratelimit-reset").then_some(value)) {
+            return rate_limit_error(reset);
+        }
+    }
+    format!("HTTP {status}: {body}")
+}
+
+fn recorded_gh_error(error: &str) -> (u16, HashMap<String, String>) {
+    let Some(reset) = rate_limit_reset(error) else {
+        return (500, HashMap::new());
+    };
+    (403, HashMap::from([("x-ratelimit-reset".to_string(), reset.to_rfc3339())]))
+}
+
 /// An `HttpClient` implementation that replays canned HTTP interactions
 /// from a `Session`.
 pub struct ReplayHttpClient {
@@ -575,7 +591,7 @@ impl super::HttpClient for ReplayHttpClient {
 impl GhApi for ReplayGhApi {
     async fn get(&self, endpoint: &str, _repo_root: &Path, label: &ChannelLabel) -> Result<String, String> {
         let interaction = self.session.next(label);
-        let Interaction::GhApi { endpoint: expected_endpoint, status, body, .. } = interaction else {
+        let Interaction::GhApi { endpoint: expected_endpoint, status, body, headers, .. } = interaction else {
             panic!("ReplayGhApi: expected gh_api interaction");
         };
 
@@ -584,7 +600,7 @@ impl GhApi for ReplayGhApi {
         if (200..300).contains(&status) {
             Ok(body)
         } else {
-            Err(format!("HTTP {status}: {body}"))
+            Err(replay_gh_error(status, &body, &headers))
         }
     }
 
@@ -603,7 +619,7 @@ impl GhApi for ReplayGhApi {
         if (200..300).contains(&status) || status == 304 {
             Ok(GhApiResponse { status, etag, body, has_next_page, total_count })
         } else {
-            Err(format!("HTTP {status}: {body}"))
+            Err(replay_gh_error(status, &body, &headers))
         }
     }
 }
@@ -799,13 +815,14 @@ impl GhApi for RecordingGhApi {
                 });
             }
             Err(err) => {
+                let (status, headers) = recorded_gh_error(err);
                 self.session.record(Interaction::GhApi {
                     label: explicit,
                     method: "GET".to_string(),
                     endpoint: endpoint.to_string(),
-                    status: 500,
+                    status,
                     body: err.clone(),
-                    headers: HashMap::new(),
+                    headers,
                 });
             }
         }
@@ -842,13 +859,14 @@ impl GhApi for RecordingGhApi {
                 });
             }
             Err(err) => {
+                let (status, headers) = recorded_gh_error(err);
                 self.session.record(Interaction::GhApi {
                     label: explicit,
                     method: "GET".to_string(),
                     endpoint: endpoint.to_string(),
-                    status: 500,
+                    status,
                     body: err.clone(),
-                    headers: HashMap::new(),
+                    headers,
                 });
             }
         }

--- a/crates/flotilla-core/src/providers/replay/tests.rs
+++ b/crates/flotilla-core/src/providers/replay/tests.rs
@@ -161,6 +161,33 @@ interactions:
 }
 
 #[tokio::test]
+async fn replay_gh_api_preserves_rate_limit_reset_time() {
+    let yaml = r#"
+interactions:
+  - channel: gh_api
+    method: GET
+    endpoint: "/repos/owner/repo/issues/42"
+    status: 403
+    body: '{"message": "API rate limit exceeded"}'
+    headers:
+      X-RateLimit-Reset: "1784822400"
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.yaml");
+    std::fs::write(&path, yaml).unwrap();
+
+    let session = Session::replaying(&path, Masks::new());
+    let api = ReplayGhApi::new(session.clone());
+    let endpoint = "/repos/owner/repo/issues/42";
+    let label = ChannelLabel::GhApi(endpoint.to_string());
+
+    let error = api.get(endpoint, Path::new("/repo"), &label).await.expect_err("403 must fail");
+
+    assert_eq!(error, "github rate limit exceeded; reset_at=2026-07-23T16:00:00+00:00");
+    session.assert_complete();
+}
+
+#[tokio::test]
 async fn replay_gh_api_get_with_headers() {
     let yaml = r#"
 interactions:

--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -276,6 +276,7 @@ mod tests {
                 state: IssueState::Open,
                 labels: Vec::new(),
                 as_of: Utc::now(),
+                observed_at: None,
                 association_keys: Vec::new(),
                 provider_name: "github".into(),
                 provider_display_name: "GitHub".into(),

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use chrono::Utc;
 use flotilla_core::{
     attachable::{shared_in_memory_attachable_store, AttachableSet, AttachableSetId, ProviderBinding, TerminalPurpose},
     config::ConfigStore,
@@ -970,9 +971,11 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     let mut issue = TestIssue::new("Start convoy from an issue").id("732").with_labels(vec!["enhancement".into()]).build();
     issue.reference = reference.clone();
     issue.body = Some("Capture the issue at admission time.".into());
+    issue.as_of = Utc::now();
     let mut issue_two = TestIssue::new("Carry a second issue").id("733").with_labels(vec!["quick-win".into()]).build();
     issue_two.reference = reference_two.clone();
     issue_two.body = Some("Include this issue in the same convoy.".into());
+    issue_two.as_of = Utc::now();
     let provider = Arc::new(FakeIssueProvider::new());
     provider.add_issues(vec![(reference.id.clone(), issue.clone()), (reference_two.id.clone(), issue_two.clone())]).await;
     let utility = Arc::new(CountingConvoyAiUtility { calls: AtomicUsize::new(0), fail: AtomicBool::new(false) });
@@ -1417,6 +1420,7 @@ async fn convoy_start_rejects_the_same_project_start_while_admission_is_in_fligh
         IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "782".into() };
     let mut issue = TestIssue::new("Convoy start freezes the TUI").id("782").build();
     issue.reference = reference.clone();
+    issue.as_of = Utc::now();
     let provider = Arc::new(FakeIssueProvider::new());
     provider.add_issues(vec![(reference.id.clone(), issue)]).await;
     let utility = Arc::new(SlowAiUtility::new());

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use chrono::Utc;
 use flotilla_core::{
     attachable::{shared_in_memory_attachable_store, AttachableSet, AttachableSetId, ProviderBinding, TerminalPurpose},
     config::ConfigStore,
@@ -971,11 +970,9 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     let mut issue = TestIssue::new("Start convoy from an issue").id("732").with_labels(vec!["enhancement".into()]).build();
     issue.reference = reference.clone();
     issue.body = Some("Capture the issue at admission time.".into());
-    issue.as_of = Utc::now();
     let mut issue_two = TestIssue::new("Carry a second issue").id("733").with_labels(vec!["quick-win".into()]).build();
     issue_two.reference = reference_two.clone();
     issue_two.body = Some("Include this issue in the same convoy.".into());
-    issue_two.as_of = Utc::now();
     let provider = Arc::new(FakeIssueProvider::new());
     provider.add_issues(vec![(reference.id.clone(), issue.clone()), (reference_two.id.clone(), issue_two.clone())]).await;
     let utility = Arc::new(CountingConvoyAiUtility { calls: AtomicUsize::new(0), fail: AtomicBool::new(false) });
@@ -1420,7 +1417,6 @@ async fn convoy_start_rejects_the_same_project_start_while_admission_is_in_fligh
         IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "782".into() };
     let mut issue = TestIssue::new("Convoy start freezes the TUI").id("782").build();
     issue.reference = reference.clone();
-    issue.as_of = Utc::now();
     let provider = Arc::new(FakeIssueProvider::new());
     provider.add_issues(vec![(reference.id.clone(), issue)]).await;
     let utility = Arc::new(SlowAiUtility::new());

--- a/crates/flotilla-protocol/src/issue_query.rs
+++ b/crates/flotilla-protocol/src/issue_query.rs
@@ -42,6 +42,7 @@ mod tests {
                 state: IssueState::Open,
                 labels: vec![],
                 as_of: "2026-07-15T09:30:00Z".parse().expect("valid timestamp"),
+                observed_at: None,
                 association_keys: vec![],
                 provider_name: "github".into(),
                 provider_display_name: "GitHub".into(),

--- a/crates/flotilla-protocol/src/provider_data.rs
+++ b/crates/flotilla-protocol/src/provider_data.rs
@@ -137,7 +137,11 @@ pub struct Issue {
     pub body: Option<String>,
     pub state: IssueState,
     pub labels: Vec<String>,
+    /// When the external source last changed the issue.
     pub as_of: DateTime<Utc>,
+    /// When Flotilla observed this exact snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<DateTime<Utc>>,
     pub association_keys: Vec<AssociationKey>,
     #[serde(default)]
     pub provider_name: String,
@@ -417,6 +421,7 @@ mod tests {
             state: IssueState::Open,
             labels: vec![],
             as_of: "2026-07-15T09:30:00Z".parse().expect("valid timestamp"),
+            observed_at: None,
             association_keys: vec![],
             provider_name: String::new(),
             provider_display_name: String::new(),
@@ -568,6 +573,7 @@ mod tests {
             state: IssueState::Open,
             labels: vec!["enhancement".into(), "provider".into()],
             as_of,
+            observed_at: Some(as_of),
             association_keys: vec![AssociationKey::IssueRef("github".into(), "747".into())],
             provider_name: "github".into(),
             provider_display_name: "GitHub".into(),

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -979,6 +979,7 @@ mod tests {
                         state: IssueState::Open,
                         labels: vec!["protocol".into()],
                         as_of: Utc.with_ymd_and_hms(2026, 7, 15, 9, 30, 0).unwrap(),
+                        observed_at: None,
                         association_keys: vec![],
                         provider_name: "linear".into(),
                         provider_display_name: "Linear".into(),

--- a/crates/flotilla-protocol/src/test_support.rs
+++ b/crates/flotilla-protocol/src/test_support.rs
@@ -187,6 +187,7 @@ impl TestIssue {
             state: IssueState::Open,
             labels: self.labels,
             as_of: "2026-07-15T09:30:00Z".parse().expect("valid test issue timestamp"),
+            observed_at: None,
             association_keys: vec![],
             provider_name: String::new(),
             provider_display_name: String::new(),


### PR DESCRIPTION
Closes #897\n\nUses fresh daemon-cached issue snapshots during convoy admission, fetches when missing/stale, and surfaces GitHub rate-limit reset times on 403 responses.