### PR TITLE
feat: split project and repository fact segments

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/presentation.rs
+++ b/crates/flotilla-controllers/src/reconcilers/presentation.rs
@@ -27,7 +27,7 @@ use flotilla_protocol::{arg, EnvironmentId};
 use flotilla_resources::{
     controller::{LabelJoinWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
     Convoy, Environment, Host, Presentation, PresentationStatus, PresentationStatusPatch, Repository, ResourceBackend, ResourceError,
-    ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, CONVOY_LABEL,
+    ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, CONVOY_LABEL, VESSEL_LABEL,
 };
 use sha2::{Digest, Sha256};
 use tracing::warn;
@@ -275,30 +275,42 @@ impl<R> PresentationReconciler<R> {
     async fn workspace_stamp(&self, obj: &ResourceObject<Presentation>) -> WorkspaceStamp {
         let namespace = &obj.metadata.namespace;
         let convoy_name = &obj.spec.convoy_ref;
-        let vessel = &obj.spec.name;
+        let vessel = obj.spec.process_selector.get(VESSEL_LABEL).or_else(|| obj.metadata.labels.get(VESSEL_LABEL));
         // Tab stamps have no TTL, so a wrong scope would stick: on a failed
-        // convoy lookup, stamp no scope at all (honestly absent — the pane
-        // identities still group the tab) rather than a spine missing its
-        // project segment.
-        let scope = match self.convoys.get(convoy_name).await {
-            Ok(convoy) => {
+        // dependency lookup, stamp no scope at all (honestly absent — the
+        // pane identities still group the tab) rather than an incomplete
+        // spine.
+        let scope = match (vessel, self.convoys.get(convoy_name).await) {
+            (Some(vessel), Ok(convoy)) => {
                 let project = project_segment(convoy.spec.project_ref.as_deref());
-                let repo_value = match convoy.spec.repositories.as_slice() {
-                    [snapshot] => {
-                        self.repositories.get(&snapshot.repo_ref.to_string()).await.ok().map(|repository| repository.spec.fact_slug())
-                    }
-                    [] => None,
-                    _ => None,
+                let repo_value = match convoy.spec.sole_repository() {
+                    Some(snapshot) => match self.repositories.get(&snapshot.repo_ref.to_string()).await {
+                        Ok(repository) => Some(repository.spec.repo_fact_value()),
+                        Err(err) => {
+                            warn!(%err, repository = %snapshot.repo_ref, convoy = %convoy_name, "repository lookup failed; stamping workspace without a scope");
+                            return WorkspaceStamp {
+                                kind: "flotilla-vessel".to_owned(),
+                                factory_id: vessel_factory_id(namespace, convoy_name, vessel),
+                                scope: None,
+                            };
+                        }
+                    },
+                    None => None,
                 };
                 let repo = repo_segment(repo_value.as_deref());
                 Some(vessel_group_path(project, repo, namespace, convoy_name, vessel))
             }
-            Err(err) => {
+            (_, Err(err)) => {
                 warn!(%err, convoy = %convoy_name, "convoy lookup failed; stamping workspace without a scope");
                 None
             }
+            (None, Ok(_)) => {
+                warn!(presentation = %obj.metadata.name, convoy = %convoy_name, "presentation has no vessel selector; stamping workspace without a scope");
+                None
+            }
         };
-        WorkspaceStamp { kind: "flotilla-vessel".to_owned(), factory_id: vessel_factory_id(namespace, convoy_name, vessel), scope }
+        let factory_vessel = vessel.map_or(obj.spec.name.as_str(), String::as_str);
+        WorkspaceStamp { kind: "flotilla-vessel".to_owned(), factory_id: vessel_factory_id(namespace, convoy_name, factory_vessel), scope }
     }
 
     fn build_attach_command(

--- a/crates/flotilla-controllers/src/reconcilers/presentation.rs
+++ b/crates/flotilla-controllers/src/reconcilers/presentation.rs
@@ -20,14 +20,14 @@ use flotilla_core::{
     HostName,
 };
 use flotilla_manifest::{
-    projection::{project_segment, vessel_factory_id, vessel_group_path},
+    projection::{project_segment, repo_segment, vessel_factory_id, vessel_group_path},
     stamp::WorkspaceStamp,
 };
 use flotilla_protocol::{arg, EnvironmentId};
 use flotilla_resources::{
     controller::{LabelJoinWatch, ReconcileOutcome, Reconciler, SecondaryWatch},
-    Convoy, Environment, Host, Presentation, PresentationStatus, PresentationStatusPatch, ResourceBackend, ResourceError, ResourceObject,
-    TerminalSession, TerminalSessionPhase, TypedResolver, CONVOY_LABEL, REPO_LABEL,
+    Convoy, Environment, Host, Presentation, PresentationStatus, PresentationStatusPatch, Repository, ResourceBackend, ResourceError,
+    ResourceObject, TerminalSession, TerminalSessionPhase, TypedResolver, CONVOY_LABEL,
 };
 use sha2::{Digest, Sha256};
 use tracing::warn;
@@ -209,6 +209,7 @@ pub struct PresentationReconciler<R> {
     environments: TypedResolver<Environment>,
     hosts: TypedResolver<Host>,
     convoys: TypedResolver<Convoy>,
+    repositories: TypedResolver<Repository>,
     hop_chain: HopChainContext,
     policies: Arc<PresentationPolicyRegistry>,
 }
@@ -226,7 +227,8 @@ impl<R> PresentationReconciler<R> {
             terminal_sessions: backend.clone().using::<TerminalSession>(namespace),
             environments: backend.clone().using::<Environment>(namespace),
             hosts: backend.clone().using::<Host>(namespace),
-            convoys: backend.using::<Convoy>(namespace),
+            convoys: backend.clone().using::<Convoy>(namespace),
+            repositories: backend.using::<Repository>(namespace),
             hop_chain,
             policies,
         }
@@ -280,9 +282,16 @@ impl<R> PresentationReconciler<R> {
         // project segment.
         let scope = match self.convoys.get(convoy_name).await {
             Ok(convoy) => {
-                let project =
-                    project_segment(convoy.spec.project_ref.as_deref(), convoy.metadata.labels.get(REPO_LABEL).map(String::as_str));
-                Some(vessel_group_path(project, namespace, convoy_name, vessel))
+                let project = project_segment(convoy.spec.project_ref.as_deref());
+                let repo_value = match convoy.spec.repositories.as_slice() {
+                    [snapshot] => {
+                        self.repositories.get(&snapshot.repo_ref.to_string()).await.ok().map(|repository| repository.spec.fact_slug())
+                    }
+                    [] => None,
+                    _ => None,
+                };
+                let repo = repo_segment(repo_value.as_deref());
+                Some(vessel_group_path(project, repo, namespace, convoy_name, vessel))
             }
             Err(err) => {
                 warn!(%err, convoy = %convoy_name, "convoy lookup failed; stamping workspace without a scope");

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -33,7 +33,8 @@ use flotilla_resources::{
     controller::Reconciler, Convoy, ConvoyRepositorySpec, ConvoySpec, Environment, EnvironmentSpec, EnvironmentStatus,
     EnvironmentStatusPatch, Host, HostDirectEnvironmentSpec, HostSpec, HostStatus, HostStatusPatch, Presentation, PresentationSpec,
     PresentationStatus, PresentationStatusPatch, Repository, RepositorySpec, ResourceBackend, StatusPatch, TerminalSession,
-    TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL,
+    TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_LABEL,
+    VESSEL_ORDINAL_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -246,7 +247,8 @@ async fn dispatched_convoy_workspace_stamp_uses_project_and_repository_dialect()
         ]),
     )
     .await;
-    let presentation = create_presentation(&backend, "presentation-a", "default").await;
+    let mut presentation = create_presentation(&backend, "presentation-a", "default").await;
+    presentation.metadata.labels.insert(VESSEL_LABEL.to_string(), "implement".to_string());
     let runtime = Arc::new(FakePresentationRuntime::default());
     let reconciler = reconciler(Arc::clone(&runtime), backend);
 
@@ -259,7 +261,7 @@ async fn dispatched_convoy_workspace_stamp_uses_project_and_repository_dialect()
             GroupSegment::text(SEGMENT_PROJECT, "platform"),
             GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla"),
             GroupSegment::text(SEGMENT_CONVOY, "flotilla/convoy-a").with_label("convoy-a"),
-            GroupSegment::text(SEGMENT_VESSEL, "convoy-a"),
+            GroupSegment::text(SEGMENT_VESSEL, "implement"),
         ]))
     );
 }

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -24,12 +24,16 @@ use flotilla_core::{
     },
     HostName,
 };
+use flotilla_manifest::{
+    keys::{SEGMENT_CONVOY, SEGMENT_PROJECT, SEGMENT_REPO, SEGMENT_VESSEL},
+    wire::{GroupPath, GroupSegment},
+};
 use flotilla_protocol::arg::Arg;
 use flotilla_resources::{
-    controller::Reconciler, Environment, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, Host, HostDirectEnvironmentSpec,
-    HostSpec, HostStatus, HostStatusPatch, Presentation, PresentationSpec, PresentationStatus, PresentationStatusPatch, ResourceBackend,
-    StatusPatch, TerminalSession, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, CONVOY_LABEL, CREW_ORDINAL_LABEL,
-    VESSEL_ORDINAL_LABEL,
+    controller::Reconciler, Convoy, ConvoyRepositorySpec, ConvoySpec, Environment, EnvironmentSpec, EnvironmentStatus,
+    EnvironmentStatusPatch, Host, HostDirectEnvironmentSpec, HostSpec, HostStatus, HostStatusPatch, Presentation, PresentationSpec,
+    PresentationStatus, PresentationStatusPatch, Repository, RepositorySpec, ResourceBackend, StatusPatch, TerminalSession,
+    TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -197,6 +201,67 @@ async fn first_apply_marks_presentation_active() {
         Some(PresentationStatusPatch::MarkActive { ref presentation_manager, ref workspace_ref, .. })
             if presentation_manager == "fake-manager" && workspace_ref == "workspace-1"
     ));
+}
+
+#[tokio::test]
+async fn dispatched_convoy_workspace_stamp_uses_project_and_repository_dialect() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_host(&backend, HOST_REF).await;
+    create_ready_host_direct_env(&backend, "env-a").await;
+    let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository");
+    let repository_key = repository_spec.key();
+    backend
+        .clone()
+        .using::<Repository>(NAMESPACE)
+        .create(&meta(&repository_key.to_string()), &repository_spec)
+        .await
+        .expect("repository create");
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .create(
+            &meta("convoy-a"),
+            &ConvoySpec::builder()
+                .workflow_ref("implement".to_string())
+                .project_ref("platform".to_string())
+                .repositories(vec![ConvoyRepositorySpec::builder()
+                    .url("https://github.com/flotilla-org/flotilla".to_string())
+                    .repo_ref(repository_key)
+                    .base_ref("main".to_string())
+                    .workspace_slug("flotilla".to_string())
+                    .subpaths(Vec::new())
+                    .build()])
+                .build(),
+        )
+        .await
+        .expect("convoy create");
+    create_running_terminal(
+        &backend,
+        "term-a",
+        "env-a",
+        BTreeMap::from([
+            (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+            (VESSEL_ORDINAL_LABEL.to_string(), "000".to_string()),
+            (CREW_ORDINAL_LABEL.to_string(), "000".to_string()),
+        ]),
+    )
+    .await;
+    let presentation = create_presentation(&backend, "presentation-a", "default").await;
+    let runtime = Arc::new(FakePresentationRuntime::default());
+    let reconciler = reconciler(Arc::clone(&runtime), backend);
+
+    reconciler.fetch_dependencies(&presentation).await.expect("dependencies");
+
+    let plans = runtime.apply_calls.lock().expect("apply calls lock");
+    assert_eq!(
+        plans[0].stamp.as_ref().and_then(|stamp| stamp.scope.clone()),
+        Some(GroupPath(vec![
+            GroupSegment::text(SEGMENT_PROJECT, "platform"),
+            GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla"),
+            GroupSegment::text(SEGMENT_CONVOY, "flotilla/convoy-a").with_label("convoy-a"),
+            GroupSegment::text(SEGMENT_VESSEL, "convoy-a"),
+        ]))
+    );
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -3,7 +3,7 @@
 //! This module is deliberately pure: callers inject the row windows they
 //! already hold and choose the grouping parameter at query time.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use chrono::Utc;
 use flotilla_protocol::{
@@ -14,6 +14,8 @@ use flotilla_protocol::{
 use flotilla_resources::{api_version, Project, Resource};
 
 use crate::salience::{evaluate_entry, SalienceFacts};
+
+const REPO_FACT_ANNOTATION: &str = "vcs.repo";
 
 #[derive(Debug, Clone, Default)]
 pub struct AwarenessInput {
@@ -71,6 +73,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .as_of(as_of)
                 .refs(vec![convoy.resource.clone()])
                 .issue_refs(convoy.issues.iter().map(|issue| issue.reference.clone()).collect())
+                .annotations(repo_fact_annotations(convoy.repo.as_ref()))
                 .build(),
             &input.salience,
             &project_ancestors,
@@ -89,6 +92,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                     .phase(AwarenessPhase::Work(vessel.phase))
                     .as_of(as_of)
                     .refs(refs)
+                    .annotations(repo_fact_annotations(convoy.repo.as_ref()))
                     .build(),
                 &input.salience,
                 &ancestors,
@@ -142,6 +146,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .state(AwarenessState::Active)
                 .as_of(as_of)
                 .refs(vec![checkout.resource.clone()])
+                .annotations(HashMap::from([(REPO_FACT_ANNOTATION.to_string(), checkout.repo_label.clone())]))
                 .build(),
             &input.salience,
             &project_ancestors,
@@ -177,6 +182,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .phase(AwarenessPhase::Session(independent.phase))
                 .as_of(as_of)
                 .refs(vec![independent.resource.clone()])
+                .annotations(repo_fact_annotations(independent.repo.as_ref()))
                 .build(),
             &input.salience,
             &project_ancestors,
@@ -210,6 +216,10 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
         })
         .collect();
     (rows, input.state)
+}
+
+fn repo_fact_annotations(repo: Option<&flotilla_protocol::RepoKey>) -> HashMap<String, String> {
+    repo.map(|repo| HashMap::from([(REPO_FACT_ANNOTATION.to_string(), repo.0.clone())])).unwrap_or_default()
 }
 
 fn awareness_family_summaries(entries: &[AwarenessEntry]) -> Vec<AwarenessFamilySummary> {

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -146,7 +146,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .state(AwarenessState::Active)
                 .as_of(as_of)
                 .refs(vec![checkout.resource.clone()])
-                .annotations(HashMap::from([(REPO_FACT_ANNOTATION.to_string(), checkout.repo_label.clone())]))
+                .annotations(repo_fact_annotations(checkout.repo_fact.as_ref()))
                 .build(),
             &input.salience,
             &project_ancestors,
@@ -182,7 +182,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .phase(AwarenessPhase::Session(independent.phase))
                 .as_of(as_of)
                 .refs(vec![independent.resource.clone()])
-                .annotations(repo_fact_annotations(independent.repo.as_ref()))
+                .annotations(repo_fact_annotations(independent.repo_fact.as_ref()))
                 .build(),
             &input.salience,
             &project_ancestors,
@@ -459,7 +459,8 @@ mod tests {
             checkouts: vec![CheckoutRow::builder()
                 .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout"))
                 .repo(RepositoryKey("repo-a".into()))
-                .repo_label("flotilla")
+                .repo_label("github.com/flotilla-org/flotilla")
+                .repo_fact(flotilla_protocol::RepoKey("flotilla-org/flotilla".into()))
                 .path("/work/flotilla")
                 .branch("feat/awareness-band")
                 .host(HostName::new("local"))
@@ -468,6 +469,8 @@ mod tests {
             independents: vec![IndependentRow::builder()
                 .resource(ResourceRef::new("flotilla.work/v1", "TerminalSession", "flotilla", "scratch"))
                 .name("scratch")
+                .repo(flotilla_protocol::RepoKey("github.com/flotilla-org/flotilla".into()))
+                .repo_fact(flotilla_protocol::RepoKey("flotilla-org/flotilla".into()))
                 .repository_key(RepositoryKey("repo-a".into()))
                 .host(HostName::new("local"))
                 .phase(SessionPhase::Running)
@@ -481,6 +484,14 @@ mod tests {
         assert_eq!(nodes[0].counts.checkouts, 1);
         assert_eq!(nodes[0].counts.independents, 1);
         assert!(nodes[0].entries.iter().any(|entry| entry.kind == AwarenessKind::Convoy && entry.label == "ship-it"));
+        for kind in [AwarenessKind::Checkout, AwarenessKind::Independent] {
+            let entry = nodes[0].entries.iter().find(|entry| entry.kind == kind).expect("awareness entry");
+            assert_eq!(
+                entry.annotations.get(REPO_FACT_ANNOTATION).map(String::as_str),
+                Some("flotilla-org/flotilla"),
+                "repo grouping uses canonical fact value, not display label",
+            );
+        }
     }
 
     #[test]

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -3,7 +3,7 @@
 //! This module is deliberately pure: callers inject the row windows they
 //! already hold and choose the grouping parameter at query time.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use chrono::Utc;
 use flotilla_protocol::{
@@ -199,6 +199,13 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
             let salience = group.entries.iter().map(|entry| entry.salience).max().unwrap_or(Salience::None);
             let node_as_of = group.entries.iter().map(|entry| entry.as_of).max().unwrap_or(as_of);
             let family_summaries = awareness_family_summaries(&group.entries);
+            let repo_facts =
+                group.entries.iter().filter_map(|entry| entry.annotations.get(REPO_FACT_ANNOTATION).cloned()).collect::<BTreeSet<_>>();
+            let annotations = if repo_facts.len() == 1 {
+                HashMap::from([(REPO_FACT_ANNOTATION.to_string(), repo_facts.first().expect("one repository fact").clone())])
+            } else {
+                HashMap::new()
+            };
             group.entries.truncate(input.limit.entries);
             AwarenessNode::builder()
                 .id(group.id)
@@ -210,6 +217,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .as_of(node_as_of)
                 .counts(group.counts)
                 .refs(group.refs)
+                .annotations(annotations)
                 .entries(group.entries)
                 .family_summaries(family_summaries)
                 .build()
@@ -492,6 +500,26 @@ mod tests {
                 "repo grouping uses canonical fact value, not display label",
             );
         }
+    }
+
+    #[test]
+    fn repository_group_carries_canonical_fact_separately_from_display_label() {
+        let (nodes, _) = project_awareness(AwarenessInput {
+            checkouts: vec![CheckoutRow::builder()
+                .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout"))
+                .repo(RepositoryKey("repo-a".into()))
+                .repo_label("github.com/flotilla-org/flotilla")
+                .repo_fact(flotilla_protocol::RepoKey("flotilla-org/flotilla".into()))
+                .path("/work/flotilla")
+                .branch("main")
+                .host(HostName::new("local"))
+                .authority(flotilla_protocol::LifecycleAuthority::Observed)
+                .build()],
+            ..AwarenessInput::default()
+        });
+
+        assert_eq!(nodes[0].label, "github.com/flotilla-org/flotilla");
+        assert_eq!(nodes[0].annotations.get(REPO_FACT_ANNOTATION).map(String::as_str), Some("flotilla-org/flotilla"),);
     }
 
     #[test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1655,7 +1655,7 @@ impl Aggregator {
             .phase(convoy_phase(phase))
             .initializing(convoy_is_initializing(status))
             .maybe_message(status.and_then(|status| status.message.clone()))
-            .maybe_repo(convoy.metadata.labels.get(flotilla_resources::REPO_LABEL).map(|repo| flotilla_protocol::RepoKey(repo.clone())))
+            .maybe_repo(self.convoy_repo_fact(convoy).map(flotilla_protocol::RepoKey))
             .maybe_started_at(status.and_then(|status| status.started_at))
             .maybe_finished_at(status.and_then(|status| status.finished_at))
             .maybe_observed_workflow_ref(status.and_then(|status| status.observed_workflow_ref.clone()))
@@ -1676,6 +1676,14 @@ impl Aggregator {
             .vessels(vessels)
             .needs_attention(needs_attention)
             .build()
+    }
+
+    fn convoy_repo_fact(&self, convoy: &ResourceObject<Convoy>) -> Option<String> {
+        match convoy.spec.repositories.as_slice() {
+            [snapshot] => self.repositories.get(&snapshot.repo_ref).map(|repository| repository.spec.fact_slug()),
+            [] => None,
+            _ => None,
+        }
     }
 
     fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {
@@ -2638,6 +2646,23 @@ mod tests {
             rows: Vec::new(),
             result_sets: state.local_result_sets().await,
         }
+    }
+
+    #[tokio::test]
+    async fn convoy_repo_fact_comes_from_single_repository_knowledge() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(1);
+        let mut aggregator = Aggregator::new(state, HostName::new("local"), event_tx);
+        let repository = repository_object("https://github.com/flotilla-org/flotilla").await;
+        let repository_key = repository.spec.key();
+        aggregator.apply_repository_event(WatchEvent::Added(repository)).await;
+        let mut convoy = convoy_with_branch("dialect").await;
+        convoy.spec.repositories[0].repo_ref = repository_key;
+        let reference = ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "dialect");
+
+        let row = aggregator.summarize(&reference, &convoy);
+
+        assert_eq!(row.repo, Some(flotilla_protocol::RepoKey("flotilla-org/flotilla".to_string())));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1273,6 +1273,11 @@ impl Aggregator {
                             .map(|repository| repository.spec.qualified_label())
                             .unwrap_or_else(|| UNKNOWN_REPOSITORY_LABEL.to_string()),
                     )
+                    .maybe_repo_fact(
+                        self.repositories
+                            .get(&spec.repo_ref)
+                            .map(|repository| flotilla_protocol::RepoKey(repository.spec.repo_fact_value())),
+                    )
                     .path(spec.path.clone())
                     .branch(spec.r#ref.clone())
                     .host(self.local_host.clone())
@@ -1578,11 +1583,11 @@ impl Aggregator {
         let name = &session.metadata.name;
         let attach = attachable_sessions.contains(&key).then(|| name.clone());
         let repository_key = session.metadata.labels.get(REPO_KEY_LABEL).cloned().map(RepositoryKey);
+        let repository = repository_key.as_ref().and_then(|key| self.repositories.get(key));
         let repository_label = repository_key.as_ref().map_or_else(
             || session.metadata.labels.get(REPO_LABEL).cloned(),
             |key| {
-                self.repositories
-                    .get(key)
+                repository
                     .map(|repository| repository.spec.qualified_label())
                     .or_else(|| session.metadata.labels.get(REPO_LABEL).filter(|label| *label != &key.0).cloned())
                     .or_else(|| Some(UNKNOWN_REPOSITORY_LABEL.to_string()))
@@ -1593,6 +1598,7 @@ impl Aggregator {
                 .resource(resource)
                 .name(name)
                 .maybe_repo(repository_label.map(flotilla_protocol::RepoKey))
+                .maybe_repo_fact(repository.map(|repository| flotilla_protocol::RepoKey(repository.spec.repo_fact_value())))
                 .maybe_repository_key(repository_key)
                 .host(host)
                 .maybe_attach(attach)
@@ -1679,11 +1685,11 @@ impl Aggregator {
     }
 
     fn convoy_repo_fact(&self, convoy: &ResourceObject<Convoy>) -> Option<String> {
-        match convoy.spec.repositories.as_slice() {
-            [snapshot] => self.repositories.get(&snapshot.repo_ref).map(|repository| repository.spec.fact_slug()),
-            [] => None,
-            _ => None,
-        }
+        convoy
+            .spec
+            .sole_repository()
+            .and_then(|snapshot| self.repositories.get(&snapshot.repo_ref))
+            .map(|repository| repository.spec.repo_fact_value())
     }
 
     fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {

--- a/crates/flotilla-manifest/fixtures/generator/src/main.rs
+++ b/crates/flotilla-manifest/fixtures/generator/src/main.rs
@@ -49,7 +49,7 @@ fn patch(target: MetadataTarget, source_id: &str, set: Vec<(&str, MetadataValueU
 
 fn group_target_vessel() -> MetadataTarget {
     MetadataTarget::Group(GroupPath(vec![
-        segment("git.repo", "flotilla-org/flotilla", None),
+        segment("vcs.repo", "flotilla-org/flotilla", None),
         segment("flotilla.convoy", "dev/manifest-extraction", Some("manifest extraction")),
         segment("flotilla.vessel", "implement", None),
     ]))
@@ -86,7 +86,7 @@ fn main() {
                 "tab.scope",
                 update(
                     MetadataValue::GroupPath(vec![
-                        path_segment("git.repo", "flotilla-org/flotilla", None),
+                        path_segment("vcs.repo", "flotilla-org/flotilla", None),
                         path_segment("flotilla.convoy", "dev/manifest-extraction", Some("manifest extraction")),
                         path_segment("flotilla.vessel", "implement", None),
                     ]),
@@ -125,7 +125,7 @@ fn main() {
             (
                 "tab.scope",
                 update(
-                    MetadataValue::GroupPath(vec![path_segment("git.repo", "flotilla-org/flotilla", Some("flotilla"))]),
+                    MetadataValue::GroupPath(vec![path_segment("vcs.repo", "flotilla-org/flotilla", Some("flotilla"))]),
                     None,
                 ),
             ),

--- a/crates/flotilla-manifest/fixtures/patch_group_catalog.json
+++ b/crates/flotilla-manifest/fixtures/patch_group_catalog.json
@@ -51,7 +51,7 @@
     "kind": "group",
     "value": [
       {
-        "key": "git.repo",
+        "key": "vcs.repo",
         "value": {
           "type": "text",
           "value": "flotilla-org/flotilla"

--- a/crates/flotilla-manifest/fixtures/patch_identity_session.json
+++ b/crates/flotilla-manifest/fixtures/patch_identity_session.json
@@ -26,7 +26,7 @@
         "type": "group-path",
         "value": [
           {
-            "key": "git.repo",
+            "key": "vcs.repo",
             "value": {
               "type": "text",
               "value": "flotilla-org/flotilla"

--- a/crates/flotilla-manifest/fixtures/patch_tab_factory.json
+++ b/crates/flotilla-manifest/fixtures/patch_tab_factory.json
@@ -26,7 +26,7 @@
         "type": "group-path",
         "value": [
           {
-            "key": "git.repo",
+            "key": "vcs.repo",
             "label": "flotilla",
             "value": {
               "type": "text",

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -17,6 +17,8 @@ pub const SOURCE_CONNECTOR: &str = "flotilla-connector";
 pub const SOURCE_ATTACH: &str = "flotilla-attach";
 /// Source id for tab stamps published by the workspace actuator.
 pub const SOURCE_ACTUATOR: &str = "flotilla-actuator";
+/// Producer provenance exposed as a fact for presentation surfaces.
+pub const SOURCE_FLOTILLA: &str = "flotilla";
 
 /// TTL for catalog facts. Pane/tab stamps carry no TTL: they are facts about
 /// the binding, not about the daemon being alive.
@@ -36,6 +38,7 @@ pub const KEY_SESSION: &str = "flotilla.session";
 /// Denormalized binding facts: survive daemon outages and give grouping
 /// rules something direct to match on.
 pub const KEY_VESSEL: &str = "flotilla.vessel";
+/// Canonical `<namespace>/<convoy>` resource identity.
 pub const KEY_CONVOY: &str = "flotilla.convoy";
 pub const KEY_NAMESPACE: &str = "flotilla.namespace";
 pub const KEY_HOST: &str = "flotilla.host";
@@ -57,6 +60,8 @@ pub const KEY_CREW_ROLES: &str = "flotilla.crew.roles";
 
 // Cross-producer vocabulary (proposed for the Leg-1 freeze, design §6/§9).
 
+/// Producer provenance suitable for a surface badge.
+pub const KEY_SOURCE: &str = "source";
 /// Badge state: `idle | waiting | active | done | failed`.
 pub const KEY_STATUS_STATE: &str = "status.state";
 /// Boolean: needs a human/crew look.
@@ -83,10 +88,11 @@ pub const KEY_FACTORY_ID: &str = "factory.id";
 
 // GroupPath segment keys (design §4).
 
-/// Project segment key — deliberately the same spelling the git-watcher
-/// uses, so flotilla groups and git-watcher groups collide into one project
-/// cluster (v0; Leg 1 renames both producers to `vcs.repo` at once).
-pub const SEGMENT_PROJECT: &str = "git.repo";
+/// Project resource-name segment. Only Project knowledge may mint it.
+pub const SEGMENT_PROJECT: &str = "flotilla.project";
+/// Canonical forge slug, or the Repository's `host:path` fallback when it
+/// has no forge slug. Shared with repository observers such as git-watcher.
+pub const SEGMENT_REPO: &str = "vcs.repo";
 pub const SEGMENT_CONVOY: &str = "flotilla.convoy";
 pub const SEGMENT_VESSEL: &str = "flotilla.vessel";
 pub const SEGMENT_ISSUE: &str = "flotilla.issue";

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -99,4 +99,6 @@ pub const SEGMENT_CONVOY: &str = "flotilla.convoy";
 pub const SEGMENT_VESSEL: &str = "flotilla.vessel";
 /// Independent terminal-session name, never a convoy vessel name.
 pub const SEGMENT_INDEPENDENT: &str = "flotilla.independent";
+/// Checkout awareness-entry identity, never a vessel or session name.
+pub const SEGMENT_CHECKOUT: &str = "flotilla.checkout";
 pub const SEGMENT_ISSUE: &str = "flotilla.issue";

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -55,6 +55,8 @@ pub const KEY_CONVOY_MESSAGE: &str = "flotilla.convoy.message";
 /// lifecycle (vessels don't complete).
 pub const KEY_WORK_PHASE: &str = "flotilla.work.phase";
 pub const KEY_VESSEL_HOST: &str = "flotilla.vessel.host";
+/// Host currently carrying an independent terminal session.
+pub const KEY_INDEPENDENT_HOST: &str = "flotilla.independent.host";
 pub const KEY_VESSEL_ENV: &str = "flotilla.vessel.env";
 pub const KEY_CREW_ROLES: &str = "flotilla.crew.roles";
 
@@ -95,4 +97,6 @@ pub const SEGMENT_PROJECT: &str = "flotilla.project";
 pub const SEGMENT_REPO: &str = "vcs.repo";
 pub const SEGMENT_CONVOY: &str = "flotilla.convoy";
 pub const SEGMENT_VESSEL: &str = "flotilla.vessel";
+/// Independent terminal-session name, never a convoy vessel name.
+pub const SEGMENT_INDEPENDENT: &str = "flotilla.independent";
 pub const SEGMENT_ISSUE: &str = "flotilla.issue";

--- a/crates/flotilla-manifest/src/lib.rs
+++ b/crates/flotilla-manifest/src/lib.rs
@@ -10,9 +10,9 @@
 //! - `flotilla pm connect` publishes the catalog against `Group`/`Identity`
 //!   targets (TTL'd, re-asserted).
 //!
-//! v0 deliberately binds to andamento's *current* pipe names and key
-//! spellings (decision recorded on #667). Every spelling and serde shape a
-//! PM sees lives in this crate, so the Leg-1 contract rename (the
+//! v0 deliberately binds to andamento's *current* pipe names and the shared
+//! fact dialect recorded in [`wire`]. Every spelling and serde shape a PM
+//! sees lives in this crate, so the Leg-1 contract extraction (the
 //! `flotilla-org/manifest` extraction) is a change to this crate only. At
 //! that point the mirrored types in [`wire`] are deleted in favour of a
 //! dependency on the shared manifest crate — flotilla becomes its third

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -24,9 +24,9 @@ use flotilla_protocol::{
 use crate::{
     keys::{
         ARCHIPELAGO_ORDINAL, CATALOG_TTL_MS, KEY_CONVOY_MESSAGE, KEY_CONVOY_PHASE, KEY_CONVOY_WORKFLOW, KEY_CREW_ROLES, KEY_FACTORY_ID,
-        KEY_MATERIALIZE_RECIPE, KEY_MATERIALIZE_TARGET, KEY_PROJECT_NAME, KEY_SCOPE, KEY_SESSION, KEY_STATUS_ATTENTION, KEY_STATUS_STATE,
-        KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_VESSEL,
-        SOURCE_CONNECTOR,
+        KEY_MATERIALIZE_RECIPE, KEY_MATERIALIZE_TARGET, KEY_PROJECT_NAME, KEY_SCOPE, KEY_SESSION, KEY_SOURCE, KEY_STATUS_ATTENTION,
+        KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_REPO,
+        SEGMENT_VESSEL, SOURCE_CONNECTOR, SOURCE_FLOTILLA,
     },
     recipe::RecipeMint,
     wire::{GroupPath, GroupSegment, MetadataIdentity, MetadataPatch, MetadataTarget, MetadataValue, MetadataValueUpdate},
@@ -154,6 +154,9 @@ impl Catalog {
 
     fn assert_facts(&mut self, target: MetadataTarget, facts: Vec<(&str, MetadataValue)>, ordinal: Option<i64>) {
         let entry = self.facts.entry(target).or_default();
+        let mut source = MetadataValueUpdate::new(MetadataValue::text(SOURCE_FLOTILLA), Some(CATALOG_TTL_MS));
+        source.ordinal = ordinal;
+        entry.insert(KEY_SOURCE.to_owned(), source);
         for (key, value) in facts {
             let mut update = MetadataValueUpdate::new(value, Some(CATALOG_TTL_MS));
             update.ordinal = ordinal;
@@ -185,32 +188,79 @@ pub fn project_catalog(input: &CatalogInput<'_>, mint: &dyn RecipeMint) -> Catal
 }
 
 fn project_awareness_node(catalog: &mut Catalog, node: &AwarenessNode, mint: &dyn RecipeMint) {
-    let project = GroupSegment::text(SEGMENT_PROJECT, node.id.clone()).with_label(node.label.clone());
-    assert_project_group(catalog, &project);
-    let project_path = GroupPath(vec![project.clone()]);
-    catalog.assert_facts(
-        MetadataTarget::Group(project_path),
-        vec![
-            (KEY_STATUS_STATE, MetadataValue::text(awareness_state(node.state))),
-            (KEY_SUMMARY_TEXT, MetadataValue::text(summary_text(&node.counts))),
-            (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:awareness/{}", node.id))),
-        ],
-        None,
-    );
+    let parent = awareness_node_segment(node);
+    if let Some(segment) = &parent {
+        if segment.key == SEGMENT_PROJECT {
+            assert_project_group(catalog, segment);
+        }
+        catalog.assert_facts(
+            MetadataTarget::Group(GroupPath(vec![segment.clone()])),
+            vec![
+                (KEY_STATUS_STATE, MetadataValue::text(awareness_state(node.state))),
+                (KEY_SUMMARY_TEXT, MetadataValue::text(summary_text(&node.counts))),
+                (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:awareness/{}", node.id))),
+            ],
+            None,
+        );
+    }
 
     for entry in &node.entries {
-        project_awareness_entry(catalog, &project, entry, mint);
+        project_awareness_entry(catalog, parent.as_ref(), entry, mint);
     }
 }
 
-fn project_awareness_entry(catalog: &mut Catalog, project: &GroupSegment, entry: &AwarenessEntry, mint: &dyn RecipeMint) {
-    let segment_key = match entry.kind {
-        AwarenessKind::Convoy => SEGMENT_CONVOY,
-        AwarenessKind::Issue => SEGMENT_ISSUE,
-        AwarenessKind::Vessel | AwarenessKind::Independent | AwarenessKind::Checkout => SEGMENT_VESSEL,
+fn awareness_node_segment(node: &AwarenessNode) -> Option<GroupSegment> {
+    match node.kind {
+        AwarenessKind::Project => {
+            if let Some(scope) = &node.scope {
+                return project_segment(Some(&scope.name));
+            }
+            if let Some(address) = node.id.strip_prefix("project/") {
+                return project_segment(address.rsplit('/').next());
+            }
+            node.id.strip_prefix("repo/").and_then(|_| repo_segment(Some(&node.label)))
+        }
+        AwarenessKind::Convoy => {
+            node.id.strip_prefix("convoy/").map(|value| GroupSegment::text(SEGMENT_CONVOY, value).with_label(node.label.clone()))
+        }
+        AwarenessKind::Fleet | AwarenessKind::Vessel | AwarenessKind::Independent | AwarenessKind::Checkout | AwarenessKind::Issue => None,
+    }
+}
+
+fn project_awareness_entry(catalog: &mut Catalog, parent: Option<&GroupSegment>, entry: &AwarenessEntry, mint: &dyn RecipeMint) {
+    let mut segments = parent.cloned().into_iter().collect::<Vec<_>>();
+    if let Some(repo) = repo_segment(entry.annotations.get(SEGMENT_REPO).map(String::as_str)) {
+        if !segments.contains(&repo) {
+            segments.push(repo);
+        }
+    }
+    match entry.kind {
+        AwarenessKind::Convoy => {
+            let value = entry.id.strip_prefix("convoy/").unwrap_or(&entry.id);
+            segments.push(GroupSegment::text(SEGMENT_CONVOY, value).with_label(entry.label.clone()));
+        }
+        AwarenessKind::Vessel => {
+            let parts = entry.id.strip_prefix("vessel/").unwrap_or(&entry.id).split('/').collect::<Vec<_>>();
+            if let [namespace, convoy, vessel] = parts.as_slice() {
+                segments.push(GroupSegment::text(SEGMENT_CONVOY, format!("{namespace}/{convoy}")).with_label((*convoy).to_owned()));
+                segments.push(GroupSegment::text(SEGMENT_VESSEL, *vessel));
+            } else {
+                segments.push(GroupSegment::text(SEGMENT_VESSEL, entry.id.clone()).with_label(entry.label.clone()));
+            }
+        }
+        AwarenessKind::Independent => {
+            let value = entry.id.rsplit('/').next().unwrap_or(&entry.id);
+            segments.push(GroupSegment::text(SEGMENT_VESSEL, value).with_label(entry.label.clone()));
+        }
+        AwarenessKind::Checkout => {
+            segments.push(GroupSegment::text(SEGMENT_VESSEL, entry.id.clone()).with_label(entry.label.clone()));
+        }
+        AwarenessKind::Issue => {
+            segments.push(GroupSegment::text(SEGMENT_ISSUE, entry.id.clone()).with_label(entry.label.clone()));
+        }
         AwarenessKind::Fleet | AwarenessKind::Project => return,
-    };
-    let path = GroupPath(vec![project.clone(), GroupSegment::text(segment_key, entry.id.clone()).with_label(entry.label.clone())]);
+    }
+    let path = GroupPath(segments);
     let mut facts = vec![
         (KEY_STATUS_STATE, MetadataValue::text(awareness_state(entry.state))),
         (KEY_SUMMARY_TEXT, MetadataValue::text(entry.label.clone())),
@@ -253,15 +303,19 @@ fn summary_text(counts: &flotilla_protocol::AwarenessCounts) -> String {
     format!("{} entries · {} issues · {} vessels · {} checkouts", counts.total, counts.issues, counts.vessels, counts.checkouts)
 }
 
-/// The project-level segment: `project_ref` when set (the project→convoy
-/// spine's primary key), repo as fallback — under the *same* segment key the
-/// git-watcher publishes, so both producers' groups collide into one project
-/// cluster. Neither ⇒ `None`: the entity is truthfully unparented at
-/// archipelago level.
-pub fn project_segment(project_ref: Option<&str>, repo: Option<&str>) -> Option<GroupSegment> {
-    let value = project_ref.or(repo)?;
+/// The Project level of the grouping spine. Its value is exclusively a
+/// Project resource name; absence stays absent.
+pub fn project_segment(project_ref: Option<&str>) -> Option<GroupSegment> {
+    project_ref.and_then(|value| value.rsplit('/').next()).map(|name| GroupSegment::text(SEGMENT_PROJECT, name))
+}
+
+/// The Repository level of the grouping spine. `repo` is the canonical
+/// forge slug, with Repository's `host:path` identity as the slugless
+/// fallback.
+pub fn repo_segment(repo: Option<&str>) -> Option<GroupSegment> {
+    let value = repo?;
     let label = value.rsplit('/').next().filter(|short| !short.is_empty() && *short != value);
-    let segment = GroupSegment::text(SEGMENT_PROJECT, value);
+    let segment = GroupSegment::text(SEGMENT_REPO, value);
     Some(match label {
         Some(label) => segment.with_label(label),
         None => segment,
@@ -270,9 +324,12 @@ pub fn project_segment(project_ref: Option<&str>, repo: Option<&str>) -> Option<
 
 /// The GroupPath of a convoy — shared spine construction so every producer
 /// lands on the same group node.
-pub fn convoy_group_path(project: Option<GroupSegment>, namespace: &str, convoy: &str) -> GroupPath {
+pub fn convoy_group_path(project: Option<GroupSegment>, repo: Option<GroupSegment>, namespace: &str, convoy: &str) -> GroupPath {
     let mut path = Vec::new();
     if let Some(segment) = project {
+        path.push(segment);
+    }
+    if let Some(segment) = repo {
         path.push(segment);
     }
     path.push(GroupSegment::text(SEGMENT_CONVOY, format!("{namespace}/{convoy}")).with_label(convoy.to_owned()));
@@ -281,8 +338,14 @@ pub fn convoy_group_path(project: Option<GroupSegment>, namespace: &str, convoy:
 
 /// The GroupPath of a convoy-hosted vessel — shared by the catalog and the
 /// actuator's tab stamp so both producers land on the same group node.
-pub fn vessel_group_path(project: Option<GroupSegment>, namespace: &str, convoy: &str, vessel: &str) -> GroupPath {
-    let mut path = convoy_group_path(project, namespace, convoy);
+pub fn vessel_group_path(
+    project: Option<GroupSegment>,
+    repo: Option<GroupSegment>,
+    namespace: &str,
+    convoy: &str,
+    vessel: &str,
+) -> GroupPath {
+    let mut path = convoy_group_path(project, repo, namespace, convoy);
     path.0.push(GroupSegment::text(SEGMENT_VESSEL, vessel.to_owned()));
     path
 }
@@ -307,13 +370,14 @@ fn assert_project_group(catalog: &mut Catalog, segment: &GroupSegment) {
 
 fn project_convoy(catalog: &mut Catalog, convoy: &ConvoyRow, mint: &dyn RecipeMint) {
     let namespace = &convoy.resource.namespace;
-    let project = project_segment(convoy.project_ref.as_deref(), convoy.repo.as_ref().map(|repo| repo.0.as_str()));
+    let project = project_segment(convoy.project_ref.as_deref());
+    let repo = repo_segment(convoy.repo.as_ref().map(|repo| repo.0.as_str()));
     if let Some(segment) = &project {
         assert_project_group(catalog, segment);
     }
-    let ordinal = project.is_none().then_some(ARCHIPELAGO_ORDINAL);
+    let ordinal = (project.is_none() && repo.is_none()).then_some(ARCHIPELAGO_ORDINAL);
 
-    let convoy_path = convoy_group_path(project.clone(), namespace, &convoy.name);
+    let convoy_path = convoy_group_path(project.clone(), repo.clone(), namespace, &convoy.name);
     let badge = convoy_badge(convoy.phase, convoy.initializing);
     let done = convoy.vessels.iter().filter(|vessel| vessel.phase == WorkPhase::Complete).count();
     let mut facts = vec![
@@ -334,7 +398,7 @@ fn project_convoy(catalog: &mut Catalog, convoy: &ConvoyRow, mint: &dyn RecipeMi
     catalog.assert_facts(MetadataTarget::Group(convoy_path), facts, ordinal);
 
     for vessel in &convoy.vessels {
-        project_vessel(catalog, convoy, vessel, project.clone(), ordinal, mint);
+        project_vessel(catalog, convoy, vessel, project.clone(), repo.clone(), ordinal, mint);
     }
 }
 
@@ -343,11 +407,12 @@ fn project_vessel(
     convoy: &ConvoyRow,
     vessel: &VesselRow,
     project: Option<GroupSegment>,
+    repo: Option<GroupSegment>,
     ordinal: Option<i64>,
     mint: &dyn RecipeMint,
 ) {
     let namespace = &convoy.resource.namespace;
-    let path = vessel_group_path(project, namespace, &convoy.name, &vessel.name);
+    let path = vessel_group_path(project, repo, namespace, &convoy.name, &vessel.name);
     let badge = work_badge(vessel.phase);
     let mut facts = vec![
         (KEY_WORK_PHASE, MetadataValue::text(vessel.phase.as_str())),
@@ -376,16 +441,15 @@ fn project_vessel(
 
 fn project_independent(catalog: &mut Catalog, independent: &IndependentRow, mint: &dyn RecipeMint) {
     let namespace = &independent.resource.namespace;
-    let project = project_segment(None, independent.repo.as_ref().map(|repo| repo.0.as_str()));
+    let repo = repo_segment(independent.repo.as_ref().map(|repo| repo.0.as_str()));
     let mut path = Vec::new();
-    if let Some(segment) = &project {
-        assert_project_group(catalog, segment);
+    if let Some(segment) = &repo {
         path.push(segment.clone());
     }
     // Free-floating vessels with no project prefix are archipelago-level:
     // grouped and ordered before everything else by default (design §4;
     // ordering semantics are gap §9.6 for the Leg-1 freeze).
-    let ordinal = project.is_none().then_some(ARCHIPELAGO_ORDINAL);
+    let ordinal = repo.is_none().then_some(ARCHIPELAGO_ORDINAL);
 
     path.push(GroupSegment::text(SEGMENT_VESSEL, independent.name.clone()));
     let group_path = GroupPath(path);

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -25,8 +25,8 @@ use crate::{
     keys::{
         ARCHIPELAGO_ORDINAL, CATALOG_TTL_MS, KEY_CONVOY_MESSAGE, KEY_CONVOY_PHASE, KEY_CONVOY_WORKFLOW, KEY_CREW_ROLES, KEY_FACTORY_ID,
         KEY_INDEPENDENT_HOST, KEY_MATERIALIZE_RECIPE, KEY_MATERIALIZE_TARGET, KEY_PROJECT_NAME, KEY_SCOPE, KEY_SESSION, KEY_SOURCE,
-        KEY_STATUS_ATTENTION, KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_INDEPENDENT,
-        SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_REPO, SEGMENT_VESSEL, SOURCE_CONNECTOR, SOURCE_FLOTILLA,
+        KEY_STATUS_ATTENTION, KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CHECKOUT, SEGMENT_CONVOY,
+        SEGMENT_INDEPENDENT, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_REPO, SEGMENT_VESSEL, SOURCE_CONNECTOR, SOURCE_FLOTILLA,
     },
     recipe::RecipeMint,
     wire::{GroupPath, GroupSegment, MetadataIdentity, MetadataPatch, MetadataTarget, MetadataValue, MetadataValueUpdate},
@@ -256,10 +256,10 @@ fn project_awareness_entry(catalog: &mut Catalog, parent: Option<&GroupSegment>,
         }
         AwarenessKind::Independent => {
             let value = entry.id.rsplit('/').next().unwrap_or(&entry.id);
-            segments.push(GroupSegment::text(SEGMENT_VESSEL, value).with_label(entry.label.clone()));
+            segments.push(GroupSegment::text(SEGMENT_INDEPENDENT, value).with_label(entry.label.clone()));
         }
         AwarenessKind::Checkout => {
-            segments.push(GroupSegment::text(SEGMENT_VESSEL, entry.id.clone()).with_label(entry.label.clone()));
+            segments.push(GroupSegment::text(SEGMENT_CHECKOUT, entry.id.clone()).with_label(entry.label.clone()));
         }
         AwarenessKind::Issue => {
             segments.push(GroupSegment::text(SEGMENT_ISSUE, entry.id.clone()).with_label(entry.label.clone()));
@@ -320,7 +320,8 @@ pub fn project_segment(project_ref: Option<&str>) -> Option<GroupSegment> {
 /// fallback.
 pub fn repo_segment(repo: Option<&str>) -> Option<GroupSegment> {
     let value = repo?;
-    let label = value.rsplit('/').next().filter(|short| !short.is_empty() && *short != value);
+    let label_source = value.strip_suffix("/.git").or_else(|| value.strip_suffix(".git")).unwrap_or(value);
+    let label = label_source.rsplit('/').next().filter(|short| !short.is_empty() && *short != value);
     let segment = GroupSegment::text(SEGMENT_REPO, value);
     Some(match label {
         Some(label) => segment.with_label(label),

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -24,9 +24,9 @@ use flotilla_protocol::{
 use crate::{
     keys::{
         ARCHIPELAGO_ORDINAL, CATALOG_TTL_MS, KEY_CONVOY_MESSAGE, KEY_CONVOY_PHASE, KEY_CONVOY_WORKFLOW, KEY_CREW_ROLES, KEY_FACTORY_ID,
-        KEY_MATERIALIZE_RECIPE, KEY_MATERIALIZE_TARGET, KEY_PROJECT_NAME, KEY_SCOPE, KEY_SESSION, KEY_SOURCE, KEY_STATUS_ATTENTION,
-        KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_REPO,
-        SEGMENT_VESSEL, SOURCE_CONNECTOR, SOURCE_FLOTILLA,
+        KEY_INDEPENDENT_HOST, KEY_MATERIALIZE_RECIPE, KEY_MATERIALIZE_TARGET, KEY_PROJECT_NAME, KEY_SCOPE, KEY_SESSION, KEY_SOURCE,
+        KEY_STATUS_ATTENTION, KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL_HOST, KEY_WORK_PHASE, SEGMENT_CONVOY, SEGMENT_INDEPENDENT,
+        SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_REPO, SEGMENT_VESSEL, SOURCE_CONNECTOR, SOURCE_FLOTILLA,
     },
     recipe::RecipeMint,
     wire::{GroupPath, GroupSegment, MetadataIdentity, MetadataPatch, MetadataTarget, MetadataValue, MetadataValueUpdate},
@@ -146,7 +146,11 @@ impl Catalog {
         }
         for (target, facts) in &previous.facts {
             if !self.facts.contains_key(target) {
-                patches.push(patch(target.clone(), BTreeMap::new(), facts.keys().cloned().collect()));
+                patches.push(patch(
+                    target.clone(),
+                    BTreeMap::new(),
+                    facts.keys().filter(|key| key.as_str() != KEY_SOURCE).cloned().collect(),
+                ));
             }
         }
         patches
@@ -165,7 +169,9 @@ impl Catalog {
     }
 }
 
-fn patch(target: MetadataTarget, set: BTreeMap<String, MetadataValueUpdate>, unset: Vec<String>) -> MetadataPatch {
+fn patch(target: MetadataTarget, mut set: BTreeMap<String, MetadataValueUpdate>, unset: Vec<String>) -> MetadataPatch {
+    set.entry(KEY_SOURCE.to_owned())
+        .or_insert_with(|| MetadataValueUpdate::new(MetadataValue::text(SOURCE_FLOTILLA), Some(CATALOG_TTL_MS)));
     MetadataPatch { target, source_id: SOURCE_CONNECTOR.to_owned(), set, unset }
 }
 
@@ -441,7 +447,7 @@ fn project_vessel(
 
 fn project_independent(catalog: &mut Catalog, independent: &IndependentRow, mint: &dyn RecipeMint) {
     let namespace = &independent.resource.namespace;
-    let repo = repo_segment(independent.repo.as_ref().map(|repo| repo.0.as_str()));
+    let repo = repo_segment(independent.repo_fact.as_ref().map(|repo| repo.0.as_str()));
     let mut path = Vec::new();
     if let Some(segment) = &repo {
         path.push(segment.clone());
@@ -451,12 +457,12 @@ fn project_independent(catalog: &mut Catalog, independent: &IndependentRow, mint
     // ordering semantics are gap §9.6 for the Leg-1 freeze).
     let ordinal = repo.is_none().then_some(ARCHIPELAGO_ORDINAL);
 
-    path.push(GroupSegment::text(SEGMENT_VESSEL, independent.name.clone()));
+    path.push(GroupSegment::text(SEGMENT_INDEPENDENT, independent.name.clone()));
     let group_path = GroupPath(path);
     let badge = session_badge(independent.phase);
     let mut facts = vec![
         (KEY_STATUS_STATE, MetadataValue::text(badge.state.as_str())),
-        (KEY_VESSEL_HOST, MetadataValue::text(independent.host.to_string())),
+        (KEY_INDEPENDENT_HOST, MetadataValue::text(independent.host.to_string())),
         (KEY_FACTORY_ID, MetadataValue::text(format!("flotilla:independents/{namespace}/{}", independent.name))),
     ];
     if badge.attention {

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -224,7 +224,7 @@ fn awareness_node_segment(node: &AwarenessNode) -> Option<GroupSegment> {
             if let Some(address) = node.id.strip_prefix("project/") {
                 return project_segment(address.rsplit('/').next());
             }
-            node.id.strip_prefix("repo/").and_then(|_| repo_segment(Some(&node.label)))
+            node.id.strip_prefix("repo/").and_then(|_| repo_segment(node.annotations.get(SEGMENT_REPO).map(String::as_str)))
         }
         AwarenessKind::Convoy => {
             node.id.strip_prefix("convoy/").map(|value| GroupSegment::text(SEGMENT_CONVOY, value).with_label(node.label.clone()))

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -76,7 +76,10 @@ fn awareness_tree_projects_project_issue_and_materializable_entries() {
         .state(AwarenessState::Active)
         .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
         .phase(flotilla_protocol::AwarenessPhase::Work(WorkPhase::Running))
-        .annotations(std::collections::HashMap::from([(KEY_VESSEL_HOST.to_string(), "feta".to_string())]))
+        .annotations(std::collections::HashMap::from([
+            (KEY_VESSEL_HOST.to_string(), "feta".to_string()),
+            (SEGMENT_REPO.to_string(), "flotilla-org/flotilla".to_string()),
+        ]))
         .build();
     let node = AwarenessNode::builder()
         .id("project/dev/platform".to_string())
@@ -91,7 +94,7 @@ fn awareness_tree_projects_project_issue_and_materializable_entries() {
     let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
-    let project = GroupSegment::text(SEGMENT_PROJECT, "project/dev/platform").with_label("platform");
+    let project = GroupSegment::text(SEGMENT_PROJECT, "platform");
     let issue_patch = find(
         &patches,
         &group(vec![
@@ -102,8 +105,15 @@ fn awareness_tree_projects_project_issue_and_materializable_entries() {
     assert_eq!(text(issue_patch, KEY_STATUS_STATE), "waiting");
     assert_eq!(issue_patch.set[KEY_STATUS_ATTENTION].value, MetadataValue::Bool(true));
 
-    let vessel_patch =
-        find(&patches, &group(vec![project, GroupSegment::text(SEGMENT_VESSEL, "vessel/dev/ship-it/coder").with_label("coder")]));
+    let vessel_patch = find(
+        &patches,
+        &group(vec![
+            project,
+            GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla"),
+            GroupSegment::text(SEGMENT_CONVOY, "dev/ship-it").with_label("ship-it"),
+            GroupSegment::text(SEGMENT_VESSEL, "coder"),
+        ]),
+    );
     assert_eq!(text(vessel_patch, KEY_WORK_PHASE), "running");
     assert_eq!(text(vessel_patch, KEY_VESSEL_HOST), "feta");
     assert_eq!(text(vessel_patch, KEY_MATERIALIZE_TARGET), "workspace");
@@ -148,14 +158,14 @@ fn convoy_with_project_ref_projects_the_full_spine() {
     let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
-    // project_ref wins over the repo as the project segment value.
     let project_segment = GroupSegment::text(SEGMENT_PROJECT, "my-project");
+    let repo_segment = GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla");
     let project = find(&patches, &group(vec![project_segment.clone()]));
     assert_eq!(text(project, KEY_PROJECT_NAME), "my-project");
     assert_eq!(text(project, KEY_FACTORY_ID), "flotilla:projects/my-project");
 
     let convoy_segment = GroupSegment::text(SEGMENT_CONVOY, "dev/manifest-extraction");
-    let convoy_patch = find(&patches, &group(vec![project_segment.clone(), convoy_segment.clone()]));
+    let convoy_patch = find(&patches, &group(vec![project_segment.clone(), repo_segment.clone(), convoy_segment.clone()]));
     assert_eq!(text(convoy_patch, KEY_CONVOY_PHASE), "active");
     assert_eq!(text(convoy_patch, KEY_CONVOY_WORKFLOW), "implement-review");
     assert_eq!(text(convoy_patch, KEY_STATUS_STATE), "active");
@@ -165,8 +175,15 @@ fn convoy_with_project_ref_projects_the_full_spine() {
     assert_eq!(convoy_patch.set[KEY_STATUS_STATE].ttl_ms, Some(CATALOG_TTL_MS));
     assert_eq!(convoy_patch.set[KEY_STATUS_STATE].ordinal, None, "projected groups carry no archipelago ordinal");
 
-    let implement =
-        find(&patches, &group(vec![project_segment.clone(), convoy_segment.clone(), GroupSegment::text(SEGMENT_VESSEL, "implement")]));
+    let implement = find(
+        &patches,
+        &group(vec![
+            project_segment.clone(),
+            repo_segment.clone(),
+            convoy_segment.clone(),
+            GroupSegment::text(SEGMENT_VESSEL, "implement"),
+        ]),
+    );
     assert_eq!(text(implement, KEY_WORK_PHASE), "running");
     assert_eq!(text(implement, KEY_STATUS_STATE), "active");
     assert_eq!(text(implement, KEY_VESSEL_HOST), "feta");
@@ -176,10 +193,42 @@ fn convoy_with_project_ref_projects_the_full_spine() {
     assert_eq!(implement.set[KEY_CREW_ROLES].value, MetadataValue::StringList(vec!["coder".to_owned(), "reviewer".to_owned()]));
 
     // No daemon-resolvable attach ⇒ truthfully recipe-less.
-    let review = find(&patches, &group(vec![project_segment, convoy_segment, GroupSegment::text(SEGMENT_VESSEL, "review")]));
+    let review = find(&patches, &group(vec![project_segment, repo_segment, convoy_segment, GroupSegment::text(SEGMENT_VESSEL, "review")]));
     assert_eq!(text(review, KEY_STATUS_STATE), "done");
     assert!(!review.set.contains_key(KEY_MATERIALIZE_RECIPE));
     assert!(!review.set.contains_key(KEY_MATERIALIZE_TARGET));
+}
+
+#[test]
+fn awareness_repository_group_does_not_masquerade_as_project() {
+    let independent = AwarenessEntry::builder()
+        .id("independent/dev/governor".to_string())
+        .kind(AwarenessKind::Independent)
+        .label("governor".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .annotations(std::collections::HashMap::from([(SEGMENT_REPO.to_string(), "flotilla-org/flotilla".to_string())]))
+        .build();
+    let node = AwarenessNode::builder()
+        .id("repo/opaque-repository-key".to_string())
+        .kind(AwarenessKind::Project)
+        .label("flotilla-org/flotilla".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .entries(vec![independent])
+        .build();
+
+    let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint());
+    let patches = catalog.reassert_patches();
+    let repo = GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla");
+
+    find(&patches, &group(vec![repo.clone(), GroupSegment::text(SEGMENT_VESSEL, "governor").with_label("governor")]));
+    assert!(
+        patches
+            .iter()
+            .all(|patch| !matches!(&patch.target, MetadataTarget::Group(path) if path.0.iter().any(|s| s.key == SEGMENT_PROJECT))),
+        "Repository-only awareness must not mint a Project segment"
+    );
 }
 
 #[test]
@@ -195,8 +244,8 @@ fn failed_convoy_surfaces_attention_and_message() {
     let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
 
-    let project_segment = GroupSegment::text(SEGMENT_PROJECT, "flotilla-org/flotilla");
-    let convoy_patch = find(&patches, &group(vec![project_segment, GroupSegment::text(SEGMENT_CONVOY, "dev/db-growth")]));
+    let repo_segment = GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla");
+    let convoy_patch = find(&patches, &group(vec![repo_segment, GroupSegment::text(SEGMENT_CONVOY, "dev/db-growth")]));
     assert_eq!(text(convoy_patch, KEY_STATUS_STATE), "failed");
     assert_eq!(convoy_patch.set[KEY_STATUS_ATTENTION].value, MetadataValue::Bool(true));
     assert_eq!(text(convoy_patch, KEY_CONVOY_MESSAGE), "vessel checkout failed: disk full");
@@ -240,7 +289,7 @@ fn ready_vessel_waits_with_attention() {
 }
 
 #[test]
-fn independent_with_repo_groups_under_project_and_publishes_identity() {
+fn independent_with_repo_groups_under_repo_and_publishes_identity() {
     let independent = independent()
         .namespace("dev")
         .name("terminal-scratch")
@@ -251,17 +300,18 @@ fn independent_with_repo_groups_under_project_and_publishes_identity() {
     let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
-    let project_segment = GroupSegment::text(SEGMENT_PROJECT, "flotilla-org/flotilla");
-    let group_target = group(vec![project_segment.clone(), GroupSegment::text(SEGMENT_VESSEL, "terminal-scratch")]);
+    let repo_segment = GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla");
+    let group_target = group(vec![repo_segment.clone(), GroupSegment::text(SEGMENT_VESSEL, "terminal-scratch")]);
     let group_patch = find(&patches, &group_target);
     assert_eq!(text(group_patch, KEY_STATUS_STATE), "active");
     assert_eq!(text(group_patch, KEY_MATERIALIZE_TARGET), "pane");
     assert_eq!(text(group_patch, KEY_MATERIALIZE_RECIPE), "flotilla attach --host 'feta' 'terminal-scratch'");
     assert_eq!(text(group_patch, KEY_FACTORY_ID), "flotilla:independents/dev/terminal-scratch");
-    assert_eq!(group_patch.set[KEY_STATUS_STATE].ordinal, None, "project-parented independents are not archipelago-ordered");
-
-    let project = find(&patches, &group(vec![project_segment.clone()]));
-    assert_eq!(text(project, KEY_PROJECT_NAME), "flotilla", "repo fallback labels the project with the short name");
+    assert_eq!(group_patch.set[KEY_STATUS_STATE].ordinal, None, "repo-parented independents are not archipelago-ordered");
+    assert!(
+        !patches.iter().any(|patch| matches!(&patch.target, MetadataTarget::Group(path) if path.0 == vec![repo_segment.clone()])),
+        "repository knowledge must not mint a Project group"
+    );
 
     let identity = find(&patches, &session_identity("feta/dev/terminal-scratch"));
     assert_eq!(text(identity, KEY_STATUS_STATE), "active");
@@ -269,7 +319,7 @@ fn independent_with_repo_groups_under_project_and_publishes_identity() {
         panic!("tab.scope is not a group path");
     };
     assert_eq!(scope.len(), 2);
-    assert_eq!(scope[0].key, SEGMENT_PROJECT);
+    assert_eq!(scope[0].key, SEGMENT_REPO);
     assert_eq!(scope[1].key, SEGMENT_VESSEL);
     assert_eq!(scope[1].value, MetadataPathValue::Text("terminal-scratch".to_owned()));
 }
@@ -297,7 +347,10 @@ fn independent_without_attach_lists_without_recipe() {
 
     let group_patch = find(
         &patches,
-        &group(vec![GroupSegment::text(SEGMENT_PROJECT, "flotilla-org/flotilla"), GroupSegment::text(SEGMENT_VESSEL, "wedged")]),
+        &group(vec![
+            GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla"),
+            GroupSegment::text(SEGMENT_VESSEL, "wedged"),
+        ]),
     );
     assert_eq!(text(group_patch, KEY_STATUS_STATE), "failed");
     assert_eq!(group_patch.set[KEY_STATUS_ATTENTION].value, MetadataValue::Bool(true));
@@ -349,13 +402,14 @@ fn reassert_covers_every_target() {
         independent().namespace("dev").name("scratch").phase(SessionPhase::Running).repo("flotilla-org/flotilla").attach("scratch").call();
     let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
-    assert_eq!(patches.len(), 3, "project group + independent group + independent identity");
+    assert_eq!(patches.len(), 2, "independent group + independent identity");
     assert!(patches.iter().all(|patch| patch.unset.is_empty()));
     assert!(patches.iter().all(|patch| patch.source_id == SOURCE_CONNECTOR));
+    assert!(patches.iter().all(|patch| text(patch, KEY_SOURCE) == SOURCE_FLOTILLA));
 }
 
 #[test]
-fn shared_spine_helpers_match_the_catalog_targets() {
+fn latent_catalog_and_live_actuator_use_the_same_dispatched_convoy_group() {
     let reference = convoy_ref("dev", "manifest-extraction");
     let convoy = ConvoyRow::builder()
         .resource(reference.clone())
@@ -363,6 +417,7 @@ fn shared_spine_helpers_match_the_catalog_targets() {
         .workflow_ref("implement-review")
         .phase(ConvoyPhase::Active)
         .repo(RepoKey("flotilla-org/flotilla".to_owned()))
+        .project_ref("project/dev/flotilla")
         .vessels(vec![vessel().convoy(&reference).name("implement").phase(WorkPhase::Running).call()])
         .build();
     let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[convoy], independents: &[] }, &mint());
@@ -370,9 +425,21 @@ fn shared_spine_helpers_match_the_catalog_targets() {
 
     // The actuator's tab stamp builds its scope with these helpers; they
     // must land on exactly the group nodes the catalog publishes.
-    let project = project_segment(None, Some("flotilla-org/flotilla"));
-    let vessel_target = MetadataTarget::Group(vessel_group_path(project.clone(), "dev", "manifest-extraction", "implement"));
-    let convoy_target = MetadataTarget::Group(convoy_group_path(project, "dev", "manifest-extraction"));
+    let project = project_segment(Some("project/dev/flotilla"));
+    let repo = repo_segment(Some("flotilla-org/flotilla"));
+    let vessel_target = MetadataTarget::Group(vessel_group_path(project.clone(), repo.clone(), "dev", "manifest-extraction", "implement"));
+    let convoy_target = MetadataTarget::Group(convoy_group_path(project, repo, "dev", "manifest-extraction"));
     find(&patches, &vessel_target);
     find(&patches, &convoy_target);
+}
+
+#[test]
+fn project_and_repo_segments_have_one_meaning_each() {
+    assert_eq!(project_segment(Some("project/dev/platform")), Some(GroupSegment::text(SEGMENT_PROJECT, "platform")));
+    assert_eq!(project_segment(None), None);
+    assert_eq!(
+        repo_segment(Some("github.com:flotilla-org/flotilla")),
+        Some(GroupSegment::text(SEGMENT_REPO, "github.com:flotilla-org/flotilla").with_label("flotilla"))
+    );
+    assert_eq!(repo_segment(None), None);
 }

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -35,6 +35,7 @@ fn independent(namespace: &str, name: &str, phase: SessionPhase, repo: Option<&s
         .resource(session_ref(namespace, name))
         .name(name)
         .maybe_repo(repo.map(|repo| RepoKey(repo.to_owned())))
+        .maybe_repo_fact(repo.map(|repo| RepoKey(repo.to_owned())))
         .host(HostName::new("feta"))
         .maybe_attach(attach.map(str::to_owned))
         .phase(phase)
@@ -290,18 +291,19 @@ fn ready_vessel_waits_with_attention() {
 
 #[test]
 fn independent_with_repo_groups_under_repo_and_publishes_identity() {
-    let independent = independent()
+    let mut independent = independent()
         .namespace("dev")
         .name("terminal-scratch")
         .phase(SessionPhase::Running)
         .repo("flotilla-org/flotilla")
         .attach("terminal-scratch")
         .call();
+    independent.repo = Some(RepoKey("github.com/flotilla-org/flotilla".to_owned()));
     let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
     let repo_segment = GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla");
-    let group_target = group(vec![repo_segment.clone(), GroupSegment::text(SEGMENT_VESSEL, "terminal-scratch")]);
+    let group_target = group(vec![repo_segment.clone(), GroupSegment::text(SEGMENT_INDEPENDENT, "terminal-scratch")]);
     let group_patch = find(&patches, &group_target);
     assert_eq!(text(group_patch, KEY_STATUS_STATE), "active");
     assert_eq!(text(group_patch, KEY_MATERIALIZE_TARGET), "pane");
@@ -320,7 +322,7 @@ fn independent_with_repo_groups_under_repo_and_publishes_identity() {
     };
     assert_eq!(scope.len(), 2);
     assert_eq!(scope[0].key, SEGMENT_REPO);
-    assert_eq!(scope[1].key, SEGMENT_VESSEL);
+    assert_eq!(scope[1].key, SEGMENT_INDEPENDENT);
     assert_eq!(scope[1].value, MetadataPathValue::Text("terminal-scratch".to_owned()));
 }
 
@@ -330,7 +332,7 @@ fn independent_without_repo_is_archipelago_ordered_first() {
     let catalog = project_catalog(&CatalogInput { awareness: None, convoys: &[], independents: &[independent] }, &mint());
     let patches = catalog.reassert_patches();
 
-    let group_patch = find(&patches, &group(vec![GroupSegment::text(SEGMENT_VESSEL, "yeoman")]));
+    let group_patch = find(&patches, &group(vec![GroupSegment::text(SEGMENT_INDEPENDENT, "yeoman")]));
     assert_eq!(group_patch.set[KEY_STATUS_STATE].ordinal, Some(ARCHIPELAGO_ORDINAL));
     let identity = find(&patches, &session_identity("feta/dev/yeoman"));
     let MetadataValue::GroupPath(scope) = &identity.set[KEY_SCOPE].value else {
@@ -349,7 +351,7 @@ fn independent_without_attach_lists_without_recipe() {
         &patches,
         &group(vec![
             GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla"),
-            GroupSegment::text(SEGMENT_VESSEL, "wedged"),
+            GroupSegment::text(SEGMENT_INDEPENDENT, "wedged"),
         ]),
     );
     assert_eq!(text(group_patch, KEY_STATUS_STATE), "failed");
@@ -380,17 +382,18 @@ fn diff_sets_changes_and_unsets_disappearances() {
     let convoy_patch = find(&patches, &convoy_target);
     assert_eq!(text(convoy_patch, KEY_CONVOY_PHASE), "active");
     assert_eq!(text(convoy_patch, KEY_STATUS_STATE), "active");
+    assert_eq!(text(convoy_patch, KEY_SOURCE), SOURCE_FLOTILLA);
     assert!(!convoy_patch.set.contains_key(KEY_CONVOY_WORKFLOW), "unchanged facts are not re-sent in a diff");
     assert!(convoy_patch.unset.contains(&KEY_STATUS_ATTENTION.to_owned()));
     assert!(convoy_patch.unset.contains(&KEY_CONVOY_MESSAGE.to_owned()));
 
     // The vanished independent is explicitly unset on both its targets.
-    let independent_group = find(&patches, &group(vec![GroupSegment::text(SEGMENT_VESSEL, "scratch")]));
-    assert!(independent_group.set.is_empty());
+    let independent_group = find(&patches, &group(vec![GroupSegment::text(SEGMENT_INDEPENDENT, "scratch")]));
+    assert_eq!(text(independent_group, KEY_SOURCE), SOURCE_FLOTILLA);
     assert!(independent_group.unset.contains(&KEY_STATUS_STATE.to_owned()));
     assert!(independent_group.unset.contains(&KEY_MATERIALIZE_RECIPE.to_owned()));
     let identity_patch = find(&patches, &session_identity("feta/dev/scratch"));
-    assert!(identity_patch.set.is_empty());
+    assert_eq!(text(identity_patch, KEY_SOURCE), SOURCE_FLOTILLA);
     assert!(identity_patch.unset.contains(&KEY_SCOPE.to_owned()));
 
     assert!(current.diff_patches(&current).is_empty(), "identical catalogs need no patches");

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -210,20 +210,32 @@ fn awareness_repository_group_does_not_masquerade_as_project() {
         .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
         .annotations(std::collections::HashMap::from([(SEGMENT_REPO.to_string(), "flotilla-org/flotilla".to_string())]))
         .build();
+    let checkout = AwarenessEntry::builder()
+        .id("checkout/feta/work/flotilla".to_string())
+        .kind(AwarenessKind::Checkout)
+        .label("main · /work/flotilla".to_string())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .annotations(std::collections::HashMap::from([(SEGMENT_REPO.to_string(), "flotilla-org/flotilla".to_string())]))
+        .build();
     let node = AwarenessNode::builder()
         .id("repo/opaque-repository-key".to_string())
         .kind(AwarenessKind::Project)
         .label("flotilla-org/flotilla".to_string())
         .state(AwarenessState::Active)
         .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
-        .entries(vec![independent])
+        .entries(vec![independent, checkout])
         .build();
 
     let catalog = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint());
     let patches = catalog.reassert_patches();
     let repo = GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla");
 
-    find(&patches, &group(vec![repo.clone(), GroupSegment::text(SEGMENT_VESSEL, "governor").with_label("governor")]));
+    find(&patches, &group(vec![repo.clone(), GroupSegment::text(SEGMENT_INDEPENDENT, "governor").with_label("governor")]));
+    find(
+        &patches,
+        &group(vec![repo.clone(), GroupSegment::text(SEGMENT_CHECKOUT, "checkout/feta/work/flotilla").with_label("main · /work/flotilla")]),
+    );
     assert!(
         patches
             .iter()
@@ -443,6 +455,10 @@ fn project_and_repo_segments_have_one_meaning_each() {
     assert_eq!(
         repo_segment(Some("github.com:flotilla-org/flotilla")),
         Some(GroupSegment::text(SEGMENT_REPO, "github.com:flotilla-org/flotilla").with_label("flotilla"))
+    );
+    assert_eq!(
+        repo_segment(Some("feta:/srv/flotilla/.git")),
+        Some(GroupSegment::text(SEGMENT_REPO, "feta:/srv/flotilla/.git").with_label("flotilla"))
     );
     assert_eq!(repo_segment(None), None);
 }

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -221,9 +221,10 @@ fn awareness_repository_group_does_not_masquerade_as_project() {
     let node = AwarenessNode::builder()
         .id("repo/opaque-repository-key".to_string())
         .kind(AwarenessKind::Project)
-        .label("flotilla-org/flotilla".to_string())
+        .label("github.com/flotilla-org/flotilla".to_string())
         .state(AwarenessState::Active)
         .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .annotations(std::collections::HashMap::from([(SEGMENT_REPO.to_string(), "flotilla-org/flotilla".to_string())]))
         .entries(vec![independent, checkout])
         .build();
 
@@ -235,6 +236,12 @@ fn awareness_repository_group_does_not_masquerade_as_project() {
     find(
         &patches,
         &group(vec![repo.clone(), GroupSegment::text(SEGMENT_CHECKOUT, "checkout/feta/work/flotilla").with_label("main · /work/flotilla")]),
+    );
+    assert!(
+        patches.iter().all(|patch| {
+            !matches!(&patch.target, MetadataTarget::Group(path) if path.0.iter().filter(|segment| segment.key == SEGMENT_REPO).count() > 1)
+        }),
+        "canonical node and entry repo facts must not duplicate the repo spine",
     );
     assert!(
         patches

--- a/crates/flotilla-manifest/src/stamp.rs
+++ b/crates/flotilla-manifest/src/stamp.rs
@@ -14,8 +14,8 @@ use flotilla_protocol::AttachBinding;
 
 use crate::{
     keys::{
-        KEY_ATTACH_REF, KEY_CONVOY, KEY_CREW_ROLE, KEY_FACTORY_ID, KEY_HOST, KEY_NAMESPACE, KEY_SCOPE, KEY_SESSION, KEY_TAB_KIND,
-        KEY_VESSEL, SOURCE_ACTUATOR, SOURCE_ATTACH,
+        KEY_ATTACH_REF, KEY_CONVOY, KEY_CREW_ROLE, KEY_FACTORY_ID, KEY_HOST, KEY_NAMESPACE, KEY_SCOPE, KEY_SESSION, KEY_SOURCE,
+        KEY_TAB_KIND, KEY_VESSEL, SOURCE_ACTUATOR, SOURCE_ATTACH, SOURCE_FLOTILLA,
     },
     wire::{GroupPath, MetadataPatch, MetadataTarget, MetadataValue, MetadataValueUpdate, PaneTarget},
 };
@@ -38,6 +38,7 @@ pub fn pane_stamp(pane: PaneTarget, attach_ref: &str, binding: Option<&AttachBin
     let mut fact = |key: &str, value: String| {
         set.insert(key.to_owned(), MetadataValueUpdate::new(MetadataValue::text(value), None));
     };
+    fact(KEY_SOURCE, SOURCE_FLOTILLA.to_owned());
     fact(KEY_ATTACH_REF, attach_ref.to_owned());
     if let Some(binding) = binding {
         fact(KEY_HOST, binding.host.to_string());
@@ -46,7 +47,7 @@ pub fn pane_stamp(pane: PaneTarget, attach_ref: &str, binding: Option<&AttachBin
             fact(KEY_SESSION, format!("{}/{}/{session}", binding.host, binding.namespace));
         }
         if let Some(convoy) = &binding.convoy {
-            fact(KEY_CONVOY, convoy.clone());
+            fact(KEY_CONVOY, format!("{}/{convoy}", binding.namespace));
         }
         if let Some(vessel) = &binding.vessel {
             fact(KEY_VESSEL, vessel.clone());
@@ -76,6 +77,7 @@ pub struct WorkspaceStamp {
 /// stamp is a fact about the tab, not about any daemon being alive.
 pub fn tab_stamp(tab_id: u64, stamp: &WorkspaceStamp) -> MetadataPatch {
     let mut set = BTreeMap::new();
+    set.insert(KEY_SOURCE.to_owned(), MetadataValueUpdate::new(MetadataValue::text(SOURCE_FLOTILLA), None));
     set.insert(KEY_TAB_KIND.to_owned(), MetadataValueUpdate::new(MetadataValue::text(stamp.kind.clone()), None));
     set.insert(KEY_FACTORY_ID.to_owned(), MetadataValueUpdate::new(MetadataValue::text(stamp.factory_id.clone()), None));
     if let Some(scope) = &stamp.scope {
@@ -113,20 +115,27 @@ mod tests {
         assert_eq!(patch.target, MetadataTarget::Pane(PaneTarget::Terminal(42)));
         assert_eq!(patch.source_id, SOURCE_ATTACH);
         assert_eq!(patch.set[KEY_SESSION].value, MetadataValue::text("feta/dev/terminal-impl-coder"));
-        assert_eq!(patch.set[KEY_CONVOY].value, MetadataValue::text("manifest-extraction"));
+        assert_eq!(patch.set[KEY_CONVOY].value, MetadataValue::text("dev/manifest-extraction"));
         assert_eq!(patch.set[KEY_VESSEL].value, MetadataValue::text("implement"));
         assert_eq!(patch.set[KEY_CREW_ROLE].value, MetadataValue::text("coder"));
         assert_eq!(patch.set[KEY_ATTACH_REF].value, MetadataValue::text("implement/coder"));
+        assert_eq!(patch.set[KEY_SOURCE].value, MetadataValue::text(SOURCE_FLOTILLA));
         assert!(patch.set.values().all(|update| update.ttl_ms.is_none()), "pane stamps carry no TTL");
     }
 
     #[test]
     fn tab_stamp_carries_kind_factory_and_scope_without_ttl() {
         use crate::{
-            keys::SOURCE_ACTUATOR,
-            projection::{project_segment, vessel_factory_id, vessel_group_path},
+            keys::{KEY_SOURCE, SOURCE_ACTUATOR, SOURCE_FLOTILLA},
+            projection::{project_segment, repo_segment, vessel_factory_id, vessel_group_path},
         };
-        let scope = vessel_group_path(project_segment(None, Some("flotilla-org/flotilla")), "dev", "manifest-extraction", "implement");
+        let scope = vessel_group_path(
+            project_segment(None),
+            repo_segment(Some("flotilla-org/flotilla")),
+            "dev",
+            "manifest-extraction",
+            "implement",
+        );
         let stamp = WorkspaceStamp {
             kind: "flotilla-vessel".to_owned(),
             factory_id: vessel_factory_id("dev", "manifest-extraction", "implement"),
@@ -139,6 +148,7 @@ mod tests {
         assert_eq!(patch.set[KEY_TAB_KIND].value, MetadataValue::text("flotilla-vessel"));
         assert_eq!(patch.set[KEY_FACTORY_ID].value, MetadataValue::text("flotilla:convoys/dev/manifest-extraction/implement"));
         assert_eq!(patch.set[KEY_SCOPE].value, scope.to_scope_value());
+        assert_eq!(patch.set[KEY_SOURCE].value, MetadataValue::text(SOURCE_FLOTILLA));
         assert!(patch.set.values().all(|update| update.ttl_ms.is_none()), "tab stamps carry no TTL");
     }
 
@@ -150,7 +160,8 @@ mod tests {
         assert_eq!(patch.set[KEY_HOST].value, MetadataValue::text("feta"));
 
         let bare = pane_stamp(PaneTarget::Terminal(1), "coder", None);
-        assert_eq!(bare.set.len(), 1, "without a binding only the attach ref is stamped");
+        assert_eq!(bare.set.len(), 2, "without a binding only the attach ref and producer provenance are stamped");
         assert_eq!(bare.set[KEY_ATTACH_REF].value, MetadataValue::text("coder"));
+        assert_eq!(bare.set[KEY_SOURCE].value, MetadataValue::text(SOURCE_FLOTILLA));
     }
 }

--- a/crates/flotilla-manifest/src/wire.rs
+++ b/crates/flotilla-manifest/src/wire.rs
@@ -27,7 +27,8 @@
 //! | `flotilla.convoy.workflow` | WorkflowTemplate resource name used by a convoy. |
 //! | `flotilla.convoy.message` | Convoy lifecycle diagnostic. |
 //! | `flotilla.work.phase` | Work phase aboard a vessel, not vessel lifecycle. |
-//! | `flotilla.vessel.host` | Host currently carrying a vessel or independent. |
+//! | `flotilla.vessel.host` | Host currently carrying a convoy vessel. |
+//! | `flotilla.independent.host` | Host currently carrying an independent terminal session. |
 //! | `flotilla.vessel.env` | Execution-environment reference for a vessel. |
 //! | `flotilla.crew.roles` | Complete crew-role list aboard a vessel. |
 //! | `status.state` | Normalized `idle`, `waiting`, `active`, `done`, or `failed` badge state. |
@@ -47,7 +48,8 @@
 //! | `flotilla.project` | Project resource name, and only present when Project knowledge exists. |
 //! | `vcs.repo` | Canonical forge slug, falling back to Repository's `host:path` identity when slugless. |
 //! | `flotilla.convoy` | `<namespace>/<convoy>` resource identity. |
-//! | `flotilla.vessel` | Vessel or independent name. |
+//! | `flotilla.vessel` | Convoy vessel name. |
+//! | `flotilla.independent` | Independent terminal-session name. |
 //! | `flotilla.issue` | Issue entry identity from the awareness projection. |
 
 use std::collections::BTreeMap;

--- a/crates/flotilla-manifest/src/wire.rs
+++ b/crates/flotilla-manifest/src/wire.rs
@@ -50,6 +50,7 @@
 //! | `flotilla.convoy` | `<namespace>/<convoy>` resource identity. |
 //! | `flotilla.vessel` | Convoy vessel name. |
 //! | `flotilla.independent` | Independent terminal-session name. |
+//! | `flotilla.checkout` | Checkout awareness-entry identity. |
 //! | `flotilla.issue` | Issue entry identity from the awareness projection. |
 
 use std::collections::BTreeMap;

--- a/crates/flotilla-manifest/src/wire.rs
+++ b/crates/flotilla-manifest/src/wire.rs
@@ -7,6 +7,48 @@
 //! replaced by a dependency on the shared `flotilla-org/manifest` crate.
 //! Never hand-tune a serde attribute here to make a test pass — regenerate
 //! the fixtures against andamento and match what it actually speaks.
+//!
+//! # Flotilla fact dialect v1
+//!
+//! Every key emitted by this crate has one value domain:
+//!
+//! | Key | Semantics |
+//! | --- | --- |
+//! | `source` | Producer provenance (`flotilla` here; other producers use their own stable name). |
+//! | `flotilla.session` | Canonical `<host>/<namespace>/<session>` pane-to-catalog join identity. |
+//! | `flotilla.vessel` | Vessel name bound to a pane. |
+//! | `flotilla.convoy` | Canonical `<namespace>/<convoy>` resource identity on panes and path segments. |
+//! | `flotilla.namespace` | Resource namespace bound to a pane. |
+//! | `flotilla.host` | Host bound to a pane. |
+//! | `flotilla.crew.role` | One bound pane's crew role. |
+//! | `flotilla.attach.ref` | Address accepted by `flotilla attach`. |
+//! | `flotilla.project.name` | Human-readable name of a Project group. |
+//! | `flotilla.convoy.phase` | Raw [`flotilla_protocol::ConvoyPhase`] value. |
+//! | `flotilla.convoy.workflow` | WorkflowTemplate resource name used by a convoy. |
+//! | `flotilla.convoy.message` | Convoy lifecycle diagnostic. |
+//! | `flotilla.work.phase` | Work phase aboard a vessel, not vessel lifecycle. |
+//! | `flotilla.vessel.host` | Host currently carrying a vessel or independent. |
+//! | `flotilla.vessel.env` | Execution-environment reference for a vessel. |
+//! | `flotilla.crew.roles` | Complete crew-role list aboard a vessel. |
+//! | `status.state` | Normalized `idle`, `waiting`, `active`, `done`, or `failed` badge state. |
+//! | `status.attention` | Boolean human-attention demand. |
+//! | `status.connectivity` | Connectivity annotation (`connected` or `disconnected`); reserved until emitted. |
+//! | `summary.text` | Short human summary, never an identity. |
+//! | `tab.scope` | Typed [`MetadataValue::GroupPath`] locating a materialized tab or identity. |
+//! | `tab.kind` | Stable workspace/tab kind. |
+//! | `materialize.target` | Kind produced by a recipe (`workspace` or `pane`). |
+//! | `materialize.recipe` | Command address used to materialize an entry. |
+//! | `factory.id` | Stable cross-producer dedupe identity. |
+//!
+//! Group path segment keys are equally single-dialect:
+//!
+//! | Segment key | Value |
+//! | --- | --- |
+//! | `flotilla.project` | Project resource name, and only present when Project knowledge exists. |
+//! | `vcs.repo` | Canonical forge slug, falling back to Repository's `host:path` identity when slugless. |
+//! | `flotilla.convoy` | `<namespace>/<convoy>` resource identity. |
+//! | `flotilla.vessel` | Vessel or independent name. |
+//! | `flotilla.issue` | Issue entry identity from the awareness projection. |
 
 use std::collections::BTreeMap;
 

--- a/crates/flotilla-manifest/src/wire/tests.rs
+++ b/crates/flotilla-manifest/src/wire/tests.rs
@@ -112,7 +112,7 @@ fn segment_identity_ignores_labels() {
     let labelled = GroupSegment::text("flotilla.convoy", "dev/manifest-extraction").with_label("manifest extraction");
     assert_eq!(plain, labelled);
 
-    let path_plain = MetadataPathSegmentValue::text("git.repo", "flotilla-org/flotilla");
-    let path_labelled = MetadataPathSegmentValue::text("git.repo", "flotilla-org/flotilla").with_label("flotilla");
+    let path_plain = MetadataPathSegmentValue::text("vcs.repo", "flotilla-org/flotilla");
+    let path_labelled = MetadataPathSegmentValue::text("vcs.repo", "flotilla-org/flotilla").with_label("flotilla");
     assert_eq!(path_plain, path_labelled);
 }

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -605,6 +605,10 @@ pub struct CheckoutRow {
     pub repo: RepositoryKey,
     /// Human-readable Repository presentation, never the opaque identity key.
     pub repo_label: String,
+    /// Canonical cross-producer `vcs.repo` fact value. Kept separate from
+    /// `repo_label`, which scoped projections may rewrite for display.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_fact: Option<RepoKey>,
     pub path: String,
     pub branch: String,
     pub host: HostName,
@@ -648,6 +652,10 @@ pub struct IndependentRow {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo: Option<RepoKey>,
+    /// Canonical cross-producer `vcs.repo` fact value. Kept separate from
+    /// `repo`, which is a presentation label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_fact: Option<RepoKey>,
     /// Canonical Repository membership fact used by the Aggregator to derive
     /// Project-scoped result sets. This is data on the row, not a query scope.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -41,6 +41,19 @@ pub struct ConvoySpec {
     pub instruction: Option<String>,
 }
 
+impl ConvoySpec {
+    /// The repository snapshot when this convoy has exactly one repository.
+    ///
+    /// A single repository is the only unambiguous source for one `vcs.repo`
+    /// grouping fact.
+    pub fn sole_repository(&self) -> Option<&ConvoyRepositorySpec> {
+        let [repository] = self.repositories.as_slice() else {
+            return None;
+        };
+        Some(repository)
+    }
+}
+
 /// Durable source-qualified issue context captured when a convoy is admitted.
 /// The reference remains stable if the Project later changes its Issue Source;
 /// the snapshot records exactly what the crew was asked to act on.

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -117,7 +117,7 @@ impl RepositorySpec {
     /// Canonical value for the cross-producer `vcs.repo` fact: a forge slug
     /// when one exists, otherwise the globally qualified `host:path`
     /// Repository identity.
-    pub fn fact_slug(&self) -> String {
+    pub fn repo_fact_value(&self) -> String {
         self.forge.as_ref().map_or_else(|| self.qualified_label(), |forge| forge.repository.clone())
     }
 
@@ -344,7 +344,7 @@ mod fact_dialect_tests {
         let forge = RepositorySpec::remote("https://github.com/flotilla-org/flotilla.git").expect("forge repository");
         let local = RepositorySpec::local("feta", "/srv/flotilla/.git").expect("local repository");
 
-        assert_eq!(forge.fact_slug(), "flotilla-org/flotilla");
-        assert_eq!(local.fact_slug(), "feta:/srv/flotilla/.git");
+        assert_eq!(forge.repo_fact_value(), "flotilla-org/flotilla");
+        assert_eq!(local.repo_fact_value(), "feta:/srv/flotilla/.git");
     }
 }

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -114,6 +114,13 @@ impl RepositorySpec {
         }
     }
 
+    /// Canonical value for the cross-producer `vcs.repo` fact: a forge slug
+    /// when one exists, otherwise the globally qualified `host:path`
+    /// Repository identity.
+    pub fn fact_slug(&self) -> String {
+        self.forge.as_ref().map_or_else(|| self.qualified_label(), |forge| forge.repository.clone())
+    }
+
     /// Globally qualified, human-readable label suitable for fleet exchange.
     pub fn qualified_label(&self) -> String {
         match &self.identity {
@@ -326,4 +333,18 @@ fn ssh_remote_host(remote: &str) -> Option<&str> {
         authority.rsplit_once('@').map_or(authority, |(_, host)| host)
     };
     Some(host)
+}
+
+#[cfg(test)]
+mod fact_dialect_tests {
+    use super::RepositorySpec;
+
+    #[test]
+    fn repo_fact_uses_forge_slug_with_host_path_fallback() {
+        let forge = RepositorySpec::remote("https://github.com/flotilla-org/flotilla.git").expect("forge repository");
+        let local = RepositorySpec::local("feta", "/srv/flotilla/.git").expect("local repository");
+
+        assert_eq!(forge.fact_slug(), "flotilla-org/flotilla");
+        assert_eq!(local.fact_slug(), "feta:/srv/flotilla/.git");
+    }
 }

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -5,7 +5,7 @@ use std::sync::{
 
 use async_trait::async_trait;
 use flotilla_manifest::{
-    keys::{KEY_SESSION, KEY_STATUS_STATE, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_VESSEL},
+    keys::{KEY_SESSION, KEY_SOURCE, KEY_STATUS_STATE, SEGMENT_INDEPENDENT, SEGMENT_ISSUE, SEGMENT_PROJECT, SOURCE_FLOTILLA},
     wire::{GroupPath, GroupSegment, MetadataIdentity, MetadataTarget, MetadataValue},
 };
 use flotilla_protocol::{
@@ -73,7 +73,7 @@ fn mint() -> FlotillaRecipes {
 }
 
 fn independent_group(name: &str) -> MetadataTarget {
-    MetadataTarget::Group(GroupPath(vec![GroupSegment::text(SEGMENT_VESSEL, name)]))
+    MetadataTarget::Group(GroupPath(vec![GroupSegment::text(SEGMENT_INDEPENDENT, name)]))
 }
 
 fn session_identity(value: &str) -> MetadataTarget {
@@ -135,7 +135,8 @@ fn rebuild_publishes_diffs_not_repeats() {
     let after_removal = state.rebuild(&mint());
     let group_patch =
         after_removal.iter().find(|patch| patch.target == independent_group("scratch")).expect("unset patch for removed independent");
-    assert!(group_patch.set.is_empty());
+    assert_eq!(group_patch.set.len(), 1, "retractions retain only producer provenance");
+    assert_eq!(group_patch.set[KEY_SOURCE].value, MetadataValue::text(SOURCE_FLOTILLA));
     assert!(group_patch.unset.contains(&KEY_STATUS_STATE.to_owned()));
 }
 

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -150,7 +150,7 @@ fn rebuild_prefers_awareness_transport_when_available() {
     assert!(patches.iter().any(|patch| {
         patch.target
             == MetadataTarget::Group(GroupPath(vec![
-                GroupSegment::text(SEGMENT_PROJECT, "project/dev/platform").with_label("platform"),
+                GroupSegment::text(SEGMENT_PROJECT, "platform"),
                 GroupSegment::text(SEGMENT_ISSUE, "issue/flotilla-org/flotilla/862").with_label("#862 awareness band"),
             ]))
     }));

--- a/crates/flotilla-tui/src/pm_open.rs
+++ b/crates/flotilla-tui/src/pm_open.rs
@@ -15,7 +15,7 @@ use flotilla_core::{
     },
 };
 use flotilla_manifest::{
-    projection::{convoy_group_path, project_segment, vessel_factory_id, vessel_group_path},
+    projection::{convoy_group_path, project_segment, repo_segment, vessel_factory_id, vessel_group_path},
     stamp::WorkspaceStamp,
 };
 use flotilla_protocol::{arg::shell_quote, HostName, RepoKey, ResourceRef};
@@ -61,17 +61,18 @@ impl PresentationPmConnector {
     }
 
     fn stamp(target: &OpenInPmTarget) -> WorkspaceStamp {
-        let project = project_segment(target.project_ref.as_deref(), target.repo_hint.as_ref().map(|repo| repo.0.as_str()));
+        let project = project_segment(target.project_ref.as_deref());
+        let repo = repo_segment(target.repo_hint.as_ref().map(|repo| repo.0.as_str()));
         match &target.vessel {
             Some(vessel) => WorkspaceStamp {
                 kind: "flotilla-vessel".to_owned(),
                 factory_id: vessel_factory_id(&target.namespace, &target.convoy, vessel),
-                scope: Some(vessel_group_path(project, &target.namespace, &target.convoy, vessel)),
+                scope: Some(vessel_group_path(project, repo, &target.namespace, &target.convoy, vessel)),
             },
             None => WorkspaceStamp {
                 kind: "flotilla-convoy".to_owned(),
                 factory_id: format!("flotilla:convoys/{}/{}", target.namespace, target.convoy),
-                scope: Some(convoy_group_path(project, &target.namespace, &target.convoy)),
+                scope: Some(convoy_group_path(project, repo, &target.namespace, &target.convoy)),
             },
         }
     }
@@ -151,6 +152,10 @@ mod tests {
     use std::sync::Mutex;
 
     use flotilla_core::providers::types::Workspace;
+    use flotilla_manifest::{
+        keys::{SEGMENT_CONVOY, SEGMENT_PROJECT, SEGMENT_REPO, SEGMENT_VESSEL},
+        wire::{GroupPath, GroupSegment},
+    };
 
     use super::*;
 
@@ -250,7 +255,18 @@ mod tests {
         assert_eq!(created.len(), 1);
         assert_eq!(created[0].0, "dev/tables/implement");
         assert_eq!(created[0].1, vec![("implement".into(), "'/opt/flotilla' attach 'terminal-implement'".into())]);
-        assert_eq!(created[0].2.as_ref().expect("workspace stamp").factory_id, "flotilla:convoys/dev/tables/implement");
+        let stamp = created[0].2.as_ref().expect("workspace stamp");
+        assert_eq!(stamp.factory_id, "flotilla:convoys/dev/tables/implement");
+        assert_eq!(
+            stamp.scope,
+            Some(GroupPath(vec![
+                GroupSegment::text(SEGMENT_PROJECT, "flotilla"),
+                GroupSegment::text(SEGMENT_REPO, "flotilla-org/flotilla").with_label("flotilla"),
+                GroupSegment::text(SEGMENT_CONVOY, "dev/tables").with_label("tables"),
+                GroupSegment::text(SEGMENT_VESSEL, "implement"),
+            ])),
+            "the live workspace stamp must match the catalog's latent vessel path"
+        );
     }
 
     #[tokio::test]

--- a/docs/adr/0018-presentation-attention-demands-regards-projection.md
+++ b/docs/adr/0018-presentation-attention-demands-regards-projection.md
@@ -144,7 +144,20 @@ awareness queries → latent presence; searchlight → materialized attachments;
 materialize missing, retract expired, latent the marginal. Reconcile-on-
 connect (#835) is this convergence run at connect time.
 
-Three refinements from the openable-latent grill (2026-07-23):
+Five refinements from the openable-latent and fact-semantics grills
+(2026-07-23):
+
+- **Facts use one dialect, with one meaning per key.** Project and Repository
+  identity are separate grouping levels: `flotilla.project` is a Project
+  resource name and exists only with Project knowledge; `vcs.repo` is the
+  canonical forge slug, with the Repository's `host:path` identity as the
+  slugless fallback. A Repository never masquerades as a Project. Producers
+  that know the same Repository use the same `vcs.repo` value, so their
+  observations join there.
+- **Every producer publishes provenance as data.** Each assertion carries a
+  `source` fact (`flotilla`, `git-watcher`, and so on), distinct from the
+  patch protocol's authority-scoped `source_id`. Surfaces may therefore badge
+  provenance without interpreting transport bookkeeping.
 
 - **Latent tabs are a sanctioned rendering**: a surface may draw latents
   *in place in its working-set idiom* — a dimmed tab where the live tab


### PR DESCRIPTION
## Summary

- split Project resource grouping (`flotilla.project`) from canonical repository grouping (`vcs.repo`)
- preserve canonical repo facts separately from mutable display labels across convoy, checkout, independent, and awareness projections
- give independent sessions their own single-meaning grouping vocabulary
- add `source=flotilla` provenance to every catalog, pane, and tab patch, including retractions
- make latent catalog paths and live workspace stamps share the canonical project → repo → convoy → vessel spine
- document the v1 fact semantics and amend ADR 0018

Companion watcher alignment: flotilla-org/andamento#19

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #948