### PR TITLE
docs: amend ADRs 0016/0018 with openable-latent grill rulings

### DIFF
--- a/docs/adr/0016-overlay-replication-for-cross-root-state.md
+++ b/docs/adr/0016-overlay-replication-for-cross-root-state.md
@@ -111,6 +111,26 @@ durable replica area, resume from the stored version on reconnect.
 - The `FleetReplicaSnapshot` broadcast path and the Plane-A peer transport
   under it are **subsumed and deletable** — the deletion ADR 0002 promised.
 
+## The read side is store-level, not per-consumer
+
+*(Amendment, 2026-07-23 openable-latent grill.)* The "merge function over
+{own log, replica per peer}" is implemented **once, in the store's read
+layer**: list/watch grows an **include-replicas** option whose returned
+replica rows are origin-tagged and staleness-stamped. Consumers (aggregator,
+fleet views, CLI listing) opt in by asking; nobody hand-assembles a second
+watch over the replica area. Two invariants by construction, not convention:
+
+- **Local-only is the default.** A consumer that doesn't ask sees exactly
+  what it saw before replication existed — reconcilers therefore never
+  encounter a replica row, preserving "home-bound runtime is reconciled
+  only at home".
+- **The include-replicas view is read-only by type.** A write through it is
+  an API error, not a policy violation.
+
+Class-specific merge (MV-register for definitions, natural-key union for
+convergent facts) slots in as branches of this same read layer when those
+classes arrive; home-bound runtime needs no branch — the replica is the view.
+
 ## Deletion is an authored tombstone; tombstones are permanent
 
 You only ever write your own log, so delete is an ordinary authored write

--- a/docs/adr/0018-presentation-attention-demands-regards-projection.md
+++ b/docs/adr/0018-presentation-attention-demands-regards-projection.md
@@ -144,6 +144,30 @@ awareness queries → latent presence; searchlight → materialized attachments;
 materialize missing, retract expired, latent the marginal. Reconcile-on-
 connect (#835) is this convergence run at connect time.
 
+Three refinements from the openable-latent grill (2026-07-23):
+
+- **Latent tabs are a sanctioned rendering**: a surface may draw latents
+  *in place in its working-set idiom* — a dimmed tab where the live tab
+  would be, carrying the entry's metadata ("this tab could exist; here is
+  its metadata"). Latent-vs-live is the surface's join: an entry whose
+  group has a materialized member carrying the identity is live. The
+  constraints stay: presence data comes from awareness queries, and only
+  materialized attachments are working-set members — latent tabs are
+  indicators, not curation.
+- **The materialize recipe is an address, not a promise.** The capability
+  fact gates *listing* on best-known state; the recipe (`flotilla attach
+  <ref>`) re-resolves through the live hop chain at execution and fails
+  honestly. For remote-placed vessels the fact derives from replicas
+  (ADR 0016), so it is stale-affirmative by up to the watch latency —
+  bounded by minting **only while the origin peer's route is live**.
+  Recipes vanish on peer disconnect; hours-stale affirmation is a lie,
+  seconds-stale is honest.
+- **"Disconnected" becomes a visible state eventually** — as an
+  annotation-tier fact on the affected entries (the presentation twin of
+  marking peer hosts unready), never a new member of the frozen
+  `status.state` vocabulary. Until built, recipe absence is the only
+  signal.
+
 Surfaces report **realization and focus observations** back to the mesh —
 one channel feeding regard decay, demand routing, and attention telemetry —
 which preserves observability without maintaining a mirror desired-layer


### PR DESCRIPTION
Records the 2026-07-23 openable-latent grill rulings in the ADRs they amend:

- **ADR 0016**: the {own log + replicas} read is store-level — an include-replicas option on list/watch, origin-tagged + staleness-stamped rows, local-only default, read-only by construction (reconcilers never see replicas).
- **ADR 0018**: latent tabs sanctioned as an in-place rendering; materialize recipe = address-not-promise (re-resolves at execution, mint gated on live route, vanishes on disconnect); 'disconnected' becomes a visible annotation-tier fact eventually, never a frozen-vocabulary badge state.

Implementation contracts: #912 (host honesty), #913 (replication slice 1, gated on Robert), #914 (openable latent), andamento#3 (latent tabs).