### PR TITLE
feat: template crew briefs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "flotilla-resources",
  "rstest",
  "sha2",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/crates/flotilla-controllers/Cargo.toml
+++ b/crates/flotilla-controllers/Cargo.toml
@@ -20,3 +20,4 @@ sha2 = "0.10"
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 rstest = { workspace = true }
+tempfile = "3"

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -1,7 +1,9 @@
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::{collections::BTreeMap, marker::PhantomData, path::PathBuf};
 
 use chrono::{DateTime, Utc};
-use flotilla_core::agent_adapter::{append_convoy_work_context, build_crew_brief, CrewAssignment, CrewBriefMember};
+use flotilla_core::agent_adapter::{
+    append_convoy_work_context, build_crew_brief_with_options, CrewAssignment, CrewBriefMember, CrewBriefTemplateResolver,
+};
 use flotilla_resources::{
     clone_key,
     controller::{
@@ -29,6 +31,7 @@ pub struct VesselReconciler {
     checkouts: TypedResolver<Checkout>,
     terminal_sessions: TypedResolver<TerminalSession>,
     namespace: String,
+    brief_templates: CrewBriefTemplateResolver,
 }
 
 impl VesselReconciler {
@@ -42,7 +45,12 @@ impl VesselReconciler {
             checkouts: backend.clone().using::<Checkout>(namespace),
             terminal_sessions: backend.using::<TerminalSession>(namespace),
             namespace: namespace.to_string(),
+            brief_templates: CrewBriefTemplateResolver::default(),
         }
+    }
+
+    pub fn new_with_config_dir(backend: ResourceBackend, namespace: &str, config_dir: impl Into<PathBuf>) -> Self {
+        Self { brief_templates: CrewBriefTemplateResolver::with_config_dir(config_dir), ..Self::new(backend, namespace) }
     }
 
     pub fn secondary_watches() -> Vec<Box<dyn SecondaryWatch<Primary = Vessel>>> {
@@ -608,7 +616,7 @@ impl Reconciler for VesselReconciler {
                     }
                     let source = match &process.source {
                         CrewSource::Tool { command } => flotilla_resources::TerminalSessionSource::Tool { command: command.clone() },
-                        CrewSource::Agent { selector, prompt } => {
+                        CrewSource::Agent { selector, prompt, brief_template } => {
                             let context = flotilla_resources::TerminalCrewContext {
                                 namespace: self.namespace.clone(),
                                 convoy: obj.spec.convoy_ref.clone(),
@@ -634,7 +642,22 @@ impl Reconciler for VesselReconciler {
                                 None if !convoy.spec.issues.is_empty() => CrewAssignment::CarriedIssue,
                                 None => CrewAssignment::Unassigned,
                             };
-                            let mut brief = build_crew_brief(&context, &obj.spec.vessel_name, &process.role, assignment, &members);
+                            let render_options = self.brief_templates.render_options(
+                                brief_template.as_deref(),
+                                convoy.spec.project_ref.as_deref(),
+                                checkout_paths.values().map(PathBuf::from),
+                            );
+                            let mut brief = match build_crew_brief_with_options(
+                                &context,
+                                &obj.spec.vessel_name,
+                                &process.role,
+                                assignment,
+                                &members,
+                                &render_options,
+                            ) {
+                                Ok(brief) => brief,
+                                Err(message) => return Ok(VesselDeps::failed(message)),
+                            };
                             append_convoy_work_context(&mut brief.content, &convoy, &repository_refs);
                             brief.copies = brief_copies.clone();
                             flotilla_resources::TerminalSessionSource::Agent { selector: selector.clone(), brief, context, message: None }

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -369,6 +369,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
                         .source(CrewSource::Agent {
                             selector: Selector { capability: "coding".to_string() },
                             prompt: Some("Work across both repositories.".to_string()),
+                            brief_template: None,
                         })
                         .build()],
                 }],
@@ -1262,6 +1263,7 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
             .source(CrewSource::Agent {
                 selector: Selector { capability: "coding".to_string() },
                 prompt: Some("Implement issue 668.".to_string()),
+                brief_template: None,
             })
             .build(),
         CrewSpec::builder()
@@ -1269,6 +1271,7 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
             .source(CrewSource::Agent {
                 selector: Selector { capability: "review".to_string() },
                 prompt: Some("Review the coder's work.".to_string()),
+                brief_template: None,
             })
             .build(),
     ];
@@ -1297,9 +1300,14 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps");
     let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
 
-    let Actuation::CreateTerminalSession { spec, .. } = outcome.actuations.first().expect("coder session actuation") else {
-        panic!("expected terminal session actuation");
-    };
+    let spec = outcome
+        .actuations
+        .iter()
+        .find_map(|actuation| match actuation {
+            Actuation::CreateTerminalSession { spec, .. } => Some(spec),
+            _ => None,
+        })
+        .expect("coder session actuation");
     let TerminalSessionSource::Agent { selector, brief, context, message } = &spec.source else {
         panic!("expected structured agent launch");
     };
@@ -1318,6 +1326,68 @@ async fn first_agent_is_provisioned_with_a_durable_crew_brief_while_later_agents
         .actuations
         .iter()
         .all(|actuation| { !matches!(actuation, Actuation::CreateTerminalSession { spec, .. } if spec.role == "reviewer") }));
+}
+
+#[tokio::test]
+async fn repo_level_brief_template_override_changes_one_block_for_that_repo_convoy() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let repo_path = temp.path().join("repo");
+    let override_dir = repo_path.join(".flotilla/brief-templates");
+    std::fs::create_dir_all(&override_dir).expect("override dir");
+    std::fs::write(
+        override_dir.join("crew.md"),
+        "{% block delivery %}Repo-local delivery gate: stop after the fixture proves the override.{% endblock %}",
+    )
+    .expect("override file");
+
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-repo-override", "implement", REPO_URL, GIT_REF).await;
+    let repo_ref = convoy.spec.repositories[0].repo_ref.clone();
+    let mut status = convoy.status.expect("convoy status");
+    status.workflow_snapshot.as_mut().expect("workflow snapshot").vessels[0].crew = vec![CrewSpec::builder()
+        .role("coder".to_string())
+        .source(CrewSource::Agent { selector: Selector { capability: "coding".to_string() }, prompt: None, brief_template: None })
+        .build()];
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .update_status("convoy-repo-override", &convoy.metadata.resource_version, &status)
+        .await
+        .expect("update convoy crew");
+    create_host_direct_policy(&backend, NAMESPACE, "policy-repo-override", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    create_ready_adopted_checkout(
+        &backend,
+        NAMESPACE,
+        "adopted-checkout-convoy-repo-override",
+        repo_path.to_str().expect("repo path should be utf-8"),
+    )
+    .await;
+    let workspace = backend
+        .clone()
+        .using::<Vessel>(NAMESPACE)
+        .create(&vessel_meta("workspace-repo-override", REPO_URL), &VesselSpec {
+            convoy_ref: "convoy-repo-override".to_string(),
+            vessel_name: "implement".to_string(),
+            placement_policy_ref: "policy-repo-override".to_string(),
+            adopted_checkout_refs: BTreeMap::from([(repo_ref, "adopted-checkout-convoy-repo-override".to_string())]),
+        })
+        .await
+        .expect("workspace create");
+
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps");
+    let outcome = reconciler.reconcile(&workspace, &deps, Utc::now());
+
+    let Actuation::CreateTerminalSession { spec, .. } = outcome.actuations.first().expect("coder session actuation") else {
+        panic!("expected terminal session actuation");
+    };
+    let TerminalSessionSource::Agent { brief, .. } = &spec.source else {
+        panic!("expected agent source");
+    };
+    assert!(brief.content.contains("Repo-local delivery gate: stop after the fixture proves the override."));
+    assert!(brief.content.contains("## Assignment\n\nNo assignment was provided with this dispatch."));
+    assert!(!brief.content.contains("For assignments that change a repository"));
 }
 
 #[tokio::test]
@@ -1374,7 +1444,11 @@ async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
                     repository_refs: None,
                     crew: vec![CrewSpec::builder()
                         .role("coder".to_string())
-                        .source(CrewSource::Agent { selector: Selector { capability: "coding".to_string() }, prompt: None })
+                        .source(CrewSource::Agent {
+                            selector: Selector { capability: "coding".to_string() },
+                            prompt: None,
+                            brief_template: None,
+                        })
                         .build()],
                 }],
             }),

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -1,8 +1,13 @@
-use std::{collections::BTreeMap, path::Path, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use flotilla_protocol::arg::{flatten, Arg};
 use flotilla_resources::TerminalBrief;
+use serde::Serialize;
 
 use crate::{
     path_context::ExecutionEnvironmentPath,
@@ -10,6 +15,10 @@ use crate::{
 };
 
 pub const TRUSTED_IMPLICIT_STANCE: &str = "trusted-implicit";
+pub const DEFAULT_CREW_BRIEF_TEMPLATE: &str = "crew.md";
+const BUILTIN_CREW_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/crew.md");
+const BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/interactive-session.md");
+const BRIEF_TEMPLATE_DIR: &str = "brief-templates";
 
 pub fn crew_brief_path(role: &str) -> String {
     let file_name: String = role
@@ -19,7 +28,7 @@ pub fn crew_brief_path(role: &str) -> String {
     format!(".flotilla/briefs/{}.md", if file_name.is_empty() { "crew" } else { &file_name })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CrewBriefMember {
     pub role: String,
     pub state: String,
@@ -42,6 +51,77 @@ pub enum CrewAssignment<'a> {
     Unassigned,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CrewBriefTemplateResolver {
+    config_dir: Option<PathBuf>,
+}
+
+impl CrewBriefTemplateResolver {
+    pub fn with_config_dir(config_dir: impl Into<PathBuf>) -> Self {
+        Self { config_dir: Some(config_dir.into()) }
+    }
+
+    pub fn render_options(
+        &self,
+        template: Option<&str>,
+        project_ref: Option<&str>,
+        repo_roots: impl IntoIterator<Item = PathBuf>,
+    ) -> CrewBriefRenderOptions {
+        let template = template.filter(|template| !template.trim().is_empty()).unwrap_or(DEFAULT_CREW_BRIEF_TEMPLATE);
+        let mut overrides = Vec::new();
+        if let Some(config_dir) = &self.config_dir {
+            push_template_override(&mut overrides, config_dir.join(BRIEF_TEMPLATE_DIR).join(template));
+            if let Some(project_ref) = project_ref {
+                push_template_override(
+                    &mut overrides,
+                    config_dir.join("projects").join(project_ref).join(BRIEF_TEMPLATE_DIR).join(template),
+                );
+            }
+        }
+        for repo_root in repo_roots {
+            push_template_override(&mut overrides, repo_root.join(".flotilla").join(BRIEF_TEMPLATE_DIR).join(template));
+        }
+        CrewBriefRenderOptions { template: template.to_string(), overrides }
+    }
+}
+
+fn push_template_override(overrides: &mut Vec<CrewBriefTemplateOverride>, path: PathBuf) {
+    match std::fs::read_to_string(&path) {
+        Ok(source) => overrides.push(CrewBriefTemplateOverride { path, source }),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => tracing::warn!(path = %path.display(), err = %err, "failed to read crew brief template override"),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrewBriefRenderOptions {
+    pub template: String,
+    pub overrides: Vec<CrewBriefTemplateOverride>,
+}
+
+impl Default for CrewBriefRenderOptions {
+    fn default() -> Self {
+        Self { template: DEFAULT_CREW_BRIEF_TEMPLATE.to_string(), overrides: Vec::new() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrewBriefTemplateOverride {
+    pub path: PathBuf,
+    pub source: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CrewBriefTemplateContext<'a> {
+    role: &'a str,
+    convoy: &'a str,
+    vessel: &'a str,
+    vessel_ref: &'a str,
+    assignment_text: &'a str,
+    members: &'a [CrewBriefMember],
+    handoff_members: Vec<&'a CrewBriefMember>,
+}
+
 pub fn build_crew_brief(
     context: &flotilla_resources::TerminalCrewContext,
     vessel: &str,
@@ -49,30 +129,92 @@ pub fn build_crew_brief(
     assignment: CrewAssignment<'_>,
     members: &[CrewBriefMember],
 ) -> flotilla_resources::TerminalBrief {
-    let mut content = format!(
-        "# Flotilla crew brief\n\nYou are `{role}` in convoy `{}`, aboard vessel `{vessel}` (`{}`).\n\n## Crew\n\n",
-        context.convoy, context.vessel_ref
-    );
-    for member in members {
-        content.push_str(&format!("- `{}`: {}\n", member.role, member.state));
+    build_crew_brief_with_options(context, vessel, role, assignment, members, &CrewBriefRenderOptions::default())
+        .expect("built-in crew brief template should render")
+}
+
+pub fn build_crew_brief_with_options(
+    context: &flotilla_resources::TerminalCrewContext,
+    vessel: &str,
+    role: &str,
+    assignment: CrewAssignment<'_>,
+    members: &[CrewBriefMember],
+    options: &CrewBriefRenderOptions,
+) -> Result<flotilla_resources::TerminalBrief, String> {
+    let assignment_text = match assignment {
+        CrewAssignment::Prompt(prompt) => prompt,
+        CrewAssignment::CarriedIssue =>
+            "Your assignment is the issue snapshot section below. Its body is the contract: work it to completion and deliver as described above.",
+        CrewAssignment::Unassigned =>
+            "No assignment was provided with this dispatch. Check `## Human instruction` below if present; otherwise report via `flotilla crew fail` rather than inventing work.",
+    };
+    let mut content = render_crew_brief_template(options, &CrewBriefTemplateContext {
+        role,
+        convoy: &context.convoy,
+        vessel,
+        vessel_ref: &context.vessel_ref,
+        assignment_text,
+        members,
+        handoff_members: members.iter().filter(|member| member.is_agent && member.role != role).collect(),
+    })?;
+    if !content.ends_with('\n') {
+        content.push('\n');
     }
-    content.push_str(
-        "\nRun `flotilla crew list` for current crew state.\nClone scratch repositories outside the vessel checkout (for example under a `mktemp -d` directory); embedded repositories make teardown refuse by default.\n",
-    );
-    for member in members.iter().filter(|member| member.is_agent && member.role != role) {
-        content.push_str(&format!("Hand off to {} with `flotilla crew {} handoff --message '...'`.\n", member.role, member.role));
-    }
-    content.push_str(&format!(
-        "For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue (ready for review, never a draft), and shepherd the pull request until all checks pass; if it is a draft for any reason, mark it ready once checks are green. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`. For other assignments, complete with `flotilla crew complete --message '...'`. If the assignment cannot be completed, report the failure with `flotilla crew fail --message '...'`.\n\n## Assignment\n\n{}\n",
-        match assignment {
-            CrewAssignment::Prompt(prompt) => prompt,
-            CrewAssignment::CarriedIssue =>
-                "Your assignment is the issue snapshot section below. Its body is the contract: work it to completion and deliver as described above.",
-            CrewAssignment::Unassigned =>
-                "No assignment was provided with this dispatch. Check `## Human instruction` below if present; otherwise report via `flotilla crew fail` rather than inventing work.",
+    Ok(flotilla_resources::TerminalBrief { path: crew_brief_path(role), content, copies: Vec::new() })
+}
+
+fn render_crew_brief_template(options: &CrewBriefRenderOptions, context: &CrewBriefTemplateContext<'_>) -> Result<String, String> {
+    let mut env = minijinja::Environment::new();
+    env.add_template(BUILTIN_CREW_BRIEF_TEMPLATE_NAME, BUILTIN_CREW_BRIEF_TEMPLATE)
+        .map_err(|err| format!("load built-in crew brief template: {err}"))?;
+    env.add_template(BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME, BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE)
+        .map_err(|err| format!("load built-in interactive-session brief template: {err}"))?;
+    let mut skip_overrides = 0;
+    let mut current_template = match options.template.as_str() {
+        DEFAULT_CREW_BRIEF_TEMPLATE => BUILTIN_CREW_BRIEF_TEMPLATE_NAME.to_string(),
+        "interactive-session.md" => BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME.to_string(),
+        custom if !options.overrides.is_empty() => {
+            let first = &options.overrides[0];
+            if is_block_only_override(&first.source) {
+                BUILTIN_CREW_BRIEF_TEMPLATE_NAME.to_string()
+            } else {
+                skip_overrides = 1;
+                let name = format!("override/base/{custom}");
+                env.add_template_owned(name.clone(), first.source.clone())
+                    .map_err(|err| format!("load crew brief template {}: {err}", first.path.display()))?;
+                name
+            }
         }
-    ));
-    flotilla_resources::TerminalBrief { path: crew_brief_path(role), content, copies: Vec::new() }
+        custom => return Err(format!("unknown crew brief template `{custom}`")),
+    };
+    for (index, template_override) in options.overrides.iter().enumerate().skip(skip_overrides) {
+        let name = format!("override/{index}/{}", options.template);
+        let source = layered_override_source(&current_template, &template_override.source);
+        env.add_template_owned(name.clone(), source)
+            .map_err(|err| format!("load crew brief template {}: {err}", template_override.path.display()))?;
+        current_template = name;
+    }
+    env.get_template(&current_template)
+        .and_then(|template| template.render(context))
+        .map_err(|err| format!("render crew brief template {}: {err}", options.template))
+}
+
+const BUILTIN_CREW_BRIEF_TEMPLATE_NAME: &str = "builtin/crew.md";
+const BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME: &str = "builtin/interactive-session.md";
+
+fn layered_override_source(parent: &str, source: &str) -> String {
+    if !is_block_only_override(source) {
+        source.to_string()
+    } else {
+        format!("{{% extends \"{parent}\" %}}\n{source}")
+    }
+}
+
+fn is_block_only_override(source: &str) -> bool {
+    // Override files without an explicit `{% extends %}` are treated as terse
+    // block fragments. A standalone template that declares its own blocks must
+    // include an explicit `{% extends %}` or avoid block declarations.
+    source.contains("{% block") && !source.contains("{% extends")
 }
 
 /// Appends the convoy's work context (branch, repositories, issue snapshots,
@@ -306,8 +448,8 @@ mod tests {
 
     use crate::{
         agent_adapter::{
-            append_convoy_work_context, build_crew_brief, AgentAdapterRegistry, AgentLaunchRequest, CapabilityTable, CrewAssignment,
-            CrewBriefMember,
+            append_convoy_work_context, build_crew_brief, build_crew_brief_with_options, AgentAdapterRegistry, AgentLaunchRequest,
+            CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefRenderOptions, CrewBriefTemplateOverride, CrewBriefTemplateResolver,
         },
         path_context::ExecutionEnvironmentPath,
         providers::{
@@ -367,6 +509,134 @@ mod tests {
             &[CrewBriefMember { role: "coder".to_string(), state: "active".to_string(), is_agent: true }],
         )
         .content
+    }
+
+    #[test]
+    fn default_brief_template_matches_legacy_bytes() {
+        let content = build_crew_brief(
+            &TerminalCrewContext {
+                namespace: "flotilla".to_string(),
+                convoy: "fix-delivery".to_string(),
+                vessel_ref: "vessel-fix-delivery-work".to_string(),
+            },
+            "work",
+            "coder",
+            CrewAssignment::Prompt("Fix the flux capacitor."),
+            &[
+                CrewBriefMember { role: "coder".to_string(), state: "active".to_string(), is_agent: true },
+                CrewBriefMember { role: "reviewer".to_string(), state: "latent".to_string(), is_agent: true },
+                CrewBriefMember { role: "watcher".to_string(), state: "active".to_string(), is_agent: false },
+            ],
+        )
+        .content;
+
+        assert_eq!(
+            content,
+            "# Flotilla crew brief\n\nYou are `coder` in convoy `fix-delivery`, aboard vessel `work` (`vessel-fix-delivery-work`).\n\n## Crew\n\n- `coder`: active\n- `reviewer`: latent\n- `watcher`: active\n\nRun `flotilla crew list` for current crew state.\nClone scratch repositories outside the vessel checkout (for example under a `mktemp -d` directory); embedded repositories make teardown refuse by default.\nHand off to reviewer with `flotilla crew reviewer handoff --message '...'`.\nFor assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue (ready for review, never a draft), and shepherd the pull request until all checks pass; if it is a draft for any reason, mark it ready once checks are green. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`. For other assignments, complete with `flotilla crew complete --message '...'`. If the assignment cannot be completed, report the failure with `flotilla crew fail --message '...'`.\n\n## Assignment\n\nFix the flux capacitor.\n"
+        );
+    }
+
+    #[test]
+    fn repo_level_override_can_replace_one_block() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let override_dir = repo.join(".flotilla/brief-templates");
+        std::fs::create_dir_all(&override_dir).expect("override dir");
+        std::fs::write(override_dir.join("crew.md"), "{% block delivery %}Complete when the local demo is ready.{% endblock %}")
+            .expect("override file");
+        let options = CrewBriefTemplateResolver::default().render_options(None, None, [repo]);
+        let brief = build_crew_brief_with_options(
+            &TerminalCrewContext { namespace: "flotilla".to_string(), convoy: "demo".to_string(), vessel_ref: "demo-work".to_string() },
+            "work",
+            "coder",
+            CrewAssignment::Prompt("Demo the override."),
+            &[CrewBriefMember { role: "coder".to_string(), state: "active".to_string(), is_agent: true }],
+            &options,
+        )
+        .expect("render brief");
+
+        assert!(brief.content.contains("Complete when the local demo is ready."));
+        assert!(brief.content.contains("## Assignment\n\nDemo the override."));
+        assert!(!brief.content.contains("For assignments that change a repository"));
+    }
+
+    #[test]
+    fn workflow_variant_selects_a_different_brief_template() {
+        let default = brief_for(CrewAssignment::Prompt("Pair with the user."));
+        let selected = build_crew_brief_with_options(
+            &TerminalCrewContext {
+                namespace: "flotilla".to_string(),
+                convoy: "interactive".to_string(),
+                vessel_ref: "interactive-work".to_string(),
+            },
+            "work",
+            "driver",
+            CrewAssignment::Prompt("Pair with the user."),
+            &[CrewBriefMember { role: "driver".to_string(), state: "active".to_string(), is_agent: true }],
+            &CrewBriefRenderOptions { template: "interactive-session.md".to_string(), overrides: Vec::new() },
+        )
+        .expect("render selected template")
+        .content;
+
+        assert!(selected.contains("For interactive sessions, keep the user-facing loop tight"));
+        assert!(selected.contains("## Assignment\n\nPair with the user."));
+        assert!(!default.contains("For interactive sessions"));
+    }
+
+    #[test]
+    fn custom_block_only_template_inherits_the_default_brief_shape() {
+        let brief = build_crew_brief_with_options(
+            &TerminalCrewContext {
+                namespace: "flotilla".to_string(),
+                convoy: "pairing".to_string(),
+                vessel_ref: "pairing-work".to_string(),
+            },
+            "work",
+            "driver",
+            CrewAssignment::Prompt("Pair with the user."),
+            &[CrewBriefMember { role: "driver".to_string(), state: "active".to_string(), is_agent: true }],
+            &CrewBriefRenderOptions {
+                template: "pairing.md".to_string(),
+                overrides: vec![CrewBriefTemplateOverride {
+                    path: "pairing.md".into(),
+                    source: "{% block delivery %}Pairing-specific delivery gate.{% endblock %}".to_string(),
+                }],
+            },
+        )
+        .expect("render custom block-only template");
+
+        assert!(brief.content.starts_with("# Flotilla crew brief\n\nYou are `driver` in convoy `pairing`"));
+        assert!(brief.content.contains("Pairing-specific delivery gate."));
+        assert!(brief.content.contains("## Assignment\n\nPair with the user.\n"));
+    }
+
+    #[test]
+    fn repo_override_wins_over_project_and_fleet_blocks() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = temp.path().join("config");
+        let repo = temp.path().join("repo");
+        for (dir, text) in [
+            (config.join("brief-templates"), "Fleet delivery."),
+            (config.join("projects/demo-project/brief-templates"), "Project delivery."),
+            (repo.join(".flotilla/brief-templates"), "Repo delivery."),
+        ] {
+            std::fs::create_dir_all(&dir).expect("override dir");
+            std::fs::write(dir.join("crew.md"), format!("{{% block delivery %}}{text}{{% endblock %}}")).expect("override file");
+        }
+        let options = CrewBriefTemplateResolver::with_config_dir(&config).render_options(None, Some("demo-project"), [repo]);
+        let brief = build_crew_brief_with_options(
+            &TerminalCrewContext { namespace: "flotilla".to_string(), convoy: "demo".to_string(), vessel_ref: "demo-work".to_string() },
+            "work",
+            "coder",
+            CrewAssignment::Prompt("Check precedence."),
+            &[CrewBriefMember { role: "coder".to_string(), state: "active".to_string(), is_agent: true }],
+            &options,
+        )
+        .expect("render brief");
+
+        assert!(brief.content.contains("Repo delivery."));
+        assert!(!brief.content.contains("Project delivery."));
+        assert!(!brief.content.contains("Fleet delivery."));
     }
 
     #[test]

--- a/crates/flotilla-core/src/agent_adapter/templates/crew.md
+++ b/crates/flotilla-core/src/agent_adapter/templates/crew.md
@@ -1,0 +1,16 @@
+# Flotilla crew brief
+
+You are `{{ role }}` in convoy `{{ convoy }}`, aboard vessel `{{ vessel }}` (`{{ vessel_ref }}`).
+
+## Crew
+
+{% block crew %}{% for member in members %}- `{{ member.role }}`: {{ member.state }}
+{% endfor %}{% endblock %}
+{% block operating_instructions %}Run `flotilla crew list` for current crew state.
+Clone scratch repositories outside the vessel checkout (for example under a `mktemp -d` directory); embedded repositories make teardown refuse by default.
+{% for member in handoff_members %}Hand off to {{ member.role }} with `flotilla crew {{ member.role }} handoff --message '...'`.
+{% endfor %}{% endblock %}{% block delivery %}For assignments that change a repository, delivery is part of the assignment: implement the change, push the branch, open a pull request that closes the issue (ready for review, never a draft), and shepherd the pull request until all checks pass; if it is a draft for any reason, mark it ready once checks are green. Do not merge it. Only then complete your assignment with `flotilla crew complete --message '<PR URL>'`. For other assignments, complete with `flotilla crew complete --message '...'`. If the assignment cannot be completed, report the failure with `flotilla crew fail --message '...'`.{% endblock %}
+
+## Assignment
+
+{% block assignment %}{{ assignment_text }}{% endblock %}

--- a/crates/flotilla-core/src/agent_adapter/templates/interactive-session.md
+++ b/crates/flotilla-core/src/agent_adapter/templates/interactive-session.md
@@ -1,0 +1,2 @@
+{% extends "builtin/crew.md" %}
+{% block delivery %}For interactive sessions, keep the user-facing loop tight: make progress without waiting when the next step is clear, ask only when blocked by missing intent or external access, and complete with `flotilla crew complete --message '...'` when the session's requested outcome is reached. If the session cannot be completed, report the failure with `flotilla crew fail --message '...'`.{% endblock %}

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1076,13 +1076,14 @@ fn handoff_crew_brief(
     prompt: Option<&str>,
     members: &[CrewListMember],
     repository_refs: &[RepositoryKey],
-) -> TerminalBrief {
+    render_options: &crate::agent_adapter::CrewBriefRenderOptions,
+) -> Result<TerminalBrief, String> {
     let assignment = match prompt {
         Some(prompt) => crate::agent_adapter::CrewAssignment::Prompt(prompt),
         None if !convoy.spec.issues.is_empty() => crate::agent_adapter::CrewAssignment::CarriedIssue,
         None => crate::agent_adapter::CrewAssignment::Unassigned,
     };
-    let mut brief = crate::agent_adapter::build_crew_brief(
+    let brief = crate::agent_adapter::build_crew_brief_with_options(
         &TerminalCrewContext {
             namespace: context.namespace.clone(),
             convoy: context.convoy.clone(),
@@ -1099,9 +1100,36 @@ fn handoff_crew_brief(
                 is_agent: member.kind == "agent",
             })
             .collect::<Vec<_>>(),
+        render_options,
     );
+    let mut brief = brief?;
     crate::agent_adapter::append_convoy_work_context(&mut brief.content, convoy, repository_refs);
-    brief
+    Ok(brief)
+}
+
+async fn crew_brief_repo_roots(
+    backend: &ResourceBackend,
+    namespace: &str,
+    convoy: &flotilla_resources::ResourceObject<ResourceConvoy>,
+    repository_refs: &[RepositoryKey],
+) -> Vec<PathBuf> {
+    let checkouts = backend.clone().using::<ResourceCheckout>(namespace);
+    let mut roots = Vec::new();
+    for repository_ref in repository_refs {
+        let Some(checkout_ref) = convoy.spec.adopted_checkout_refs.get(repository_ref) else {
+            continue;
+        };
+        let Ok(checkout) = checkouts.get(checkout_ref).await else {
+            continue;
+        };
+        let Some(path) =
+            checkout.status.as_ref().and_then(|status| status.path.clone()).or_else(|| checkout.spec.target_path().map(str::to_string))
+        else {
+            continue;
+        };
+        roots.push(PathBuf::from(path));
+    }
+    roots
 }
 
 fn pending_crew_message(text: &str) -> TerminalCrewMessage {
@@ -4848,7 +4876,7 @@ impl InProcessDaemon {
             .enumerate()
             .find(|(_, process)| process.role == target && target != context.caller_role)
             .ok_or_else(|| crew_handoff_address_error(target, &context.vessel))?;
-        let CrewSource::Agent { selector, prompt } = &process.source else {
+        let CrewSource::Agent { selector, prompt, brief_template } = &process.source else {
             return Err(format!("crew target `{target}` is a tool process and cannot receive a handoff"));
         };
         let repository_refs = task
@@ -4908,7 +4936,11 @@ impl InProcessDaemon {
                         .ok_or_else(|| format!("vessel `{}` has no active session to anchor the handoff", context.vessel_ref))?
                 };
                 let current = self.crew_list_internal(requested).await?;
-                let brief = handoff_crew_brief(&context, &convoy, target, prompt.as_deref(), &current.members, &repository_refs);
+                let repo_roots = crew_brief_repo_roots(&self.resource_backend, &context.namespace, &convoy, &repository_refs).await;
+                let render_options = crate::agent_adapter::CrewBriefTemplateResolver::with_config_dir(self.config.base_path().as_path())
+                    .render_options(brief_template.as_deref(), convoy.spec.project_ref.as_deref(), repo_roots);
+                let brief =
+                    handoff_crew_brief(&context, &convoy, target, prompt.as_deref(), &current.members, &repository_refs, &render_options)?;
                 sessions
                     .create(&identity.input_meta(), &flotilla_resources::TerminalSessionSpec {
                         env_ref: anchor.spec.env_ref,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -660,11 +660,19 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
     let processes = vec![
         CrewSpec::builder()
             .role("coder".to_string())
-            .source(CrewSource::Agent { selector: Selector { capability: "coding".into() }, prompt: Some("Implement the change.".into()) })
+            .source(CrewSource::Agent {
+                selector: Selector { capability: "coding".into() },
+                prompt: Some("Implement the change.".into()),
+                brief_template: None,
+            })
             .build(),
         CrewSpec::builder()
             .role("reviewer".to_string())
-            .source(CrewSource::Agent { selector: Selector { capability: "review".into() }, prompt: Some("Review the change.".into()) })
+            .source(CrewSource::Agent {
+                selector: Selector { capability: "review".into() },
+                prompt: Some("Review the change.".into()),
+                brief_template: None,
+            })
             .build(),
     ];
     convoys

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1711,7 +1711,7 @@ impl Aggregator {
             .map(|process| {
                 let command_preview = match &process.source {
                     CrewSource::Tool { command } => command.clone(),
-                    CrewSource::Agent { selector, prompt } => prompt.clone().unwrap_or_else(|| selector.capability.clone()),
+                    CrewSource::Agent { selector, prompt, .. } => prompt.clone().unwrap_or_else(|| selector.capability.clone()),
                 };
                 CrewMemberSummary {
                     role: process.role.clone(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -731,16 +731,18 @@ fn spawn_controller_loops(
         tokio::spawn({
             let backend = backend.clone();
             let namespace_string = namespace_string.clone();
+            let config_dir = state.config.base_path().as_path().to_path_buf();
             let supervision = supervision.clone();
             async move {
                 supervise("vessel", supervision, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
+                    let config_dir = config_dir.clone();
                     async move {
                         ControllerLoop {
                             primary: backend.clone().using::<Vessel>(&namespace_string),
                             secondaries: VesselReconciler::secondary_watches(),
-                            reconciler: VesselReconciler::new(backend.clone(), &namespace_string),
+                            reconciler: VesselReconciler::new_with_config_dir(backend.clone(), &namespace_string, config_dir),
                             resync_interval: controller_resync_interval,
                             backend,
                         }
@@ -1995,6 +1997,7 @@ mod tests {
                     .source(CrewSource::Agent {
                         selector: Selector { capability: "custom-code".to_string() },
                         prompt: Some("Keep this definition".to_string()),
+                        brief_template: None,
                     })
                     .build()])
                 .build()])
@@ -2729,6 +2732,7 @@ mod tests {
                                     prompt: Some(
                                         "Implement issue 668 without leaking this full brief into the launch command.".to_string(),
                                     ),
+                                    brief_template: None,
                                 })
                                 .build(),
                             CrewSpec::builder()
@@ -2736,6 +2740,7 @@ mod tests {
                                 .source(CrewSource::Agent {
                                     selector: Selector { capability: "review".to_string() },
                                     prompt: Some("Review the coder's work.".to_string()),
+                                    brief_template: None,
                                 })
                                 .build(),
                             CrewSpec::builder()
@@ -3086,7 +3091,11 @@ mod tests {
                         .name("implement".to_string())
                         .crew(vec![CrewSpec::builder()
                             .role("architect".to_string())
-                            .source(CrewSource::Agent { selector: Selector { capability: "architect".to_string() }, prompt: None })
+                            .source(CrewSource::Agent {
+                                selector: Selector { capability: "architect".to_string() },
+                                prompt: None,
+                                brief_template: None,
+                            })
                             .build()])
                         .build()])
                     .build(),

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -72,6 +72,8 @@ pub enum CrewSource {
         selector: Selector,
         #[serde(default)]
         prompt: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        brief_template: Option<String>,
     },
     Tool {
         command: String,
@@ -90,7 +92,7 @@ pub fn single_agent_contained_workflow_spec() -> WorkflowTemplateSpec {
             .stance(Stance::Contained)
             .crew(vec![CrewSpec::builder()
                 .role("coder".to_string())
-                .source(CrewSource::Agent { selector: Selector { capability: "code".to_string() }, prompt: None })
+                .source(CrewSource::Agent { selector: Selector { capability: "code".to_string() }, prompt: None, brief_template: None })
                 .build()])
             .build()])
         .build()
@@ -444,6 +446,7 @@ mod tests {
                             .source(CrewSource::Agent {
                                 selector: Selector { capability: "code".to_string() },
                                 prompt: Some("Implement {{inputs.feature}} for {{workflow.name}}".to_string()),
+                                brief_template: None,
                             })
                             .build(),
                         CrewSpec::builder()
@@ -460,6 +463,7 @@ mod tests {
                         .source(CrewSource::Agent {
                             selector: Selector { capability: "code-review".to_string() },
                             prompt: Some("Review {{workflow.namespace}}".to_string()),
+                            brief_template: None,
                         })
                         .build()])
                     .build(),
@@ -522,6 +526,7 @@ mod tests {
         spec.vessels[0].crew[0].source = CrewSource::Agent {
             selector: Selector { capability: "code".to_string() },
             prompt: Some("Implement {{inputs.branch}}".to_string()),
+            brief_template: None,
         };
 
         let errors = validate(&spec).expect_err("unknown input references should fail");
@@ -541,6 +546,7 @@ mod tests {
         spec.vessels[0].crew[0].source = CrewSource::Agent {
             selector: Selector { capability: "code".to_string() },
             prompt: Some("Implement {{workflow.uid}}".to_string()),
+            brief_template: None,
         };
 
         let errors = validate(&spec).expect_err("unknown workflow fields should fail");
@@ -560,6 +566,7 @@ mod tests {
         spec.vessels[0].crew[0].source = CrewSource::Agent {
             selector: Selector { capability: "code".to_string() },
             prompt: Some("Implement {{inputs.feature }} and {{workflow.name.extra}}".to_string()),
+            brief_template: None,
         };
 
         let errors = validate(&spec).expect_err("malformed owned interpolation should fail");

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -132,6 +132,7 @@ pub fn valid_workflow_template_spec() -> WorkflowTemplateSpec {
                             prompt: Some(
                                 "Convoy {{workflow.name}} - implement {{inputs.feature}} on branch {{inputs.branch}}.".to_string(),
                             ),
+                            brief_template: None,
                         })
                         .build(),
                     CrewSpec::builder()
@@ -149,6 +150,7 @@ pub fn valid_workflow_template_spec() -> WorkflowTemplateSpec {
                         .source(CrewSource::Agent {
                             selector: Selector { capability: "code-review".to_string() },
                             prompt: Some("Review branch {{inputs.branch}} for correctness and style.".to_string()),
+                            brief_template: None,
                         })
                         .build(),
                     CrewSpec::builder()

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -634,7 +634,7 @@ fn bootstrap_preserves_agent_processes_for_runtime_resolution() {
     let Some(ConvoyStatusPatch::Bootstrap { workflow_snapshot, .. }) = outcome.patch else {
         panic!("agent workflow should bootstrap");
     };
-    let CrewSource::Agent { selector, prompt } = &workflow_snapshot.vessels[0].crew[0].source else {
+    let CrewSource::Agent { selector, prompt, .. } = &workflow_snapshot.vessels[0].crew[0].source else {
         panic!("agent source should survive in the workflow snapshot");
     };
     assert_eq!(selector.capability, "code");

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -25,6 +25,7 @@ fn sample_snapshot() -> WorkflowSnapshot {
                         source: CrewSource::Agent {
                             selector: Selector { capability: "code".to_string() },
                             prompt: Some("Implement {{inputs.feature}}".to_string()),
+                            brief_template: None,
                         },
                         labels: BTreeMap::new(),
                     },
@@ -45,6 +46,7 @@ fn sample_snapshot() -> WorkflowSnapshot {
                     source: CrewSource::Agent {
                         selector: Selector { capability: "code-review".to_string() },
                         prompt: Some("Review {{inputs.feature}}".to_string()),
+                        brief_template: None,
                     },
                     labels: BTreeMap::new(),
                 }],

--- a/crates/flotilla-resources/tests/workflow_template_validation.rs
+++ b/crates/flotilla-resources/tests/workflow_template_validation.rs
@@ -239,6 +239,28 @@ vessels:
 }
 
 #[test]
+fn parse_preserves_agent_brief_template_selection() {
+    let spec = parse_spec(
+        r#"
+inputs: []
+vessels:
+  - name: interact
+    crew:
+      - role: driver
+        selector:
+          capability: code
+        brief_template: interactive-session.md
+"#,
+    );
+
+    let flotilla_resources::CrewSource::Agent { brief_template, .. } = &spec.vessels[0].crew[0].source else {
+        panic!("driver should be agent-backed");
+    };
+    assert_eq!(brief_template.as_deref(), Some("interactive-session.md"));
+    assert!(validate(&spec).is_ok(), "brief template selection should validate");
+}
+
+#[test]
 fn parser_round_trip_preserves_sample_workflow() {
     let first: WorkflowTemplateDocument = serde_yml::from_str(valid_workflow_template_yaml()).expect("parse workflow template document");
     let encoded = serde_yml::to_string(&first.spec).expect("serialize workflow template spec");


### PR DESCRIPTION
## Summary

- Move generated crew brief bodies into bundled minijinja templates while preserving the default `crew.md` output byte-for-byte.
- Add fleet/project/repo override resolution with block-only override layering, including repo-level overrides from `.flotilla/brief-templates/<template>`.
- Add `brief_template` selection to agent workflow crew entries and wire initial provisioning plus handoff-created sessions through the shared renderer.

Closes #960.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`