### PR TITLE
feat: replicate home-bound runtime resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,6 +1196,7 @@ dependencies = [
 name = "flotilla"
 version = "0.1.0"
 dependencies = [
+ "bon",
  "clap",
  "color-eyre",
  "flotilla-commands",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ ratatui = "0.30"
 tokio = { workspace = true }
 color-eyre = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+bon = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = "0.0.12"

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -32,7 +32,8 @@ use flotilla_protocol::{
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
     apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
-    list_resource_kind, normalize_project_spec, resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind,
+    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, resolve_project_issue_sources,
+    terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas,
     Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec,
     ConvoyStatusPatch, CrewSource, Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost,
@@ -139,6 +140,8 @@ struct ResourceWatchCommandContext {
     backend: ResourceBackend,
     namespace: String,
     kind: String,
+    include_replicas: bool,
+    cursor: Option<flotilla_protocol::ResourceWatchCursor>,
     command_id: u64,
     node_id: NodeId,
     repo_identity: RepoIdentity,
@@ -147,7 +150,17 @@ struct ResourceWatchCommandContext {
 }
 
 async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> CommandValue {
-    let watch = match watch_resource_kind(&context.backend, &context.namespace, &context.kind).await {
+    let start = context.cursor.map(|cursor| match cursor.generation {
+        Some(generation) => WatchStart::FromVersionInGeneration { generation, resource_version: cursor.resource_version },
+        None => WatchStart::FromVersion(cursor.resource_version),
+    });
+    let result = match (context.include_replicas, start) {
+        (true, Some(_)) => Err(ResourceError::invalid("include-replicas watches cannot resume from an origin resourceVersion")),
+        (true, None) => watch_resource_kind_including_replicas(&context.backend, &context.namespace, &context.kind).await,
+        (false, Some(start)) => watch_resource_kind_from(&context.backend, &context.namespace, &context.kind, start).await,
+        (false, None) => watch_resource_kind(&context.backend, &context.namespace, &context.kind).await,
+    };
+    let watch = match result {
         Ok(watch) => watch,
         Err(error) => return CommandValue::Error { message: error.to_string() },
     };
@@ -155,6 +168,8 @@ async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> Com
     let kind = watch.kind;
     let plural = watch.plural;
     let namespace = watch.namespace;
+    let initial_resource_version = watch.resource_version;
+    let generation = watch.generation;
     for event in watch.initial {
         if context.token.is_cancelled() {
             return CommandValue::Cancelled;
@@ -163,9 +178,19 @@ async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> Com
             kind: kind.clone(),
             plural: plural.clone(),
             namespace: namespace.clone(),
+            resource_version: initial_resource_version.clone(),
+            generation: generation.clone(),
             event,
         });
     }
+    send_resource_watch_event(&context.event_tx, context.command_id, &context.node_id, &context.repo_identity, ResourceWatchResponse {
+        kind: kind.clone(),
+        plural: plural.clone(),
+        namespace: namespace.clone(),
+        resource_version: initial_resource_version.clone(),
+        generation: generation.clone(),
+        event: serde_json::json!({"type": "BOOKMARK"}),
+    });
 
     let mut stream = watch.stream;
     loop {
@@ -174,12 +199,23 @@ async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> Com
             event = stream.next() => {
                 match event {
                     Some(Ok(event)) => {
+                        let resource_version = event["object"]["metadata"]["resourceVersion"]
+                            .as_str()
+                            .unwrap_or(&initial_resource_version)
+                            .to_string();
                         send_resource_watch_event(
                             &context.event_tx,
                             context.command_id,
                             &context.node_id,
                             &context.repo_identity,
-                            ResourceWatchResponse { kind: kind.clone(), plural: plural.clone(), namespace: namespace.clone(), event },
+                            ResourceWatchResponse {
+                                kind: kind.clone(),
+                                plural: plural.clone(),
+                                namespace: namespace.clone(),
+                                resource_version,
+                                generation: generation.clone(),
+                                event,
+                            },
                         );
                     }
                     Some(Err(error)) => return CommandValue::Error { message: error.to_string() },
@@ -5550,7 +5586,7 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ResourceWatch { namespace, kind } = command.action {
+        if let flotilla_protocol::CommandAction::ResourceWatch { namespace, kind, include_replicas, cursor } = command.action {
             let repo_identity = empty_repo_identity();
             let description = format!("watch resource {namespace}/{kind}");
             let token = CancellationToken::new();
@@ -5575,6 +5611,8 @@ impl InProcessDaemon {
                         .backend(backend)
                         .namespace(namespace)
                         .kind(kind)
+                        .include_replicas(include_replicas)
+                        .maybe_cursor(cursor)
                         .command_id(id)
                         .node_id(command_node_id.clone())
                         .repo_identity(repo_identity.clone())
@@ -6523,8 +6561,11 @@ impl DaemonHandle for InProcessDaemon {
                 Ok(v) => Ok(flotilla_protocol::CommandValue::FleetReplicaSnapshot(Box::new(v))),
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
             },
-            CommandAction::QueryResourceList { namespace, kind } => match list_resource_kind(&self.resource_backend, namespace, kind).await
-            {
+            CommandAction::QueryResourceList { namespace, kind, include_replicas } => match if *include_replicas {
+                list_resource_kind_including_replicas(&self.resource_backend, namespace, kind).await
+            } else {
+                list_resource_kind(&self.resource_backend, namespace, kind).await
+            } {
                 Ok(v) => Ok(flotilla_protocol::CommandValue::ResourceList(Box::new(ResourceJsonResponse {
                     kind: v.kind,
                     plural: v.plural,

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -720,7 +720,11 @@ async fn resource_list_and_get_queries_return_wire_json() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::QueryResourceList { namespace: "flotilla".to_string(), kind: "convoys".to_string() },
+                action: CommandAction::QueryResourceList {
+                    namespace: "flotilla".to_string(),
+                    kind: "convoys".to_string(),
+                    include_replicas: false,
+                },
             },
             uuid::Uuid::new_v4(),
         )
@@ -773,7 +777,12 @@ async fn resource_watch_emits_initial_resources_as_wire_events() {
             node_id: None,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ResourceWatch { namespace: "flotilla".to_string(), kind: "convoys".to_string() },
+            action: CommandAction::ResourceWatch {
+                namespace: "flotilla".to_string(),
+                kind: "convoys".to_string(),
+                include_replicas: false,
+                cursor: None,
+            },
         })
         .await
         .expect("watch command");
@@ -793,6 +802,72 @@ async fn resource_watch_emits_initial_resources_as_wire_events() {
 
     daemon.cancel(command_id).await.expect("cancel watch");
     assert!(matches!(recv_command_finished(&mut rx, command_id).await, CommandValue::Cancelled));
+}
+
+#[tokio::test]
+async fn resource_watch_resumes_after_a_stored_cursor_without_relisting() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let daemon =
+        InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
+    let convoys = daemon.resource_backend().using::<ResourceConvoy>("flotilla");
+    convoys
+        .create(
+            &InputMeta::builder().name("before-cursor".to_string()).build(),
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
+        )
+        .await
+        .expect("create initial convoy");
+    let cursor = convoys.list().await.expect("list cursor").resource_version;
+
+    let mut rx = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceWatch {
+                namespace: "flotilla".to_string(),
+                kind: "convoys".to_string(),
+                include_replicas: false,
+                cursor: Some(flotilla_protocol::ResourceWatchCursor { resource_version: cursor, generation: None }),
+            },
+        })
+        .await
+        .expect("resume watch command");
+
+    let bookmark = loop {
+        match recv_event(&mut rx).await {
+            DaemonEvent::CommandStepUpdate { command_id: id, status, .. } if id == command_id => {
+                let StepStatus::Produced { value } = status else { continue };
+                let CommandValue::ResourceWatchEvent(event) = *value else { continue };
+                break event;
+            }
+            _ => {}
+        }
+    };
+    assert_eq!(bookmark.event["type"], "BOOKMARK");
+
+    convoys
+        .create(
+            &InputMeta::builder().name("after-cursor".to_string()).build(),
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
+        )
+        .await
+        .expect("create convoy after cursor");
+    let added = loop {
+        match recv_event(&mut rx).await {
+            DaemonEvent::CommandStepUpdate { command_id: id, status, .. } if id == command_id => {
+                let StepStatus::Produced { value } = status else { continue };
+                let CommandValue::ResourceWatchEvent(event) = *value else { continue };
+                if event.event["type"] == "ADDED" {
+                    break event;
+                }
+            }
+            _ => {}
+        }
+    };
+    assert_eq!(added.event["object"]["metadata"]["name"], "after-cursor");
+    daemon.cancel(command_id).await.expect("cancel resumed watch");
 }
 
 async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBackend, image: &str, agent_adapters: BTreeSet<String>) {

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -191,6 +191,7 @@ pub struct ConnectedConfiguredPeer {
     pub label: ConfigLabel,
     pub node: NodeInfo,
     pub generation: u64,
+    pub resource_socket_path: Option<PathBuf>,
     pub inbound_rx: mpsc::Receiver<PeerWireMessage>,
 }
 
@@ -1394,7 +1395,8 @@ impl PeerManager {
                         let subscribe_result = transport.subscribe().await;
                         let remote_node = transport.remote_node_info();
                         let remote_session_id = transport.remote_session_id();
-                        Ok((sender, subscribe_result, remote_node, remote_session_id))
+                        let resource_socket_path = transport.resource_socket_path();
+                        Ok((sender, subscribe_result, remote_node, remote_session_id, resource_socket_path))
                     }
                     Err(e) => Err(e),
                 }
@@ -1403,7 +1405,7 @@ impl PeerManager {
             };
 
             match connect_result {
-                Ok((sender, subscribe_result, remote_node, remote_session_id)) => {
+                Ok((sender, subscribe_result, remote_node, remote_session_id, resource_socket_path)) => {
                     let Some(remote_node) = remote_node else {
                         warn!(target = %label.0, "peer transport connected without remote node identity");
                         self.note_dial_result(&label, Err("peer transport connected without remote node identity"));
@@ -1449,7 +1451,13 @@ impl PeerManager {
                     match subscribe_result {
                         Ok(rx) => {
                             self.note_dial_result(&label, Ok(()));
-                            receivers.push(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, inbound_rx: rx })
+                            receivers.push(ConnectedConfiguredPeer {
+                                label: label.clone(),
+                                node: remote_node,
+                                generation,
+                                resource_socket_path,
+                                inbound_rx: rx,
+                            })
                         }
                         Err(e) => {
                             warn!(peer = %name, target = %label.0, err = %e, "failed to subscribe to peer");
@@ -1654,10 +1662,11 @@ impl PeerManager {
             let rx = transport.subscribe().await?;
             let remote_node = transport.remote_node_info();
             let remote_session_id = transport.remote_session_id();
-            Ok::<_, String>((sender, rx, remote_node, remote_session_id))
+            let resource_socket_path = transport.resource_socket_path();
+            Ok::<_, String>((sender, rx, remote_node, remote_session_id, resource_socket_path))
         }
         .await;
-        let (sender, rx, remote_node, remote_session_id) = match result {
+        let (sender, rx, remote_node, remote_session_id, resource_socket_path) = match result {
             Ok(connection) => connection,
             Err(error) => {
                 self.note_dial_result(label, Err(&error));
@@ -1706,7 +1715,7 @@ impl PeerManager {
         }
 
         self.note_dial_result(label, Ok(()));
-        Ok(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, inbound_rx: rx })
+        Ok(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, resource_socket_path, inbound_rx: rx })
     }
 
     /// Clear all stored peer data originating from a specific host.

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -191,7 +191,6 @@ pub struct ConnectedConfiguredPeer {
     pub label: ConfigLabel,
     pub node: NodeInfo,
     pub generation: u64,
-    pub resource_socket_path: Option<PathBuf>,
     pub inbound_rx: mpsc::Receiver<PeerWireMessage>,
 }
 
@@ -1395,8 +1394,7 @@ impl PeerManager {
                         let subscribe_result = transport.subscribe().await;
                         let remote_node = transport.remote_node_info();
                         let remote_session_id = transport.remote_session_id();
-                        let resource_socket_path = transport.resource_socket_path();
-                        Ok((sender, subscribe_result, remote_node, remote_session_id, resource_socket_path))
+                        Ok((sender, subscribe_result, remote_node, remote_session_id))
                     }
                     Err(e) => Err(e),
                 }
@@ -1405,7 +1403,7 @@ impl PeerManager {
             };
 
             match connect_result {
-                Ok((sender, subscribe_result, remote_node, remote_session_id, resource_socket_path)) => {
+                Ok((sender, subscribe_result, remote_node, remote_session_id)) => {
                     let Some(remote_node) = remote_node else {
                         warn!(target = %label.0, "peer transport connected without remote node identity");
                         self.note_dial_result(&label, Err("peer transport connected without remote node identity"));
@@ -1451,13 +1449,7 @@ impl PeerManager {
                     match subscribe_result {
                         Ok(rx) => {
                             self.note_dial_result(&label, Ok(()));
-                            receivers.push(ConnectedConfiguredPeer {
-                                label: label.clone(),
-                                node: remote_node,
-                                generation,
-                                resource_socket_path,
-                                inbound_rx: rx,
-                            })
+                            receivers.push(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, inbound_rx: rx })
                         }
                         Err(e) => {
                             warn!(peer = %name, target = %label.0, err = %e, "failed to subscribe to peer");
@@ -1662,11 +1654,10 @@ impl PeerManager {
             let rx = transport.subscribe().await?;
             let remote_node = transport.remote_node_info();
             let remote_session_id = transport.remote_session_id();
-            let resource_socket_path = transport.resource_socket_path();
-            Ok::<_, String>((sender, rx, remote_node, remote_session_id, resource_socket_path))
+            Ok::<_, String>((sender, rx, remote_node, remote_session_id))
         }
         .await;
-        let (sender, rx, remote_node, remote_session_id, resource_socket_path) = match result {
+        let (sender, rx, remote_node, remote_session_id) = match result {
             Ok(connection) => connection,
             Err(error) => {
                 self.note_dial_result(label, Err(&error));
@@ -1715,7 +1706,7 @@ impl PeerManager {
         }
 
         self.note_dial_result(label, Ok(()));
-        Ok(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, resource_socket_path, inbound_rx: rx })
+        Ok(ConnectedConfiguredPeer { label: label.clone(), node: remote_node, generation, inbound_rx: rx })
     }
 
     /// Clear all stored peer data originating from a specific host.

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -434,6 +434,10 @@ impl PeerTransport for SshTransport {
         }
     }
 
+    fn resource_socket_path(&self) -> Option<PathBuf> {
+        Some(self.local_socket_path.clone())
+    }
+
     async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String> {
         if self.status != PeerConnectionStatus::Connected {
             return Err("not connected".to_string());

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -434,10 +434,6 @@ impl PeerTransport for SshTransport {
         }
     }
 
-    fn resource_socket_path(&self) -> Option<PathBuf> {
-        Some(self.local_socket_path.clone())
-    }
-
     async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String> {
         if self.status != PeerConnectionStatus::Connected {
             return Err("not connected".to_string());

--- a/crates/flotilla-daemon/src/peer/transport.rs
+++ b/crates/flotilla-daemon/src/peer/transport.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
 use flotilla_protocol::{GoodbyeReason, NodeInfo, PeerWireMessage};
@@ -26,6 +26,12 @@ pub trait PeerTransport: Send + Sync {
 
     /// Human-readable address used for connection attempts and diagnostics.
     fn connection_address(&self) -> String;
+
+    /// A local Unix socket forwarded to the remote daemon, when this
+    /// transport provides one.
+    fn resource_socket_path(&self) -> Option<PathBuf> {
+        None
+    }
 
     /// Subscribe to inbound peer wire messages.
     async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String>;

--- a/crates/flotilla-daemon/src/peer/transport.rs
+++ b/crates/flotilla-daemon/src/peer/transport.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use flotilla_protocol::{GoodbyeReason, NodeInfo, PeerWireMessage};
@@ -26,12 +26,6 @@ pub trait PeerTransport: Send + Sync {
 
     /// Human-readable address used for connection attempts and diagnostics.
     fn connection_address(&self) -> String;
-
-    /// A local Unix socket forwarded to the remote daemon, when this
-    /// transport provides one.
-    fn resource_socket_path(&self) -> Option<PathBuf> {
-        None
-    }
 
     /// Subscribe to inbound peer wire messages.
     async fn subscribe(&mut self) -> Result<mpsc::Receiver<PeerWireMessage>, String>;

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -126,8 +126,14 @@ pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &Con
     }
     let (peer_data_tx, peer_data_rx) = mpsc::channel(256);
     let remote_command_router = build_remote_command_router(&daemon, &peer_manager);
-    let (handle, _peer_connected_tx) =
-        spawn_peer_networking_runtime(daemon, peer_manager, Some(peer_data_rx), peer_data_tx, remote_command_router);
+    let (handle, _peer_connected_tx) = spawn_peer_networking_runtime(
+        daemon,
+        peer_manager,
+        Some(peer_data_rx),
+        peer_data_tx,
+        remote_command_router,
+        Some(config.state_dir().as_path().join("peers")),
+    );
     Ok(handle)
 }
 
@@ -152,11 +158,14 @@ pub fn spawn_test_peer_networking(
         None, // No inbound task — test drives outbound via PeerConnectedNotice
         peer_data_tx,
         remote_command_router,
+        None,
     )
 }
 
 /// The daemon server that listens on a Unix socket and dispatches requests
 /// to an `InProcessDaemon`.
+#[derive(bon::Builder)]
+#[builder(builder_type(vis = "pub(in crate::server)"))]
 pub struct DaemonServer {
     daemon: Arc<InProcessDaemon>,
     socket_path: PathBuf,
@@ -172,6 +181,7 @@ pub struct DaemonServer {
     /// Manages connections to remote peer hosts and stores their provider data.
     peer_manager: Arc<Mutex<PeerManager>>,
     remote_command_router: RemoteCommandRouter,
+    peer_resource_socket_dir: PathBuf,
     agent_state_store: SharedAgentStateStore,
     /// Registry of per-environment Unix sockets. Initialized on startup and
     /// populated when environments are created (wired in Phase D).
@@ -206,6 +216,7 @@ impl DaemonServer {
 
         let agent_state_store = Arc::clone(daemon.agent_state_store());
         let remote_command_router = build_remote_command_router(&daemon, &peer_manager);
+        let peer_resource_socket_dir = config.state_dir().as_path().join("peers");
 
         Ok(Self {
             daemon,
@@ -220,6 +231,7 @@ impl DaemonServer {
             peer_data_rx: Some(peer_data_rx),
             peer_manager,
             remote_command_router,
+            peer_resource_socket_dir,
             agent_state_store,
             environment_sockets: Arc::new(tokio::sync::Mutex::new(EnvironmentSocketRegistry::new())),
         })
@@ -270,6 +282,7 @@ impl DaemonServer {
         let peer_data_tx = self.peer_data_tx;
         let agent_state_store = self.agent_state_store;
         let remote_command_router = self.remote_command_router;
+        let peer_resource_socket_dir = self.peer_resource_socket_dir;
 
         // Spawn idle timeout watcher (disabled for follower-mode daemons
         // which serve peer connections and should stay up indefinitely)
@@ -316,6 +329,7 @@ impl DaemonServer {
             peer_data_rx,
             peer_data_tx.clone(),
             remote_command_router.clone(),
+            Some(peer_resource_socket_dir),
         );
 
         // SIGTERM handler
@@ -393,8 +407,9 @@ fn spawn_peer_networking_runtime(
     peer_data_rx: Option<mpsc::Receiver<InboundPeerEnvelope>>,
     peer_data_tx: mpsc::Sender<InboundPeerEnvelope>,
     remote_command_router: RemoteCommandRouter,
+    resource_socket_dir: Option<PathBuf>,
 ) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) {
-    PeerRuntime::new(daemon, peer_manager, peer_data_rx, peer_data_tx, remote_command_router).spawn()
+    PeerRuntime::new(daemon, peer_manager, peer_data_rx, peer_data_tx, remote_command_router, resource_socket_dir).spawn()
 }
 
 /// Handle a single client connection.

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -5,6 +5,7 @@ mod peer_runtime;
 mod remote_commands;
 mod replicator;
 mod request_dispatch;
+mod resource_http;
 mod shared;
 #[cfg(feature = "test-support")]
 pub mod test_support;
@@ -24,7 +25,7 @@ use flotilla_core::{
 };
 use flotilla_protocol::{ConfigLabel, ConnectionRole, EnvironmentId, HostName, Message, NodeId, PROTOCOL_VERSION};
 use flotilla_resources::{ResourceBackend, SqliteBackend};
-use flotilla_transport::message::{unix_message_session, MessageSession};
+use flotilla_transport::message::{unix_message_session_with_prefix, MessageSession};
 use tokio::{
     net::UnixListener,
     sync::{mpsc, watch, Mutex, Notify},
@@ -51,6 +52,7 @@ use crate::peer::{ConnectionDirection, ConnectionMeta, InboundPeerEnvelope, Peer
 pub(crate) struct PeerConnectedNotice {
     pub peer: NodeId,
     pub generation: u64,
+    pub resource_socket_path: Option<PathBuf>,
 }
 
 fn build_remote_command_router(daemon: &Arc<InProcessDaemon>, peer_manager: &Arc<Mutex<PeerManager>>) -> RemoteCommandRouter {
@@ -403,7 +405,7 @@ fn spawn_peer_networking_runtime(
 /// (forward-compatible with HTTP transport).
 #[allow(clippy::too_many_arguments)]
 async fn handle_client(
-    stream: tokio::net::UnixStream,
+    mut stream: tokio::net::UnixStream,
     daemon: Arc<InProcessDaemon>,
     shutdown_rx: watch::Receiver<bool>,
     peer_data_tx: mpsc::Sender<InboundPeerEnvelope>,
@@ -415,8 +417,22 @@ async fn handle_client(
     agent_state_store: SharedAgentStateStore,
     environment_context: Option<EnvironmentId>,
 ) {
+    let mut first_byte = [0_u8; 1];
+    match tokio::io::AsyncReadExt::read_exact(&mut stream, &mut first_byte).await {
+        Ok(_) if first_byte[0].is_ascii_uppercase() => {
+            if let Err(error) = resource_http::serve_resource_http(stream, first_byte[0], daemon.resource_backend().clone()).await {
+                warn!(%error, "resource HTTP connection failed");
+            }
+            return;
+        }
+        Ok(_) => {}
+        Err(error) => {
+            warn!(%error, "failed to read connection preface");
+            return;
+        }
+    }
     handle_client_session(
-        unix_message_session(stream),
+        unix_message_session_with_prefix(stream, first_byte.to_vec()),
         daemon,
         shutdown_rx,
         peer_data_tx,

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -3,6 +3,7 @@ pub mod environment_sockets;
 mod peer_connection;
 mod peer_runtime;
 mod remote_commands;
+mod replicator;
 mod request_dispatch;
 mod shared;
 #[cfg(feature = "test-support")]

--- a/crates/flotilla-daemon/src/server/peer_connection.rs
+++ b/crates/flotilla-daemon/src/server/peer_connection.rs
@@ -115,7 +115,7 @@ impl PeerConnection {
 
         sync_peer_query_state(&self.peer_manager, &self.daemon).await;
         self.daemon.publish_peer_connection_status(&peer_node, PeerConnectionState::Connected).await;
-        let _ = self.peer_connected_tx.send(PeerConnectedNotice { peer: node_id.clone(), generation });
+        let _ = self.peer_connected_tx.send(PeerConnectedNotice { peer: node_id.clone(), generation, resource_socket_path: None });
 
         loop {
             tokio::select! {

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -14,7 +14,10 @@ use futures::future::join_all;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, info, warn};
 
-use super::{remote_commands::RemoteCommandRouter, shared::sync_peer_query_state, PeerConnectedNotice, SshTransport};
+use super::{
+    remote_commands::RemoteCommandRouter, replicator::spawn_peer_replicators, shared::sync_peer_query_state, PeerConnectedNotice,
+    SshTransport,
+};
 use crate::peer::{dispatch_pending_sends, HandleResult, InboundPeerEnvelope, PeerManager, PeerSender};
 
 pub(super) enum ForwardResult {
@@ -201,6 +204,7 @@ impl PeerRuntime {
                                 }
                             }
                             let plan = disconnect_peer_and_rebuild(&pm, &daemon_for_cleanup, &peer_name, generation).await;
+                            remote_command_router_for_cleanup.fail_pending_remote_commands_for_host(&peer_name).await;
                             remote_command_router_for_cleanup.fail_pending_remote_steps_for_host(&peer_name).await;
                             if plan.was_active {
                                 daemon_for_cleanup
@@ -273,6 +277,7 @@ impl PeerRuntime {
                                         }
                                     }
                                     let plan = disconnect_peer_and_rebuild(&pm, &daemon_for_cleanup, &peer_name, generation).await;
+                                    remote_command_router_for_cleanup.fail_pending_remote_commands_for_host(&peer_name).await;
                                     remote_command_router_for_cleanup.fail_pending_remote_steps_for_host(&peer_name).await;
                                     if plan.was_active {
                                         daemon_for_cleanup
@@ -615,6 +620,7 @@ impl PeerRuntime {
         });
 
         let outbound_daemon = Arc::clone(&self.daemon);
+        let outbound_remote_command_router = self.remote_command_router.clone();
         let mut peer_connected_rx = peer_connected_rx;
         tokio::spawn(async move {
             let mut event_rx = outbound_daemon.subscribe();
@@ -627,6 +633,11 @@ impl PeerRuntime {
                     notice = peer_connected_rx.recv() => {
                         let Some(notice) = notice else { break };
                         debug!(peer = %notice.peer, generation = notice.generation, "sending local state to newly connected peer");
+                        spawn_peer_replicators(
+                            outbound_remote_command_router.clone(),
+                            Arc::clone(&outbound_daemon),
+                            notice.peer.clone(),
+                        );
                         send_local_to_peer(
                             &outbound_daemon,
                             &outbound_peer_manager,

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -180,7 +180,11 @@ impl PeerRuntime {
                             current_peer = Some(initial_connection.node.clone());
                             let mut inbound_rx = initial_connection.inbound_rx;
                             let generation = initial_connection.generation;
-                            let _ = peer_connected_tx_clone.send(PeerConnectedNotice { peer: peer_name.clone(), generation });
+                            let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
+                                peer: peer_name.clone(),
+                                generation,
+                                resource_socket_path: initial_connection.resource_socket_path,
+                            });
                             last_known_session_id = {
                                 let pm_lock = pm.lock().await;
                                 pm_lock.peer_session_id(&peer_name)
@@ -256,7 +260,11 @@ impl PeerRuntime {
                                             PeerConnectionState::Connected,
                                         )
                                         .await;
-                                    let _ = peer_connected_tx_clone.send(PeerConnectedNotice { peer: peer_name.clone(), generation });
+                                    let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
+                                        peer: peer_name.clone(),
+                                        generation,
+                                        resource_socket_path: connection.resource_socket_path,
+                                    });
                                     attempt = 1;
                                     let sender = {
                                         let pm_lock = pm.lock().await;
@@ -637,6 +645,7 @@ impl PeerRuntime {
                             outbound_remote_command_router.clone(),
                             Arc::clone(&outbound_daemon),
                             notice.peer.clone(),
+                            notice.resource_socket_path,
                         );
                         send_local_to_peer(
                             &outbound_daemon,

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -115,12 +116,15 @@ enum PostHandleAction {
 const PING_INTERVAL: Duration = Duration::from_secs(30);
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(90);
 
+#[derive(bon::Builder)]
+#[builder(builder_type(vis = "pub(super)"))]
 pub(super) struct PeerRuntime {
     daemon: Arc<InProcessDaemon>,
     peer_manager: Arc<Mutex<PeerManager>>,
     peer_data_rx: Option<mpsc::Receiver<InboundPeerEnvelope>>,
     peer_data_tx: mpsc::Sender<InboundPeerEnvelope>,
     remote_command_router: RemoteCommandRouter,
+    resource_socket_dir: Option<PathBuf>,
 }
 
 impl PeerRuntime {
@@ -130,8 +134,9 @@ impl PeerRuntime {
         peer_data_rx: Option<mpsc::Receiver<InboundPeerEnvelope>>,
         peer_data_tx: mpsc::Sender<InboundPeerEnvelope>,
         remote_command_router: RemoteCommandRouter,
+        resource_socket_dir: Option<PathBuf>,
     ) -> Self {
-        Self { daemon, peer_manager, peer_data_rx, peer_data_tx, remote_command_router }
+        Self { daemon, peer_manager, peer_data_rx, peer_data_tx, remote_command_router, resource_socket_dir }
     }
 
     pub(super) fn spawn(self) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) {
@@ -142,6 +147,7 @@ impl PeerRuntime {
         let peer_connected_tx_for_ssh = peer_connected_tx.clone();
         let peer_daemon = Arc::clone(&self.daemon);
         let remote_command_router_task = self.remote_command_router.clone();
+        let resource_socket_dir = self.resource_socket_dir;
         let peer_data_rx = self.peer_data_rx;
 
         let inbound_handle = tokio::spawn(async move {
@@ -170,6 +176,7 @@ impl PeerRuntime {
                     let initial_connection = initial_connections.remove(&target.label);
                     let peer_connected_tx_clone = peer_connected_tx_for_ssh.clone();
                     let target_label = target.label.clone();
+                    let resource_socket_dir = resource_socket_dir.clone();
 
                     tokio::spawn(async move {
                         let mut current_peer: Option<NodeInfo> = None;
@@ -183,7 +190,9 @@ impl PeerRuntime {
                             let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
                                 peer: peer_name.clone(),
                                 generation,
-                                resource_socket_path: initial_connection.resource_socket_path,
+                                resource_socket_path: resource_socket_dir
+                                    .as_ref()
+                                    .map(|directory| directory.join(format!("{}.sock", target_label.0))),
                             });
                             last_known_session_id = {
                                 let pm_lock = pm.lock().await;
@@ -263,7 +272,9 @@ impl PeerRuntime {
                                     let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
                                         peer: peer_name.clone(),
                                         generation,
-                                        resource_socket_path: connection.resource_socket_path,
+                                        resource_socket_path: resource_socket_dir
+                                            .as_ref()
+                                            .map(|directory| directory.join(format!("{}.sock", target_label.0))),
                                     });
                                     attempt = 1;
                                     let sender = {

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -587,6 +587,28 @@ impl RemoteCommandRouter {
         }
     }
 
+    pub(super) async fn fail_pending_remote_commands_for_host(&self, node_id: &NodeId) {
+        let failed = {
+            let mut pending = self.pending_remote_commands.lock().await;
+            pending.extract_if(|_, entry| entry.target_node_id == *node_id).map(|(_, entry)| entry).collect::<Vec<_>>()
+        };
+        for entry in failed {
+            let message = format!("remote command peer disconnected: {node_id}");
+            if let Some(completion) = entry.query_completion {
+                let _ = completion.send(CommandValue::Error { message });
+                continue;
+            }
+            let repo_identity = entry.repo_identity.unwrap_or_else(|| RepoIdentity { authority: "local".into(), path: String::new() });
+            self.daemon.send_event(DaemonEvent::CommandFinished {
+                command_id: entry.command_id,
+                node_id: node_id.clone(),
+                repo_identity,
+                repo: entry.repo,
+                result: CommandValue::Error { message },
+            });
+        }
+    }
+
     async fn execute_forwarded_command(
         &self,
         request_id: u64,

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -19,25 +19,41 @@ pub(super) fn spawn_peer_replicators(
     peer: NodeId,
     resource_socket_path: Option<PathBuf>,
 ) {
-    let http = resource_socket_path.map(HttpBackend::from_unix_socket).transpose().map_err(|error| error.to_string());
-    match http {
-        Ok(http) => flotilla_resources::for_each_registered_resource!(spawn_kind, &router, &daemon, &peer, &http),
+    let transport = match resource_socket_path {
+        Some(path) => HttpBackend::from_unix_socket(path).map(ReplicationTransport::Http).map_err(|error| error.to_string()),
+        #[cfg(feature = "test-support")]
+        None => Ok(ReplicationTransport::Routed(router)),
+        #[cfg(not(feature = "test-support"))]
+        None => {
+            debug!(%peer, "peer has no forwarded resource socket; replication waits for an outbound SSH connection");
+            return;
+        }
+    };
+    match transport {
+        Ok(transport) => flotilla_resources::for_each_registered_resource!(spawn_kind, &daemon, &peer, &transport),
         Err(error) => warn!(%peer, %error, "could not start peer resource replicators"),
     }
 }
 
-fn spawn_kind<T: Resource>(router: &RemoteCommandRouter, daemon: &Arc<InProcessDaemon>, peer: &NodeId, http: &Option<HttpBackend>) {
+#[derive(Clone)]
+enum ReplicationTransport {
+    Http(HttpBackend),
+    #[cfg(feature = "test-support")]
+    Routed(RemoteCommandRouter),
+}
+
+fn spawn_kind<T: Resource>(daemon: &Arc<InProcessDaemon>, peer: &NodeId, transport: &ReplicationTransport) {
     if T::REPLICATION_CLASS != ReplicationClass::HomeBoundRuntime {
         return;
     }
-    let router = router.clone();
     let daemon = Arc::clone(daemon);
     let peer = peer.clone();
-    let http = http.clone();
+    let transport = transport.clone();
     tokio::spawn(async move {
-        let result = match http {
-            Some(http) => replicate_kind_over_http::<T>(http, &daemon, &peer).await,
-            None => replicate_kind_over_routed_watch::<T>(&router, &daemon, &peer).await,
+        let result = match transport {
+            ReplicationTransport::Http(http) => replicate_kind_over_http::<T>(http, &daemon, &peer).await,
+            #[cfg(feature = "test-support")]
+            ReplicationTransport::Routed(router) => replicate_kind_over_routed_watch::<T>(&router, &daemon, &peer).await,
         };
         if let Err(error) = result {
             debug!(%peer, kind = T::API_PATHS.kind, %error, "resource replicator stopped");
@@ -45,7 +61,11 @@ fn spawn_kind<T: Resource>(router: &RemoteCommandRouter, daemon: &Arc<InProcessD
     });
 }
 
-async fn replicate_kind_over_http<T: Resource>(http: HttpBackend, daemon: &Arc<InProcessDaemon>, peer: &NodeId) -> Result<(), String> {
+pub(super) async fn replicate_kind_over_http<T: Resource>(
+    http: HttpBackend,
+    daemon: &Arc<InProcessDaemon>,
+    peer: &NodeId,
+) -> Result<(), String> {
     let remote = ResourceBackend::Http(http).using::<T>(REPLICATION_NAMESPACE);
     let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
     let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
@@ -80,6 +100,7 @@ async fn apply_http_watch<T: Resource>(
     Ok(())
 }
 
+#[cfg(feature = "test-support")]
 async fn replicate_kind_over_routed_watch<T: Resource>(
     router: &RemoteCommandRouter,
     daemon: &Arc<InProcessDaemon>,
@@ -99,6 +120,7 @@ async fn replicate_kind_over_routed_watch<T: Resource>(
     }
 }
 
+#[cfg(feature = "test-support")]
 async fn run_routed_watch<T: Resource>(
     router: &RemoteCommandRouter,
     daemon: &Arc<InProcessDaemon>,
@@ -161,6 +183,7 @@ async fn run_routed_watch<T: Resource>(
     }
 }
 
+#[cfg(feature = "test-support")]
 async fn apply_response<T: Resource>(
     writer: &flotilla_resources::ReplicaWriter<T>,
     initial: &mut Vec<ResourceObject<T>>,

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -1,0 +1,140 @@
+use std::sync::Arc;
+
+use chrono::Utc;
+use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
+use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, NodeId, ResourceWatchCursor, ResourceWatchResponse};
+use flotilla_resources::{Convoy, K8sWatchEvent, Resource, ResourceList, ResourceObject, TerminalSession, Vessel};
+use tracing::{debug, warn};
+
+use super::remote_commands::RemoteCommandRouter;
+
+const REPLICATION_NAMESPACE: &str = "flotilla";
+
+pub(super) fn spawn_peer_replicators(router: RemoteCommandRouter, daemon: Arc<InProcessDaemon>, peer: NodeId) {
+    spawn_kind::<Convoy>(router.clone(), Arc::clone(&daemon), peer.clone());
+    spawn_kind::<Vessel>(router.clone(), Arc::clone(&daemon), peer.clone());
+    spawn_kind::<TerminalSession>(router, daemon, peer);
+}
+
+fn spawn_kind<T: Resource>(router: RemoteCommandRouter, daemon: Arc<InProcessDaemon>, peer: NodeId) {
+    tokio::spawn(async move {
+        if let Err(error) = replicate_kind::<T>(&router, &daemon, &peer).await {
+            debug!(%peer, kind = T::API_PATHS.kind, %error, "resource replicator stopped");
+        }
+    });
+}
+
+async fn replicate_kind<T: Resource>(router: &RemoteCommandRouter, daemon: &Arc<InProcessDaemon>, peer: &NodeId) -> Result<(), String> {
+    let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
+    let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
+    match run_watch::<T>(router, daemon, peer, cursor.clone()).await {
+        Ok(()) => Ok(()),
+        Err(error)
+            if cursor.is_some() && (error.contains("expired") || error.contains("generation") || error.contains("resourceVersion")) =>
+        {
+            debug!(%peer, kind = T::API_PATHS.kind, %error, "replica cursor rejected; relisting origin");
+            run_watch::<T>(router, daemon, peer, None).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn run_watch<T: Resource>(
+    router: &RemoteCommandRouter,
+    daemon: &Arc<InProcessDaemon>,
+    peer: &NodeId,
+    cursor: Option<flotilla_resources::ReplicaCursor>,
+) -> Result<(), String> {
+    let resuming = cursor.is_some();
+    let protocol_cursor =
+        cursor.map(|cursor| ResourceWatchCursor { resource_version: cursor.resource_version, generation: cursor.generation });
+    let mut events = daemon.subscribe();
+    let command_id = router
+        .dispatch_execute_for_principal(
+            Command {
+                node_id: Some(peer.clone()),
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ResourceWatch {
+                    namespace: REPLICATION_NAMESPACE.to_string(),
+                    kind: T::API_PATHS.plural.to_string(),
+                    include_replicas: false,
+                    cursor: protocol_cursor,
+                },
+            },
+            None,
+        )
+        .await?;
+    let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
+    let mut initial = Vec::<ResourceObject<T>>::new();
+    let mut initializing = !resuming;
+
+    loop {
+        match events.recv().await {
+            Ok(DaemonEvent::CommandStepUpdate {
+                command_id: event_command_id,
+                status: flotilla_protocol::StepStatus::Produced { value },
+                ..
+            }) if event_command_id == command_id => {
+                let CommandValue::ResourceWatchEvent(response) = *value else {
+                    continue;
+                };
+                if response.kind != T::API_PATHS.kind {
+                    continue;
+                }
+                apply_response(&writer, &mut initial, &mut initializing, *response).await?;
+            }
+            Ok(DaemonEvent::CommandFinished { command_id: event_command_id, result, .. }) if event_command_id == command_id => {
+                return match result {
+                    CommandValue::Cancelled | CommandValue::Ok => Ok(()),
+                    CommandValue::Error { message } => Err(message),
+                    other => Err(format!("resource watch ended unexpectedly: {other:?}")),
+                };
+            }
+            Ok(_) => {}
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!(%peer, kind = T::API_PATHS.kind, skipped, "resource replicator lagged; reconnect will resume from stored cursor");
+                return Err("resource replicator event subscriber lagged".to_string());
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return Err("daemon event stream closed".to_string()),
+        }
+    }
+}
+
+async fn apply_response<T: Resource>(
+    writer: &flotilla_resources::ReplicaWriter<T>,
+    initial: &mut Vec<ResourceObject<T>>,
+    initializing: &mut bool,
+    response: ResourceWatchResponse,
+) -> Result<(), String> {
+    if response.event["type"] == "BOOKMARK" {
+        if *initializing {
+            writer
+                .replace(
+                    &ResourceList {
+                        items: std::mem::take(initial),
+                        resource_version: response.resource_version,
+                        generation: response.generation,
+                    },
+                    Utc::now(),
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+            *initializing = false;
+        }
+        return Ok(());
+    }
+
+    let event: K8sWatchEvent<T> =
+        serde_json::from_value(response.event).map_err(|error| format!("decode replicated {} event: {error}", T::API_PATHS.kind))?;
+    let event = event.into_watch_event().map_err(|error| error.to_string())?;
+    if *initializing && matches!(event, flotilla_resources::WatchEvent::Added(_)) {
+        let object = match event {
+            flotilla_resources::WatchEvent::Added(object) => object,
+            _ => unreachable!("matched added event"),
+        };
+        initial.push(object);
+        return Ok(());
+    }
+    writer.apply(event, Utc::now()).await.map_err(|error| error.to_string())
+}

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -1,45 +1,105 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use chrono::Utc;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, NodeId, ResourceWatchCursor, ResourceWatchResponse};
-use flotilla_resources::{Convoy, K8sWatchEvent, Resource, ResourceList, ResourceObject, TerminalSession, Vessel};
+use flotilla_resources::{
+    HttpBackend, K8sWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, WatchStart,
+};
+use futures::StreamExt;
 use tracing::{debug, warn};
 
 use super::remote_commands::RemoteCommandRouter;
 
 const REPLICATION_NAMESPACE: &str = "flotilla";
 
-pub(super) fn spawn_peer_replicators(router: RemoteCommandRouter, daemon: Arc<InProcessDaemon>, peer: NodeId) {
-    spawn_kind::<Convoy>(router.clone(), Arc::clone(&daemon), peer.clone());
-    spawn_kind::<Vessel>(router.clone(), Arc::clone(&daemon), peer.clone());
-    spawn_kind::<TerminalSession>(router, daemon, peer);
+pub(super) fn spawn_peer_replicators(
+    router: RemoteCommandRouter,
+    daemon: Arc<InProcessDaemon>,
+    peer: NodeId,
+    resource_socket_path: Option<PathBuf>,
+) {
+    let http = resource_socket_path.map(HttpBackend::from_unix_socket).transpose().map_err(|error| error.to_string());
+    match http {
+        Ok(http) => flotilla_resources::for_each_registered_resource!(spawn_kind, &router, &daemon, &peer, &http),
+        Err(error) => warn!(%peer, %error, "could not start peer resource replicators"),
+    }
 }
 
-fn spawn_kind<T: Resource>(router: RemoteCommandRouter, daemon: Arc<InProcessDaemon>, peer: NodeId) {
+fn spawn_kind<T: Resource>(router: &RemoteCommandRouter, daemon: &Arc<InProcessDaemon>, peer: &NodeId, http: &Option<HttpBackend>) {
+    if T::REPLICATION_CLASS != ReplicationClass::HomeBoundRuntime {
+        return;
+    }
+    let router = router.clone();
+    let daemon = Arc::clone(daemon);
+    let peer = peer.clone();
+    let http = http.clone();
     tokio::spawn(async move {
-        if let Err(error) = replicate_kind::<T>(&router, &daemon, &peer).await {
+        let result = match http {
+            Some(http) => replicate_kind_over_http::<T>(http, &daemon, &peer).await,
+            None => replicate_kind_over_routed_watch::<T>(&router, &daemon, &peer).await,
+        };
+        if let Err(error) = result {
             debug!(%peer, kind = T::API_PATHS.kind, %error, "resource replicator stopped");
         }
     });
 }
 
-async fn replicate_kind<T: Resource>(router: &RemoteCommandRouter, daemon: &Arc<InProcessDaemon>, peer: &NodeId) -> Result<(), String> {
+async fn replicate_kind_over_http<T: Resource>(http: HttpBackend, daemon: &Arc<InProcessDaemon>, peer: &NodeId) -> Result<(), String> {
+    let remote = ResourceBackend::Http(http).using::<T>(REPLICATION_NAMESPACE);
     let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
     let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
-    match run_watch::<T>(router, daemon, peer, cursor.clone()).await {
+    if let Some(cursor) = cursor {
+        let start = match cursor.generation {
+            Some(generation) => WatchStart::FromVersionInGeneration { generation, resource_version: cursor.resource_version },
+            None => WatchStart::FromVersion(cursor.resource_version),
+        };
+        match remote.watch(start).await {
+            Ok(watch) => return apply_http_watch(watch, &writer).await,
+            Err(error @ (ResourceError::WatchExpired { .. } | ResourceError::Invalid { .. })) => {
+                debug!(%peer, kind = T::API_PATHS.kind, %error, "replica cursor rejected; relisting origin");
+            }
+            Err(error) => return Err(error.to_string()),
+        }
+    }
+
+    let listed = remote.list().await.map_err(|error| error.to_string())?;
+    let start = WatchStart::resuming_from(&listed);
+    writer.replace(&listed, Utc::now()).await.map_err(|error| error.to_string())?;
+    let watch = remote.watch(start).await.map_err(|error| error.to_string())?;
+    apply_http_watch(watch, &writer).await
+}
+
+async fn apply_http_watch<T: Resource>(
+    mut watch: flotilla_resources::WatchStream<T>,
+    writer: &flotilla_resources::ReplicaWriter<T>,
+) -> Result<(), String> {
+    while let Some(event) = watch.next().await {
+        writer.apply(event.map_err(|error| error.to_string())?, Utc::now()).await.map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+async fn replicate_kind_over_routed_watch<T: Resource>(
+    router: &RemoteCommandRouter,
+    daemon: &Arc<InProcessDaemon>,
+    peer: &NodeId,
+) -> Result<(), String> {
+    let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
+    let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
+    match run_routed_watch::<T>(router, daemon, peer, cursor.clone()).await {
         Ok(()) => Ok(()),
         Err(error)
             if cursor.is_some() && (error.contains("expired") || error.contains("generation") || error.contains("resourceVersion")) =>
         {
             debug!(%peer, kind = T::API_PATHS.kind, %error, "replica cursor rejected; relisting origin");
-            run_watch::<T>(router, daemon, peer, None).await
+            run_routed_watch::<T>(router, daemon, peer, None).await
         }
         Err(error) => Err(error),
     }
 }
 
-async fn run_watch<T: Resource>(
+async fn run_routed_watch<T: Resource>(
     router: &RemoteCommandRouter,
     daemon: &Arc<InProcessDaemon>,
     peer: &NodeId,

--- a/crates/flotilla-daemon/src/server/resource_http.rs
+++ b/crates/flotilla-daemon/src/server/resource_http.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeMap;
+
+use flotilla_resources::{
+    list_resource_kind, list_resource_kind_including_replicas, watch_resource_kind, watch_resource_kind_from,
+    watch_resource_kind_including_replicas, DynamicResourceWatch, ResourceBackend, ResourceError, WatchStart,
+};
+use futures::StreamExt;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::UnixStream,
+};
+
+const MAX_REQUEST_HEADER_BYTES: usize = 16 * 1024;
+
+pub(super) async fn serve_resource_http(mut stream: UnixStream, first_byte: u8, backend: ResourceBackend) -> Result<(), String> {
+    let mut request = vec![first_byte];
+    while !request.ends_with(b"\r\n\r\n") {
+        if request.len() >= MAX_REQUEST_HEADER_BYTES {
+            return write_error(&mut stream, 431, "request headers too large").await;
+        }
+        let mut buffer = [0_u8; 1024];
+        let read = stream.read(&mut buffer).await.map_err(|error| format!("read resource HTTP request: {error}"))?;
+        if read == 0 {
+            return Ok(());
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+
+    let request = std::str::from_utf8(&request).map_err(|error| format!("resource HTTP request is not UTF-8: {error}"))?;
+    let request_line = request.lines().next().ok_or_else(|| "resource HTTP request has no request line".to_string())?;
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next().unwrap_or_default();
+    let target = request_parts.next().unwrap_or_default();
+    if method != "GET" {
+        return write_error(&mut stream, 405, "resource API is read-only").await;
+    }
+
+    let (path, raw_query) = target.split_once('?').map_or((target, ""), |parts| parts);
+    let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
+    let ["apis", "flotilla.work", "v1", "namespaces", namespace, kind] = segments.as_slice() else {
+        return write_error(&mut stream, 404, "unknown resource API path").await;
+    };
+    let query = parse_query(raw_query);
+    let include_replicas =
+        ["includeReplicas", "include-replicas", "include_replicas"].iter().filter_map(|key| query.get(*key)).any(|value| value == "true");
+    let watch = query.get("watch").is_some_and(|value| value == "true");
+
+    if !watch {
+        let listed = if include_replicas {
+            list_resource_kind_including_replicas(&backend, namespace, kind).await
+        } else {
+            list_resource_kind(&backend, namespace, kind).await
+        };
+        return match listed {
+            Ok(listed) => write_json(&mut stream, 200, &listed.value).await,
+            Err(error) => write_resource_error(&mut stream, error).await,
+        };
+    }
+
+    let watched = if include_replicas {
+        if query.contains_key("resourceVersion") {
+            Err(ResourceError::invalid("include-replicas watches do not support resourceVersion resume"))
+        } else {
+            watch_resource_kind_including_replicas(&backend, namespace, kind).await
+        }
+    } else if let Some(resource_version) = query.get("resourceVersion") {
+        let start = match query.get("generation") {
+            Some(generation) => {
+                WatchStart::FromVersionInGeneration { generation: generation.clone(), resource_version: resource_version.clone() }
+            }
+            None => WatchStart::FromVersion(resource_version.clone()),
+        };
+        watch_resource_kind_from(&backend, namespace, kind, start).await
+    } else {
+        watch_resource_kind(&backend, namespace, kind).await
+    };
+
+    match watched {
+        Ok(watch) => stream_watch(&mut stream, watch).await,
+        Err(error) => write_resource_error(&mut stream, error).await,
+    }
+}
+
+fn parse_query(raw_query: &str) -> BTreeMap<String, String> {
+    raw_query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| pair.split_once('=').unwrap_or((pair, "")))
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
+}
+
+async fn stream_watch(stream: &mut UnixStream, mut watch: DynamicResourceWatch) -> Result<(), String> {
+    stream
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n")
+        .await
+        .map_err(|error| format!("write resource watch headers: {error}"))?;
+    for event in watch.initial {
+        write_watch_event(stream, &event).await?;
+    }
+    while let Some(event) = watch.stream.next().await {
+        let event = event.map_err(|error| error.to_string())?;
+        write_watch_event(stream, &event).await?;
+    }
+    Ok(())
+}
+
+async fn write_watch_event(stream: &mut UnixStream, event: &serde_json::Value) -> Result<(), String> {
+    let mut encoded = serde_json::to_vec(event).map_err(|error| format!("encode resource watch event: {error}"))?;
+    encoded.push(b'\n');
+    stream.write_all(&encoded).await.map_err(|error| format!("write resource watch event: {error}"))
+}
+
+async fn write_json(stream: &mut UnixStream, status: u16, value: &serde_json::Value) -> Result<(), String> {
+    let body = serde_json::to_vec(value).map_err(|error| format!("encode resource HTTP response: {error}"))?;
+    let head = format!(
+        "HTTP/1.1 {status} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        reason(status),
+        body.len()
+    );
+    stream.write_all(head.as_bytes()).await.map_err(|error| format!("write resource HTTP headers: {error}"))?;
+    stream.write_all(&body).await.map_err(|error| format!("write resource HTTP body: {error}"))
+}
+
+async fn write_resource_error(stream: &mut UnixStream, error: ResourceError) -> Result<(), String> {
+    let status = match error {
+        ResourceError::WatchExpired { .. } => 410,
+        ResourceError::Invalid { .. } => 400,
+        ResourceError::NotFound { .. } => 404,
+        ResourceError::Conflict { .. } => 409,
+        ResourceError::Unauthorized { .. } => 403,
+        ResourceError::Other { .. } => 500,
+    };
+    write_error(stream, status, &error.to_string()).await
+}
+
+async fn write_error(stream: &mut UnixStream, status: u16, message: &str) -> Result<(), String> {
+    write_json(stream, status, &serde_json::json!({"message": message})).await
+}
+
+fn reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        400 => "Bad Request",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        409 => "Conflict",
+        410 => "Gone",
+        431 => "Request Header Fields Too Large",
+        _ => "Internal Server Error",
+    }
+}

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -107,6 +107,7 @@ pub async fn spawn_in_memory_request_topology(
             Some(leader_peer_data_rx),
             leader_peer_data_tx.clone(),
             leader_remote_router.clone(),
+            None,
         );
     let (follower_runtime_handle, _follower_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) =
         spawn_peer_networking_runtime(
@@ -115,6 +116,7 @@ pub async fn spawn_in_memory_request_topology(
             Some(follower_peer_data_rx),
             follower_peer_data_tx,
             follower_remote_router,
+            None,
         );
 
     let (client_session, server_session) = flotilla_transport::message::message_session_pair();
@@ -195,6 +197,7 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
             Some(leader_peer_data_rx),
             leader_peer_data_tx.clone(),
             leader_remote_router.clone(),
+            None,
         );
     let (follower_runtime_handle, _follower_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) =
         spawn_peer_networking_runtime(
@@ -203,6 +206,7 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
             Some(follower_peer_data_rx),
             follower_peer_data_tx,
             follower_remote_router,
+            None,
         );
 
     // Spawn the server-side client session handler BEFORE the client handshake,

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -29,10 +29,10 @@ use flotilla_protocol::{
     TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, InputMeta,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend, ResourceError, Stance, StatusPatch,
-    TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
-    WorkflowTemplate,
+    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, HttpBackend, InMemoryBackend, InputMeta,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend, ResourceError, ResourceProvenance, Stance,
+    StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
+    TerminalSessionStatusPatch, WatchEvent, WatchStart, WorkflowTemplate,
 };
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
@@ -55,10 +55,87 @@ use super::{
         PendingRemoteCommand, PendingRemoteCommandMap, RemoteCommandRouter,
     },
     request_dispatch::RequestDispatcher,
+    resource_http::serve_resource_http,
     shared::{sync_peer_query_state, write_message, SocketPeerSender},
     test_support::{apply_convoy_replica_feed, seed_trusted_remote_convoy_project},
     DaemonServer, PeerConnectedNotice,
 };
+
+#[tokio::test]
+async fn resource_http_lists_and_watches_over_a_unix_socket() {
+    let source = ResourceBackend::InMemory(InMemoryBackend::default());
+    let source_convoys = source.using::<Convoy>("flotilla");
+    source_convoys
+        .create(
+            &InputMeta::builder().name("before-watch".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create initial convoy");
+    source_convoys
+        .create(
+            &InputMeta::builder().name("replica-row".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create replica source row");
+    let replica_snapshot = source_convoys.list().await.expect("list replica source rows");
+    source
+        .replica_writer::<Convoy>(NodeId::new("remote-root"), "flotilla")
+        .replace(&replica_snapshot, chrono::Utc::now())
+        .await
+        .expect("seed replica rows");
+    source_convoys.delete("replica-row").await.expect("remove local copy of replica row");
+
+    let socket_path = PathBuf::from(format!("/tmp/flotilla-resource-http-{}.sock", uuid::Uuid::new_v4()));
+    let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind resource HTTP socket");
+    let server_backend = source.clone();
+    let server = tokio::spawn(async move {
+        for _ in 0..3 {
+            let (mut stream, _) = listener.accept().await.expect("accept resource HTTP request");
+            let first_byte = tokio::io::AsyncReadExt::read_u8(&mut stream).await.expect("read HTTP preface");
+            let backend = server_backend.clone();
+            tokio::spawn(async move {
+                serve_resource_http(stream, first_byte, backend).await.expect("serve resource HTTP request");
+            });
+        }
+    });
+
+    let remote = ResourceBackend::Http(HttpBackend::from_unix_socket(&socket_path).expect("build Unix-socket resource client"));
+    let overlay = remote.including_replicas::<Convoy>("flotilla").list().await.expect("list overlay over Unix-socket HTTP");
+    assert!(overlay.items.iter().any(|item| {
+        item.object.metadata.name == "replica-row"
+            && matches!(
+                item.provenance,
+                ResourceProvenance::Replica { ref origin_root, .. }
+                    if origin_root == &NodeId::new("remote-root")
+            )
+    }));
+    let listed = remote.using::<Convoy>("flotilla").list().await.expect("list convoys over Unix-socket HTTP");
+    assert_eq!(listed.items.len(), 1);
+    let mut watch =
+        remote.using::<Convoy>("flotilla").watch(WatchStart::resuming_from(&listed)).await.expect("watch convoys over Unix-socket HTTP");
+
+    source_convoys
+        .create(
+            &InputMeta::builder().name("after-watch".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create watched convoy");
+    let event = tokio::time::timeout(Duration::from_secs(2), futures::StreamExt::next(&mut watch))
+        .await
+        .expect("HTTP watch event timeout")
+        .expect("HTTP watch ended")
+        .expect("valid HTTP watch event");
+    assert!(matches!(
+        event,
+        WatchEvent::Added(object) if object.metadata.name == "after-watch"
+    ));
+
+    server.await.expect("resource HTTP server task");
+    std::fs::remove_file(&socket_path).expect("remove resource HTTP socket");
+}
 use crate::peer::{
     test_support::{ensure_test_connection_generation, handle_test_peer_data, wait_for_command_result, BlockingPeerSender, MockPeerSender},
     InboundPeerEnvelope, PeerConnectionStatus, PeerManager, PeerSender, PeerTransport,

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -788,7 +788,12 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
             node_id: Some(node("feta")),
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ResourceWatch { namespace: "flotilla".into(), kind: "convoys".into() },
+            action: CommandAction::ResourceWatch {
+                namespace: "flotilla".into(),
+                kind: "convoys".into(),
+                include_replicas: false,
+                cursor: None,
+            },
         })
         .await
         .expect("dispatch_execute should succeed");
@@ -806,7 +811,12 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
                 node_id: Some(node("feta")),
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ResourceWatch { namespace: "flotilla".into(), kind: "convoys".into() }
+                action: CommandAction::ResourceWatch {
+                    namespace: "flotilla".into(),
+                    kind: "convoys".into(),
+                    include_replicas: false,
+                    cursor: None,
+                }
             });
         }
         other => panic!("expected routed command request, got {other:?}"),

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -54,6 +54,7 @@ use super::{
         extract_command_repo_identity, ForwardedCommand, ForwardedCommandMap, ForwardedCommandState, PendingRemoteCancelMap,
         PendingRemoteCommand, PendingRemoteCommandMap, RemoteCommandRouter,
     },
+    replicator::replicate_kind_over_http,
     request_dispatch::RequestDispatcher,
     resource_http::serve_resource_http,
     shared::{sync_peer_query_state, write_message, SocketPeerSender},
@@ -135,6 +136,97 @@ async fn resource_http_lists_and_watches_over_a_unix_socket() {
 
     server.await.expect("resource HTTP server task");
     std::fs::remove_file(&socket_path).expect("remove resource HTTP socket");
+}
+
+#[tokio::test]
+async fn http_replicator_relists_after_an_origin_generation_change() {
+    let old_origin = ResourceBackend::InMemory(InMemoryBackend::observed());
+    old_origin
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("old-generation".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create old-generation convoy");
+    let old_list = old_origin.using::<Convoy>("flotilla").list().await.expect("list old generation");
+
+    let holder_backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let origin_root = NodeId::new("remote-root");
+    holder_backend
+        .replica_writer::<Convoy>(origin_root.clone(), "flotilla")
+        .replace(&old_list, chrono::Utc::now())
+        .await
+        .expect("seed old-generation cursor");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let holder = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        test_config_store(temp.path().join("holder")),
+        fake_discovery(false),
+        HostName::new("holder"),
+        holder_backend.clone(),
+    )
+    .await;
+
+    let new_origin = ResourceBackend::InMemory(InMemoryBackend::observed());
+    new_origin
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("new-generation".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create new-generation convoy");
+    let new_generation =
+        new_origin.using::<Convoy>("flotilla").list().await.expect("list new generation").generation.expect("new origin generation");
+
+    let socket_path = PathBuf::from(format!("/tmp/flotilla-replicator-http-{}.sock", uuid::Uuid::new_v4()));
+    let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind replicator HTTP socket");
+    let server = tokio::spawn(async move {
+        for _ in 0..3 {
+            let (mut stream, _) = listener.accept().await.expect("accept replicator HTTP request");
+            let first_byte = tokio::io::AsyncReadExt::read_u8(&mut stream).await.expect("read HTTP preface");
+            let backend = new_origin.clone();
+            tokio::spawn(async move {
+                serve_resource_http(stream, first_byte, backend).await.expect("serve replicator HTTP request");
+            });
+        }
+    });
+
+    let http = HttpBackend::from_unix_socket(&socket_path).expect("build replicator HTTP client");
+    let holder_for_replication = Arc::clone(&holder);
+    let origin_for_replication = origin_root.clone();
+    let replicator =
+        tokio::spawn(async move { replicate_kind_over_http::<Convoy>(http, &holder_for_replication, &origin_for_replication).await });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let listed = holder_backend.including_replicas::<Convoy>("flotilla").list().await.expect("list relisted replicas");
+            if listed.items.iter().any(|item| item.object.metadata.name == "new-generation") {
+                assert!(
+                    listed.items.iter().all(|item| item.object.metadata.name != "old-generation"),
+                    "generation relist must atomically discard old rows"
+                );
+                let cursor = holder_backend
+                    .replica_writer::<Convoy>(origin_root.clone(), "flotilla")
+                    .cursor()
+                    .await
+                    .expect("read relisted cursor")
+                    .expect("relisted cursor");
+                assert_eq!(cursor.generation.as_deref(), Some(new_generation.as_str()));
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("generation relist timeout");
+
+    replicator.abort();
+    server.abort();
+    let _ = replicator.await;
+    let _ = server.await;
+    std::fs::remove_file(&socket_path).expect("remove replicator HTTP socket");
 }
 use crate::peer::{
     test_support::{ensure_test_connection_generation, handle_test_peer_data, wait_for_command_result, BlockingPeerSender, MockPeerSender},

--- a/crates/flotilla-daemon/tests/overlay_replication.rs
+++ b/crates/flotilla-daemon/tests/overlay_replication.rs
@@ -134,10 +134,61 @@ async fn connected_daemons_replicate_home_bound_runtime_kinds_and_deletes() {
     .await
     .expect("last-known replication timed out");
 
+    let synced_before_disconnect = match &kiwi
+        .resource_backend()
+        .including_replicas::<Convoy>("flotilla")
+        .list()
+        .await
+        .expect("list replicas before disconnect")
+        .items
+        .iter()
+        .find(|item| item.object.metadata.name == "last-known-convoy")
+        .expect("last-known replica before disconnect")
+        .provenance
+    {
+        ResourceProvenance::Replica { last_synced_at, .. } => *last_synced_at,
+        ResourceProvenance::Local => panic!("expected replica provenance"),
+    };
+
     drop(topology);
     let disconnected = kiwi.resource_backend().including_replicas::<Convoy>("flotilla").list().await.expect("list disconnected replicas");
     assert!(
         disconnected.items.iter().any(|item| item.object.metadata.name == "last-known-convoy"),
         "origin absence must not remove last-known replica rows"
     );
+
+    remote
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("created-offline".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create convoy while disconnected");
+    let reconnected = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("reconnect topology");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let listed = kiwi.resource_backend().including_replicas::<Convoy>("flotilla").list().await.expect("list reconnected replicas");
+            if listed.items.iter().any(|item| item.object.metadata.name == "created-offline") {
+                let retained = listed
+                    .items
+                    .iter()
+                    .find(|item| item.object.metadata.name == "last-known-convoy")
+                    .expect("retained replica after reconnect");
+                assert!(
+                    matches!(
+                        retained.provenance,
+                        ResourceProvenance::Replica { last_synced_at, .. }
+                            if last_synced_at == synced_before_disconnect
+                    ),
+                    "resume must not full-relist and restamp unchanged rows"
+                );
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("reconnect replication timed out");
+    drop(reconnected);
 }

--- a/crates/flotilla-daemon/tests/overlay_replication.rs
+++ b/crates/flotilla-daemon/tests/overlay_replication.rs
@@ -1,0 +1,143 @@
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use flotilla_core::{config::ConfigStore, in_process::InProcessDaemon, providers::discovery::test_support::fake_discovery};
+use flotilla_daemon::server::test_support::spawn_in_memory_request_topology;
+use flotilla_protocol::HostName;
+use flotilla_resources::{
+    Convoy, ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend, ResourceProvenance, TerminalSession, TerminalSessionSource,
+    TerminalSessionSpec, Vessel, VesselSpec,
+};
+
+fn config(path: std::path::PathBuf, machine_id: &str) -> Arc<ConfigStore> {
+    std::fs::create_dir_all(&path).expect("create config");
+    std::fs::write(path.join("daemon.toml"), format!("machine_id = \"{machine_id}\"\n")).expect("write daemon config");
+    Arc::new(ConfigStore::with_base(path))
+}
+
+async fn daemon(path: std::path::PathBuf, machine_id: &str, host: &str) -> Arc<InProcessDaemon> {
+    InProcessDaemon::new_with_resource_backend(
+        vec![],
+        config(path, machine_id),
+        fake_discovery(false),
+        HostName::new(host),
+        ResourceBackend::InMemory(InMemoryBackend::default()),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn connected_daemons_replicate_home_bound_runtime_kinds_and_deletes() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let kiwi = daemon(temp.path().join("kiwi"), "kiwi-root", "kiwi").await;
+    let feta = daemon(temp.path().join("feta"), "feta-root", "feta").await;
+    let remote = feta.resource_backend();
+    remote
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("remote-convoy".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create remote convoy");
+    remote
+        .using::<Vessel>("flotilla")
+        .create(&InputMeta::builder().name("remote-vessel".to_string()).build(), &VesselSpec {
+            convoy_ref: "remote-convoy".to_string(),
+            vessel_name: "work".to_string(),
+            placement_policy_ref: "host-direct".to_string(),
+            adopted_checkout_refs: BTreeMap::new(),
+        })
+        .await
+        .expect("create remote vessel");
+    remote
+        .using::<TerminalSession>("flotilla")
+        .create(
+            &InputMeta::builder().name("remote-session".to_string()).build(),
+            &TerminalSessionSpec::builder()
+                .env_ref("env".to_string())
+                .role("coder".to_string())
+                .source(TerminalSessionSource::Tool { command: "true".to_string() })
+                .cwd("/tmp".to_string())
+                .pool("passthrough".to_string())
+                .build(),
+        )
+        .await
+        .expect("create remote terminal session");
+
+    let topology = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("connect topology");
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let convoys = kiwi.resource_backend().including_replicas::<Convoy>("flotilla").list().await.expect("list convoy replicas");
+            let vessels = kiwi.resource_backend().including_replicas::<Vessel>("flotilla").list().await.expect("list vessel replicas");
+            let sessions =
+                kiwi.resource_backend().including_replicas::<TerminalSession>("flotilla").list().await.expect("list session replicas");
+            if convoys.items.len() == 1 && vessels.items.len() == 1 && sessions.items.len() == 1 {
+                assert!(matches!(convoys.items[0].provenance, ResourceProvenance::Replica { .. }));
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replication timed out");
+    assert!(
+        kiwi.resource_backend().using::<Convoy>("flotilla").list().await.expect("list local convoys").items.is_empty(),
+        "default resource reads must remain local-only"
+    );
+
+    remote.using::<Convoy>("flotilla").delete("remote-convoy").await.expect("delete remote convoy");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if kiwi
+                .resource_backend()
+                .including_replicas::<Convoy>("flotilla")
+                .list()
+                .await
+                .expect("list convoy replicas after delete")
+                .items
+                .is_empty()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replicated delete timed out");
+
+    remote
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("last-known-convoy".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create last-known remote convoy");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if kiwi
+                .resource_backend()
+                .including_replicas::<Convoy>("flotilla")
+                .list()
+                .await
+                .expect("list last-known convoy")
+                .items
+                .iter()
+                .any(|item| item.object.metadata.name == "last-known-convoy")
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("last-known replication timed out");
+
+    drop(topology);
+    let disconnected = kiwi.resource_backend().including_replicas::<Convoy>("flotilla").list().await.expect("list disconnected replicas");
+    assert!(
+        disconnected.items.iter().any(|item| item.object.metadata.name == "last-known-convoy"),
+        "origin absence must not remove last-known replica rows"
+    );
+}

--- a/crates/flotilla-daemon/tests/peer_connect_flow.rs
+++ b/crates/flotilla-daemon/tests/peer_connect_flow.rs
@@ -53,22 +53,27 @@ impl PeerSender for NotifyPeerSender {
     }
 }
 
-/// Wait until the captured message count reaches `target`, or timeout.
-async fn wait_for_messages(sent: &Arc<StdMutex<Vec<PeerWireMessage>>>, notify: &Notify, target: usize) {
+async fn wait_for_local_state(sent: &Arc<StdMutex<Vec<PeerWireMessage>>>, notify: &Notify, node_id: &NodeId) {
     tokio::time::timeout(std::time::Duration::from_secs(5), async {
         loop {
-            // Register interest BEFORE checking the condition so a
-            // notify_waiters() that fires between the check and the
-            // await is not lost.
             let notified = notify.notified();
-            if sent.lock().expect("lock").len() >= target {
+            let complete = {
+                let messages = sent.lock().expect("lock");
+                messages.iter().any(|message| matches!(message, PeerWireMessage::HostSummary(summary) if summary.node.node_id == *node_id))
+                    && messages.iter().any(|message| matches!(message, PeerWireMessage::Data(data) if data.origin_node_id == *node_id))
+            };
+            if complete {
                 return;
             }
             notified.await;
         }
     })
     .await
-    .expect("timed out waiting for peer messages");
+    .expect("timed out waiting for local peer state");
+}
+
+fn local_data_count(messages: &[PeerWireMessage], node_id: &NodeId) -> usize {
+    messages.iter().filter(|message| matches!(message, PeerWireMessage::Data(data) if data.origin_node_id == *node_id)).count()
 }
 
 #[tokio::test]
@@ -98,8 +103,7 @@ async fn peer_connect_triggers_local_state_send() {
 
     peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation }).expect("send notice");
 
-    // Expect at least 2 messages: HostSummary + Data for the repo
-    wait_for_messages(&sent, &notify, 2).await;
+    wait_for_local_state(&sent, &notify, &node_a).await;
 
     let messages = sent.lock().expect("lock");
     assert!(
@@ -139,9 +143,10 @@ async fn peer_reconnect_resends_local_state() {
 
     // First connection
     peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation: gen1 }).expect("send notice 1");
-    wait_for_messages(&sent, &notify, 2).await;
+    wait_for_local_state(&sent, &notify, &node_a).await;
 
     let first_count = sent.lock().expect("lock").len();
+    let first_data_count = local_data_count(&sent.lock().expect("lock"), &node_a);
     assert!(first_count > 0, "first connect should have sent messages");
 
     // Disconnect + reconnect
@@ -151,9 +156,18 @@ async fn peer_reconnect_resends_local_state() {
         ensure_test_connection_generation(&mut pm, &node_b, || Arc::clone(&sender))
     };
 
-    // Second connection — expect at least first_count + 2 more messages
     peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation: gen2 }).expect("send notice 2");
-    wait_for_messages(&sent, &notify, first_count + 2).await;
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let notified = notify.notified();
+            if local_data_count(&sent.lock().expect("lock"), &node_a) > first_data_count {
+                break;
+            }
+            notified.await;
+        }
+    })
+    .await
+    .expect("timed out waiting for reconnect local state");
 
     let total_count = sent.lock().expect("lock").len();
     assert!(total_count > first_count, "reconnect should resend local state (first: {first_count}, total: {total_count})");

--- a/crates/flotilla-daemon/tests/peer_connect_flow.rs
+++ b/crates/flotilla-daemon/tests/peer_connect_flow.rs
@@ -101,7 +101,7 @@ async fn peer_connect_triggers_local_state_send() {
 
     let (_handle, peer_connected_tx) = flotilla_daemon::server::spawn_test_peer_networking(Arc::clone(&daemon), Arc::clone(&peer_manager));
 
-    peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation }).expect("send notice");
+    peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation, resource_socket_path: None }).expect("send notice");
 
     wait_for_local_state(&sent, &notify, &node_a).await;
 
@@ -142,7 +142,9 @@ async fn peer_reconnect_resends_local_state() {
     let (_handle, peer_connected_tx) = flotilla_daemon::server::spawn_test_peer_networking(Arc::clone(&daemon), Arc::clone(&peer_manager));
 
     // First connection
-    peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation: gen1 }).expect("send notice 1");
+    peer_connected_tx
+        .send(PeerConnectedNotice { peer: node_b.clone(), generation: gen1, resource_socket_path: None })
+        .expect("send notice 1");
     wait_for_local_state(&sent, &notify, &node_a).await;
 
     let first_count = sent.lock().expect("lock").len();
@@ -156,7 +158,9 @@ async fn peer_reconnect_resends_local_state() {
         ensure_test_connection_generation(&mut pm, &node_b, || Arc::clone(&sender))
     };
 
-    peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation: gen2 }).expect("send notice 2");
+    peer_connected_tx
+        .send(PeerConnectedNotice { peer: node_b.clone(), generation: gen2, resource_socket_path: None })
+        .expect("send notice 2");
     tokio::time::timeout(std::time::Duration::from_secs(5), async {
         loop {
             let notified = notify.notified();

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -59,7 +59,17 @@ pub struct ResourceWatchResponse {
     pub kind: String,
     pub plural: String,
     pub namespace: String,
+    pub resource_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
     pub event: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceWatchCursor {
+    pub resource_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
 }
 
 /// Structured resolved attach command for a workspace pane.
@@ -371,6 +381,8 @@ pub enum CommandAction {
     QueryResourceList {
         namespace: String,
         kind: String,
+        #[serde(default, skip_serializing_if = "is_false")]
+        include_replicas: bool,
     },
     QueryResourceGet {
         namespace: String,
@@ -384,6 +396,10 @@ pub enum CommandAction {
     ResourceWatch {
         namespace: String,
         kind: String,
+        #[serde(default, skip_serializing_if = "is_false")]
+        include_replicas: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cursor: Option<ResourceWatchCursor>,
     },
 }
 
@@ -914,7 +930,7 @@ mod tests {
                 node_id: Some(NodeId::new("feta")),
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::QueryResourceList { namespace: "flotilla".into(), kind: "convoys".into() },
+                action: CommandAction::QueryResourceList { namespace: "flotilla".into(), kind: "convoys".into(), include_replicas: false },
             },
             Command {
                 node_id: Some(NodeId::new("feta")),
@@ -930,7 +946,12 @@ mod tests {
                 node_id: Some(NodeId::new("feta")),
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::ResourceWatch { namespace: "flotilla".into(), kind: "convoys".into() },
+                action: CommandAction::ResourceWatch {
+                    namespace: "flotilla".into(),
+                    kind: "convoys".into(),
+                    include_replicas: false,
+                    cursor: None,
+                },
             },
             Command {
                 node_id: None,
@@ -1196,6 +1217,8 @@ mod tests {
                 kind: "Convoy".into(),
                 plural: "convoys".into(),
                 namespace: "flotilla".into(),
+                resource_version: "7".into(),
+                generation: None,
                 event: serde_json::json!({
                     "type": "ADDED",
                     "object": { "apiVersion": "flotilla.work/v1", "kind": "Convoy", "metadata": { "name": "demo" }, "spec": {} }

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -109,7 +109,7 @@ pub(crate) mod test_helpers {
 pub use commands::{
     AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyStartIntent,
     IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand,
-    ResourceJsonResponse, ResourceWatchResponse, StepStatus,
+    ResourceJsonResponse, ResourceWatchCursor, ResourceWatchResponse, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -68,13 +68,16 @@ pub struct ReplicaReadResolver<T: Resource> {
 impl<T: Resource> ReplicaReadResolver<T> {
     pub async fn list(&self) -> Result<ReadResourceList<T>, ResourceError> {
         ensure_replication_enabled::<T>()?;
+        if let ResourceBackend::Http(backend) = &self.backend {
+            return backend.list_including_replicas_typed::<T>(&self.namespace).await;
+        }
         let local = self.backend.using::<T>(&self.namespace).list().await?;
         let mut items =
             local.items.into_iter().map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local }).collect::<Vec<_>>();
         let replicas = match &self.backend {
             ResourceBackend::InMemory(backend) => backend.list_replicas_typed::<T>(&self.namespace).await?,
             ResourceBackend::Sqlite(backend) => backend.list_replicas_typed::<T>(&self.namespace).await?,
-            ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP replica read views are not available on this client")),
+            ResourceBackend::Http(_) => unreachable!("HTTP handled above"),
         };
         items.extend(replicas);
         items.sort_by(|left, right| {
@@ -93,10 +96,13 @@ impl<T: Resource> ReplicaReadResolver<T> {
 
     pub async fn watch(&self) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
         ensure_replication_enabled::<T>()?;
+        if let ResourceBackend::Http(backend) = &self.backend {
+            return backend.watch_including_replicas_typed::<T>(&self.namespace).await;
+        }
         let replicas = match &self.backend {
             ResourceBackend::InMemory(backend) => backend.watch_replicas_typed::<T>(&self.namespace).await?,
             ResourceBackend::Sqlite(backend) => backend.watch_replicas_typed::<T>(&self.namespace).await?,
-            ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP replica read views are not available on this client")),
+            ResourceBackend::Http(_) => unreachable!("HTTP handled above"),
         };
         let local = self.backend.using::<T>(&self.namespace).watch(WatchStart::Now).await?.map(|event| event.map(ReadWatchEvent::local));
         Ok(stream::select(local, replicas).boxed())

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -1,9 +1,14 @@
 use std::{collections::BTreeMap, marker::PhantomData};
 
+use chrono::{DateTime, Utc};
+use flotilla_protocol::NodeId;
+use futures::{stream, StreamExt};
+
 use crate::{
     error::ResourceError,
     http::HttpBackend,
     in_memory::InMemoryBackend,
+    replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEventKind},
     resource::{InputMeta, Resource, ResourceObject},
     retention::ResourceStoreDiagnostics,
     sqlite::SqliteBackend,
@@ -32,12 +37,125 @@ impl ResourceBackend {
         TypedResolver { backend: self.clone(), namespace: namespace.to_string(), _marker: PhantomData }
     }
 
+    /// A read-only union of locally-authored objects and durable replicas.
+    ///
+    /// This deliberately returns a different resolver type with no mutation
+    /// methods, so controllers cannot accidentally reconcile replica rows.
+    pub fn including_replicas<T: Resource>(&self, namespace: &str) -> ReplicaReadResolver<T> {
+        ReplicaReadResolver { backend: self.clone(), namespace: namespace.to_string(), _marker: PhantomData }
+    }
+
+    pub fn replica_writer<T: Resource>(&self, origin_root: NodeId, namespace: &str) -> ReplicaWriter<T> {
+        ReplicaWriter { backend: self.clone(), origin_root, namespace: namespace.to_string(), _marker: PhantomData }
+    }
+
     pub async fn diagnostics(&self) -> Result<Option<ResourceStoreDiagnostics>, ResourceError> {
         match self {
             Self::InMemory(backend) => backend.diagnostics().await.map(Some),
             Self::Http(_) => Ok(None),
             Self::Sqlite(backend) => backend.diagnostics().await.map(Some),
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReplicaReadResolver<T: Resource> {
+    backend: ResourceBackend,
+    namespace: String,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Resource> ReplicaReadResolver<T> {
+    pub async fn list(&self) -> Result<ReadResourceList<T>, ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        let local = self.backend.using::<T>(&self.namespace).list().await?;
+        let mut items =
+            local.items.into_iter().map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local }).collect::<Vec<_>>();
+        let replicas = match &self.backend {
+            ResourceBackend::InMemory(backend) => backend.list_replicas_typed::<T>(&self.namespace).await?,
+            ResourceBackend::Sqlite(backend) => backend.list_replicas_typed::<T>(&self.namespace).await?,
+            ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP replica read views are not available on this client")),
+        };
+        items.extend(replicas);
+        items.sort_by(|left, right| {
+            left.object.metadata.name.cmp(&right.object.metadata.name).then_with(|| match (&left.provenance, &right.provenance) {
+                (ResourceProvenance::Local, ResourceProvenance::Local) => std::cmp::Ordering::Equal,
+                (ResourceProvenance::Local, ResourceProvenance::Replica { .. }) => std::cmp::Ordering::Less,
+                (ResourceProvenance::Replica { .. }, ResourceProvenance::Local) => std::cmp::Ordering::Greater,
+                (
+                    ResourceProvenance::Replica { origin_root: left_origin, .. },
+                    ResourceProvenance::Replica { origin_root: right_origin, .. },
+                ) => left_origin.cmp(right_origin),
+            })
+        });
+        Ok(ReadResourceList { items })
+    }
+
+    pub async fn watch(&self) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        let replicas = match &self.backend {
+            ResourceBackend::InMemory(backend) => backend.watch_replicas_typed::<T>(&self.namespace).await?,
+            ResourceBackend::Sqlite(backend) => backend.watch_replicas_typed::<T>(&self.namespace).await?,
+            ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP replica read views are not available on this client")),
+        };
+        let local = self.backend.using::<T>(&self.namespace).watch(WatchStart::Now).await?.map(|event| event.map(ReadWatchEvent::local));
+        Ok(stream::select(local, replicas).boxed())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReplicaWriter<T: Resource> {
+    backend: ResourceBackend,
+    origin_root: NodeId,
+    namespace: String,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Resource> ReplicaWriter<T> {
+    pub async fn replace(&self, listed: &ResourceList<T>, synced_at: DateTime<Utc>) -> Result<(), ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        match &self.backend {
+            ResourceBackend::InMemory(backend) => {
+                backend.replace_replicas_typed(&self.origin_root, &self.namespace, listed, synced_at).await
+            }
+            ResourceBackend::Sqlite(backend) => backend.replace_replicas_typed(&self.origin_root, &self.namespace, listed, synced_at).await,
+            ResourceBackend::Http(_) => Err(ResourceError::invalid("HTTP backends cannot hold replicas")),
+        }
+    }
+
+    pub async fn apply(&self, event: crate::WatchEvent<T>, synced_at: DateTime<Utc>) -> Result<(), ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        let (kind, object) = match event {
+            crate::WatchEvent::Added(object) => (StoredReplicaEventKind::Added, object),
+            crate::WatchEvent::Modified(object) => (StoredReplicaEventKind::Modified, object),
+            crate::WatchEvent::Deleted(object) => (StoredReplicaEventKind::Deleted, object),
+        };
+        match &self.backend {
+            ResourceBackend::InMemory(backend) => {
+                backend.apply_replica_typed(&self.origin_root, &self.namespace, kind, &object, synced_at).await
+            }
+            ResourceBackend::Sqlite(backend) => {
+                backend.apply_replica_typed(&self.origin_root, &self.namespace, kind, &object, synced_at).await
+            }
+            ResourceBackend::Http(_) => Err(ResourceError::invalid("HTTP backends cannot hold replicas")),
+        }
+    }
+
+    pub async fn cursor(&self) -> Result<Option<ReplicaCursor>, ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        match &self.backend {
+            ResourceBackend::InMemory(backend) => backend.replica_cursor_typed::<T>(&self.origin_root, &self.namespace).await,
+            ResourceBackend::Sqlite(backend) => backend.replica_cursor_typed::<T>(&self.origin_root, &self.namespace).await,
+            ResourceBackend::Http(_) => Err(ResourceError::invalid("HTTP backends cannot hold replicas")),
+        }
+    }
+}
+
+fn ensure_replication_enabled<T: Resource>() -> Result<(), ResourceError> {
+    if T::REPLICATION_CLASS == crate::ReplicationClass::HomeBoundRuntime {
+        Ok(())
+    } else {
+        Err(ResourceError::invalid(format!("{} is not enabled for overlay replication", T::API_PATHS.kind)))
     }
 }
 

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -109,11 +109,13 @@ impl<T: Resource> ReplicaReadResolver<T> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, bon::Builder)]
+#[builder(builder_type(vis = "pub(in crate::backend)"))]
 pub struct ReplicaWriter<T: Resource> {
     backend: ResourceBackend,
     origin_root: NodeId,
     namespace: String,
+    #[builder(skip)]
     _marker: PhantomData<T>,
 }
 

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -4,13 +4,23 @@ use chrono::{DateTime, Utc};
 use flotilla_protocol::{IssueRef, IssueState, PrincipalRef};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement, RepositoryKey};
+use crate::{status_patch::StatusPatch, workflow_template::VesselRequirement, ApiPaths, ReplicationClass, RepositoryKey, Resource};
 
 mod reconcile;
 
 pub use reconcile::{reconcile, ConvoyEvent, ConvoyReconciler, ReconcileOutcome};
 
-define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Convoy;
+
+impl Resource for Convoy {
+    type Spec = ConvoySpec;
+    type Status = ConvoyStatus;
+    type StatusPatch = ConvoyStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "convoys", kind: "Convoy" };
+    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoySpec {

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -4,23 +4,13 @@ use chrono::{DateTime, Utc};
 use flotilla_protocol::{IssueRef, IssueState, PrincipalRef};
 use serde::{Deserialize, Serialize};
 
-use crate::{status_patch::StatusPatch, workflow_template::VesselRequirement, ApiPaths, ReplicationClass, RepositoryKey, Resource};
+use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement, ReplicationClass, RepositoryKey};
 
 mod reconcile;
 
 pub use reconcile::{reconcile, ConvoyEvent, ConvoyReconciler, ReconcileOutcome};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Convoy;
-
-impl Resource for Convoy {
-    type Spec = ConvoySpec;
-    type Status = ConvoyStatus;
-    type StatusPatch = ConvoyStatusPatch;
-
-    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "convoys", kind: "Convoy" };
-    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
-}
+define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoySpec {

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -11,6 +11,9 @@ use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::{
     error::ResourceError,
+    replica::{
+        ReadResourceList, ReadResourceObject, ReadWatchEvent, ResourceProvenance, LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION,
+    },
     resource::{
         ApiPaths, InputMeta, K8sInputResourceObject, K8sResourceList, K8sResourceObject, K8sStatusResourceObject, K8sWatchEvent, Resource,
         ResourceObject,
@@ -31,6 +34,15 @@ impl HttpBackend {
 
     pub fn from_kubeconfig(path: impl AsRef<std::path::Path>) -> Result<Self, ResourceError> {
         kubeconfig::from_kubeconfig(path)
+    }
+
+    #[cfg(unix)]
+    pub fn from_unix_socket(path: impl AsRef<std::path::Path>) -> Result<Self, ResourceError> {
+        let http = Client::builder()
+            .unix_socket(path.as_ref())
+            .build()
+            .map_err(|error| ResourceError::other(format!("build Unix-socket HTTP client: {error}")))?;
+        Ok(Self::new(http, "http://flotilla.local"))
     }
 
     fn namespaced_url(&self, paths: ApiPaths, namespace: &str, name: Option<&str>, status: bool) -> String {
@@ -82,6 +94,55 @@ impl HttpBackend {
         let response = self.http.get(url).send().await.map_err(|err| ResourceError::other(format!("LIST resources: {err}")))?;
         let list: K8sResourceList<T> = Self::decode_response(response, None).await?;
         list.into_resource_list()
+    }
+
+    pub(crate) async fn list_including_replicas_typed<T: Resource>(&self, namespace: &str) -> Result<ReadResourceList<T>, ResourceError> {
+        let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
+        let response = self
+            .http
+            .get(url)
+            .query(&[("includeReplicas", "true")])
+            .send()
+            .await
+            .map_err(|err| ResourceError::other(format!("LIST resources including replicas: {err}")))?;
+        let list: K8sResourceList<T> = Self::decode_response(response, None).await?;
+        let items = list
+            .items
+            .into_iter()
+            .map(ResourceObject::from_k8s_object)
+            .map(|object| object.and_then(read_resource_object))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ReadResourceList { items })
+    }
+
+    pub(crate) async fn watch_including_replicas_typed<T: Resource>(
+        &self,
+        namespace: &str,
+    ) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
+        let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
+        let response = self
+            .http
+            .get(url)
+            .query(&[("watch", "true"), ("includeReplicas", "true")])
+            .send()
+            .await
+            .map_err(|err| ResourceError::other(format!("WATCH resources including replicas: {err}")))?;
+        let status = response.status();
+        if !status.is_success() {
+            let bytes = response.bytes().await.map_err(|err| ResourceError::other(format!("read watch error body: {err}")))?;
+            return Err(map_status_error(status, &bytes, None));
+        }
+        let state = HttpWatchState::<T> {
+            stream: Box::pin(response.bytes_stream()),
+            buffer: Vec::new(),
+            done: false,
+            _marker: std::marker::PhantomData,
+        };
+        Ok(stream::unfold(state, |mut state| async move {
+            let event = next_http_watch_event(&mut state).await?;
+            Some((event.and_then(read_watch_event), state))
+        })
+        .boxed())
     }
 
     pub(crate) async fn list_typed_matching_labels<T: Resource>(
@@ -161,8 +222,9 @@ impl HttpBackend {
         match &start {
             WatchStart::Now => {}
             WatchStart::FromVersion(version) => query.push(("resourceVersion", Cow::Owned(version.clone()))),
-            WatchStart::FromVersionInGeneration { .. } => {
-                return Err(ResourceError::invalid("http resource watches do not use generations"));
+            WatchStart::FromVersionInGeneration { generation, resource_version } => {
+                query.push(("resourceVersion", Cow::Owned(resource_version.clone())));
+                query.push(("generation", Cow::Owned(generation.clone())));
             }
         }
         let response =
@@ -170,9 +232,12 @@ impl HttpBackend {
         let status = response.status();
         if !status.is_success() {
             if status == StatusCode::GONE {
-                if let WatchStart::FromVersion(requested_version) = start {
-                    return Err(ResourceError::WatchExpired { requested_version, compacted_through: None });
-                }
+                let requested_version = match start {
+                    WatchStart::FromVersion(requested_version)
+                    | WatchStart::FromVersionInGeneration { resource_version: requested_version, .. } => requested_version,
+                    WatchStart::Now => String::new(),
+                };
+                return Err(ResourceError::WatchExpired { requested_version, compacted_through: None });
             }
             let bytes = response.bytes().await.map_err(|err| ResourceError::other(format!("read watch error body: {err}")))?;
             return Err(map_status_error(status, &bytes, None));
@@ -184,49 +249,15 @@ impl HttpBackend {
             done: false,
             _marker: std::marker::PhantomData,
         };
+        let generation = match start {
+            WatchStart::FromVersionInGeneration { generation, .. } => Some(generation),
+            _ => None,
+        };
         Ok(WatchStream::new(
-            None,
+            generation,
             Box::pin(stream::unfold(state, |mut state| async move {
-                if state.done {
-                    return None;
-                }
-                loop {
-                    if let Some(position) = state.buffer.iter().position(|byte| *byte == b'\n') {
-                        let line = state.buffer.drain(..=position).collect::<Vec<_>>();
-                        let mut line = &line[..line.len().saturating_sub(1)];
-                        if line.last() == Some(&b'\r') {
-                            line = &line[..line.len().saturating_sub(1)];
-                        }
-                        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
-                            continue;
-                        }
-                        let item = parse_watch_line::<T>(line);
-                        if item.is_err() {
-                            state.done = true;
-                        }
-                        return Some((item, state));
-                    }
-
-                    match state.stream.next().await {
-                        Some(Ok(chunk)) => state.buffer.extend_from_slice(&chunk),
-                        Some(Err(err)) => {
-                            state.done = true;
-                            return Some((Err(ResourceError::other(format!("watch stream error: {err}"))), state));
-                        }
-                        None if state.buffer.is_empty() => return None,
-                        None => {
-                            let line = std::mem::take(&mut state.buffer);
-                            if line.iter().all(|byte| byte.is_ascii_whitespace()) {
-                                return None;
-                            }
-                            let item = parse_watch_line::<T>(&line);
-                            if item.is_err() {
-                                state.done = true;
-                            }
-                            return Some((item, state));
-                        }
-                    }
-                }
+                let event = next_http_watch_event(&mut state).await?;
+                Some((event, state))
             })),
         ))
     }
@@ -237,6 +268,73 @@ struct HttpWatchState<T: Resource> {
     buffer: Vec<u8>,
     done: bool,
     _marker: std::marker::PhantomData<T>,
+}
+
+async fn next_http_watch_event<T: Resource>(state: &mut HttpWatchState<T>) -> Option<Result<WatchEvent<T>, ResourceError>> {
+    if state.done {
+        return None;
+    }
+    loop {
+        if let Some(position) = state.buffer.iter().position(|byte| *byte == b'\n') {
+            let line = state.buffer.drain(..=position).collect::<Vec<_>>();
+            let mut line = &line[..line.len().saturating_sub(1)];
+            if line.last() == Some(&b'\r') {
+                line = &line[..line.len().saturating_sub(1)];
+            }
+            if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+                continue;
+            }
+            let item = parse_watch_line::<T>(line);
+            if item.is_err() {
+                state.done = true;
+            }
+            return Some(item);
+        }
+
+        match state.stream.next().await {
+            Some(Ok(chunk)) => state.buffer.extend_from_slice(&chunk),
+            Some(Err(err)) => {
+                state.done = true;
+                return Some(Err(ResourceError::other(format!("watch stream error: {err}"))));
+            }
+            None if state.buffer.is_empty() => return None,
+            None => {
+                let line = std::mem::take(&mut state.buffer);
+                if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+                    return None;
+                }
+                let item = parse_watch_line::<T>(&line);
+                if item.is_err() {
+                    state.done = true;
+                }
+                return Some(item);
+            }
+        }
+    }
+}
+
+fn read_resource_object<T: Resource>(object: ResourceObject<T>) -> Result<ReadResourceObject<T>, ResourceError> {
+    let origin = object.metadata.annotations.get(ORIGIN_ROOT_ANNOTATION);
+    let synced_at = object.metadata.annotations.get(LAST_SYNCED_AT_ANNOTATION);
+    let provenance = match (origin, synced_at) {
+        (None, None) => ResourceProvenance::Local,
+        (Some(origin), Some(synced_at)) => ResourceProvenance::Replica {
+            origin_root: flotilla_protocol::NodeId::new(origin.clone()),
+            last_synced_at: chrono::DateTime::parse_from_rfc3339(synced_at)
+                .map_err(|error| ResourceError::decode(format!("decode replica sync timestamp: {error}")))?
+                .with_timezone(&chrono::Utc),
+        },
+        _ => return Err(ResourceError::decode("replica provenance annotations are incomplete")),
+    };
+    Ok(ReadResourceObject { object, provenance })
+}
+
+fn read_watch_event<T: Resource>(event: WatchEvent<T>) -> Result<ReadWatchEvent<T>, ResourceError> {
+    match event {
+        WatchEvent::Added(object) => read_resource_object(object).map(ReadWatchEvent::Added),
+        WatchEvent::Modified(object) => read_resource_object(object).map(ReadWatchEvent::Modified),
+        WatchEvent::Deleted(object) => read_resource_object(object).map(ReadWatchEvent::Deleted),
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -38,8 +38,8 @@ struct ReplicaState {
 #[derive(Debug, Default)]
 struct ReplicaPartition {
     objects: HashMap<String, Value>,
+    synced_at_by_name: HashMap<String, chrono::DateTime<Utc>>,
     cursor: Option<ReplicaCursor>,
-    synced_at: Option<chrono::DateTime<Utc>>,
 }
 
 #[derive(Debug)]
@@ -178,12 +178,14 @@ impl InMemoryBackend {
             if partition_key != &key {
                 continue;
             }
-            let Some(last_synced_at) = partition.synced_at else {
-                continue;
-            };
-            for value in partition.objects.values().cloned() {
+            for (name, value) in &partition.objects {
+                let last_synced_at = partition
+                    .synced_at_by_name
+                    .get(name)
+                    .copied()
+                    .ok_or_else(|| ResourceError::other(format!("replica row '{name}' has no sync timestamp")))?;
                 items.push(ReadResourceObject {
-                    object: Self::decode_object(value)?,
+                    object: Self::decode_object(value.clone())?,
                     provenance: ResourceProvenance::Replica { origin_root: origin_root.clone(), last_synced_at },
                 });
             }
@@ -228,8 +230,10 @@ impl InMemoryBackend {
         let mut state = self.replicas.lock().await;
         let old = state.partitions.remove(&replica_key).unwrap_or_default();
         let mut objects = HashMap::new();
+        let mut synced_at_by_name = HashMap::new();
         for object in &listed.items {
             objects.insert(object.metadata.name.clone(), Self::encode_object(object)?);
+            synced_at_by_name.insert(object.metadata.name.clone(), synced_at);
         }
         let mut events = Vec::new();
         for (name, value) in &objects {
@@ -252,8 +256,8 @@ impl InMemoryBackend {
         }
         state.partitions.insert(replica_key, ReplicaPartition {
             objects,
+            synced_at_by_name,
             cursor: Some(ReplicaCursor { resource_version: listed.resource_version.clone(), generation: listed.generation.clone() }),
-            synced_at: Some(synced_at),
         });
         for event in events {
             Self::notify_replica_watchers(&mut state, &store_key, event);
@@ -277,12 +281,13 @@ impl InMemoryBackend {
         match kind {
             StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
                 partition.objects.insert(object.metadata.name.clone(), encoded.clone());
+                partition.synced_at_by_name.insert(object.metadata.name.clone(), synced_at);
             }
             StoredReplicaEventKind::Deleted => {
                 partition.objects.remove(&object.metadata.name);
+                partition.synced_at_by_name.remove(&object.metadata.name);
             }
         }
-        partition.synced_at = Some(synced_at);
         partition.cursor = Some(ReplicaCursor {
             resource_version: object.metadata.resource_version.clone(),
             generation: partition.cursor.as_ref().and_then(|cursor| cursor.generation.clone()),

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -4,12 +4,14 @@ use std::{
 };
 
 use chrono::Utc;
+use flotilla_protocol::NodeId;
 use futures::{stream, StreamExt};
 use serde_json::Value;
 use tokio::sync::{mpsc, Mutex};
 
 use crate::{
     error::ResourceError,
+    replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
     resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
     retention::{EventRetention, ResourceStoreDiagnostics},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
@@ -20,8 +22,24 @@ type StoreKey = (String, String, String, String);
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryBackend {
     stores: Arc<Mutex<HashMap<StoreKey, ResourceStore>>>,
+    replicas: Arc<Mutex<ReplicaState>>,
     generation: Option<String>,
     event_retention: EventRetention,
+}
+
+type ReplicaKey = (NodeId, StoreKey);
+
+#[derive(Debug, Default)]
+struct ReplicaState {
+    partitions: HashMap<ReplicaKey, ReplicaPartition>,
+    watchers: HashMap<StoreKey, Vec<mpsc::UnboundedSender<StoredReplicaEvent>>>,
+}
+
+#[derive(Debug, Default)]
+struct ReplicaPartition {
+    objects: HashMap<String, Value>,
+    cursor: Option<ReplicaCursor>,
+    synced_at: Option<chrono::DateTime<Utc>>,
 }
 
 #[derive(Debug)]
@@ -79,15 +97,20 @@ impl Default for ResourceStore {
 
 impl InMemoryBackend {
     pub fn observed() -> Self {
-        Self { stores: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()), event_retention: EventRetention::default() }
+        Self {
+            stores: Arc::default(),
+            replicas: Arc::default(),
+            generation: Some(uuid::Uuid::new_v4().to_string()),
+            event_retention: EventRetention::default(),
+        }
     }
 
     pub fn with_event_retention(event_retention: EventRetention) -> Self {
-        Self { stores: Arc::default(), generation: None, event_retention }
+        Self { stores: Arc::default(), replicas: Arc::default(), generation: None, event_retention }
     }
 
     pub fn observed_with_event_retention(event_retention: EventRetention) -> Self {
-        Self { stores: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()), event_retention }
+        Self { stores: Arc::default(), replicas: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()), event_retention }
     }
 
     pub(crate) async fn diagnostics(&self) -> Result<ResourceStoreDiagnostics, ResourceError> {
@@ -139,6 +162,147 @@ impl InMemoryBackend {
 
     fn encode_object<T: Resource>(object: &ResourceObject<T>) -> Result<Value, ResourceError> {
         serde_json::to_value(object.to_k8s_object()).map_err(|err| ResourceError::decode(format!("encode object: {err}")))
+    }
+
+    fn notify_replica_watchers(state: &mut ReplicaState, key: &StoreKey, event: StoredReplicaEvent) {
+        if let Some(watchers) = state.watchers.get_mut(key) {
+            watchers.retain(|watcher| watcher.send(event.clone()).is_ok());
+        }
+    }
+
+    pub(crate) async fn list_replicas_typed<T: Resource>(&self, namespace: &str) -> Result<Vec<ReadResourceObject<T>>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let replicas = self.replicas.lock().await;
+        let mut items = Vec::new();
+        for ((origin_root, partition_key), partition) in &replicas.partitions {
+            if partition_key != &key {
+                continue;
+            }
+            let Some(last_synced_at) = partition.synced_at else {
+                continue;
+            };
+            for value in partition.objects.values().cloned() {
+                items.push(ReadResourceObject {
+                    object: Self::decode_object(value)?,
+                    provenance: ResourceProvenance::Replica { origin_root: origin_root.clone(), last_synced_at },
+                });
+            }
+        }
+        Ok(items)
+    }
+
+    pub(crate) async fn watch_replicas_typed<T: Resource>(
+        &self,
+        namespace: &str,
+    ) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.replicas.lock().await.watchers.entry(key).or_default().push(tx);
+        Ok(stream::unfold(rx, |mut rx| async {
+            let event = rx.recv().await?;
+            let decoded = Self::decode_object::<T>(event.object).map(|object| {
+                let object = ReadResourceObject {
+                    object,
+                    provenance: ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at },
+                };
+                match event.kind {
+                    StoredReplicaEventKind::Added => ReadWatchEvent::Added(object),
+                    StoredReplicaEventKind::Modified => ReadWatchEvent::Modified(object),
+                    StoredReplicaEventKind::Deleted => ReadWatchEvent::Deleted(object),
+                }
+            });
+            Some((decoded, rx))
+        })
+        .boxed())
+    }
+
+    pub(crate) async fn replace_replicas_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+        listed: &ResourceList<T>,
+        synced_at: chrono::DateTime<Utc>,
+    ) -> Result<(), ResourceError> {
+        let store_key = Self::store_key::<T>(namespace);
+        let replica_key = (origin_root.clone(), store_key.clone());
+        let mut state = self.replicas.lock().await;
+        let old = state.partitions.remove(&replica_key).unwrap_or_default();
+        let mut objects = HashMap::new();
+        for object in &listed.items {
+            objects.insert(object.metadata.name.clone(), Self::encode_object(object)?);
+        }
+        let mut events = Vec::new();
+        for (name, value) in &objects {
+            events.push(StoredReplicaEvent {
+                origin_root: origin_root.clone(),
+                synced_at,
+                kind: if old.objects.contains_key(name) { StoredReplicaEventKind::Modified } else { StoredReplicaEventKind::Added },
+                object: value.clone(),
+            });
+        }
+        for (name, value) in old.objects {
+            if !objects.contains_key(&name) {
+                events.push(StoredReplicaEvent {
+                    origin_root: origin_root.clone(),
+                    synced_at,
+                    kind: StoredReplicaEventKind::Deleted,
+                    object: value,
+                });
+            }
+        }
+        state.partitions.insert(replica_key, ReplicaPartition {
+            objects,
+            cursor: Some(ReplicaCursor { resource_version: listed.resource_version.clone(), generation: listed.generation.clone() }),
+            synced_at: Some(synced_at),
+        });
+        for event in events {
+            Self::notify_replica_watchers(&mut state, &store_key, event);
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn apply_replica_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+        kind: StoredReplicaEventKind,
+        object: &ResourceObject<T>,
+        synced_at: chrono::DateTime<Utc>,
+    ) -> Result<(), ResourceError> {
+        let store_key = Self::store_key::<T>(namespace);
+        let replica_key = (origin_root.clone(), store_key.clone());
+        let encoded = Self::encode_object(object)?;
+        let mut state = self.replicas.lock().await;
+        let partition = state.partitions.entry(replica_key).or_default();
+        match kind {
+            StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
+                partition.objects.insert(object.metadata.name.clone(), encoded.clone());
+            }
+            StoredReplicaEventKind::Deleted => {
+                partition.objects.remove(&object.metadata.name);
+            }
+        }
+        partition.synced_at = Some(synced_at);
+        partition.cursor = Some(ReplicaCursor {
+            resource_version: object.metadata.resource_version.clone(),
+            generation: partition.cursor.as_ref().and_then(|cursor| cursor.generation.clone()),
+        });
+        Self::notify_replica_watchers(&mut state, &store_key, StoredReplicaEvent {
+            origin_root: origin_root.clone(),
+            synced_at,
+            kind,
+            object: encoded,
+        });
+        Ok(())
+    }
+
+    pub(crate) async fn replica_cursor_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+    ) -> Result<Option<ReplicaCursor>, ResourceError> {
+        let key = (origin_root.clone(), Self::store_key::<T>(namespace));
+        Ok(self.replicas.lock().await.partitions.get(&key).and_then(|partition| partition.cursor.clone()))
     }
 
     fn decode_event<T: Resource>(event: StoredEvent) -> Result<WatchEvent<T>, ResourceError> {

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -19,7 +19,8 @@ use crate::{
 
 type StoreKey = (String, String, String, String);
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, bon::Builder)]
+#[builder(builder_type(vis = "pub(in crate::in_memory)"))]
 pub struct InMemoryBackend {
     stores: Arc<Mutex<HashMap<StoreKey, ResourceStore>>>,
     replicas: Arc<Mutex<ReplicaState>>,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -15,6 +15,7 @@ mod principal_attention;
 mod project;
 mod provisioning_identity;
 mod registry;
+mod replica;
 mod repository;
 mod resource;
 mod retention;
@@ -25,7 +26,7 @@ mod vessel;
 mod watch;
 mod workflow_template;
 
-pub use backend::{ResourceBackend, TypedResolver};
+pub use backend::{ReplicaReadResolver, ReplicaWriter, ResourceBackend, TypedResolver};
 pub use checkout::{
     Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch,
     CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec, IntegrationCondition, LandedEvidence, ObservedCheckoutSpec,
@@ -64,9 +65,11 @@ pub use project::{
 };
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
-    apply_resource_document, get_resource_kind, list_resource_kind, resource_list_api_version, watch_resource_kind, DynamicResourceList,
-    DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
+    apply_resource_document, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas, resource_list_api_version,
+    watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas, DynamicResourceList, DynamicResourceObject,
+    DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
 };
+pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{
     ensure_repository, resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity, Repository,
     RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey, RepositorySpec, RepositoryStatus,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -90,6 +90,27 @@ pub use terminal_session::{
 };
 pub use vessel::{Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch};
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! for_each_registered_resource {
+    ($callback:ident, $($argument:expr),* $(,)?) => {{
+        $callback::<$crate::Checkout>($($argument),*);
+        $callback::<$crate::Clone>($($argument),*);
+        $callback::<$crate::Convoy>($($argument),*);
+        $callback::<$crate::Demand>($($argument),*);
+        $callback::<$crate::Environment>($($argument),*);
+        $callback::<$crate::Host>($($argument),*);
+        $callback::<$crate::PlacementPolicy>($($argument),*);
+        $callback::<$crate::Presentation>($($argument),*);
+        $callback::<$crate::Project>($($argument),*);
+        $callback::<$crate::Regard>($($argument),*);
+        $callback::<$crate::Repository>($($argument),*);
+        $callback::<$crate::TerminalSession>($($argument),*);
+        $callback::<$crate::Vessel>($($argument),*);
+        $callback::<$crate::WorkflowTemplate>($($argument),*);
+    }};
+}
 pub use workflow_template::{
     single_agent_contained_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation,
     Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -54,6 +54,7 @@ pub struct DynamicResourceObject {
     pub value: Value,
 }
 
+#[derive(bon::Builder)]
 pub struct DynamicResourceWatch {
     pub kind: String,
     pub plural: String,

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -6,8 +6,8 @@ use serde_json::{json, Value};
 
 use crate::{
     api_version, Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, K8sListMeta, K8sResourceList, ObjectMeta,
-    OwnerReference, PlacementPolicy, Presentation, Project, Regard, Repository, Resource, ResourceBackend, ResourceError, ResourceList,
-    ResourceObject, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
+    OwnerReference, PlacementPolicy, Presentation, Project, ReadWatchEvent, Regard, Repository, Resource, ResourceBackend, ResourceError,
+    ResourceList, ResourceObject, ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,6 +56,8 @@ pub struct DynamicResourceWatch {
     pub kind: String,
     pub plural: String,
     pub namespace: String,
+    pub resource_version: String,
+    pub generation: Option<String>,
     pub initial: Vec<Value>,
     pub stream: BoxStream<'static, Result<Value, ResourceError>>,
 }
@@ -146,6 +148,14 @@ pub async fn list_resource_kind(
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, list_typed(backend, namespace).await)
 }
 
+pub async fn list_resource_kind_including_replicas(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+) -> Result<DynamicResourceList, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, list_typed_including_replicas(backend, namespace).await)
+}
+
 pub async fn get_resource_kind(
     backend: &ResourceBackend,
     namespace: &str,
@@ -160,7 +170,24 @@ pub async fn watch_resource_kind(
     namespace: &str,
     requested_kind: &str,
 ) -> Result<DynamicResourceWatch, ResourceError> {
-    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, watch_typed(backend, namespace).await)
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, watch_typed(backend, namespace, None).await)
+}
+
+pub async fn watch_resource_kind_from(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+    start: WatchStart,
+) -> Result<DynamicResourceWatch, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, watch_typed(backend, namespace, Some(start)).await)
+}
+
+pub async fn watch_resource_kind_including_replicas(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+) -> Result<DynamicResourceWatch, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, watch_typed_including_replicas(backend, namespace).await)
 }
 
 pub async fn apply_resource_document(
@@ -250,6 +277,25 @@ async fn list_typed<T: Resource>(backend: &ResourceBackend, namespace: &str) -> 
     })
 }
 
+async fn list_typed_including_replicas<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+) -> Result<DynamicResourceList, ResourceError> {
+    let listed = backend.including_replicas::<T>(namespace).list().await?;
+    let items = listed.items.iter().map(read_object_value).collect::<Result<Vec<_>, _>>()?;
+    Ok(DynamicResourceList {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value: json!({
+            "apiVersion": api_version(T::API_PATHS),
+            "kind": format!("{}List", T::API_PATHS.kind),
+            "metadata": {"resourceVersion": "overlay"},
+            "items": items,
+        }),
+    })
+}
+
 async fn get_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name: &str) -> Result<DynamicResourceObject, ResourceError> {
     let object = backend.using::<T>(namespace).get(name).await?;
     Ok(DynamicResourceObject {
@@ -260,16 +306,64 @@ async fn get_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name
     })
 }
 
-async fn watch_typed<T: Resource>(backend: &ResourceBackend, namespace: &str) -> Result<DynamicResourceWatch, ResourceError> {
+async fn watch_typed<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_start: Option<WatchStart>,
+) -> Result<DynamicResourceWatch, ResourceError> {
     let resolver = backend.using::<T>(namespace);
-    let listed = resolver.list().await?;
-    let start = WatchStart::resuming_from(&listed);
-    let initial = listed.items.iter().map(|object| watch_event_value("ADDED", object)).collect::<Result<Vec<_>, _>>()?;
-    let stream = resolver.watch(start).await?.map(|event| event.and_then(|event| typed_watch_event_value(&event))).boxed();
+    let (resource_version, generation, initial, start) = match requested_start {
+        Some(start) => {
+            let resource_version = match &start {
+                WatchStart::Now => String::new(),
+                WatchStart::FromVersion(resource_version) => resource_version.clone(),
+                WatchStart::FromVersionInGeneration { resource_version, .. } => resource_version.clone(),
+            };
+            let generation = match &start {
+                WatchStart::FromVersionInGeneration { generation, .. } => Some(generation.clone()),
+                _ => None,
+            };
+            (resource_version, generation, Vec::new(), start)
+        }
+        None => {
+            let listed = resolver.list().await?;
+            let initial = listed.items.iter().map(|object| watch_event_value("ADDED", object)).collect::<Result<Vec<_>, _>>()?;
+            (listed.resource_version.clone(), listed.generation.clone(), initial, WatchStart::resuming_from(&listed))
+        }
+    };
+    let watch = resolver.watch(start).await?;
+    let stream_generation = watch.generation().map(ToOwned::to_owned).or(generation);
+    let stream = watch.map(|event| event.and_then(|event| typed_watch_event_value(&event))).boxed();
     Ok(DynamicResourceWatch {
         kind: T::API_PATHS.kind.to_string(),
         plural: T::API_PATHS.plural.to_string(),
         namespace: namespace.to_string(),
+        resource_version,
+        generation: stream_generation,
+        initial,
+        stream,
+    })
+}
+
+async fn watch_typed_including_replicas<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+) -> Result<DynamicResourceWatch, ResourceError> {
+    let resolver = backend.including_replicas::<T>(namespace);
+    let stream = resolver.watch().await?.map(|event| event.and_then(|event| read_watch_event_value(&event))).boxed();
+    let initial = resolver
+        .list()
+        .await?
+        .items
+        .iter()
+        .map(|object| Ok(json!({"type": "ADDED", "object": read_object_value(object)?})))
+        .collect::<Result<Vec<_>, ResourceError>>()?;
+    Ok(DynamicResourceWatch {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        resource_version: "overlay".to_string(),
+        generation: None,
         initial,
         stream,
     })
@@ -310,6 +404,27 @@ fn list_value<T: Resource>(listed: &ResourceList<T>) -> Result<Value, ResourceEr
 
 fn object_value<T: Resource>(object: &ResourceObject<T>) -> Result<Value, ResourceError> {
     serde_json::to_value(object.to_k8s_object()).map_err(|error| ResourceError::decode(format!("encode resource object: {error}")))
+}
+
+fn read_object_value<T: Resource>(object: &crate::ReadResourceObject<T>) -> Result<Value, ResourceError> {
+    let mut value = object_value(&object.object)?;
+    if let ResourceProvenance::Replica { origin_root, last_synced_at } = &object.provenance {
+        let annotations = value["metadata"]["annotations"]
+            .as_object_mut()
+            .ok_or_else(|| ResourceError::decode("resource metadata annotations are not an object"))?;
+        annotations.insert("flotilla.work/origin-root".to_string(), Value::String(origin_root.to_string()));
+        annotations.insert("flotilla.work/last-synced-at".to_string(), Value::String(last_synced_at.to_rfc3339()));
+    }
+    Ok(value)
+}
+
+fn read_watch_event_value<T: Resource>(event: &ReadWatchEvent<T>) -> Result<Value, ResourceError> {
+    let (event_type, object) = match event {
+        ReadWatchEvent::Added(object) => ("ADDED", object),
+        ReadWatchEvent::Modified(object) => ("MODIFIED", object),
+        ReadWatchEvent::Deleted(object) => ("DELETED", object),
+    };
+    Ok(json!({"type": event_type, "object": read_object_value(object)?}))
 }
 
 fn typed_watch_event_value<T: Resource>(event: &WatchEvent<T>) -> Result<Value, ResourceError> {

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -5,7 +5,9 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::{
-    api_version, Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, K8sListMeta, K8sResourceList, ObjectMeta,
+    api_version,
+    replica::{LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION},
+    Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, K8sListMeta, K8sResourceList, ObjectMeta,
     OwnerReference, PlacementPolicy, Presentation, Project, ReadWatchEvent, Regard, Repository, Resource, ResourceBackend, ResourceError,
     ResourceList, ResourceObject, ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
 };
@@ -396,7 +398,7 @@ async fn apply_typed<T: Resource>(
 
 fn list_value<T: Resource>(listed: &ResourceList<T>) -> Result<Value, ResourceError> {
     let list = K8sResourceList {
-        metadata: K8sListMeta { resource_version: listed.resource_version.clone() },
+        metadata: K8sListMeta { resource_version: listed.resource_version.clone(), generation: listed.generation.clone() },
         items: listed.items.iter().map(ResourceObject::to_k8s_object).collect(),
     };
     serde_json::to_value(list).map_err(|error| ResourceError::decode(format!("encode resource list: {error}")))
@@ -412,8 +414,8 @@ fn read_object_value<T: Resource>(object: &crate::ReadResourceObject<T>) -> Resu
         let annotations = value["metadata"]["annotations"]
             .as_object_mut()
             .ok_or_else(|| ResourceError::decode("resource metadata annotations are not an object"))?;
-        annotations.insert("flotilla.work/origin-root".to_string(), Value::String(origin_root.to_string()));
-        annotations.insert("flotilla.work/last-synced-at".to_string(), Value::String(last_synced_at.to_rfc3339()));
+        annotations.insert(ORIGIN_ROOT_ANNOTATION.to_string(), Value::String(origin_root.to_string()));
+        annotations.insert(LAST_SYNCED_AT_ANNOTATION.to_string(), Value::String(last_synced_at.to_rfc3339()));
     }
     Ok(value)
 }

--- a/crates/flotilla-resources/src/replica.rs
+++ b/crates/flotilla-resources/src/replica.rs
@@ -1,0 +1,71 @@
+use chrono::{DateTime, Utc};
+use flotilla_protocol::NodeId;
+use serde::{Deserialize, Serialize};
+
+use crate::{Resource, ResourceObject, WatchEvent};
+
+/// Cross-root behavior for a resource kind.
+///
+/// Replication is deliberately opt-in at the kind declaration. Additional
+/// classes will grow their own read semantics in later overlay slices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplicationClass {
+    None,
+    HomeBoundRuntime,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum ResourceProvenance {
+    Local,
+    Replica { origin_root: NodeId, last_synced_at: DateTime<Utc> },
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadResourceObject<T: Resource> {
+    pub object: ResourceObject<T>,
+    pub provenance: ResourceProvenance,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadResourceList<T: Resource> {
+    pub items: Vec<ReadResourceObject<T>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReadWatchEvent<T: Resource> {
+    Added(ReadResourceObject<T>),
+    Modified(ReadResourceObject<T>),
+    Deleted(ReadResourceObject<T>),
+}
+
+impl<T: Resource> ReadWatchEvent<T> {
+    pub(crate) fn local(event: WatchEvent<T>) -> Self {
+        match event {
+            WatchEvent::Added(object) => Self::Added(ReadResourceObject { object, provenance: ResourceProvenance::Local }),
+            WatchEvent::Modified(object) => Self::Modified(ReadResourceObject { object, provenance: ResourceProvenance::Local }),
+            WatchEvent::Deleted(object) => Self::Deleted(ReadResourceObject { object, provenance: ResourceProvenance::Local }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplicaCursor {
+    pub resource_version: String,
+    pub generation: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StoredReplicaEvent {
+    pub origin_root: NodeId,
+    pub synced_at: DateTime<Utc>,
+    pub kind: StoredReplicaEventKind,
+    pub object: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StoredReplicaEventKind {
+    Added,
+    Modified,
+    Deleted,
+}

--- a/crates/flotilla-resources/src/replica.rs
+++ b/crates/flotilla-resources/src/replica.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Resource, ResourceObject, WatchEvent};
 
+pub(crate) const ORIGIN_ROOT_ANNOTATION: &str = "flotilla.work/origin-root";
+pub(crate) const LAST_SYNCED_AT_ANNOTATION: &str = "flotilla.work/last-synced-at";
+
 /// Cross-root behavior for a resource kind.
 ///
 /// Replication is deliberately opt-in at the kind declaration. Additional
@@ -55,7 +58,7 @@ pub struct ReplicaCursor {
     pub generation: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, bon::Builder)]
 pub(crate) struct StoredReplicaEvent {
     pub origin_root: NodeId,
     pub synced_at: DateTime<Utc>,

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -67,6 +67,7 @@ pub trait Resource: Send + Sync + 'static {
     type StatusPatch: StatusPatch<Self::Status>;
 
     const API_PATHS: ApiPaths;
+    const REPLICATION_CLASS: crate::ReplicationClass = crate::ReplicationClass::None;
 
     fn validate_spec_update(_current: &Self::Spec, _requested: &Self::Spec) -> Result<(), ResourceError> {
         Ok(())

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -11,6 +11,20 @@ use crate::{
 };
 
 macro_rules! define_resource {
+    ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty, replication = $replication:expr) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct $name;
+
+        impl $crate::resource::Resource for $name {
+            type Spec = $spec;
+            type Status = $status;
+            type StatusPatch = $patch;
+
+            const API_PATHS: $crate::resource::ApiPaths =
+                $crate::resource::ApiPaths { group: "flotilla.work", version: "v1", plural: $plural, kind: stringify!($name) };
+            const REPLICATION_CLASS: $crate::ReplicationClass = $replication;
+        }
+    };
     ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty, immutable_spec) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct $name;
@@ -304,6 +318,8 @@ pub struct K8sResourceObject<T: Resource> {
 pub struct K8sListMeta {
     #[serde(rename = "resourceVersion")]
     pub resource_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -321,7 +337,7 @@ impl<T: Resource> K8sResourceList<T> {
         Ok(ResourceList {
             items: self.items.into_iter().map(ResourceObject::from_k8s_object).collect::<Result<_, _>>()?,
             resource_version: self.metadata.resource_version,
-            generation: None,
+            generation: self.metadata.generation,
         })
     }
 }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -5,7 +5,8 @@ use std::{
     time::Duration,
 };
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
+use flotilla_protocol::NodeId;
 use futures::{stream, StreamExt};
 use rusqlite::{params, Connection as RusqliteConnection, OptionalExtension};
 use serde_json::Value;
@@ -14,6 +15,7 @@ use tokio_rusqlite::Connection;
 
 use crate::{
     error::ResourceError,
+    replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
     resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
     retention::{EventRetention, ResourceStoreDiagnostics},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
@@ -22,6 +24,8 @@ use crate::{
 type StoreKey = (String, String, String, String);
 type WatchSender = mpsc::UnboundedSender<StoredEvent>;
 type WatchersByStore = HashMap<StoreKey, Vec<WatchSender>>;
+type ReplicaWatchSender = mpsc::UnboundedSender<StoredReplicaEvent>;
+type ReplicaWatchersByStore = HashMap<StoreKey, Vec<ReplicaWatchSender>>;
 
 #[derive(Debug, Clone)]
 pub struct SqliteBackend {
@@ -29,6 +33,7 @@ pub struct SqliteBackend {
     // Mutations notify and watches register from the connection thread so a
     // committed event cannot land between replay and live delivery.
     watchers: Arc<Mutex<WatchersByStore>>,
+    replica_watchers: Arc<Mutex<ReplicaWatchersByStore>>,
     event_retention: EventRetention,
 }
 
@@ -92,7 +97,12 @@ impl SqliteBackend {
 
     fn from_connection(mut connection: RusqliteConnection, event_retention: EventRetention) -> Result<Self, ResourceError> {
         Self::initialize_connection(&mut connection, event_retention)?;
-        Ok(Self { connection: connection.into(), watchers: Arc::new(Mutex::new(HashMap::new())), event_retention })
+        Ok(Self {
+            connection: connection.into(),
+            watchers: Arc::new(Mutex::new(HashMap::new())),
+            replica_watchers: Arc::new(Mutex::new(HashMap::new())),
+            event_retention,
+        })
     }
 
     async fn from_async_connection(connection: Connection, event_retention: EventRetention) -> Result<Self, ResourceError> {
@@ -100,7 +110,12 @@ impl SqliteBackend {
             .call(move |connection| Self::initialize_connection(connection, event_retention))
             .await
             .map_err(Self::map_connection_error)?;
-        Ok(Self { connection, watchers: Arc::new(Mutex::new(HashMap::new())), event_retention })
+        Ok(Self {
+            connection,
+            watchers: Arc::new(Mutex::new(HashMap::new())),
+            replica_watchers: Arc::new(Mutex::new(HashMap::new())),
+            event_retention,
+        })
     }
 
     fn initialize_connection(connection: &mut RusqliteConnection, event_retention: EventRetention) -> Result<(), ResourceError> {
@@ -151,6 +166,29 @@ impl SqliteBackend {
                     namespace TEXT NOT NULL,
                     compacted_through INTEGER NOT NULL,
                     PRIMARY KEY (group_name, version, kind, namespace)
+                );
+
+                CREATE TABLE IF NOT EXISTS replica_objects (
+                    origin_root TEXT NOT NULL,
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    body_json TEXT NOT NULL,
+                    PRIMARY KEY (origin_root, group_name, version, kind, namespace, name)
+                );
+
+                CREATE TABLE IF NOT EXISTS replica_cursors (
+                    origin_root TEXT NOT NULL,
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    resource_version TEXT NOT NULL,
+                    generation TEXT,
+                    last_synced_at TEXT NOT NULL,
+                    PRIMARY KEY (origin_root, group_name, version, kind, namespace)
                 );
                 "#,
             )
@@ -354,6 +392,283 @@ impl SqliteBackend {
                 entries.retain(|watcher| watcher.send(event.clone()).is_ok());
             }
         }
+    }
+
+    fn notify_replica_watchers(watchers: &Mutex<ReplicaWatchersByStore>, key: &StoreKey, event: StoredReplicaEvent) {
+        if let Ok(mut watchers) = watchers.lock() {
+            if let Some(entries) = watchers.get_mut(key) {
+                entries.retain(|watcher| watcher.send(event.clone()).is_ok());
+            }
+        }
+    }
+
+    pub(crate) async fn list_replicas_typed<T: Resource>(&self, namespace: &str) -> Result<Vec<ReadResourceObject<T>>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        self.call(move |connection| {
+            let mut statement = connection
+                .prepare(
+                    r#"
+                    SELECT o.origin_root, c.last_synced_at, o.body_json
+                    FROM replica_objects o
+                    JOIN replica_cursors c
+                      ON c.origin_root = o.origin_root
+                     AND c.group_name = o.group_name
+                     AND c.version = o.version
+                     AND c.kind = o.kind
+                     AND c.namespace = o.namespace
+                    WHERE o.group_name = ?1 AND o.version = ?2 AND o.kind = ?3 AND o.namespace = ?4
+                    ORDER BY o.origin_root, o.name
+                    "#,
+                )
+                .map_err(|err| Self::map_sqlite(err, "prepare sqlite replica list"))?;
+            let rows = statement
+                .query_map(params![key.0, key.1, key.2, key.3], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+                })
+                .map_err(|err| Self::map_sqlite(err, "query sqlite replica list"))?;
+            let mut items = Vec::new();
+            for row in rows {
+                let (origin_root, last_synced_at, body) = row.map_err(|err| Self::map_sqlite(err, "read sqlite replica list row"))?;
+                let value =
+                    serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode replica object JSON: {err}")))?;
+                let last_synced_at = DateTime::parse_from_rfc3339(&last_synced_at)
+                    .map_err(|err| ResourceError::decode(format!("decode replica sync timestamp: {err}")))?
+                    .with_timezone(&Utc);
+                items.push(ReadResourceObject {
+                    object: Self::decode_object(value)?,
+                    provenance: ResourceProvenance::Replica { origin_root: NodeId::new(origin_root), last_synced_at },
+                });
+            }
+            Ok(items)
+        })
+        .await
+    }
+
+    pub(crate) async fn watch_replicas_typed<T: Resource>(
+        &self,
+        namespace: &str,
+    ) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.replica_watchers
+            .lock()
+            .map_err(|_| ResourceError::other("sqlite replica watch lock poisoned"))?
+            .entry(key)
+            .or_default()
+            .push(tx);
+        Ok(stream::unfold(rx, |mut rx| async {
+            let event = rx.recv().await?;
+            let decoded = Self::decode_object::<T>(event.object).map(|object| {
+                let object = ReadResourceObject {
+                    object,
+                    provenance: ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at },
+                };
+                match event.kind {
+                    StoredReplicaEventKind::Added => ReadWatchEvent::Added(object),
+                    StoredReplicaEventKind::Modified => ReadWatchEvent::Modified(object),
+                    StoredReplicaEventKind::Deleted => ReadWatchEvent::Deleted(object),
+                }
+            });
+            Some((decoded, rx))
+        })
+        .boxed())
+    }
+
+    pub(crate) async fn replace_replicas_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+        listed: &ResourceList<T>,
+        synced_at: DateTime<Utc>,
+    ) -> Result<(), ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let operation_key = key.clone();
+        let origin = origin_root.to_string();
+        let generation = listed.generation.clone();
+        let resource_version = listed.resource_version.clone();
+        let synced = synced_at.to_rfc3339();
+        let encoded = listed
+            .items
+            .iter()
+            .map(|object| {
+                Ok((
+                    object.metadata.name.clone(),
+                    serde_json::to_string(&Self::encode_object(object)?)
+                        .map_err(|err| ResourceError::decode(format!("encode replica object JSON: {err}")))?,
+                ))
+            })
+            .collect::<Result<Vec<_>, ResourceError>>()?;
+        let events = self
+            .call(move |connection| {
+                let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite replica replacement"))?;
+                let old = {
+                    let mut statement = tx
+                        .prepare(
+                            r#"
+                            SELECT name, body_json FROM replica_objects
+                            WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5
+                            "#,
+                        )
+                        .map_err(|err| Self::map_sqlite(err, "prepare old sqlite replicas"))?;
+                    let rows = statement
+                        .query_map(params![origin, key.0, key.1, key.2, key.3], |row| {
+                            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                        })
+                        .map_err(|err| Self::map_sqlite(err, "query old sqlite replicas"))?;
+                    rows.collect::<Result<HashMap<_, _>, _>>().map_err(|err| Self::map_sqlite(err, "read old sqlite replica row"))?
+                };
+                tx.execute(
+                    r#"
+                    DELETE FROM replica_objects
+                    WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5
+                    "#,
+                    params![origin, key.0, key.1, key.2, key.3],
+                )
+                .map_err(|err| Self::map_sqlite(err, "clear sqlite replica partition"))?;
+                for (name, body) in &encoded {
+                    tx.execute(
+                        r#"
+                        INSERT INTO replica_objects (origin_root, group_name, version, kind, namespace, name, body_json)
+                        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                        "#,
+                        params![origin, key.0, key.1, key.2, key.3, name, body],
+                    )
+                    .map_err(|err| Self::map_sqlite(err, "insert sqlite replica object"))?;
+                }
+                tx.execute(
+                    r#"
+                    INSERT INTO replica_cursors
+                        (origin_root, group_name, version, kind, namespace, resource_version, generation, last_synced_at)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                    ON CONFLICT(origin_root, group_name, version, kind, namespace)
+                    DO UPDATE SET resource_version = excluded.resource_version,
+                                  generation = excluded.generation,
+                                  last_synced_at = excluded.last_synced_at
+                    "#,
+                    params![origin, key.0, key.1, key.2, key.3, resource_version, generation, synced],
+                )
+                .map_err(|err| Self::map_sqlite(err, "write sqlite replica cursor"))?;
+                tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite replica replacement"))?;
+
+                let new_names = encoded.iter().map(|(name, _)| name.clone()).collect::<std::collections::HashSet<_>>();
+                let mut events = encoded
+                    .into_iter()
+                    .map(|(name, body)| {
+                        let kind = if old.contains_key(&name) { StoredReplicaEventKind::Modified } else { StoredReplicaEventKind::Added };
+                        Ok((
+                            kind,
+                            serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode replica event: {err}")))?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, ResourceError>>()?;
+                for (name, body) in old {
+                    if !new_names.contains(&name) {
+                        events.push((
+                            StoredReplicaEventKind::Deleted,
+                            serde_json::from_str(&body)
+                                .map_err(|err| ResourceError::decode(format!("decode deleted replica event: {err}")))?,
+                        ));
+                    }
+                }
+                Ok(events)
+            })
+            .await?;
+        for (kind, object) in events {
+            Self::notify_replica_watchers(&self.replica_watchers, &operation_key, StoredReplicaEvent {
+                origin_root: origin_root.clone(),
+                synced_at,
+                kind,
+                object,
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn apply_replica_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+        kind: StoredReplicaEventKind,
+        object: &ResourceObject<T>,
+        synced_at: DateTime<Utc>,
+    ) -> Result<(), ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let operation_key = key.clone();
+        let origin = origin_root.to_string();
+        let name = object.metadata.name.clone();
+        let resource_version = object.metadata.resource_version.clone();
+        let value = Self::encode_object(object)?;
+        let body =
+            serde_json::to_string(&value).map_err(|err| ResourceError::decode(format!("encode sqlite replica event JSON: {err}")))?;
+        let synced = synced_at.to_rfc3339();
+        self.call(move |connection| {
+            let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite replica event"))?;
+            match kind {
+                StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
+                    tx.execute(
+                        r#"
+                        INSERT INTO replica_objects (origin_root, group_name, version, kind, namespace, name, body_json)
+                        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                        ON CONFLICT(origin_root, group_name, version, kind, namespace, name)
+                        DO UPDATE SET body_json = excluded.body_json
+                        "#,
+                        params![origin, key.0, key.1, key.2, key.3, name, body],
+                    )
+                    .map_err(|err| Self::map_sqlite(err, "upsert sqlite replica event object"))?;
+                }
+                StoredReplicaEventKind::Deleted => {
+                    tx.execute(
+                        r#"
+                        DELETE FROM replica_objects
+                        WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5 AND name = ?6
+                        "#,
+                        params![origin, key.0, key.1, key.2, key.3, name],
+                    )
+                    .map_err(|err| Self::map_sqlite(err, "delete sqlite replica event object"))?;
+                }
+            }
+            tx.execute(
+                r#"
+                UPDATE replica_cursors
+                SET resource_version = ?6, last_synced_at = ?7
+                WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5
+                "#,
+                params![origin, key.0, key.1, key.2, key.3, resource_version, synced],
+            )
+            .map_err(|err| Self::map_sqlite(err, "advance sqlite replica cursor"))?;
+            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite replica event"))
+        })
+        .await?;
+        Self::notify_replica_watchers(&self.replica_watchers, &operation_key, StoredReplicaEvent {
+            origin_root: origin_root.clone(),
+            synced_at,
+            kind,
+            object: value,
+        });
+        Ok(())
+    }
+
+    pub(crate) async fn replica_cursor_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+    ) -> Result<Option<ReplicaCursor>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let origin = origin_root.to_string();
+        self.call(move |connection| {
+            connection
+                .query_row(
+                    r#"
+                    SELECT resource_version, generation FROM replica_cursors
+                    WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5
+                    "#,
+                    params![origin, key.0, key.1, key.2, key.3],
+                    |row| Ok(ReplicaCursor { resource_version: row.get(0)?, generation: row.get(1)? }),
+                )
+                .optional()
+                .map_err(|err| Self::map_sqlite(err, "read sqlite replica cursor"))
+        })
+        .await
     }
 
     pub(crate) async fn get_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceObject<T>, ResourceError> {

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -177,6 +177,7 @@ impl SqliteBackend {
                     namespace TEXT NOT NULL,
                     name TEXT NOT NULL,
                     body_json TEXT NOT NULL,
+                    last_synced_at TEXT NOT NULL,
                     PRIMARY KEY (origin_root, group_name, version, kind, namespace, name)
                 );
 
@@ -194,6 +195,38 @@ impl SqliteBackend {
                 "#,
             )
             .map_err(|err| ResourceError::other(format!("initialize sqlite resource store: {err}")))?;
+        let has_replica_object_sync_timestamp = {
+            let mut statement = connection
+                .prepare("PRAGMA table_info(replica_objects)")
+                .map_err(|err| Self::map_sqlite(err, "inspect sqlite replica object schema"))?;
+            let columns = statement
+                .query_map([], |row| row.get::<_, String>(1))
+                .map_err(|err| Self::map_sqlite(err, "query sqlite replica object schema"))?;
+            columns
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| Self::map_sqlite(err, "read sqlite replica object schema"))?
+                .iter()
+                .any(|column| column == "last_synced_at")
+        };
+        if !has_replica_object_sync_timestamp {
+            connection
+                .execute_batch(
+                    r#"
+                    ALTER TABLE replica_objects ADD COLUMN last_synced_at TEXT;
+                    UPDATE replica_objects
+                    SET last_synced_at = (
+                        SELECT c.last_synced_at
+                        FROM replica_cursors c
+                        WHERE c.origin_root = replica_objects.origin_root
+                          AND c.group_name = replica_objects.group_name
+                          AND c.version = replica_objects.version
+                          AND c.kind = replica_objects.kind
+                          AND c.namespace = replica_objects.namespace
+                    );
+                    "#,
+                )
+                .map_err(|err| Self::map_sqlite(err, "migrate sqlite replica object timestamps"))?;
+        }
         let startup_diagnostics = Self::diagnostics_from_connection(connection, event_retention)?;
         if !startup_diagnostics.warnings.is_empty() {
             tracing::warn!(
@@ -409,14 +442,8 @@ impl SqliteBackend {
             let mut statement = connection
                 .prepare(
                     r#"
-                    SELECT o.origin_root, c.last_synced_at, o.body_json
+                    SELECT o.origin_root, o.last_synced_at, o.body_json
                     FROM replica_objects o
-                    JOIN replica_cursors c
-                      ON c.origin_root = o.origin_root
-                     AND c.group_name = o.group_name
-                     AND c.version = o.version
-                     AND c.kind = o.kind
-                     AND c.namespace = o.namespace
                     WHERE o.group_name = ?1 AND o.version = ?2 AND o.kind = ?3 AND o.namespace = ?4
                     ORDER BY o.origin_root, o.name
                     "#,
@@ -529,10 +556,11 @@ impl SqliteBackend {
                 for (name, body) in &encoded {
                     tx.execute(
                         r#"
-                        INSERT INTO replica_objects (origin_root, group_name, version, kind, namespace, name, body_json)
-                        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                        INSERT INTO replica_objects
+                            (origin_root, group_name, version, kind, namespace, name, body_json, last_synced_at)
+                        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                         "#,
-                        params![origin, key.0, key.1, key.2, key.3, name, body],
+                        params![origin, key.0, key.1, key.2, key.3, name, body, synced],
                     )
                     .map_err(|err| Self::map_sqlite(err, "insert sqlite replica object"))?;
                 }
@@ -608,12 +636,14 @@ impl SqliteBackend {
                 StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
                     tx.execute(
                         r#"
-                        INSERT INTO replica_objects (origin_root, group_name, version, kind, namespace, name, body_json)
-                        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                        INSERT INTO replica_objects
+                            (origin_root, group_name, version, kind, namespace, name, body_json, last_synced_at)
+                        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                         ON CONFLICT(origin_root, group_name, version, kind, namespace, name)
-                        DO UPDATE SET body_json = excluded.body_json
+                        DO UPDATE SET body_json = excluded.body_json,
+                                      last_synced_at = excluded.last_synced_at
                         "#,
-                        params![origin, key.0, key.1, key.2, key.3, name, body],
+                        params![origin, key.0, key.1, key.2, key.3, name, body, synced],
                     )
                     .map_err(|err| Self::map_sqlite(err, "upsert sqlite replica event object"))?;
                 }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -27,7 +27,8 @@ type WatchersByStore = HashMap<StoreKey, Vec<WatchSender>>;
 type ReplicaWatchSender = mpsc::UnboundedSender<StoredReplicaEvent>;
 type ReplicaWatchersByStore = HashMap<StoreKey, Vec<ReplicaWatchSender>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, bon::Builder)]
+#[builder(builder_type(vis = "pub(in crate::sqlite)"))]
 pub struct SqliteBackend {
     connection: Connection,
     // Mutations notify and watches register from the connection thread so a

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -4,11 +4,21 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    resource::define_resource, status_patch::StatusPatch, InputMeta, OwnerReference, Resource, ResourceObject, Selector, Vessel,
+    status_patch::StatusPatch, ApiPaths, InputMeta, OwnerReference, ReplicationClass, Resource, ResourceObject, Selector, Vessel,
     CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
-define_resource!(TerminalSession, "terminalsessions", TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TerminalSession;
+
+impl Resource for TerminalSession {
+    type Spec = TerminalSessionSpec;
+    type Status = TerminalSessionStatus;
+    type StatusPatch = TerminalSessionStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "terminalsessions", kind: "TerminalSession" };
+    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct TerminalSessionIdentity {

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -4,21 +4,18 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    status_patch::StatusPatch, ApiPaths, InputMeta, OwnerReference, ReplicationClass, Resource, ResourceObject, Selector, Vessel,
-    CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    resource::define_resource, status_patch::StatusPatch, InputMeta, OwnerReference, ReplicationClass, Resource, ResourceObject, Selector,
+    Vessel, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct TerminalSession;
-
-impl Resource for TerminalSession {
-    type Spec = TerminalSessionSpec;
-    type Status = TerminalSessionStatus;
-    type StatusPatch = TerminalSessionStatusPatch;
-
-    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "terminalsessions", kind: "TerminalSession" };
-    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
-}
+define_resource!(
+    TerminalSession,
+    "terminalsessions",
+    TerminalSessionSpec,
+    TerminalSessionStatus,
+    TerminalSessionStatusPatch,
+    replication = ReplicationClass::HomeBoundRuntime
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct TerminalSessionIdentity {

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -3,9 +3,19 @@ use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryKey, Stance};
+use crate::{status_patch::StatusPatch, ApiPaths, ReplicationClass, RepositoryKey, Resource, Stance};
 
-define_resource!(Vessel, "vessels", VesselSpec, VesselStatus, VesselStatusPatch);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Vessel;
+
+impl Resource for Vessel {
+    type Spec = VesselSpec;
+    type Status = VesselStatus;
+    type StatusPatch = VesselStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "vessels", kind: "Vessel" };
+    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VesselSpec {

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -3,19 +3,9 @@ use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{status_patch::StatusPatch, ApiPaths, ReplicationClass, RepositoryKey, Resource, Stance};
+use crate::{resource::define_resource, status_patch::StatusPatch, ReplicationClass, RepositoryKey, Stance};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Vessel;
-
-impl Resource for Vessel {
-    type Spec = VesselSpec;
-    type Status = VesselStatus;
-    type StatusPatch = VesselStatusPatch;
-
-    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "vessels", kind: "Vessel" };
-    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
-}
+define_resource!(Vessel, "vessels", VesselSpec, VesselStatus, VesselStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VesselSpec {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -189,6 +189,7 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
     let remote_backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let remote = remote_backend.using::<Convoy>("flotilla");
     remote.create(&convoy_meta("remote"), &convoy_spec("remote-template")).await.expect("create remote convoy");
+    remote.create(&convoy_meta("untouched"), &convoy_spec("untouched-template")).await.expect("create untouched remote convoy");
     let remote_list = remote.list().await.expect("list remote convoy");
     let synced_at = Utc::now();
 
@@ -198,7 +199,7 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
     assert_eq!(local_only.items.iter().map(|item| item.metadata.name.as_str()).collect::<Vec<_>>(), ["local"]);
 
     let all = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list resources including replicas");
-    assert_eq!(all.items.len(), 2);
+    assert_eq!(all.items.len(), 3);
     assert!(matches!(all.items[0].provenance, ResourceProvenance::Local));
     let replica = all.items.iter().find(|item| item.object.metadata.name == "remote").expect("remote replica row");
     assert_eq!(replica.provenance, ResourceProvenance::Replica { origin_root: origin.clone(), last_synced_at: synced_at });
@@ -219,15 +220,33 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
     assert_eq!(cursor.generation, remote_list.generation);
 
     let mut watch = backend.including_replicas::<Convoy>("flotilla").watch().await.expect("watch resources including replicas");
+    let remote_object = remote.get("remote").await.expect("get remote convoy before update");
+    remote
+        .update(&convoy_meta("remote"), &remote_object.metadata.resource_version, &convoy_spec("updated-template"))
+        .await
+        .expect("update one remote convoy");
+    let modified = remote.watch(WatchStart::resuming_from(&remote_list)).await.expect("watch remote update").next().await;
+    let modified = modified.expect("remote update event").expect("valid remote update");
+    let updated_sync = synced_at + chrono::Duration::seconds(1);
+    backend.replica_writer::<Convoy>(origin.clone(), "flotilla").apply(modified, updated_sync).await.expect("apply remote update");
+    let modified_event = timeout(Duration::from_secs(1), watch.next()).await.expect("replica update watch timeout");
+    assert!(matches!(modified_event, Some(Ok(flotilla_resources::ReadWatchEvent::Modified(_)))));
+    let after_update = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list after replica update");
+    let updated = after_update.items.iter().find(|item| item.object.metadata.name == "remote").expect("updated replica row");
+    assert_eq!(updated.provenance, ResourceProvenance::Replica { origin_root: origin.clone(), last_synced_at: updated_sync });
+    let untouched = after_update.items.iter().find(|item| item.object.metadata.name == "untouched").expect("untouched replica row");
+    assert_eq!(untouched.provenance, ResourceProvenance::Replica { origin_root: origin.clone(), last_synced_at: synced_at });
+
+    let before_delete = remote.list().await.expect("list before remote delete");
     remote.delete("remote").await.expect("delete remote convoy");
-    let deleted = remote.watch(WatchStart::resuming_from(&remote_list)).await.expect("watch remote delete").next().await;
+    let deleted = remote.watch(WatchStart::resuming_from(&before_delete)).await.expect("watch remote delete").next().await;
     let deleted = deleted.expect("remote delete event").expect("valid remote delete");
     backend.replica_writer::<Convoy>(origin, "flotilla").apply(deleted, Utc::now()).await.expect("apply remote delete");
 
     let event = timeout(Duration::from_secs(1), watch.next()).await.expect("replica delete watch timeout");
     assert!(matches!(event, Some(Ok(flotilla_resources::ReadWatchEvent::Deleted(_)))));
     let remaining = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list after replica delete");
-    assert_eq!(remaining.items.len(), 1);
+    assert_eq!(remaining.items.len(), 2);
 
     let mut new_generation = remote.list().await.expect("list new origin generation");
     new_generation.generation = Some("generation-2".to_string());

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -1,10 +1,11 @@
 use std::time::Duration;
 
+use chrono::Utc;
 use flotilla_protocol::ResourceRef;
 use flotilla_resources::{
     Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, OwnerReference, PrincipalRef,
-    Regard, RegardExpiryPolicy, RegardSource, RegardSpec, Resource, ResourceBackend, ResourceError, ResourceObject, TypedResolver,
-    WatchEvent, WatchStart, WorkflowTemplate,
+    Regard, RegardExpiryPolicy, RegardSource, RegardSpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
+    TypedResolver, WatchEvent, WatchStart, WorkflowTemplate,
 };
 use futures::StreamExt;
 use tokio::time::timeout;
@@ -178,6 +179,71 @@ fn resource_ref(kind: &str, name: &str) -> ResourceRef {
 
 pub fn in_memory_backend() -> ResourceBackend {
     ResourceBackend::InMemory(InMemoryBackend::default())
+}
+
+pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
+    let local = backend.using::<Convoy>("flotilla");
+    local.create(&convoy_meta("local"), &convoy_spec("local-template")).await.expect("create local convoy");
+
+    let origin = flotilla_protocol::NodeId::new("feta-root");
+    let remote_backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let remote = remote_backend.using::<Convoy>("flotilla");
+    remote.create(&convoy_meta("remote"), &convoy_spec("remote-template")).await.expect("create remote convoy");
+    let remote_list = remote.list().await.expect("list remote convoy");
+    let synced_at = Utc::now();
+
+    backend.replica_writer::<Convoy>(origin.clone(), "flotilla").replace(&remote_list, synced_at).await.expect("store remote replica");
+
+    let local_only = local.list().await.expect("list local-only resources");
+    assert_eq!(local_only.items.iter().map(|item| item.metadata.name.as_str()).collect::<Vec<_>>(), ["local"]);
+
+    let all = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list resources including replicas");
+    assert_eq!(all.items.len(), 2);
+    assert!(matches!(all.items[0].provenance, ResourceProvenance::Local));
+    let replica = all.items.iter().find(|item| item.object.metadata.name == "remote").expect("remote replica row");
+    assert_eq!(replica.provenance, ResourceProvenance::Replica { origin_root: origin.clone(), last_synced_at: synced_at });
+    let wire =
+        flotilla_resources::list_resource_kind_including_replicas(&backend, "flotilla", "convoys").await.expect("list replica wire view");
+    let wire_replica = wire.value["items"]
+        .as_array()
+        .expect("wire items")
+        .iter()
+        .find(|item| item["metadata"]["name"] == "remote")
+        .expect("wire replica row");
+    assert_eq!(wire_replica["metadata"]["annotations"]["flotilla.work/origin-root"], "feta-root");
+    assert!(wire_replica["metadata"]["annotations"]["flotilla.work/last-synced-at"].is_string());
+
+    let cursor =
+        backend.replica_writer::<Convoy>(origin.clone(), "flotilla").cursor().await.expect("read replica cursor").expect("replica cursor");
+    assert_eq!(cursor.resource_version, remote_list.resource_version);
+    assert_eq!(cursor.generation, remote_list.generation);
+
+    let mut watch = backend.including_replicas::<Convoy>("flotilla").watch().await.expect("watch resources including replicas");
+    remote.delete("remote").await.expect("delete remote convoy");
+    let deleted = remote.watch(WatchStart::resuming_from(&remote_list)).await.expect("watch remote delete").next().await;
+    let deleted = deleted.expect("remote delete event").expect("valid remote delete");
+    backend.replica_writer::<Convoy>(origin, "flotilla").apply(deleted, Utc::now()).await.expect("apply remote delete");
+
+    let event = timeout(Duration::from_secs(1), watch.next()).await.expect("replica delete watch timeout");
+    assert!(matches!(event, Some(Ok(flotilla_resources::ReadWatchEvent::Deleted(_)))));
+    let remaining = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list after replica delete");
+    assert_eq!(remaining.items.len(), 1);
+
+    let mut new_generation = remote.list().await.expect("list new origin generation");
+    new_generation.generation = Some("generation-2".to_string());
+    new_generation.resource_version = "0".to_string();
+    backend
+        .replica_writer::<Convoy>(flotilla_protocol::NodeId::new("feta-root"), "flotilla")
+        .replace(&new_generation, Utc::now())
+        .await
+        .expect("replace origin generation");
+    let cursor = backend
+        .replica_writer::<Convoy>(flotilla_protocol::NodeId::new("feta-root"), "flotilla")
+        .cursor()
+        .await
+        .expect("read replaced cursor")
+        .expect("replaced cursor");
+    assert_eq!(cursor.generation.as_deref(), Some("generation-2"));
 }
 
 pub fn resolver<F: ResourceContractFixture>(backend: ResourceBackend, namespace: &str) -> TypedResolver<F::Resource> {

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -7,8 +7,8 @@ use common::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip,
         assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
         assert_metadata_roundtrip, assert_namespace_isolation, assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
-        assert_stale_resource_version_conflicts, assert_store_diagnostics_report_retained_events_with_backend,
-        assert_watch_from_version_replays, assert_watch_now_semantics,
+        assert_replica_read_view_contract, assert_stale_resource_version_conflicts,
+        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays, assert_watch_now_semantics,
         assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture, DemandFixture, RegardFixture,
     },
@@ -114,6 +114,11 @@ macro_rules! resource_contract_tests {
 resource_contract_tests!(convoy_contract, ConvoyFixture);
 resource_contract_tests!(regard_contract, RegardFixture);
 resource_contract_tests!(demand_contract, DemandFixture);
+
+#[tokio::test]
+async fn replica_read_view_contract() {
+    assert_replica_read_view_contract(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
 
 #[tokio::test]
 async fn list_matching_labels_returns_only_exact_matches() {

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -8,9 +8,10 @@ use common::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip_with_backend,
         assert_delete_emits_event_with_backend, assert_identical_status_update_is_noop_with_backend,
         assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
-        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_stale_resource_version_conflicts_with_backend,
-        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays_with_backend,
-        assert_watch_now_semantics_with_backend, assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
+        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_replica_read_view_contract,
+        assert_stale_resource_version_conflicts_with_backend, assert_store_diagnostics_report_retained_events_with_backend,
+        assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend,
+        assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture, DemandFixture, RegardFixture,
     },
     convoy_meta, convoy_spec, convoy_status, pending_task_state, resource_meta, TestLoopHarness,
@@ -18,9 +19,9 @@ use common::{
 use flotilla_controllers::reconcilers::VesselReconciler;
 use flotilla_resources::{
     controller::{Actuation, ControllerLoop, Reconciler},
-    ApiPaths, Convoy, ConvoyPhase, ConvoyReconciler, EventRetention, NoStatusPatch, Resource, ResourceBackend, ResourceError,
-    SqliteBackend, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec, WatchEvent, WatchStart, WorkPhase,
-    WorkflowTemplate, CONVOY_LABEL, VESSEL_REF_LABEL,
+    ApiPaths, Convoy, ConvoyPhase, ConvoyReconciler, EventRetention, InMemoryBackend, NoStatusPatch, Resource, ResourceBackend,
+    ResourceError, SqliteBackend, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec, WatchEvent, WatchStart,
+    WorkPhase, WorkflowTemplate, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 use futures::StreamExt;
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
@@ -154,6 +155,34 @@ macro_rules! resource_contract_tests {
 resource_contract_tests!(convoy_contract, ConvoyFixture);
 resource_contract_tests!(regard_contract, RegardFixture);
 resource_contract_tests!(demand_contract, DemandFixture);
+
+#[tokio::test]
+async fn replica_read_view_contract() {
+    assert_replica_read_view_contract(backend()).await;
+}
+
+#[tokio::test]
+async fn replica_rows_and_cursor_survive_backend_restart() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("resources.sqlite");
+    let origin = flotilla_protocol::NodeId::new("feta-root");
+    let source = ResourceBackend::InMemory(InMemoryBackend::default());
+    source.using::<Convoy>("flotilla").create(&convoy_meta("remote"), &convoy_spec("template")).await.expect("create source convoy");
+    let listed = source.using::<Convoy>("flotilla").list().await.expect("list source convoy");
+
+    {
+        let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("open sqlite backend"));
+        backend.replica_writer::<Convoy>(origin.clone(), "flotilla").replace(&listed, Utc::now()).await.expect("persist replica");
+    }
+
+    let reopened = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("reopen sqlite backend"));
+    let replicas = reopened.including_replicas::<Convoy>("flotilla").list().await.expect("list persisted replicas");
+    assert_eq!(replicas.items.len(), 1);
+    assert_eq!(replicas.items[0].object.metadata.name, "remote");
+    let cursor =
+        reopened.replica_writer::<Convoy>(origin, "flotilla").cursor().await.expect("read persisted cursor").expect("persisted cursor");
+    assert_eq!(cursor.resource_version, listed.resource_version);
+}
 
 #[tokio::test]
 async fn objects_and_resource_versions_survive_restart() {

--- a/crates/flotilla-transport/src/message.rs
+++ b/crates/flotilla-transport/src/message.rs
@@ -1,20 +1,19 @@
-use std::path::Path;
+use std::{io::Cursor, path::Path};
 
 use flotilla_protocol::{framing::write_message_line, Message};
 use tokio::{
-    io::{AsyncBufReadExt, BufReader, BufWriter},
+    io::{AsyncBufReadExt, AsyncReadExt, BufReader, BufWriter},
     net::UnixStream,
     sync::Mutex,
 };
 
 use crate::memory::{memory_session_pair, Session};
 
+type PrefixedUnixReader = tokio::io::Lines<BufReader<tokio::io::Chain<Cursor<Vec<u8>>, tokio::net::unix::OwnedReadHalf>>>;
+
 enum MessageSessionInner {
     Memory(Session<Message>),
-    Unix {
-        reader: Mutex<tokio::io::Lines<BufReader<tokio::net::unix::OwnedReadHalf>>>,
-        writer: Mutex<BufWriter<tokio::net::unix::OwnedWriteHalf>>,
-    },
+    Unix { reader: Box<Mutex<PrefixedUnixReader>>, writer: Mutex<BufWriter<tokio::net::unix::OwnedWriteHalf>> },
 }
 
 pub struct MessageSession {
@@ -52,10 +51,14 @@ pub async fn connect_unix_message_session(socket_path: &Path) -> Result<MessageS
 }
 
 pub fn unix_message_session(stream: UnixStream) -> MessageSession {
+    unix_message_session_with_prefix(stream, Vec::new())
+}
+
+pub fn unix_message_session_with_prefix(stream: UnixStream, prefix: Vec<u8>) -> MessageSession {
     let (read_half, write_half) = stream.into_split();
     MessageSession {
         inner: MessageSessionInner::Unix {
-            reader: Mutex::new(BufReader::new(read_half).lines()),
+            reader: Box::new(Mutex::new(BufReader::new(Cursor::new(prefix).chain(read_half)).lines())),
             writer: Mutex::new(BufWriter::new(write_half)),
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,9 @@ struct ResourceListArgs {
     /// Route the query to a peer host
     #[arg(long)]
     host: Option<String>,
+    /// Include read-only replicas from peer roots
+    #[arg(long)]
+    include_replicas: bool,
 }
 
 #[derive(clap::Args)]
@@ -722,7 +725,11 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
                         node_id,
                         provisioning_target: None,
                         context_repo: None,
-                        action: CommandAction::QueryResourceList { namespace: args.namespace, kind: args.kind },
+                        action: CommandAction::QueryResourceList {
+                            namespace: args.namespace,
+                            kind: args.kind,
+                            include_replicas: args.include_replicas,
+                        },
                     },
                     uuid::Uuid::new_v4(),
                 )
@@ -809,7 +816,12 @@ async fn run_resource_watch(cli: &Cli, args: ResourceListArgs, format: OutputFor
             node_id,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ResourceWatch { namespace: args.namespace, kind: args.kind },
+            action: CommandAction::ResourceWatch {
+                namespace: args.namespace,
+                kind: args.kind,
+                include_replicas: args.include_replicas,
+                cursor: None,
+            },
         })
         .await
         .map_err(|e| color_eyre::eyre::eyre!(e))?;
@@ -1442,7 +1454,7 @@ mod tests {
         assert!(matches!(
             list.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::List(ResourceListArgs { kind, namespace, host: Some(host) })
+                command: ResourceSubCommand::List(ResourceListArgs { kind, namespace, host: Some(host), include_replicas: false })
             }) if kind == "convoys" && namespace == "flotilla" && host == "feta"
         ));
 
@@ -1470,7 +1482,7 @@ mod tests {
         assert!(matches!(
             watch.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::Watch(ResourceListArgs { kind, namespace, host: None })
+                command: ResourceSubCommand::Watch(ResourceListArgs { kind, namespace, host: None, include_replicas: false })
             }) if kind == "terminalsessions" && namespace == "flotilla"
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,7 +231,7 @@ enum ResourceSubCommand {
     Watch(ResourceListArgs),
 }
 
-#[derive(clap::Args)]
+#[derive(clap::Args, bon::Builder)]
 struct ResourceListArgs {
     /// Resource kind or plural name, e.g. convoys or WorkflowTemplate
     kind: String,


### PR DESCRIPTION
## Summary

- add durable per-origin replica partitions and cursors to the in-memory and SQLite resource stores
- replicate Convoy, Vessel, and TerminalSession resources over the SSH-forwarded Unix socket using the k8s-style HTTP list/watch API
- add read-only `include-replicas` list/watch views with origin and per-object last-sync provenance while preserving local-only defaults
- resume watches across reconnects, preserve last-known rows while peers are absent, and atomically relist when origin generations change

## Impact

Fleet roots can now read live, durable remote home-bound runtime state without exposing replica writes to reconcilers. Existing consumers remain local-only unless they explicitly request replicas.

The resource HTTP surface deliberately shares the primary daemon Unix socket. The connection preface multiplexes read-only HTTP and the existing framed control protocol, so SSH forwarding reuses the daemon's existing peer trust boundary rather than opening a second listener.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

## Follow-up

- #923 adds generation-aware retry supervision for transient kind-local watch failures without risking duplicate replicators across reconnects.

Closes #913
