### PR TITLE
fix: bound host readiness by heartbeat freshness

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3169,9 +3169,10 @@ async fn validate_workflow_agent_adapters(
             let host = backend.clone().using::<ResourceHost>(namespace).get(&host_direct.host_ref).await.map_err(|error| {
                 format!("placement `{}` host `{}` is not ready: {error}", placement.metadata.name, host_direct.host_ref)
             })?;
-            let status = host
+            let mut status = host
                 .status
                 .ok_or_else(|| format!("placement `{}` host `{}` has no observed status", placement.metadata.name, host_direct.host_ref))?;
+            status.apply_heartbeat_readiness(Utc::now());
             if !status.ready {
                 return Err(format!("placement `{}` host `{}` is not ready", placement.metadata.name, host_direct.host_ref));
             }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -156,7 +156,7 @@ async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_requ
     hosts
         .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
             capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["claude-code"]))].into_iter().collect(),
-            heartbeat_at: None,
+            heartbeat_at: Some(Utc::now()),
             ready: true,
             resource_store: None,
         })
@@ -185,6 +185,45 @@ async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_requ
         .expect_err("host without codex must be rejected");
 
     assert_eq!(error, "workflow requires agent adapter `codex`, which is not available in placement `host-direct-test` (host `host-test`)");
+}
+
+#[tokio::test]
+async fn agent_adapter_admission_rejects_a_host_with_stale_heartbeat() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = hosts.create(&InputMeta::builder().name("host-test".to_string()).build(), &HostSpec {}).await.expect("host create");
+    hosts
+        .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
+            capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["codex"]))].into_iter().collect(),
+            heartbeat_at: Some(Utc::now() - ChronoDuration::seconds(61)),
+            ready: true,
+            resource_store: None,
+        })
+        .await
+        .expect("host status update");
+    let placement = backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &InputMeta::builder().name("host-direct-test".to_string()).build(),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: host.metadata.name,
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("placement create");
+    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
+    workflow.vessels[0].stance = Stance::Trusted;
+
+    let error = validate_workflow_agent_adapters(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect_err("stale host heartbeat must be rejected");
+
+    assert_eq!(error, "placement `host-direct-test` host `host-test` is not ready");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -105,10 +105,8 @@ pub(super) struct RemoteCommandRouter {
 
 #[derive(bon::Builder)]
 struct PlacementRoute {
-    target: ConvoyStartTarget,
     host_name: HostName,
     node_id: NodeId,
-    address: String,
     sender: Arc<dyn PeerSender>,
 }
 
@@ -212,12 +210,11 @@ impl RemoteCommandRouter {
                 let send_result = match &existing_convoy_target {
                     Some(target) => self.send_routed_to_convoy_home(&target.home, &target.node_id, routed).await,
                     None => match &placement_route {
-                        Some(route) => route.sender.send(PeerWireMessage::Routed(routed)).await.map_err(|cause| {
-                            format!(
-                                "connect to {} at {} for placement policy {} (host {}): {cause}",
-                                route.host_name, route.address, route.target.policy_name, route.target.host_id
-                            )
-                        }),
+                        Some(route) => route
+                            .sender
+                            .send(PeerWireMessage::Routed(routed))
+                            .await
+                            .map_err(|cause| format!("peer host {} is not connected: {cause}", route.host_name)),
                         None => self.send_routed_to(&target_node_id, routed).await,
                     },
                 };
@@ -882,21 +879,14 @@ impl RemoteStepExecutor for RemoteCommandRouter {
 impl RemoteCommandRouter {
     async fn resolve_placement_route(&self, target: ConvoyStartTarget) -> Result<PlacementRoute, String> {
         let environment_id = EnvironmentId::host(target.host_id.clone());
-        let (host_name, node_id, address, sender) = {
+        let (host_name, node_id, sender) = {
             let pm = self.peer_manager.lock().await;
-            let (node_id, host_name) = pm
-                .node_for_host_environment(&environment_id)
-                .map_err(|cause| format!("resolve placement policy {} target host {}: {cause}", target.policy_name, target.host_id))?;
-            let address = pm.connection_address_for(&node_id, &host_name);
-            let sender = pm.resolve_sender(&node_id).map_err(|cause| {
-                format!(
-                    "connect to {host_name} at {address} for placement policy {} (host {}): {cause}",
-                    target.policy_name, target.host_id
-                )
-            })?;
-            (host_name, node_id, address, sender)
+            let (node_id, host_name) =
+                pm.node_for_host_environment(&environment_id).map_err(|_| format!("peer host {} is not connected", target.host_id))?;
+            let sender = pm.resolve_sender(&node_id).map_err(|_| format!("peer host {host_name} is not connected"))?;
+            (host_name, node_id, sender)
         };
-        Ok(PlacementRoute::builder().target(target).host_name(host_name).node_id(node_id).address(address).sender(sender).build())
+        Ok(PlacementRoute::builder().host_name(host_name).node_id(node_id).sender(sender).build())
     }
 
     async fn send_routed_to_convoy_home(

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1078,7 +1078,7 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
 
     assert_eq!(
         remote_command_router.dispatch_execute(command.clone()).await.expect_err("missing live route must reject remote placement"),
-        format!("connect to feta at peer://feta for placement policy {remote_policy_name} (host {remote_host_id}): unknown peer: feta")
+        "peer host feta is not connected"
     );
 
     peer_manager.lock().await.register_sender(NodeId::new("feta"), Arc::new(MockPeerSender { sent: Arc::clone(&sent) }));

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -3,12 +3,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, retention::ResourceStoreDiagnostics, status_patch::StatusPatch};
+use crate::{resource::define_resource, retention::ResourceStoreDiagnostics, status_patch::StatusPatch, ReplicationClass};
 
-define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch);
+define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
 
 pub const AGENT_ADAPTERS_CAPABILITY: &str = "agent_adapters";
 pub const TERMINAL_POOLS_CAPABILITY: &str = "terminal_pools";
+pub const HEARTBEAT_READY_TTL_SECS: i64 = 60;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostSpec {}
@@ -28,6 +29,13 @@ pub struct HostStatus {
 impl HostStatus {
     pub fn agent_adapters(&self) -> Result<BTreeSet<String>, serde_json::Error> {
         self.capabilities.get(AGENT_ADAPTERS_CAPABILITY).cloned().map(serde_json::from_value).transpose().map(Option::unwrap_or_default)
+    }
+
+    pub fn apply_heartbeat_readiness(&mut self, now: DateTime<Utc>) {
+        self.ready = self.ready
+            && self
+                .heartbeat_at
+                .is_some_and(|heartbeat_at| now.signed_duration_since(heartbeat_at) <= chrono::Duration::seconds(HEARTBEAT_READY_TTL_SECS));
     }
 }
 

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -6,10 +6,11 @@ use serde_json::{json, Value};
 
 use crate::{
     api_version,
+    host::HostStatus,
     replica::{LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION},
-    Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, K8sListMeta, K8sResourceList, ObjectMeta,
-    OwnerReference, PlacementPolicy, Presentation, Project, ReadWatchEvent, Regard, Repository, Resource, ResourceBackend, ResourceError,
-    ResourceList, ResourceObject, ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
+    Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, ObjectMeta, OwnerReference, PlacementPolicy,
+    Presentation, Project, ReadWatchEvent, Regard, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject,
+    ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -398,15 +399,24 @@ async fn apply_typed<T: Resource>(
 }
 
 fn list_value<T: Resource>(listed: &ResourceList<T>) -> Result<Value, ResourceError> {
-    let list = K8sResourceList {
-        metadata: K8sListMeta { resource_version: listed.resource_version.clone(), generation: listed.generation.clone() },
-        items: listed.items.iter().map(ResourceObject::to_k8s_object).collect(),
-    };
-    serde_json::to_value(list).map_err(|error| ResourceError::decode(format!("encode resource list: {error}")))
+    let items = listed.items.iter().map(object_value).collect::<Result<Vec<_>, _>>()?;
+    let mut metadata = json!({"resourceVersion": listed.resource_version.clone()});
+    if let Some(generation) = &listed.generation {
+        metadata["generation"] = Value::String(generation.clone());
+    }
+    Ok(json!({
+        "apiVersion": api_version(T::API_PATHS),
+        "kind": format!("{}List", T::API_PATHS.kind),
+        "metadata": metadata,
+        "items": items,
+    }))
 }
 
 fn object_value<T: Resource>(object: &ResourceObject<T>) -> Result<Value, ResourceError> {
-    serde_json::to_value(object.to_k8s_object()).map_err(|error| ResourceError::decode(format!("encode resource object: {error}")))
+    let mut value =
+        serde_json::to_value(object.to_k8s_object()).map_err(|error| ResourceError::decode(format!("encode resource object: {error}")))?;
+    apply_host_heartbeat_readiness::<T>(&mut value)?;
+    Ok(value)
 }
 
 fn read_object_value<T: Resource>(object: &crate::ReadResourceObject<T>) -> Result<Value, ResourceError> {
@@ -441,8 +451,26 @@ fn typed_watch_event_value<T: Resource>(event: &WatchEvent<T>) -> Result<Value, 
 fn watch_event_value<T: Resource>(event_type: &str, object: &ResourceObject<T>) -> Result<Value, ResourceError> {
     Ok(json!({
         "type": event_type,
-        "object": object.to_k8s_object(),
+        "object": object_value(object)?,
     }))
+}
+
+fn apply_host_heartbeat_readiness<T: Resource>(value: &mut Value) -> Result<(), ResourceError> {
+    if T::API_PATHS.kind != Host::API_PATHS.kind {
+        return Ok(());
+    }
+    let Some(status_value) = value.get_mut("status") else {
+        return Ok(());
+    };
+    if status_value.is_null() {
+        return Ok(());
+    }
+    let mut status: HostStatus = serde_json::from_value(status_value.clone())
+        .map_err(|error| ResourceError::decode(format!("decode Host status for heartbeat readiness: {error}")))?;
+    status.apply_heartbeat_readiness(chrono::Utc::now());
+    *status_value = serde_json::to_value(status)
+        .map_err(|error| ResourceError::decode(format!("encode Host status for heartbeat readiness: {error}")))?;
+    Ok(())
 }
 
 pub fn resource_list_api_version(kind: &str) -> Result<String, ResourceError> {
@@ -457,11 +485,12 @@ fn api_version_typed<T: Resource>() -> String {
 mod tests {
     use std::collections::BTreeMap;
 
-    use flotilla_protocol::ResourceRef;
+    use chrono::{Duration, Utc};
+    use flotilla_protocol::{NodeId, ResourceRef};
 
     use super::*;
     use crate::{
-        Convoy, ConvoySpec, Demand, DemandAddressee, DemandKind, DemandSpec, InMemoryBackend, InputMeta, PrincipalRef, Regard,
+        Convoy, ConvoySpec, Demand, DemandAddressee, DemandKind, DemandSpec, HostSpec, InMemoryBackend, InputMeta, PrincipalRef, Regard,
         RegardExpiryPolicy, RegardSource, RegardSpec,
     };
 
@@ -480,6 +509,56 @@ mod tests {
         assert_eq!(listed.value["items"][0]["apiVersion"], "flotilla.work/v1");
         assert_eq!(listed.value["items"][0]["kind"], "Convoy");
         assert_eq!(listed.value["items"][0]["metadata"]["name"], "demo");
+    }
+
+    #[tokio::test]
+    async fn host_resource_list_marks_stale_heartbeat_not_ready() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let hosts = backend.using::<Host>("flotilla");
+        let host = hosts.create(&InputMeta::builder().name("feta".to_string()).build(), &HostSpec {}).await.expect("create host");
+        hosts
+            .update_status("feta", &host.metadata.resource_version, &HostStatus {
+                capabilities: BTreeMap::new(),
+                heartbeat_at: Some(Utc::now() - Duration::seconds(61)),
+                ready: true,
+                resource_store: None,
+            })
+            .await
+            .expect("write stale heartbeat");
+
+        let listed = list_resource_kind(&backend, "flotilla", "hosts").await.expect("list hosts");
+
+        assert_eq!(listed.value["items"][0]["status"]["ready"], false);
+        assert!(listed.value["items"][0]["status"]["heartbeat_at"].is_string());
+    }
+
+    #[tokio::test]
+    async fn host_replica_resource_list_derives_ready_from_origin_heartbeat() {
+        let source = ResourceBackend::InMemory(InMemoryBackend::default());
+        let source_hosts = source.using::<Host>("flotilla");
+        let host =
+            source_hosts.create(&InputMeta::builder().name("feta".to_string()).build(), &HostSpec {}).await.expect("create source host");
+        source_hosts
+            .update_status("feta", &host.metadata.resource_version, &HostStatus {
+                capabilities: BTreeMap::new(),
+                heartbeat_at: Some(Utc::now() - Duration::seconds(61)),
+                ready: true,
+                resource_store: None,
+            })
+            .await
+            .expect("write source stale heartbeat");
+        let source_list = source_hosts.list().await.expect("list source hosts");
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        backend
+            .replica_writer::<Host>(NodeId::new("feta-node"), "flotilla")
+            .replace(&source_list, Utc::now())
+            .await
+            .expect("write host replica");
+
+        let listed = list_resource_kind_including_replicas(&backend, "flotilla", "hosts").await.expect("list host replicas");
+
+        assert_eq!(listed.value["items"][0]["status"]["ready"], false);
+        assert_eq!(listed.value["items"][0]["metadata"]["annotations"][ORIGIN_ROOT_ANNOTATION], "feta-node");
     }
 
     #[tokio::test]

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -800,7 +800,7 @@ pub async fn run_command(daemon: &dyn DaemonHandle, command: Command, format: Ou
                 }
                 let result = result.clone();
                 return match result {
-                    CommandValue::Error { message } => Err(message),
+                    CommandValue::Error { .. } => Ok(result),
                     CommandValue::Cancelled => Err("command cancelled".into()),
                     result => Ok(result),
                 };
@@ -829,7 +829,7 @@ async fn run_query_command(daemon: &dyn DaemonHandle, command: Command, format: 
         }
     }
     match result {
-        CommandValue::Error { message } => Err(message),
+        CommandValue::Error { .. } => Ok(result),
         CommandValue::Cancelled => Err("command cancelled".into()),
         result => Ok(result),
     }

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -1071,6 +1071,79 @@ mod query_event_formatting {
     }
 }
 
+mod command_query_execution {
+    use std::collections::HashMap;
+
+    use async_trait::async_trait;
+    use flotilla_core::daemon::DaemonHandle;
+    use flotilla_protocol::{
+        output::OutputFormat, Command, CommandAction, CommandValue, DaemonEvent, QueryCursor, RepoInfo, RepoSelector, RepoSnapshot,
+        StatusResponse, StreamKey, TopologyResponse,
+    };
+    use tokio::sync::broadcast;
+    use uuid::Uuid;
+
+    use crate::cli::run_command;
+
+    struct QueryDaemon {
+        result: CommandValue,
+    }
+
+    #[async_trait]
+    impl DaemonHandle for QueryDaemon {
+        fn subscribe(&self) -> broadcast::Receiver<DaemonEvent> {
+            let (_tx, rx) = broadcast::channel(1);
+            rx
+        }
+
+        async fn get_state(&self, _repo: &RepoSelector) -> Result<RepoSnapshot, String> {
+            unreachable!("query command test does not call get_state")
+        }
+
+        async fn list_repos(&self) -> Result<Vec<RepoInfo>, String> {
+            unreachable!("query command test does not call list_repos")
+        }
+
+        async fn execute(&self, _command: Command) -> Result<u64, String> {
+            unreachable!("query command test does not call execute")
+        }
+
+        async fn cancel(&self, _command_id: u64) -> Result<(), String> {
+            unreachable!("query command test does not call cancel")
+        }
+
+        async fn replay_since(&self, _last_seen: &HashMap<StreamKey, u64>) -> Result<Vec<DaemonEvent>, String> {
+            unreachable!("query command test does not call replay_since")
+        }
+
+        async fn subscribe_queries(&self, _subscriber_id: Uuid, _queries: &[QueryCursor]) -> Result<Vec<DaemonEvent>, String> {
+            unreachable!("query command test does not call subscribe_queries")
+        }
+
+        async fn execute_query(&self, _command: Command, _session_id: Uuid) -> Result<CommandValue, String> {
+            Ok(self.result.clone())
+        }
+
+        async fn get_status(&self) -> Result<StatusResponse, String> {
+            unreachable!("query command test does not call get_status")
+        }
+
+        async fn get_topology(&self) -> Result<TopologyResponse, String> {
+            unreachable!("query command test does not call get_topology")
+        }
+    }
+
+    #[tokio::test]
+    async fn query_command_error_returns_result_after_formatting() {
+        let daemon = QueryDaemon { result: CommandValue::Error { message: "repo not found".into() } };
+        let command = Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryHostList {} };
+
+        let result = run_command(&daemon, command, OutputFormat::Json).await.expect("query errors are command results");
+
+        assert_eq!(result, CommandValue::Error { message: "repo not found".into() });
+    }
+}
+
 mod result_set_event_formatting {
     use flotilla_protocol::{
         result_set::{QueryChanges, ResultDelta, ResultSet, Rows},

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,7 +619,13 @@ async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
 async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) -> Result<()> {
     reset_sigpipe();
     let daemon = connect_daemon(cli).await?;
-    let result = flotilla_tui::cli::run_command(&*daemon, command, format).await.map_err(|e| color_eyre::eyre::eyre!(e))?;
+    let result = match flotilla_tui::cli::run_command(&*daemon, command, format).await {
+        Ok(result) => result,
+        Err(message) => exit_command_error(message, format),
+    };
+    if let CommandValue::Error { .. } = result {
+        std::process::exit(1);
+    }
     if let CommandValue::ConvoyStarted { name, attach_command: Some(command), binding } = result {
         if matches!(format, OutputFormat::Human) {
             stamp_pane_identity(&name, binding.as_ref()).await;
@@ -627,6 +633,14 @@ async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) 
         }
     }
     Ok(())
+}
+
+fn exit_command_error(message: String, format: OutputFormat) -> ! {
+    match format {
+        OutputFormat::Human => eprintln!("error: {message}"),
+        OutputFormat::Json => println!("{}", flotilla_protocol::output::json_pretty(&CommandValue::Error { message })),
+    }
+    std::process::exit(1);
 }
 
 async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&str>, format: OutputFormat) -> Result<()> {


### PR DESCRIPTION
Closes #962.

## What changed
- Host resources now opt into home-bound runtime replication so peer host rows can be listed through the resource overlay.
- Host readiness exposed through resource list/get/watch is derived from heartbeat freshness with a 60s TTL, so stale heartbeats no longer report `ready: true`.
- Host-direct placement admission applies the same heartbeat freshness rule before trusting `Host.status.ready`.
- Unavailable host-direct dispatch now reports a one-line `peer host <name> is not connected` diagnostic instead of bubbling a color-eyre report.

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`