### PR TITLE
docs: add agent skills config (issue tracker, triage labels, domain docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,20 @@ Use labels to tag topics. Combine as appropriate (e.g. `bug` + `ui`, or `from-re
 | `duplicate` | Already exists |
 | `wontfix` | Will not be worked on |
 
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked on GitHub at `flotilla-org/flotilla` (always pass `-R flotilla-org/flotilla`); external PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical triage roles map to repo labels; `ready-for-agent` maps to the existing `ready` label. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
 ## Testing Providers with Record/Replay
 
 Providers (git, GitHub, Claude, etc.) integrate with external systems. The `replay` module captures and replays interactions to enable deterministic, offline testing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Issues have a **type** (lifecycle stage) and **labels** (topic tags). `gh issue 
 | `Feature` | A request, idea, or new functionality |
 | `Brainstorm` | Needs design thinking before it can become a task or feature |
 
-Use labels to tag topics. Combine as appropriate (e.g. `bug` + `ui`, or `from-review` + `refactor` + `quick-win`).
+Use labels to tag topics. Combine as appropriate (e.g. `bug` + `ui`, or `from-review` + `refactor` + `quick-win`). Triage-state labels (`needs-triage`, `needs-info`, `ready`, `ready-for-human`, `wontfix`) are a separate, orthogonal vocabulary — see `docs/agents/triage-labels.md`.
 
 | Label | Use for |
 |-------|---------|

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,37 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **single-context** repo: one `CONTEXT.md` and one `docs/adr/` at the repo root cover the whole Cargo workspace. There is no `CONTEXT-MAP.md` and no per-crate ADR directories.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the project's domain language and current-state map.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. They are numbered and cumulative (0001 onwards); later ADRs refine earlier ones.
+- **`docs/roadmap.md`** and the **Plane-A freeze** section of `CLAUDE.md` — these constrain what work is admissible. Plane A (correlation, `WorkItem`, the `ProviderData → WorkItem → Snapshot` pipeline, peer-merge) is bugfix-only; new capability belongs on the control-plane side.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-k8s-isomorphic-resource-model.md
+│   ├── 0002-multi-host-is-resource-store-federation.md
+│   └── …
+└── crates/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids (e.g. **Task == Vessel**; legs are implicit and orthogonal to vessels).
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0003 (observed/adopted/managed resources) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -26,7 +26,7 @@ If any of these files don't exist, **proceed silently**. Don't flag their absenc
 
 ## Use the glossary's vocabulary
 
-When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids (e.g. **Task == Vessel**; legs are implicit and orthogonal to vessels).
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids — e.g. `Task` is retired (it conflated stage with placement and is ambiguous between `Leg` and `Vessel`); say `Vessel` for the placement unit or `Leg` for the workflow phase.
 
 If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,56 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on **`flotilla-org/flotilla`**. Use the `gh` CLI for all operations.
+
+**Always pass `-R flotilla-org/flotilla` explicitly.** Do not rely on `gh` inferring the repo from `git remote` — clones of this repo may be forks (e.g. `changedirection/flotilla` for Claude Code Web sessions) whose remotes point elsewhere, while issues and PRs always live upstream.
+
+## Conventions
+
+- **Create an issue**: `gh issue create -R flotilla-org/flotilla --title "..." --body "..."`. Use a heredoc for multi-line bodies. Then set the issue type (see below).
+- **Read an issue**: `gh issue view <number> -R flotilla-org/flotilla --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list -R flotilla-org/flotilla --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> -R flotilla-org/flotilla --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> -R flotilla-org/flotilla --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> -R flotilla-org/flotilla --comment "..."`
+
+## Issue types
+
+Every issue gets a **type** (lifecycle stage), distinct from labels: `Task`, `Bug`, `Feature`, or `Brainstorm`. `gh issue create` does not support `--type`, so set it after creation via the API:
+
+```bash
+gh api -X PATCH repos/flotilla-org/flotilla/issues/<number> -f type="TypeName"
+```
+
+| Type | Use for |
+|------|---------|
+| `Task` | A specific piece of work |
+| `Bug` | An unexpected problem or behavior |
+| `Feature` | A request, idea, or new functionality |
+| `Brainstorm` | Needs design thinking before it can become a task or feature |
+
+## Labels
+
+Triage-role labels are mapped in `docs/agents/triage-labels.md`. Topic labels (`bug`, `ui`, `multi-host`, `from-review`, `quick-win`, …) are documented in the "Issue Types and Labels" section of `CLAUDE.md` — combine as appropriate.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** External PRs go through the normal review flow; `/triage` only reads issues.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue on `flotilla-org/flotilla` (and set its type).
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> -R flotilla-org/flotilla --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create -R flotilla-org/flotilla --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/flotilla-org/flotilla/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/flotilla-org/flotilla/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list -R flotilla-org/flotilla --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> -R flotilla-org/flotilla --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> -R flotilla-org/flotilla --body "<answer>"`, then `gh issue close <n> -R flotilla-org/flotilla`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,21 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used on `flotilla-org/flotilla`.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                                                    |
+| -------------------------- | -------------------- | -------------------------------------------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue                                     |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information                                    |
+| `ready-for-agent`          | `ready`              | Earned: body alone is a dispatchable contract — an agent can start NOW      |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation                                               |
+| `wontfix`                  | `wontfix`            | Will not be actioned                                                        |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+## `ready` is earned, not applied
+
+`ready` follows the board's body-is-contract discipline: the issue **body alone** must be a dispatchable contract — an agent with no other context can pick it up and start. After a grill or a split, rewrite the body into that contract *before* touching the label. Never apply `ready` as a courtesy or a guess.
+
+## Orthogonal to types and topic labels
+
+Triage roles say where an issue sits in the triage state machine. They are orthogonal to the issue **type** (`Task`/`Bug`/`Feature`/`Brainstorm`) and to topic labels (`bug`, `ui`, `multi-host`, `quick-win`, …) — see `docs/agents/issue-tracker.md` and the "Issue Types and Labels" section of `CLAUDE.md`.


### PR DESCRIPTION
Scaffolds the per-repo configuration that the mattpocock engineering skills (`triage`, `to-issues`, `to-prd`, `qa`, `wayfinder`, `domain-modeling`, `tdd`, `diagnosing-bugs`) read:

- **`docs/agents/issue-tracker.md`** — GitHub tracker on `flotilla-org/flotilla`, with `-R` mandatory on every `gh` call (fork clones can't rely on remote inference), the issue-type convention (Task/Bug/Feature/Brainstorm set via `gh api PATCH`), PRs-as-request-surface off, and wayfinder operations.
- **`docs/agents/triage-labels.md`** — maps the five canonical triage roles to repo labels; `ready-for-agent` maps to the existing `ready` label and documents its earned, body-is-contract semantics.
- **`docs/agents/domain.md`** — single-context layout (root `CONTEXT.md` + `docs/adr/`), with the Plane-A freeze and roadmap called out as admissibility constraints.
- **`CLAUDE.md`** — new `## Agent skills` section pointing at the three docs.

Also created the missing triage labels on the repo: `needs-triage`, `needs-info`, `ready-for-human` (`ready` and `wontfix` already existed).