### PR TITLE
fix: share peer resource socket path formula

### DIFF
--- a/crates/flotilla-daemon/src/peer/mod.rs
+++ b/crates/flotilla-daemon/src/peer/mod.rs
@@ -13,6 +13,7 @@ pub use manager::{
     ReversePathKey, RouteHop, RouteState,
 };
 pub use merge::merge_provider_data;
+pub(crate) use ssh_transport::peer_resource_socket_path;
 pub use ssh_transport::SshTransport;
 pub use transport::{PeerConnectionStatus, PeerSender, PeerTransport};
 

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -31,6 +31,16 @@ const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Channel buffer size for inbound and outbound peer data messages.
 const CHANNEL_BUFFER: usize = 256;
 
+pub(crate) fn peer_resource_socket_path(peer_resource_socket_dir: &Path, config_label: &ConfigLabel) -> Result<PathBuf, String> {
+    // Sanitise: reject labels containing path separators to prevent path
+    // traversal (e.g. `../` in hosts.toml).
+    let name_str = config_label.0.as_str();
+    if name_str.contains('/') || name_str.contains('\\') || name_str.contains('\0') {
+        return Err(format!("peer host name must not contain path separators: {name_str:?}"));
+    }
+    Ok(peer_resource_socket_dir.join(format!("{}.sock", config_label.0)))
+}
+
 struct ChannelPeerSender {
     tx: tokio::sync::Mutex<Option<mpsc::Sender<PeerWireMessage>>>,
 }
@@ -97,13 +107,7 @@ impl SshTransport {
         local_session_id: uuid::Uuid,
         state_dir: &Path,
     ) -> Result<Self, String> {
-        // Sanitise: reject host names containing path separators to prevent
-        // path traversal (e.g. `../` in hosts.toml).
-        let name_str = config_label.0.as_str();
-        if name_str.contains('/') || name_str.contains('\\') || name_str.contains('\0') {
-            return Err(format!("peer host name must not contain path separators: {name_str:?}"));
-        }
-        let local_socket_path = state_dir.join("peers").join(format!("{}.sock", config_label.0));
+        let local_socket_path = peer_resource_socket_path(&state_dir.join("peers"), &config_label)?;
         let expected_host_name = HostName::new(&config.expected_host_name);
 
         Ok(Self {

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -9,7 +9,8 @@ use flotilla_core::{
     daemon::DaemonHandle, in_process::InProcessDaemon, path_context::ExecutionEnvironmentPath, step::RemoteStepBatchRequest,
 };
 use flotilla_protocol::{
-    DaemonEvent, NodeId, NodeInfo, PeerConnectionState, PeerDataMessage, PeerWireMessage, RepoIdentity, RepositoryKey, RoutedPeerMessage,
+    ConfigLabel, DaemonEvent, NodeId, NodeInfo, PeerConnectionState, PeerDataMessage, PeerWireMessage, RepoIdentity, RepositoryKey,
+    RoutedPeerMessage,
 };
 use futures::future::join_all;
 use tokio::sync::{mpsc, Mutex};
@@ -19,7 +20,7 @@ use super::{
     remote_commands::RemoteCommandRouter, replicator::spawn_peer_replicators, shared::sync_peer_query_state, PeerConnectedNotice,
     SshTransport,
 };
-use crate::peer::{dispatch_pending_sends, HandleResult, InboundPeerEnvelope, PeerManager, PeerSender};
+use crate::peer::{dispatch_pending_sends, peer_resource_socket_path, HandleResult, InboundPeerEnvelope, PeerManager, PeerSender};
 
 pub(super) enum ForwardResult {
     Disconnected,
@@ -116,6 +117,14 @@ enum PostHandleAction {
 const PING_INTERVAL: Duration = Duration::from_secs(30);
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(90);
 
+fn resource_socket_path_for(resource_socket_dir: Option<&Path>, target_label: &ConfigLabel) -> Option<PathBuf> {
+    resource_socket_dir.and_then(|directory| {
+        peer_resource_socket_path(directory, target_label)
+            .inspect_err(|error| warn!(target = %target_label.0, %error, "invalid peer resource socket path"))
+            .ok()
+    })
+}
+
 #[derive(bon::Builder)]
 #[builder(builder_type(vis = "pub(super)"))]
 pub(super) struct PeerRuntime {
@@ -190,9 +199,7 @@ impl PeerRuntime {
                             let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
                                 peer: peer_name.clone(),
                                 generation,
-                                resource_socket_path: resource_socket_dir
-                                    .as_ref()
-                                    .map(|directory| directory.join(format!("{}.sock", target_label.0))),
+                                resource_socket_path: resource_socket_path_for(resource_socket_dir.as_deref(), &target_label),
                             });
                             last_known_session_id = {
                                 let pm_lock = pm.lock().await;
@@ -272,9 +279,7 @@ impl PeerRuntime {
                                     let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
                                         peer: peer_name.clone(),
                                         generation,
-                                        resource_socket_path: resource_socket_dir
-                                            .as_ref()
-                                            .map(|directory| directory.join(format!("{}.sock", target_label.0))),
+                                        resource_socket_path: resource_socket_path_for(resource_socket_dir.as_deref(), &target_label),
                                     });
                                     attempt = 1;
                                     let sender = {


### PR DESCRIPTION
## Summary

- Add a shared peer resource socket path helper that validates configured peer labels and builds `<peer-resource-socket-dir>/<label>.sock`.
- Use the helper from `SshTransport::new` and both peer runtime reconnect notice call sites so the forwarded resource socket path formula cannot drift across the Plane-A seam.
- Preserve the existing invalid-label behavior for SSH transport setup and log a warning if runtime notice construction ever sees an invalid target label.

Closes #925.

## Validation

- `cargo test -p flotilla-daemon --locked ssh_transport`
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`