### PR TITLE
feat: add interactive session workflow

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -529,8 +529,10 @@ mod tests {
     }
 
     #[test]
-    fn convoy_start_bare_issue_resolves_to_project_defaulted_selector() {
-        let resolved = parse(&["convoy", "start", "--project", "flotilla", "--issue", "834"]).resolve().expect("resolve");
+    fn convoy_start_interactive_workflow_with_bare_issue_resolves() {
+        let resolved = parse(&["convoy", "start", "--project", "flotilla", "--workflow", "interactive-single", "--issue", "834"])
+            .resolve()
+            .expect("resolve");
 
         assert_eq!(resolved, Resolved::NeedsContext {
             command: Command {
@@ -544,7 +546,7 @@ mod tests {
                         issues: vec![IssueSelector::Id("834".into())],
                         name: None,
                         branch: None,
-                        workflow_ref: None,
+                        workflow_ref: Some("interactive-single".into()),
                         inputs: vec![],
                         instruction: None,
                         placement_policy: None,

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -560,6 +560,35 @@ mod tests {
     }
 
     #[test]
+    fn convoy_start_bare_issue_resolves_to_project_defaulted_selector() {
+        let resolved = parse(&["convoy", "start", "--project", "flotilla", "--issue", "834"]).resolve().expect("resolve");
+
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyStart {
+                    intent: Box::new(ConvoyStartIntent {
+                        namespace: None,
+                        project_ref: "flotilla".into(),
+                        issues: vec![IssueSelector::Id("834".into())],
+                        name: None,
+                        branch: None,
+                        workflow_ref: None,
+                        inputs: vec![],
+                        instruction: None,
+                        placement_policy: None,
+                        auto_attach: true,
+                    }),
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
     fn convoy_create_resolves() {
         let resolved = parse(&[
             "convoy",

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -13,14 +13,14 @@ use flotilla_protocol::{IssueRef, IssueSource, IssueState};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{Actuation, Reconciler},
-    ensure_repository, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Convoy, ConvoyIssue, ConvoyPhase,
-    ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec,
-    DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec,
-    PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend, ResourceError, Selector, Stance, TerminalSession,
-    TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec,
-    WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL,
-    VESSEL_REF_LABEL,
+    ensure_repository, interactive_single_workflow_spec, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec,
+    Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec,
+    DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta,
+    IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend,
+    ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
+    CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
@@ -1436,22 +1436,7 @@ async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
         .clone()
         .using::<Convoy>(NAMESPACE)
         .update_status("convoy-issue-brief", &convoy.metadata.resource_version, &ConvoyStatus {
-            workflow_snapshot: Some(WorkflowSnapshot {
-                vessels: vec![VesselRequirement {
-                    name: "implement".to_string(),
-                    stance: Stance::Trusted,
-                    depends_on: Vec::new(),
-                    repository_refs: None,
-                    crew: vec![CrewSpec::builder()
-                        .role("coder".to_string())
-                        .source(CrewSource::Agent {
-                            selector: Selector { capability: "coding".to_string() },
-                            prompt: None,
-                            brief_template: None,
-                        })
-                        .build()],
-                }],
-            }),
+            workflow_snapshot: Some(WorkflowSnapshot { vessels: interactive_single_workflow_spec().vessels }),
             ..Default::default()
         })
         .await
@@ -1464,7 +1449,7 @@ async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
         .using::<Vessel>(NAMESPACE)
         .create(&vessel_meta("workspace-issue-brief", "https://github.com/flotilla-org/flotilla"), &VesselSpec {
             convoy_ref: "convoy-issue-brief".to_string(),
-            vessel_name: "implement".to_string(),
+            vessel_name: "work".to_string(),
             placement_policy_ref: "policy-issue-brief".to_string(),
             adopted_checkout_refs: BTreeMap::from([(repository_key, "adopted-checkout-issue-brief".to_string())]),
         })
@@ -1482,6 +1467,7 @@ async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
         panic!("expected structured agent launch");
     };
     assert!(brief.content.contains("## Assignment\n\nYour assignment is the issue snapshot section below."));
+    assert!(brief.content.contains("For interactive sessions, keep the user-facing loop tight"));
     assert!(brief.content.contains("## Issue snapshot"));
     assert!(brief.content.contains("The issue body is the contract."));
     assert!(!brief.content.contains("No assignment was provided"));

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -68,18 +68,22 @@ impl CrewBriefTemplateResolver {
         repo_roots: impl IntoIterator<Item = PathBuf>,
     ) -> CrewBriefRenderOptions {
         let template = template.filter(|template| !template.trim().is_empty()).unwrap_or(DEFAULT_CREW_BRIEF_TEMPLATE);
+        let override_filename = match template {
+            "interactive-session" => "interactive-session.md",
+            other => other,
+        };
         let mut overrides = Vec::new();
         if let Some(config_dir) = &self.config_dir {
-            push_template_override(&mut overrides, config_dir.join(BRIEF_TEMPLATE_DIR).join(template));
+            push_template_override(&mut overrides, config_dir.join(BRIEF_TEMPLATE_DIR).join(override_filename));
             if let Some(project_ref) = project_ref {
                 push_template_override(
                     &mut overrides,
-                    config_dir.join("projects").join(project_ref).join(BRIEF_TEMPLATE_DIR).join(template),
+                    config_dir.join("projects").join(project_ref).join(BRIEF_TEMPLATE_DIR).join(override_filename),
                 );
             }
         }
         for repo_root in repo_roots {
-            push_template_override(&mut overrides, repo_root.join(".flotilla").join(BRIEF_TEMPLATE_DIR).join(template));
+            push_template_override(&mut overrides, repo_root.join(".flotilla").join(BRIEF_TEMPLATE_DIR).join(override_filename));
         }
         CrewBriefRenderOptions { template: template.to_string(), overrides }
     }
@@ -581,6 +585,37 @@ mod tests {
         assert!(selected.contains("For interactive sessions, keep the user-facing loop tight"));
         assert!(selected.contains("## Assignment\n\nPair with the user."));
         assert!(!default.contains("For interactive sessions"));
+    }
+
+    #[test]
+    fn extensionless_interactive_template_uses_markdown_override_filename() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let override_dir = repo.join(".flotilla/brief-templates");
+        std::fs::create_dir_all(&override_dir).expect("override dir");
+        std::fs::write(
+            override_dir.join("interactive-session.md"),
+            "{% block delivery %}Interactive override from the conventional Markdown filename.{% endblock %}",
+        )
+        .expect("override file");
+
+        let options = CrewBriefTemplateResolver::default().render_options(Some("interactive-session"), None, [repo]);
+        let brief = build_crew_brief_with_options(
+            &TerminalCrewContext {
+                namespace: "flotilla".to_string(),
+                convoy: "interactive".to_string(),
+                vessel_ref: "interactive-work".to_string(),
+            },
+            "work",
+            "driver",
+            CrewAssignment::Prompt("Pair with the user."),
+            &[CrewBriefMember { role: "driver".to_string(), state: "active".to_string(), is_agent: true }],
+            &options,
+        )
+        .expect("render selected template");
+
+        assert!(brief.content.contains("Interactive override from the conventional Markdown filename."));
+        assert_eq!(options.overrides[0].path, override_dir.join("interactive-session.md"));
     }
 
     #[test]

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -172,7 +172,7 @@ fn render_crew_brief_template(options: &CrewBriefRenderOptions, context: &CrewBr
     let mut skip_overrides = 0;
     let mut current_template = match options.template.as_str() {
         DEFAULT_CREW_BRIEF_TEMPLATE => BUILTIN_CREW_BRIEF_TEMPLATE_NAME.to_string(),
-        "interactive-session.md" => BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME.to_string(),
+        "interactive-session" | "interactive-session.md" => BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME.to_string(),
         custom if !options.overrides.is_empty() => {
             let first = &options.overrides[0];
             if is_block_only_override(&first.source) {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -304,6 +304,7 @@ fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
                     .build()])
                 .build(),
         ),
+        ("interactive-single", flotilla_resources::interactive_single_workflow_spec()),
         ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
     ]
 }

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -1,5 +1,5 @@
 //! Integration tests for the `ConvoyCreate` + `WorkflowTemplateApply` daemon actions
-//! and the seeded `scratch` WorkflowTemplate registered at startup.
+//! and the bundled WorkflowTemplates registered at startup.
 
 use std::{sync::Arc, time::Duration};
 
@@ -94,6 +94,24 @@ async fn scratch_workflow_template_is_seeded_at_startup() {
         [crew]
             if crew.role == "coder"
                 && matches!(&crew.source, CrewSource::Agent { selector, .. } if selector.capability == "code")
+    ));
+
+    let interactive = templates.get("interactive-single").await.expect("interactive template should be seeded");
+    assert_eq!(interactive.spec.vessels.len(), 1);
+    assert_eq!(interactive.spec.vessels[0].name, "work");
+    assert_eq!(interactive.spec.vessels[0].stance, Stance::Trusted);
+    assert!(matches!(
+        interactive.spec.vessels[0].crew.as_slice(),
+        [crew]
+            if crew.role == "coder"
+                && matches!(
+                    &crew.source,
+                    CrewSource::Agent {
+                        selector,
+                        brief_template: Some(brief_template),
+                        ..
+                    } if selector.capability == "code" && brief_template == "interactive-session"
+                )
     ));
 }
 

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -113,6 +113,7 @@ macro_rules! for_each_registered_resource {
     }};
 }
 pub use workflow_template::{
-    single_agent_contained_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation,
-    Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    interactive_single_workflow_spec, single_agent_contained_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition,
+    InterpolationField, InterpolationLocation, Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate,
+    WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -98,6 +98,23 @@ pub fn single_agent_contained_workflow_spec() -> WorkflowTemplateSpec {
         .build()
 }
 
+pub fn interactive_single_workflow_spec() -> WorkflowTemplateSpec {
+    WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Trusted)
+            .crew(vec![CrewSpec::builder()
+                .role("coder".to_string())
+                .source(CrewSource::Agent {
+                    selector: Selector { capability: "code".to_string() },
+                    prompt: None,
+                    brief_template: Some("interactive-session".to_string()),
+                })
+                .build()])
+            .build()])
+        .build()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
     DuplicateVesselName { name: String },

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -9,9 +9,10 @@ use common::{
 };
 use flotilla_resources::{
     controller::{Actuation, Reconciler},
-    controller_patches, reconcile, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, CrewSource, CrewWorkPhase,
-    InMemoryBackend, InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ResourceBackend, ValidationError, Vessel,
-    VesselPhase, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
+    controller_patches, interactive_single_workflow_spec, reconcile, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch,
+    CrewSource, CrewWorkPhase, InMemoryBackend, InputMeta, InputValue, OwnerReference, Presentation, PresentationSpec, ResourceBackend,
+    ValidationError, Vessel, VesselPhase, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkflowSnapshot, WorkflowTemplate,
+    CONVOY_LABEL, VESSEL_LABEL,
 };
 
 async fn reconcile_once_with_resources(
@@ -671,6 +672,33 @@ fn all_agent_crew_done_rolls_vessel_work_complete() {
     let outcome = reconcile(&convoy, None, timestamp(21));
 
     assert_eq!(outcome.patch, Some(controller_patches::roll_up_work("implement".to_string(), WorkPhase::Complete, timestamp(21), None,)));
+}
+
+#[test]
+fn interactive_convoy_stays_active_until_crew_reports_complete() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.workflow_snapshot = Some(WorkflowSnapshot { vessels: interactive_single_workflow_spec().vessels });
+    let mut work = status.work.remove("implement").expect("seed work");
+    work.phase = WorkPhase::Running;
+    status.work = BTreeMap::from([("work".to_string(), work)]);
+    let mut crew = status.crew_work.remove("implement").expect("seed crew");
+    crew.get_mut("coder").expect("coder work").phase = CrewWorkPhase::Working;
+    status.crew_work = BTreeMap::from([("work".to_string(), crew)]);
+    status.observed_workflow_ref = Some("interactive-single".to_string());
+    status.observed_workflows = Some(BTreeMap::from([("interactive-single".to_string(), "42".to_string())]));
+    let mut spec = valid_convoy_spec();
+    spec.workflow_ref = "interactive-single".to_string();
+
+    let waiting = convoy_object("interactive", spec.clone(), Some(status.clone()));
+    assert_eq!(reconcile(&waiting, None, timestamp(21)).patch, None);
+
+    status.crew_work.get_mut("work").expect("work crew").get_mut("coder").expect("coder work").phase = CrewWorkPhase::Done;
+    let completed = convoy_object("interactive", spec, Some(status));
+    assert_eq!(
+        reconcile(&completed, None, timestamp(22)).patch,
+        Some(controller_patches::roll_up_work("work".to_string(), WorkPhase::Complete, timestamp(22), None))
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #959.

## What changed

- register a bundled `interactive-single` workflow with one trusted `work` vessel and one `coder` crew member
- select the bundled `interactive-session` crew brief by workflow, including support for the extensionless template name from the issue contract
- preserve existing crew-owned settlement semantics: the interactive convoy remains Active while the crew is Working and completes only after `crew complete`
- cover CLI workflow selection, startup seeding, issue-context brief rendering, and settlement behavior

Direct repo-only interactive admission was not cheap within the Project-based `convoy start` shape, so follow-up #975 captures that extension. Existing issue-less Project dispatch remains available through `--instruction` and workflow inputs.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- targeted workflow, reconciler, brief-rendering, CLI, and startup-seeding tests
- sandbox-safe workspace suite; one unrelated fixed-timeout teardown test timed out under concurrent build saturation, then passed in isolation in 2.69s