### PR TITLE
fix: gossip learned peer display names

### DIFF
--- a/crates/flotilla-daemon/src/peer/channel_tests.rs
+++ b/crates/flotilla-daemon/src/peer/channel_tests.rs
@@ -23,6 +23,7 @@ fn snapshot_msg(origin: &str, repo: &RepoIdentity, seq: u64) -> PeerDataMessage 
     }
     PeerDataMessage {
         origin_node_id: node(origin),
+        origin_display_name: origin.to_string(),
         repo_identity: repo.clone(),
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/repo")),

--- a/crates/flotilla-daemon/src/peer/channel_transport.rs
+++ b/crates/flotilla-daemon/src/peer/channel_transport.rs
@@ -348,6 +348,7 @@ mod tests {
     fn test_snapshot_msg(origin: &str, seq: u64) -> PeerWireMessage {
         PeerWireMessage::Data(PeerDataMessage {
             origin_node_id: NodeId::new(origin),
+            origin_display_name: origin.to_string(),
             repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
             repository_key: None,
             host_repo_root: Some(PathBuf::from("/repo")),

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -281,6 +281,9 @@ pub struct PeerManager {
     /// `transport_peers`, this survives disconnect so topology diagnostics
     /// remain attributable while retries are failing.
     learned_transport_peers: HashMap<ConfigLabel, NodeId>,
+    /// Self-declared display names learned from peer gossip, including nodes
+    /// reached through another peer.
+    learned_node_names: HashMap<NodeId, String>,
     generations: HashMap<NodeId, u64>,
     routes: HashMap<NodeId, RouteState>,
     /// TODO: expire abandoned reverse-path entries when routed replies time out
@@ -324,6 +327,7 @@ impl PeerManager {
             reconnect_suppressed_until: HashMap::new(),
             transport_peers: HashMap::new(),
             learned_transport_peers: HashMap::new(),
+            learned_node_names: HashMap::new(),
             generations: HashMap::new(),
             routes: HashMap::new(),
             reverse_paths: HashMap::new(),
@@ -356,6 +360,7 @@ impl PeerManager {
             .values()
             .find(|summary| summary.node.node_id == *node_id)
             .map(|summary| summary.node.clone())
+            .or_else(|| self.learned_node_names.get(node_id).map(|display_name| NodeInfo::new(node_id.clone(), display_name.clone())))
             .unwrap_or_else(|| NodeInfo::new(node_id.clone(), node_id.to_string()))
     }
 
@@ -616,6 +621,9 @@ impl PeerManager {
 
     fn store_snapshot_from(&mut self, via_peer: &NodeId, via_generation: u64, msg: PeerDataMessage) -> HandleResult {
         let origin = msg.origin_node_id.clone();
+        if !msg.origin_display_name.is_empty() {
+            self.learned_node_names.insert(origin.clone(), msg.origin_display_name.clone());
+        }
         let repo = msg.repo_identity.clone();
         let repository_key = msg.repository_key.clone();
         let host_repo_root = msg.host_repo_root.clone();
@@ -760,6 +768,7 @@ impl PeerManager {
                 request_id,
                 requester_node_id,
                 responder_node_id,
+                responder_display_name,
                 remaining_hops,
                 repo_identity,
                 repository_key,
@@ -782,6 +791,7 @@ impl PeerManager {
                     self.last_seen_clocks.remove(&(responder_node_id.clone(), repo_identity.clone()));
                     return self.store_snapshot_from(&connection_peer, connection_generation, PeerDataMessage {
                         origin_node_id: responder_node_id,
+                        origin_display_name: responder_display_name,
                         repo_identity,
                         repository_key,
                         host_repo_root,
@@ -806,6 +816,7 @@ impl PeerManager {
                     request_id,
                     requester_node_id,
                     responder_node_id,
+                    responder_display_name,
                     remaining_hops: remaining_hops.saturating_sub(1),
                     repo_identity,
                     repository_key,

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -19,6 +19,7 @@ fn snapshot_msg(origin: &str, seq: u64) -> PeerDataMessage {
     }
     PeerDataMessage {
         origin_node_id: NodeId::new(origin),
+        origin_display_name: origin.to_string(),
         repo_identity: test_repo(),
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/home/dev/repo")),
@@ -105,6 +106,7 @@ async fn handle_snapshot_without_host_repo_root_stores_none() {
     let mut mgr = PeerManager::new(NodeId::new("local"));
     let msg = PeerDataMessage {
         origin_node_id: NodeId::new("remote"),
+        origin_display_name: "remote".into(),
         repo_identity: test_repo(),
         repository_key: None,
         host_repo_root: None,
@@ -126,6 +128,7 @@ async fn legacy_direct_request_resync_is_ignored() {
 
     let msg = PeerDataMessage {
         origin_node_id: NodeId::new("remote"),
+        origin_display_name: "remote".into(),
         repo_identity: test_repo(),
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/home/dev/repo")),
@@ -148,6 +151,7 @@ async fn handle_delta_returns_needs_resync() {
 
     let msg = PeerDataMessage {
         origin_node_id: NodeId::new("remote"),
+        origin_display_name: "remote".into(),
         repo_identity: test_repo(),
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/home/dev/repo")),
@@ -237,6 +241,7 @@ async fn relay_skips_peers_already_in_clock() {
     clock.tick(&NodeId::new("leader"));
     let msg = PeerDataMessage {
         origin_node_id: NodeId::new("F1"),
+        origin_display_name: "F1".into(),
         repo_identity: test_repo(),
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/home/dev/repo")),
@@ -694,6 +699,7 @@ async fn late_resync_snapshot_is_dropped_without_pending_request() {
                 request_id: 1,
                 requester_node_id: NodeId::new("local"),
                 responder_node_id: NodeId::new("target"),
+                responder_display_name: "target".into(),
                 remaining_hops: 3,
                 repo_identity: test_repo(),
                 repository_key: None,
@@ -923,6 +929,37 @@ async fn topology_routes_sort_fallbacks_by_most_recently_learned() {
 }
 
 #[tokio::test]
+async fn topology_routes_use_gossiped_name_for_learned_peer() {
+    let mut mgr = PeerManager::new(NodeId::new("feta-id"));
+    let relay_generation =
+        accepted_generation(mgr.activate_connection(NodeId::new("kiwi-id"), MockPeerSender::discard(), ConnectionMeta {
+            direction: ConnectionDirection::Inbound,
+            config_label: None,
+            expected_peer: None,
+            config_backed: false,
+        }));
+    let mut message = snapshot_msg("udder-id", 1);
+    message.origin_display_name = "udder".into();
+
+    let result = mgr
+        .handle_inbound(InboundPeerEnvelope {
+            msg: PeerWireMessage::Data(message),
+            connection_generation: relay_generation,
+            connection_peer: NodeId::new("kiwi-id"),
+        })
+        .await;
+
+    assert_eq!(result, HandleResult::Updated(test_repo()));
+    let route = mgr
+        .topology_routes()
+        .into_iter()
+        .find(|route| route.target.node_id == NodeId::new("udder-id"))
+        .expect("learned route should be exposed");
+    assert_eq!(route.target.display_name, "udder");
+    assert_eq!(route.next_hop.node_id, NodeId::new("kiwi-id"));
+}
+
+#[tokio::test]
 async fn disconnect_peer_keeps_unrelated_pending_resync_requests() {
     let mut mgr = PeerManager::new(NodeId::new("local"));
     let _ = accepted_generation(mgr.activate_connection(NodeId::new("target"), MockPeerSender::discard(), ConnectionMeta {
@@ -1028,6 +1065,7 @@ async fn failover_resync_for_relayed_origin_accepts_same_clock_snapshot() {
                 request_id,
                 requester_node_id: NodeId::new("local"),
                 responder_node_id: NodeId::new("target"),
+                responder_display_name: "target".into(),
                 remaining_hops: 4,
                 repo_identity: baseline.repo_identity.clone(),
                 repository_key: None,
@@ -1092,6 +1130,7 @@ async fn failover_resync_accepts_snapshot_without_host_repo_root() {
                 request_id,
                 requester_node_id: NodeId::new("local"),
                 responder_node_id: NodeId::new("target"),
+                responder_display_name: "target".into(),
                 remaining_hops: 4,
                 repo_identity: baseline.repo_identity.clone(),
                 repository_key: None,
@@ -1213,6 +1252,7 @@ async fn failover_resync_clears_stale_and_rebinds_provenance() {
                 request_id: request,
                 requester_node_id: NodeId::new("local"),
                 responder_node_id: NodeId::new("target"),
+                responder_display_name: "target".into(),
                 remaining_hops: 4,
                 repo_identity: baseline.repo_identity.clone(),
                 repository_key: None,

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -739,6 +739,7 @@ mod tests {
             .expect("serialize hello");
             let peer = serde_json::to_string(&Message::Peer(Box::new(PeerWireMessage::Data(PeerDataMessage {
                 origin_node_id: NodeId::new("remote"),
+                origin_display_name: "remote".into(),
                 repo_identity: flotilla_protocol::RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
                 repository_key: None,
                 host_repo_root: Some(PathBuf::from("/home/remote/repo")),

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -499,6 +499,7 @@ impl PeerRuntime {
                                                             request_id,
                                                             requester_node_id,
                                                             responder_node_id: local_node_id,
+                                                            responder_display_name: peer_daemon.host_name().to_string(),
                                                             remaining_hops: PeerManager::DEFAULT_ROUTED_HOPS,
                                                             repo_identity: repo,
                                                             repository_key,
@@ -922,6 +923,7 @@ pub(super) async fn send_local_to_peers(
     clock.tick(node_id);
     let msg = PeerDataMessage {
         origin_node_id: node_id.clone(),
+        origin_display_name: daemon.host_name().to_string(),
         repo_identity: identity,
         repository_key: daemon.repository_key_for_path(repo_path).await,
         host_repo_root: Some(repo_path.to_path_buf()),
@@ -992,6 +994,7 @@ pub(super) async fn send_local_to_peer(
         clock.tick(node_id);
         let msg = PeerDataMessage {
             origin_node_id: node_id.clone(),
+            origin_display_name: daemon.host_name().to_string(),
             repo_identity: identity,
             repository_key: daemon.repository_key_for_path(&repo_path).await,
             host_repo_root: Some(repo_path.clone()),

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -428,6 +428,7 @@ fn node_info(name: &str) -> NodeInfo {
 fn peer_snapshot(host: &str, repo_identity: &RepoIdentity, repo_path: &Path, checkout_path: &str, branch: &str) -> PeerDataMessage {
     PeerDataMessage {
         origin_node_id: NodeId::new(host),
+        origin_display_name: host.to_string(),
         repo_identity: repo_identity.clone(),
         repository_key: None,
         host_repo_root: Some(repo_path.to_path_buf()),
@@ -2651,6 +2652,7 @@ async fn daemon_server_does_not_replay_configured_peers_without_host_environment
 fn test_peer_msg(host: &str) -> PeerDataMessage {
     PeerDataMessage {
         origin_node_id: NodeId::new(host),
+        origin_display_name: host.to_string(),
         repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/tmp/repo")),

--- a/crates/flotilla-daemon/tests/multi_host.rs
+++ b/crates/flotilla-daemon/tests/multi_host.rs
@@ -48,6 +48,7 @@ fn snapshot_msg(origin: &str, seq: u64, data: ProviderData) -> PeerDataMessage {
     }
     PeerDataMessage {
         origin_node_id: node(origin),
+        origin_display_name: origin.to_string(),
         repo_identity: test_repo(),
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/home/dev/repo")),
@@ -606,6 +607,7 @@ async fn delta_message_returns_needs_resync() {
 
     let msg = PeerDataMessage {
         origin_node_id: node("follower"),
+        origin_display_name: "follower".into(),
         repo_identity: test_repo(),
         repository_key: None,
         host_repo_root: Some(PathBuf::from("/home/dev/repo")),

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -463,6 +463,7 @@ fn observe_focus_request_round_trips_typed_resource_targets() {
 fn message_peer_data_roundtrip() {
     let msg = Message::Peer(Box::new(PeerWireMessage::Data(PeerDataMessage {
         origin_node_id: NodeId::new("desktop"),
+        origin_display_name: "Desktop".into(),
         repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
         repository_key: Some(RepositoryKey("repo_peer".into())),
         host_repo_root: Some(PathBuf::from("/tmp/repo")),
@@ -493,6 +494,7 @@ fn message_peer_routed_resync_snapshot_roundtrip() {
         request_id: 6,
         requester_node_id: NodeId::new("laptop"),
         responder_node_id: NodeId::new("desktop"),
+        responder_display_name: "Desktop".into(),
         remaining_hops: 4,
         repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
         repository_key: Some(RepositoryKey("repo_peer".into())),

--- a/crates/flotilla-protocol/src/peer.rs
+++ b/crates/flotilla-protocol/src/peer.rs
@@ -56,6 +56,7 @@ impl VectorClock {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerDataMessage {
     pub origin_node_id: NodeId,
+    pub origin_display_name: String,
     pub repo_identity: RepoIdentity,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository_key: Option<RepositoryKey>,
@@ -100,6 +101,7 @@ pub enum RoutedPeerMessage {
         request_id: u64,
         requester_node_id: NodeId,
         responder_node_id: NodeId,
+        responder_display_name: String,
         remaining_hops: u8,
         repo_identity: RepoIdentity,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -327,7 +329,7 @@ mod tests {
     #[test]
     fn vector_clock_serde_default() {
         // Deserializing a message without a clock field should give default
-        let json = r#"{"origin_node_id":"desktop","repo_identity":{"authority":"github.com","path":"owner/repo"},"kind":{"type":"request_resync","since_seq":0}}"#;
+        let json = r#"{"origin_node_id":"desktop","origin_display_name":"Desktop","repo_identity":{"authority":"github.com","path":"owner/repo"},"kind":{"type":"request_resync","since_seq":0}}"#;
         let msg: PeerDataMessage = serde_json::from_str(json).expect("deserialize without clock");
         assert!(msg.clock.0.is_empty(), "default clock should be empty");
         assert_eq!(msg.host_repo_root, None);
@@ -337,6 +339,7 @@ mod tests {
     fn peer_data_message_snapshot_roundtrip() {
         let msg = PeerDataMessage {
             origin_node_id: NodeId::new("desktop"),
+            origin_display_name: "Desktop".into(),
             repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
             repository_key: Some(RepositoryKey("repo_opaque".into())),
             host_repo_root: Some(PathBuf::from("/home/dev/repo")),
@@ -345,9 +348,11 @@ mod tests {
         };
         let json_value = serde_json::to_value(&msg).expect("serialize");
         assert_eq!(json_value["origin_node_id"], "desktop");
+        assert_eq!(json_value["origin_display_name"], "Desktop");
         let json = serde_json::to_string(&msg).expect("serialize");
         let back: PeerDataMessage = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.origin_node_id, msg.origin_node_id);
+        assert_eq!(back.origin_display_name, msg.origin_display_name);
         assert_eq!(back.repo_identity, msg.repo_identity);
         assert_eq!(back.host_repo_root, msg.host_repo_root);
     }
@@ -356,6 +361,7 @@ mod tests {
     fn peer_data_message_snapshot_roundtrip_without_host_repo_root() {
         let msg = PeerDataMessage {
             origin_node_id: NodeId::new("desktop"),
+            origin_display_name: "Desktop".into(),
             repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
             repository_key: None,
             host_repo_root: None,
@@ -372,6 +378,7 @@ mod tests {
     fn peer_data_message_request_resync() {
         let msg = PeerDataMessage {
             origin_node_id: NodeId::new("cloud"),
+            origin_display_name: "Cloud".into(),
             repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
             repository_key: None,
             host_repo_root: Some(PathBuf::from("/opt/repo")),
@@ -417,6 +424,7 @@ mod tests {
 
         let msg = PeerDataMessage {
             origin_node_id: NodeId::new("laptop"),
+            origin_display_name: "Laptop".into(),
             repo_identity: RepoIdentity { authority: "github.com".into(), path: "owner/repo".into() },
             repository_key: None,
             host_repo_root: Some(PathBuf::from("/home/dev/repo")),


### PR DESCRIPTION
Closes #908.

Peers now include their self-declared display name with both ordinary snapshot gossip and routed resync snapshots. The peer manager retains those learned names and uses them when constructing topology routes, falling back to raw node IDs only when no name is known.

A regression test covers feta learning `udder-id` via `kiwi-id` and verifies that the route target is rendered with the learned `udder` name.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
