### PR TITLE
feat: brief instructs ready-for-review PRs, never drafts

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -63,7 +63,7 @@ pub fn build_crew_brief(
         content.push_str(&format!("Hand off to {} with `flotilla crew {} handoff --message '...'`.\n", member.role, member.role));
     }
     content.push_str(&format!(
-        "For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue, and shepherd the pull request until all checks pass. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`. For other assignments, complete with `flotilla crew complete --message '...'`. If the assignment cannot be completed, report the failure with `flotilla crew fail --message '...'`.\n\n## Assignment\n\n{}\n",
+        "For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue (ready for review, never a draft), and shepherd the pull request until all checks pass; if it is a draft for any reason, mark it ready once checks are green. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`. For other assignments, complete with `flotilla crew complete --message '...'`. If the assignment cannot be completed, report the failure with `flotilla crew fail --message '...'`.\n\n## Assignment\n\n{}\n",
         match assignment {
             CrewAssignment::Prompt(prompt) => prompt,
             CrewAssignment::CarriedIssue =>
@@ -349,7 +349,7 @@ mod tests {
         );
 
         assert!(brief.content.contains(
-            "For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue, and shepherd the pull request until all checks pass. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`."
+            "For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue (ready for review, never a draft), and shepherd the pull request until all checks pass; if it is a draft for any reason, mark it ready once checks are green. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`."
         ));
         assert!(brief.content.contains("Clone scratch repositories outside the vessel checkout"));
     }


### PR DESCRIPTION
Convoy cycle-time thread 2 (#928): done-in-draft PRs sit until a human notices — measured 68 min PR-open→merge on #916 vs 8-18 min when crews deliver ready. The crew brief now instructs: open the PR ready for review, never a draft, and if it is a draft for any reason mark it ready once checks are green. 'Do not merge' unchanged — settlement stays with the steward.