### PR TITLE
fix: tolerate missing superseded repositories

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3940,16 +3940,14 @@ impl InProcessDaemon {
                     Err(error) => return Err(error.to_string()),
                 }
             } else if !still_referenced && has_durable_checkout {
-                let old_repository = repository_objects
-                    .iter()
-                    .find(|repository| repository.metadata.name == old_key.to_string())
-                    .expect("superseded key came from the listed repositories");
-                let mut meta = InputMeta::from(&old_repository.metadata);
-                meta.annotations.insert(SUPERSEDED_BY_ANNOTATION.to_string(), repository_key.to_string());
-                repositories
-                    .update(&meta, &old_repository.metadata.resource_version, &old_repository.spec)
-                    .await
-                    .map_err(|error| error.to_string())?;
+                if let Some(old_repository) = repository_objects.iter().find(|repository| repository.metadata.name == old_key.to_string()) {
+                    let mut meta = InputMeta::from(&old_repository.metadata);
+                    meta.annotations.insert(SUPERSEDED_BY_ANNOTATION.to_string(), repository_key.to_string());
+                    match repositories.update(&meta, &old_repository.metadata.resource_version, &old_repository.spec).await {
+                        Ok(_) | Err(ResourceError::NotFound { .. }) => {}
+                        Err(error) => return Err(error.to_string()),
+                    }
+                }
             }
         }
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -3062,6 +3062,52 @@ async fn repository_identity_change_removes_old_repo_key_observed_checkouts() {
 }
 
 #[tokio::test]
+async fn repository_identity_change_tolerates_missing_superseded_repository_retained_by_durable_checkout() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let state = FakeVcsState::builder(repo.clone()).branch("main", true).checkout("main").is_main(true).path(&repo).build().build();
+    let discovered_repo = Arc::new(std::sync::RwLock::new("old-repo".to_string()));
+    let mut discovery = fake_vcs_discovery(state);
+    discovery.repo_detectors.push(Box::new(MutableRemoteHostDetector { owner: "owner", repo: Arc::clone(&discovered_repo) }));
+
+    let daemon = InProcessDaemon::new(Vec::new(), test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::clone(&discovered_repo)).await;
+    daemon.add_repo(&repo).await.expect("add repository with old identity");
+
+    let old_key = RepositorySpec::remote("https://github.com/owner/old-repo").expect("old repository spec").key();
+    let new_key = RepositorySpec::remote("https://github.com/owner/new-repo").expect("new repository spec").key();
+    let durable = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    durable
+        .create(
+            &InputMeta::builder().name("durable-old-checkout".to_string()).build(),
+            &ResourceCheckoutSpec::Observed(
+                ObservedCheckoutSpec::builder()
+                    .r#ref("main".to_string())
+                    .path(repo.to_string_lossy().into_owned())
+                    .repo_ref(old_key.clone())
+                    .host_ref("host-test".to_string())
+                    .is_main(true)
+                    .build(),
+            ),
+        )
+        .await
+        .expect("durable checkout create should succeed");
+
+    let repositories = daemon.resource_backend().using::<Repository>("flotilla");
+    repositories.delete(&old_key.to_string()).await.expect("simulate already-disappeared old Repository");
+    *discovered_repo.write().expect("mutable remote detector should not be poisoned") = "new-repo".to_string();
+
+    daemon.add_repo(&repo).await.expect("migrate repository identity with missing superseded Repository");
+
+    repositories.get(&new_key.to_string()).await.expect("new Repository should be materialized");
+    assert!(matches!(repositories.get(&old_key.to_string()).await, Err(flotilla_resources::ResourceError::NotFound { .. })));
+    let projects = daemon.resource_backend().using::<Project>("flotilla").list().await.expect("project list");
+    assert!(projects.items.iter().any(|project| project.spec.repositories.iter().any(|entry| entry.repo == new_key)));
+}
+
+#[tokio::test]
 async fn repository_identity_change_reconciles_old_identity_shared_by_another_root() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo_a = temp.path().join("repo-a");

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -60,7 +60,7 @@ async fn open_in_pm_intent_dispatches_only_local_targets_to_the_injected_connect
     let connector = Arc::new(RecordingPmConnector::default());
     app.pm_connector = Some(connector.clone());
 
-    let local_target = pm_target(local);
+    let local_target = pm_target(local.clone());
     app.execute_table_intent(TableIntent::OpenInPm(local_target.clone()));
     tokio::task::yield_now().await;
     app.drain_background_updates();
@@ -68,7 +68,7 @@ async fn open_in_pm_intent_dispatches_only_local_targets_to_the_injected_connect
     assert_eq!(*connector.calls.lock().expect("recorded calls"), vec![local_target]);
     assert_eq!(app.model.status_message.as_deref(), Some("Opened tables in PM"));
 
-    let remote_target = pm_target(HostName::new("feta"));
+    let remote_target = pm_target(HostName::new(format!("remote-{}", local.as_str())));
     app.execute_table_intent(TableIntent::OpenInPm(remote_target));
     assert_eq!(connector.calls.lock().expect("recorded calls").len(), 1, "remote targets must not dispatch");
     assert!(app.model.status_message.as_deref().is_some_and(|message| message.contains("not reachable from this PM yet")));


### PR DESCRIPTION
## Summary

- Avoid panicking when identity reconciliation retains a superseded repository key because of a durable Checkout, but the old Repository object has already disappeared.
- Tolerate the old Repository also disappearing between the initial list snapshot and the annotation update.
- Add a regression test for a durable Checkout whose superseded Repository was deleted before reconciliation.
- Harden the PM open test fixture so its synthetic remote host cannot equal the local machine hostname.

## Root Cause

`reconcile_whole_repository_project` assumed every retained superseded key still had a Repository object in the earlier list snapshot. Concurrent reconciliation or partial resource-store state can violate that assumption, so the retained-resource annotation path could hit an `expect` and panic.

Closes #893

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon repository_identity_change_tolerates_missing_superseded_repository_retained_by_durable_checkout`
- `cargo test -p flotilla-tui --locked open_in_pm_intent_dispatches_only_local_targets_to_the_injected_connector`