### PR TITLE
Move default Rustls provider to Ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "reqwest",
  "rstest",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yml",
@@ -1411,10 +1412,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1424,11 +1423,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2073,12 +2070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,62 +2592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,7 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
@@ -2700,7 +2635,6 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2712,16 +2646,6 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2738,9 +2662,6 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "rand_xoshiro"
@@ -2970,7 +2891,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3056,12 +2976,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3018,7 @@ checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3128,7 +3043,6 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -3731,21 +3645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4310,16 +4209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,15 +4535,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4686,28 +4566,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4732,12 +4595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4748,12 +4605,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4768,22 +4619,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4798,12 +4637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4814,12 +4647,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4834,12 +4661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4850,12 +4671,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,19 @@ indexmap = "2"
 color-eyre = "0.6"
 rstest = "0.23"
 bon = "3"
+# Keep the TLS provider explicit so reqwest does not pull aws-lc-sys onto the clean-build critical path.
+reqwest = { version = "0.13.2", default-features = false, features = ["rustls-no-provider"] }
+rustls = { version = "0.23.37", default-features = false, features = ["ring"] }
 
 [package]
 name = "flotilla"
 version = "0.1.0"
 edition = "2021"
 license.workspace = true
+
+[features]
+default = []
+aws-lc-provider = ["flotilla-core/aws-lc-provider", "flotilla-daemon/aws-lc-provider"]
 
 [dependencies]
 flotilla-commands = { path = "crates/flotilla-commands" }

--- a/crates/flotilla-core/Cargo.toml
+++ b/crates/flotilla-core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [features]
 default = []
+aws-lc-provider = ["flotilla-resources/aws-lc-provider"]
 replay = []
 test-support = ["flotilla-protocol/test-support"]
 
@@ -23,7 +24,7 @@ indexmap = { workspace = true }
 color-eyre = { workspace = true }
 dirs = "6"
 toml = "0.8"
-reqwest = { version = "0.13.2", features = ["json"] }
+reqwest = { workspace = true, features = ["charset", "http2", "json", "system-proxy"] }
 http = "1"
 bytes = "1"
 minijinja = "2"

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -36,5 +36,6 @@ pub mod step;
 pub mod template;
 pub mod terminal_manager;
 
-// Re-export host types from protocol for convenience.
+// Re-export shared infrastructure and host types for convenience.
 pub use flotilla_protocol::HostName;
+pub use flotilla_resources::tls;

--- a/crates/flotilla-core/src/providers/ai_utility/claude_api.rs
+++ b/crates/flotilla-core/src/providers/ai_utility/claude_api.rs
@@ -7,7 +7,7 @@ use tracing::info;
 use super::Model;
 use crate::providers::{http_execute, HttpClient};
 
-static REQUEST_FACTORY: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(reqwest::Client::new);
+static REQUEST_FACTORY: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(crate::tls::client);
 
 const API_BASE: &str = "https://api.anthropic.com";
 const API_VERSION: &str = "2023-06-01";

--- a/crates/flotilla-core/src/providers/coding_agent/mod.rs
+++ b/crates/flotilla-core/src/providers/coding_agent/mod.rs
@@ -12,7 +12,7 @@ use crate::providers::types::{CloudAgentSession, RepoCriteria};
 /// `reqwest::Request` objects). Actual execution goes through the
 /// injected `HttpClient` trait, which has its own client. This is
 /// necessary because reqwest only exposes `RequestBuilder` via `Client`.
-static REQUEST_FACTORY: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+static REQUEST_FACTORY: LazyLock<reqwest::Client> = LazyLock::new(crate::tls::client);
 
 #[async_trait]
 pub trait CloudAgentService: Send + Sync {

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -449,7 +449,7 @@ pub struct ReqwestHttpClient {
 impl ReqwestHttpClient {
     pub fn new() -> Self {
         const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-        let client = reqwest::Client::builder().timeout(REQUEST_TIMEOUT).build().expect("build HTTP client");
+        let client = crate::tls::client_builder().timeout(REQUEST_TIMEOUT).build().expect("build HTTP client");
         Self { client }
     }
 }

--- a/crates/flotilla-core/src/providers/replay/tests.rs
+++ b/crates/flotilla-core/src/providers/replay/tests.rs
@@ -309,7 +309,7 @@ interactions:
     let session = Session::replaying(&path, Masks::new());
     let client = ReplayHttpClient::new(session.clone());
 
-    let request = reqwest::Client::new()
+    let request = crate::tls::client()
         .get("https://example.test/v1/sessions")
         .header("authorization", "Bearer token-1")
         .header("anthropic-version", "2023-06-01")

--- a/crates/flotilla-daemon/Cargo.toml
+++ b/crates/flotilla-daemon/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [features]
 default = []
+aws-lc-provider = ["flotilla-core/aws-lc-provider", "flotilla-resources/aws-lc-provider"]
 skip-no-sandbox-tests = ["flotilla-resources/skip-no-sandbox-tests"]
 test-support = ["flotilla-protocol/test-support", "dep:flotilla-client"]
 

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [features]
 default = []
+aws-lc-provider = ["rustls/aws_lc_rs"]
 skip-no-sandbox-tests = []
 
 [dependencies]
@@ -16,7 +17,8 @@ tokio = { workspace = true }
 bon = { workspace = true }
 futures = "0.3"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
-reqwest = { version = "0.13.2", default-features = false, features = ["json", "query", "rustls", "stream"] }
+reqwest = { workspace = true, features = ["json", "query", "stream"] }
+rustls = { workspace = true }
 serde_yml = "0.0.12"
 base64 = "0.22"
 bytes = "1"

--- a/crates/flotilla-resources/src/http/kubeconfig.rs
+++ b/crates/flotilla-resources/src/http/kubeconfig.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path};
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use reqwest::{Certificate, Client, Identity};
+use reqwest::{Certificate, Identity};
 use serde::Deserialize;
 
 use crate::{error::ResourceError, http::HttpBackend};
@@ -85,7 +85,7 @@ pub fn from_kubeconfig(path: impl AsRef<Path>) -> Result<HttpBackend, ResourceEr
         .find(|user| user.name == context.context.user)
         .ok_or_else(|| ResourceError::invalid(format!("user '{}' not found", context.context.user)))?;
 
-    let mut builder = Client::builder().tls_backend_rustls();
+    let mut builder = crate::tls::client_builder().tls_backend_rustls();
     if let Some(ca_bytes) =
         read_pem_bytes(path, cluster.cluster.certificate_authority.as_deref(), cluster.cluster.certificate_authority_data.as_deref())?
     {

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -38,7 +38,7 @@ impl HttpBackend {
 
     #[cfg(unix)]
     pub fn from_unix_socket(path: impl AsRef<std::path::Path>) -> Result<Self, ResourceError> {
-        let http = Client::builder()
+        let http = crate::tls::client_builder()
             .unix_socket(path.as_ref())
             .build()
             .map_err(|error| ResourceError::other(format!("build Unix-socket HTTP client: {error}")))?;

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -22,6 +22,7 @@ mod retention;
 mod sqlite;
 mod status_patch;
 mod terminal_session;
+pub mod tls;
 mod vessel;
 mod watch;
 mod workflow_template;

--- a/crates/flotilla-resources/src/tls.rs
+++ b/crates/flotilla-resources/src/tls.rs
@@ -1,0 +1,109 @@
+use std::sync::OnceLock;
+
+use rustls::crypto::{CryptoProvider, WebPkiSupportedAlgorithms};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TlsProvider {
+    Ring,
+    AwsLc,
+}
+
+pub const fn selected_provider() -> TlsProvider {
+    if cfg!(feature = "aws-lc-provider") {
+        TlsProvider::AwsLc
+    } else {
+        TlsProvider::Ring
+    }
+}
+
+/// Installs the workspace-selected Rustls provider as this process's default.
+///
+/// Ring is the normal provider so clean development and CI builds avoid
+/// aws-lc-sys. Production builds can opt back into AWS-LC with the
+/// `aws-lc-provider` Cargo feature.
+pub fn install_default_provider() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+
+    INSTALLED.get_or_init(|| {
+        let selected = selected_provider();
+        let expected = crypto_provider();
+        if let Some(installed) = CryptoProvider::get_default() {
+            assert!(
+                providers_match(installed, &expected),
+                "a different Rustls crypto provider was installed before Flotilla selected {selected:?}"
+            );
+            return;
+        }
+
+        expected.install_default().unwrap_or_else(|_| panic!("failed to install Flotilla's {selected:?} Rustls crypto provider"));
+    });
+}
+
+/// Returns a Reqwest client builder after installing the selected provider.
+pub fn client_builder() -> reqwest::ClientBuilder {
+    install_default_provider();
+    reqwest::Client::builder()
+}
+
+/// Builds a Reqwest client with the selected provider installed.
+pub fn client() -> reqwest::Client {
+    client_builder().build().expect("build Reqwest client with Flotilla's TLS provider")
+}
+
+fn crypto_provider() -> CryptoProvider {
+    #[cfg(feature = "aws-lc-provider")]
+    {
+        rustls::crypto::aws_lc_rs::default_provider()
+    }
+    #[cfg(not(feature = "aws-lc-provider"))]
+    {
+        rustls::crypto::ring::default_provider()
+    }
+}
+
+fn providers_match(actual: &CryptoProvider, expected: &CryptoProvider) -> bool {
+    actual.cipher_suites == expected.cipher_suites
+        && same_dyn_items(&actual.kx_groups, &expected.kx_groups)
+        && signature_algorithms_match(actual.signature_verification_algorithms, expected.signature_verification_algorithms)
+        && std::ptr::eq(actual.secure_random, expected.secure_random)
+        && std::ptr::eq(actual.key_provider, expected.key_provider)
+}
+
+fn signature_algorithms_match(actual: WebPkiSupportedAlgorithms, expected: WebPkiSupportedAlgorithms) -> bool {
+    same_dyn_items(actual.all, expected.all)
+        && actual.mapping.len() == expected.mapping.len()
+        && actual.mapping.iter().zip(expected.mapping).all(
+            |((actual_scheme, actual_algorithms), (expected_scheme, expected_algorithms))| {
+                actual_scheme == expected_scheme && same_dyn_items(actual_algorithms, expected_algorithms)
+            },
+        )
+}
+
+fn same_dyn_items<T: ?Sized>(actual: &[&T], expected: &[&T]) -> bool {
+    actual.len() == expected.len() && actual.iter().zip(expected).all(|(actual, expected)| std::ptr::eq(*actual, *expected))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installs_selected_provider_idempotently() {
+        install_default_provider();
+        install_default_provider();
+
+        let installed = CryptoProvider::get_default().expect("TLS provider installed");
+        assert!(providers_match(installed, &crypto_provider()));
+        client();
+    }
+
+    #[test]
+    fn provider_comparison_rejects_modified_provider() {
+        let expected = crypto_provider();
+        let mut modified = expected.clone();
+        modified.cipher_suites.clear();
+
+        assert!(providers_match(&expected, &crypto_provider()));
+        assert!(!providers_match(&modified, &expected));
+    }
+}

--- a/crates/flotilla-resources/tests/http_wire.rs
+++ b/crates/flotilla-resources/tests/http_wire.rs
@@ -84,7 +84,7 @@ async fn list_decodes_collection_resource_version() {
     })
     .to_string();
     let (base_url, _request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let listed = resolver.list().await.expect("list should succeed");
@@ -118,7 +118,7 @@ async fn update_status_uses_status_subresource_path_and_body() {
     })
     .to_string();
     let (base_url, request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let updated = resolver.update_status("alpha", "7", &convoy_status(ConvoyPhase::Active)).await.expect("status update should succeed");
@@ -138,7 +138,7 @@ async fn watch_decodes_kubernetes_watch_events() {
         "{\"type\":\"DELETED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"8\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"workflow_ref\":\"review\",\"inputs\":{},\"placement_policy\":\"laptop-docker\"},\"status\":{\"phase\":\"Pending\"}}}\n"
     );
     let (base_url, request_rx) = spawn_one_shot_server(response("200 OK", body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let mut watch = resolver.watch(WatchStart::FromVersion("6".to_string())).await.expect("watch should succeed");
@@ -178,7 +178,7 @@ async fn stale_watch_maps_http_gone_to_typed_expiry() {
     })
     .to_string();
     let (base_url, request_rx) = spawn_one_shot_server(response("410 Gone", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let error = resolver.watch(WatchStart::FromVersion("6".to_string())).await.expect_err("stale watch should expire");
@@ -193,7 +193,7 @@ async fn stale_watch_maps_http_gone_to_typed_expiry() {
 async fn stale_watch_maps_http_gone_before_reading_a_truncated_body() {
     let response = "HTTP/1.1 410 Gone\r\nContent-Type: application/json\r\nContent-Length: 100\r\nConnection: close\r\n\r\n{";
     let (base_url, _request_rx) = spawn_one_shot_server(response.to_string()).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let error = resolver.watch(WatchStart::FromVersion("6".to_string())).await.expect_err("stale watch should expire");
@@ -207,7 +207,7 @@ async fn watch_decodes_crlf_terminated_events() {
     let body =
         "{\"type\":\"ADDED\",\"object\":{\"apiVersion\":\"flotilla.work/v1\",\"kind\":\"Convoy\",\"metadata\":{\"name\":\"alpha\",\"namespace\":\"flotilla\",\"resourceVersion\":\"7\",\"labels\":{},\"annotations\":{},\"creationTimestamp\":\"2026-04-13T12:00:00Z\"},\"spec\":{\"workflow_ref\":\"review\",\"inputs\":{},\"placement_policy\":\"laptop-docker\"},\"status\":{\"phase\":\"Pending\"}}}\r\n";
     let (base_url, _request_rx) = spawn_one_shot_server(response("200 OK", body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let mut watch = resolver.watch(WatchStart::Now).await.expect("watch should succeed");
@@ -224,7 +224,7 @@ async fn watch_decodes_crlf_terminated_events() {
 async fn status_errors_map_to_resource_errors() {
     let body = serde_json::json!({ "message": "resource version conflict" }).to_string();
     let (base_url, _request_rx) = spawn_one_shot_server(response("409 Conflict", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let err = resolver.update(&convoy_meta("alpha"), "7", &convoy_spec("review")).await.expect_err("update should conflict");
@@ -242,7 +242,7 @@ async fn status_errors_map_to_resource_errors() {
 async fn not_found_errors_preserve_requested_name() {
     let body = serde_json::json!({ "message": "convoys.flotilla.work \"alpha\" not found" }).to_string();
     let (base_url, _request_rx) = spawn_one_shot_server(response("404 Not Found", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let err = resolver.get("alpha").await.expect_err("get should fail");
@@ -256,7 +256,7 @@ async fn not_found_errors_preserve_requested_name() {
 #[cfg_attr(feature = "skip-no-sandbox-tests", ignore = "excluded by `skip-no-sandbox-tests`; run without that feature to include")]
 async fn server_disconnect_ends_watch_stream_cleanly() {
     let (base_url, _request_rx) = spawn_one_shot_server(response("200 OK", "")).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let mut watch = resolver.watch(WatchStart::Now).await.expect("watch should succeed");
@@ -273,7 +273,7 @@ async fn filtered_list_encodes_exact_match_label_selector() {
     })
     .to_string();
     let (base_url, request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
     let selector = BTreeMap::from([
         ("flotilla.work/convoy".to_string(), "convoy-a".to_string()),

--- a/crates/flotilla-resources/tests/provisioning_http_wire.rs
+++ b/crates/flotilla-resources/tests/provisioning_http_wire.rs
@@ -94,7 +94,7 @@ async fn http_list_decodes_owner_references() {
     })
     .to_string();
     let (base_url, _request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
 
     let listed = resolver.list().await.expect("list should succeed");
@@ -134,7 +134,7 @@ async fn http_create_serializes_owner_references() {
     })
     .to_string();
     let (base_url, request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
-    let backend = ResourceBackend::Http(HttpBackend::new(reqwest::Client::new(), base_url));
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
     let resolver = backend.using::<Convoy>("flotilla");
     let meta = InputMeta {
         name: "alpha".to_string(),

--- a/src/bin/flotillad.rs
+++ b/src/bin/flotillad.rs
@@ -32,6 +32,7 @@ impl Cli {
 
 #[tokio::main]
 async fn main() -> Result<(), String> {
+    flotilla_core::tls::install_default_provider();
     let cli = Cli::parse();
     let paths = PathPolicy::from_process_env();
     flotilla_daemon::cli::run(&cli.socket_path(), &cli.config_dir(), paths.state_dir.as_path(), cli.timeout).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,6 +285,7 @@ impl Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    flotilla_core::tls::install_default_provider();
     color_eyre::install()?;
     let mut cli = Cli::try_parse().unwrap_or_else(|error| exit_cli_parse_error(error));
     let format = OutputFormat::from_json_flag(cli.json);


### PR DESCRIPTION
## Summary

- switch Reqwest to `rustls-no-provider` and explicitly install Rustls's Ring provider for normal Flotilla builds
- centralize provider-aware Reqwest construction so binaries, resource HTTP clients, request factories, and tests cannot race provider selection
- preserve Reqwest's prior `charset`, HTTP/2, JSON, system-proxy, query, and stream behavior
- add `--features aws-lc-provider` as an opt-in production path when deployment-specific profiling shows a runtime benefit or the broader AWS-LC algorithm set is required

## Clean-build timings

Measured on the same Apple M4 host (10 logical CPUs), with Cargo/rustc 1.94.1, an empty isolated target directory, `RUSTC_WRAPPER=` to bypass sccache, and:

```console
cargo build --workspace --locked --timings
```

The baseline is `f4333f23`, as recorded by the build profile behind #928/#929. The accepted Ring sample was taken after competing Cargo processes had cleared.

| Metric | AWS-LC baseline | Ring default | Change |
| --- | ---: | ---: | ---: |
| `/usr/bin/time` wall | 418.57s | 349.67s | **-68.90s (-16.5%)** |
| Cargo total | 418.3s | 349.5s | -68.8s (-16.4%) |
| Provider package units | `aws-lc-sys` 189.11s | `ring` 21.75s | -167.36s (-88.5%) |
| Native build-script run | 182.91s | 6.69s | -176.22s (-96.3%) |
| Average active units | 5.68 | 6.90 | +1.22 |
| All 10 slots active | 46.4% | 60.1% | +13.7pp |

Before, `aws-lc-sys`'s build-script run occupied 26.88–209.79s and gated Rustls/Reqwest into resources → core → daemon. With Ring, its build-script run is 18.21–24.90s and the Ring library finishes at 37.35s; the critical gate moves back to ordinary Rust crates. The wall reduction is smaller than the provider-unit reduction because the old native build overlapped other dependency work.

## TLS/security posture

This keeps the Rustls protocol stack, platform certificate verification, TLS 1.2/1.3 support, and Flotilla's standard default cipher-suite policy. Ring is one of Rustls's built-in crypto providers, and Flotilla installs and verifies that exact built-in provider at process startup and at every owned Reqwest construction seam.

This is equivalent for Flotilla's documented security requirements, but the provider capabilities are not byte-for-byte identical:

- the previous AWS-LC configuration was not FIPS mode, and Flotilla has no documented FIPS requirement
- AWS-LC's default provider additionally exposes the hybrid `X25519MLKEM768` group and some less-common P-521/signature-verification combinations; Ring does not
- Flotilla does not require those capabilities; ordinary X25519/P-256/P-384 key exchange and RSA/ECDSA/Ed25519 verification remain available

Platform-native TLS was rejected because it would introduce platform-divergent OpenSSL/Security Framework/Schannel behavior and change the current Rustls/platform-verifier and kubeconfig PEM assumptions.

For production deployments that demonstrate an AWS-LC runtime advantage or need its broader algorithm catalogue, `cargo build --release --features aws-lc-provider` restores AWS-LC as the explicitly selected runtime provider. Cargo features are additive, so this ergonomic opt-in compiles Ring too, but provider selection remains deterministic; `aws-lc-sys` is intentionally absent from the default clean-build graph.

## Validation

- default `cargo tree --workspace --locked -i aws-lc-sys -e features` finds no active `aws-lc-sys` package
- `cargo tree --workspace --locked --features aws-lc-provider -i aws-lc-sys -e features` confirms the opt-in graph
- provider-selection tests pass with both Ring and `aws-lc-provider`
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #934
