### PR TITLE
fix: use readable convoy checkout directories

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -7,12 +7,12 @@ use flotilla_resources::{
     controller::{
         delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
     },
-    Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy, CrewSource, DockerCheckoutStrategy,
-    DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, FreshCloneCheckoutSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy,
-    PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey, Resource, ResourceBackend, ResourceError, ResourceObject, Stance,
-    TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase,
-    VesselStatusPatch, CONVOY_LABEL, VESSEL_REF_LABEL,
+    repository_workspace_slugs, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
+    CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase,
+    EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
+    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey, Resource,
+    ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase,
+    TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -239,6 +239,14 @@ impl Reconciler for VesselReconciler {
         } else {
             None
         };
+        let clone_directory_slugs = if strategy.needs_shared_clone() {
+            let repository_catalog = self.repositories.list().await?;
+            let keyed_repositories =
+                repository_catalog.items.iter().map(|repository| (repository.spec.key(), &repository.spec)).collect::<Vec<_>>();
+            repository_workspace_slugs(keyed_repositories.iter().map(|(key, spec)| (key, *spec)))
+        } else {
+            BTreeMap::new()
+        };
 
         let precreated_environment_ref = match &strategy {
             PlacementStrategy::DockerFreshCloneInContainer { host_ref, image, env, .. } => {
@@ -320,7 +328,7 @@ impl Reconciler for VesselReconciler {
                 let clone_path = format!(
                     "{}/{}",
                     shared_clone_root.as_deref().expect("shared-clone placement has a root").trim_end_matches('/'),
-                    repo_key
+                    clone_directory_slugs.get(&repository_key).expect("repository catalog should contain the convoy repository")
                 );
                 match self.clones.get(&clone_name).await {
                     Ok(existing) => {
@@ -374,7 +382,7 @@ impl Reconciler for VesselReconciler {
                         checkout_target_path(
                             shared_clone_root.as_deref().expect("shared-clone placement has a root"),
                             &convoy_checkout_slug,
-                            &repository.spec.catalog_slug(),
+                            &convoy_repository.workspace_slug,
                             checkout_slug.as_deref().expect("repository checkout requires a branch"),
                         )
                     }

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -239,14 +239,6 @@ impl Reconciler for VesselReconciler {
         } else {
             None
         };
-        let clone_directory_slugs = if strategy.needs_shared_clone() {
-            let repository_catalog = self.repositories.list().await?;
-            let keyed_repositories =
-                repository_catalog.items.iter().map(|repository| (repository.spec.key(), &repository.spec)).collect::<Vec<_>>();
-            repository_workspace_slugs(keyed_repositories.iter().map(|(key, spec)| (key, *spec)))
-        } else {
-            BTreeMap::new()
-        };
 
         let precreated_environment_ref = match &strategy {
             PlacementStrategy::DockerFreshCloneInContainer { host_ref, image, env, .. } => {
@@ -325,11 +317,6 @@ impl Reconciler for VesselReconciler {
             let adopted_checkout_ref = obj.spec.adopted_checkout_refs.get(&repository_key).cloned();
             let clone_name = if adopted_checkout_ref.is_none() && strategy.needs_shared_clone() {
                 let clone_name = format!("clone-{}", clone_key(&canonical_repo, &clone_env_ref));
-                let clone_path = format!(
-                    "{}/{}",
-                    shared_clone_root.as_deref().expect("shared-clone placement has a root").trim_end_matches('/'),
-                    clone_directory_slugs.get(&repository_key).expect("repository catalog should contain the convoy repository")
-                );
                 match self.clones.get(&clone_name).await {
                     Ok(existing) => {
                         if existing.spec.repo_ref != repository_key || existing.spec.env_ref != clone_env_ref {
@@ -344,22 +331,40 @@ impl Reconciler for VesselReconciler {
                             return Ok(VesselDeps::failed(message));
                         }
                     }
-                    Err(ResourceError::NotFound { .. }) => actuations.push(Actuation::CreateClone {
-                        meta: InputMeta::builder()
-                            .name(clone_name.clone())
-                            .labels(BTreeMap::from([
-                                (REPO_KEY_LABEL.to_string(), repo_key.clone()),
-                                (ENV_LABEL.to_string(), clone_env_ref.clone()),
-                                (REPO_LABEL.to_string(), convoy_repository.workspace_slug.clone()),
-                            ]))
-                            .build(),
-                        spec: CloneSpec {
-                            repo_ref: repository_key.clone(),
-                            url: convoy_repository.url.clone(),
-                            env_ref: clone_env_ref.clone(),
-                            path: clone_path,
-                        },
-                    }),
+                    Err(ResourceError::NotFound { .. }) => {
+                        let repository_catalog = self.repositories.list().await?;
+                        let keyed_repositories = repository_catalog
+                            .items
+                            .iter()
+                            .filter(|candidate| candidate.spec.key() != repository_key)
+                            .map(|candidate| (candidate.spec.key(), &candidate.spec))
+                            .chain(std::iter::once((repository_key.clone(), &repository.spec)))
+                            .collect::<Vec<_>>();
+                        let clone_directory_slug = repository_workspace_slugs(keyed_repositories.iter().map(|(key, spec)| (key, *spec)))
+                            .remove(&repository_key)
+                            .expect("the current repository was included in slug allocation");
+                        let clone_path = format!(
+                            "{}/{}",
+                            shared_clone_root.as_deref().expect("shared-clone placement has a root").trim_end_matches('/'),
+                            clone_directory_slug
+                        );
+                        actuations.push(Actuation::CreateClone {
+                            meta: InputMeta::builder()
+                                .name(clone_name.clone())
+                                .labels(BTreeMap::from([
+                                    (REPO_KEY_LABEL.to_string(), repo_key.clone()),
+                                    (ENV_LABEL.to_string(), clone_env_ref.clone()),
+                                    (REPO_LABEL.to_string(), convoy_repository.workspace_slug.clone()),
+                                ]))
+                                .build(),
+                            spec: CloneSpec {
+                                repo_ref: repository_key.clone(),
+                                url: convoy_repository.url.clone(),
+                                env_ref: clone_env_ref.clone(),
+                                path: clone_path,
+                            },
+                        });
+                    }
                     Err(err) => return Err(err),
                 }
                 Some(clone_name)

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -276,8 +276,8 @@ async fn unrelated_convoys_with_the_same_branch_use_distinct_worktree_paths() {
     let first_path = checkout_path(&first_outcome);
     let second_path = checkout_path(&second_outcome);
 
-    assert_eq!(first_path, "/Users/alice/dev/flotilla-repos/convoy-one/github-com-flotilla-org-flotilla.feat-task-provisioning");
-    assert_eq!(second_path, "/Users/alice/dev/flotilla-repos/convoy-two/github-com-flotilla-org-flotilla.feat-task-provisioning");
+    assert_eq!(first_path, "/Users/alice/dev/flotilla-repos/convoy-one/flotilla.feat-task-provisioning");
+    assert_eq!(second_path, "/Users/alice/dev/flotilla-repos/convoy-two/flotilla.feat-task-provisioning");
     assert_ne!(first_path, second_path);
 }
 
@@ -822,7 +822,15 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
     let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
     let deps = reconciler.fetch_dependencies(&vessel).await.expect("deps should load");
     let outcome = reconciler.reconcile(&vessel, &deps, Utc::now());
-    assert_eq!(outcome.actuations.iter().filter(|actuation| matches!(actuation, Actuation::CreateClone { .. })).count(), 1);
+    let clone = outcome
+        .actuations
+        .iter()
+        .find_map(|actuation| match actuation {
+            Actuation::CreateClone { spec, .. } => Some(spec),
+            _ => None,
+        })
+        .expect("scoped repository clone should be created");
+    assert_eq!(clone.path, "/Users/alice/dev/flotilla-repos/cleat");
     let (checkout_name, checkout) = outcome
         .actuations
         .iter()

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3090,26 +3090,6 @@ pub struct AddRepoOutcome {
     pub identity_change: Option<RepositoryIdentityChange>,
 }
 
-fn normalize_workspace_slug(candidate: &str) -> String {
-    let normalized = candidate
-        .chars()
-        .map(|character| if character.is_ascii_alphanumeric() { character.to_ascii_lowercase() } else { '-' })
-        .collect::<String>()
-        .split('-')
-        .filter(|segment| !segment.is_empty())
-        .collect::<Vec<_>>()
-        .join("-");
-    let normalized = if normalized.is_empty() { "repository" } else { &normalized };
-    normalized.chars().take(48).collect::<String>().trim_matches('-').to_string()
-}
-
-fn disambiguate_workspace_slug(slug: &str, repo_ref: &RepositoryKey) -> String {
-    let suffix = repo_ref.0.chars().take(8).collect::<String>();
-    let max_base_len = 48_usize.saturating_sub(suffix.len() + 1);
-    let base = slug.chars().take(max_base_len).collect::<String>().trim_matches('-').to_string();
-    format!("{base}-{suffix}")
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ProjectTargetSyntax {
     ExplicitPath,
@@ -3670,7 +3650,7 @@ impl InProcessDaemon {
             .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
         let repositories = self.resource_backend.clone().using::<Repository>(namespace);
         let mut unresolved = Vec::new();
-        let mut snapshots = BTreeMap::<RepositoryKey, (String, String, String, Option<String>, BTreeSet<String>)>::new();
+        let mut snapshots = BTreeMap::<RepositoryKey, (String, RepositorySpec, Option<String>, BTreeSet<String>)>::new();
         for entry in &project.spec.repositories {
             match repositories.get(&entry.repo.to_string()).await {
                 Ok(repository) => {
@@ -3686,20 +3666,20 @@ impl InProcessDaemon {
                         }
                     };
                     let base_ref = entry.default_branch.clone().or_else(|| repository.status.as_ref()?.default_branch.clone());
-                    let snapshot = snapshots.entry(entry.repo.clone()).or_insert_with(|| {
-                        (url, repository.spec.leaf_slug(), repository.spec.catalog_slug(), base_ref.clone(), BTreeSet::new())
-                    });
-                    if snapshot.3 != base_ref {
+                    let snapshot = snapshots
+                        .entry(entry.repo.clone())
+                        .or_insert_with(|| (url, repository.spec.clone(), base_ref.clone(), BTreeSet::new()));
+                    if snapshot.2 != base_ref {
                         unresolved.push(format!("repository {} has conflicting project default branches", entry.repo));
                     }
                     if let Some(subpath) = &entry.subpath {
-                        snapshot.4.insert(subpath.clone());
+                        snapshot.3.insert(subpath.clone());
                     }
                 }
                 Err(error) => unresolved.push(format!("repository {}: {error}", entry.repo)),
             }
         }
-        for (repo_ref, (_, _, _, base_ref, _)) in &snapshots {
+        for (repo_ref, (_, _, base_ref, _)) in &snapshots {
             if base_ref.is_none() {
                 unresolved.push(format!("repository {repo_ref} has no resolved default branch"));
             }
@@ -3708,42 +3688,15 @@ impl InProcessDaemon {
             return Err(format!("project {project_ref} is not ready: {}", unresolved.join("; ")));
         }
 
-        let leaf_slugs = snapshots
-            .iter()
-            .map(|(repo_ref, (_, leaf_slug, _, _, _))| (repo_ref.clone(), normalize_workspace_slug(leaf_slug)))
-            .collect::<BTreeMap<_, _>>();
-        let mut leaf_slug_counts = BTreeMap::<String, usize>::new();
-        for slug in leaf_slugs.values() {
-            *leaf_slug_counts.entry(slug.clone()).or_default() += 1;
-        }
-        let candidate_slugs = snapshots
-            .iter()
-            .map(|(repo_ref, (_, _, catalog_slug, _, _))| {
-                let leaf_slug = &leaf_slugs[repo_ref];
-                let slug = if leaf_slug_counts[leaf_slug] == 1 { leaf_slug.clone() } else { normalize_workspace_slug(catalog_slug) };
-                (repo_ref.clone(), slug)
-            })
-            .collect::<BTreeMap<_, _>>();
-        let mut candidate_slug_counts = BTreeMap::<String, usize>::new();
-        for slug in candidate_slugs.values() {
-            *candidate_slug_counts.entry(slug.clone()).or_default() += 1;
-        }
+        let workspace_slugs = flotilla_resources::repository_workspace_slugs(snapshots.iter().map(|(key, (_, spec, _, _))| (key, spec)));
         let mut repositories = snapshots
             .into_iter()
-            .map(|(repo_ref, (url, _, _, base_ref, subpaths))| {
-                let candidate = &candidate_slugs[&repo_ref];
-                let workspace_slug = if candidate_slug_counts[candidate] == 1 {
-                    candidate.clone()
-                } else {
-                    disambiguate_workspace_slug(candidate, &repo_ref)
-                };
-                ConvoyRepositorySpec {
-                    url,
-                    repo_ref,
-                    base_ref: base_ref.expect("missing base refs were rejected"),
-                    workspace_slug,
-                    subpaths: subpaths.into_iter().collect(),
-                }
+            .map(|(repo_ref, (url, _, base_ref, subpaths))| ConvoyRepositorySpec {
+                url,
+                workspace_slug: workspace_slugs[&repo_ref].clone(),
+                repo_ref,
+                base_ref: base_ref.expect("missing base refs were rejected"),
+                subpaths: subpaths.into_iter().collect(),
             })
             .collect::<Vec<_>>();
         repositories.sort_by(|left, right| left.workspace_slug.cmp(&right.workspace_slug).then_with(|| left.repo_ref.cmp(&right.repo_ref)));
@@ -6077,13 +6030,10 @@ impl InProcessDaemon {
                         .and_then(|status| status.default_branch.clone())
                         .or_else(|| if adopted_checkout.is_some() { r#ref.clone() } else { None })
                         .ok_or_else(|| format!("repository {repo_ref} has no resolved default branch"))?;
-                    Ok::<_, String>(vec![ConvoyRepositorySpec {
-                        url,
-                        repo_ref,
-                        base_ref,
-                        workspace_slug: normalize_workspace_slug(&repository_spec.leaf_slug()),
-                        subpaths: Vec::new(),
-                    }])
+                    let workspace_slug = flotilla_resources::repository_workspace_slugs([(&repo_ref, &repository_spec)])
+                        .remove(&repo_ref)
+                        .expect("repository slug should resolve");
+                    Ok::<_, String>(vec![ConvoyRepositorySpec { url, repo_ref, base_ref, workspace_slug, subpaths: Vec::new() }])
                 }
                 .await;
                 match resolved {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -52,13 +52,15 @@ const TEST_LOCAL_ATTACH_HOST: &str = "local";
 
 #[test]
 fn workspace_slugs_are_dns_safe_bounded_and_disambiguatable() {
-    let normalized = normalize_workspace_slug("My_repo...with spaces");
-    assert_eq!(normalized, "my-repo-with-spaces");
-    assert!(normalize_workspace_slug(&"a".repeat(100)).len() <= 48);
+    let first = RepositorySpec::remote("https://github.com/org-a/My_repo...with spaces").expect("first repository");
+    let second = RepositorySpec::remote("https://gitlab.com/org-b/My_repo...with spaces").expect("second repository");
+    let first_key = first.key();
+    let second_key = second.key();
+    let slugs = flotilla_resources::repository_workspace_slugs([(&first_key, &first), (&second_key, &second)]);
 
-    let left = disambiguate_workspace_slug("same-repo", &flotilla_resources::RepositoryKey("abcdefgh1111".to_string()));
-    let right = disambiguate_workspace_slug("same-repo", &flotilla_resources::RepositoryKey("ijklmnop2222".to_string()));
-    assert_ne!(left, right);
+    assert_eq!(slugs[&first_key], "github-com-org-a-my-repo-with-spaces");
+    assert_eq!(slugs[&second_key], "gitlab-com-org-b-my-repo-with-spaces");
+    assert!(slugs.values().all(|slug| slug.len() <= 48));
 }
 
 #[test]

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -72,9 +72,9 @@ pub use registry::{
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{
-    ensure_repository, repository_display_labels, resolve_default_branch, DefaultBranchObservation, DefaultBranchProvenance, ForgeIdentity,
-    Repository, RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey, RepositorySpec, RepositoryStatus,
-    RepositoryStatusPatch,
+    ensure_repository, repository_display_labels, repository_workspace_slugs, resolve_default_branch, DefaultBranchObservation,
+    DefaultBranchProvenance, ForgeIdentity, Repository, RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey,
+    RepositorySpec, RepositoryStatus, RepositoryStatusPatch,
 };
 pub use resource::{
     api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -156,6 +156,65 @@ pub fn repository_display_labels<'a>(
         .collect()
 }
 
+/// Short, path-safe repository names, qualified only when names collide.
+///
+/// Repository keys remain opaque identity and must not leak into paths as the
+/// whole directory name. A key prefix is used only as a final disambiguator,
+/// after both the URL basename and readable remote-derived slug collide.
+pub fn repository_workspace_slugs<'a>(
+    repositories: impl IntoIterator<Item = (&'a RepositoryKey, &'a RepositorySpec)>,
+) -> BTreeMap<RepositoryKey, String> {
+    let repositories = repositories.into_iter().collect::<Vec<_>>();
+    let leaf_slugs =
+        repositories.iter().map(|(key, spec)| ((*key).clone(), normalize_workspace_slug(&spec.leaf_slug()))).collect::<BTreeMap<_, _>>();
+    let mut leaf_slug_counts = BTreeMap::<String, usize>::new();
+    for slug in leaf_slugs.values() {
+        *leaf_slug_counts.entry(slug.clone()).or_default() += 1;
+    }
+
+    let candidates = repositories
+        .iter()
+        .map(|(key, spec)| {
+            let leaf_slug = &leaf_slugs[*key];
+            let candidate =
+                if leaf_slug_counts[leaf_slug] == 1 { leaf_slug.clone() } else { normalize_workspace_slug(&spec.catalog_slug()) };
+            ((*key).clone(), candidate)
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut candidate_counts = BTreeMap::<String, usize>::new();
+    for slug in candidates.values() {
+        *candidate_counts.entry(slug.clone()).or_default() += 1;
+    }
+
+    candidates
+        .into_iter()
+        .map(|(key, candidate)| {
+            let slug = if candidate_counts[&candidate] == 1 { candidate } else { disambiguate_workspace_slug(&candidate, &key) };
+            (key, slug)
+        })
+        .collect()
+}
+
+fn normalize_workspace_slug(candidate: &str) -> String {
+    let normalized = candidate
+        .chars()
+        .map(|character| if character.is_ascii_alphanumeric() { character.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    let normalized = if normalized.is_empty() { "repository" } else { &normalized };
+    normalized.chars().take(48).collect::<String>().trim_matches('-').to_string()
+}
+
+fn disambiguate_workspace_slug(slug: &str, repo_ref: &RepositoryKey) -> String {
+    let suffix = repo_ref.0.chars().take(8).collect::<String>();
+    let max_base_len = 48_usize.saturating_sub(suffix.len() + 1);
+    let base = slug.chars().take(max_base_len).collect::<String>().trim_matches('-').to_string();
+    format!("{base}-{suffix}")
+}
+
 pub async fn ensure_repository(
     repositories: &TypedResolver<Repository>,
     key: &RepositoryKey,

--- a/crates/flotilla-resources/tests/repository_in_memory.rs
+++ b/crates/flotilla-resources/tests/repository_in_memory.rs
@@ -138,6 +138,25 @@ fn repository_display_labels_use_forge_slugs_and_qualify_collisions() {
 }
 
 #[test]
+fn repository_workspace_slugs_are_short_and_qualify_basename_collisions() {
+    let cleat = RepositorySpec::remote("https://github.com/flotilla-org/cleat").expect("cleat repository");
+    let flotilla = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("flotilla repository");
+    let andamento = RepositorySpec::remote("https://github.com/flotilla-org/andamento").expect("andamento repository");
+    let github_shared = RepositorySpec::remote("https://github.com/org-a/shared").expect("github shared repository");
+    let gitlab_shared = RepositorySpec::remote("https://gitlab.com/org-b/shared").expect("gitlab shared repository");
+    let repositories = [cleat, flotilla, andamento, github_shared, gitlab_shared];
+    let keyed_repositories = repositories.iter().map(|spec| (spec.key(), spec)).collect::<Vec<_>>();
+    let slugs = flotilla_resources::repository_workspace_slugs(keyed_repositories.iter().map(|(key, spec)| (key, *spec)));
+
+    assert_eq!(slugs[&repositories[0].key()], "cleat");
+    assert_eq!(slugs[&repositories[1].key()], "flotilla");
+    assert_eq!(slugs[&repositories[2].key()], "andamento");
+    assert_eq!(slugs[&repositories[3].key()], "github-com-org-a-shared");
+    assert_eq!(slugs[&repositories[4].key()], "gitlab-com-org-b-shared");
+    assert!(repositories.iter().all(|repository| slugs[&repository.key()] != repository.key().to_string()));
+}
+
+#[test]
 fn repository_declarations_reject_unresolved_aliases_and_inconsistent_forges() {
     assert!(RepositorySpec::remote("work-github:flotilla-org/flotilla.git").is_err());
     assert!(RepositorySpec::remote("git@github.com:flotilla-org/flotilla.git").is_err());


### PR DESCRIPTION
## What changed

- centralize short, path-safe repository workspace slug allocation
- use collision-qualified readable slugs for shared clone directories
- use the convoy's snapshotted workspace slug for single-repository checkout paths
- cover cleat, flotilla, andamento, basename collisions, clone paths, and worktree paths with regressions

## Why

Convoy paths exposed opaque repository-key hashes for shared clones and verbose remote-derived slugs for single-repository worktrees. Repository identity remains canonical and opaque, while the on-disk presentation is now human-readable.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #907