### PR TITLE
fix: label repositories with readable slugs

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -165,7 +165,7 @@ impl AggregatorProjectionState {
 
     pub async fn replace_store_catalog(
         &self,
-        repositories: HashSet<RepositoryKey>,
+        repositories: HashMap<RepositoryKey, String>,
         projects: HashMap<QueryScope, Vec<RepositoryKey>>,
     ) -> Vec<ResultDelta> {
         let mut deltas = self.independents.write().await.replace_catalog(repositories.clone(), projects.clone());
@@ -427,7 +427,12 @@ mod tests {
     async fn fleet_awareness_subscription_demands_project_issue_windows() {
         let state = AggregatorProjectionState::new();
         let project = scope("roadmap");
-        state.replace_store_catalog(HashSet::from([RepositoryKey("repo-a".into())]), HashMap::from([(project.clone(), vec![])])).await;
+        state
+            .replace_store_catalog(
+                HashMap::from([(RepositoryKey("repo-a".into()), "a".to_string())]),
+                HashMap::from([(project.clone(), vec![])]),
+            )
+            .await;
 
         let awareness = QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
         state.replace_subscriber_expanding_awareness(Uuid::new_v4(), &[QueryCursor { query: awareness, since: None }]).await;
@@ -439,7 +444,12 @@ mod tests {
     async fn fleet_awareness_groups_loaded_project_issues_under_projects() {
         let state = AggregatorProjectionState::new();
         let project = scope("roadmap");
-        state.replace_store_catalog(HashSet::from([RepositoryKey("repo-a".into())]), HashMap::from([(project.clone(), vec![])])).await;
+        state
+            .replace_store_catalog(
+                HashMap::from([(RepositoryKey("repo-a".into()), "a".to_string())]),
+                HashMap::from([(project.clone(), vec![])]),
+            )
+            .await;
         let issue_query = QueryId::Issues { scope: project.clone(), search: None };
         state.replace_subscriber(Uuid::new_v4(), &[QueryCursor { query: issue_query.clone(), since: None }]);
         let generation = *state.subscribe_demand().borrow().get(&issue_query).expect("issue query generation");

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use flotilla_protocol::{
     AwarenessCounts, AwarenessEntry, AwarenessFamily, AwarenessFamilySummary, AwarenessGrouping, AwarenessKind, AwarenessLimit,
     AwarenessNode, AwarenessPhase, AwarenessState, CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef,
-    ResultSetState, Salience, WorkPhase,
+    ResultSetState, Salience, WorkPhase, UNKNOWN_REPOSITORY_LABEL,
 };
 use flotilla_resources::{api_version, Project, Resource};
 
@@ -130,7 +130,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
             .scope
             .as_ref()
             .map(group_key_for_scope)
-            .unwrap_or_else(|| GroupKey::new(format!("repo/{}", checkout.repo), checkout.repo.to_string()));
+            .unwrap_or_else(|| GroupKey::new(format!("repo/{}", checkout.repo), checkout.repo_label.clone()));
         let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
         let project_ancestors =
             input.scope.as_ref().map(|scope| project_resource_ref(&scope.namespace, &scope.name)).into_iter().collect::<Vec<_>>();
@@ -153,7 +153,12 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
             .scope
             .as_ref()
             .map(group_key_for_scope)
-            .or_else(|| independent.repository_key.as_ref().map(|repo| GroupKey::new(format!("repo/{repo}"), repo.to_string())))
+            .or_else(|| {
+                independent.repository_key.as_ref().map(|repo| {
+                    let label = independent.repo.as_ref().map_or_else(|| UNKNOWN_REPOSITORY_LABEL.to_string(), |label| label.0.clone());
+                    GroupKey::new(format!("repo/{repo}"), label)
+                })
+            })
             .unwrap_or_else(|| GroupKey::new("unparented", "Unparented"));
         let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
         let project_ancestors =
@@ -444,6 +449,7 @@ mod tests {
             checkouts: vec![CheckoutRow::builder()
                 .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout"))
                 .repo(RepositoryKey("repo-a".into()))
+                .repo_label("flotilla")
                 .path("/work/flotilla")
                 .branch("feat/awareness-band")
                 .host(HostName::new("local"))
@@ -523,6 +529,7 @@ mod tests {
             checkouts: vec![CheckoutRow::builder()
                 .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "platform"))
                 .repo(RepositoryKey("repo-a".into()))
+                .repo_label("platform")
                 .path("/work/platform")
                 .branch("main")
                 .host(HostName::new("local"))

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -32,19 +32,19 @@ use flotilla_protocol::{
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
     apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
-    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, resolve_project_issue_sources,
-    terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas,
-    Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec,
-    ConvoyStatusPatch, CrewSource, Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
-    IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
-    PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource,
-    ResourceBackend, ResourceError, ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
-    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
-    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL,
-    VESSEL_LABEL, VESSEL_REF_LABEL,
+    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
+    resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
+    watch_resource_kind_including_replicas, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
+    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, ConditionValue,
+    Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CrewSource,
+    Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution,
+    IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec,
+    Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
+    ResourceObject, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
+    Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+    CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -4471,11 +4471,12 @@ impl InProcessDaemon {
         let namespace = self.provisioning_namespace().await;
         let projects = self.resource_backend.clone().using::<Project>(&namespace).list().await.map_err(|error| error.to_string())?;
         let repositories = self.resource_backend.clone().using::<Repository>(&namespace).list().await.map_err(|error| error.to_string())?;
-        let repository_slugs = repositories
+        let repositories = repositories
             .items
             .into_iter()
-            .map(|repository| (RepositoryKey(repository.metadata.name), repository.spec.catalog_slug()))
-            .collect::<HashMap<_, _>>();
+            .map(|repository| (RepositoryKey(repository.metadata.name.clone()), repository))
+            .collect::<Vec<_>>();
+        let repository_slugs = repository_display_labels(repositories.iter().map(|(key, repository)| (key, &repository.spec)));
 
         let mut entries = projects
             .items

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -331,11 +331,11 @@ async fn project_list_query_returns_all_projects_with_addresses_and_repository_s
     assert_eq!(response.projects.iter().map(|project| project.name.as_str()).collect::<Vec<_>>(), vec!["cleat", "suite"]);
     assert_eq!(response.projects[0].address.to_string(), "project/flotilla/cleat");
     assert_eq!(response.projects[0].repositories.len(), 1);
-    assert_eq!(response.projects[0].repositories[0].slug.as_deref(), Some("github-com-flotilla-org-cleat"));
+    assert_eq!(response.projects[0].repositories[0].slug.as_deref(), Some("flotilla-org/cleat"));
     assert_eq!(response.projects[1].repositories.len(), 2, "repository slices should count as one repository");
     assert_eq!(response.projects[1].repositories.iter().filter_map(|repository| repository.slug.as_deref()).collect::<Vec<_>>(), vec![
-        "github-com-flotilla-org-cleat",
-        "github-com-flotilla-org-flotilla"
+        "flotilla-org/cleat",
+        "flotilla-org/flotilla"
     ]);
     assert_eq!(response.projects[1].issue_source.as_ref().map(|source| source.scope.as_str()), Some("FLOT"));
     assert_eq!(response.projects[1].default_workflow_ref, "review-and-fix");

--- a/crates/flotilla-core/src/scoped_store.rs
+++ b/crates/flotilla-core/src/scoped_store.rs
@@ -6,13 +6,14 @@ use std::{
 };
 
 use flotilla_protocol::{
-    CheckoutRow, HostName, IndependentRow, QueryChanges, QueryScope, RepositoryKey, ResourceRef, ResultDelta, ResultSet,
-    ResultSetCondition, ResultSetState, Rows,
+    CheckoutRow, HostName, IndependentRow, QueryChanges, QueryScope, RepoKey, RepositoryKey, ResourceRef, ResultDelta, ResultSet,
+    ResultSetCondition, ResultSetState, Rows, UNKNOWN_REPOSITORY_LABEL,
 };
 
 pub(crate) trait ScopedStoreRow: Clone + PartialEq {
     fn resource(&self) -> &ResourceRef;
     fn repository_key(&self) -> Option<&RepositoryKey>;
+    fn apply_repository_label(&mut self, labels: &HashMap<RepositoryKey, String>);
     fn compare(left: &Self, right: &Self) -> Ordering;
     fn rows(scope: Option<QueryScope>, rows: Vec<Self>) -> Rows;
     fn changes(scope: Option<QueryScope>, changed: Vec<Self>, removed: Vec<ResourceRef>) -> QueryChanges;
@@ -25,6 +26,14 @@ impl ScopedStoreRow for CheckoutRow {
 
     fn repository_key(&self) -> Option<&RepositoryKey> {
         Some(&self.repo)
+    }
+
+    fn apply_repository_label(&mut self, labels: &HashMap<RepositoryKey, String>) {
+        if let Some(label) = labels.get(&self.repo) {
+            self.repo_label = label.clone();
+        } else if self.repo_label == self.repo.0 {
+            self.repo_label = UNKNOWN_REPOSITORY_LABEL.to_string();
+        }
     }
 
     fn compare(left: &Self, right: &Self) -> Ordering {
@@ -52,6 +61,17 @@ impl ScopedStoreRow for IndependentRow {
 
     fn repository_key(&self) -> Option<&RepositoryKey> {
         self.repository_key.as_ref()
+    }
+
+    fn apply_repository_label(&mut self, labels: &HashMap<RepositoryKey, String>) {
+        if let Some(repository_key) = &self.repository_key {
+            let label = labels
+                .get(repository_key)
+                .cloned()
+                .or_else(|| self.repo.as_ref().filter(|label| label.0 != repository_key.0).map(|label| label.0.clone()))
+                .unwrap_or_else(|| UNKNOWN_REPOSITORY_LABEL.to_string());
+            self.repo = Some(RepoKey(label));
+        }
     }
 
     fn compare(left: &Self, right: &Self) -> Ordering {
@@ -104,6 +124,7 @@ impl<R: ScopedStoreRow> MaterializedSet<R> {
 #[builder(builder_type(vis = "pub(crate)"))]
 pub(crate) struct ScopedStoreProjection<R> {
     known_repositories: HashSet<RepositoryKey>,
+    repository_labels: HashMap<RepositoryKey, String>,
     projects: HashMap<QueryScope, Vec<RepositoryKey>>,
     local_by_repo: HashMap<Option<RepositoryKey>, HashMap<ResourceRef, R>>,
     replicas_by_repo: HashMap<Option<RepositoryKey>, HashMap<HostName, HashMap<ResourceRef, R>>>,
@@ -114,6 +135,7 @@ impl<R> Default for ScopedStoreProjection<R> {
     fn default() -> Self {
         Self {
             known_repositories: HashSet::new(),
+            repository_labels: HashMap::new(),
             projects: HashMap::new(),
             local_by_repo: HashMap::new(),
             replicas_by_repo: HashMap::new(),
@@ -125,10 +147,11 @@ impl<R> Default for ScopedStoreProjection<R> {
 impl<R: ScopedStoreRow> ScopedStoreProjection<R> {
     pub fn replace_catalog(
         &mut self,
-        repositories: HashSet<RepositoryKey>,
+        repositories: HashMap<RepositoryKey, String>,
         projects: HashMap<QueryScope, Vec<RepositoryKey>>,
     ) -> Vec<ResultDelta> {
-        self.known_repositories = repositories;
+        self.known_repositories = repositories.keys().cloned().collect();
+        self.repository_labels = repositories;
         self.projects = projects;
         self.recompute_all()
     }
@@ -218,10 +241,15 @@ impl<R: ScopedStoreRow> ScopedStoreProjection<R> {
                 };
                 let missing = repositories.iter().filter(|repo| !self.known_repositories.contains(*repo)).collect::<Vec<_>>();
                 if !missing.is_empty() {
-                    let missing = missing.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
                     return MaterializedSet::unavailable(
                         project,
-                        format!("project {}/{} references unavailable repositories: {missing}", project.namespace, project.name),
+                        format!(
+                            "project {}/{} references {} unavailable {}",
+                            project.namespace,
+                            project.name,
+                            missing.len(),
+                            if missing.len() == 1 { "repository" } else { "repositories" }
+                        ),
                     );
                 }
                 MaterializedSet {
@@ -237,13 +265,23 @@ impl<R: ScopedStoreRow> ScopedStoreProjection<R> {
         let mut rows = HashMap::new();
         for repository in repositories {
             rows.extend(
-                self.local_by_repo.get(&repository).into_iter().flat_map(|rows| rows.iter()).map(|(key, row)| (key.clone(), row.clone())),
+                self.local_by_repo
+                    .get(&repository)
+                    .into_iter()
+                    .flat_map(|rows| rows.iter())
+                    .map(|(key, row)| (key.clone(), self.label_row(row))),
             );
             if let Some(replicas) = self.replicas_by_repo.get(&repository) {
-                rows.extend(replicas.values().flat_map(|rows| rows.iter()).map(|(key, row)| (key.clone(), row.clone())));
+                rows.extend(replicas.values().flat_map(|rows| rows.iter()).map(|(key, row)| (key.clone(), self.label_row(row))));
             }
         }
         rows
+    }
+
+    fn label_row(&self, row: &R) -> R {
+        let mut row = row.clone();
+        row.apply_repository_label(&self.repository_labels);
+        row
     }
 }
 
@@ -283,6 +321,7 @@ mod tests {
         CheckoutRow::builder()
             .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", name).on_host(HostName::new(host)))
             .repo(self::repo(repo))
+            .repo_label(name)
             .path(format!("/work/{name}"))
             .branch("main")
             .host(HostName::new(host))
@@ -313,7 +352,7 @@ mod tests {
         let mut projection = ScopedCheckoutProjection::default();
         let project = QueryScope::new("flotilla", "suite");
         projection.replace_catalog(
-            HashSet::from([repo("repo-a"), repo("repo-b")]),
+            HashMap::from([(repo("repo-a"), "a".to_string()), (repo("repo-b"), "b".to_string())]),
             HashMap::from([(project.clone(), vec![repo("repo-a"), repo("repo-b")])]),
         );
         projection.replace_local_rows(vec![checkout("repo-a", "local", "laptop")]);
@@ -327,10 +366,57 @@ mod tests {
     }
 
     #[test]
+    fn replica_checkout_keeps_its_forge_slug_without_a_local_repository_catalog() {
+        let mut projection = ScopedCheckoutProjection::default();
+        let mut row = checkout("remote-repo", "widgets", "kiwi");
+        row.repo_label = "flotilla-org/widgets".to_string();
+        projection.replace_replica_rows(HashMap::from([(HostName::new("kiwi"), vec![row])]));
+
+        let rows = projection.result_set(&None).rows.as_checkouts().expect("fleet checkout rows").to_vec();
+
+        assert!(matches!(rows.as_slice(), [row] if row.repo_label == "flotilla-org/widgets"));
+    }
+
+    #[test]
+    fn replica_independent_keeps_its_forge_slug_without_a_local_repository_catalog() {
+        let mut projection = ScopedIndependentProjection::default();
+        let mut row = independent(Some("remote-repo"), "governor", "kiwi");
+        row.repo = Some(RepoKey("flotilla-org/widgets".to_string()));
+        projection.replace_replica_rows(HashMap::from([(HostName::new("kiwi"), vec![row])]));
+
+        let rows = projection.result_set(&None).rows.as_independents().expect("fleet independent rows").to_vec();
+
+        assert!(matches!(rows.as_slice(), [row] if row.repo.as_ref().is_some_and(|label| label.0 == "flotilla-org/widgets")));
+    }
+
+    #[test]
+    fn replica_rows_never_use_the_identity_key_as_their_display_label() {
+        let repository = "opaque-repository-key";
+        let mut checkouts = ScopedCheckoutProjection::default();
+        let mut checkout = checkout(repository, "widgets", "kiwi");
+        checkout.repo_label = repository.to_string();
+        checkouts.replace_replica_rows(HashMap::from([(HostName::new("kiwi"), vec![checkout])]));
+
+        let mut independents = ScopedIndependentProjection::default();
+        let mut independent = independent(Some(repository), "governor", "kiwi");
+        independent.repo = Some(RepoKey(repository.to_string()));
+        independents.replace_replica_rows(HashMap::from([(HostName::new("kiwi"), vec![independent])]));
+
+        let checkout_rows = checkouts.result_set(&None).rows.as_checkouts().expect("fleet checkout rows").to_vec();
+        let independent_rows = independents.result_set(&None).rows.as_independents().expect("fleet independent rows").to_vec();
+        assert!(matches!(checkout_rows.as_slice(), [row] if row.repo_label == UNKNOWN_REPOSITORY_LABEL));
+        assert!(matches!(
+            independent_rows.as_slice(),
+            [row] if row.repo.as_ref().is_some_and(|label| label.0 == UNKNOWN_REPOSITORY_LABEL)
+        ));
+    }
+
+    #[test]
     fn project_independents_exclude_repositoryless_rows_but_fleet_keeps_them() {
         let mut projection = ScopedIndependentProjection::default();
         let project = QueryScope::new("flotilla", "suite");
-        projection.replace_catalog(HashSet::from([repo("repo-a")]), HashMap::from([(project.clone(), vec![repo("repo-a")])]));
+        projection
+            .replace_catalog(HashMap::from([(repo("repo-a"), "a".to_string())]), HashMap::from([(project.clone(), vec![repo("repo-a")])]));
         projection.replace_local_rows(vec![independent(Some("repo-a"), "governor", "laptop"), independent(None, "yeoman", "laptop")]);
 
         let project_rows = projection.result_set(&Some(project)).rows.as_independents().expect("project independent rows").to_vec();
@@ -345,7 +431,7 @@ mod tests {
         let mut projection = ScopedCheckoutProjection::default();
         let repository = repo("repo-a");
         let project = QueryScope::new("flotilla", "suite");
-        projection.replace_catalog(HashSet::from([repository.clone()]), HashMap::from([(project, vec![repository])]));
+        projection.replace_catalog(HashMap::from([(repository.clone(), "a".to_string())]), HashMap::from([(project, vec![repository])]));
 
         let sets = projection.local_result_sets();
 
@@ -356,15 +442,30 @@ mod tests {
     }
 
     #[test]
+    fn checkout_fleet_export_preserves_the_source_qualified_label() {
+        let mut projection = ScopedCheckoutProjection::default();
+        let repository = repo("repo-a");
+        projection.replace_catalog(HashMap::from([(repository, "flotilla-org/widgets".to_string())]), HashMap::new());
+        let mut row = checkout("repo-a", "widgets", "laptop");
+        row.repo_label = "github.com/flotilla-org/widgets".to_string();
+        projection.replace_local_rows(vec![row]);
+
+        let local_rows = projection.result_set(&None).rows.as_checkouts().expect("local checkout rows").to_vec();
+        let exported_rows = projection.local_result_sets()[0].rows.as_checkouts().expect("exported checkout rows").to_vec();
+
+        assert!(matches!(local_rows.as_slice(), [row] if row.repo_label == "flotilla-org/widgets"));
+        assert!(matches!(exported_rows.as_slice(), [row] if row.repo_label == "github.com/flotilla-org/widgets"));
+    }
+
+    #[test]
     fn project_membership_change_emits_typed_checkout_addition_and_removal() {
         let mut projection = ScopedCheckoutProjection::default();
         let project = QueryScope::new("flotilla", "suite");
-        projection
-            .replace_catalog(HashSet::from([repo("repo-a"), repo("repo-b")]), HashMap::from([(project.clone(), vec![repo("repo-a")])]));
+        let repositories = HashMap::from([(repo("repo-a"), "a".to_string()), (repo("repo-b"), "b".to_string())]);
+        projection.replace_catalog(repositories.clone(), HashMap::from([(project.clone(), vec![repo("repo-a")])]));
         projection.replace_local_rows(vec![checkout("repo-a", "a", "local"), checkout("repo-b", "b", "local")]);
 
-        let deltas = projection
-            .replace_catalog(HashSet::from([repo("repo-a"), repo("repo-b")]), HashMap::from([(project.clone(), vec![repo("repo-b")])]));
+        let deltas = projection.replace_catalog(repositories, HashMap::from([(project.clone(), vec![repo("repo-b")])]));
         let delta =
             deltas.into_iter().find(|delta| delta.query() == QueryId::Checkouts { scope: Some(project.clone()) }).expect("project delta");
         assert_eq!(delta.changes.as_checkouts().expect("changed checkout")[0].resource.name, "b");
@@ -374,13 +475,22 @@ mod tests {
     #[test]
     fn independent_fleet_export_is_unscoped_and_local_only() {
         let mut projection = ScopedIndependentProjection::default();
-        projection.replace_local_rows(vec![independent(Some("repo-a"), "local", "laptop")]);
+        projection.replace_catalog(HashMap::from([(repo("repo-a"), "flotilla-org/widgets".to_string())]), HashMap::new());
+        let mut local = independent(Some("repo-a"), "local", "laptop");
+        local.repo = Some(RepoKey("github.com/flotilla-org/widgets".to_string()));
+        projection.replace_local_rows(vec![local]);
         projection.replace_replica_rows(HashMap::from([(HostName::new("kiwi"), vec![independent(Some("repo-a"), "remote", "kiwi")])]));
 
         let sets = projection.local_result_sets();
+        let local_rows = projection.result_set(&None).rows.as_independents().expect("local independent rows").to_vec();
 
         assert_eq!(sets.len(), 1);
         assert_eq!(sets[0].query(), QueryId::Independents { scope: None });
-        assert!(matches!(sets[0].rows.as_independents().expect("independent rows"), [row] if row.name == "local"));
+        assert!(matches!(
+            sets[0].rows.as_independents().expect("exported independent rows"),
+            [row] if row.name == "local"
+                && row.repo.as_ref().is_some_and(|label| label.0 == "github.com/flotilla-org/widgets")
+        ));
+        assert!(local_rows.iter().all(|row| row.repo.as_ref().is_some_and(|label| label.0 == "flotilla-org/widgets")));
     }
 }

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -17,13 +17,14 @@ use flotilla_protocol::{
         ResultDelta, Rows, SessionPhase, VesselRow, WorkPhase,
     },
     Change, DaemonEvent, EntryOp, FleetReplicaSnapshot, HostName, LifecycleAuthority, ProviderData, RepoDelta, RepoIdentity, RepoSnapshot,
-    RepositoryKey, ResourceRef,
+    RepositoryKey, ResourceRef, UNKNOWN_REPOSITORY_LABEL,
 };
 use flotilla_resources::{
-    api_version, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource, Demand, DemandAddressee,
-    DemandState, Environment, Presentation, Project, Regard, RegardExpiryPolicy, Repository, Resource, ResourceError, ResourceList,
-    ResourceObject, TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, Vessel, VesselRequirement, WatchEvent,
-    WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL, VESSEL_LABEL,
+    api_version, repository_display_labels, Checkout, CheckoutSpec, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoyStatus, CrewSource,
+    Demand, DemandAddressee, DemandState, Environment, Presentation, Project, Regard, RegardExpiryPolicy, Repository, Resource,
+    ResourceError, ResourceList, ResourceObject, TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, Vessel,
+    VesselRequirement, WatchEvent, WatchStart, WatchStream, WorkPhase as ResourceWorkPhase, WorkState, CONVOY_LABEL, REPO_KEY_LABEL,
+    REPO_LABEL, VESSEL_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::{broadcast, mpsc};
@@ -1097,8 +1098,12 @@ impl Aggregator {
         self.rebuild_checkout_rows().await
     }
 
+    fn repository_labels(&self) -> HashMap<RepositoryKey, String> {
+        repository_display_labels(self.repositories.iter().map(|(key, repository)| (key, &repository.spec))).into_iter().collect()
+    }
+
     async fn rebuild_store_catalog(&self) {
-        let repositories = self.repositories.keys().cloned().collect();
+        let repositories = self.repository_labels();
         let projects = self
             .projects
             .values()
@@ -1125,6 +1130,12 @@ impl Aggregator {
                 Ok(CheckoutRow::builder()
                     .resource(self.checkout_ref(&checkout.metadata.namespace, &checkout.metadata.name))
                     .repo(spec.repo_ref.clone())
+                    .repo_label(
+                        self.repositories
+                            .get(&spec.repo_ref)
+                            .map(|repository| repository.spec.qualified_label())
+                            .unwrap_or_else(|| UNKNOWN_REPOSITORY_LABEL.to_string()),
+                    )
                     .path(spec.path.clone())
                     .branch(spec.r#ref.clone())
                     .host(self.local_host.clone())
@@ -1397,12 +1408,23 @@ impl Aggregator {
         }
         let name = &session.metadata.name;
         let attach = attachable_references.contains(name).then(|| name.clone());
+        let repository_key = session.metadata.labels.get(REPO_KEY_LABEL).cloned().map(RepositoryKey);
+        let repository_label = repository_key.as_ref().map_or_else(
+            || session.metadata.labels.get(REPO_LABEL).cloned(),
+            |key| {
+                self.repositories
+                    .get(key)
+                    .map(|repository| repository.spec.qualified_label())
+                    .or_else(|| session.metadata.labels.get(REPO_LABEL).filter(|label| *label != &key.0).cloned())
+                    .or_else(|| Some(UNKNOWN_REPOSITORY_LABEL.to_string()))
+            },
+        );
         Some(
             IndependentRow::builder()
                 .resource(self.session_ref(&session.metadata.namespace, name))
                 .name(name)
-                .maybe_repo(session.metadata.labels.get(REPO_LABEL).map(|repo| flotilla_protocol::RepoKey(repo.clone())))
-                .maybe_repository_key(session.metadata.labels.get(REPO_KEY_LABEL).cloned().map(RepositoryKey))
+                .maybe_repo(repository_label.map(flotilla_protocol::RepoKey))
+                .maybe_repository_key(repository_key)
                 .host(self.local_host.clone())
                 .maybe_attach(attach)
                 .phase(SessionPhase::Running)
@@ -1659,10 +1681,10 @@ mod tests {
     };
     use flotilla_resources::{
         ConvoyRepositorySpec, ConvoySpec, CrewSpec, DemandKind, DemandSpec, DemandStatus, DemandTransition, EnvironmentSpec,
-        HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta, PlacementStatus, PresentationPhase, PresentationSpec,
-        PresentationStatus, PrincipalRef as AttentionPrincipalRef, RegardSource, RegardSpec, RegardStatus, ResourceBackend, Stance,
-        TerminalAttention, TerminalAttentionSource, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement,
-        WorkflowSnapshot,
+        HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta, ObservedCheckoutSpec, PlacementStatus, PresentationPhase,
+        PresentationSpec, PresentationStatus, PrincipalRef as AttentionPrincipalRef, RegardSource, RegardSpec, RegardStatus,
+        RepositorySpec, ResourceBackend, Stance, TerminalAttention, TerminalAttentionSource, TerminalSessionSource, TerminalSessionSpec,
+        TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
     };
     use futures::stream;
     use tokio::{sync::Mutex, time::timeout};
@@ -2132,6 +2154,109 @@ mod tests {
             })
             .await
             .expect("create scripted environment")
+    }
+
+    async fn repository_object(url: &str) -> ResourceObject<Repository> {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let spec = RepositorySpec::remote(url).expect("valid repository URL");
+        backend
+            .using::<Repository>("flotilla")
+            .create(&InputMeta::builder().name(spec.key().to_string()).build(), &spec)
+            .await
+            .expect("create scripted repository")
+    }
+
+    async fn checkout_object(name: &str, path: &str, repo_ref: RepositoryKey) -> ResourceObject<Checkout> {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        backend
+            .using::<Checkout>("flotilla")
+            .create(
+                &InputMeta::builder().name(name.to_string()).build(),
+                &CheckoutSpec::Observed(ObservedCheckoutSpec {
+                    r#ref: "main".to_string(),
+                    path: path.to_string(),
+                    repo_ref,
+                    host_ref: "local".to_string(),
+                    is_main: true,
+                }),
+            )
+            .await
+            .expect("create scripted checkout")
+    }
+
+    async fn repository_replica_snapshot(host: &str, url: &str) -> FleetReplicaSnapshot {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(16);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new(host), event_tx);
+        let repository = repository_object(url).await;
+        let repository_key = repository.spec.key();
+        aggregator.apply_repository_event(WatchEvent::Added(repository)).await;
+        aggregator
+            .apply_checkout_event(WatchEvent::Added(checkout_object(host, &format!("/work/{host}"), repository_key).await))
+            .await
+            .expect("source checkout");
+        FleetReplicaSnapshot {
+            host: HostName::new(host),
+            generation: Some(format!("{host}-generation")),
+            rows: Vec::new(),
+            result_sets: state.local_result_sets().await,
+        }
+    }
+
+    #[tokio::test]
+    async fn awareness_repository_labels_use_forge_slugs_and_qualify_collisions() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(16);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+        let repositories = [
+            ("flotilla", Some("/work/flotilla"), repository_object("https://github.com/flotilla-org/flotilla").await),
+            ("flotilla-widgets", Some("/work/flotilla-widgets"), repository_object("https://github.com/flotilla-org/widgets").await),
+            ("acme-widgets", Some("/work/acme-widgets"), repository_object("https://gitlab.com/acme/widgets").await),
+            ("reticulate", None, repository_object("https://github.com/changedirection/reticulate").await),
+        ];
+        let reticulate_key = repositories[3].2.spec.key();
+
+        for (_, _, repository) in &repositories {
+            aggregator.apply_repository_event(WatchEvent::Added(repository.clone())).await;
+        }
+        for (name, path, repository) in repositories {
+            let Some(path) = path else { continue };
+            aggregator
+                .apply_checkout_event(WatchEvent::Added(checkout_object(name, path, repository.spec.key()).await))
+                .await
+                .expect("project checkout");
+        }
+        let mut reticulate_session = session_object("reticulate-scratch").await;
+        reticulate_session.metadata.labels = BTreeMap::from([
+            (REPO_KEY_LABEL.to_string(), reticulate_key.to_string()),
+            (REPO_LABEL.to_string(), reticulate_key.to_string()),
+        ]);
+        aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Added(reticulate_session)).await;
+
+        let result = state.awareness_result_set(&None, flotilla_protocol::AwarenessGrouping::Project, Default::default()).await;
+        let mut labels = result.rows.as_awareness().expect("awareness rows").iter().map(|node| node.label.as_str()).collect::<Vec<_>>();
+        labels.sort_unstable();
+
+        assert_eq!(labels, ["acme/widgets", "changedirection/reticulate", "flotilla-org/flotilla", "flotilla-org/widgets"]);
+    }
+
+    #[tokio::test]
+    async fn fleet_awareness_qualifies_matching_forge_slugs_from_different_services() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(16);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("receiver"), event_tx);
+        aggregator
+            .apply_replica_cache(vec![
+                repository_replica_snapshot("github-host", "https://github.com/acme/widgets").await,
+                repository_replica_snapshot("gitlab-host", "https://gitlab.com/acme/widgets").await,
+            ])
+            .await;
+
+        let result = state.awareness_result_set(&None, flotilla_protocol::AwarenessGrouping::Project, Default::default()).await;
+        let mut labels = result.rows.as_awareness().expect("awareness rows").iter().map(|node| node.label.as_str()).collect::<Vec<_>>();
+        labels.sort_unstable();
+
+        assert_eq!(labels, ["github.com/acme/widgets", "gitlab.com/acme/widgets"]);
     }
 
     #[tokio::test]
@@ -2855,11 +2980,12 @@ mod tests {
     async fn replica_cache_merges_repository_checkout_rows_and_sets_origin_host() {
         let state = AggregatorProjectionState::new();
         let repo = RepositoryKey("repo-widgets".into());
-        state.replace_store_catalog(HashSet::from([repo.clone()]), HashMap::new()).await;
+        state.replace_store_catalog(HashMap::from([(repo.clone(), "widgets".to_string())]), HashMap::new()).await;
         let scope = None;
         let row = CheckoutRow::builder()
             .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "remote-checkout"))
             .repo(repo)
+            .repo_label("widgets")
             .path("/srv/widgets")
             .branch("main")
             .host(HostName::new("incorrect-source-host"))
@@ -2892,7 +3018,12 @@ mod tests {
         let state = AggregatorProjectionState::new();
         let repository = RepositoryKey("repo-flotilla".into());
         let scope = QueryScope::new("flotilla", "flotilla");
-        state.replace_store_catalog(HashSet::from([repository.clone()]), HashMap::from([(scope.clone(), vec![repository.clone()])])).await;
+        state
+            .replace_store_catalog(
+                HashMap::from([(repository.clone(), "flotilla".to_string())]),
+                HashMap::from([(scope.clone(), vec![repository.clone()])]),
+            )
+            .await;
         let (tx, mut rx) = broadcast::channel(8);
         let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), tx);
 

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -36,7 +36,7 @@ pub use lifecycle::LifecycleAuthority;
 pub use path_context::{DaemonHostPath, ExecutionEnvironmentPath};
 pub use peer::{CommandPeerEvent, GoodbyeReason, PeerDataKind, PeerDataMessage, PeerWireMessage, RoutedPeerMessage, VectorClock};
 pub use provisioning_target::ProvisioningTarget;
-pub use repository::RepositoryKey;
+pub use repository::{RepositoryKey, UNKNOWN_REPOSITORY_LABEL};
 pub use step::{CheckoutIntent, Step, StepAction, StepExecutionContext, StepOutcome};
 pub use view_address::ViewAddress;
 

--- a/crates/flotilla-protocol/src/repository.rs
+++ b/crates/flotilla-protocol/src/repository.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+pub const UNKNOWN_REPOSITORY_LABEL: &str = "Unknown repository";
+
 /// Storage-safe key of a Repository resource.
 ///
 /// The key is opaque on the wire. Its derivation and referent verification

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -601,7 +601,10 @@ pub struct IssueRow {
 #[builder(on(String, into))]
 pub struct CheckoutRow {
     pub resource: ResourceRef,
+    /// Canonical Repository identity used for joins.
     pub repo: RepositoryKey,
+    /// Human-readable Repository presentation, never the opaque identity key.
+    pub repo_label: String,
     pub path: String,
     pub branch: String,
     pub host: HostName,
@@ -867,6 +870,7 @@ mod tests {
                 rows: vec![CheckoutRow::builder()
                     .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout-a").on_host(HostName::new("kiwi")))
                     .repo(RepositoryKey("repo_abc123".into()))
+                    .repo_label("flotilla")
                     .path("/work/flotilla")
                     .branch("feature/query")
                     .host(HostName::new("kiwi"))
@@ -919,6 +923,7 @@ mod tests {
                 changed: vec![CheckoutRow::builder()
                     .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout-new").on_host(HostName::new("mango")))
                     .repo(RepositoryKey("repo_abc123".into()))
+                    .repo_label("flotilla")
                     .path("/work/flotilla")
                     .branch("feature/query")
                     .host(HostName::new("mango"))

--- a/crates/flotilla-protocol/src/view_address.rs
+++ b/crates/flotilla-protocol/src/view_address.rs
@@ -96,13 +96,7 @@ impl ViewAddress {
             Self::Issues { scope } => format!("issues?project={}/{}", scope.namespace, scope.name),
             Self::Checkouts { scope: Some(scope) } => format!("checkouts?project={}/{}", scope.namespace, scope.name),
             Self::Checkouts { scope: None } => "checkouts".to_string(),
-            Self::Repo { identity, repository_key } => {
-                let mut label = format!("repo/{}/{}", identity.authority, identity.path);
-                if let Some(key) = repository_key {
-                    label.push_str(&format!("?key={}", key.0));
-                }
-                label
-            }
+            Self::Repo { identity, .. } => format!("repo/{}/{}", identity.authority, identity.path),
         }
     }
 }
@@ -344,7 +338,7 @@ mod tests {
             identity: RepoIdentity { authority: "local".into(), path: "/tmp/repo 0".into() },
             repository_key: Some(RepositoryKey("repo/key with space".into())),
         };
-        assert_eq!(repo.human_label(), "repo/local//tmp/repo 0?key=repo/key with space");
+        assert_eq!(repo.human_label(), "repo/local//tmp/repo 0");
         assert_eq!(repo.to_string(), "repo/local/%2Ftmp%2Frepo%200?key=repo%2Fkey%20with%20space");
     }
 

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -71,8 +71,8 @@ pub use registry::{
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{
-    ensure_repository, resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity, Repository,
-    RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey, RepositorySpec, RepositoryStatus,
+    ensure_repository, repository_display_labels, resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity,
+    Repository, RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey, RepositorySpec, RepositoryStatus,
     RepositoryStatusPatch,
 };
 pub use resource::{

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -113,6 +113,47 @@ impl RepositorySpec {
             RepositoryIdentity::Local { .. } => self.leaf_slug(),
         }
     }
+
+    /// Globally qualified, human-readable label suitable for fleet exchange.
+    pub fn qualified_label(&self) -> String {
+        match &self.identity {
+            RepositoryIdentity::Remote { canonical_remote } => {
+                canonical_remote.split_once("://").map_or_else(|| canonical_remote.clone(), |(_, label)| label.to_string())
+            }
+            RepositoryIdentity::Local { .. } => identity_description(&self.identity),
+        }
+    }
+}
+
+/// Human-readable labels for a repository catalog.
+///
+/// Repository keys remain opaque identity. Remote presentation uses the
+/// forge's `owner/repository` slug; local repositories use their leaf slug.
+/// The full readable identity is the fallback when those labels collide.
+pub fn repository_display_labels<'a>(
+    repositories: impl IntoIterator<Item = (&'a RepositoryKey, &'a RepositorySpec)>,
+) -> BTreeMap<RepositoryKey, String> {
+    let repositories = repositories.into_iter().collect::<Vec<_>>();
+    let candidates = repositories
+        .iter()
+        .map(|(key, spec)| {
+            let label = spec.forge().map_or_else(|| spec.leaf_slug(), |forge| forge.repository.clone());
+            ((*key).clone(), label)
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut candidate_counts = BTreeMap::<String, usize>::new();
+    for label in candidates.values() {
+        *candidate_counts.entry(label.clone()).or_default() += 1;
+    }
+
+    repositories
+        .into_iter()
+        .map(|(key, spec)| {
+            let candidate = &candidates[key];
+            let label = if candidate_counts[candidate] == 1 { candidate.clone() } else { spec.qualified_label() };
+            (key.clone(), label)
+        })
+        .collect()
 }
 
 pub async fn ensure_repository(

--- a/crates/flotilla-resources/tests/repository_in_memory.rs
+++ b/crates/flotilla-resources/tests/repository_in_memory.rs
@@ -1,7 +1,7 @@
 use flotilla_resources::{
-    normalize_project_spec, resolve_project_issue_sources, DefaultBranchObservation, DefaultBranchProvenance, InMemoryBackend, InputMeta,
-    IssueSource, IssueSourceResolution, IssueSourceUnavailable, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryIdentity,
-    RepositoryKey, RepositorySpec, ResourceBackend, SqliteBackend,
+    normalize_project_spec, repository_display_labels, resolve_project_issue_sources, DefaultBranchObservation, DefaultBranchProvenance,
+    InMemoryBackend, InputMeta, IssueSource, IssueSourceResolution, IssueSourceUnavailable, ProjectRepositorySpec, ProjectSpec, Repository,
+    RepositoryIdentity, RepositoryKey, RepositorySpec, ResourceBackend, SqliteBackend,
 };
 
 #[tokio::test]
@@ -114,6 +114,27 @@ fn remote_less_worktrees_converge_on_host_and_git_common_directory() {
 
     assert_eq!(first.key(), second.key());
     assert!(matches!(first.identity(), RepositoryIdentity::Local { .. }));
+}
+
+#[test]
+fn repository_display_labels_use_forge_slugs_and_qualify_collisions() {
+    let flotilla = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("flotilla repository");
+    let flotilla_widgets = RepositorySpec::remote("https://github.com/flotilla-org/widgets").expect("flotilla widgets repository");
+    let acme_widgets = RepositorySpec::remote("https://gitlab.com/acme/widgets").expect("acme widgets repository");
+    let mirrored_widgets = RepositorySpec::remote("https://github.com/acme/widgets").expect("mirrored widgets repository");
+    let repositories = [
+        (flotilla.key(), flotilla),
+        (flotilla_widgets.key(), flotilla_widgets),
+        (acme_widgets.key(), acme_widgets),
+        (mirrored_widgets.key(), mirrored_widgets),
+    ];
+
+    let labels = repository_display_labels(repositories.iter().map(|(key, spec)| (key, spec)));
+
+    assert_eq!(labels[&repositories[0].0], "flotilla-org/flotilla");
+    assert_eq!(labels[&repositories[1].0], "flotilla-org/widgets");
+    assert_eq!(labels[&repositories[2].0], "gitlab.com/acme/widgets");
+    assert_eq!(labels[&repositories[3].0], "github.com/acme/widgets");
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -456,7 +456,7 @@ impl App {
                     .iter()
                     .find_map(|(identity, repo)| (repo.repository_key.as_ref() == Some(&repository_key)).then(|| identity.clone()))
                 else {
-                    self.set_status_message(Some(format!("Cannot open PR: repository {repository_key} is not tracked")));
+                    self.set_status_message(Some("Cannot open PR: repository is not tracked".to_string()));
                     return;
                 };
                 let Ok(node_id) = self.table_intent_node_id(host.as_ref()) else {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1947,6 +1947,7 @@ fn app_applies_checkout_sets_and_removal_deltas_to_the_typed_query_cache() {
     let row = flotilla_protocol::CheckoutRow::builder()
         .resource(flotilla_protocol::ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "widgets"))
         .repo(flotilla_protocol::RepositoryKey("repo_widgets".into()))
+        .repo_label("widgets")
         .path("/work/widgets")
         .branch("main")
         .host(HostName::new("kiwi"))

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -164,7 +164,7 @@ fn format_project_list_human(response: &ProjectListResponse) -> String {
             project
                 .repositories
                 .iter()
-                .map(|repository| repository.slug.as_deref().unwrap_or(&repository.key.0))
+                .map(|repository| repository.slug.as_deref().unwrap_or(flotilla_protocol::UNKNOWN_REPOSITORY_LABEL))
                 .collect::<Vec<_>>()
                 .join(", ")
         } else {

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -263,6 +263,27 @@ mod project_list_human {
         assert!(output.contains("4 repositories"));
         assert!(!output.contains("one, two, three, four"));
     }
+
+    #[test]
+    fn project_list_never_falls_back_to_a_repository_key() {
+        let project = ProjectListEntry::builder()
+            .namespace("flotilla".to_string())
+            .name("missing-repository".to_string())
+            .display_name("Missing repository".to_string())
+            .address(ViewAddress::Project { namespace: "flotilla".into(), name: "missing-repository".into() })
+            .repositories(vec![ProjectListRepository {
+                key: RepositoryKey("umfdl0jvpivapi195j3h2n74gh69gbfub13294vogopginvd1m8g".to_string()),
+                slug: None,
+            }])
+            .maybe_issue_source(None)
+            .default_workflow_ref("single-agent-contained".to_string())
+            .build();
+
+        let output = format_project_list_human(&ProjectListResponse { projects: vec![project] });
+
+        assert!(output.contains("Unknown repository"));
+        assert!(!output.contains("umfdl0jvpivapi195j3h2n74gh69gbfub13294vogopginvd1m8g"));
+    }
 }
 
 mod watch_human {

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -1027,7 +1027,7 @@ static CHECKOUT_COLUMNS: [ColumnSpec<CheckoutRow>; 5] = [
         label: "REPOSITORY",
         width: WidthHint::Flexible { minimum: 14, weight: 2 },
         alignment: Alignment::Left,
-        extract: |row| CellValue::plain(row.repo.to_string()),
+        extract: |row| CellValue::plain(&row.repo_label),
     },
     ColumnSpec {
         id: "authority",
@@ -1186,7 +1186,7 @@ fn checkout_description(row: &CheckoutRow) -> Vec<DetailField> {
         DetailField { label: "Host", value: row.host.to_string() },
         DetailField { label: "Path", value: row.path.clone() },
         DetailField { label: "Branch", value: row.branch.clone() },
-        DetailField { label: "Repository", value: row.repo.to_string() },
+        DetailField { label: "Repository", value: row.repo_label.clone() },
         DetailField { label: "Authority", value: row.authority.as_label_value().to_string() },
     ]
 }
@@ -1522,6 +1522,7 @@ mod tests {
         let checkout = CheckoutRow::builder()
             .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "roadmap"))
             .repo(RepositoryKey("repo_flotilla".into()))
+            .repo_label("flotilla")
             .path("/work/flotilla")
             .branch("main")
             .host(HostName::new("kiwi"))
@@ -1670,6 +1671,7 @@ mod tests {
         let row = CheckoutRow::builder()
             .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "widgets-api"))
             .repo(RepositoryKey("repo_widgets".into()))
+            .repo_label("widgets-api")
             .path("/work/widgets-api")
             .branch("feature/scoped-tabs")
             .host(HostName::new("kiwi"))
@@ -1694,7 +1696,7 @@ mod tests {
             "kiwi",
             "/work/widgets-api",
             "feature/scoped-tabs",
-            "repo_widgets",
+            "widgets-api",
             "observed",
         ]);
         assert!(view.rows[0].actions.is_empty());


### PR DESCRIPTION
## Summary

- keep `RepositoryKey` as canonical identity while projecting forge-derived display labels
- carry readable repository labels through checkout, independent-session, project-list, awareness, and TUI surfaces
- preserve globally qualified labels across fleet replication and disambiguate same-slug repositories across forge services
- remove opaque keys from human-facing fallback text and view-address labels

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #919
