### PR TITLE
chore: manage target cache growth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,10 @@ jobs:
         with:
           toolchain: nightly-2026-03-12
           components: rustfmt
-      - run: scripts/test-prune-target.sh
-      - run: cargo +nightly-2026-03-12 fmt --check
+      - name: Test target pruning policy
+        run: scripts/test-prune-target.sh
+      - name: Check Rust formatting
+        run: cargo +nightly-2026-03-12 fmt --check
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Cached dependency artifacts pay off across runs; short-lived incremental
+  # generations cost more to upload and store than they save in CI.
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   fmt:
     name: Format
@@ -20,6 +25,7 @@ jobs:
         with:
           toolchain: nightly-2026-03-12
           components: rustfmt
+      - run: scripts/test-prune-target.sh
       - run: cargo +nightly-2026-03-12 fmt --check
 
   clippy:
@@ -38,10 +44,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-clippy-v2-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-clippy-v2-
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
+      - name: Remove incremental state before caching
+        if: always()
+        run: |
+          if [ -d target ]; then
+            find target -type d -name incremental -prune -exec rm -rf {} +
+          fi
 
   test:
     name: Test
@@ -57,7 +69,13 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-test-v2-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-test-v2-
       - run: cargo test --workspace --locked
+      - name: Remove incremental state before caching
+        if: always()
+        run: |
+          if [ -d target ]; then
+            find target -type d -name incremental -prune -exec rm -rf {} +
+          fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,10 @@ concurrency:
   group: nightly
   cancel-in-progress: true
 
+env:
+  # These targets are cached, but no CI checkout has a long-lived edit-build loop.
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   check-changes:
     name: Check for changes
@@ -53,9 +57,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-coverage-nightly-2026-03-12-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-coverage-v2-nightly-2026-03-12-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-coverage-nightly-2026-03-12-
+            ${{ runner.os }}-cargo-coverage-v2-nightly-2026-03-12-
       - name: Generate coverage report
         run: |
           # NOTE: --branch crashes llvm-cov (SIGSEGV from --show-mcdc in nightly LLVM).
@@ -76,6 +80,12 @@ jobs:
         with:
           name: coverage-site
           path: target/llvm-cov/html/
+      - name: Remove incremental state before caching
+        if: always()
+        run: |
+          if [ -d target ]; then
+            find target -type d -name incremental -prune -exec rm -rf {} +
+          fi
 
   dylint:
     name: Dylint
@@ -98,9 +108,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-dylint-nightly-2026-03-12-${{ hashFiles('lints/**/Cargo.lock', 'Cargo.lock') }}
+          key: ${{ runner.os }}-dylint-v2-nightly-2026-03-12-${{ hashFiles('lints/**/Cargo.lock', 'Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-dylint-nightly-2026-03-12-
+            ${{ runner.os }}-dylint-v2-nightly-2026-03-12-
       - name: Install cargo-dylint
         run: |
           command -v cargo-dylint && command -v dylint-link || cargo install cargo-dylint dylint-link --locked
@@ -119,6 +129,12 @@ jobs:
         with:
           name: dylint-badge
           path: _badges/
+      - name: Remove incremental state before caching
+        if: always()
+        run: |
+          if [ -d target ]; then
+            find target -type d -name incremental -prune -exec rm -rf {} +
+          fi
 
   deploy:
     name: Deploy to Pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,13 @@ cargo test --workspace --locked                # CI test gate
 cargo +nightly-2026-03-12 fmt                  # apply pinned formatting
 cargo dylint --all -- --all-targets             # custom lints (requires cargo-dylint + dylint-link)
 cargo run                                      # run, auto-detect repo from cwd
+scripts/prune-target.sh --dry-run              # preview per-checkout target cache pruning
+scripts/prune-target.sh                        # prune aged/oversized target artifacts
 ```
 
 Before pushing, run the exact CI commands: `cargo +nightly-2026-03-12 fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`.
+
+Developer incrementals stay enabled, with aged generations pruned under the target cache policy. See [docs/development.md](docs/development.md) for setup, thresholds, measurement, and the CI decision.
 
 **Nightly toolchain:** All nightly-dependent tools (rustfmt, llvm-cov, Dylint) are pinned to `nightly-2026-03-12`. Install with `rustup toolchain install nightly-2026-03-12 --component rustfmt llvm-tools-preview`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,7 +30,7 @@ FLOTILLA_TARGET_GC_DAYS=14 \
   scripts/prune-target.sh
 ```
 
-Run the command in each long-lived checkout. With Cargo's default configuration it acts only on that checkout's `target/` and does not traverse sibling worktrees or shared development roots. When `CARGO_TARGET_DIR` is set, the command intentionally honors it; unset or redirect a shared target before pruning if other checkouts still use that cache.
+Run the command in each long-lived checkout. With Cargo's default configuration it acts only on that checkout's `target/` and does not traverse sibling worktrees or shared development roots. When `CARGO_TARGET_DIR` is set, the command intentionally honors it; unset or redirect a shared target before pruning if other checkouts still use that cache. Relative values are anchored to this checkout's root, so use an absolute value if Cargo is normally invoked elsewhere.
 
 ### CI decision
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,48 @@
+# Development
+
+## Cargo target cache policy
+
+A checkout's `target/` is managed cache state. Developer builds keep Cargo's incremental compilation enabled because it materially shortens the edit-build loop, but old generations and dependency artifacts must not accumulate indefinitely.
+
+Install the pruning tool once:
+
+```bash
+cargo install cargo-sweep --version 0.8.0 --locked
+```
+
+Preview the per-checkout policy, then apply it when no build or test is running:
+
+```bash
+scripts/prune-target.sh --dry-run
+scripts/prune-target.sh
+```
+
+Preview mode runs the complete policy against a temporary hard-linked copy beside the target directory. This lets later size decisions observe the earlier simulated removals without changing the real target; the temporary copy is removed before the command exits.
+
+The command removes incremental generations and other Cargo artifact families unused for 30 days. It then removes the oldest remaining generations until incremental state is at most 10 GiB, and asks `cargo-sweep` to reduce the complete target to at most 20 GiB by discarding stale dependency/fingerprint companions. Recent compiler products are retained whenever they fit within the ceilings, so ordinary developer builds remain warm.
+
+Both thresholds can be overridden for an exceptional checkout:
+
+```bash
+FLOTILLA_TARGET_GC_DAYS=14 \
+  FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE=15GiB \
+  FLOTILLA_TARGET_GC_MAX_SIZE=30GiB \
+  scripts/prune-target.sh
+```
+
+Run the command in each long-lived checkout; it deliberately does not traverse sibling worktrees or shared development roots.
+
+### CI decision
+
+GitHub Actions keeps target caches because compiled dependencies are expensive and reusable across runs with the same lockfile. Compiler incremental state is disabled in CI with `CARGO_INCREMENTAL=0`: clippy, tests, coverage, and Dylint run in short-lived checkouts, so uploading their incremental generations costs cache time and storage without a dependable later edit-build loop to amortize it. Cache keys were rotated when this policy was introduced, and every target-caching job removes restored incremental directories before the cache post-action saves a new entry; old generations are therefore neither restored through the new key prefixes nor re-uploaded.
+
+### Validation measurement
+
+The policy was validated on 2026-07-23 against a clone-on-write copy of a real, long-lived Flotilla target in a scratch checkout. The copy isolated the measurement from active developer work and exercised the same inode-heavy copy shape as a warm hull. Its source target occupied 50 GiB; splitting hard-linked artifact identities into cloned files made the scratch copy's initial `du` total 68 GiB.
+
+| State | Total target | `debug/incremental` | `debug/deps` | Files |
+|---|---:|---:|---:|---:|
+| Before | 68 GiB | 28 GiB | 38 GiB | 180,542 |
+| After `scripts/prune-target.sh` | 20 GiB | 9.9 GiB | 9.2 GiB | 52,150 |
+
+The run took 131.59 seconds and removed 362 of 539 incremental generation directories before pruning stale dependency families. It reclaimed 48 GiB and reduced file count by 71%, while retaining the newest 177 incremental generations.

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,7 +30,7 @@ FLOTILLA_TARGET_GC_DAYS=14 \
   scripts/prune-target.sh
 ```
 
-Run the command in each long-lived checkout; it deliberately does not traverse sibling worktrees or shared development roots.
+Run the command in each long-lived checkout. With Cargo's default configuration it acts only on that checkout's `target/` and does not traverse sibling worktrees or shared development roots. When `CARGO_TARGET_DIR` is set, the command intentionally honors it; unset or redirect a shared target before pruning if other checkouts still use that cache.
 
 ### CI decision
 

--- a/scripts/prune-target.sh
+++ b/scripts/prune-target.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly default_age_days=30
+readonly default_incremental_max_size=10GiB
+readonly default_max_size=20GiB
+
+age_days=${FLOTILLA_TARGET_GC_DAYS:-$default_age_days}
+incremental_max_size=${FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE:-$default_incremental_max_size}
+max_size=${FLOTILLA_TARGET_GC_MAX_SIZE:-$default_max_size}
+mode=apply
+preview_target_dir=
+candidate_file=
+
+usage() {
+  echo "Usage: scripts/prune-target.sh [--dry-run]"
+  echo
+  echo "Prune this checkout's Cargo target by age, then cap its size."
+  echo "Environment overrides:"
+  echo "  FLOTILLA_TARGET_GC_DAYS                  retention in days (default: $default_age_days)"
+  echo "  FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE  incremental ceiling (default: $default_incremental_max_size)"
+  echo "  FLOTILLA_TARGET_GC_MAX_SIZE              target ceiling (default: $default_max_size)"
+}
+
+case ${1:-} in
+  "")
+    ;;
+  --dry-run)
+    mode=preview
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if (( $# != 0 )); then
+  usage >&2
+  exit 2
+fi
+
+if [[ ! $age_days =~ ^[0-9]+$ ]]; then
+  echo "FLOTILLA_TARGET_GC_DAYS must be a non-negative integer; got '$age_days'." >&2
+  exit 2
+fi
+
+if ! command -v cargo-sweep >/dev/null 2>&1; then
+  echo "cargo-sweep is required. Install the tested version with:" >&2
+  echo "  cargo install cargo-sweep --version 0.8.0 --locked" >&2
+  exit 1
+fi
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
+
+if [[ $target_dir != /* ]]; then
+  target_dir=$repo_root/$target_dir
+fi
+
+if [[ -z $target_dir ]]; then
+  echo "Refusing an empty target directory." >&2
+  exit 1
+fi
+
+if [[ ! -d $target_dir ]]; then
+  echo "Cargo target directory does not exist: $target_dir"
+  exit 0
+fi
+
+target_dir=$(cd -- "$target_dir" && pwd -P)
+if [[ $target_dir == / ]]; then
+  echo "Refusing unsafe target directory '$target_dir'." >&2
+  exit 1
+fi
+display_target_dir=$target_dir
+export CARGO_TARGET_DIR=$target_dir
+
+size_to_kib() {
+  local value=$1
+  local number
+
+  case $value in
+    *GiB)
+      number=${value%GiB}
+      [[ $number =~ ^[0-9]+$ ]] || return 1
+      echo $((number * 1024 * 1024))
+      ;;
+    *MiB)
+      number=${value%MiB}
+      [[ $number =~ ^[0-9]+$ ]] || return 1
+      echo $((number * 1024))
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+incremental_max_kib=$(size_to_kib "$incremental_max_size") || {
+  echo "FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE must use whole MiB or GiB units; got '$incremental_max_size'." >&2
+  exit 2
+}
+size_to_kib "$max_size" >/dev/null || {
+  echo "FLOTILLA_TARGET_GC_MAX_SIZE must use whole MiB or GiB units; got '$max_size'." >&2
+  exit 2
+}
+
+format_kib() {
+  awk -v kib="$1" 'BEGIN {
+    if (kib >= 1024 * 1024) {
+      printf "%.2f GiB", kib / 1024 / 1024
+    } else {
+      printf "%.1f MiB", kib / 1024
+    }
+  }'
+}
+
+incremental_size_kib() {
+  find "$target_dir" -type d -name incremental -prune -exec du -sk {} \; 2>/dev/null | awk '{ total += $1 } END { print total + 0 }'
+}
+
+size_kib() {
+  du -sk "$1" | awk '{ print $1 }'
+}
+
+generation_mtime() {
+  if [[ $(uname -s) == Darwin ]]; then
+    stat -f %m "$1"
+  else
+    stat -c %Y "$1"
+  fi
+}
+
+cleanup_temp_files() {
+  if [[ -n $candidate_file ]]; then
+    rm -f -- "$candidate_file"
+  fi
+  if [[ -n $preview_target_dir && -d $preview_target_dir ]]; then
+    rm -rf -- "$preview_target_dir"
+  fi
+}
+
+trap cleanup_temp_files EXIT
+
+prepare_preview_target() {
+  local target_name
+  local target_parent
+
+  if [[ $mode != preview ]]; then
+    return
+  fi
+
+  target_parent=$(dirname -- "$target_dir")
+  target_name=$(basename -- "$target_dir")
+  preview_target_dir=$(mktemp -d "$target_parent/.${target_name}.flotilla-target-gc-preview.XXXXXX")
+  cp -a -l "$target_dir/." "$preview_target_dir/"
+  target_dir=$preview_target_dir
+  export CARGO_TARGET_DIR=$target_dir
+}
+
+prune_aged_incrementals() {
+  local count=0
+  local reclaimed_kib=0
+  local generation
+  local generation_kib
+
+  if [[ ! -d $target_dir ]]; then
+    return 0
+  fi
+
+  while IFS= read -r generation; do
+    generation_kib=$(size_kib "$generation")
+    rm -rf -- "$generation"
+    count=$((count + 1))
+    reclaimed_kib=$((reclaimed_kib + generation_kib))
+  done < <(find "$target_dir" -type d -path '*/incremental/*/s-*' -mtime +"$age_days" -prune -print)
+
+  if (( count > 0 )); then
+    if [[ $mode == preview ]]; then
+      echo "Would remove $count incremental generations older than $age_days days ($(format_kib "$reclaimed_kib"))"
+    else
+      echo "Removed $count incremental generations older than $age_days days ($(format_kib "$reclaimed_kib"))"
+    fi
+  fi
+}
+
+cap_incrementals() {
+  local current_kib
+  local generation
+  local generation_kib
+  local mtime
+  local removed_count=0
+  local removed_kib=0
+
+  if [[ ! -d $target_dir ]]; then
+    return 0
+  fi
+
+  current_kib=$(incremental_size_kib)
+  if (( current_kib <= incremental_max_kib )); then
+    return
+  fi
+
+  candidate_file=$(mktemp "${TMPDIR:-/tmp}/flotilla-target-gc.XXXXXX")
+  while IFS= read -r generation; do
+    mtime=$(generation_mtime "$generation")
+    generation_kib=$(size_kib "$generation")
+    printf '%s\t%s\t%s\n' "$mtime" "$generation_kib" "$generation" >> "$candidate_file"
+  done < <(find "$target_dir" -type d -path '*/incremental/*/s-*' -prune -print)
+
+  while IFS=$'\t' read -r mtime generation_kib generation; do
+    if (( current_kib <= incremental_max_kib )); then
+      break
+    fi
+    rm -rf -- "$generation"
+    current_kib=$((current_kib - generation_kib))
+    removed_count=$((removed_count + 1))
+    removed_kib=$((removed_kib + generation_kib))
+  done < <(sort -n "$candidate_file")
+  rm -f -- "$candidate_file"
+  candidate_file=
+
+  if [[ $mode == preview ]]; then
+    echo "Would remove $removed_count oldest incremental generations ($(format_kib "$removed_kib")) to reach $incremental_max_size"
+  else
+    echo "Removed $removed_count oldest incremental generations ($(format_kib "$removed_kib")) to reach $incremental_max_size"
+  fi
+}
+
+run_sweep() {
+  local description=$1
+  local after_kib
+  local before_kib
+  local sweep_output
+
+  shift
+  if [[ $mode == apply ]]; then
+    cargo sweep "$@"
+    return
+  fi
+
+  before_kib=$(size_kib "$target_dir")
+  if ! sweep_output=$(cargo sweep "$@" 2>&1); then
+    printf '%s\n' "$sweep_output" >&2
+    return 1
+  fi
+  after_kib=$(size_kib "$target_dir")
+
+  if (( before_kib > after_kib )); then
+    echo "Would remove $description ($(format_kib "$((before_kib - after_kib))"))"
+  else
+    echo "Would remove no $description"
+  fi
+}
+
+prune_aged_other_artifacts() {
+  run_sweep "Cargo artifact families older than $age_days days" --time "$age_days" "$repo_root"
+}
+
+cap_target() {
+  run_sweep "Cargo artifact families to reach $max_size" --maxsize "$max_size" "$repo_root"
+}
+
+prepare_preview_target
+
+echo "Pruning incremental generations older than $age_days days in $display_target_dir"
+prune_aged_incrementals
+
+echo "Pruning other Cargo artifacts older than $age_days days in $repo_root"
+prune_aged_other_artifacts
+
+echo "Capping incremental generations at $incremental_max_size in $display_target_dir"
+cap_incrementals
+
+echo "Capping Cargo artifacts at $max_size in $repo_root"
+cap_target

--- a/scripts/test-prune-target.sh
+++ b/scripts/test-prune-target.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/flotilla-target-gc-test.XXXXXX")
+target_dir=$test_root/target
+stub_bin=$test_root/bin
+stub_log=$test_root/cargo-sweep.log
+relative_log=$test_root/cargo-sweep-relative.log
+relative_target_dir=$test_root/relative-target
+relative_target_link_name=.flotilla-target-gc-relative-test.$$
+relative_target_link=$repo_root/$relative_target_link_name
+stale_dependency=$target_dir/debug/deps/stale.rlib
+final_cap_dependency=$target_dir/debug/deps/final-old.rlib
+
+cleanup() {
+  rm -f -- "$relative_target_link"
+  rm -rf -- "$test_root"
+}
+
+fail() {
+  echo "target GC test failed: $*" >&2
+  exit 1
+}
+
+trap cleanup EXIT
+
+mkdir -p "$stub_bin" "$target_dir/debug/deps"
+for generation in old middle new; do
+  generation_dir=$target_dir/debug/incremental/probe/s-$generation
+  mkdir -p "$generation_dir"
+  dd if=/dev/zero of="$generation_dir/artifact.o" bs=1048576 count=2 >/dev/null 2>&1
+done
+dd if=/dev/zero of="$stale_dependency" bs=1048576 count=2 >/dev/null 2>&1
+dd if=/dev/zero of="$final_cap_dependency" bs=1048576 count=2 >/dev/null 2>&1
+
+touch -t 202001010000 "$target_dir/debug/incremental/probe/s-old"
+touch "$target_dir/debug/incremental/probe/s-middle"
+touch "$target_dir/debug/incremental/probe/s-new"
+
+cat > "$stub_bin/cargo-sweep" <<'STUB'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$FLOTILLA_SWEEP_TEST_LOG"
+printf 'target=%s\n' "$CARGO_TARGET_DIR" >> "$FLOTILLA_SWEEP_TEST_LOG"
+
+if [[ ${FLOTILLA_SWEEP_TEST_FAIL:-0} == 1 ]]; then
+  exit 42
+fi
+
+if [[ " $* " == *" --time "* ]]; then
+  rm -f -- "$CARGO_TARGET_DIR/debug/deps/stale.rlib"
+  echo "selected stale.rlib" >> "$FLOTILLA_SWEEP_TEST_LOG"
+  echo "[INFO] Cleaned 2.00 MiB from \"$CARGO_TARGET_DIR\""
+else
+  rm -f -- "$CARGO_TARGET_DIR/debug/deps/final-old.rlib"
+  echo "selected final-old.rlib" >> "$FLOTILLA_SWEEP_TEST_LOG"
+  echo "[INFO] Cleaned 2.00 MiB from \"$CARGO_TARGET_DIR\""
+fi
+STUB
+chmod +x "$stub_bin/cargo-sweep"
+
+run_gc() {
+  PATH="$stub_bin:$PATH" \
+    CARGO_TARGET_DIR="$target_dir" \
+    FLOTILLA_SWEEP_TEST_FAIL="${FLOTILLA_SWEEP_TEST_FAIL:-0}" \
+    FLOTILLA_SWEEP_TEST_LOG="$stub_log" \
+    FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE=3MiB \
+    FLOTILLA_TARGET_GC_MAX_SIZE=100MiB \
+    "$repo_root/scripts/prune-target.sh" "$@"
+}
+
+mkdir -p "$relative_target_dir/debug/deps"
+canonical_relative_target_dir=$(cd -- "$relative_target_dir" && pwd -P)
+ln -s "$relative_target_dir" "$relative_target_link"
+(
+  cd "$test_root"
+  PATH="$stub_bin:$PATH" \
+    CARGO_TARGET_DIR="$relative_target_link_name" \
+    FLOTILLA_SWEEP_TEST_LOG="$relative_log" \
+    FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE=100MiB \
+    FLOTILLA_TARGET_GC_MAX_SIZE=100MiB \
+    "$repo_root/scripts/prune-target.sh" >/dev/null
+)
+grep -Fq "target=$canonical_relative_target_dir" "$relative_log" || fail "cargo-sweep did not receive the canonical relative target"
+
+if PATH="$stub_bin:$PATH" CARGO_TARGET_DIR=// "$repo_root/scripts/prune-target.sh" --dry-run >/dev/null 2>&1; then
+  fail "root alias was accepted as the target directory"
+fi
+
+if FLOTILLA_SWEEP_TEST_FAIL=1 run_gc --dry-run >/dev/null 2>&1; then
+  fail "preview ignored a cargo-sweep failure"
+fi
+[[ -z $(find "$test_root" -maxdepth 1 -type d -name '.target.flotilla-target-gc-preview.*' -print -quit) ]] || fail "failed preview clone was not cleaned up"
+
+preview_output=$(run_gc --dry-run)
+
+[[ -d $target_dir/debug/incremental/probe/s-old ]] || fail "preview removed the aged generation"
+[[ -d $target_dir/debug/incremental/probe/s-middle ]] || fail "preview removed the size-cap generation"
+[[ -f $stale_dependency ]] || fail "preview removed the stale dependency"
+[[ -f $final_cap_dependency ]] || fail "preview removed the final-cap dependency"
+grep -Fq "Would remove 1 incremental generations older" <<< "$preview_output" || fail "preview missed the aged generation"
+grep -Fq "Would remove 1 oldest incremental generations" <<< "$preview_output" || fail "preview double-counted the aged generation"
+grep -Fq "Would remove Cargo artifact families older than 30 days (2.0 MiB)" <<< "$preview_output" || fail "preview missed the stale dependency"
+grep -Fq "Would remove Cargo artifact families to reach 100MiB (2.0 MiB)" <<< "$preview_output" || fail "preview missed the final-cap dependency"
+[[ $(grep -Fc "selected stale.rlib" "$stub_log") == 1 ]] || fail "preview did not select the aged Cargo family once"
+[[ $(grep -Fc "selected final-old.rlib" "$stub_log") == 1 ]] || fail "preview did not select the final Cargo family once"
+! grep -Fq -- "--dry-run" "$stub_log" || fail "preview did not simulate the preceding removals"
+[[ -z $(find "$test_root" -maxdepth 1 -type d -name '.target.flotilla-target-gc-preview.*' -print -quit) ]] || fail "preview clone was not cleaned up"
+
+run_gc >/dev/null
+
+[[ ! -e $target_dir/debug/incremental/probe/s-old ]] || fail "apply retained the aged generation"
+[[ ! -e $target_dir/debug/incremental/probe/s-middle ]] || fail "apply retained the oldest excess generation"
+[[ -d $target_dir/debug/incremental/probe/s-new ]] || fail "apply removed the newest generation"
+[[ ! -e $stale_dependency ]] || fail "apply retained the stale dependency"
+[[ ! -e $final_cap_dependency ]] || fail "apply retained the final-cap dependency"
+[[ $(grep -Fc "selected stale.rlib" "$stub_log") == 2 ]] || fail "preview and apply selected different aged Cargo families"
+[[ $(grep -Fc "selected final-old.rlib" "$stub_log") == 2 ]] || fail "preview and apply selected different final Cargo families"
+
+echo "target GC behavior tests passed"

--- a/scripts/test-prune-target.sh
+++ b/scripts/test-prune-target.sh
@@ -74,6 +74,21 @@ run_gc() {
     "$repo_root/scripts/prune-target.sh" "$@"
 }
 
+assert_invalid_config() {
+  local output
+  local variable=$1
+  local value=$2
+
+  if output=$(env \
+    PATH="$stub_bin:$PATH" \
+    CARGO_TARGET_DIR="$target_dir" \
+    "$variable=$value" \
+    "$repo_root/scripts/prune-target.sh" --dry-run 2>&1); then
+    fail "$variable accepted invalid value '$value'"
+  fi
+  grep -Fq "$variable" <<< "$output" || fail "$variable error did not identify the invalid setting"
+}
+
 mkdir -p "$relative_target_dir/debug/deps"
 canonical_relative_target_dir=$(cd -- "$relative_target_dir" && pwd -P)
 ln -s "$relative_target_dir" "$relative_target_link"
@@ -91,6 +106,10 @@ grep -Fq "target=$canonical_relative_target_dir" "$relative_log" || fail "cargo-
 if PATH="$stub_bin:$PATH" CARGO_TARGET_DIR=// "$repo_root/scripts/prune-target.sh" --dry-run >/dev/null 2>&1; then
   fail "root alias was accepted as the target directory"
 fi
+
+assert_invalid_config FLOTILLA_TARGET_GC_DAYS nope
+assert_invalid_config FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE 3GB
+assert_invalid_config FLOTILLA_TARGET_GC_MAX_SIZE 20GB
 
 if FLOTILLA_SWEEP_TEST_FAIL=1 run_gc --dry-run >/dev/null 2>&1; then
   fail "preview ignored a cargo-sweep failure"


### PR DESCRIPTION
## Summary

- add a per-checkout `cargo-sweep`-backed policy that prunes aged incremental generations and stale dependency families, then enforces incremental and whole-target size ceilings
- provide a faithful `--dry-run` preview and injected behavioral coverage for pruning, safety, cleanup, and relative target handling
- keep developer incrementals enabled while disabling and stripping incremental state from CI caches
- document installation, thresholds, workflow, CI rationale, and a real long-lived target measurement

## Validation

- real scratch target: 68 GiB / 180,542 files before; 20 GiB / 52,150 files after (48 GiB and 71% reclaimed)
- `cargo +nightly-2026-03-12 fmt --check`
- `scripts/test-prune-target.sh`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #935
