### PR TITLE
feat: add Forgejo issue provider

### DIFF
--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use flotilla_protocol::NodeId;
+use flotilla_protocol::{IssueSource, NodeId};
 use serde::{Deserialize, Serialize};
 
 use crate::path_context::{DaemonHostPath, ExecutionEnvironmentPath};
@@ -25,6 +25,20 @@ pub struct ChangeRequestConfig {
 pub struct IssueTrackerConfig {
     #[serde(flatten)]
     pub preference: ProviderPreference,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forgejo: Option<ForgejoIssueTrackerConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ForgejoIssueTrackerConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_agent: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -187,6 +201,8 @@ pub struct RepoFileConfig {
     pub path: String,
     #[serde(default)]
     pub vcs: RepoVcsConfig,
+    #[serde(default)]
+    pub issue_tracker: RepoIssueTrackerConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -201,6 +217,17 @@ pub struct RepoVcsConfig {
 pub struct RepoGitConfig {
     pub checkout_strategy: Option<String>,
     pub checkout_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct RepoIssueTrackerConfig {
+    #[serde(default)]
+    pub forgejo: Option<RepoForgejoIssueTrackerConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct RepoForgejoIssueTrackerConfig {
+    pub scope: Option<String>,
 }
 
 /// Global SSH settings for remote host connections.
@@ -539,6 +566,41 @@ impl ConfigStore {
     /// Resolve checkout config for a repo: per-repo override > global > defaults.
     pub fn resolve_checkout_config(&self, repo_root: &ExecutionEnvironmentPath) -> ResolvedCheckoutConfig {
         let global = self.load_config();
+        if let Some(repo_cfg) = self.load_repo_file_config(repo_root) {
+            return ResolvedCheckoutConfig {
+                strategy: repo_cfg.vcs.git.checkout_strategy.unwrap_or_else(|| global.vcs.git.checkout_strategy.clone()),
+                path: repo_cfg.vcs.git.checkout_path.unwrap_or_else(|| global.vcs.git.checkout_path.clone()),
+            };
+        }
+        ResolvedCheckoutConfig { strategy: global.vcs.git.checkout_strategy.clone(), path: global.vcs.git.checkout_path.clone() }
+    }
+
+    pub fn resolve_repo_issue_source(&self, repo_root: &ExecutionEnvironmentPath) -> Option<IssueSource> {
+        let repo_cfg = self.load_repo_file_config(repo_root)?;
+        let forgejo = repo_cfg.issue_tracker.forgejo?;
+        let scope = forgejo.scope?.trim().to_string();
+        if scope.is_empty() {
+            tracing::warn!(repo = %repo_root.as_path().display(), "repo Forgejo issue source scope is empty");
+            return None;
+        }
+        let service = self
+            .load_config()
+            .issue_tracker
+            .forgejo
+            .and_then(|config| config.service_url)
+            .map(|url| url.trim_end_matches('/').to_string())
+            .filter(|url| !url.is_empty());
+        let Some(service) = service else {
+            tracing::warn!(
+                repo = %repo_root.as_path().display(),
+                "repo has a Forgejo issue binding but [issue_tracker.forgejo].service_url is not configured"
+            );
+            return None;
+        };
+        Some(IssueSource { service, scope })
+    }
+
+    fn load_repo_file_config(&self, repo_root: &ExecutionEnvironmentPath) -> Option<RepoFileConfig> {
         let key = repo_file_key(repo_root.as_path());
         let repo_file = self.repos_dir().join(format!("{key}.toml"));
         if let Ok(content) = std::fs::read_to_string(repo_file.as_path()) {
@@ -546,22 +608,16 @@ impl ConfigStore {
                 Ok(repo_cfg) => {
                     if repo_cfg.path != repo_root.as_path().to_string_lossy() {
                         tracing::warn!(path = %repo_file, expected = %repo_root.as_path().display(), actual = %repo_cfg.path, "repo config path mismatch");
-                        return ResolvedCheckoutConfig {
-                            strategy: global.vcs.git.checkout_strategy.clone(),
-                            path: global.vcs.git.checkout_path.clone(),
-                        };
+                        return None;
                     }
-                    return ResolvedCheckoutConfig {
-                        strategy: repo_cfg.vcs.git.checkout_strategy.unwrap_or_else(|| global.vcs.git.checkout_strategy.clone()),
-                        path: repo_cfg.vcs.git.checkout_path.unwrap_or_else(|| global.vcs.git.checkout_path.clone()),
-                    };
+                    return Some(repo_cfg);
                 }
                 Err(e) => {
                     tracing::warn!(path = %repo_file, err = %e, "failed to parse");
                 }
             }
         }
-        ResolvedCheckoutConfig { strategy: global.vcs.git.checkout_strategy.clone(), path: global.vcs.git.checkout_path.clone() }
+        None
     }
 }
 

--- a/crates/flotilla-core/src/config/tests.rs
+++ b/crates/flotilla-core/src/config/tests.rs
@@ -19,6 +19,10 @@ fn write_repo_file(base: &Path, filename: &str, content: &str) {
     std::fs::write(repos_dir.join(filename), content).unwrap();
 }
 
+fn write_forgejo_config(base: &Path, service_url: &str) {
+    std::fs::write(base.join("config.toml"), format!("[issue_tracker.forgejo]\nservice_url = \"{service_url}\"\n")).unwrap();
+}
+
 fn legacy_path_to_slug(path: &Path) -> String {
     let raw = path.to_string_lossy().to_lowercase();
     let mut prev_hyphen = false;
@@ -99,6 +103,49 @@ fn load_and_migrate_repos_migrates_legacy_file_and_preserves_overrides() {
 
     store.remove_repo(&ee(&repo));
     assert!(store.load_and_migrate_repos().is_empty());
+}
+
+#[test]
+fn resolve_repo_issue_source_reads_forgejo_binding() {
+    let dir = tempdir().expect("create config tempdir");
+    let base = dir.path();
+    let repo = make_dir(base, "forgejo-repo");
+    let content = format!("path = \"{}\"\n[issue_tracker.forgejo]\nscope = \"fork-issues/zellij\"\n", repo.display());
+    write_repo_file(base, &format!("{}.toml", repo_file_key(&repo)), &content);
+    write_forgejo_config(base, "https://forgejo.example.test");
+
+    let store = ConfigStore::with_base(base);
+    let source = store.resolve_repo_issue_source(&ee(repo)).expect("repo issue source");
+
+    assert_eq!(source.service, "https://forgejo.example.test");
+    assert_eq!(source.scope, "fork-issues/zellij");
+}
+
+#[test]
+fn resolve_repo_issue_source_requires_global_forgejo_service_url() {
+    let dir = tempdir().expect("create config tempdir");
+    let base = dir.path();
+    let repo = make_dir(base, "forgejo-repo");
+    let content = format!("path = \"{}\"\n[issue_tracker.forgejo]\nscope = \"team/widgets\"\n", repo.display());
+    write_repo_file(base, &format!("{}.toml", repo_file_key(&repo)), &content);
+
+    let store = ConfigStore::with_base(base);
+
+    assert!(store.resolve_repo_issue_source(&ee(repo)).is_none());
+}
+
+#[test]
+fn resolve_repo_issue_source_ignores_mismatched_repo_file() {
+    let dir = tempdir().expect("create config tempdir");
+    let base = dir.path();
+    let repo = make_dir(base, "forgejo-repo");
+    let other = make_dir(base, "other-repo");
+    let content = format!("path = \"{}\"\n[issue_tracker.forgejo]\nscope = \"fork-issues/zellij\"\n", other.display());
+    write_repo_file(base, &format!("{}.toml", repo_file_key(&repo)), &content);
+
+    let store = ConfigStore::with_base(base);
+
+    assert!(store.resolve_repo_issue_source(&ee(repo)).is_none());
 }
 
 #[test]

--- a/crates/flotilla-core/src/convert.rs
+++ b/crates/flotilla-core/src/convert.rs
@@ -237,6 +237,7 @@ pub fn unmet_requirement_to_proto(factory: &str, requirement: &UnmetRequirement)
         UnmetRequirement::MissingBinary(binary) => ("missing_binary", Some(binary.clone())),
         UnmetRequirement::MissingEnvVar(key) => ("missing_env_var", Some(key.clone())),
         UnmetRequirement::MissingAuth(provider) => ("missing_auth", Some(provider.clone())),
+        UnmetRequirement::MissingConfig(key) => ("missing_config", Some(key.clone())),
         UnmetRequirement::MissingRemoteHost(platform) => ("missing_remote_host", Some(host_platform_name(*platform).to_string())),
         UnmetRequirement::NoVcsCheckout => ("no_vcs_checkout", None),
         UnmetRequirement::UnknownProviderPreference { key, .. } => ("unknown_provider_preference", Some(key.clone())),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -778,6 +778,14 @@ fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla
     bag.repo_identity().unwrap_or_else(|| fallback_repo_identity(path))
 }
 
+fn configured_repo_identity_or_bag_or_path(config: &ConfigStore, path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {
+    let repo_root = ExecutionEnvironmentPath::new(path);
+    config
+        .resolve_repo_issue_source(&repo_root)
+        .map(|source| flotilla_protocol::RepoIdentity { authority: source.service, path: source.scope })
+        .unwrap_or_else(|| repo_identity_from_bag_or_path(path, bag))
+}
+
 fn normalize_checkout_for_environment(
     environment_manager: &EnvironmentManager,
     environment_id: Option<&EnvironmentId>,
@@ -1475,7 +1483,7 @@ impl InProcessDaemon {
                 debug!(count = unmet.len(), ?unmet, "providers not activated: missing requirements");
             }
 
-            let identity = repo_identity_from_bag_or_path(&path, &host_repo_bag);
+            let identity = configured_repo_identity_or_bag_or_path(&config, &path, &host_repo_bag);
             match startup_repository_inspector.inspect_path(&path, None).await {
                 Ok(inspection) => {
                     repository_keys_by_path.insert(path.clone(), inspection.key());
@@ -2254,6 +2262,10 @@ impl InProcessDaemon {
     }
 
     async fn detect_repo_identity(&self, repo_path: &Path) -> flotilla_protocol::RepoIdentity {
+        let repo_root = ExecutionEnvironmentPath::new(repo_path);
+        if let Some(source) = self.config.resolve_repo_issue_source(&repo_root) {
+            return flotilla_protocol::RepoIdentity { authority: source.service, path: source.scope };
+        }
         match discover_repo_for_environment(
             &self.environment_manager,
             &self.discovery,
@@ -4166,7 +4178,7 @@ impl InProcessDaemon {
         if !unmet.is_empty() {
             debug!(count = unmet.len(), ?unmet, "providers not activated: missing requirements");
         }
-        let identity = repo_identity_from_bag_or_path(&path, &host_repo_bag);
+        let identity = configured_repo_identity_or_bag_or_path(&self.config, &path, &host_repo_bag);
         // Resolve the storage identity before publishing RepoTracked so a
         // surface can subscribe to issues{repository} immediately. The
         // background refresh also reconciles the Repository resource and

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -41,7 +41,7 @@ use crate::{
                 fake_discovery, fake_discovery_with_provider_set, git_process_discovery, init_git_repo_with_remote, DiscoveryMockRunner,
                 FakeDiscoveryProviders, FakeTerminalPool, MergedPrProcessRunner,
             },
-            EnvironmentAssertion, EnvironmentBag,
+            EnvironmentAssertion, EnvironmentBag, HostPlatform,
         },
         environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount},
         ChannelLabel, CommandOutput, CommandRunner,
@@ -49,6 +49,16 @@ use crate::{
 };
 
 const TEST_LOCAL_ATTACH_HOST: &str = "local";
+
+fn overwrite_single_saved_repo_config(config_base: &Path, repo: &Path, body: String) {
+    let store = ConfigStore::with_base(config_base);
+    store.save_repo(&ExecutionEnvironmentPath::new(repo));
+    let repos_dir = config_base.join("repos");
+    let entries =
+        std::fs::read_dir(&repos_dir).expect("read repos dir").map(|entry| entry.expect("repo config entry").path()).collect::<Vec<_>>();
+    assert_eq!(entries.len(), 1, "expected one saved repo config");
+    std::fs::write(&entries[0], body).expect("write repo config");
+}
 
 #[test]
 fn workspace_slugs_are_dns_safe_bounded_and_disambiguatable() {
@@ -79,6 +89,29 @@ fn convoy_branch_validation_rejects_refs_that_checkout_cannot_create() {
         assert!(validate_convoy_branch(branch).is_err(), "{branch} should be rejected");
     }
     validate_convoy_branch("fix/issue-732").expect("normal branch should be accepted");
+}
+
+#[test]
+fn configured_repo_identity_prefers_repo_file_forgejo_binding() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("config.toml"), "[issue_tracker.forgejo]\nservice_url = \"https://forgejo.example.test\"\n")
+        .expect("write global config");
+    overwrite_single_saved_repo_config(
+        &config_base,
+        &repo,
+        format!("path = \"{}\"\n[issue_tracker.forgejo]\nscope = \"fork-issues/zellij\"\n", repo.display()),
+    );
+    let config = ConfigStore::with_base(config_base);
+    let bag = EnvironmentBag::new().with(EnvironmentAssertion::remote_host(HostPlatform::GitHub, "github-org", "github-repo", "origin"));
+
+    let identity = configured_repo_identity_or_bag_or_path(&config, &repo, &bag);
+
+    assert_eq!(identity.authority, "https://forgejo.example.test");
+    assert_eq!(identity.path, "fork-issues/zellij");
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/providers/discovery/factories/github.rs
+++ b/crates/flotilla-core/src/providers/discovery/factories/github.rs
@@ -1,18 +1,22 @@
-//! GitHub factories for change request and issue tracker providers.
+//! GitHub and Forgejo factories for change request and issue tracker providers.
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
 
 use crate::{
-    config::ConfigStore,
+    config::{ConfigStore, ForgejoIssueTrackerConfig},
     path_context::ExecutionEnvironmentPath,
     providers::{
         change_request::{github::GitHubChangeRequest, ChangeRequestTracker},
         discovery::{EnvironmentBag, Factory, HostPlatform, ProviderCategory, ProviderDescriptor, UnmetRequirement},
         github_api::GhApiClient,
-        issue_tracker::{github::GitHubIssueProvider, IssueProvider},
-        CommandRunner,
+        issue_tracker::{
+            forgejo::{ForgejoAuth, ForgejoIssueProvider, ForgejoIssueProviderConfig},
+            github::GitHubIssueProvider,
+            IssueProvider,
+        },
+        CommandRunner, ReqwestHttpClient,
     },
 };
 
@@ -98,6 +102,101 @@ impl Factory for GitHubIssueProviderFactory {
 }
 
 // ---------------------------------------------------------------------------
+// ForgejoIssueProviderFactory
+// ---------------------------------------------------------------------------
+
+pub struct ForgejoIssueProviderFactory;
+
+#[async_trait]
+impl Factory for ForgejoIssueProviderFactory {
+    type Descriptor = ProviderDescriptor;
+    type Output = dyn IssueProvider;
+
+    fn descriptor(&self) -> ProviderDescriptor {
+        ProviderDescriptor::labeled_simple(ProviderCategory::IssueProvider, "forgejo", "Forgejo Issues", "#", "Issues", "issue")
+    }
+
+    async fn probe(
+        &self,
+        _env: &EnvironmentBag,
+        config: &ConfigStore,
+        _repo_root: &ExecutionEnvironmentPath,
+        runner: Arc<dyn CommandRunner>,
+    ) -> Result<Arc<dyn IssueProvider>, Vec<UnmetRequirement>> {
+        let Some(forgejo) = config.load_config().issue_tracker.forgejo else {
+            return Err(vec![UnmetRequirement::MissingConfig("[issue_tracker.forgejo]".into())]);
+        };
+        let service_url = forgejo
+            .service_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .ok_or_else(|| vec![UnmetRequirement::MissingConfig("[issue_tracker.forgejo].service_url".into())])?;
+        let auth = resolve_forgejo_auth(config, &forgejo).map_err(|error| {
+            tracing::warn!(%error, "Forgejo authentication unavailable");
+            vec![UnmetRequirement::MissingAuth("forgejo".into())]
+        })?;
+        let provider_config = ForgejoIssueProviderConfig::new(service_url.into(), forgejo.api_base_url, auth);
+        Ok(Arc::new(ForgejoIssueProvider::new(Arc::new(ReqwestHttpClient::new()), runner, provider_config)))
+    }
+}
+
+fn resolve_forgejo_auth(config: &ConfigStore, forgejo: &ForgejoIssueTrackerConfig) -> Result<ForgejoAuth, String> {
+    let path = resolve_forgejo_token_path(config, forgejo)?;
+    let token =
+        std::fs::read_to_string(&path).map_err(|error| format!("forgejo token file {}: {error}", path.display()))?.trim().to_string();
+    if token.is_empty() {
+        return Err(format!("forgejo token file {} is empty", path.display()));
+    }
+    Ok(ForgejoAuth { token, token_path: path })
+}
+
+fn resolve_forgejo_token_path(config: &ConfigStore, forgejo: &ForgejoIssueTrackerConfig) -> Result<PathBuf, String> {
+    let config_parent =
+        config.base_path().as_path().parent().map(PathBuf::from).unwrap_or_else(|| config.base_path().as_path().to_path_buf());
+    if let Some(path) = &forgejo.token_path {
+        return Ok(config_path(&config_parent, path));
+    }
+    if let Some(agent) = &forgejo.token_agent {
+        return Ok(config_parent.join(format!("lab-forgejo-{agent}-token")));
+    }
+    let mut candidates = std::fs::read_dir(&config_parent)
+        .map_err(|error| format!("read {}: {error}", config_parent.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| {
+            path.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.starts_with("lab-forgejo-") && name.ends_with("-token"))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort();
+    match candidates.as_slice() {
+        [path] => Ok(path.clone()),
+        [] => Err(format!(
+            "no lab Forgejo token file found; set [issue_tracker.forgejo].token_path or create {}/lab-forgejo-<agent>-token",
+            config_parent.display()
+        )),
+        _ => Err("multiple lab Forgejo token files found; set [issue_tracker.forgejo].token_path or token_agent".into()),
+    }
+}
+
+fn config_path(config_parent: &std::path::Path, path: &str) -> PathBuf {
+    let path = path.trim();
+    if let Some(rest) = path.strip_prefix("~/.config/") {
+        return config_parent.join(rest);
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        config_parent.join(path)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -107,7 +206,7 @@ mod tests {
 
     use flotilla_protocol::{IssueRef, IssueSource};
 
-    use super::{GitHubChangeRequestFactory, GitHubIssueProviderFactory};
+    use super::{config_path, ForgejoIssueProviderFactory, GitHubChangeRequestFactory, GitHubIssueProviderFactory};
     use crate::{
         config::ConfigStore,
         path_context::ExecutionEnvironmentPath,
@@ -277,6 +376,134 @@ mod tests {
         assert_eq!(desc.backend, "github");
         assert_eq!(desc.implementation, "github");
         assert_eq!(desc.display_name, "GitHub Issues");
+        assert_eq!(desc.abbreviation, "#");
+        assert_eq!(desc.section_label, "Issues");
+        assert_eq!(desc.item_noun, "issue");
+    }
+
+    // ── ForgejoIssueProviderFactory tests ──
+
+    fn write_token(base: &std::path::Path, name: &str) {
+        std::fs::create_dir_all(base).expect("create config parent");
+        std::fs::write(base.join(name), "test-token\n").expect("write token");
+    }
+
+    fn write_forgejo_config(config_base: &std::path::Path, body: &str) {
+        std::fs::create_dir_all(config_base).expect("create config base");
+        std::fs::write(
+            config_base.join("config.toml"),
+            format!("[issue_tracker.forgejo]\nservice_url = \"https://forgejo.example.test\"\n{body}"),
+        )
+        .expect("write config");
+    }
+
+    #[test]
+    fn config_path_expands_home_relative_token_paths() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let resolved = config_path(std::path::Path::new("/tmp/config-parent"), "~/lab-token");
+
+        assert_eq!(resolved, home.join("lab-token"));
+    }
+
+    #[tokio::test]
+    async fn forgejo_issue_provider_factory_uses_single_lab_token_file() {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        let config_parent = dir.path();
+        write_token(config_parent, "lab-forgejo-coder-token");
+        let config_base = config_parent.join("flotilla");
+        write_forgejo_config(&config_base, "");
+        let config = ConfigStore::with_base(config_base);
+        let runner = Arc::new(DiscoveryMockRunner::builder().build());
+
+        let provider = ForgejoIssueProviderFactory
+            .probe(&EnvironmentBag::new(), &config, &ExecutionEnvironmentPath::new("/repo"), runner)
+            .await
+            .expect("Forgejo issue provider should be available");
+
+        assert!(provider.supports(&IssueSource { service: "https://forgejo.example.test".into(), scope: "fork-issues/zellij".into() }));
+    }
+
+    #[tokio::test]
+    async fn forgejo_issue_provider_factory_honors_configured_token_agent() {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        let config_parent = dir.path();
+        let config_base = config_parent.join("flotilla");
+        write_token(config_parent, "lab-forgejo-coder-token");
+        write_token(config_parent, "lab-forgejo-planner-token");
+        write_forgejo_config(&config_base, "token_agent = \"planner\"\n");
+        let config = ConfigStore::with_base(config_base);
+        let runner = Arc::new(DiscoveryMockRunner::builder().build());
+
+        let provider = ForgejoIssueProviderFactory
+            .probe(&EnvironmentBag::new(), &config, &ExecutionEnvironmentPath::new("/repo"), runner)
+            .await
+            .expect("Forgejo issue provider should use configured token agent");
+
+        assert!(provider.supports(&IssueSource { service: "forgejo".into(), scope: "team/widgets".into() }));
+    }
+
+    #[tokio::test]
+    async fn forgejo_issue_provider_factory_requires_configuration() {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        let config = ConfigStore::with_base(dir.path().join("flotilla"));
+        let runner = Arc::new(DiscoveryMockRunner::builder().build());
+
+        let unmet = ForgejoIssueProviderFactory
+            .probe(&EnvironmentBag::new(), &config, &ExecutionEnvironmentPath::new("/repo"), runner)
+            .await
+            .err()
+            .expect("should fail without Forgejo configuration");
+
+        assert!(unmet
+            .iter()
+            .any(|requirement| matches!(requirement, UnmetRequirement::MissingConfig(key) if key == "[issue_tracker.forgejo]")));
+    }
+
+    #[tokio::test]
+    async fn forgejo_issue_provider_factory_requires_service_url() {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        let config_base = dir.path().join("flotilla");
+        std::fs::create_dir_all(&config_base).expect("create config base");
+        std::fs::write(config_base.join("config.toml"), "[issue_tracker.forgejo]\ntoken_agent = \"coder\"\n").expect("write config");
+        let config = ConfigStore::with_base(config_base);
+        let runner = Arc::new(DiscoveryMockRunner::builder().build());
+
+        let unmet = ForgejoIssueProviderFactory
+            .probe(&EnvironmentBag::new(), &config, &ExecutionEnvironmentPath::new("/repo"), runner)
+            .await
+            .err()
+            .expect("should fail without Forgejo service URL");
+
+        assert!(unmet.iter().any(
+            |requirement| matches!(requirement, UnmetRequirement::MissingConfig(key) if key == "[issue_tracker.forgejo].service_url")
+        ));
+    }
+
+    #[tokio::test]
+    async fn forgejo_issue_provider_factory_reports_missing_auth_without_token() {
+        let dir = tempfile::tempdir().expect("failed to create tempdir");
+        let config_base = dir.path().join("flotilla");
+        write_forgejo_config(&config_base, "");
+        let config = ConfigStore::with_base(config_base);
+        let runner = Arc::new(DiscoveryMockRunner::builder().build());
+
+        let unmet = ForgejoIssueProviderFactory
+            .probe(&EnvironmentBag::new(), &config, &ExecutionEnvironmentPath::new("/repo"), runner)
+            .await
+            .err()
+            .expect("should fail without Forgejo token");
+
+        assert!(unmet.iter().any(|requirement| matches!(requirement, UnmetRequirement::MissingAuth(provider) if provider == "forgejo")));
+    }
+
+    #[tokio::test]
+    async fn forgejo_issue_provider_factory_descriptor() {
+        let desc = ForgejoIssueProviderFactory.descriptor();
+        assert_eq!(desc.backend, "forgejo");
+        assert_eq!(desc.implementation, "forgejo");
+        assert_eq!(desc.display_name, "Forgejo Issues");
         assert_eq!(desc.abbreviation, "#");
         assert_eq!(desc.section_label, "Issues");
         assert_eq!(desc.item_noun, "issue");

--- a/crates/flotilla-core/src/providers/discovery/factories/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/factories/mod.rs
@@ -55,7 +55,7 @@ impl FactoryRegistry {
             vcs: vec![Box::new(git::GitVcsFactory)],
             checkout_managers: checkout_manager_factories(),
             change_requests: vec![Box::new(github::GitHubChangeRequestFactory)],
-            issue_trackers: vec![Box::new(github::GitHubIssueProviderFactory)],
+            issue_trackers: vec![Box::new(github::GitHubIssueProviderFactory), Box::new(github::ForgejoIssueProviderFactory)],
             cloud_agents: vec![
                 Box::new(claude::ClaudeCodingAgentFactory),
                 Box::new(cursor::CursorCodingAgentFactory),

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -244,6 +244,7 @@ pub enum UnmetRequirement {
     MissingBinary(String),
     MissingEnvVar(String),
     MissingAuth(String),
+    MissingConfig(String),
     MissingRemoteHost(HostPlatform),
     NoVcsCheckout,
     /// Config references a backend or implementation that no factory provides.

--- a/crates/flotilla-core/src/providers/discovery/tests.rs
+++ b/crates/flotilla-core/src/providers/discovery/tests.rs
@@ -125,6 +125,7 @@ fn unmet_requirement_variants() {
         UnmetRequirement::MissingBinary("git".into()),
         UnmetRequirement::MissingEnvVar("TOKEN".into()),
         UnmetRequirement::MissingAuth("github".into()),
+        UnmetRequirement::MissingConfig("[provider]".into()),
         UnmetRequirement::MissingRemoteHost(HostPlatform::GitHub),
         UnmetRequirement::NoVcsCheckout,
         UnmetRequirement::UnknownProviderPreference { category: ProviderCategory::AiUtility, key: "nonexistent".into() },

--- a/crates/flotilla-core/src/providers/issue_tracker/fixtures/forgejo_issues.yaml
+++ b/crates/flotilla-core/src/providers/issue_tracker/fixtures/forgejo_issues.yaml
@@ -1,0 +1,83 @@
+rounds:
+- interactions:
+  - channel: http
+    method: GET
+    url: https://forgejo.lab.flotilla.work/api/v1/repos/fork-issues/zellij/issues?state=open&type=issues&sort=recentupdate&page=1&limit=30
+    request_headers:
+      accept: application/json
+      authorization: token <LAB_FORGEJO_TOKEN>
+    status: 200
+    response_body: |
+      [
+        {
+          "number": 9,
+          "title": "Wire Forgejo issue provider into convoy startup",
+          "body": "Synthetic Forgejo fixture issue used by replay tests.",
+          "state": "open",
+          "labels": [{"name": "ready"}],
+          "updated_at": "2026-07-24T12:00:00Z",
+          "pull_request": null
+        },
+        {
+          "number": 8,
+          "title": "List Forgejo issues by label",
+          "body": "Synthetic Forgejo fixture issue used by replay tests.",
+          "state": "open",
+          "labels": [{"name": "provider"}],
+          "updated_at": "2026-07-24T11:00:00Z",
+          "pull_request": null
+        }
+      ]
+    response_headers:
+      content-type: application/json;charset=utf-8
+      x-total-count: '2'
+  - channel: http
+    method: GET
+    url: https://forgejo.lab.flotilla.work/api/v1/repos/fork-issues/zellij/issues/9
+    request_headers:
+      authorization: token <LAB_FORGEJO_TOKEN>
+      accept: application/json
+    status: 200
+    response_body: |
+      {
+        "number": 9,
+        "title": "Wire Forgejo issue provider into convoy startup",
+        "body": "Synthetic Forgejo fixture issue used by replay tests.",
+        "state": "open",
+        "labels": [{"name": "ready"}],
+        "updated_at": "2026-07-24T12:00:00Z",
+        "pull_request": null
+      }
+    response_headers:
+      content-type: application/json;charset=utf-8
+  - channel: http
+    method: GET
+    url: https://forgejo.lab.flotilla.work/api/v1/repos/fork-issues/zellij/issues?state=all&type=issues&since=2026-01-01T00%3A00%3A00Z&sort=recentupdate&limit=30
+    request_headers:
+      accept: application/json
+      authorization: token <LAB_FORGEJO_TOKEN>
+    status: 200
+    response_body: |
+      [
+        {
+          "number": 9,
+          "title": "Wire Forgejo issue provider into convoy startup",
+          "body": "Synthetic Forgejo fixture issue used by replay tests.",
+          "state": "open",
+          "labels": [{"name": "ready"}],
+          "updated_at": "2026-07-24T12:00:00Z",
+          "pull_request": null
+        },
+        {
+          "number": 7,
+          "title": "Closed synthetic Forgejo issue",
+          "body": "Synthetic Forgejo fixture issue used by replay tests.",
+          "state": "closed",
+          "labels": [],
+          "updated_at": "2026-07-24T10:00:00Z",
+          "pull_request": null
+        }
+      ]
+    response_headers:
+      content-type: application/json;charset=utf-8
+      x-total-count: '2'

--- a/crates/flotilla-core/src/providers/issue_tracker/forgejo.rs
+++ b/crates/flotilla-core/src/providers/issue_tracker/forgejo.rs
@@ -1,0 +1,430 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use flotilla_protocol::{
+    issue_query::{IssueQuery, IssueResultPage},
+    AssociationKey, Issue, IssueChangeset, IssueRef, IssueSource, IssueState,
+};
+
+use crate::providers::{http_execute, run, CommandRunner, HttpClient};
+
+const MAX_FORGEJO_LIMIT: usize = 50;
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ForgejoAuth {
+    pub token: String,
+    pub token_path: PathBuf,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ForgejoIssueProviderConfig {
+    pub service_url: String,
+    pub api_base_url: String,
+    pub auth: ForgejoAuth,
+}
+
+impl ForgejoIssueProviderConfig {
+    pub fn new(service_url: String, api_base_url: Option<String>, auth: ForgejoAuth) -> Self {
+        let service_url = service_url.trim_end_matches('/').to_string();
+        let api_base_url = api_base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("{service_url}/api/v1"));
+        Self { service_url, api_base_url, auth }
+    }
+}
+
+pub struct ForgejoIssueProvider {
+    http: Arc<dyn HttpClient>,
+    runner: Arc<dyn CommandRunner>,
+    client: reqwest::Client,
+    config: ForgejoIssueProviderConfig,
+}
+
+impl ForgejoIssueProvider {
+    pub fn new(http: Arc<dyn HttpClient>, runner: Arc<dyn CommandRunner>, config: ForgejoIssueProviderConfig) -> Self {
+        let client = crate::tls::client_builder().build().expect("build Forgejo request client");
+        Self { http, runner, client, config }
+    }
+
+    fn request(&self, path: &str, query: &[(&str, String)]) -> Result<reqwest::Request, String> {
+        let mut url = format!("{}/{}", self.config.api_base_url.trim_end_matches('/'), path.trim_start_matches('/'));
+        if !query.is_empty() {
+            let query = query
+                .iter()
+                .map(|(name, value)| format!("{}={}", urlencoding::encode(name), urlencoding::encode(value)))
+                .collect::<Vec<_>>()
+                .join("&");
+            url.push('?');
+            url.push_str(&query);
+        }
+        self.client
+            .get(url)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header(reqwest::header::AUTHORIZATION, format!("token {}", self.config.auth.token))
+            .build()
+            .map_err(|error| error.to_string())
+    }
+
+    async fn get_json(&self, path: &str, query: &[(&str, String)]) -> Result<(serde_json::Value, bool), String> {
+        let response = http_execute!(self.http, self.request(path, query)?)?;
+        let status = response.status();
+        let has_more = response
+            .headers()
+            .get(reqwest::header::LINK)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|link| link.contains("rel=\"next\""));
+        let body = String::from_utf8_lossy(response.body()).to_string();
+        if !status.is_success() {
+            return Err(format!("Forgejo HTTP {status}: {body}"));
+        }
+        serde_json::from_str(&body).map(|value| (value, has_more)).map_err(|error| error.to_string())
+    }
+
+    fn html_url(&self, reference: &IssueRef) -> String {
+        format!("{}/{}/issues/{}", self.config.service_url.trim_end_matches('/'), reference.source.scope, reference.id)
+    }
+}
+
+fn normalized_service(value: &str) -> &str {
+    value.trim_end_matches('/')
+}
+
+pub fn is_forgejo_source(source: &IssueSource, service_url: &str) -> bool {
+    let service = normalized_service(&source.service);
+    service == "forgejo" || service == normalized_service(service_url)
+}
+
+fn clamp_limit(count: usize) -> usize {
+    if count > MAX_FORGEJO_LIMIT {
+        tracing::warn!(requested = %count, max = MAX_FORGEJO_LIMIT, "Forgejo API page size capped");
+        MAX_FORGEJO_LIMIT
+    } else {
+        count
+    }
+}
+
+fn parse_issue(source: &IssueSource, value: &serde_json::Value, fetched_at: DateTime<Utc>) -> Option<Issue> {
+    if !value["pull_request"].is_null() {
+        return None;
+    }
+    let number = value["number"].as_i64()?;
+    let title = value["title"].as_str()?.to_string();
+    let body = value["body"].as_str().map(str::to_string);
+    let state = match value["state"].as_str()? {
+        "open" => IssueState::Open,
+        "closed" => IssueState::Closed,
+        _ => return None,
+    };
+    let labels = value["labels"]
+        .as_array()
+        .map(|labels| labels.iter().filter_map(|label| label["name"].as_str().map(str::to_string)).collect())
+        .unwrap_or_default();
+    let as_of = value["updated_at"].as_str().and_then(|value| value.parse::<DateTime<Utc>>().ok()).unwrap_or(fetched_at);
+    let id = number.to_string();
+    Some(
+        Issue::builder()
+            .reference(IssueRef { source: source.clone(), id: id.clone() })
+            .title(title)
+            .maybe_body(body)
+            .state(state)
+            .labels(labels)
+            .as_of(as_of)
+            .observed_at(fetched_at)
+            .association_keys(vec![AssociationKey::IssueRef("forgejo".into(), id)])
+            .provider_name("forgejo".into())
+            .provider_display_name("Forgejo".into())
+            .build(),
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn browser_open_command(url: &str) -> (&'static str, Vec<String>) {
+    ("open", vec![url.to_string()])
+}
+
+#[cfg(target_os = "windows")]
+fn browser_open_command(url: &str) -> (&'static str, Vec<String>) {
+    ("cmd", vec!["/C".into(), "start".into(), String::new(), url.to_string()])
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn browser_open_command(url: &str) -> (&'static str, Vec<String>) {
+    ("xdg-open", vec![url.to_string()])
+}
+
+#[async_trait]
+impl super::IssueProvider for ForgejoIssueProvider {
+    fn supports(&self, source: &IssueSource) -> bool {
+        is_forgejo_source(source, &self.config.service_url)
+    }
+
+    async fn query(&self, source: &IssueSource, params: &IssueQuery, page: u32, count: usize) -> Result<IssueResultPage, String> {
+        let limit = clamp_limit(count);
+        let mut query = vec![
+            ("state", "open".to_string()),
+            ("type", "issues".to_string()),
+            ("sort", "recentupdate".to_string()),
+            ("page", page.to_string()),
+            ("limit", limit.to_string()),
+        ];
+        if let Some(label) = &params.label {
+            query.push(("labels", label.clone()));
+        }
+        if let Some(search) = &params.search {
+            query.push(("q", search.clone()));
+        }
+        let (value, has_more) = self.get_json(&format!("repos/{}/issues", source.scope), &query).await?;
+        let fetched_at = Utc::now();
+        let raw_items = value.as_array().ok_or("Forgejo issue list response was not an array")?;
+        let items = raw_items.iter().filter_map(|value| parse_issue(source, value, fetched_at)).collect();
+        Ok(IssueResultPage { items, total: None, has_more })
+    }
+
+    async fn fetch_by_id(&self, reference: &IssueRef) -> Result<Issue, String> {
+        let (value, _) = self.get_json(&format!("repos/{}/issues/{}", reference.source.scope, reference.id), &[]).await?;
+        parse_issue(&reference.source, &value, Utc::now()).ok_or_else(|| format!("failed to parse Forgejo issue {}", reference.id))
+    }
+
+    async fn list_changed_since(&self, source: &IssueSource, since: &str, count: usize) -> Result<IssueChangeset, String> {
+        let limit = clamp_limit(count);
+        let query = vec![
+            ("state", "all".to_string()),
+            ("type", "issues".to_string()),
+            ("since", since.to_string()),
+            ("sort", "recentupdate".to_string()),
+            ("limit", limit.to_string()),
+        ];
+        let (value, has_more) = self.get_json(&format!("repos/{}/issues", source.scope), &query).await?;
+        let fetched_at = Utc::now();
+        let raw_items = value.as_array().ok_or("Forgejo changed-since response was not an array")?;
+        let mut updated = Vec::new();
+        let mut closed = Vec::new();
+        for value in raw_items {
+            match value["state"].as_str() {
+                Some("open") => {
+                    if let Some(issue) = parse_issue(source, value, fetched_at) {
+                        updated.push(issue);
+                    }
+                }
+                Some("closed") => {
+                    if let Some(number) = value["number"].as_i64() {
+                        closed.push(IssueRef { source: source.clone(), id: number.to_string() });
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(IssueChangeset { updated, closed, has_more })
+    }
+
+    async fn open_in_browser(&self, reference: &IssueRef) -> Result<(), String> {
+        let url = self.html_url(reference);
+        let (cmd, args) = browser_open_command(&url);
+        let args = args.iter().map(String::as_str).collect::<Vec<_>>();
+        run!(self.runner, cmd, &args, Path::new("/"))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use super::*;
+    use crate::providers::{
+        issue_tracker::{tests::assert_provider_contract, IssueProvider},
+        replay::{self, Masks},
+        testing::MockRunner,
+        ChannelLabel,
+    };
+
+    type RecordedRequest = (String, String, HashMap<String, String>);
+
+    struct MockHttp {
+        responses: Mutex<Vec<http::Response<bytes::Bytes>>>,
+        requests: Mutex<Vec<RecordedRequest>>,
+    }
+
+    impl MockHttp {
+        fn new(responses: Vec<http::Response<bytes::Bytes>>) -> Self {
+            Self { responses: Mutex::new(responses), requests: Mutex::new(Vec::new()) }
+        }
+
+        fn requests(&self) -> Vec<RecordedRequest> {
+            self.requests.lock().expect("request lock poisoned").clone()
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for MockHttp {
+        async fn execute(&self, request: reqwest::Request, _label: &ChannelLabel) -> Result<http::Response<bytes::Bytes>, String> {
+            let headers =
+                request.headers().iter().map(|(name, value)| (name.to_string(), value.to_str().unwrap_or("").to_string())).collect();
+            self.requests.lock().expect("request lock poisoned").push((request.method().to_string(), request.url().to_string(), headers));
+            Ok(self.responses.lock().expect("response lock poisoned").remove(0))
+        }
+    }
+
+    const LAB_SERVICE_URL: &str = "https://forgejo.lab.flotilla.work";
+
+    fn source() -> IssueSource {
+        IssueSource { service: LAB_SERVICE_URL.into(), scope: "fork-issues/zellij".into() }
+    }
+
+    fn contract_source() -> IssueSource {
+        source()
+    }
+
+    fn auth() -> ForgejoAuth {
+        ForgejoAuth { token: "test-token".into(), token_path: PathBuf::from("/tmp/lab-forgejo-test-token") }
+    }
+
+    fn response(body: &str, has_next: bool) -> http::Response<bytes::Bytes> {
+        let mut builder = http::Response::builder().status(200);
+        if has_next {
+            builder =
+                builder.header("link", "<https://forgejo.lab.flotilla.work/api/v1/repos/fork-issues/zellij/issues?page=2>; rel=\"next\"");
+        }
+        builder.body(bytes::Bytes::from(body.to_string())).expect("response")
+    }
+
+    fn provider(http: Arc<dyn HttpClient>) -> ForgejoIssueProvider {
+        ForgejoIssueProvider::new(
+            http,
+            Arc::new(MockRunner::new(vec![])),
+            ForgejoIssueProviderConfig::new(LAB_SERVICE_URL.into(), None, auth()),
+        )
+    }
+
+    fn fixture(name: &str) -> String {
+        crate::providers::testing::fixture_path("issue_tracker", name)
+    }
+
+    fn replay_auth() -> ForgejoAuth {
+        if !replay::is_live() {
+            return ForgejoAuth { token: "fixture-token".into(), token_path: PathBuf::from("fixture-token") };
+        }
+        let token_path = std::env::var_os("LAB_FORGEJO_TOKEN_PATH")
+            .map(PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|home| home.join(".config/lab-forgejo-coder-token")))
+            .expect("set LAB_FORGEJO_TOKEN_PATH for live Forgejo recording");
+        let token = std::fs::read_to_string(&token_path)
+            .unwrap_or_else(|error| panic!("read Forgejo token {}: {error}", token_path.display()))
+            .trim()
+            .to_string();
+        ForgejoAuth { token, token_path }
+    }
+
+    #[tokio::test]
+    async fn record_replay_satisfies_provider_contract() {
+        let auth = replay_auth();
+        let mut masks = Masks::new();
+        masks.add(&auth.token, "<LAB_FORGEJO_TOKEN>");
+        let session = replay::test_session(&fixture("forgejo_issues.yaml"), masks);
+        let http = replay::test_http_client(&session);
+        let provider = ForgejoIssueProvider::new(
+            http,
+            Arc::new(MockRunner::new(vec![])),
+            ForgejoIssueProviderConfig::new(LAB_SERVICE_URL.into(), None, auth),
+        );
+
+        assert_provider_contract(&provider, &contract_source(), "9", "2026-01-01T00:00:00Z").await;
+
+        session.finish();
+    }
+
+    #[tokio::test]
+    async fn query_sends_forgejo_issue_filters() {
+        let http = Arc::new(MockHttp::new(vec![response("[]", false)]));
+        let provider = provider(http.clone());
+
+        provider
+            .query(&source(), &IssueQuery { search: Some("anchor".into()), label: Some("ready".into()) }, 2, 75)
+            .await
+            .expect("query should succeed");
+
+        let requests = http.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].0, "GET");
+        assert_eq!(
+            requests[0].1,
+            "https://forgejo.lab.flotilla.work/api/v1/repos/fork-issues/zellij/issues?state=open&type=issues&sort=recentupdate&page=2&limit=50&labels=ready&q=anchor"
+        );
+        assert_eq!(requests[0].2.get("authorization").map(String::as_str), Some("token test-token"));
+    }
+
+    #[tokio::test]
+    async fn fetch_by_id_preserves_source_and_body() {
+        let http = Arc::new(MockHttp::new(vec![response(
+            r#"{"number":9,"title":"Atomic tabs","body":"Details","state":"open","labels":[{"name":"ready"}],"updated_at":"2026-07-24T10:00:00Z"}"#,
+            false,
+        )]));
+        let provider = provider(http);
+
+        let reference = IssueRef { source: source(), id: "9".into() };
+        let issue = provider.fetch_by_id(&reference).await.expect("fetch should succeed");
+
+        assert_eq!(issue.reference, reference);
+        assert_eq!(issue.title, "Atomic tabs");
+        assert_eq!(issue.body.as_deref(), Some("Details"));
+        assert_eq!(issue.labels, vec!["ready"]);
+        assert_eq!(issue.provider_name, "forgejo");
+    }
+
+    #[tokio::test]
+    async fn changed_since_partitions_open_and_closed() {
+        let http = Arc::new(MockHttp::new(vec![response(
+            r#"[
+                {"number":9,"title":"Open","state":"open","labels":[]},
+                {"number":10,"title":"Closed","state":"closed","labels":[]}
+            ]"#,
+            true,
+        )]));
+        let provider = provider(http);
+
+        let changes = provider.list_changed_since(&source(), "2026-07-01T00:00:00Z", 10).await.expect("changes should succeed");
+
+        assert_eq!(changes.updated.iter().map(|issue| issue.reference.id.as_str()).collect::<Vec<_>>(), vec!["9"]);
+        assert_eq!(changes.closed, vec![IssueRef { source: source(), id: "10".into() }]);
+        assert!(changes.has_more);
+    }
+
+    #[test]
+    fn supports_configured_forgejo_service_and_generic_alias() {
+        let provider = provider(Arc::new(MockHttp::new(vec![])));
+
+        assert!(provider.supports(&IssueSource { service: "forgejo".into(), scope: "fork-issues/zellij".into() }));
+        assert!(provider.supports(&IssueSource { service: LAB_SERVICE_URL.into(), scope: "fork-issues/zellij".into() }));
+        assert!(
+            !provider.supports(&IssueSource { service: "https://other-forgejo.example.test".into(), scope: "fork-issues/zellij".into() })
+        );
+        assert!(!provider.supports(&IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }));
+    }
+
+    #[tokio::test]
+    async fn open_in_browser_uses_platform_opener_with_source_scope() {
+        let runner = Arc::new(MockRunner::new(vec![Ok(String::new())]));
+        let provider = ForgejoIssueProvider::new(
+            Arc::new(MockHttp::new(vec![])),
+            runner.clone(),
+            ForgejoIssueProviderConfig::new(LAB_SERVICE_URL.into(), None, auth()),
+        );
+        let reference = IssueRef { source: source(), id: "9".into() };
+
+        provider.open_in_browser(&reference).await.expect("open in browser should succeed");
+
+        let url = "https://forgejo.lab.flotilla.work/fork-issues/zellij/issues/9";
+        let (expected_cmd, expected_args) = browser_open_command(url);
+        assert_eq!(runner.calls(), vec![(expected_cmd.into(), expected_args)]);
+    }
+}

--- a/crates/flotilla-core/src/providers/issue_tracker/mod.rs
+++ b/crates/flotilla-core/src/providers/issue_tracker/mod.rs
@@ -1,3 +1,4 @@
+pub mod forgejo;
 pub mod github;
 
 use std::sync::Arc;


### PR DESCRIPTION
Closes #977.

## Summary
- add an HTTP-backed Forgejo IssueProvider for the lab hub with source-addressed fetch, scoped listing, label/search filters, changed-since polling, and browser opening
- add injected config/token-file discovery for lab Forgejo auth plus repo-file issue source binding via [issue_tracker.forgejo]
- wire repo-file Forgejo bindings into durable tracked repo identity selection on daemon startup and repo add
- add replay-backed provider contract coverage with a synthetic Forgejo fixture plus unit coverage for query/auth/config behavior

## Test Plan
- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test -p flotilla-core --locked forgejo --features replay
- cargo test -p flotilla-core --locked configured_repo_identity_prefers_repo_file_forgejo_binding --features test-support
- sandbox-safe workspace tests: TMPDIR=.codex-tmp cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests

## Notes
- Local run of flotilla convoy start --project zellij-fork --issue 9 --no-attach could not verify the exact acceptance path because this daemon state does not contain a zellij-fork Project resource: resource not found.