### PR TITLE
fix: materialize latent convoy recipes

### DIFF
--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -28,7 +28,7 @@ use crate::{
         KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_VESSEL,
         SOURCE_CONNECTOR,
     },
-    recipe::RecipeMint,
+    recipe::{Recipe, RecipeMint},
     wire::{GroupPath, GroupSegment, MetadataIdentity, MetadataPatch, MetadataTarget, MetadataValue, MetadataValueUpdate},
 };
 
@@ -171,7 +171,7 @@ pub fn project_catalog(input: &CatalogInput<'_>, mint: &dyn RecipeMint) -> Catal
     let mut catalog = Catalog::default();
     if let Some(nodes) = input.awareness {
         for node in nodes {
-            project_awareness_node(&mut catalog, node, mint);
+            project_awareness_node(&mut catalog, node, input.convoys, mint);
         }
         return catalog;
     }
@@ -184,33 +184,42 @@ pub fn project_catalog(input: &CatalogInput<'_>, mint: &dyn RecipeMint) -> Catal
     catalog
 }
 
-fn project_awareness_node(catalog: &mut Catalog, node: &AwarenessNode, mint: &dyn RecipeMint) {
+fn project_awareness_node(catalog: &mut Catalog, node: &AwarenessNode, convoys: &[ConvoyRow], mint: &dyn RecipeMint) {
     let project = GroupSegment::text(SEGMENT_PROJECT, node.id.clone()).with_label(node.label.clone());
     assert_project_group(catalog, &project);
     let project_path = GroupPath(vec![project.clone()]);
-    catalog.assert_facts(
-        MetadataTarget::Group(project_path),
-        vec![
-            (KEY_STATUS_STATE, MetadataValue::text(awareness_state(node.state))),
-            (KEY_SUMMARY_TEXT, MetadataValue::text(summary_text(&node.counts))),
-            (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:awareness/{}", node.id))),
-        ],
-        None,
-    );
+    let mut facts = vec![
+        (KEY_STATUS_STATE, MetadataValue::text(awareness_state(node.state))),
+        (KEY_SUMMARY_TEXT, MetadataValue::text(summary_text(&node.counts))),
+        (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:awareness/{}", node.id))),
+    ];
+    if let Some(recipe) = awareness_project_recipe(node, mint) {
+        facts.push((KEY_MATERIALIZE_TARGET, MetadataValue::text("workspace")));
+        facts.push((KEY_MATERIALIZE_RECIPE, MetadataValue::text(recipe.command())));
+    }
+    catalog.assert_facts(MetadataTarget::Group(project_path), facts, None);
 
     for entry in &node.entries {
-        project_awareness_entry(catalog, &project, entry, mint);
+        project_awareness_entry(catalog, &project, entry, convoys, mint);
     }
 }
 
-fn project_awareness_entry(catalog: &mut Catalog, project: &GroupSegment, entry: &AwarenessEntry, mint: &dyn RecipeMint) {
+fn project_awareness_entry(
+    catalog: &mut Catalog,
+    project: &GroupSegment,
+    entry: &AwarenessEntry,
+    convoys: &[ConvoyRow],
+    mint: &dyn RecipeMint,
+) {
     let segment_key = match entry.kind {
         AwarenessKind::Convoy => SEGMENT_CONVOY,
         AwarenessKind::Issue => SEGMENT_ISSUE,
         AwarenessKind::Vessel | AwarenessKind::Independent | AwarenessKind::Checkout => SEGMENT_VESSEL,
         AwarenessKind::Fleet | AwarenessKind::Project => return,
     };
-    let path = GroupPath(vec![project.clone(), GroupSegment::text(segment_key, entry.id.clone()).with_label(entry.label.clone())]);
+    let path = awareness_entry_path(project, entry).unwrap_or_else(|| {
+        GroupPath(vec![project.clone(), GroupSegment::text(segment_key, entry.id.clone()).with_label(entry.label.clone())])
+    });
     let mut facts = vec![
         (KEY_STATUS_STATE, MetadataValue::text(awareness_state(entry.state))),
         (KEY_SUMMARY_TEXT, MetadataValue::text(entry.label.clone())),
@@ -225,18 +234,59 @@ fn project_awareness_entry(catalog: &mut Catalog, project: &GroupSegment, entry:
     if matches!(entry.state, AwarenessState::Waiting | AwarenessState::Failed) {
         facts.push((KEY_STATUS_ATTENTION, MetadataValue::Bool(true)));
     }
-    if let Some(recipe) = awareness_view_target(&entry.id).and_then(|target| mint.scoped_view(&target)) {
+    // The awareness transport wins over raw convoy rows in `project_catalog`.
+    // Resolve attach recipes from the held fleet rows here; otherwise a
+    // scoped-view awareness recipe shadows the vessel's live attach recipe.
+    if let Some(recipe) = awareness_entry_recipe(entry, convoys, mint) {
         facts.push((KEY_MATERIALIZE_TARGET, MetadataValue::text("workspace")));
         facts.push((KEY_MATERIALIZE_RECIPE, MetadataValue::text(recipe.command())));
     }
     catalog.assert_facts(MetadataTarget::Group(path), facts, None);
 }
 
-fn awareness_view_target(id: &str) -> Option<ViewAddress> {
-    match id.parse().ok()? {
-        address @ (ViewAddress::Project { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. }) => Some(address),
+fn awareness_project_recipe(node: &AwarenessNode, mint: &dyn RecipeMint) -> Option<Recipe> {
+    if !matches!(node.kind, AwarenessKind::Project) {
+        return None;
+    }
+    let address = node.id.parse().ok()?;
+    let ViewAddress::Project { .. } = &address else {
+        return None;
+    };
+    mint.scoped_view(&address)
+}
+
+fn awareness_entry_recipe(entry: &AwarenessEntry, convoys: &[ConvoyRow], mint: &dyn RecipeMint) -> Option<Recipe> {
+    if matches!(entry.kind, AwarenessKind::Issue) {
+        return None;
+    }
+    match entry.id.parse().ok()? {
+        ViewAddress::Project { namespace, name } => mint.scoped_view(&ViewAddress::Project { namespace, name }),
+        ViewAddress::Vessel { namespace, convoy, vessel } => find_vessel(convoys, &namespace, &convoy, &vessel)
+            .and_then(|vessel| vessel.materialize.as_deref().and_then(|attach_ref| mint.attach(attach_ref, &vessel.host))),
+        ViewAddress::Convoy { namespace, name } => find_convoy(convoys, &namespace, &name).and_then(|convoy| {
+            let [vessel] = convoy.vessels.as_slice() else {
+                return None;
+            };
+            vessel.materialize.as_deref().and_then(|attach_ref| mint.attach(attach_ref, &vessel.host))
+        }),
         _ => None,
     }
+}
+
+fn awareness_entry_path(project: &GroupSegment, entry: &AwarenessEntry) -> Option<GroupPath> {
+    match entry.id.parse().ok()? {
+        ViewAddress::Convoy { namespace, name } => Some(convoy_group_path(Some(project.clone()), &namespace, &name)),
+        ViewAddress::Vessel { namespace, convoy, vessel } => Some(vessel_group_path(Some(project.clone()), &namespace, &convoy, &vessel)),
+        _ => None,
+    }
+}
+
+fn find_convoy<'a>(convoys: &'a [ConvoyRow], namespace: &str, name: &str) -> Option<&'a ConvoyRow> {
+    convoys.iter().find(|convoy| convoy.resource.namespace == namespace && convoy.name == name)
+}
+
+fn find_vessel<'a>(convoys: &'a [ConvoyRow], namespace: &str, convoy_name: &str, vessel_name: &str) -> Option<&'a VesselRow> {
+    find_convoy(convoys, namespace, convoy_name)?.vessels.iter().find(|vessel| vessel.name == vessel_name)
 }
 
 fn awareness_state(state: AwarenessState) -> &'static str {

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -61,7 +61,7 @@ fn text(patch: &MetadataPatch, key: &str) -> String {
 }
 
 #[test]
-fn awareness_tree_projects_project_issue_and_materializable_entries() {
+fn awareness_tree_resolves_open_recipes_without_shadowing_live_attach() {
     let issue = AwarenessEntry::builder()
         .id("issue/flotilla-org/flotilla/862".to_string())
         .kind(AwarenessKind::Issue)
@@ -69,7 +69,14 @@ fn awareness_tree_projects_project_issue_and_materializable_entries() {
         .state(AwarenessState::Waiting)
         .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
         .build();
-    let vessel = AwarenessEntry::builder()
+    let convoy_entry = AwarenessEntry::builder()
+        .id("convoy/dev/ship-it".to_string())
+        .kind(AwarenessKind::Convoy)
+        .label("ship-it".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .build();
+    let vessel_entry = AwarenessEntry::builder()
         .id("vessel/dev/ship-it/coder".to_string())
         .kind(AwarenessKind::Vessel)
         .label("coder".to_string())
@@ -84,14 +91,26 @@ fn awareness_tree_projects_project_issue_and_materializable_entries() {
         .label("platform".to_string())
         .state(AwarenessState::Waiting)
         .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
-        .counts(AwarenessCounts::builder().total(2).issues(1).vessels(1).build())
-        .entries(vec![issue, vessel])
+        .counts(AwarenessCounts::builder().total(3).issues(1).vessels(1).build())
+        .entries(vec![issue, convoy_entry, vessel_entry])
+        .build();
+    let reference = convoy_ref("dev", "ship-it");
+    let convoy = ConvoyRow::builder()
+        .resource(reference.clone())
+        .name("ship-it")
+        .workflow_ref("implement")
+        .phase(ConvoyPhase::Active)
+        .vessels(vec![vessel().convoy(&reference).name("coder").phase(WorkPhase::Running).materialize("terminal-ship-it-coder").call()])
         .build();
 
-    let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint());
+    let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
     let project = GroupSegment::text(SEGMENT_PROJECT, "project/dev/platform").with_label("platform");
+    let project_patch = find(&patches, &group(vec![project.clone()]));
+    assert_eq!(text(project_patch, KEY_MATERIALIZE_TARGET), "workspace");
+    assert_eq!(text(project_patch, KEY_MATERIALIZE_RECIPE), "flotilla view 'project/dev/platform'");
+
     let issue_patch = find(
         &patches,
         &group(vec![
@@ -101,13 +120,104 @@ fn awareness_tree_projects_project_issue_and_materializable_entries() {
     );
     assert_eq!(text(issue_patch, KEY_STATUS_STATE), "waiting");
     assert_eq!(issue_patch.set[KEY_STATUS_ATTENTION].value, MetadataValue::Bool(true));
+    assert!(!issue_patch.set.contains_key(KEY_MATERIALIZE_RECIPE));
 
-    let vessel_patch =
-        find(&patches, &group(vec![project, GroupSegment::text(SEGMENT_VESSEL, "vessel/dev/ship-it/coder").with_label("coder")]));
+    let convoy_target = MetadataTarget::Group(convoy_group_path(Some(project.clone()), "dev", "ship-it"));
+    let convoy_patch = find(&patches, &convoy_target);
+    assert_eq!(text(convoy_patch, KEY_MATERIALIZE_TARGET), "workspace");
+    assert_eq!(text(convoy_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach --host 'feta' 'terminal-ship-it-coder'");
+
+    let vessel_target = MetadataTarget::Group(vessel_group_path(Some(project), "dev", "ship-it", "coder"));
+    let vessel_patch = find(&patches, &vessel_target);
     assert_eq!(text(vessel_patch, KEY_WORK_PHASE), "running");
     assert_eq!(text(vessel_patch, KEY_VESSEL_HOST), "feta");
     assert_eq!(text(vessel_patch, KEY_MATERIALIZE_TARGET), "workspace");
-    assert_eq!(text(vessel_patch, KEY_MATERIALIZE_RECIPE), "flotilla view 'vessel/dev/ship-it/coder'");
+    assert_eq!(text(vessel_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach --host 'feta' 'terminal-ship-it-coder'");
+}
+
+#[test]
+fn local_one_vessel_convoy_awareness_materializes_the_local_agent_cli() {
+    let convoy_entry = AwarenessEntry::builder()
+        .id("convoy/dev/local-ship".to_string())
+        .kind(AwarenessKind::Convoy)
+        .label("local-ship".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .build();
+    let node = AwarenessNode::builder()
+        .id("project/dev/platform".to_string())
+        .kind(AwarenessKind::Project)
+        .label("platform".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .counts(AwarenessCounts::builder().total(1).vessels(1).build())
+        .entries(vec![convoy_entry])
+        .build();
+    let reference = convoy_ref("dev", "local-ship");
+    let convoy = ConvoyRow::builder()
+        .resource(reference.clone().on_host(HostName::new("kiwi")))
+        .name("local-ship")
+        .workflow_ref("implement")
+        .phase(ConvoyPhase::Active)
+        .vessels(vec![VesselRow::builder()
+            .resource(reference.subresource("vessels/coder"))
+            .name("coder")
+            .phase(WorkPhase::Running)
+            .host(HostName::new("kiwi"))
+            .materialize("terminal-local-ship-coder")
+            .build()])
+        .build();
+
+    let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[convoy], independents: &[] }, &mint());
+    let patches = catalog.reassert_patches();
+
+    let project = GroupSegment::text(SEGMENT_PROJECT, "project/dev/platform").with_label("platform");
+    let convoy_patch = find(&patches, &MetadataTarget::Group(convoy_group_path(Some(project), "dev", "local-ship")));
+    assert_eq!(text(convoy_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach --host 'kiwi' 'terminal-local-ship-coder'");
+}
+
+#[test]
+fn multi_vessel_convoy_awareness_lists_without_recipe_until_pane_sets_are_representable() {
+    let convoy_entry = AwarenessEntry::builder()
+        .id("convoy/dev/ship-it".to_string())
+        .kind(AwarenessKind::Convoy)
+        .label("ship-it".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .build();
+    let node = AwarenessNode::builder()
+        .id("project/dev/platform".to_string())
+        .kind(AwarenessKind::Project)
+        .label("platform".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .counts(AwarenessCounts::builder().total(1).vessels(2).build())
+        .entries(vec![convoy_entry])
+        .build();
+    let reference = convoy_ref("dev", "ship-it");
+    let convoy = ConvoyRow::builder()
+        .resource(reference.clone())
+        .name("ship-it")
+        .workflow_ref("implement-review")
+        .phase(ConvoyPhase::Active)
+        .vessels(vec![
+            vessel().convoy(&reference).name("coder").phase(WorkPhase::Running).materialize("terminal-ship-it-coder").call(),
+            vessel().convoy(&reference).name("reviewer").phase(WorkPhase::Running).materialize("terminal-ship-it-reviewer").call(),
+        ])
+        .build();
+
+    let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[convoy], independents: &[] }, &mint());
+    let patches = catalog.reassert_patches();
+
+    let convoy_patch = find(
+        &patches,
+        &group(vec![
+            GroupSegment::text(SEGMENT_PROJECT, "project/dev/platform").with_label("platform"),
+            GroupSegment::text(SEGMENT_CONVOY, "dev/ship-it").with_label("ship-it"),
+        ]),
+    );
+    assert!(!convoy_patch.set.contains_key(KEY_MATERIALIZE_RECIPE));
+    assert!(!convoy_patch.set.contains_key(KEY_MATERIALIZE_TARGET));
 }
 
 #[test]

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -125,10 +125,8 @@ fn awareness_tree_resolves_open_recipes_without_shadowing_live_attach() {
     assert_eq!(issue_patch.set[KEY_STATUS_ATTENTION].value, MetadataValue::Bool(true));
     assert!(!issue_patch.set.contains_key(KEY_MATERIALIZE_RECIPE));
 
-    let convoy_patch = find(
-        &patches,
-        &group(vec![project.clone(), GroupSegment::text(SEGMENT_CONVOY, "dev/ship-it").with_label("ship-it")]),
-    );
+    let convoy_patch =
+        find(&patches, &group(vec![project.clone(), GroupSegment::text(SEGMENT_CONVOY, "dev/ship-it").with_label("ship-it")]));
     assert_eq!(text(convoy_patch, KEY_MATERIALIZE_TARGET), "workspace");
     assert_eq!(text(convoy_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach --host 'feta' 'terminal-ship-it-coder'");
 

--- a/docs/adr/0018-presentation-attention-demands-regards-projection.md
+++ b/docs/adr/0018-presentation-attention-demands-regards-projection.md
@@ -163,6 +163,14 @@ Three refinements from the openable-latent grill (2026-07-23):
   bounded by minting **only while the origin peer's route is live**.
   Recipes vanish on peer disconnect; hours-stale affirmation is a lie,
   seconds-stale is honest.
+- **Open semantics are level-specific.** Opening a vessel latent attaches
+  to the vessel's primary crew session (`flotilla attach --host <host>
+  <session-ref>`). Opening a one-vessel convoy collapses to the same attach
+  target; multi-vessel convoys require a pane-set recipe shape before they
+  can honestly materialize as one action. Opening a Project latent opens
+  the scoped focal TUI (`flotilla view <project-address>`). Issue entries
+  deliberately carry no recipe: they are starting points, not tabs in
+  waiting.
 - **"Disconnected" becomes a visible state eventually** — as an
   annotation-tier fact on the affected entries (the presentation twin of
   marking peer hosts unready), never a new member of the frozen


### PR DESCRIPTION
## Summary

- Mint awareness Project recipes as `flotilla view <project-address>` while leaving Issue entries recipe-less.
- Resolve Vessel awareness recipes from the fleet-merged `ConvoyRow` data so they materialize as `flotilla attach --host <host> <session-ref>`.
- Collapse one-vessel Convoy awareness opens to the same host-qualified attach recipe as its vessel, for both local and remote/feta-placed rows.
- Use the canonical convoy/vessel group paths for awareness entries that parse as typed addresses, so materialized workspace stamps join the same nodes.
- Carry the per-level open semantics into ADR 0018.

## Cause

The views-instead-of-attach bug was awareness recipe shadowing. When the PM connector had awareness rows, `project_catalog` returned after projecting awareness and skipped the raw convoy projection. The awareness projector then minted `flotilla view ...` for parseable Vessel and Convoy addresses, so the live `VesselRow.materialize` attach capability produced by the aggregator, including replica-read-view remote sessions, never reached the PM catalog. The daemon-side materialize resolution through replicas was already covered by aggregator tests; the missing piece was resolving awareness recipes through the held convoy rows before projecting them.

## Multi-vessel follow-up

Multi-vessel Convoy latents remain recipe-less because the current manifest recipe shape is command-only and cannot represent an atomic generated pane set. Filed #952 for the pane-set recipe schema and projection work.

Closes #949

## Test Plan

- [x] `cargo test -p flotilla-manifest --locked`
- [x] `cargo test -p flotilla-tui pm_connect --locked`
- [x] `cargo test -p flotilla-daemon aggregator::tests:: --locked`
- [x] `cargo +nightly-2026-03-12 fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked`
