### PR TITLE
feat: open remote convoy latents

### DIFF
--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -229,6 +229,27 @@ impl HostRegistry {
             .map(Some)
     }
 
+    pub(crate) async fn host_name_for_node(&self, node_id: &NodeId) -> Option<HostName> {
+        let environment_id = self.node_environments.read().await.get(node_id).cloned()?;
+        self.hosts
+            .read()
+            .await
+            .get(&environment_id)
+            .filter(|state| !state.removed)
+            .and_then(|state| state.summary.as_ref()?.host_name.clone())
+    }
+
+    pub(crate) async fn live_routed_host_name(&self, target_node: &NodeId) -> Option<HostName> {
+        let routes = self.topology_routes.read().await;
+        let route = routes.iter().find(|route| route.target.node_id == *target_node)?;
+        if !route.connected && route.fallbacks.is_empty() {
+            return None;
+        }
+        drop(routes);
+
+        self.host_name_for_node(target_node).await
+    }
+
     pub(crate) async fn replay_host_events(&self, last_seen: &HashMap<StreamKey, u64>) -> Vec<DaemonEvent> {
         let configured = self.configured_peers.read().await.clone();
         let node_connectivity = self.node_connectivity.read().await.clone();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -41,10 +41,11 @@ use flotilla_resources::{
     HostDirectPlacementPolicySpec, InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution,
     IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec,
     Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
-    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
-    Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
-    CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    ResourceObject, ResourceProvenance, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
+    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL,
+    VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -5171,12 +5172,20 @@ impl InProcessDaemon {
     }
 
     pub async fn resolve_attach_command_internal(&self, reference: &str) -> Result<ResolvedAttach, String> {
+        self.resolve_attach_command_on_host_internal(reference, None).await
+    }
+
+    pub async fn resolve_attach_command_on_host_internal(
+        &self,
+        reference: &str,
+        host: Option<&HostName>,
+    ) -> Result<ResolvedAttach, String> {
         // Preserve validation precedence without paying to build the candidate index.
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }
         let index = self.attach_candidate_index().await?;
-        index.resolve(self, reference, None, false).await
+        index.resolve(self, reference, host, false).await
     }
 
     pub async fn resolve_transient_attach_command_internal(
@@ -5198,17 +5207,41 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = HashSet::new();
         for reference in references {
-            if index.resolve(self, reference, Some(&self.host_name), false).await.is_ok() {
+            if index.resolve(self, reference, None, false).await.is_ok() {
                 resolved.insert(reference.clone());
             }
         }
         Ok(resolved)
     }
 
+    pub async fn resolvable_attach_targets_internal(&self, targets: &[(String, HostName)]) -> Result<Vec<bool>, String> {
+        let index = self.attach_candidate_index().await?;
+        let mut resolved = Vec::with_capacity(targets.len());
+        for (reference, host) in targets {
+            resolved.push(index.resolve(self, reference, Some(host), false).await.is_ok());
+        }
+        Ok(resolved)
+    }
+
+    pub async fn origin_host_names_internal(&self, origins: &HashSet<NodeId>) -> HashMap<NodeId, HostName> {
+        let mut hosts = HashMap::new();
+        for origin in origins {
+            if let Some(host) = self.host_registry.host_name_for_node(origin).await {
+                hosts.insert(origin.clone(), host);
+            }
+        }
+        hosts
+    }
+
     async fn attach_candidate_index(&self) -> Result<AttachCandidateIndex, String> {
         let namespace = self.provisioning_namespace().await;
-        let durable_sessions =
-            self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace).list().await.map_err(|err| err.to_string())?.items;
+        let durable_sessions = self
+            .resource_backend
+            .including_replicas::<ResourceTerminalSession>(&namespace)
+            .list()
+            .await
+            .map_err(|err| err.to_string())?
+            .items;
         let observed_sessions = self
             .observed_resource_backend
             .clone()
@@ -5218,7 +5251,16 @@ impl InProcessDaemon {
             .map_err(|err| err.to_string())?
             .items;
         let mut sessions_by_name = HashMap::new();
-        for session in durable_sessions.into_iter().chain(observed_sessions) {
+        let mut replicated_sessions = Vec::new();
+        for session in durable_sessions {
+            match session.provenance {
+                ResourceProvenance::Local => {
+                    sessions_by_name.insert(session.object.metadata.name.clone(), session.object);
+                }
+                ResourceProvenance::Replica { .. } => replicated_sessions.push(session),
+            }
+        }
+        for session in observed_sessions {
             sessions_by_name.insert(session.metadata.name.clone(), session);
         }
         let mut candidates = Vec::new();
@@ -5231,6 +5273,39 @@ impl InProcessDaemon {
                 references: attach_reference_keys(&session.metadata.name, &session.metadata.labels),
                 host: self.host_name.clone(),
                 target: AttachTarget::Local(Box::new(session)),
+            });
+        }
+        let mut indexed_remote_sessions = HashSet::new();
+        for replicated in replicated_sessions {
+            let session = replicated.object;
+            if session.status.as_ref().map(|status| status.phase) != Some(ResourceTerminalSessionPhase::Running) {
+                continue;
+            }
+            let ResourceProvenance::Replica { origin_root, .. } = replicated.provenance else {
+                unreachable!("local durable sessions were partitioned above");
+            };
+            let Some(host) = self.host_registry.live_routed_host_name(&origin_root).await else {
+                continue;
+            };
+            indexed_remote_sessions.insert((host.clone(), session.metadata.name.clone()));
+            let convoy = session.metadata.labels.get(CONVOY_LABEL).cloned().unwrap_or_else(|| "-".to_string());
+            let role = session.metadata.labels.get(ROLE_LABEL).cloned().unwrap_or_else(|| session.spec.role.clone());
+            let crew = session.metadata.labels.get(VESSEL_LABEL).map_or_else(|| role.clone(), |vessel| format!("{vessel}/{role}"));
+            let row = FleetListRow::builder()
+                .convoy(convoy)
+                .vessel(session.spec.env_ref.clone())
+                .crew(crew)
+                .crew_state("running")
+                .host(host.clone())
+                .namespace(session.metadata.namespace.clone())
+                .session(session.metadata.name.clone())
+                .staleness(FleetStaleness::Local)
+                .build();
+            candidates.push(AttachCandidate {
+                label: attach_reference_label(&session.metadata.name, &session.metadata.labels),
+                references: attach_reference_keys(&session.metadata.name, &session.metadata.labels),
+                host,
+                target: AttachTarget::Replica { row: Box::new(row) },
             });
         }
 
@@ -5255,6 +5330,9 @@ impl InProcessDaemon {
                         continue;
                     }
                     if let Some(session) = &row.session {
+                        if indexed_remote_sessions.contains(&(row.host.clone(), session.clone())) {
+                            continue;
+                        }
                         if independent_references.contains(session.as_str()) {
                             continue;
                         }
@@ -5343,9 +5421,9 @@ impl InProcessDaemon {
         let resolver = ssh_resolver_from_config(self.config.base_path())?;
         let mut command =
             vec![flotilla_protocol::arg::Arg::Literal("flotilla".to_string()), flotilla_protocol::arg::Arg::Literal("attach".to_string())];
+        command.push(flotilla_protocol::arg::Arg::Literal("--host".to_string()));
+        command.push(flotilla_protocol::arg::Arg::Quoted(target_host.to_string()));
         if transient {
-            command.push(flotilla_protocol::arg::Arg::Literal("--host".to_string()));
-            command.push(flotilla_protocol::arg::Arg::Quoted(target_host.to_string()));
             command.push(flotilla_protocol::arg::Arg::Literal("--transient".to_string()));
         }
         command.push(flotilla_protocol::arg::Arg::Quoted(reference.to_string()));
@@ -6584,7 +6662,8 @@ impl DaemonHandle for InProcessDaemon {
                     Err(error) => Ok(flotilla_protocol::CommandValue::Error { message: error.to_string() }),
                 }
             }
-            CommandAction::Attach { reference } => match self.resolve_attach_command_internal(reference).await {
+            CommandAction::Attach { reference, host } => match self.resolve_attach_command_on_host_internal(reference, host.as_ref()).await
+            {
                 Ok(resolved) => {
                     if let Some(binding) = &resolved.binding {
                         if let Err(error) = self.emit_attach_regard(binding, session_id).await {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1600,7 +1600,7 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -1680,7 +1680,7 @@ async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command(
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -1721,7 +1721,7 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -1737,6 +1737,191 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
     assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
     assert!(!command.contains("remote-provider-session"), "remote hop must not include terminal-provider attach args: {command}");
     assert_eq!(command.matches("flotilla attach").count(), 1, "command should contain exactly one recursive attach invocation: {command}");
+}
+
+#[tokio::test]
+async fn replicated_session_recipe_tracks_live_route_and_resolves_through_the_hop() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let (remote_host, _) = non_local_attach_hosts();
+    let remote_hostname = format!("{remote_host}.local");
+    write_attach_hosts_config(&config_base, &[(remote_host, &remote_hostname, Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    publish_attach_host_summary(&daemon, remote_host, remote_host).await;
+    let remote_node = node(remote_host);
+    let remote_backend = flotilla_resources::ResourceBackend::InMemory(flotilla_resources::InMemoryBackend::default());
+    let remote_sessions = remote_backend.using::<ResourceTerminalSession>("flotilla");
+    let session_name = "terminal-convoy-a-implement-coder";
+    let created = remote_sessions
+        .create(
+            &input_meta_with_labels(
+                session_name,
+                BTreeMap::from([
+                    (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+                    (VESSEL_LABEL.to_string(), "implement".to_string()),
+                    (ROLE_LABEL.to_string(), "coder".to_string()),
+                ]),
+            ),
+            &ResourceTerminalSessionSpec {
+                env_ref: "remote-env".to_string(),
+                role: "coder".to_string(),
+                source: TerminalSessionSource::Tool { command: "bash".to_string() },
+                cwd: "/repo".to_string(),
+                pool: "fake-terminals".to_string(),
+            },
+        )
+        .await
+        .expect("create remote session");
+    remote_sessions
+        .update_status(session_name, &created.metadata.resource_version, &ResourceTerminalSessionStatus {
+            phase: ResourceTerminalSessionPhase::Running,
+            session_id: Some("remote-provider-session".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("mark remote session running");
+    daemon
+        .resource_backend()
+        .replica_writer::<ResourceTerminalSession>(remote_node.node_id.clone(), "flotilla")
+        .replace(&remote_sessions.list().await.expect("list remote sessions"), Utc::now())
+        .await
+        .expect("store remote session replica");
+
+    let references = vec![session_name.to_string()];
+    assert!(
+        !daemon.resolvable_attach_references_internal(&references).await.expect("disconnected capability query").contains(session_name),
+        "a durable replica must not mint a recipe without a live route"
+    );
+
+    daemon
+        .set_topology_routes(vec![TopologyRoute {
+            target: remote_node.clone(),
+            next_hop: remote_node.clone(),
+            direct: true,
+            connected: true,
+            fallbacks: vec![],
+            last_attempt: None,
+            last_error: None,
+        }])
+        .await;
+    assert_eq!(
+        daemon.host_registry.live_routed_host_name(&remote_node.node_id).await,
+        Some(HostName::new(remote_host)),
+        "the route should resolve the replica origin to its advertised host name"
+    );
+
+    let resolved = daemon.resolve_attach_command_internal(session_name).await.expect("resolve replicated session through live route");
+    assert!(
+        daemon.resolvable_attach_references_internal(&references).await.expect("connected capability query").contains(session_name),
+        "the recipe should appear when the origin route becomes live"
+    );
+    assert!(resolved.command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")), "attach should use the live hop");
+    assert!(resolved.command.contains("flotilla attach"), "attach should re-resolve on the remote daemon");
+    assert_eq!(resolved.binding.expect("remote binding").host, HostName::new(remote_host));
+
+    daemon.set_topology_routes(Vec::new()).await;
+    assert!(
+        !daemon.resolvable_attach_references_internal(&references).await.expect("disconnected capability query").contains(session_name),
+        "the recipe should vanish when the route disconnects"
+    );
+}
+
+#[tokio::test]
+async fn host_qualified_attach_disambiguates_same_named_local_and_replica_sessions() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let (remote_host, _) = non_local_attach_hosts();
+    let remote_hostname = format!("{remote_host}.local");
+    write_attach_hosts_config(&config_base, &[(remote_host, &remote_hostname, Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let local_env = create_local_attach_environment(&daemon).await;
+    let session_name = "terminal-convoy-a-implement-coder";
+    create_running_attach_session(&daemon, &local_env, session_name, "local-provider-session", "convoy-a", "implement", "coder").await;
+
+    publish_attach_host_summary(&daemon, remote_host, remote_host).await;
+    let remote_node = node(remote_host);
+    let remote_backend = flotilla_resources::ResourceBackend::InMemory(flotilla_resources::InMemoryBackend::default());
+    let remote_sessions = remote_backend.using::<ResourceTerminalSession>("flotilla");
+    let created = remote_sessions
+        .create(
+            &input_meta_with_labels(
+                session_name,
+                BTreeMap::from([
+                    (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+                    (VESSEL_LABEL.to_string(), "implement".to_string()),
+                    (ROLE_LABEL.to_string(), "coder".to_string()),
+                ]),
+            ),
+            &ResourceTerminalSessionSpec {
+                env_ref: "remote-env".to_string(),
+                role: "coder".to_string(),
+                source: TerminalSessionSource::Tool { command: "bash".to_string() },
+                cwd: "/repo".to_string(),
+                pool: "fake-terminals".to_string(),
+            },
+        )
+        .await
+        .expect("create remote session");
+    remote_sessions
+        .update_status(session_name, &created.metadata.resource_version, &ResourceTerminalSessionStatus {
+            phase: ResourceTerminalSessionPhase::Running,
+            session_id: Some("remote-provider-session".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("mark remote session running");
+    daemon
+        .resource_backend()
+        .replica_writer::<ResourceTerminalSession>(remote_node.node_id.clone(), "flotilla")
+        .replace(&remote_sessions.list().await.expect("list remote sessions"), Utc::now())
+        .await
+        .expect("store remote session replica");
+    daemon
+        .set_topology_routes(vec![TopologyRoute {
+            target: remote_node.clone(),
+            next_hop: remote_node,
+            direct: true,
+            connected: true,
+            fallbacks: vec![],
+            last_attempt: None,
+            last_error: None,
+        }])
+        .await;
+
+    let local_host = daemon.host_name.clone();
+    let remote_host = HostName::new(remote_host);
+    assert!(daemon
+        .resolve_attach_command_internal(session_name)
+        .await
+        .expect_err("bare same-name reference should be ambiguous")
+        .contains("ambiguous"));
+    assert_eq!(
+        daemon
+            .resolvable_attach_targets_internal(&[
+                (session_name.to_string(), local_host.clone()),
+                (session_name.to_string(), remote_host.clone()),
+            ])
+            .await
+            .expect("host-qualified capability query"),
+        vec![true, true]
+    );
+
+    let local =
+        daemon.resolve_attach_command_on_host_internal(session_name, Some(&local_host)).await.expect("resolve local same-name session");
+    assert_eq!(local.command, "attach local-provider-session");
+    assert_eq!(local.binding.expect("local binding").host, local_host);
+
+    let remote =
+        daemon.resolve_attach_command_on_host_internal(session_name, Some(&remote_host)).await.expect("resolve remote same-name session");
+    assert!(remote.command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")));
+    assert!(remote.command.contains("--host"));
+    assert_eq!(remote.binding.expect("remote binding").host, remote_host);
 }
 
 #[tokio::test]
@@ -1773,7 +1958,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -1804,7 +1989,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "coder".to_string() },
+                action: CommandAction::Attach { reference: "coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -1827,7 +2012,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "terminal-remote-coder".to_string() },
+                action: CommandAction::Attach { reference: "terminal-remote-coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -1953,7 +2138,7 @@ async fn attach_query_ignores_fleet_replica_hosts_that_are_not_configured() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "removed-env".to_string() },
+                action: CommandAction::Attach { reference: "removed-env".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2010,7 +2195,7 @@ async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2063,7 +2248,7 @@ async fn attach_query_prefers_exact_reference_over_prefix_matches() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2138,7 +2323,7 @@ async fn attach_query_rejects_ambiguous_prefix() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2171,7 +2356,7 @@ async fn attach_query_reports_no_matching_reference() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "missing".to_string() },
+                action: CommandAction::Attach { reference: "missing".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2199,7 +2384,7 @@ async fn attach_query_reports_unreachable_next_hop_for_remote_session_without_ho
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2247,7 +2432,7 @@ async fn attach_query_reports_route_that_points_back_to_local_host() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2281,7 +2466,7 @@ async fn attach_query_reports_ambiguous_routed_host_name() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2305,7 +2490,7 @@ async fn attach_query_rejects_empty_reference() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "".to_string() },
+                action: CommandAction::Attach { reference: "".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2342,7 +2527,7 @@ async fn attach_query_errors_when_recorded_terminal_pool_is_unavailable() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string() },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
             },
             uuid::Uuid::new_v4(),
         )

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -21,27 +21,28 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     api_version, repository_display_labels, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource,
-    Demand, DemandAddressee, DemandState, Environment, Presentation, Project, Regard, RegardExpiryPolicy, Repository, Resource,
-    ResourceError, ResourceList, ResourceObject, TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, Vessel,
-    VesselRequirement, WatchEvent, WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_KEY_LABEL,
-    REPO_LABEL, VESSEL_LABEL,
+    Demand, DemandAddressee, DemandState, Environment, Presentation, Project, ReadResourceList, ReadResourceObject, ReadWatchEvent, Regard,
+    RegardExpiryPolicy, ReplicaReadResolver, Repository, Resource, ResourceError, ResourceList, ResourceObject, ResourceProvenance,
+    TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, Vessel, VesselRequirement, WatchEvent, WatchStart,
+    WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, VESSEL_LABEL,
 };
-use futures::StreamExt;
+use futures::{stream::BoxStream, StreamExt};
 use tokio::sync::{broadcast, mpsc};
 
 use crate::issue_materializer::{IssueMaterializationResolver, IssueMaterializer};
 
 type PresentationKey = (String, String, String);
-type SessionKey = (String, String);
+type ConvoyKey = (String, String, Option<flotilla_protocol::NodeId>);
+type SessionKey = (String, String, Option<flotilla_protocol::NodeId>);
 type ChangeRequestFingerprint = HashMap<String, (String, String)>;
 
 #[derive(bon::Builder)]
 pub struct AggregatorResolvers {
-    durable_convoys: TypedResolver<Convoy>,
+    durable_convoys: ReplicaReadResolver<Convoy>,
     durable_demands: TypedResolver<Demand>,
     durable_environments: TypedResolver<Environment>,
     durable_presentations: TypedResolver<Presentation>,
-    durable_sessions: TypedResolver<TerminalSession>,
+    durable_sessions: ReplicaReadResolver<TerminalSession>,
     durable_projects: TypedResolver<Project>,
     durable_repositories: TypedResolver<Repository>,
     durable_regards: TypedResolver<Regard>,
@@ -53,11 +54,11 @@ pub struct AggregatorResolvers {
 
 #[derive(bon::Builder)]
 struct AggregatorSourceRefs<'a> {
-    durable_convoys: &'a dyn AggregatorWatchSource<Convoy>,
+    durable_convoys: &'a dyn AggregatorReplicaWatchSource<Convoy>,
     durable_demands: &'a dyn AggregatorWatchSource<Demand>,
     durable_environments: &'a dyn AggregatorWatchSource<Environment>,
     durable_presentations: &'a dyn AggregatorWatchSource<Presentation>,
-    durable_sessions: &'a dyn AggregatorWatchSource<TerminalSession>,
+    durable_sessions: &'a dyn AggregatorReplicaWatchSource<TerminalSession>,
     durable_projects: &'a dyn AggregatorWatchSource<Project>,
     durable_repositories: &'a dyn AggregatorWatchSource<Repository>,
     durable_regards: &'a dyn AggregatorWatchSource<Regard>,
@@ -93,8 +94,33 @@ impl<T: Resource> AggregatorWatchSource<T> for TypedResolver<T> {
 }
 
 #[async_trait]
+trait AggregatorReplicaWatchSource<T: Resource>: Send + Sync {
+    async fn list_and_watch(
+        &self,
+    ) -> Result<(ReadResourceList<T>, BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>), ResourceError>;
+}
+
+#[async_trait]
+impl<T: Resource> AggregatorReplicaWatchSource<T> for ReplicaReadResolver<T> {
+    async fn list_and_watch(
+        &self,
+    ) -> Result<(ReadResourceList<T>, BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>), ResourceError> {
+        // The aggregate replica view has no single resumable cursor. Subscribe
+        // first so a racing write is present in the list, the watch, or both.
+        let watch = self.watch().await?;
+        let listed = self.list().await?;
+        Ok((listed, watch))
+    }
+}
+
+#[async_trait]
 pub(crate) trait AttachCapabilityResolver: Send + Sync {
-    async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String>;
+    async fn resolvable_attach_targets(&self, targets: &[(String, HostName)]) -> Result<Vec<bool>, String>;
+
+    async fn origin_host_names(&self, origins: &HashSet<flotilla_protocol::NodeId>) -> HashMap<flotilla_protocol::NodeId, HostName> {
+        let _ = origins;
+        HashMap::new()
+    }
 }
 
 #[async_trait]
@@ -111,8 +137,12 @@ impl ConvoyChangeRequestResolver for InProcessDaemon {
 
 #[async_trait]
 impl AttachCapabilityResolver for InProcessDaemon {
-    async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String> {
-        self.resolvable_attach_references_internal(references).await
+    async fn resolvable_attach_targets(&self, targets: &[(String, HostName)]) -> Result<Vec<bool>, String> {
+        self.resolvable_attach_targets_internal(targets).await
+    }
+
+    async fn origin_host_names(&self, origins: &HashSet<flotilla_protocol::NodeId>) -> HashMap<flotilla_protocol::NodeId, HostName> {
+        self.origin_host_names_internal(origins).await
     }
 }
 
@@ -121,16 +151,17 @@ pub struct Aggregator {
     state: AggregatorProjectionState,
     local_host: HostName,
     #[builder(skip)]
-    convoys_by_source: HashMap<LocalSource, HashMap<ResourceRef, ResourceObject<Convoy>>>,
+    convoys_by_source: HashMap<LocalSource, HashMap<ConvoyKey, ReadResourceObject<Convoy>>>,
     #[builder(skip)]
     demands: HashMap<ResourceRef, ResourceObject<Demand>>,
     #[builder(skip)]
     presentations_by_source: HashMap<LocalSource, HashMap<ResourceRef, ResourceObject<Presentation>>>,
     #[builder(skip)]
-    sessions_by_source: HashMap<LocalSource, HashMap<SessionKey, ResourceObject<TerminalSession>>>,
+    sessions_by_source: HashMap<LocalSource, HashMap<SessionKey, ReadResourceObject<TerminalSession>>>,
     presentation_workspaces: HashMap<PresentationKey, String>,
-    terminal_sessions: HashMap<SessionKey, ResourceObject<TerminalSession>>,
-    attachable_references: HashSet<String>,
+    terminal_sessions: HashMap<SessionKey, ReadResourceObject<TerminalSession>>,
+    attachable_sessions: HashSet<SessionKey>,
+    origin_hosts: HashMap<flotilla_protocol::NodeId, HostName>,
     projects: HashMap<(String, String), ResourceObject<Project>>,
     repositories: HashMap<RepositoryKey, ResourceObject<Repository>>,
     #[builder(skip)]
@@ -189,7 +220,8 @@ impl Aggregator {
             sessions_by_source: HashMap::new(),
             presentation_workspaces: HashMap::new(),
             terminal_sessions: HashMap::new(),
-            attachable_references: HashSet::new(),
+            attachable_sessions: HashSet::new(),
+            origin_hosts: HashMap::new(),
             projects: HashMap::new(),
             repositories: HashMap::new(),
             regards: HashMap::new(),
@@ -307,11 +339,11 @@ impl Aggregator {
             }
         }
         self.state.replace_local_independent_rows(Vec::new()).await;
-        let mut durable_convoy_stream = self.recover_convoy_watch(LocalSource::Durable, durable_convoys).await?;
+        let mut durable_convoy_stream = self.recover_replica_convoy_watch(durable_convoys).await?;
         let mut durable_demand_stream = self.recover_demand_watch(durable_demands).await?;
         let mut durable_environment_stream = self.recover_environment_watch(durable_environments).await?;
         let mut durable_presentation_stream = self.recover_presentation_watch(LocalSource::Durable, durable_presentations).await?;
-        let mut durable_session_stream = self.recover_session_watch(LocalSource::Durable, durable_sessions).await?;
+        let mut durable_session_stream = self.recover_replica_session_watch(durable_sessions).await?;
         let mut durable_project_stream = self.recover_project_watch(durable_projects).await?;
         let mut durable_repository_stream = self.recover_repository_watch(durable_repositories).await?;
         let mut durable_regard_stream = self.recover_regard_watch(durable_regards).await?;
@@ -374,6 +406,14 @@ impl Aggregator {
                             self.refresh_all_change_requests().await;
                         }
                     }
+                    Ok(
+                        DaemonEvent::PeerStatusChanged { .. }
+                        | DaemonEvent::HostSnapshot(_)
+                        | DaemonEvent::HostRemoved { .. },
+                    ) => {
+                        self.rebuild_independents_projection().await;
+                        self.rebuild_local_projection().await;
+                    }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
                         tracing::warn!(skipped, "aggregator lagged behind daemon refresh events");
@@ -389,9 +429,9 @@ impl Aggregator {
                     }
                 },
                 event = durable_convoy_stream.next() => match event {
-                    Some(Ok(event)) => self.apply_convoy_event_from(LocalSource::Durable, event).await,
+                    Some(Ok(event)) => self.apply_replica_convoy_event(event).await,
                     Some(Err(ResourceError::WatchExpired { .. })) => {
-                        durable_convoy_stream = self.recover_convoy_watch(LocalSource::Durable, durable_convoys).await?;
+                        durable_convoy_stream = self.recover_replica_convoy_watch(durable_convoys).await?;
                     }
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator durable convoy watch ended")),
@@ -421,9 +461,9 @@ impl Aggregator {
                     None => return Err(ResourceError::other("aggregator durable presentation watch ended")),
                 },
                 event = durable_session_stream.next() => match event {
-                    Some(Ok(event)) => self.apply_session_event_from(LocalSource::Durable, event).await,
+                    Some(Ok(event)) => self.apply_replica_session_event(event).await,
                     Some(Err(ResourceError::WatchExpired { .. })) => {
-                        durable_session_stream = self.recover_session_watch(LocalSource::Durable, durable_sessions).await?;
+                        durable_session_stream = self.recover_replica_session_watch(durable_sessions).await?;
                     }
                     Some(Err(err)) => return Err(err),
                     None => return Err(ResourceError::other("aggregator durable terminal session watch ended")),
@@ -510,6 +550,15 @@ impl Aggregator {
         }
     }
 
+    async fn recover_replica_convoy_watch(
+        &mut self,
+        resolver: &dyn AggregatorReplicaWatchSource<Convoy>,
+    ) -> Result<BoxStream<'static, Result<ReadWatchEvent<Convoy>, ResourceError>>, ResourceError> {
+        let (items, watch) = Self::recover_replica_watch(resolver).await?;
+        self.replace_replica_convoys(items).await;
+        Ok(watch)
+    }
+
     async fn recover_presentation_watch(
         &mut self,
         source: LocalSource,
@@ -562,6 +611,27 @@ impl Aggregator {
             match self.list_and_watch_sessions(source, resolver).await {
                 Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
                 result => return result,
+            }
+        }
+    }
+
+    async fn recover_replica_session_watch(
+        &mut self,
+        resolver: &dyn AggregatorReplicaWatchSource<TerminalSession>,
+    ) -> Result<BoxStream<'static, Result<ReadWatchEvent<TerminalSession>, ResourceError>>, ResourceError> {
+        let (items, watch) = Self::recover_replica_watch(resolver).await?;
+        self.replace_replica_sessions(items).await;
+        Ok(watch)
+    }
+
+    async fn recover_replica_watch<T: Resource>(
+        resolver: &dyn AggregatorReplicaWatchSource<T>,
+    ) -> Result<(Vec<ReadResourceObject<T>>, BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>), ResourceError> {
+        loop {
+            match resolver.list_and_watch().await {
+                Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
+                Ok((listed, watch)) => return Ok((listed.items, watch)),
+                Err(error) => return Err(error),
             }
         }
     }
@@ -649,10 +719,22 @@ impl Aggregator {
     }
 
     async fn replace_convoy_source(&mut self, source: LocalSource, convoys: Vec<ResourceObject<Convoy>>) {
+        self.replace_convoy_read_source(
+            source,
+            convoys.into_iter().map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local }).collect(),
+        )
+        .await;
+    }
+
+    async fn replace_replica_convoys(&mut self, convoys: Vec<ReadResourceObject<Convoy>>) {
+        self.replace_convoy_read_source(LocalSource::Durable, convoys).await;
+    }
+
+    async fn replace_convoy_read_source(&mut self, source: LocalSource, convoys: Vec<ReadResourceObject<Convoy>>) {
         let previous = self.effective_convoys();
-        let replacement =
-            convoys.into_iter().map(|convoy| (self.convoy_ref(&convoy.metadata.namespace, &convoy.metadata.name), convoy)).collect();
+        let replacement = convoys.into_iter().map(|convoy| (convoy_key(&convoy), convoy)).collect();
         self.convoys_by_source.insert(source, replacement);
+        self.refresh_origin_hosts().await;
         let current = self.effective_convoys();
         let references = previous.keys().chain(current.keys()).cloned().collect::<HashSet<_>>();
         self.convoy_change_requests.retain(|reference, _| current.contains_key(reference));
@@ -782,24 +864,38 @@ impl Aggregator {
     }
 
     async fn apply_convoy_event_from(&mut self, source: LocalSource, event: WatchEvent<Convoy>) {
+        self.apply_convoy_read_event_from(source, local_read_event(event)).await;
+    }
+
+    async fn apply_replica_convoy_event(&mut self, event: ReadWatchEvent<Convoy>) {
+        self.apply_convoy_read_event_from(LocalSource::Durable, event).await;
+    }
+
+    async fn apply_convoy_read_event_from(&mut self, source: LocalSource, event: ReadWatchEvent<Convoy>) {
         let convoy = match &event {
-            WatchEvent::Added(convoy) | WatchEvent::Modified(convoy) | WatchEvent::Deleted(convoy) => convoy,
+            ReadWatchEvent::Added(convoy) | ReadWatchEvent::Modified(convoy) | ReadWatchEvent::Deleted(convoy) => convoy,
         };
-        let reference = self.convoy_ref(&convoy.metadata.namespace, &convoy.metadata.name);
-        let previous = self.projected_convoy(&reference).cloned();
+        let key = convoy_key(convoy);
+        let previous = self.effective_convoys();
         match event {
-            WatchEvent::Added(convoy) | WatchEvent::Modified(convoy) => {
-                self.convoys_by_source.entry(source).or_default().insert(reference.clone(), convoy);
+            ReadWatchEvent::Added(convoy) | ReadWatchEvent::Modified(convoy) => {
+                self.convoys_by_source.entry(source).or_default().insert(key, convoy);
             }
-            WatchEvent::Deleted(_) => {
-                self.convoys_by_source.entry(source).or_default().remove(&reference);
+            ReadWatchEvent::Deleted(_) => {
+                self.convoys_by_source.entry(source).or_default().remove(&key);
             }
         }
-        let current = self.projected_convoy(&reference).cloned();
-        self.handle_convoy_transition(&reference, previous.as_ref(), current.as_ref());
-        if current.is_none() {
-            self.change_request_refresh_generations.remove(&reference);
+        self.refresh_origin_hosts().await;
+        // Refreshing one origin can make other buffered convoy refs
+        // projectable too, so transition detection must compare the whole
+        // effective view rather than only the event's key.
+        let current = self.effective_convoys();
+        let references = previous.keys().chain(current.keys()).cloned().collect::<HashSet<_>>();
+        for reference in references {
+            self.handle_convoy_transition(&reference, previous.get(&reference), current.get(&reference));
         }
+        self.convoy_change_requests.retain(|reference, _| current.contains_key(reference));
+        self.change_request_refresh_generations.retain(|reference, _| current.contains_key(reference));
         self.rebuild_local_projection().await;
     }
 
@@ -928,29 +1024,32 @@ impl Aggregator {
     }
 
     fn effective_convoys(&self) -> HashMap<ResourceRef, ResourceObject<Convoy>> {
-        let mut effective_convoys = HashMap::new();
-        for source in LOCAL_SOURCE_PRECEDENCE {
-            let Some(convoys) = self.convoys_by_source.get(&source) else { continue };
-            effective_convoys.extend(convoys.iter().map(|(reference, convoy)| (reference.clone(), convoy.clone())));
-        }
-        effective_convoys.retain(|_, convoy| convoy.metadata.deletion_timestamp.is_none());
+        self.effective_convoy_reads().into_iter().map(|(reference, convoy)| (reference, convoy.object)).collect()
+    }
+
+    fn effective_convoy_reads(&self) -> HashMap<ResourceRef, ReadResourceObject<Convoy>> {
+        let mut effective_convoys = self.effective_convoy_reads_including_deleted();
+        effective_convoys.retain(|_, convoy| convoy.object.metadata.deletion_timestamp.is_none());
         effective_convoys
     }
 
-    fn effective_convoy(&self, reference: &ResourceRef) -> Option<&ResourceObject<Convoy>> {
-        LOCAL_SOURCE_PRECEDENCE.iter().rev().find_map(|source| self.convoys_by_source.get(source)?.get(reference))
-    }
-
-    fn projected_convoy(&self, reference: &ResourceRef) -> Option<&ResourceObject<Convoy>> {
-        self.effective_convoy(reference).filter(|convoy| convoy.metadata.deletion_timestamp.is_none())
+    fn effective_convoy_reads_including_deleted(&self) -> HashMap<ResourceRef, ReadResourceObject<Convoy>> {
+        let mut effective_by_origin = HashMap::new();
+        for source in LOCAL_SOURCE_PRECEDENCE {
+            let Some(convoys) = self.convoys_by_source.get(&source) else { continue };
+            effective_by_origin.extend(convoys.iter().map(|(key, convoy)| (key.clone(), convoy.clone())));
+        }
+        effective_by_origin.into_values().filter_map(|convoy| self.read_convoy_ref(&convoy).map(|reference| (reference, convoy))).collect()
     }
 
     async fn rebuild_local_projection(&mut self) {
-        let effective_convoys = self.effective_convoys();
+        self.refresh_origin_hosts().await;
+        let effective_convoys = self.effective_convoy_reads();
         let salience_changed = self.rebuild_salience_projection().await;
         let presentation_keys = effective_convoys
             .values()
             .flat_map(|convoy| {
+                let convoy = &convoy.object;
                 convoy.status.as_ref().and_then(|status| status.workflow_snapshot.as_ref()).into_iter().flat_map(|snapshot| {
                     snapshot
                         .vessels
@@ -979,22 +1078,46 @@ impl Aggregator {
         }
         self.presentation_workspaces = presentation_workspaces;
 
-        let replacement = effective_convoys
-            .into_values()
-            .map(|convoy| {
-                let row = self.summarize(&convoy);
-                (row.resource.clone(), row)
-            })
-            .collect::<HashMap<_, _>>();
+        let mut local_replacement = HashMap::new();
+        let mut replica_replacements: HashMap<HostName, HashMap<ResourceRef, ConvoyRow>> = HashMap::new();
+        for (reference, convoy) in effective_convoys {
+            let row = self.summarize(&reference, &convoy.object);
+            match convoy.provenance {
+                ResourceProvenance::Local => {
+                    local_replacement.insert(row.resource.clone(), row);
+                }
+                ResourceProvenance::Replica { .. } => {
+                    let host = reference.host.clone().expect("replica convoy reference is host-qualified");
+                    replica_replacements.entry(host).or_default().insert(row.resource.clone(), row);
+                }
+            }
+        }
 
         let (changed, removed, result_set) = {
             let mut view = self.state.write().await;
-            let changed = replacement
+            let changed = local_replacement
                 .iter()
                 .filter(|(reference, row)| view.local_rows.get(*reference) != Some(*row))
                 .map(|(_, row)| row.clone())
+                .chain(replica_replacements.iter().flat_map(|(host, rows)| {
+                    let prior = view.replica_rows.get(host);
+                    rows.iter()
+                        .filter(move |(reference, row)| prior.and_then(|prior| prior.get(*reference)) != Some(*row))
+                        .map(|(_, row)| row.clone())
+                }))
                 .collect::<Vec<_>>();
-            let removed = view.local_rows.keys().filter(|reference| !replacement.contains_key(*reference)).cloned().collect::<Vec<_>>();
+            let removed = view
+                .local_rows
+                .keys()
+                .filter(|reference| !local_replacement.contains_key(*reference))
+                .cloned()
+                .chain(view.replica_rows.iter().flat_map(|(host, rows)| {
+                    let replacement = replica_replacements.get(host);
+                    rows.keys()
+                        .filter(move |reference| replacement.is_none_or(|replacement| !replacement.contains_key(*reference)))
+                        .cloned()
+                }))
+                .collect::<Vec<_>>();
             if changed.is_empty() && removed.is_empty() {
                 drop(view);
                 if salience_changed && !self.bootstrapping {
@@ -1002,7 +1125,8 @@ impl Aggregator {
                 }
                 return;
             }
-            view.local_rows = replacement;
+            view.local_rows = local_replacement;
+            view.replica_rows = replica_replacements;
             view.seq = view.seq.saturating_add(1);
             (changed, removed, view.result_set())
         };
@@ -1029,26 +1153,39 @@ impl Aggregator {
     }
 
     async fn replace_session_source(&mut self, source: LocalSource, sessions: Vec<ResourceObject<TerminalSession>>) {
-        let replacement =
-            sessions.into_iter().map(|session| ((session.metadata.namespace.clone(), session.metadata.name.clone()), session)).collect();
+        self.replace_session_read_source(
+            source,
+            sessions.into_iter().map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local }).collect(),
+        )
+        .await;
+    }
+
+    async fn replace_replica_sessions(&mut self, sessions: Vec<ReadResourceObject<TerminalSession>>) {
+        self.replace_session_read_source(LocalSource::Durable, sessions).await;
+    }
+
+    async fn replace_session_read_source(&mut self, source: LocalSource, sessions: Vec<ReadResourceObject<TerminalSession>>) {
+        let replacement = sessions.into_iter().map(|session| (session_key(&session), session)).collect();
         self.sessions_by_source.insert(source, replacement);
         self.rebuild_independents_projection().await;
         self.rebuild_local_projection().await;
     }
 
     async fn apply_session_event_from(&mut self, source: LocalSource, event: WatchEvent<TerminalSession>) {
+        self.apply_session_read_event_from(source, local_read_event(event)).await;
+    }
+
+    async fn apply_replica_session_event(&mut self, event: ReadWatchEvent<TerminalSession>) {
+        self.apply_session_read_event_from(LocalSource::Durable, event).await;
+    }
+
+    async fn apply_session_read_event_from(&mut self, source: LocalSource, event: ReadWatchEvent<TerminalSession>) {
         match event {
-            WatchEvent::Added(session) | WatchEvent::Modified(session) => {
-                self.sessions_by_source
-                    .entry(source)
-                    .or_default()
-                    .insert((session.metadata.namespace.clone(), session.metadata.name.clone()), session);
+            ReadWatchEvent::Added(session) | ReadWatchEvent::Modified(session) => {
+                self.sessions_by_source.entry(source).or_default().insert(session_key(&session), session);
             }
-            WatchEvent::Deleted(session) => {
-                self.sessions_by_source
-                    .entry(source)
-                    .or_default()
-                    .remove(&(session.metadata.namespace.clone(), session.metadata.name.clone()));
+            ReadWatchEvent::Deleted(session) => {
+                self.sessions_by_source.entry(source).or_default().remove(&session_key(&session));
             }
         }
         self.rebuild_independents_projection().await;
@@ -1168,22 +1305,42 @@ impl Aggregator {
             effective_sessions.extend(sessions.iter().map(|(key, session)| (key.clone(), session.clone())));
         }
         self.terminal_sessions = effective_sessions;
+        self.refresh_origin_hosts().await;
         let salience_changed = self.rebuild_salience_projection().await;
 
-        self.attachable_references = match &self.attach_resolver {
-            Some(daemon) => {
-                let references = self.terminal_sessions.values().map(|session| session.metadata.name.clone()).collect::<Vec<_>>();
-                daemon.resolvable_attach_references(&references).await.unwrap_or_default()
+        let attach_candidates = self
+            .terminal_sessions
+            .iter()
+            .filter_map(|(key, session)| {
+                self.read_host(&session.provenance).map(|host| (key.clone(), session.object.metadata.name.clone(), host))
+            })
+            .collect::<Vec<_>>();
+        self.attachable_sessions = match &self.attach_resolver {
+            Some(resolver) => {
+                let targets = attach_candidates.iter().map(|(_, reference, host)| (reference.clone(), host.clone())).collect::<Vec<_>>();
+                match resolver.resolvable_attach_targets(&targets).await {
+                    Ok(resolved) if resolved.len() == attach_candidates.len() => {
+                        attach_candidates.into_iter().zip(resolved).filter_map(|((key, _, _), resolved)| resolved.then_some(key)).collect()
+                    }
+                    Ok(_) | Err(_) => HashSet::new(),
+                }
             }
             None => HashSet::new(),
         };
 
-        let replacement = self
-            .terminal_sessions
-            .values()
-            .filter_map(|session| self.summarize_independent(session, &self.attachable_references))
-            .collect();
-        let deltas = self.state.replace_local_independent_rows(replacement).await;
+        let mut local_replacement = Vec::new();
+        let mut replica_replacements: HashMap<HostName, Vec<IndependentRow>> = HashMap::new();
+        for session in self.terminal_sessions.values() {
+            let Some(row) = self.summarize_independent(session, &self.attachable_sessions) else { continue };
+            match &session.provenance {
+                ResourceProvenance::Local => local_replacement.push(row),
+                ResourceProvenance::Replica { .. } => {
+                    replica_replacements.entry(row.host.clone()).or_default().push(row);
+                }
+            }
+        }
+        let mut deltas = self.state.replace_local_independent_rows(local_replacement).await;
+        deltas.extend(self.state.replace_independent_replica_rows(replica_replacements).await);
         let store_changed = !deltas.is_empty();
         self.emit_store_deltas(deltas).await;
         if salience_changed && !store_changed && !self.bootstrapping {
@@ -1192,31 +1349,13 @@ impl Aggregator {
     }
 
     pub async fn apply_replica_cache(&mut self, snapshots: Vec<FleetReplicaSnapshot>) {
-        let mut convoy_replacements = HashMap::new();
-        let mut independent_replacements = HashMap::new();
         let mut checkout_replacements = HashMap::new();
         for snapshot in snapshots {
             let host = snapshot.host;
-            let mut convoy_rows = HashMap::new();
-            let mut independent_rows = Vec::new();
             let mut checkout_rows = Vec::new();
             for result_set in snapshot.result_sets {
                 match result_set.rows {
-                    Rows::Convoys(convoys) => {
-                        for mut row in convoys {
-                            set_convoy_row_host(&mut row, &host);
-                            convoy_rows.insert(row.resource.clone(), row);
-                        }
-                    }
-                    Rows::Independents { scope: None, rows: independents } => {
-                        for mut row in independents {
-                            set_independent_row_host(&mut row, &host);
-                            independent_rows.push(row);
-                        }
-                    }
-                    Rows::Independents { scope: Some(_), .. } => {
-                        tracing::warn!(host = %host, "ignoring derived project independents set in fleet replica snapshot");
-                    }
+                    Rows::Convoys(_) | Rows::Independents { .. } => {}
                     Rows::Issues { .. } => {
                         tracing::warn!(host = %host, "ignoring demand-backed issues in fleet replica snapshot");
                     }
@@ -1234,36 +1373,8 @@ impl Aggregator {
                     }
                 }
             }
-            convoy_replacements.insert(host.clone(), convoy_rows);
-            independent_replacements.insert(host.clone(), independent_rows);
             checkout_replacements.insert(host, checkout_rows);
         }
-
-        let convoy_change = {
-            let mut view = self.state.write().await;
-            view.replace_replica_rows(convoy_replacements)
-        };
-        if let Some((changed, removed)) = convoy_change {
-            if self.emitted_queries.contains(&QueryId::Convoys) {
-                self.emit_delta(changed, removed).await;
-            } else {
-                self.emitted_queries.insert(QueryId::Convoys);
-                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.result_set().await)));
-            }
-            let represented = self.state.represented_issue_refs().await;
-            for delta in self.state.suppress_issues(&represented) {
-                let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
-            }
-            if let Some(materializer) = &self.issue_materializer {
-                // The direct delta hides represented rows immediately; refiltering
-                // republishes loaded windows so rows can reappear when representation
-                // changes again.
-                materializer.refilter_active_queries();
-            }
-        }
-
-        let independent_deltas = self.state.replace_independent_replica_rows(independent_replacements).await;
-        self.emit_store_deltas(independent_deltas).await;
 
         let checkout_deltas = self.state.replace_checkout_replica_rows(checkout_replacements).await;
         self.emit_store_deltas(checkout_deltas).await;
@@ -1320,30 +1431,40 @@ impl Aggregator {
             })
             .collect();
         let mut sessions = self.terminal_sessions.values().collect::<Vec<_>>();
-        sessions
-            .sort_by(|left, right| (&left.metadata.namespace, &left.metadata.name).cmp(&(&right.metadata.namespace, &right.metadata.name)));
+        sessions.sort_by(|left, right| {
+            (&left.object.metadata.namespace, &left.object.metadata.name)
+                .cmp(&(&right.object.metadata.namespace, &right.object.metadata.name))
+        });
+        let effective_convoys = self
+            .effective_convoy_reads_including_deleted()
+            .into_iter()
+            .map(|(reference, convoy)| (reference, convoy.object))
+            .collect::<HashMap<_, _>>();
         let attention = sessions
             .into_iter()
-            .filter_map(|session| {
-                let convoy = session.metadata.labels.get(CONVOY_LABEL)?;
-                let vessel = session.metadata.labels.get(VESSEL_LABEL)?;
-                let status = session.status.as_ref()?;
-                let observation = status.attention.as_ref()?;
+            .flat_map(|session| {
+                let Some(session_host) = self.read_host(&session.provenance) else { return Vec::new() };
+                let session = &session.object;
+                let Some(convoy) = session.metadata.labels.get(CONVOY_LABEL) else { return Vec::new() };
+                let Some(vessel) = session.metadata.labels.get(VESSEL_LABEL) else { return Vec::new() };
+                let Some(status) = session.status.as_ref() else { return Vec::new() };
+                let Some(observation) = status.attention.as_ref() else { return Vec::new() };
                 if status.phase != TerminalSessionPhase::Running || observation.is_stale_at(now) {
-                    return None;
+                    return Vec::new();
                 }
-                let convoy_ref = self.convoy_ref(&session.metadata.namespace, convoy);
-                let work_unsettled = self
-                    .effective_convoy(&convoy_ref)
-                    .and_then(|convoy| convoy.status.as_ref())
-                    .and_then(|status| status.work.get(vessel))
-                    .is_none_or(|work| !work.phase.is_terminal());
-                Some(AttentionFact {
-                    target: convoy_ref.subresource(format!("vessels/{vessel}")),
-                    state: observation.state,
-                    work_unsettled,
-                    as_of: observation.as_of,
-                })
+                effective_convoys
+                    .iter()
+                    .filter(|(reference, _)| reference.namespace == session.metadata.namespace && &reference.name == convoy)
+                    .filter_map(|(reference, convoy)| {
+                        let work = convoy.status.as_ref().and_then(|status| status.work.get(vessel));
+                        (self.vessel_host(reference, work) == session_host).then(|| AttentionFact {
+                            target: reference.subresource(format!("vessels/{vessel}")),
+                            state: observation.state,
+                            work_unsettled: work.is_none_or(|work| !work.phase.is_terminal()),
+                            as_of: observation.as_of,
+                        })
+                    })
+                    .collect()
             })
             .collect();
         SalienceFacts { demands, regards, attention }
@@ -1376,6 +1497,55 @@ impl Aggregator {
         ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
     }
 
+    fn read_convoy_ref(&self, convoy: &ReadResourceObject<Convoy>) -> Option<ResourceRef> {
+        Some(
+            ResourceRef::new(
+                api_version(Convoy::API_PATHS),
+                Convoy::API_PATHS.kind,
+                &convoy.object.metadata.namespace,
+                &convoy.object.metadata.name,
+            )
+            .on_host(self.read_host(&convoy.provenance)?),
+        )
+    }
+
+    fn read_host(&self, provenance: &ResourceProvenance) -> Option<HostName> {
+        match provenance {
+            ResourceProvenance::Local => Some(self.local_host.clone()),
+            ResourceProvenance::Replica { origin_root, .. } => self.origin_hosts.get(origin_root).cloned(),
+        }
+    }
+
+    async fn refresh_origin_hosts(&mut self) {
+        let origins = self
+            .convoys_by_source
+            .values()
+            .flat_map(|convoys| convoys.values())
+            .map(|convoy| &convoy.provenance)
+            .chain(self.sessions_by_source.values().flat_map(|sessions| sessions.values()).map(|session| &session.provenance))
+            .filter_map(|provenance| match provenance {
+                ResourceProvenance::Local => None,
+                ResourceProvenance::Replica { origin_root, .. } => Some(origin_root.clone()),
+            })
+            .collect::<HashSet<_>>();
+        self.origin_hosts = match &self.attach_resolver {
+            Some(resolver) => resolver.origin_host_names(&origins).await,
+            None => HashMap::new(),
+        };
+    }
+
+    fn terminal_session_ref(&self, session: &ReadResourceObject<TerminalSession>) -> Option<ResourceRef> {
+        Some(
+            ResourceRef::new(
+                api_version(TerminalSession::API_PATHS),
+                TerminalSession::API_PATHS.kind,
+                &session.object.metadata.namespace,
+                &session.object.metadata.name,
+            )
+            .on_host(self.read_host(&session.provenance)?),
+        )
+    }
+
     fn presentation_ref(&self, namespace: &str, name: &str) -> ResourceRef {
         ResourceRef::new(api_version(Presentation::API_PATHS), Presentation::API_PATHS.kind, namespace, name)
             .on_host(self.local_host.clone())
@@ -1389,25 +1559,24 @@ impl Aggregator {
         ResourceRef::new(api_version(Regard::API_PATHS), Regard::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
     }
 
-    fn session_ref(&self, namespace: &str, name: &str) -> ResourceRef {
-        ResourceRef::new(api_version(TerminalSession::API_PATHS), TerminalSession::API_PATHS.kind, namespace, name)
-            .on_host(self.local_host.clone())
-    }
-
     fn checkout_ref(&self, namespace: &str, name: &str) -> ResourceRef {
         ResourceRef::new(api_version(Checkout::API_PATHS), Checkout::API_PATHS.kind, namespace, name).on_host(self.local_host.clone())
     }
 
     fn summarize_independent(
         &self,
-        session: &ResourceObject<TerminalSession>,
-        attachable_references: &HashSet<String>,
+        session: &ReadResourceObject<TerminalSession>,
+        attachable_sessions: &HashSet<SessionKey>,
     ) -> Option<IndependentRow> {
+        let resource = self.terminal_session_ref(session)?;
+        let host = resource.host.clone().expect("terminal session read reference is host-qualified");
+        let key = session_key(session);
+        let session = &session.object;
         if !is_independent_session(session) {
             return None;
         }
         let name = &session.metadata.name;
-        let attach = attachable_references.contains(name).then(|| name.clone());
+        let attach = attachable_sessions.contains(&key).then(|| name.clone());
         let repository_key = session.metadata.labels.get(REPO_KEY_LABEL).cloned().map(RepositoryKey);
         let repository_label = repository_key.as_ref().map_or_else(
             || session.metadata.labels.get(REPO_LABEL).cloned(),
@@ -1421,11 +1590,11 @@ impl Aggregator {
         );
         Some(
             IndependentRow::builder()
-                .resource(self.session_ref(&session.metadata.namespace, name))
+                .resource(resource)
                 .name(name)
                 .maybe_repo(repository_label.map(flotilla_protocol::RepoKey))
                 .maybe_repository_key(repository_key)
-                .host(self.local_host.clone())
+                .host(host)
                 .maybe_attach(attach)
                 .phase(SessionPhase::Running)
                 .build(),
@@ -1435,25 +1604,34 @@ impl Aggregator {
         self.presentation_workspaces.get(&(namespace.to_string(), convoy.to_string(), vessel.to_string())).cloned()
     }
 
-    fn vessel_materialize(&self, namespace: &str, convoy: &str, vessel: &str) -> Option<String> {
+    fn vessel_host(&self, convoy_ref: &ResourceRef, state: Option<&WorkState>) -> HostName {
+        state
+            .and_then(|state| state.placement.as_ref())
+            .and_then(|placement| placement.fields.get("host"))
+            .and_then(serde_json::Value::as_str)
+            .map(HostName::new)
+            .or_else(|| convoy_ref.host.clone())
+            .unwrap_or_else(|| self.local_host.clone())
+    }
+
+    fn vessel_materialize(&self, namespace: &str, convoy: &str, vessel: &str, vessel_host: &HostName) -> Option<String> {
         self.terminal_sessions
             .values()
             .filter(|session| {
-                session.metadata.namespace == namespace
-                    && session.metadata.labels.get(CONVOY_LABEL).is_some_and(|value| value == convoy)
-                    && session.metadata.labels.get(VESSEL_LABEL).is_some_and(|value| value == vessel)
-                    && session.status.as_ref().is_some_and(|status| status.phase == TerminalSessionPhase::Running)
-                    && self.attachable_references.contains(&session.metadata.name)
+                session.object.metadata.namespace == namespace
+                    && session.object.metadata.labels.get(CONVOY_LABEL).is_some_and(|value| value == convoy)
+                    && session.object.metadata.labels.get(VESSEL_LABEL).is_some_and(|value| value == vessel)
+                    && session.object.status.as_ref().is_some_and(|status| status.phase == TerminalSessionPhase::Running)
+                    && self.read_host(&session.provenance).as_ref() == Some(vessel_host)
+                    && self.attachable_sessions.contains(&session_key(session))
             })
-            .min_by_key(|session| &session.metadata.name)
-            .map(|session| session.metadata.name.clone())
+            .min_by_key(|session| &session.object.metadata.name)
+            .map(|session| session.object.metadata.name.clone())
     }
 
-    fn summarize(&self, convoy: &ResourceObject<Convoy>) -> ConvoyRow {
-        let namespace = &convoy.metadata.namespace;
+    fn summarize(&self, resource: &ResourceRef, convoy: &ResourceObject<Convoy>) -> ConvoyRow {
         let name = &convoy.metadata.name;
-        let resource = self.convoy_ref(namespace, name);
-        let change_request = self.convoy_change_requests.get(&resource).cloned();
+        let change_request = self.convoy_change_requests.get(resource).cloned();
         let status = convoy.status.as_ref();
         let phase = status.map(|status| status.phase).unwrap_or_default();
         let vessels: Vec<VesselRow> = status
@@ -1463,14 +1641,14 @@ impl Aggregator {
                     .vessels
                     .iter()
                     .map(|definition| {
-                        self.summarize_vessel(&resource, definition, status.and_then(|status| status.work.get(&definition.name)))
+                        self.summarize_vessel(resource, definition, status.and_then(|status| status.work.get(&definition.name)))
                     })
                     .collect()
             })
             .unwrap_or_default();
         let needs_attention = vessels.iter().any(|vessel| vessel.needs_attention);
         ConvoyRow::builder()
-            .resource(resource)
+            .resource(resource.clone())
             .name(name)
             .workflow_ref(&convoy.spec.workflow_ref)
             .dispatching_principal_ref(convoy.spec.dispatching_principal_ref.clone())
@@ -1503,11 +1681,7 @@ impl Aggregator {
     fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {
         let requested_stance = definition.stance.to_string();
         let placement = state.and_then(|state| state.placement.as_ref());
-        let vessel_host = placement
-            .and_then(|placement| placement.fields.get("host"))
-            .and_then(serde_json::Value::as_str)
-            .map(HostName::new)
-            .unwrap_or_else(|| self.local_host.clone());
+        let vessel_host = self.vessel_host(convoy_ref, state);
         let vessel_resource =
             placement.and_then(|placement| placement.fields.get("vessel_ref")).and_then(serde_json::Value::as_str).map(|name| {
                 ResourceRef::new(api_version(Vessel::API_PATHS), Vessel::API_PATHS.kind, &convoy_ref.namespace, name)
@@ -1536,10 +1710,11 @@ impl Aggregator {
         let work_unsettled = !state.is_some_and(|state| state.phase.is_terminal());
         let now = chrono::Utc::now();
         let needs_attention = self.terminal_sessions.values().any(|session| {
-            session.metadata.namespace == convoy_ref.namespace
-                && session.metadata.labels.get(CONVOY_LABEL) == Some(&convoy_ref.name)
-                && session.metadata.labels.get(VESSEL_LABEL) == Some(&definition.name)
-                && session.status.as_ref().is_some_and(|status| {
+            session.object.metadata.namespace == convoy_ref.namespace
+                && session.object.metadata.labels.get(CONVOY_LABEL) == Some(&convoy_ref.name)
+                && session.object.metadata.labels.get(VESSEL_LABEL) == Some(&definition.name)
+                && self.read_host(&session.provenance).as_ref() == Some(&vessel_host)
+                && session.object.status.as_ref().is_some_and(|status| {
                     status.phase == TerminalSessionPhase::Running
                         && status
                             .attention
@@ -1560,9 +1735,9 @@ impl Aggregator {
             .requested_stance(requested_stance)
             .maybe_effective_stance(effective_stance)
             .depends_on(definition.depends_on.clone())
-            .host(vessel_host)
+            .host(vessel_host.clone())
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
-            .maybe_materialize(self.vessel_materialize(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
+            .maybe_materialize(self.vessel_materialize(&convoy_ref.namespace, &convoy_ref.name, &definition.name, &vessel_host))
             .complete_work(state.is_some_and(|state| !state.phase.is_terminal()))
             .needs_attention(needs_attention)
             .build()
@@ -1575,6 +1750,31 @@ impl Drop for Aggregator {
             task.abort();
         }
     }
+}
+
+fn local_read_event<T: Resource>(event: WatchEvent<T>) -> ReadWatchEvent<T> {
+    let local = |object| ReadResourceObject { object, provenance: ResourceProvenance::Local };
+    match event {
+        WatchEvent::Added(object) => ReadWatchEvent::Added(local(object)),
+        WatchEvent::Modified(object) => ReadWatchEvent::Modified(local(object)),
+        WatchEvent::Deleted(object) => ReadWatchEvent::Deleted(local(object)),
+    }
+}
+
+fn convoy_key(convoy: &ReadResourceObject<Convoy>) -> ConvoyKey {
+    let origin = match &convoy.provenance {
+        ResourceProvenance::Local => None,
+        ResourceProvenance::Replica { origin_root, .. } => Some(origin_root.clone()),
+    };
+    (convoy.object.metadata.namespace.clone(), convoy.object.metadata.name.clone(), origin)
+}
+
+fn session_key(session: &ReadResourceObject<TerminalSession>) -> SessionKey {
+    let origin = match &session.provenance {
+        ResourceProvenance::Local => None,
+        ResourceProvenance::Replica { origin_root, .. } => Some(origin_root.clone()),
+    };
+    (session.object.metadata.namespace.clone(), session.object.metadata.name.clone(), origin)
 }
 
 fn regard_as_of(regard: &ResourceObject<Regard>) -> chrono::DateTime<chrono::Utc> {
@@ -1609,18 +1809,6 @@ fn presentation_key(presentation: &ResourceObject<Presentation>) -> Option<Prese
 fn is_independent_session(session: &ResourceObject<TerminalSession>) -> bool {
     !session.metadata.labels.contains_key(CONVOY_LABEL)
         && session.status.as_ref().map(|status| status.phase) == Some(TerminalSessionPhase::Running)
-}
-
-fn set_convoy_row_host(row: &mut ConvoyRow, host: &HostName) {
-    row.resource.host = Some(host.clone());
-    for vessel in &mut row.vessels {
-        vessel.resource.host = Some(host.clone());
-    }
-}
-
-fn set_independent_row_host(row: &mut IndependentRow, host: &HostName) {
-    row.resource.host = Some(host.clone());
-    row.host = host.clone();
 }
 
 fn set_checkout_row_host(row: &mut CheckoutRow, host: &HostName) {
@@ -1668,7 +1856,7 @@ mod tests {
     use std::{
         collections::{BTreeMap, VecDeque},
         sync::{
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc,
         },
         time::Duration,
@@ -1765,6 +1953,189 @@ mod tests {
         let convoy = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
         assert!(convoy.vessels.first().expect("vessel row").needs_attention);
         assert!(convoy.needs_attention);
+    }
+
+    #[tokio::test]
+    async fn replicated_session_materializes_remote_vessel_and_federates_attention() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(8);
+        let resolver = Arc::new(CountingAttachResolver::with_origin("feta-node-id", "feta"));
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("kiwi"), event_tx).with_attach_resolver(Arc::clone(&resolver));
+        let mut convoy = convoy_with_vessel("convoy-a").await;
+        convoy.status.as_mut().expect("convoy status").work.get_mut("implement").expect("work status").placement = Some(PlacementStatus {
+            fields: BTreeMap::from([
+                ("host".to_string(), serde_json::json!("feta")),
+                ("vessel_ref".to_string(), serde_json::json!("convoy-a-implement")),
+            ]),
+        });
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy)).await;
+
+        let now = Utc::now();
+        let mut session = session_object("terminal-convoy-a-implement-coder").await;
+        session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        session.status.as_mut().expect("running status").attention =
+            Some(TerminalAttention { state: TerminalAttentionState::NeedsInput, as_of: now, source: TerminalAttentionSource::Hook });
+        aggregator
+            .replace_replica_sessions(vec![ReadResourceObject {
+                object: session,
+                provenance: ResourceProvenance::Replica {
+                    origin_root: flotilla_protocol::NodeId::new("feta-node-id"),
+                    last_synced_at: now,
+                },
+            }])
+            .await;
+
+        let result = state.result_set().await;
+        let convoy = result.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
+        let vessel = convoy.vessels.first().expect("vessel row");
+        assert_eq!(vessel.host, HostName::new("feta"));
+        assert_eq!(vessel.materialize.as_deref(), Some("terminal-convoy-a-implement-coder"));
+        assert!(vessel.needs_attention);
+        assert!(convoy.needs_attention);
+    }
+
+    #[tokio::test]
+    async fn same_named_local_session_does_not_make_remote_replica_attachable() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(8);
+        let resolver = Arc::new(HostSelectiveAttachResolver {
+            attachable_host: HostName::new("kiwi"),
+            origin_hosts: HashMap::from([(flotilla_protocol::NodeId::new("feta-node-id"), HostName::new("feta"))]),
+        });
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("kiwi"), event_tx).with_attach_resolver(resolver);
+        let mut convoy = convoy_with_vessel("convoy-a").await;
+        convoy.status.as_mut().expect("convoy status").work.get_mut("implement").expect("work status").placement =
+            Some(PlacementStatus { fields: BTreeMap::from([("host".to_string(), serde_json::json!("feta"))]) });
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy)).await;
+
+        let session_name = "terminal-convoy-a-implement-coder";
+        let mut local_session = session_object(session_name).await;
+        local_session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        aggregator.replace_session_source(LocalSource::Durable, vec![local_session]).await;
+
+        let mut remote_session = session_object(session_name).await;
+        remote_session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        aggregator
+            .replace_replica_sessions(vec![ReadResourceObject {
+                object: remote_session,
+                provenance: ResourceProvenance::Replica {
+                    origin_root: flotilla_protocol::NodeId::new("feta-node-id"),
+                    last_synced_at: Utc::now(),
+                },
+            }])
+            .await;
+
+        let result = state.result_set().await;
+        let vessel = &result.rows.as_convoys().expect("convoy rows")[0].vessels[0];
+        assert_eq!(vessel.host, HostName::new("feta"));
+        assert_eq!(vessel.materialize, None);
+    }
+
+    #[tokio::test]
+    async fn replicated_convoy_appears_origin_tagged_in_fleet_awareness() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(8);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("kiwi"), event_tx)
+            .with_attach_resolver(Arc::new(CountingAttachResolver::with_origin("feta-node-id", "feta")));
+        let now = Utc::now();
+        aggregator
+            .replace_replica_convoys(vec![ReadResourceObject {
+                object: convoy_with_vessel("feta-convoy").await,
+                provenance: ResourceProvenance::Replica {
+                    origin_root: flotilla_protocol::NodeId::new("feta-node-id"),
+                    last_synced_at: now,
+                },
+            }])
+            .await;
+
+        let result = state
+            .awareness_result_set(&None, flotilla_protocol::AwarenessGrouping::Convoy, flotilla_protocol::AwarenessLimit::default())
+            .await;
+        let rows = result.rows.as_awareness().expect("awareness rows");
+        let convoy = rows
+            .iter()
+            .flat_map(|node| &node.entries)
+            .find(|entry| entry.kind == flotilla_protocol::AwarenessKind::Convoy && entry.label == "feta-convoy")
+            .expect("remote convoy awareness entry");
+        assert_eq!(convoy.refs[0].host, Some(HostName::new("feta")));
+        assert!(
+            state.local_result_set().await.rows.as_convoys().expect("local convoy rows").is_empty(),
+            "a replica must not be re-exported as this root's local fleet contribution"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_bootstraps_materialization_from_the_store_replica_read_view() {
+        let durable = ResourceBackend::InMemory(InMemoryBackend::default());
+        let observed = ResourceBackend::InMemory(InMemoryBackend::observed());
+        let mut convoy = convoy_with_vessel("convoy-a").await;
+        convoy.status.as_mut().expect("convoy status").work.get_mut("implement").expect("work status").placement =
+            Some(PlacementStatus { fields: BTreeMap::from([("host".to_string(), serde_json::json!("feta"))]) });
+        let convoy_resolver = durable.clone().using::<Convoy>("flotilla");
+        let created = convoy_resolver
+            .create(&InputMeta::builder().name(convoy.metadata.name.clone()).build(), &convoy.spec)
+            .await
+            .expect("seed local convoy");
+        convoy_resolver
+            .update_status(&created.metadata.name, &created.metadata.resource_version, convoy.status.as_ref().expect("convoy status"))
+            .await
+            .expect("seed local convoy status");
+
+        let mut session = session_object("terminal-convoy-a-implement-coder").await;
+        session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        durable
+            .replica_writer::<TerminalSession>(flotilla_protocol::NodeId::new("feta-node-id"), "flotilla")
+            .replace(
+                &ResourceList { items: vec![session], resource_version: "1".to_string(), generation: Some("feta-generation".to_string()) },
+                Utc::now(),
+            )
+            .await
+            .expect("seed remote session replica");
+
+        let state = AggregatorProjectionState::new();
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+        let (replica_tx, replica_rx) = broadcast::channel(1);
+        let attach_resolver = Arc::new(CountingAttachResolver::with_origin("feta-node-id", "feta"));
+        let run_state = state.clone();
+        let run = tokio::spawn(async move {
+            Aggregator::new(run_state, HostName::new("kiwi"), event_tx)
+                .with_attach_resolver(attach_resolver)
+                .run(
+                    AggregatorResolvers::builder()
+                        .durable_convoys(durable.including_replicas::<Convoy>("flotilla"))
+                        .durable_demands(durable.clone().using::<Demand>("flotilla"))
+                        .durable_environments(durable.clone().using::<Environment>("flotilla"))
+                        .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
+                        .durable_sessions(durable.including_replicas::<TerminalSession>("flotilla"))
+                        .durable_projects(durable.using::<Project>("flotilla"))
+                        .durable_repositories(durable.using::<Repository>("flotilla"))
+                        .durable_regards(durable.using::<Regard>("flotilla"))
+                        .observed_convoys(observed.clone().using::<Convoy>("flotilla"))
+                        .observed_presentations(observed.clone().using::<Presentation>("flotilla"))
+                        .observed_sessions(observed.using::<TerminalSession>("flotilla"))
+                        .observed_checkouts(observed.using::<Checkout>("flotilla"))
+                        .build(),
+                    replica_rx,
+                )
+                .await
+        });
+
+        let event = timeout(Duration::from_secs(1), event_rx.recv()).await.expect("aggregator bootstrap").expect("convoy result set");
+        let DaemonEvent::ResultSet(result) = event else { panic!("expected initial result set") };
+        let convoy = result.rows.as_convoys().expect("convoy rows").first().expect("local convoy");
+        assert_eq!(convoy.vessels[0].materialize.as_deref(), Some("terminal-convoy-a-implement-coder"));
+
+        drop(replica_tx);
+        assert!(run
+            .await
+            .expect("aggregator task")
+            .expect_err("closed replica channel should stop run")
+            .to_string()
+            .contains("replica channel closed"));
     }
 
     #[tokio::test]
@@ -1915,12 +2286,35 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl<T: Resource> AggregatorReplicaWatchSource<T> for ScriptedSource<T> {
+        async fn list_and_watch(
+            &self,
+        ) -> Result<(ReadResourceList<T>, BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>), ResourceError> {
+            let listed = AggregatorWatchSource::list(self).await?;
+            let watch = AggregatorWatchSource::watch(self, WatchStart::resuming_from(&listed)).await?;
+            let items =
+                listed.items.into_iter().map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local }).collect();
+            Ok((ReadResourceList { items }, watch.map(|event| event.map(local_read_event)).boxed()))
+        }
+    }
+
     struct CountingAttachResolver {
         calls: AtomicUsize,
+        origin_hosts: HashMap<flotilla_protocol::NodeId, HostName>,
+    }
+
+    struct HostSelectiveAttachResolver {
+        attachable_host: HostName,
+        origin_hosts: HashMap<flotilla_protocol::NodeId, HostName>,
     }
 
     struct FlippingAttachResolver {
         calls: AtomicUsize,
+    }
+
+    struct ToggleAttachResolver {
+        live: AtomicBool,
     }
 
     struct ScriptedChangeRequestResolver {
@@ -1930,6 +2324,19 @@ mod tests {
     }
 
     struct BlockingChangeRequestResolver;
+
+    impl CountingAttachResolver {
+        fn new() -> Self {
+            Self { calls: AtomicUsize::new(0), origin_hosts: HashMap::new() }
+        }
+
+        fn with_origin(origin: &str, host: &str) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                origin_hosts: HashMap::from([(flotilla_protocol::NodeId::new(origin), HostName::new(host))]),
+            }
+        }
+    }
 
     #[async_trait]
     impl ConvoyChangeRequestResolver for BlockingChangeRequestResolver {
@@ -1958,17 +2365,47 @@ mod tests {
 
     #[async_trait]
     impl AttachCapabilityResolver for CountingAttachResolver {
-        async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String> {
+        async fn resolvable_attach_targets(&self, targets: &[(String, HostName)]) -> Result<Vec<bool>, String> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            Ok(references.iter().cloned().collect())
+            Ok(vec![true; targets.len()])
+        }
+
+        async fn origin_host_names(&self, origins: &HashSet<flotilla_protocol::NodeId>) -> HashMap<flotilla_protocol::NodeId, HostName> {
+            self.origin_hosts
+                .iter()
+                .filter(|(origin, _)| origins.contains(*origin))
+                .map(|(origin, host)| (origin.clone(), host.clone()))
+                .collect()
+        }
+    }
+
+    #[async_trait]
+    impl AttachCapabilityResolver for HostSelectiveAttachResolver {
+        async fn resolvable_attach_targets(&self, targets: &[(String, HostName)]) -> Result<Vec<bool>, String> {
+            Ok(targets.iter().map(|(_, host)| host == &self.attachable_host).collect())
+        }
+
+        async fn origin_host_names(&self, origins: &HashSet<flotilla_protocol::NodeId>) -> HashMap<flotilla_protocol::NodeId, HostName> {
+            self.origin_hosts
+                .iter()
+                .filter(|(origin, _)| origins.contains(*origin))
+                .map(|(origin, host)| (origin.clone(), host.clone()))
+                .collect()
         }
     }
 
     #[async_trait]
     impl AttachCapabilityResolver for FlippingAttachResolver {
-        async fn resolvable_attach_references(&self, references: &[String]) -> Result<HashSet<String>, String> {
+        async fn resolvable_attach_targets(&self, targets: &[(String, HostName)]) -> Result<Vec<bool>, String> {
             let call = self.calls.fetch_add(1, Ordering::SeqCst);
-            Ok(if call == 0 { HashSet::new() } else { references.iter().cloned().collect() })
+            Ok(vec![call != 0; targets.len()])
+        }
+    }
+
+    #[async_trait]
+    impl AttachCapabilityResolver for ToggleAttachResolver {
+        async fn resolvable_attach_targets(&self, targets: &[(String, HostName)]) -> Result<Vec<bool>, String> {
+            Ok(vec![self.live.load(Ordering::SeqCst); targets.len()])
         }
     }
 
@@ -2002,7 +2439,7 @@ mod tests {
 
     async fn run_with_test_sources(
         aggregator: Aggregator,
-        durable_convoys: &dyn AggregatorWatchSource<Convoy>,
+        durable_convoys: &dyn AggregatorReplicaWatchSource<Convoy>,
         durable_presentations: &dyn AggregatorWatchSource<Presentation>,
         observed_convoys: &dyn AggregatorWatchSource<Convoy>,
         observed_presentations: &dyn AggregatorWatchSource<Presentation>,
@@ -2263,7 +2700,7 @@ mod tests {
     async fn independents_projection_resolves_attach_capabilities_once_per_rebuild() {
         let state = AggregatorProjectionState::new();
         let (event_tx, _) = broadcast::channel(4);
-        let resolver = Arc::new(CountingAttachResolver { calls: AtomicUsize::new(0) });
+        let resolver = Arc::new(CountingAttachResolver::new());
         let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx).with_attach_resolver(Arc::clone(&resolver));
 
         aggregator
@@ -2403,6 +2840,86 @@ mod tests {
 
         let after = state.result_set().await;
         assert_eq!(after.rows.as_convoys().expect("convoy rows")[0].vessels[0].materialize.as_deref(), Some("terminal-convoy-a-implement"));
+    }
+
+    #[tokio::test]
+    async fn peer_route_changes_retract_and_restore_materialization_without_restart() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, mut event_rx) = broadcast::channel(16);
+        let resolver = Arc::new(ToggleAttachResolver { live: AtomicBool::new(true) });
+        let mut session = session_object("terminal-convoy-a-implement").await;
+        session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        let durable_convoys = ScriptedSource::new(
+            vec![ResourceList { items: vec![convoy_with_vessel("convoy-a").await], resource_version: "1".to_string(), generation: None }],
+            vec![Ok(pending_watch())],
+        );
+        let durable_demands = ScriptedSource::<Demand>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_environments = ScriptedSource::<Environment>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_presentations = ScriptedSource::<Presentation>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_sessions =
+            ScriptedSource::new(vec![ResourceList { items: vec![session], resource_version: "1".to_string(), generation: None }], vec![
+                Ok(pending_watch()),
+            ]);
+        let durable_projects = ScriptedSource::<Project>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_repositories = ScriptedSource::<Repository>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let durable_regards = ScriptedSource::<Regard>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let observed_convoys = ScriptedSource::<Convoy>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let observed_presentations = ScriptedSource::<Presentation>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let observed_sessions = ScriptedSource::<TerminalSession>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let observed_checkouts = ScriptedSource::<Checkout>::new(vec![empty_list()], vec![Ok(pending_watch())]);
+        let sources = AggregatorSourceRefs::builder()
+            .durable_convoys(&durable_convoys)
+            .durable_demands(&durable_demands)
+            .durable_environments(&durable_environments)
+            .durable_presentations(&durable_presentations)
+            .durable_sessions(&durable_sessions)
+            .durable_projects(&durable_projects)
+            .durable_repositories(&durable_repositories)
+            .durable_regards(&durable_regards)
+            .observed_convoys(&observed_convoys)
+            .observed_presentations(&observed_presentations)
+            .observed_sessions(&observed_sessions)
+            .observed_checkouts(&observed_checkouts)
+            .build();
+        let (_replica_tx, replica_rx) = broadcast::channel(1);
+        let run = Aggregator::new(state, HostName::new("kiwi"), event_tx.clone())
+            .with_attach_resolver(Arc::clone(&resolver))
+            .run_with_sources(sources, replica_rx);
+        tokio::pin!(run);
+
+        tokio::select! {
+            result = &mut run => panic!("aggregator stopped during route transition test: {result:?}"),
+            () = async {
+                let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy set").await;
+                let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial result set") };
+                assert_eq!(
+                    initial.rows.as_convoys().expect("convoy rows")[0].vessels[0].materialize.as_deref(),
+                    Some("terminal-convoy-a-implement")
+                );
+
+                resolver.live.store(false, Ordering::SeqCst);
+                let _ = event_tx.send(DaemonEvent::PeerStatusChanged {
+                    node_id: flotilla_protocol::NodeId::new("feta"),
+                    status: flotilla_protocol::PeerConnectionState::Disconnected,
+                });
+                let disconnected = recv_query_event(&mut event_rx, QueryId::Convoys, "disconnect should retract recipe").await;
+                let DaemonEvent::ResultDelta(disconnected) = disconnected else { panic!("expected disconnect delta") };
+                assert_eq!(disconnected.changes.as_convoys().expect("convoy changes")[0].vessels[0].materialize, None);
+
+                resolver.live.store(true, Ordering::SeqCst);
+                let _ = event_tx.send(DaemonEvent::PeerStatusChanged {
+                    node_id: flotilla_protocol::NodeId::new("feta"),
+                    status: flotilla_protocol::PeerConnectionState::Connected,
+                });
+                let reconnected = recv_query_event(&mut event_rx, QueryId::Convoys, "reconnect should restore recipe").await;
+                let DaemonEvent::ResultDelta(reconnected) = reconnected else { panic!("expected reconnect delta") };
+                assert_eq!(
+                    reconnected.changes.as_convoys().expect("convoy changes")[0].vessels[0].materialize.as_deref(),
+                    Some("terminal-convoy-a-implement")
+                );
+            } => {}
+        }
     }
 
     #[tokio::test]
@@ -2731,48 +3248,6 @@ mod tests {
         assert!(!aggregator.repo_snapshot_changed_change_requests(&with_change_request));
     }
 
-    fn remote_snapshot(host: &str, generation: &str, name: &str) -> FleetReplicaSnapshot {
-        let host = HostName::new(host);
-        let convoy = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", name).on_host(host.clone());
-        let row = ConvoyRow::builder()
-            .resource(convoy)
-            .name(name)
-            .workflow_ref("scratch")
-            .phase(ConvoyPhase::Active)
-            .project_ref("my-project")
-            .build();
-        FleetReplicaSnapshot {
-            host,
-            generation: Some(generation.to_string()),
-            rows: Vec::new(),
-            result_sets: vec![ResultSet { seq: 1, rows: Rows::Convoys(vec![row]), state: Default::default() }],
-        }
-    }
-
-    fn remote_independent_snapshot(
-        host: &str,
-        generation: &str,
-        name: &str,
-        repository_key: Option<RepositoryKey>,
-    ) -> FleetReplicaSnapshot {
-        let host = HostName::new(host);
-        let session = ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", name);
-        let row = IndependentRow::builder()
-            .resource(session)
-            .name(name)
-            .maybe_repository_key(repository_key)
-            .host(HostName::new("incorrect-source-host"))
-            .attach(name)
-            .phase(SessionPhase::Running)
-            .build();
-        FleetReplicaSnapshot {
-            host,
-            generation: Some(generation.to_string()),
-            rows: Vec::new(),
-            result_sets: vec![ResultSet { seq: 1, rows: Rows::Independents { scope: None, rows: vec![row] }, state: Default::default() }],
-        }
-    }
-
     fn convoy_names(rows: &Rows) -> Vec<&str> {
         rows.as_convoys().expect("convoy rows").iter().map(|row| row.name.as_str()).collect()
     }
@@ -2909,74 +3384,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replica_replacement_emits_removed_and_changed_rows() {
-        let state = AggregatorProjectionState::new();
-        let (tx, mut rx) = broadcast::channel(8);
-        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
-
-        aggregator.apply_replica_cache(vec![remote_snapshot("feta", "generation-1", "old")]).await;
-        assert!(matches!(rx.recv().await.expect("initial event"), DaemonEvent::ResultSet(_)));
-
-        aggregator.apply_replica_cache(vec![remote_snapshot("feta", "generation-2", "new")]).await;
-        let DaemonEvent::ResultDelta(delta) = rx.recv().await.expect("replacement event") else { panic!("expected result delta") };
-        assert_eq!(delta.changes.as_convoys().expect("convoy changes").iter().map(|row| row.name.as_str()).collect::<Vec<_>>(), vec![
-            "new"
-        ]);
-        let removed = delta.changes.removed_resources().expect("convoy removals");
-        assert_eq!(removed.len(), 1);
-        assert_eq!(removed[0].name, "old");
-
-        let result_set = state.result_set().await;
-        assert_eq!(convoy_names(&result_set.rows), vec!["new"]);
-    }
-
-    #[tokio::test]
-    async fn replica_cache_preserves_project_ref() {
-        let state = AggregatorProjectionState::new();
-        let (tx, mut rx) = broadcast::channel(8);
-        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
-
-        aggregator.apply_replica_cache(vec![remote_snapshot("feta", "generation-1", "remote-convoy")]).await;
-        assert!(matches!(rx.recv().await.expect("initial event"), DaemonEvent::ResultSet(_)));
-
-        let result_set = state.result_set().await;
-        let rows = result_set.rows.as_convoys().expect("convoy rows");
-        let row = rows.first().expect("replica convoy row");
-        assert_eq!(row.project_ref.as_deref(), Some("my-project"));
-    }
-
-    #[tokio::test]
-    async fn replica_cache_preserves_vessel_placement_host() {
-        let state = AggregatorProjectionState::new();
-        let mut snapshot = remote_snapshot("kiwi", "generation-1", "remote-convoy");
-        let vessel_host = HostName::new("feta");
-        let vessel = VesselRow::builder()
-            .resource(ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "remote-convoy").subresource("vessels/implement"))
-            .vessel_resource(
-                ResourceRef::new("flotilla.work/v1", "Vessel", "flotilla", "remote-convoy-implement").on_host(vessel_host.clone()),
-            )
-            .name("implement")
-            .phase(WorkPhase::Running)
-            .host(vessel_host.clone())
-            .build();
-        let Rows::Convoys(rows) = &mut snapshot.result_sets[0].rows else {
-            panic!("expected convoy rows");
-        };
-        rows[0].vessels = vec![vessel];
-        let (tx, mut rx) = broadcast::channel(8);
-        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
-
-        aggregator.apply_replica_cache(vec![snapshot]).await;
-        assert!(matches!(rx.recv().await.expect("initial event"), DaemonEvent::ResultSet(_)));
-
-        let result_set = state.result_set().await;
-        let vessel = &result_set.rows.as_convoys().expect("convoy rows")[0].vessels[0];
-        assert_eq!(vessel.resource.host, Some(HostName::new("kiwi")));
-        assert_eq!(vessel.host, vessel_host);
-        assert_eq!(vessel.vessel_resource.as_ref().expect("vessel resource").host, Some(HostName::new("feta")));
-    }
-
-    #[tokio::test]
     async fn replica_cache_merges_repository_checkout_rows_and_sets_origin_host() {
         let state = AggregatorProjectionState::new();
         let repo = RepositoryKey("repo-widgets".into());
@@ -3014,54 +3421,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replica_cache_unions_independents_and_stamps_origin_host() {
-        let state = AggregatorProjectionState::new();
-        let repository = RepositoryKey("repo-flotilla".into());
-        let scope = QueryScope::new("flotilla", "flotilla");
-        state
-            .replace_store_catalog(
-                HashMap::from([(repository.clone(), "flotilla".to_string())]),
-                HashMap::from([(scope.clone(), vec![repository.clone()])]),
-            )
-            .await;
-        let (tx, mut rx) = broadcast::channel(8);
-        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
-
-        aggregator
-            .apply_replica_cache(vec![remote_independent_snapshot("feta", "generation-1", "terminal-yeoman", Some(repository.clone()))])
-            .await;
-        let event = rx.recv().await.expect("independents replica event");
-        assert!(
-            matches!(event, DaemonEvent::ResultDelta(ref delta) if delta.query() == (QueryId::Independents { scope: None })),
-            "unexpected first replica event: {event:?}",
-        );
-
-        let result_set = state.independents_result_set(&Some(scope)).await;
-        let rows = result_set.rows.as_independents().expect("independent rows");
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].resource.host, Some(HostName::new("feta")));
-        assert_eq!(rows[0].host, HostName::new("feta"));
-    }
-
-    #[tokio::test]
-    async fn complete_replica_cache_removes_hosts_missing_from_next_refresh() {
-        let state = AggregatorProjectionState::new();
-        let (tx, mut rx) = broadcast::channel(8);
-        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
-
-        aggregator.apply_replica_cache(vec![remote_snapshot("feta", "generation-1", "feta-convoy")]).await;
-        assert!(matches!(rx.recv().await.expect("initial event"), DaemonEvent::ResultSet(_)));
-
-        aggregator.apply_replica_cache(Vec::new()).await;
-        let DaemonEvent::ResultDelta(delta) = rx.recv().await.expect("removal event") else { panic!("expected result delta") };
-        assert!(delta.changes.as_convoys().expect("convoy changes").is_empty());
-        let removed = delta.changes.removed_resources().expect("convoy removals");
-        assert_eq!(removed.len(), 1);
-        assert_eq!(removed[0].name, "feta-convoy");
-        assert!(state.result_set().await.rows.is_empty());
-    }
-
-    #[tokio::test]
     async fn restart_relist_removes_local_rows_missing_from_stores() {
         let durable = ResourceBackend::InMemory(InMemoryBackend::default());
         let observed = ResourceBackend::InMemory(InMemoryBackend::observed());
@@ -3083,11 +3442,11 @@ mod tests {
         let result = Aggregator::new(state.clone(), HostName::new("local"), event_tx)
             .run(
                 AggregatorResolvers::builder()
-                    .durable_convoys(durable.clone().using::<Convoy>("flotilla"))
+                    .durable_convoys(durable.including_replicas::<Convoy>("flotilla"))
                     .durable_demands(durable.clone().using::<Demand>("flotilla"))
                     .durable_environments(durable.clone().using::<Environment>("flotilla"))
                     .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
-                    .durable_sessions(durable.using::<TerminalSession>("flotilla"))
+                    .durable_sessions(durable.including_replicas::<TerminalSession>("flotilla"))
                     .durable_projects(durable.using::<Project>("flotilla"))
                     .durable_repositories(durable.using::<Repository>("flotilla"))
                     .durable_regards(durable.using::<Regard>("flotilla"))

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -852,11 +852,11 @@ fn spawn_aggregator_task(
                 aggregator
                     .run(
                         AggregatorResolvers::builder()
-                            .durable_convoys(durable.clone().using::<Convoy>(&namespace))
+                            .durable_convoys(durable.including_replicas::<Convoy>(&namespace))
                             .durable_demands(durable.clone().using::<Demand>(&namespace))
                             .durable_environments(durable.clone().using::<Environment>(&namespace))
                             .durable_presentations(durable.using::<Presentation>(&namespace))
-                            .durable_sessions(durable.using::<flotilla_resources::TerminalSession>(&namespace))
+                            .durable_sessions(durable.including_replicas::<flotilla_resources::TerminalSession>(&namespace))
                             .durable_projects(durable.using::<Project>(&namespace))
                             .durable_repositories(durable.using::<Repository>(&namespace))
                             .durable_regards(durable.using::<Regard>(&namespace))

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -1,17 +1,16 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use flotilla_client::SocketDaemon;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
 use flotilla_protocol::{
-    result_set::{ConvoyPhase, ConvoyRow, ResultSet, Rows},
-    FleetReplicaSnapshot, HostName, NodeInfo, ResourceRef, SurfaceDeclaration,
+    result_set::{ConvoyPhase, ConvoyRow},
+    HostName, NodeInfo, ResourceRef, SurfaceDeclaration,
 };
 use flotilla_resources::{api_version, Convoy, InputMeta, Project, ProjectSpec, Resource, Stance, WorkflowTemplate};
 use tokio::sync::{mpsc, watch, Mutex, Notify};
 
 use super::{build_remote_command_router, handle_client_session, spawn_peer_networking_runtime};
 use crate::{
-    aggregator::Aggregator,
     peer::{channel_transport::channel_transport_pair_with_nodes, PeerManager},
     server::PeerConnectedNotice,
 };
@@ -19,14 +18,8 @@ use crate::{
 pub async fn apply_convoy_replica_feed(daemon: &InProcessDaemon, namespace: &str, name: &str, home: HostName) {
     let resource = ResourceRef::new(api_version(Convoy::API_PATHS), Convoy::API_PATHS.kind, namespace, name).on_host(home.clone());
     let row = ConvoyRow::builder().resource(resource).name(name).workflow_ref("scratch").phase(ConvoyPhase::Pending).build();
-    let snapshot = FleetReplicaSnapshot {
-        host: home,
-        generation: Some("test-generation".to_string()),
-        rows: vec![],
-        result_sets: vec![ResultSet { seq: 1, rows: Rows::Convoys(vec![row]), state: Default::default() }],
-    };
-    let mut aggregator = Aggregator::new(daemon.aggregator_projection_state().await, daemon.host_name().clone(), daemon.event_sender());
-    aggregator.apply_replica_cache(vec![snapshot]).await;
+    let state = daemon.aggregator_projection_state().await;
+    state.write().await.replace_replica_rows(HashMap::from([(home, HashMap::from([(row.resource.clone(), row)]))]));
 }
 
 pub async fn seed_trusted_remote_convoy_project(daemon: &InProcessDaemon, namespace: &str) {

--- a/crates/flotilla-manifest/fixtures/generator/src/main.rs
+++ b/crates/flotilla-manifest/fixtures/generator/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
             ("flotilla.work.phase", update(text("running"), Some(30_000))),
             ("status.state", update(text("active"), Some(30_000))),
             ("materialize.target", update(text("pane"), Some(30_000))),
-            ("materialize.recipe", update(text("flotilla attach implement"), Some(30_000))),
+            ("materialize.recipe", update(text("flotilla attach --host 'feta' 'implement'"), Some(30_000))),
             ("factory.id", update(text("flotilla:convoys/dev/manifest-extraction/implement"), Some(30_000))),
         ],
         vec!["status.attention"],

--- a/crates/flotilla-manifest/fixtures/patch_group_catalog.json
+++ b/crates/flotilla-manifest/fixtures/patch_group_catalog.json
@@ -24,7 +24,7 @@
       "ttl_ms": 30000,
       "value": {
         "type": "text",
-        "value": "flotilla attach implement"
+        "value": "flotilla attach --host 'feta' 'implement'"
       }
     },
     "materialize.target": {

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -61,6 +61,10 @@ pub const KEY_CREW_ROLES: &str = "flotilla.crew.roles";
 pub const KEY_STATUS_STATE: &str = "status.state";
 /// Boolean: needs a human/crew look.
 pub const KEY_STATUS_ATTENTION: &str = "status.attention";
+/// Proposed annotation-tier connectivity fact: `connected | disconnected`.
+/// This is deliberately outside the frozen `status.state` badge vocabulary;
+/// producers do not emit it until the disconnected annotation slice lands.
+pub const KEY_STATUS_CONNECTIVITY: &str = "status.connectivity";
 /// Short human summary line, e.g. "2/3 vessels done".
 pub const KEY_SUMMARY_TEXT: &str = "summary.text";
 /// GroupPath an identity/tab belongs to — the join's catalog half

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -367,7 +367,7 @@ fn project_vessel(
     }
     // Vessels materialise at workspace granularity (ADR 0012); the recipe
     // exists iff the daemon can resolve the attach — a capability fact.
-    if let Some(recipe) = vessel.materialize.as_deref().and_then(|attach_ref| mint.attach(attach_ref)) {
+    if let Some(recipe) = vessel.materialize.as_deref().and_then(|attach_ref| mint.attach(attach_ref, &vessel.host)) {
         facts.push((KEY_MATERIALIZE_TARGET, MetadataValue::text("workspace")));
         facts.push((KEY_MATERIALIZE_RECIPE, MetadataValue::text(recipe.command())));
     }
@@ -398,7 +398,7 @@ fn project_independent(catalog: &mut Catalog, independent: &IndependentRow, mint
     if badge.attention {
         facts.push((KEY_STATUS_ATTENTION, MetadataValue::Bool(true)));
     }
-    if let Some(recipe) = independent.attach.as_deref().and_then(|attach_ref| mint.attach(attach_ref)) {
+    if let Some(recipe) = independent.attach.as_deref().and_then(|attach_ref| mint.attach(attach_ref, &independent.host)) {
         facts.push((KEY_MATERIALIZE_TARGET, MetadataValue::text("pane")));
         facts.push((KEY_MATERIALIZE_RECIPE, MetadataValue::text(recipe.command())));
     }

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -171,7 +171,7 @@ fn convoy_with_project_ref_projects_the_full_spine() {
     assert_eq!(text(implement, KEY_STATUS_STATE), "active");
     assert_eq!(text(implement, KEY_VESSEL_HOST), "feta");
     assert_eq!(text(implement, KEY_MATERIALIZE_TARGET), "workspace");
-    assert_eq!(text(implement, KEY_MATERIALIZE_RECIPE), "flotilla attach terminal-implement");
+    assert_eq!(text(implement, KEY_MATERIALIZE_RECIPE), "flotilla attach --host 'feta' 'terminal-implement'");
     assert_eq!(text(implement, KEY_FACTORY_ID), "flotilla:convoys/dev/manifest-extraction/implement");
     assert_eq!(implement.set[KEY_CREW_ROLES].value, MetadataValue::StringList(vec!["coder".to_owned(), "reviewer".to_owned()]));
 
@@ -256,7 +256,7 @@ fn independent_with_repo_groups_under_project_and_publishes_identity() {
     let group_patch = find(&patches, &group_target);
     assert_eq!(text(group_patch, KEY_STATUS_STATE), "active");
     assert_eq!(text(group_patch, KEY_MATERIALIZE_TARGET), "pane");
-    assert_eq!(text(group_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach terminal-scratch");
+    assert_eq!(text(group_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach --host 'feta' 'terminal-scratch'");
     assert_eq!(text(group_patch, KEY_FACTORY_ID), "flotilla:independents/dev/terminal-scratch");
     assert_eq!(group_patch.set[KEY_STATUS_STATE].ordinal, None, "project-parented independents are not archipelago-ordered");
 

--- a/crates/flotilla-manifest/src/recipe.rs
+++ b/crates/flotilla-manifest/src/recipe.rs
@@ -1,10 +1,12 @@
 //! Recipe minting — the commands a PM runs to materialise a catalog entry.
 //!
 //! The formatter is pluggable so v0 can ship attach-only: entities with a
-//! live session get `flotilla attach <ref>`; everything else truthfully
+//! live session get a host-qualified `flotilla attach`; everything else truthfully
 //! lists without a recipe until `flotilla view <address>` (ADR 0013,
 //! flotilla-org/flotilla#589) gives scoped views a command. The connector
 //! owns the GroupPath → address mapping when that lands.
+
+use flotilla_protocol::{arg::shell_quote, HostName};
 
 /// A materialisation recipe. Command-only for now; the Leg-1 freeze is asked
 /// to bless a `{kind: command | layout}` shape (gap report §9.1) since
@@ -26,7 +28,7 @@ pub trait RecipeMint: Send + Sync {
     /// Recipe attaching a live entity — a session into a pane, or a vessel's
     /// running session into a workspace; `attach_ref` is any reference the
     /// daemon accepts (rows expose it as a capability fact).
-    fn attach(&self, attach_ref: &str) -> Option<Recipe>;
+    fn attach(&self, attach_ref: &str, host: &HostName) -> Option<Recipe>;
     /// Recipe materialising a scoped view of an entity with no live session.
     fn scoped_view(&self, target: &flotilla_protocol::ViewAddress) -> Option<Recipe>;
 }
@@ -44,8 +46,8 @@ impl FlotillaRecipes {
 }
 
 impl RecipeMint for FlotillaRecipes {
-    fn attach(&self, attach_ref: &str) -> Option<Recipe> {
-        Some(Recipe::Command(format!("{} attach {attach_ref}", self.flotilla_bin)))
+    fn attach(&self, attach_ref: &str, host: &HostName) -> Option<Recipe> {
+        Some(Recipe::Command(format!("{} attach --host {} {}", self.flotilla_bin, shell_quote(host.as_str()), shell_quote(attach_ref))))
     }
 
     fn scoped_view(&self, target: &flotilla_protocol::ViewAddress) -> Option<Recipe> {
@@ -60,7 +62,10 @@ mod tests {
     #[test]
     fn flotilla_mint_formats_attach_and_scoped_view_recipes() {
         let mint = FlotillaRecipes::new("flotilla");
-        assert_eq!(mint.attach("implement"), Some(Recipe::Command("flotilla attach implement".to_owned())));
+        assert_eq!(
+            mint.attach("implement", &HostName::new("feta")),
+            Some(Recipe::Command("flotilla attach --host 'feta' 'implement'".to_owned()))
+        );
         assert_eq!(
             mint.scoped_view(&flotilla_protocol::ViewAddress::Vessel {
                 namespace: "dev".to_owned(),

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -204,6 +204,9 @@ pub enum CommandAction {
     },
     Attach {
         reference: String,
+        /// Restrict resolution to the host that advertised the recipe.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        host: Option<crate::HostName>,
     },
     /// Resolve an attach for a temporary foreground excursion. Unlike the
     /// human-facing CLI attach, recursive hops must not stamp PM metadata.
@@ -757,7 +760,7 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".into() },
+                action: CommandAction::Attach { reference: "convoy-a".into(), host: None },
             },
             Command {
                 node_id: None,

--- a/docs/adr/0018-presentation-attention-demands-regards-projection.md
+++ b/docs/adr/0018-presentation-attention-demands-regards-projection.md
@@ -156,7 +156,8 @@ Three refinements from the openable-latent grill (2026-07-23):
   indicators, not curation.
 - **The materialize recipe is an address, not a promise.** The capability
   fact gates *listing* on best-known state; the recipe (`flotilla attach
-  <ref>`) re-resolves through the live hop chain at execution and fails
+  --host <host> <ref>`) preserves the advertising host as part of its
+  address, re-resolves through the live hop chain at execution, and fails
   honestly. For remote-placed vessels the fact derives from replicas
   (ADR 0016), so it is stale-affirmative by up to the watch latency —
   bounded by minting **only while the origin peer's route is live**.
@@ -165,8 +166,9 @@ Three refinements from the openable-latent grill (2026-07-23):
 - **"Disconnected" becomes a visible state eventually** — as an
   annotation-tier fact on the affected entries (the presentation twin of
   marking peer hosts unready), never a new member of the frozen
-  `status.state` vocabulary. Until built, recipe absence is the only
-  signal.
+  `status.state` vocabulary. The proposed fact key is
+  `status.connectivity=disconnected`; until built, recipe absence is the
+  only signal.
 
 Surfaces report **realization and focus observations** back to the mesh —
 one channel feeding regard decay, demand routing, and attention telemetry —

--- a/src/main.rs
+++ b/src/main.rs
@@ -629,7 +629,7 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
                 action: if transient {
                     CommandAction::AttachTransient { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
                 } else {
-                    CommandAction::Attach { reference: reference.to_string() }
+                    CommandAction::Attach { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
                 },
             },
             uuid::Uuid::new_v4(),
@@ -1528,6 +1528,17 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(SubCommand::Attach { reference, transient: true, host: Some(host) })
+                if reference == "terminal-scratch" && host == "feta"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_host_qualified_materialize_recipe() {
+        let cli = Cli::try_parse_from(["flotilla", "attach", "--host", "feta", "terminal-scratch"])
+            .expect("host-qualified attach cli should parse");
+        assert!(matches!(
+            cli.command,
+            Some(SubCommand::Attach { reference, transient: false, host: Some(host) })
                 if reference == "terminal-scratch" && host == "feta"
         ));
     }


### PR DESCRIPTION
## Summary

- read convoy and terminal-session replica views directly in the aggregator
- publish origin-tagged remote convoy awareness and federate remote session attention
- mint materialization recipes only when the replica origin has a live route, and execute them through the recursive remote attach hop
- retract and restore recipes as peer routes disappear and return
- propose the `status.connectivity` manifest fact key without adding a badge

## Why

Remote-placed convoy vessels were visible through fleet state, but their latent terminal sessions were not openable from another daemon. The aggregator only consumed local durable rows, and attach capability checks flattened session names without preserving replica provenance.

This change keeps replica origin identity through projection, resolves origin node IDs to topology host names, and gates each host-qualified session independently. Users can now open a remote-placed convoy vessel when its route is live, while disconnected routes fail honestly and remove the recipe until connectivity returns.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- focused remote replica, route transition, bootstrap, and same-name cross-host collision regressions

Closes #914