### PR TITLE
fix: filter awareness issues by ready label

### DIFF
--- a/crates/flotilla-commands/src/commands/issue.rs
+++ b/crates/flotilla-commands/src/commands/issue.rs
@@ -64,7 +64,7 @@ impl IssueNoun {
                     // SENTINEL: repo is empty — dispatch must fill it from --repo or FLOTILLA_REPO.
                     action: CommandAction::QueryIssues {
                         repo: RepoSelector::Query("".into()),
-                        params: IssueQuery { search: Some(query.join(" ")) },
+                        params: IssueQuery { search: Some(query.join(" ")), label: None },
                         page: 1,
                         count: 50,
                     },
@@ -169,7 +169,7 @@ mod tests {
                 context_repo: None,
                 action: CommandAction::QueryIssues {
                     repo: RepoSelector::Query("".into()),
-                    params: flotilla_protocol::issue_query::IssueQuery { search: Some("my query".into()) },
+                    params: flotilla_protocol::issue_query::IssueQuery { search: Some("my query".into()), label: None },
                     page: 1,
                     count: 50,
                 },

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use flotilla_protocol::{
+    issue_query::READY_ISSUE_LABEL,
     result_set::{
         AwarenessGrouping, AwarenessLimit, CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryId, QueryScope, ResultDelta,
         ResultSet, ResultSetState, Rows,
@@ -213,7 +214,7 @@ impl AggregatorProjectionState {
         let mut expanded = cursors.to_vec();
         if cursors.iter().any(|cursor| matches!(cursor.query, QueryId::Awareness { scope: None, .. })) {
             for scope in self.checkouts.read().await.project_scopes() {
-                let query = QueryId::Issues { scope, search: None };
+                let query = QueryId::Issues { scope, search: None, label: Some(READY_ISSUE_LABEL.into()) };
                 if !expanded.iter().any(|cursor| cursor.query == query) {
                     expanded.push(QueryCursor { query, since: None });
                 }
@@ -340,7 +341,9 @@ impl AggregatorProjectionState {
         scopes
             .into_iter()
             .filter_map(|scope| {
-                self.demand_backed.result_set(&QueryId::Issues { scope: scope.clone(), search: None }).map(|set| (scope, set))
+                self.demand_backed
+                    .result_set(&QueryId::Issues { scope: scope.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) })
+                    .map(|set| (scope, set))
             })
             .collect()
     }
@@ -437,7 +440,11 @@ mod tests {
         let awareness = QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
         state.replace_subscriber_expanding_awareness(Uuid::new_v4(), &[QueryCursor { query: awareness, since: None }]).await;
 
-        assert!(state.subscribe_demand().borrow().contains_key(&QueryId::Issues { scope: project, search: None }));
+        assert!(state.subscribe_demand().borrow().contains_key(&QueryId::Issues {
+            scope: project,
+            search: None,
+            label: Some(READY_ISSUE_LABEL.into()),
+        }));
     }
 
     #[tokio::test]
@@ -450,7 +457,7 @@ mod tests {
                 HashMap::from([(project.clone(), vec![])]),
             )
             .await;
-        let issue_query = QueryId::Issues { scope: project.clone(), search: None };
+        let issue_query = QueryId::Issues { scope: project.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) };
         state.replace_subscriber(Uuid::new_v4(), &[QueryCursor { query: issue_query.clone(), since: None }]);
         let generation = *state.subscribe_demand().borrow().get(&issue_query).expect("issue query generation");
         state.replace_issues(&issue_query, generation, vec![issue_row("flotilla-org/flotilla", "862")], ResultSetState {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4229,7 +4229,7 @@ async fn issue_subscription_materializes_until_its_in_process_handle_drops() {
         InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
     let subscriber = uuid::Uuid::new_v4();
     let subscription = daemon.query_subscription(subscriber);
-    let query = QueryId::Issues { scope: QueryScope::new("flotilla", "abc"), search: None };
+    let query = QueryId::Issues { scope: QueryScope::new("flotilla", "abc"), search: None, label: None };
 
     let events =
         daemon.subscribe_queries(subscriber, &[QueryCursor { query: query.clone(), since: None }]).await.expect("subscribe to issue query");
@@ -4254,7 +4254,7 @@ async fn recreated_issue_materialization_replays_even_when_cursor_matches_initia
     let daemon =
         InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
     let subscriber = uuid::Uuid::new_v4();
-    let query = QueryId::Issues { scope: QueryScope::new("flotilla", "recreated"), search: None };
+    let query = QueryId::Issues { scope: QueryScope::new("flotilla", "recreated"), search: None, label: None };
 
     daemon.subscribe_queries(subscriber, &[QueryCursor { query: query.clone(), since: None }]).await.expect("initial subscription");
     daemon.unsubscribe_queries(subscriber).await;

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -1315,7 +1315,7 @@ mod tests {
         let second = provider.query(&source, &IssueQuery::default(), 2, 1).await.expect("second page");
         assert_eq!(second.items[0].reference.id, "opaque-A");
         assert!(!second.has_more);
-        let search = provider.query(&source, &IssueQuery { search: Some("newer".into()) }, 1, 10).await.expect("search");
+        let search = provider.query(&source, &IssueQuery { search: Some("newer".into()), label: None }, 1, 10).await.expect("search");
         assert_eq!(search.items[0].reference.id, "opaque-B");
 
         let changes = provider.list_changed_since(&source, &cutoff, 10).await.expect("cutoff changes");

--- a/crates/flotilla-core/src/providers/issue_tracker/github.rs
+++ b/crates/flotilla-core/src/providers/issue_tracker/github.rs
@@ -75,8 +75,11 @@ impl super::IssueProvider for GitHubIssueProvider {
         let as_of = Utc::now();
         let (items, has_more, total) = match &params.search {
             None => {
-                let endpoint =
-                    format!("repos/{}/issues?state=open&sort=updated&direction=desc&per_page={}&page={}", source.scope, per_page, page);
+                let label = params.label.as_ref().map(|label| format!("&labels={}", urlencoding::encode(label))).unwrap_or_default();
+                let endpoint = format!(
+                    "repos/{}/issues?state=open&sort=updated&direction=desc&per_page={}&page={}{}",
+                    source.scope, per_page, page, label
+                );
                 let response = gh_api_get_with_headers!(self.api, &endpoint, &self.host_root)?;
                 let raw_items: Vec<serde_json::Value> = serde_json::from_str(&response.body).map_err(|error| error.to_string())?;
                 let issues = raw_items
@@ -87,7 +90,8 @@ impl super::IssueProvider for GitHubIssueProvider {
                 (issues, response.has_next_page, None)
             }
             Some(search_term) => {
-                let raw_query = format!("repo:{} is:issue is:open {}", source.scope, search_term);
+                let label = params.label.as_ref().map(|label| format!(" label:\"{label}\"")).unwrap_or_default();
+                let raw_query = format!("repo:{} is:issue is:open{} {}", source.scope, label, search_term);
                 let encoded_query = urlencoding::encode(&raw_query);
                 let endpoint = format!("search/issues?q={}&sort=updated&order=desc&per_page={}&page={}", encoded_query, per_page, page);
                 let response = gh_api_get_with_headers!(self.api, &endpoint, &self.host_root)?;
@@ -254,11 +258,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_sends_label_filter_to_github() {
+        let api = Arc::new(MockGhApi::new(vec![ok_response("[]", false)]));
+        let provider = GitHubIssueProvider::new(api.clone(), Arc::new(MockRunner::new(vec![])), Path::new("/neutral"));
+
+        provider
+            .query(&source(), &IssueQuery { search: None, label: Some("ready now".into()) }, 2, 10)
+            .await
+            .expect("label-filtered issue query should succeed");
+
+        assert_eq!(api.requests(), vec![(
+            "repos/owner/repo/issues?state=open&sort=updated&direction=desc&per_page=10&page=2&labels=ready%20now".into(),
+            PathBuf::from("/neutral"),
+        )]);
+    }
+
+    #[tokio::test]
     async fn search_query_returns_total_and_pagination() {
         let body = r#"{"total_count":5,"items":[{"number":1,"title":"Bug","state":"open","labels":[]}]}"#;
         let provider = mock_provider(vec![ok_response(body, true)]);
 
-        let page = provider.query(&source(), &IssueQuery { search: Some("bug".into()) }, 2, 10).await.expect("issue search should succeed");
+        let page = provider
+            .query(&source(), &IssueQuery { search: Some("bug".into()), label: None }, 2, 10)
+            .await
+            .expect("issue search should succeed");
 
         assert_eq!(page.items.len(), 1);
         assert_eq!(page.total, Some(5));

--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -5,8 +5,8 @@ use std::{
 
 use chrono::Utc;
 use flotilla_protocol::{
-    DemandBackedMetadata, IssueRef, IssueRow, QueryChanges, QueryCursor, QueryId, ResultDelta, ResultSet, ResultSetCondition,
-    ResultSetState, Rows,
+    issue_query::READY_ISSUE_LABEL, DemandBackedMetadata, IssueRef, IssueRow, QueryChanges, QueryCursor, QueryId, ResultDelta, ResultSet,
+    ResultSetCondition, ResultSetState, Rows,
 };
 use tokio::sync::{broadcast, watch};
 use uuid::Uuid;
@@ -58,7 +58,7 @@ impl QueryRegistry {
                 continue;
             }
             for scope in scopes {
-                queries.insert(QueryId::Issues { scope: scope.clone(), search: None });
+                queries.insert(QueryId::Issues { scope: scope.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) });
             }
         }
         let created = reconcile_demand(&mut state);
@@ -84,7 +84,7 @@ impl QueryRegistry {
     /// Replace the current window of a live issue materialization. A fetch
     /// that completes after the last subscriber left is discarded.
     pub fn replace_issues(&self, query: &QueryId, generation: u64, rows: Vec<IssueRow>, result_state: ResultSetState) -> Option<ResultSet> {
-        let QueryId::Issues { scope, search } = query else { return None };
+        let QueryId::Issues { scope, search, label } = query else { return None };
         let mut state = self.inner.lock().expect("query registry lock poisoned");
         if state.generations.get(query) != Some(&generation) {
             return None;
@@ -92,7 +92,7 @@ impl QueryRegistry {
         let current = state.demand_backed.get_mut(query)?;
         *current = ResultSet {
             seq: current.seq.saturating_add(1),
-            rows: Rows::Issues { scope: scope.clone(), search: search.clone(), rows },
+            rows: Rows::Issues { scope: scope.clone(), search: search.clone(), label: label.clone(), rows },
             state: result_state,
         };
         Some(current.clone())
@@ -108,7 +108,7 @@ impl QueryRegistry {
         removed: Vec<IssueRef>,
         result_state: ResultSetState,
     ) -> Option<ResultDelta> {
-        let QueryId::Issues { scope, search } = query else { return None };
+        let QueryId::Issues { scope, search, label } = query else { return None };
         let mut registry = self.inner.lock().expect("query registry lock poisoned");
         if registry.generations.get(query) != Some(&generation) {
             return None;
@@ -128,7 +128,7 @@ impl QueryRegistry {
         current.state = result_state.clone();
         Some(ResultDelta {
             seq: current.seq,
-            changes: QueryChanges::Issues { scope: scope.clone(), search: search.clone(), changed, removed },
+            changes: QueryChanges::Issues { scope: scope.clone(), search: search.clone(), label: label.clone(), changed, removed },
             state: Some(result_state),
         })
     }
@@ -140,7 +140,7 @@ impl QueryRegistry {
         let mut registry = self.inner.lock().expect("query registry lock poisoned");
         let mut deltas = Vec::new();
         for (query, current) in &mut registry.demand_backed {
-            let QueryId::Issues { scope, search } = query else { continue };
+            let QueryId::Issues { scope, search, label } = query else { continue };
             let Rows::Issues { rows, .. } = &mut current.rows else { continue };
             let mut removed = Vec::new();
             rows.retain(|row| {
@@ -158,7 +158,13 @@ impl QueryRegistry {
             let result_state = current.state.clone();
             deltas.push(ResultDelta {
                 seq: current.seq,
-                changes: QueryChanges::Issues { scope: scope.clone(), search: search.clone(), changed: Vec::new(), removed },
+                changes: QueryChanges::Issues {
+                    scope: scope.clone(),
+                    search: search.clone(),
+                    label: label.clone(),
+                    changed: Vec::new(),
+                    removed,
+                },
                 state: Some(result_state.clone()),
             });
         }
@@ -222,16 +228,18 @@ fn reconcile_demand(state: &mut RegistryState) -> HashSet<QueryId> {
 fn issue_demand_query(query: &QueryId) -> Option<QueryId> {
     match query {
         QueryId::Issues { .. } => Some(query.clone()),
-        QueryId::Awareness { scope: Some(scope), .. } => Some(QueryId::Issues { scope: scope.clone(), search: None }),
+        QueryId::Awareness { scope: Some(scope), .. } => {
+            Some(QueryId::Issues { scope: scope.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) })
+        }
         QueryId::Convoys | QueryId::Independents { .. } | QueryId::Checkouts { .. } | QueryId::Awareness { scope: None, .. } => None,
     }
 }
 
 fn unavailable_issues_result_set(query: QueryId) -> ResultSet {
-    let QueryId::Issues { scope, search } = query else { unreachable!("demand-backed registry only materializes issue queries") };
+    let QueryId::Issues { scope, search, label } = query else { unreachable!("demand-backed registry only materializes issue queries") };
     ResultSet {
         seq: 1,
-        rows: Rows::Issues { scope, search, rows: vec![] },
+        rows: Rows::Issues { scope, search, label, rows: vec![] },
         state: ResultSetState {
             demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: false }),
             conditions: vec![ResultSetCondition::IssueSourceUnavailable {
@@ -249,7 +257,7 @@ mod tests {
     use super::*;
 
     fn issues(name: &str) -> QueryId {
-        QueryId::Issues { scope: QueryScope::new("flotilla", name), search: None }
+        QueryId::Issues { scope: QueryScope::new("flotilla", name), search: None, label: None }
     }
 
     fn awareness(name: &str) -> QueryId {
@@ -392,7 +400,8 @@ mod tests {
     #[test]
     fn project_awareness_subscription_demands_its_issue_window() {
         let registry = QueryRegistry::default();
-        let issue_query = issues("roadmap");
+        let issue_query =
+            QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None, label: Some(READY_ISSUE_LABEL.into()) };
         registry.replace(Uuid::new_v4(), &[cursor(awareness("roadmap"))]);
 
         assert!(registry.result_set(&issue_query).is_some());

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -581,7 +581,7 @@ mod tests {
         github_api::GhApiClient, issue_tracker::github::GitHubIssueProvider, ChannelLabel, CommandOutput, CommandRunner,
     };
     use flotilla_protocol::{
-        issue_query::IssueResultPage,
+        issue_query::{IssueResultPage, READY_ISSUE_LABEL},
         result_set::{ConvoyIssueRow, ConvoyPhase, ConvoyRow},
         test_support::TestIssue,
         Issue, IssueChangeset, QueryCursor, ResourceRef,
@@ -1091,6 +1091,49 @@ mod tests {
                 .map(|row| row.reference.id.as_str())
                 .collect::<Vec<_>>(),
             vec!["NEW-10"]
+        );
+    }
+
+    #[tokio::test]
+    async fn incremental_refresh_reconciles_label_filter_membership() {
+        let state = AggregatorProjectionState::new();
+        let query = QueryId::Issues {
+            scope: QueryScope::new("flotilla", "repo_ready_refresh"),
+            search: None,
+            label: Some(READY_ISSUE_LABEL.into()),
+        };
+        let source = IssueSource { service: "https://issues.example".into(), scope: "ready/refresh".into() };
+        let mut loses_ready = issue("LOSES-READY");
+        loses_ready.labels = vec![READY_ISSUE_LABEL.into()];
+        let mut gains_ready = issue("GAINS-READY");
+        gains_ready.labels = vec![READY_ISSUE_LABEL.into()];
+        let provider =
+            Arc::new(ScriptedProvider::new(vec![IssueResultPage { items: vec![loses_ready], total: Some(1), has_more: false }], vec![
+                IssueChangeset { updated: vec![issue("LOSES-READY"), gains_ready], closed: vec![], has_more: false },
+            ]));
+        let (materializer, mut events) = manager(&state, &query, vec![source.clone()], provider);
+        let _ = next_event(&mut events).await;
+
+        materializer.refresh(&query);
+
+        let DaemonEvent::ResultDelta(delta) = next_event(&mut events).await else { panic!("refresh must emit a delta") };
+        assert_eq!(delta.changes.as_issues().expect("newly ready issue")[0].reference, IssueRef {
+            source: source.clone(),
+            id: "GAINS-READY".into()
+        });
+        assert_eq!(delta.changes.removed_issues().expect("issue that lost ready"), &[IssueRef { source, id: "LOSES-READY".into() }]);
+        assert_eq!(
+            state
+                .result_set_for(&query)
+                .await
+                .expect("refreshed ready window")
+                .rows
+                .as_issues()
+                .expect("ready issue rows")
+                .iter()
+                .map(|row| row.reference.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["GAINS-READY"]
         );
     }
 

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -251,8 +251,8 @@ async fn load_window(
     state: &AggregatorProjectionState,
     event_tx: &broadcast::Sender<DaemonEvent>,
 ) -> MaterializedWindow {
-    let QueryId::Issues { scope, search } = query else { unreachable!("issue materializer only accepts issue queries") };
-    let params = IssueQuery { search: search.clone() };
+    let QueryId::Issues { scope, search, label } = query else { unreachable!("issue materializer only accepts issue queries") };
+    let params = IssueQuery { search: search.clone(), label: label.clone() };
     let sources = match resolver.resolve_issue_sources(scope).await {
         Ok(sources) if !sources.is_empty() => sources,
         Ok(_) => {
@@ -433,7 +433,7 @@ async fn refresh_window(
                 }
                 for issue in changes.updated {
                     let reference = issue.reference.clone();
-                    if issue.state == IssueState::Open {
+                    if issue.state == IssueState::Open && issue_matches_query(&issue, query) {
                         source.rows.insert(reference.clone(), IssueRow { reference, issue });
                     } else {
                         source.rows.remove(&reference);
@@ -557,8 +557,13 @@ async fn query_page(
 }
 
 fn issue_params(query: &QueryId) -> IssueQuery {
-    let QueryId::Issues { search, .. } = query else { unreachable!("issue params require an issue query") };
-    IssueQuery { search: search.clone() }
+    let QueryId::Issues { search, label, .. } = query else { unreachable!("issue params require an issue query") };
+    IssueQuery { search: search.clone(), label: label.clone() }
+}
+
+fn issue_matches_query(issue: &flotilla_protocol::Issue, query: &QueryId) -> bool {
+    let QueryId::Issues { label, .. } = query else { return false };
+    label.as_ref().is_none_or(|label| issue.labels.iter().any(|candidate| candidate.eq_ignore_ascii_case(label)))
 }
 
 async fn changed_since(
@@ -824,7 +829,7 @@ mod tests {
     }
 
     fn project_query(name: &str) -> QueryId {
-        QueryId::Issues { scope: QueryScope::new("flotilla", name), search: None }
+        QueryId::Issues { scope: QueryScope::new("flotilla", name), search: None, label: None }
     }
 
     fn subscribe(state: &AggregatorProjectionState, query: &QueryId) -> u64 {
@@ -952,7 +957,7 @@ mod tests {
     #[tokio::test]
     async fn project_demand_unions_constituent_source_windows() {
         let state = AggregatorProjectionState::new();
-        let query = QueryId::Issues { scope: QueryScope::new("flotilla", "platform"), search: None };
+        let query = QueryId::Issues { scope: QueryScope::new("flotilla", "platform"), search: None, label: None };
         let source_a = IssueSource { service: "https://issues.example".into(), scope: "widgets/api".into() };
         let source_b = IssueSource { service: "https://issues.example".into(), scope: "widgets/ui".into() };
         let provider = Arc::new(ScriptedProvider::new(vec![page(&["WIDGET-123"], false), page(&["WIDGET-123"], false)], vec![]));

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -385,7 +385,7 @@ async fn project_issue_subscription_materializes_window_and_ephemeral_search() {
     let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), Arc::clone(&config), None, options).await.expect("start runtime");
     let mut events = daemon.subscribe();
     let scope = QueryScope::new("flotilla", "widgets");
-    let query = QueryId::Issues { scope: scope.clone(), search: None };
+    let query = QueryId::Issues { scope: scope.clone(), search: None, label: None };
 
     daemon
         .subscribe_queries(uuid::Uuid::new_v4(), &[QueryCursor { query: query.clone(), since: None }])
@@ -424,7 +424,7 @@ async fn project_issue_subscription_materializes_window_and_ephemeral_search() {
     assert_eq!(delta.changes.as_issues().expect("appended issue rows")[0].reference.id, "WIDGET-050");
     assert!(!delta.state.as_ref().and_then(|state| state.demand.as_ref()).expect("updated demand metadata").has_more);
 
-    let search = QueryId::Issues { scope, search: Some("WIDGET-050".into()) };
+    let search = QueryId::Issues { scope, search: Some("WIDGET-050".into()), label: None };
     daemon
         .subscribe_queries(uuid::Uuid::new_v4(), &[QueryCursor { query: search.clone(), since: None }])
         .await

--- a/crates/flotilla-protocol/src/issue_query.rs
+++ b/crates/flotilla-protocol/src/issue_query.rs
@@ -4,10 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::provider_data::Issue;
 
+/// The label that makes an issue eligible for the awareness band.
+pub const READY_ISSUE_LABEL: &str = "ready";
+
 /// Parameters for an issue query.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IssueQuery {
     pub search: Option<String>,
+    pub label: Option<String>,
 }
 
 /// A single page of query results.
@@ -27,6 +31,7 @@ mod tests {
     fn issue_query_default_has_no_search() {
         let q = IssueQuery::default();
         assert!(q.search.is_none());
+        assert!(q.label.is_none());
     }
 
     #[test]

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -684,7 +684,7 @@ fn subscribe_queries_request_round_trips_cursors() {
 
 #[test]
 fn fetch_more_request_round_trips_parameterized_query() {
-    let request = Request::FetchMore { query: QueryId::Issues { scope: QueryScope::new("flotilla", "widget"), search: None } };
+    let request = Request::FetchMore { query: QueryId::Issues { scope: QueryScope::new("flotilla", "widget"), search: None, label: None } };
     let encoded = serde_json::to_string(&request).expect("serialize fetch-more request");
     assert!(encoded.contains("\"fetch_more\""));
     assert_eq!(serde_json::from_str::<Request>(&encoded).expect("deserialize fetch-more request"), request);

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -41,6 +41,9 @@ pub enum QueryId {
         /// window for the Project.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         search: Option<String>,
+        /// An optional provider-side label filter.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
     },
     /// Concrete observed checkouts fleet-wide (`None`) or in one Project.
     Checkouts { scope: Option<QueryScope> },
@@ -151,6 +154,8 @@ pub enum QueryChanges {
         scope: QueryScope,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         search: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
         changed: Vec<IssueRow>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         removed: Vec<IssueRef>,
@@ -176,7 +181,9 @@ impl QueryChanges {
         match self {
             Self::Convoys { .. } => QueryId::Convoys,
             Self::Independents { scope, .. } => QueryId::Independents { scope: scope.clone() },
-            Self::Issues { scope, search, .. } => QueryId::Issues { scope: scope.clone(), search: search.clone() },
+            Self::Issues { scope, search, label, .. } => {
+                QueryId::Issues { scope: scope.clone(), search: search.clone(), label: label.clone() }
+            }
             Self::Checkouts { scope, .. } => QueryId::Checkouts { scope: scope.clone() },
             Self::Awareness { scope, grouping, limit, .. } => {
                 QueryId::Awareness { scope: scope.clone(), grouping: *grouping, limit: *limit }
@@ -308,6 +315,8 @@ pub enum Rows {
         scope: QueryScope,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         search: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
         rows: Vec<IssueRow>,
     },
     Checkouts {
@@ -327,7 +336,9 @@ impl Rows {
         match self {
             Self::Convoys(_) => QueryId::Convoys,
             Self::Independents { scope, .. } => QueryId::Independents { scope: scope.clone() },
-            Self::Issues { scope, search, .. } => QueryId::Issues { scope: scope.clone(), search: search.clone() },
+            Self::Issues { scope, search, label, .. } => {
+                QueryId::Issues { scope: scope.clone(), search: search.clone(), label: label.clone() }
+            }
             Self::Checkouts { scope, .. } => QueryId::Checkouts { scope: scope.clone() },
             Self::Awareness { scope, grouping, limit, .. } => {
                 QueryId::Awareness { scope: scope.clone(), grouping: *grouping, limit: *limit }
@@ -957,7 +968,7 @@ mod tests {
 
     #[test]
     fn issues_query_round_trips_with_owned_project_scope() {
-        let query = QueryId::Issues { scope: QueryScope::new("flotilla", "dashboard"), search: None };
+        let query = QueryId::Issues { scope: QueryScope::new("flotilla", "dashboard"), search: None, label: None };
 
         let json = serde_json::to_string(&query).expect("serialize scoped query");
         assert_eq!(json, r#"{"issues":{"scope":{"namespace":"flotilla","name":"dashboard"}}}"#);
@@ -966,10 +977,19 @@ mod tests {
 
     #[test]
     fn ephemeral_issue_search_is_part_of_query_identity() {
-        let query = QueryId::Issues { scope: QueryScope::new("flotilla", "dashboard"), search: Some("is:open crash".into()) };
+        let query = QueryId::Issues { scope: QueryScope::new("flotilla", "dashboard"), search: Some("is:open crash".into()), label: None };
 
         let json = serde_json::to_string(&query).expect("serialize scoped query");
         assert_eq!(json, r#"{"issues":{"scope":{"namespace":"flotilla","name":"dashboard"},"search":"is:open crash"}}"#);
+        assert_eq!(serde_json::from_str::<QueryId>(&json).expect("deserialize scoped query"), query);
+    }
+
+    #[test]
+    fn issue_label_filter_is_part_of_query_identity() {
+        let query = QueryId::Issues { scope: QueryScope::new("flotilla", "dashboard"), search: None, label: Some("ready".into()) };
+
+        let json = serde_json::to_string(&query).expect("serialize scoped query");
+        assert_eq!(json, r#"{"issues":{"scope":{"namespace":"flotilla","name":"dashboard"},"label":"ready"}}"#);
         assert_eq!(serde_json::from_str::<QueryId>(&json).expect("deserialize scoped query"), query);
     }
 
@@ -983,6 +1003,7 @@ mod tests {
             changes: QueryChanges::Issues {
                 scope: scope.clone(),
                 search: None,
+                label: None,
                 changed: vec![IssueRow {
                     reference: reference.clone(),
                     issue: Issue {
@@ -1003,7 +1024,7 @@ mod tests {
             state: None,
         };
 
-        assert_eq!(delta.query(), QueryId::Issues { scope, search: None });
+        assert_eq!(delta.query(), QueryId::Issues { scope, search: None, label: None });
         let json = serde_json::to_string(&delta).expect("serialize issue delta");
         let decoded = serde_json::from_str::<ResultDelta>(&json).expect("deserialize issue delta");
         assert_eq!(decoded, delta);
@@ -1026,7 +1047,7 @@ mod tests {
         };
         let delta = ResultDelta {
             seq: 2,
-            changes: QueryChanges::Issues { scope, search: None, changed: vec![], removed: vec![] },
+            changes: QueryChanges::Issues { scope, search: None, label: None, changed: vec![], removed: vec![] },
             state: Some(state.clone()),
         };
 

--- a/crates/flotilla-tui/src/app/issue_view.rs
+++ b/crates/flotilla-tui/src/app/issue_view.rs
@@ -306,7 +306,7 @@ mod tests {
             pending_fetch: None,
         });
         state.search = Some(IssuePagingState {
-            params: IssueQuery { search: Some("search".into()) },
+            params: IssueQuery { search: Some("search".into()), label: None },
             items: vec![test_issue("2", "Search result")],
             next_page: 2,
             total: Some(1),
@@ -381,7 +381,7 @@ mod tests {
             pending_fetch: None,
         });
         state.search = Some(IssuePagingState {
-            params: IssueQuery { search: Some("test".into()) },
+            params: IssueQuery { search: Some("test".into()), label: None },
             items: vec![],
             next_page: 1,
             total: None,

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -1848,7 +1848,7 @@ fn set_search_query_resets_search_paging_state() {
     let mut view = IssueViewState::new();
     view.search_query = Some("alpha".into());
     view.search = Some(IssuePagingState {
-        params: IssueQuery { search: Some("alpha".into()) },
+        params: IssueQuery { search: Some("alpha".into()), label: None },
         items: vec![TestIssue::new("Alpha result").id("1").build()],
         next_page: 2,
         total: Some(10),
@@ -1880,7 +1880,7 @@ fn stale_search_results_discarded_by_drain() {
     let mut view = IssueViewState::new();
     view.search_query = Some("beta".into());
     view.search = Some(IssuePagingState {
-        params: IssueQuery { search: Some("beta".into()) },
+        params: IssueQuery { search: Some("beta".into()), label: None },
         items: vec![],
         next_page: 1,
         total: None,
@@ -1893,7 +1893,7 @@ fn stale_search_results_discarded_by_drain() {
     app.issue_update_tx
         .send(IssueQueryUpdate::PageFetched {
             repo: repo.clone(),
-            params: IssueQuery { search: Some("alpha".into()) },
+            params: IssueQuery { search: Some("alpha".into()), label: None },
             requested_page: 1,
             page: IssueResultPage {
                 items: vec![TestIssue::new("Stale alpha result").id("stale").build()],
@@ -1907,7 +1907,7 @@ fn stale_search_results_discarded_by_drain() {
     app.issue_update_tx
         .send(IssueQueryUpdate::PageFetched {
             repo: repo.clone(),
-            params: IssueQuery { search: Some("beta".into()) },
+            params: IssueQuery { search: Some("beta".into()), label: None },
             requested_page: 1,
             page: IssueResultPage { items: vec![TestIssue::new("Fresh beta result").id("fresh").build()], total: Some(1), has_more: false },
         })

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -692,7 +692,8 @@ impl App {
 
     pub(crate) fn set_project_issue_start_pending(&mut self, ctx: &ProjectIssueStartContext, status: PendingStatus, description: String) {
         let ViewAddress::Project { namespace, name } = &ctx.address else { return };
-        let query = flotilla_protocol::QueryId::Issues { scope: flotilla_protocol::QueryScope::new(namespace, name), search: None };
+        let query =
+            flotilla_protocol::QueryId::Issues { scope: flotilla_protocol::QueryScope::new(namespace, name), search: None, label: None };
         let Some(index) = self.views.find(&ctx.address) else { return };
         let Some(view) = self.views.get_mut(index) else { return };
         let state = view.project_table_state.table_mut(crate::table_view::ProjectPanelKind::Issues);

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -549,7 +549,7 @@ fn first_page_search_failure_clears_active_search_state() {
     let view = app.issue_views.entry(repo.clone()).or_default();
     view.search_query = Some("beta".into());
     view.search = Some(issue_view::IssuePagingState {
-        params: IssueQuery { search: Some("beta".into()) },
+        params: IssueQuery { search: Some("beta".into()), label: None },
         items: vec![],
         next_page: 1,
         total: None,
@@ -560,7 +560,7 @@ fn first_page_search_failure_clears_active_search_state() {
     app.issue_update_tx
         .send(issue_view::IssueQueryUpdate::QueryFailed {
             repo: repo.clone(),
-            params: IssueQuery { search: Some("beta".into()) },
+            params: IssueQuery { search: Some("beta".into()), label: None },
             requested_page: 1,
             message: "search failed".into(),
         })
@@ -1851,7 +1851,7 @@ fn app_keeps_fleet_and_project_independent_results_separate() {
 fn app_applies_materialized_issue_sets_and_deltas_to_the_typed_query_cache() {
     let mut app = stub_app();
     let scope = flotilla_protocol::QueryScope::new("flotilla", "roadmap");
-    let query = flotilla_protocol::QueryId::Issues { scope: scope.clone(), search: None };
+    let query = flotilla_protocol::QueryId::Issues { scope: scope.clone(), search: None, label: None };
     let source = IssueSource { service: "https://issues.example".into(), scope: "widgets/api".into() };
     let mut first = TestIssue::new("First materialized issue").id("LINEAR-1").build();
     first.reference.source = source.clone();
@@ -1862,6 +1862,7 @@ fn app_applies_materialized_issue_sets_and_deltas_to_the_typed_query_cache() {
         rows: flotilla_protocol::Rows::Issues {
             scope: scope.clone(),
             search: None,
+            label: None,
             rows: vec![flotilla_protocol::IssueRow { reference: first_ref.clone(), issue: first }],
         },
         state: flotilla_protocol::ResultSetState {
@@ -1882,6 +1883,7 @@ fn app_applies_materialized_issue_sets_and_deltas_to_the_typed_query_cache() {
         changes: flotilla_protocol::QueryChanges::Issues {
             scope,
             search: None,
+            label: None,
             changed: vec![flotilla_protocol::IssueRow { reference: second_ref, issue: second }],
             removed: vec![first_ref],
         },
@@ -1902,7 +1904,7 @@ fn app_applies_materialized_issue_sets_and_deltas_to_the_typed_query_cache() {
 fn app_keeps_issue_rows_in_id_order_when_an_existing_issue_is_updated() {
     let mut app = stub_app();
     let scope = flotilla_protocol::QueryScope::new("flotilla", "roadmap");
-    let query = flotilla_protocol::QueryId::Issues { scope: scope.clone(), search: None };
+    let query = flotilla_protocol::QueryId::Issues { scope: scope.clone(), search: None, label: None };
     let mut high_id = TestIssue::new("High ID").id("10").build();
     high_id.as_of = "2026-07-15T12:00:00Z".parse().expect("timestamp");
     let mut low_id = TestIssue::new("Low ID").id("1").build();
@@ -1913,6 +1915,7 @@ fn app_keeps_issue_rows_in_id_order_when_an_existing_issue_is_updated() {
         rows: flotilla_protocol::Rows::Issues {
             scope: scope.clone(),
             search: None,
+            label: None,
             rows: vec![flotilla_protocol::IssueRow { reference: high_id.reference.clone(), issue: high_id }, flotilla_protocol::IssueRow {
                 reference: low_id.reference.clone(),
                 issue: low_id.clone(),
@@ -1927,6 +1930,7 @@ fn app_keeps_issue_rows_in_id_order_when_an_existing_issue_is_updated() {
         changes: flotilla_protocol::QueryChanges::Issues {
             scope,
             search: None,
+            label: None,
             changed: vec![flotilla_protocol::IssueRow { reference: low_id.reference.clone(), issue: low_id }],
             removed: vec![],
         },
@@ -1972,7 +1976,7 @@ fn app_applies_checkout_sets_and_removal_deltas_to_the_typed_query_cache() {
 async fn materialized_issue_scroll_requests_the_next_demand_backed_page() {
     let mut app = stub_app();
     let scope = flotilla_protocol::QueryScope::new("flotilla", "roadmap");
-    let query = flotilla_protocol::QueryId::Issues { scope: scope.clone(), search: None };
+    let query = flotilla_protocol::QueryId::Issues { scope: scope.clone(), search: None, label: None };
     app.open_view("issues?project=flotilla%2Froadmap".parse().expect("address"));
     let source = IssueSource { service: "https://issues.example".into(), scope: "widgets/api".into() };
     let rows = (1..=50)
@@ -1985,7 +1989,7 @@ async fn materialized_issue_scroll_requests_the_next_demand_backed_page() {
 
     app.handle_daemon_event(DaemonEvent::ResultSet(Box::new(flotilla_protocol::ResultSet {
         seq: 1,
-        rows: flotilla_protocol::Rows::Issues { scope, search: None, rows },
+        rows: flotilla_protocol::Rows::Issues { scope, search: None, label: None, rows },
         state: flotilla_protocol::ResultSetState {
             demand: Some(flotilla_protocol::DemandBackedMetadata {
                 as_of: "2026-07-15T12:00:00Z".parse().expect("timestamp"),
@@ -2008,13 +2012,15 @@ async fn materialized_issue_scroll_requests_the_next_demand_backed_page() {
 fn source_search_replaces_the_issue_subscription_without_changing_the_persisted_view() {
     let mut app = stub_app();
     app.open_view("issues?project=flotilla%2Froadmap".parse().expect("address"));
-    let base = flotilla_protocol::QueryId::Issues { scope: flotilla_protocol::QueryScope::new("flotilla", "roadmap"), search: None };
+    let base =
+        flotilla_protocol::QueryId::Issues { scope: flotilla_protocol::QueryScope::new("flotilla", "roadmap"), search: None, label: None };
     assert!(app.query_cursors().iter().any(|cursor| cursor.query == base));
 
     app.process_app_actions(vec![crate::widgets::AppAction::SetSourceSearch(Some("widget".into()))]);
     let search = flotilla_protocol::QueryId::Issues {
         scope: flotilla_protocol::QueryScope::new("flotilla", "roadmap"),
         search: Some("widget".into()),
+        label: None,
     };
     let queries = app.query_cursors().into_iter().map(|cursor| cursor.query).collect::<Vec<_>>();
     assert!(queries.contains(&search));
@@ -2035,7 +2041,11 @@ fn escape_restores_the_base_issue_window_even_before_search_results_arrive() {
 
     assert_eq!(app.views.active_table_state().source_search, None);
     assert!(app.query_cursors().iter().any(|cursor| cursor.query
-        == flotilla_protocol::QueryId::Issues { scope: flotilla_protocol::QueryScope::new("flotilla", "roadmap"), search: None }));
+        == flotilla_protocol::QueryId::Issues {
+            scope: flotilla_protocol::QueryScope::new("flotilla", "roadmap"),
+            search: None,
+            label: None,
+        }));
 }
 
 // -- Convoys tab rendering --

--- a/crates/flotilla-tui/src/app/view_kind.rs
+++ b/crates/flotilla-tui/src/app/view_kind.rs
@@ -27,6 +27,7 @@ pub(crate) fn queries(address: &ViewAddress, source_search: Option<&str>) -> Vec
                 QueryId::Issues {
                     scope: QueryScope::new(namespace, name),
                     search: source_search.filter(|search| !search.is_empty()).map(str::to_owned),
+                    label: None,
                 },
                 QueryId::Independents { scope: Some(QueryScope::new(namespace, name)) },
             ]
@@ -99,7 +100,7 @@ mod tests {
             },
             QueryId::Convoys,
             QueryId::Checkouts { scope: Some(QueryScope::new("flotilla", "roadmap")) },
-            QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None },
+            QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None, label: None },
             QueryId::Independents { scope: Some(QueryScope::new("flotilla", "roadmap")) },
         ]);
         assert_eq!(kind_modes(Some(&address)), vec![BindingModeId::Convoys, BindingModeId::DemandTable, BindingModeId::Project]);
@@ -111,6 +112,7 @@ mod tests {
         assert_eq!(queries(&address, Some("widget")), vec![QueryId::Issues {
             scope: QueryScope::new("flotilla", "roadmap"),
             search: Some("widget".into()),
+            label: None,
         }]);
     }
 

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -544,9 +544,11 @@ pub struct QueryRows<'a, R> {
 /// curated table families to prevent subscription/projection drift.
 pub fn query_for(address: &ViewAddress, source_search: Option<&str>) -> Option<QueryId> {
     match address {
-        ViewAddress::Issues { scope } => {
-            Some(QueryId::Issues { scope: scope.clone(), search: source_search.filter(|search| !search.is_empty()).map(str::to_owned) })
-        }
+        ViewAddress::Issues { scope } => Some(QueryId::Issues {
+            scope: scope.clone(),
+            search: source_search.filter(|search| !search.is_empty()).map(str::to_owned),
+            label: None,
+        }),
         ViewAddress::Checkouts { scope } => Some(QueryId::Checkouts { scope: scope.clone() }),
         ViewAddress::Independents { scope } => Some(QueryId::Independents { scope: scope.clone() }),
         _ => None,
@@ -1531,7 +1533,7 @@ mod tests {
         let issue = TestIssue::new("Composite project issue").id("ENG-42").build();
         let issue_row = IssueRow { reference: issue.reference.clone(), issue };
         let independent = independent("governor", "feta", Some("terminal-governor"));
-        let issue_query = QueryId::Issues { scope: scope.clone(), search: None };
+        let issue_query = QueryId::Issues { scope: scope.clone(), search: None, label: None };
         let checkout_query = QueryId::Checkouts { scope: Some(scope.clone()) };
         let independent_query = QueryId::Independents { scope: Some(scope.clone()) };
         let awareness_query =
@@ -1640,7 +1642,7 @@ mod tests {
         let issue = TestIssue::new("Start convoy from scoped issue").id("ENG-42").build();
         let row = IssueRow { reference: issue.reference.clone(), issue };
         let scope = QueryScope::new("flotilla", "roadmap");
-        let query = QueryId::Issues { scope: scope.clone(), search: None };
+        let query = QueryId::Issues { scope: scope.clone(), search: None, label: None };
         let state = ResultSetState {
             demand: Some(DemandBackedMetadata { as_of: "2026-07-20T12:00:00Z".parse().expect("timestamp"), has_more: true }),
             conditions: vec![ResultSetCondition::IssueSourceUnavailable { source: None, message: "one source is unavailable".into() }],
@@ -1763,7 +1765,7 @@ mod tests {
         let mut state = TableState::default();
         let convoy = RowId::new("dev/tables");
         let issue = RowId::new("issue:809");
-        let issues_query = QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None };
+        let issues_query = QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None, label: None };
         state.begin_pending(QueryId::Convoys, convoy.clone(), "Delete convoy".into()).expect("convoy should become pending");
         state.begin_pending(issues_query.clone(), issue.clone(), "Start convoy".into()).expect("issue should become pending");
 

--- a/crates/flotilla-tui/src/widgets/issue_search.rs
+++ b/crates/flotilla-tui/src/widgets/issue_search.rs
@@ -48,7 +48,7 @@ impl InteractiveWidget for IssueSearchWidget {
                         context_repo: None,
                         action: CommandAction::QueryIssues {
                             repo: RepoSelector::Identity(repo_identity.clone()),
-                            params: IssueQuery { search: Some(query.clone()) },
+                            params: IssueQuery { search: Some(query.clone()), label: None },
                             page: 1,
                             count: 50,
                         },

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -191,6 +191,7 @@ impl ProjectPageWidget {
         Some(QueryId::Issues {
             scope: scope.clone(),
             search: state.issue_source_search().filter(|search| !search.is_empty()).map(str::to_owned),
+            label: None,
         })
     }
 
@@ -692,7 +693,7 @@ mod tests {
         state
             .table_mut(ProjectPanelKind::Issues)
             .begin_pending(
-                QueryId::Issues { scope: flotilla_protocol::QueryScope::new("flotilla", "roadmap"), search: None },
+                QueryId::Issues { scope: flotilla_protocol::QueryScope::new("flotilla", "roadmap"), search: None, label: None },
                 panels[0].table.rows[1].id.clone(),
                 "Start convoy".into(),
             )

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -635,7 +635,7 @@ mod tests {
         let issue = flotilla_protocol::test_support::TestIssue::new("Fix pagination").id("ENG-42").build();
         let row = flotilla_protocol::IssueRow { reference: issue.reference.clone(), issue };
         let scope = flotilla_protocol::QueryScope::new("flotilla", "roadmap");
-        let query = flotilla_protocol::QueryId::Issues { scope, search: None };
+        let query = flotilla_protocol::QueryId::Issues { scope, search: None, label: None };
         let state = flotilla_protocol::ResultSetState {
             demand: Some(flotilla_protocol::DemandBackedMetadata {
                 as_of: "2026-07-20T12:00:00Z".parse().expect("timestamp"),


### PR DESCRIPTION
## Summary

- add an optional label parameter to scoped issue query identities and result/delta rows
- request the centralized `ready` label for awareness-band issue materialization
- keep project-page issue panels and source searches unfiltered
- pass label filters through the GitHub provider and preserve them during incremental refreshes

## Why

Awareness projections subscribed to the same unfiltered open-issue windows used by project browsing, so every open issue could appear in the sidebar. ADR 0018 defines awareness issues as those that have earned the `ready` label, while project pages must continue to browse all open issues.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #966