### PR TITLE
feat: resume completed convoy crew

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -39,6 +39,20 @@ pub enum ConvoyVerb {
         #[arg(long)]
         reason: String,
     },
+    /// Re-task completed crew in an intact convoy vessel
+    Resume {
+        /// Convoy resource name
+        name: String,
+        /// Follow-up brief delivered to the existing crew session
+        #[arg(long)]
+        prompt: String,
+        /// Vessel name; inferred when exactly one completed crew member matches
+        #[arg(long)]
+        vessel: Option<String>,
+        /// Crew role; inferred when exactly one completed crew member matches
+        #[arg(long)]
+        role: Option<String>,
+    },
     /// Start a convoy through Project-scoped admission completion
     Start {
         /// Project whose definitions and repository set admission snapshots
@@ -188,6 +202,24 @@ impl ConvoyNoun {
                     host: HostResolution::Local,
                 })
             }
+            ConvoyVerb::Resume { name, prompt, vessel, role } => {
+                if self.subject.is_some() {
+                    return Err("convoy resume takes its name after `resume`".to_string());
+                }
+                if prompt.trim().is_empty() {
+                    return Err("convoy resume requires a non-empty --prompt".to_string());
+                }
+                Ok(Resolved::NeedsContext {
+                    command: Command {
+                        node_id: None,
+                        provisioning_target: None,
+                        context_repo: None,
+                        action: CommandAction::ConvoyResume { namespace: None, name, prompt, vessel, role },
+                    },
+                    repo: RepoContext::None,
+                    host: HostResolution::Local,
+                })
+            }
             ConvoyVerb::Start {
                 project,
                 issue,
@@ -321,6 +353,15 @@ impl std::fmt::Display for ConvoyNoun {
             }
             ConvoyVerb::Abandon { name, reason } => {
                 write!(f, " abandon {} --reason {}", quote_value(name), quote_value(reason))?;
+            }
+            ConvoyVerb::Resume { name, prompt, vessel, role } => {
+                write!(f, " resume {} --prompt {}", quote_value(name), quote_value(prompt))?;
+                if let Some(vessel) = vessel {
+                    write!(f, " --vessel {}", quote_value(vessel))?;
+                }
+                if let Some(role) = role {
+                    write!(f, " --role {}", quote_value(role))?;
+                }
             }
             ConvoyVerb::Start {
                 project,
@@ -472,6 +513,54 @@ mod tests {
     #[test]
     fn round_trip_delete() {
         assert_round_trip::<ConvoyNoun>(&["convoy", "delete", "failed-convoy"]);
+    }
+
+    #[test]
+    fn convoy_resume_resolves_with_optional_crew_selector() {
+        let resolved = parse(&[
+            "convoy",
+            "resume",
+            "convoy-a",
+            "--prompt",
+            "Rebase onto main and shepherd the PR",
+            "--vessel",
+            "implement",
+            "--role",
+            "coder",
+        ])
+        .resolve()
+        .expect("resolve");
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyResume {
+                    namespace: None,
+                    name: "convoy-a".into(),
+                    prompt: "Rebase onto main and shepherd the PR".into(),
+                    vessel: Some("implement".into()),
+                    role: Some("coder".into()),
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+    }
+
+    #[test]
+    fn round_trip_resume() {
+        assert_round_trip::<ConvoyNoun>(&[
+            "convoy",
+            "resume",
+            "convoy-a",
+            "--prompt",
+            "rebase",
+            "--vessel",
+            "implement",
+            "--role",
+            "coder",
+        ]);
     }
 
     #[test]

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -341,6 +341,7 @@ pub async fn build_plan(
         CommandAction::ConvoyWorkForceComplete { .. }
         | CommandAction::ConvoyDelete { .. }
         | CommandAction::ConvoyAbandon { .. }
+        | CommandAction::ConvoyResume { .. }
         | CommandAction::CrewComplete { .. }
         | CommandAction::CrewFail { .. }
         | CommandAction::CrewHandoff { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2110,7 +2110,8 @@ impl InProcessDaemon {
     ) -> Result<Option<ExistingConvoyTarget>, String> {
         let (namespace, name) = match action {
             flotilla_protocol::CommandAction::ConvoyDelete { namespace, name, .. }
-            | flotilla_protocol::CommandAction::ConvoyAbandon { namespace, name, .. } => {
+            | flotilla_protocol::CommandAction::ConvoyAbandon { namespace, name, .. }
+            | flotilla_protocol::CommandAction::ConvoyResume { namespace, name, .. } => {
                 (namespace.clone().unwrap_or(self.provisioning_namespace().await), name.as_str())
             }
             flotilla_protocol::CommandAction::ConvoyWorkForceComplete { convoy, .. } => {
@@ -4981,6 +4982,83 @@ impl InProcessDaemon {
         .map_err(|err| err.to_string())
     }
 
+    pub async fn convoy_resume_internal(
+        &self,
+        namespace: &str,
+        name: &str,
+        prompt: &str,
+        requested_vessel: Option<&str>,
+        requested_role: Option<&str>,
+    ) -> Result<(), String> {
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
+        let convoy = convoys.get(name).await.map_err(|err| err.to_string())?;
+        let status = convoy.status.as_ref().ok_or_else(|| format!("convoy `{name}` has no status"))?;
+        let candidates = status
+            .crew_work
+            .iter()
+            .flat_map(|(vessel, crew)| crew.iter().map(move |(role, state)| (vessel, role, state)))
+            .filter(|(vessel, role, state)| {
+                state.phase == flotilla_resources::CrewWorkPhase::Done
+                    && requested_vessel.is_none_or(|requested| requested == vessel.as_str())
+                    && requested_role.is_none_or(|requested| requested == role.as_str())
+            })
+            .map(|(vessel, role, _)| (vessel.clone(), role.clone()))
+            .collect::<Vec<_>>();
+        let (vessel, role) = match candidates.as_slice() {
+            [] => {
+                let scope = match (requested_vessel, requested_role) {
+                    (Some(vessel), Some(role)) => format!(" for vessel `{vessel}` role `{role}`"),
+                    (Some(vessel), None) => format!(" for vessel `{vessel}`"),
+                    (None, Some(role)) => format!(" for role `{role}`"),
+                    (None, None) => String::new(),
+                };
+                return Err(format!("convoy `{name}` has no completed crew work{scope}"));
+            }
+            [candidate] => candidate.clone(),
+            _ => {
+                let matches = candidates.iter().map(|(vessel, role)| format!("{vessel}/{role}")).collect::<Vec<_>>().join(", ");
+                return Err(format!(
+                    "convoy `{name}` has multiple completed crew members ({matches}); select one with --vessel and --role"
+                ));
+            }
+        };
+
+        let sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(namespace);
+        let session = sessions
+            .list_matching_labels(&BTreeMap::from([
+                (CONVOY_LABEL.to_string(), name.to_string()),
+                (VESSEL_LABEL.to_string(), vessel.clone()),
+                (ROLE_LABEL.to_string(), role.clone()),
+            ]))
+            .await
+            .map_err(|err| err.to_string())?
+            .items
+            .into_iter()
+            .next()
+            .ok_or_else(|| format!("completed crew member `{role}` on vessel `{vessel}` has no intact terminal session"))?;
+        match session.status.as_ref().map(|status| status.phase) {
+            Some(ResourceTerminalSessionPhase::Running) => self.deliver_to_crew_session(&session, prompt).await?,
+            Some(ResourceTerminalSessionPhase::Stopped) => {
+                queue_pending_crew_message(&sessions, &session, prompt).await?;
+                apply_resource_status_patch(&sessions, &session.metadata.name, &TerminalSessionStatusPatch::MarkStarting)
+                    .await
+                    .map_err(|err| err.to_string())?;
+            }
+            Some(ResourceTerminalSessionPhase::Starting) | None => queue_pending_crew_message(&sessions, &session, prompt).await?,
+            Some(ResourceTerminalSessionPhase::Failed) => {
+                return Err(format!("crew member `{role}` on vessel `{vessel}` failed provisioning and cannot be resumed"));
+            }
+        }
+        apply_resource_status_patch(
+            &convoys,
+            name,
+            &convoy_external_patches::resume_crew_work(vessel, role, chrono::Utc::now(), prompt.to_string()),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|err| err.to_string())
+    }
+
     async fn deliver_to_crew_session(
         &self,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
@@ -5743,6 +5821,17 @@ impl InProcessDaemon {
         if let flotilla_protocol::CommandAction::CrewHandoff { context, target, message } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
             let result = match self.crew_handoff_internal(context, target, message).await {
+                Ok(()) => flotilla_protocol::CommandValue::Ok,
+                Err(message) => flotilla_protocol::CommandValue::Error { message },
+            };
+            self.finish_context_free_command(id, empty_identity, result);
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ConvoyResume { namespace, name, prompt, vessel, role } = &command.action {
+            let empty_identity = self.start_context_free_command(id, command.description().to_string());
+            let namespace = namespace.clone().unwrap_or(self.provisioning_namespace().await);
+            let result = match self.convoy_resume_internal(&namespace, name, prompt, vessel.as_deref(), role.as_deref()).await {
                 Ok(()) => flotilla_protocol::CommandValue::Ok,
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             };

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4990,6 +4990,9 @@ impl InProcessDaemon {
         requested_vessel: Option<&str>,
         requested_role: Option<&str>,
     ) -> Result<(), String> {
+        if prompt.trim().is_empty() {
+            return Err("convoy resume requires a non-empty prompt".to_string());
+        }
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
         let convoy = convoys.get(name).await.map_err(|err| err.to_string())?;
         let status = convoy.status.as_ref().ok_or_else(|| format!("convoy `{name}` has no status"))?;

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -885,6 +885,117 @@ async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
 }
 
 #[tokio::test]
+async fn convoy_resume_delivers_follow_up_to_unique_completed_crew_session() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+    daemon
+        .crew_complete_internal(&CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() }, Some("ready".into()))
+        .await
+        .expect("complete coder work");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyResume {
+                namespace: Some("flotilla".into()),
+                name: "demo".into(),
+                prompt: "Rebase onto main and shepherd the PR".into(),
+                vessel: None,
+                role: None,
+            },
+        })
+        .await
+        .expect("resume command");
+
+    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
+    assert_eq!(terminal_pool.delivered.lock().await.as_slice(), &[(
+        "session-coder".to_string(),
+        "Rebase onto main and shepherd the PR".to_string(),
+        true,
+    )]);
+    let convoy = daemon.resource_backend().using::<Convoy>("flotilla").get("demo").await.expect("convoy");
+    let coder = &convoy.status.expect("convoy status").crew_work["implement"]["coder"];
+    assert_eq!(coder.phase, CrewWorkPhase::Working);
+    assert_eq!(coder.finished_at, None);
+    assert_eq!(coder.message.as_deref(), Some("Rebase onto main and shepherd the PR"));
+}
+
+#[tokio::test]
+async fn convoy_resume_requires_a_selector_when_completed_crew_is_ambiguous() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+    for role in ["coder", "reviewer"] {
+        daemon
+            .crew_complete_internal(
+                &CrewCommandContext {
+                    namespace: Some("flotilla".into()),
+                    convoy: Some("demo".into()),
+                    vessel_ref: Some("demo-implement".into()),
+                    role: Some(role.into()),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .expect("complete crew work");
+    }
+
+    let error = daemon
+        .convoy_resume_internal("flotilla", "demo", "Continue", None, None)
+        .await
+        .expect_err("ambiguous crew should require selection");
+
+    assert!(error.contains("--vessel and --role"), "unexpected error: {error}");
+    assert!(terminal_pool.delivered.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn convoy_resume_restarts_an_intact_stopped_crew_session_with_the_follow_up_prompt() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+    daemon
+        .crew_complete_internal(&CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() }, None)
+        .await
+        .expect("complete coder work");
+    let terminals = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let coder = terminals.get("terminal-demo-implement-coder").await.expect("coder session");
+    terminals
+        .update_status("terminal-demo-implement-coder", &coder.metadata.resource_version, &ResourceTerminalSessionStatus {
+            phase: ResourceTerminalSessionPhase::Stopped,
+            session_id: Some("session-coder".into()),
+            crew: coder.status.as_ref().and_then(|status| status.crew.clone()),
+            ..Default::default()
+        })
+        .await
+        .expect("stop coder session");
+
+    daemon
+        .convoy_resume_internal("flotilla", "demo", "Rebase onto main", Some("implement"), Some("coder"))
+        .await
+        .expect("resume stopped coder");
+
+    assert!(terminal_pool.delivered.lock().await.is_empty());
+    let coder = terminals.get("terminal-demo-implement-coder").await.expect("restarting coder session");
+    assert_eq!(coder.status.expect("coder status").phase, ResourceTerminalSessionPhase::Starting);
+    assert!(matches!(
+        coder.spec.source,
+        TerminalSessionSource::Agent { message: Some(ref message), .. } if message.text == "Rebase onto main"
+    ));
+}
+
+#[tokio::test]
 async fn crew_fail_uses_ambient_identity_to_fail_callers_work() {
     let temp = tempfile::tempdir().expect("tempdir");
     std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -959,6 +959,18 @@ async fn convoy_resume_requires_a_selector_when_completed_crew_is_ambiguous() {
 }
 
 #[tokio::test]
+async fn convoy_resume_rejects_an_empty_protocol_prompt_before_delivery() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(temp.path()).await;
+
+    let error = daemon.convoy_resume_internal("flotilla", "demo", "  ", None, None).await.expect_err("empty prompt should be rejected");
+
+    assert_eq!(error, "convoy resume requires a non-empty prompt");
+    assert!(terminal_pool.delivered.lock().await.is_empty());
+}
+
+#[tokio::test]
 async fn convoy_resume_restarts_an_intact_stopped_crew_session_with_the_follow_up_prompt() {
     let temp = tempfile::tempdir().expect("tempdir");
     std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -182,6 +182,7 @@ impl RemoteCommandRouter {
                     CommandAction::ConvoyStartPrepared { .. }
                         | CommandAction::ConvoyDelete { .. }
                         | CommandAction::ConvoyAbandon { .. }
+                        | CommandAction::ConvoyResume { .. }
                         | CommandAction::ConvoyWorkForceComplete { .. }
                         | CommandAction::ResourceWatch { .. }
                 )

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -275,6 +275,16 @@ pub enum CommandAction {
         name: String,
         reason: String,
     },
+    ConvoyResume {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
+        name: String,
+        prompt: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        vessel: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        role: Option<String>,
+    },
     CrewHandoff {
         context: CrewCommandContext,
         target: String,
@@ -456,6 +466,7 @@ impl Command {
             CommandAction::ConvoyWorkForceComplete { .. } => "Force-completing work...",
             CommandAction::ConvoyDelete { .. } => "Deleting convoy...",
             CommandAction::ConvoyAbandon { .. } => "Abandoning convoy...",
+            CommandAction::ConvoyResume { .. } => "Resuming convoy crew...",
             CommandAction::CrewHandoff { .. } => "Handing off to crew member...",
             CommandAction::CrewComplete { .. } => "Completing crew work...",
             CommandAction::CrewFail { .. } => "Failing crew work...",
@@ -822,6 +833,18 @@ mod tests {
                 provisioning_target: None,
                 context_repo: None,
                 action: CommandAction::ConvoyDelete { namespace: Some("flotilla".into()), name: "failed-convoy".into(), force: false },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyResume {
+                    namespace: Some("flotilla".into()),
+                    name: "convoy-a".into(),
+                    prompt: "Rebase onto main".into(),
+                    vessel: Some("implement".into()),
+                    role: Some("coder".into()),
+                },
             },
             Command {
                 node_id: None,

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -294,6 +294,12 @@ pub enum ConvoyStatusPatch {
         handed_off_at: DateTime<Utc>,
         message: String,
     },
+    ResumeCrewWork {
+        vessel: String,
+        role: String,
+        resumed_at: DateTime<Utc>,
+        prompt: String,
+    },
     RollUpWork {
         work: String,
         phase: WorkPhase,
@@ -476,6 +482,17 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                     }
                 }
             }
+            Self::ResumeCrewWork { vessel, role, resumed_at, prompt } => {
+                if let Some(work) = status.work.get_mut(vessel) {
+                    work.completion_authority = WorkCompletionAuthority::CrewRollup;
+                }
+                if let Some(state) = status.crew_work.get_mut(vessel).and_then(|crew| crew.get_mut(role)) {
+                    state.phase = CrewWorkPhase::Working;
+                    state.started_at.get_or_insert(*resumed_at);
+                    state.finished_at = None;
+                    state.message = Some(prompt.clone());
+                }
+            }
             Self::RollUpWork { work, phase, transitioned_at, message } => {
                 if let Some(state) = status.work.get_mut(work) {
                     // Work roll-up reports the same process across continuation and re-settlement.
@@ -594,5 +611,9 @@ pub mod external_patches {
         message: String,
     ) -> ConvoyStatusPatch {
         ConvoyStatusPatch::HandoffCrewWork { vessel, sender_role, target_role, handed_off_at, message }
+    }
+
+    pub fn resume_crew_work(vessel: String, role: String, resumed_at: DateTime<Utc>, prompt: String) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::ResumeCrewWork { vessel, role, resumed_at, prompt }
     }
 }

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -212,6 +212,40 @@ fn handoff_to_done_crew_reopens_target_and_marks_sender_handed_back() {
 }
 
 #[test]
+fn resume_reopens_completed_crew_without_restarting_its_timeline() {
+    let mut coder = crew_work(CrewWorkPhase::Done);
+    coder.finished_at = Some(ts(15));
+    coder.message = Some("ready".to_string());
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Completed,
+        workflow_snapshot: Some(sample_snapshot()),
+        work: BTreeMap::from([("implement".to_string(), WorkState {
+            phase: WorkPhase::Complete,
+            completion_authority: WorkCompletionAuthority::CrewRollup,
+            ready_at: Some(ts(8)),
+            started_at: Some(ts(9)),
+            finished_at: Some(ts(16)),
+            message: Some("complete".to_string()),
+            placement: None,
+        })]),
+        crew_work: BTreeMap::from([("implement".to_string(), BTreeMap::from([("coder".to_string(), coder)]))]),
+        message: None,
+        started_at: Some(ts(1)),
+        finished_at: Some(ts(16)),
+        observed_workflow_ref: Some("single-agent-contained".to_string()),
+        observed_workflows: Some(BTreeMap::new()),
+    };
+
+    external_patches::resume_crew_work("implement".to_string(), "coder".to_string(), ts(20), "Rebase onto main".to_string())
+        .apply(&mut status);
+
+    assert_eq!(status.crew_work["implement"]["coder"].phase, CrewWorkPhase::Working);
+    assert_eq!(status.crew_work["implement"]["coder"].started_at, Some(ts(10)));
+    assert_eq!(status.crew_work["implement"]["coder"].finished_at, None);
+    assert_eq!(status.crew_work["implement"]["coder"].message.as_deref(), Some("Rebase onto main"));
+}
+
+#[test]
 fn running_vessel_work_starts_pending_agents_without_reopening_done_agents() {
     let mut pending_coder = crew_work(CrewWorkPhase::Pending);
     pending_coder.started_at = None;

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -63,6 +63,7 @@ define_patch_kinds! {
     ConvoyMarkCrewCompleted => DUPLICATE_RESETTLEMENT,
     ConvoyMarkCrewFailed => DUPLICATE_RESETTLEMENT,
     ConvoyHandoffCrewWork => CONTINUATION,
+    ConvoyResumeCrewWork => CONTINUATION,
     ConvoyRollUpWork => DUPLICATE_CONTINUATION_RESETTLEMENT,
     TerminalMarkStarting => NEW_ATTEMPT,
     TerminalMarkRunning => DUPLICATE,
@@ -96,6 +97,7 @@ fn convoy_patch_kind(patch: &ConvoyStatusPatch) -> PatchKind {
         ConvoyStatusPatch::MarkCrewCompleted { .. } => PatchKind::ConvoyMarkCrewCompleted,
         ConvoyStatusPatch::MarkCrewFailed { .. } => PatchKind::ConvoyMarkCrewFailed,
         ConvoyStatusPatch::HandoffCrewWork { .. } => PatchKind::ConvoyHandoffCrewWork,
+        ConvoyStatusPatch::ResumeCrewWork { .. } => PatchKind::ConvoyResumeCrewWork,
         ConvoyStatusPatch::RollUpWork { .. } => PatchKind::ConvoyRollUpWork,
     }
 }
@@ -675,6 +677,22 @@ fn continuation_transitions_keep_started_at_and_clear_finished_at() {
                     target_role: "coder".to_string(),
                     handed_off_at: ts(30),
                     message: "address review".to_string(),
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, crew_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "crew resume",
+            kind: PatchKind::ConvoyResumeCrewWork,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = crew_timestamps(&status);
+                let patch = ConvoyStatusPatch::ResumeCrewWork {
+                    vessel: "implement".to_string(),
+                    role: "coder".to_string(),
+                    resumed_at: ts(30),
+                    prompt: "rebase onto main".to_string(),
                 };
                 apply_and_replay(&mut status, &patch);
                 (before, crew_timestamps(&status))

--- a/docs/charters/governor.md
+++ b/docs/charters/governor.md
@@ -124,6 +124,17 @@ crew push, or land the PR), don't `--force` past it. `--force` skips the gate
 and nothing else; abandonment (best-effort push, stamped authority + reason)
 is the archive path for judged-out work.
 
+If a completed convoy's PR needs a rebase or late follow-up before landing,
+return ownership to its intact crew and warm vessel:
+
+```sh
+flotilla convoy resume <name> --prompt "Rebase onto main and shepherd the PR"
+```
+
+When more than one completed crew member matches, add `--vessel <name>` and
+`--role <role>`. Use direct `cleat send` only for live corrective intervention,
+not to reopen settled crew work.
+
 ## Recording
 
 - Rulings from grills and design decisions land on the issue **when made**,


### PR DESCRIPTION
## Summary

- add `flotilla convoy resume <name> --prompt <brief>` to re-task completed crew in an intact vessel
- infer the target when exactly one completed crew member matches, with `--vessel` and `--role` selectors for ambiguous convoys
- deliver directly to a running session or queue the prompt and restart a stopped session
- reopen crew, vessel work, and convoy lifecycle state through the existing reconciliation path
- route resume commands to the convoy's home host

## Why

A convoy can complete before its PR merges while its checkout, terminal, context, and warm build cache remain intact. When the PR later conflicts or receives follow-up work, the authoring crew should regain ownership inside that warm vessel instead of forcing a fresh-context resolution.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- focused CLI, protocol, lifecycle, active-session, ambiguity, and stopped-session tests
- `cargo test --workspace --locked` (feature tests passed; one unrelated daemon provisioner timing test expired under concurrent host load and passed immediately in isolation)

Closes #957