### PR TITLE
fix: polish daemon reconnect experience

### DIFF
--- a/crates/flotilla-client/build.rs
+++ b/crates/flotilla-client/build.rs
@@ -27,6 +27,5 @@ fn main() {
         .filter(|value| !value.is_empty())
         .or_else(|| git_output(&["rev-parse", "--short=12", "HEAD"]))
         .unwrap_or_else(|| "unknown".to_string());
-
     println!("cargo::rustc-env=FLOTILLA_BUILD_ID={build_id}");
 }

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -18,6 +18,8 @@ use flotilla_transport::message::{connect_unix_message_session, MessageSession};
 use tokio::sync::{broadcast, oneshot, Mutex};
 use tracing::{debug, error, warn};
 
+pub mod reconnect;
+
 /// Std RwLock for local seq tracking — the critical sections are single HashMap
 /// operations (no async work while holding the lock), and using a sync lock
 /// avoids the race where a spawned seq update hasn't run before the next delta
@@ -60,21 +62,21 @@ impl Drop for SpawnLockGuard {
 ///
 /// Sends a `Hello` with `ConnectionRole::Client` and a fresh `session_id`,
 /// then waits for the server's Hello reply.
-async fn do_client_hello(session: &MessageSession) -> Result<(), String> {
+async fn do_client_hello(session: &MessageSession) -> Result<Option<String>, String> {
     do_client_hello_with_surface(session, None).await
 }
 
-async fn do_client_hello_with_declared_surface(session: &MessageSession, surface: SurfaceDeclaration) -> Result<(), String> {
+async fn do_client_hello_with_declared_surface(session: &MessageSession, surface: SurfaceDeclaration) -> Result<Option<String>, String> {
     do_client_hello_with_surface(session, Some(surface)).await
 }
 
-async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<SurfaceDeclaration>) -> Result<(), String> {
+async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<SurfaceDeclaration>) -> Result<Option<String>, String> {
     let session_id = uuid::Uuid::new_v4();
     session
         .write(Message::Hello {
             protocol_version: PROTOCOL_VERSION,
             node_id: NodeId::new("client"),
-            display_name: "client".into(),
+            display_name: flotilla_protocol::hello_display_name("client"),
             session_id,
             connection_role: Some(ConnectionRole::Client),
             surface,
@@ -83,10 +85,14 @@ async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<
         .map_err(|e| format!("failed to send Hello: {e}"))?;
 
     match session.read().await.map_err(|e| format!("failed to read Hello reply: {e}"))? {
-        Some(Message::Hello { protocol_version, .. }) if protocol_version != PROTOCOL_VERSION => Err(format!(
-            "daemon protocol version mismatch: daemon has {protocol_version}, client has {PROTOCOL_VERSION} — restart the daemon"
-        )),
-        Some(Message::Hello { .. }) => Ok(()),
+        Some(Message::Hello { protocol_version, display_name, .. }) if protocol_version != PROTOCOL_VERSION => {
+            let daemon_build = flotilla_protocol::hello_build_id(&display_name).unwrap_or("unknown");
+            Err(format!(
+                "daemon protocol version mismatch: daemon has {protocol_version} ({daemon_build}), client has {PROTOCOL_VERSION} ({})",
+                flotilla_protocol::BUILD_ID
+            ))
+        }
+        Some(Message::Hello { display_name, .. }) => Ok(flotilla_protocol::hello_build_id(&display_name).map(str::to_owned)),
         Some(other) => Err(format!("expected Hello reply, got: {other:?}")),
         None => Err("connection closed before Hello reply".into()),
     }
@@ -103,6 +109,7 @@ pub struct SocketDaemon {
     local_seqs: Arc<SeqMap>,
     subscribed_queries: Arc<QuerySet>,
     initial_sync_complete: Arc<AtomicBool>,
+    daemon_build_id: Option<String>,
 }
 
 impl SocketDaemon {
@@ -126,16 +133,20 @@ impl SocketDaemon {
     /// handshake with `ConnectionRole::Client` so the server assigns cursor
     /// ownership to our `session_id`.
     pub async fn from_session_stateful(session: MessageSession) -> Result<Arc<Self>, String> {
-        do_client_hello(&session).await?;
-        Self::from_session(session)
+        let daemon_build_id = do_client_hello(&session).await?;
+        Self::from_session_with_build_id(session, daemon_build_id)
     }
 
     pub async fn from_session_stateful_with_surface(session: MessageSession, surface: SurfaceDeclaration) -> Result<Arc<Self>, String> {
-        do_client_hello_with_declared_surface(&session, surface).await?;
-        Self::from_session(session)
+        let daemon_build_id = do_client_hello_with_declared_surface(&session, surface).await?;
+        Self::from_session_with_build_id(session, daemon_build_id)
     }
 
     pub fn from_session(session: MessageSession) -> Result<Arc<Self>, String> {
+        Self::from_session_with_build_id(session, None)
+    }
+
+    fn from_session_with_build_id(session: MessageSession, daemon_build_id: Option<String>) -> Result<Arc<Self>, String> {
         let session = Arc::new(session);
 
         let (event_tx, _) = broadcast::channel(256);
@@ -215,6 +226,7 @@ impl SocketDaemon {
             local_seqs: Arc::clone(&local_seqs),
             subscribed_queries: Arc::clone(&subscribed_queries),
             initial_sync_complete,
+            daemon_build_id,
         });
 
         Ok(daemon)
@@ -910,6 +922,10 @@ async fn recover_query_gap(ctx: &EventContext) {
 
 #[async_trait]
 impl DaemonHandle for SocketDaemon {
+    fn build_id(&self) -> Option<&str> {
+        self.daemon_build_id.as_deref()
+    }
+
     fn subscribe(&self) -> broadcast::Receiver<DaemonEvent> {
         match self.event_tx.upgrade() {
             Some(event_tx) => event_tx.subscribe(),

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -19,6 +19,7 @@ use tokio::sync::{broadcast, oneshot, Mutex};
 use tracing::{debug, error, warn};
 
 pub mod reconnect;
+pub const BUILD_ID: &str = env!("FLOTILLA_BUILD_ID");
 
 /// Std RwLock for local seq tracking — the critical sections are single HashMap
 /// operations (no async work while holding the lock), and using a sync lock
@@ -76,7 +77,7 @@ async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<
         .write(Message::Hello {
             protocol_version: PROTOCOL_VERSION,
             node_id: NodeId::new("client"),
-            display_name: flotilla_protocol::hello_display_name("client"),
+            display_name: flotilla_protocol::hello_display_name("client", BUILD_ID),
             session_id,
             connection_role: Some(ConnectionRole::Client),
             surface,
@@ -89,7 +90,7 @@ async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<
             let daemon_build = flotilla_protocol::hello_build_id(&display_name).unwrap_or("unknown");
             Err(format!(
                 "daemon protocol version mismatch: daemon has {protocol_version} ({daemon_build}), client has {PROTOCOL_VERSION} ({})",
-                flotilla_protocol::BUILD_ID
+                BUILD_ID
             ))
         }
         Some(Message::Hello { display_name, .. }) => Ok(flotilla_protocol::hello_build_id(&display_name).map(str::to_owned)),

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -92,6 +92,30 @@ fn session_harness() -> SessionHarness {
     SessionHarness { daemon, session: server }
 }
 
+#[tokio::test]
+async fn stateful_handshake_records_daemon_build_identity() {
+    let (client, server) = message_session_pair();
+    let server_task = tokio::spawn(async move {
+        let hello = server.read().await.expect("read client hello").expect("client hello");
+        assert!(matches!(hello, Message::Hello { .. }));
+        server
+            .write(Message::Hello {
+                protocol_version: PROTOCOL_VERSION,
+                node_id: NodeId::new("daemon"),
+                display_name: flotilla_protocol::hello_display_name("daemon"),
+                session_id: uuid::Uuid::new_v4(),
+                connection_role: Some(ConnectionRole::Client),
+                surface: None,
+            })
+            .await
+            .expect("write daemon hello");
+    });
+
+    let daemon = SocketDaemon::from_session_stateful(client).await.expect("handshake succeeds");
+    assert_eq!(daemon.build_id(), Some(flotilla_protocol::BUILD_ID));
+    server_task.await.expect("server task");
+}
+
 fn broken_request_harness() -> (SharedSession, SharedPending, Arc<AtomicU64>) {
     let (client, server) = message_session_pair();
     drop(server);

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -102,7 +102,7 @@ async fn stateful_handshake_records_daemon_build_identity() {
             .write(Message::Hello {
                 protocol_version: PROTOCOL_VERSION,
                 node_id: NodeId::new("daemon"),
-                display_name: flotilla_protocol::hello_display_name("daemon"),
+                display_name: flotilla_protocol::hello_display_name("daemon", BUILD_ID),
                 session_id: uuid::Uuid::new_v4(),
                 connection_role: Some(ConnectionRole::Client),
                 surface: None,
@@ -112,7 +112,7 @@ async fn stateful_handshake_records_daemon_build_identity() {
     });
 
     let daemon = SocketDaemon::from_session_stateful(client).await.expect("handshake succeeds");
-    assert_eq!(daemon.build_id(), Some(flotilla_protocol::BUILD_ID));
+    assert_eq!(daemon.build_id(), Some(BUILD_ID));
     server_task.await.expect("server task");
 }
 

--- a/crates/flotilla-client/src/reconnect.rs
+++ b/crates/flotilla-client/src/reconnect.rs
@@ -1,0 +1,141 @@
+use std::{future::Future, time::Duration};
+
+use flotilla_core::daemon::DaemonHandle;
+use tracing::warn;
+
+const INITIAL_DELAY: Duration = Duration::from_millis(500);
+const MAX_DELAY: Duration = Duration::from_secs(30);
+pub const REEXEC_BUILD_ENV: &str = "FLOTILLA_REEXEC_BUILD";
+
+pub struct ReconnectBackoff {
+    next_base: Duration,
+}
+
+impl Default for ReconnectBackoff {
+    fn default() -> Self {
+        Self { next_base: INITIAL_DELAY }
+    }
+}
+
+impl ReconnectBackoff {
+    pub fn reset(&mut self) {
+        self.next_base = INITIAL_DELAY;
+    }
+
+    pub fn next_delay(&mut self) -> Duration {
+        let random = uuid::Uuid::new_v4().as_u128() as u64;
+        self.next_delay_with_jitter(random as f64 / u64::MAX as f64)
+    }
+
+    #[doc(hidden)]
+    pub fn next_delay_with_jitter(&mut self, unit: f64) -> Duration {
+        let base = self.next_base;
+        self.next_base = std::cmp::min(base.saturating_mul(2), MAX_DELAY);
+        let factor = 0.5 + 0.5 * unit.clamp(0.0, 1.0);
+        Duration::from_secs_f64(base.as_secs_f64() * factor)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ReconnectNotice {
+    Attempt { attempt: usize },
+    Retry { attempt: usize, error: String, delay: Duration },
+}
+
+pub fn is_incompatible_daemon_error(error: &str) -> bool {
+    error.contains("protocol version mismatch")
+}
+
+pub fn build_mismatch(daemon: &dyn DaemonHandle) -> Option<String> {
+    let daemon_build = daemon.build_id()?;
+    (daemon_build != flotilla_protocol::BUILD_ID)
+        .then(|| format!("daemon build {daemon_build} differs from this client ({})", flotilla_protocol::BUILD_ID))
+}
+
+/// Connect to a daemon with the shared retry policy used by every long-lived
+/// client. Callers choose how to narrate each attempt.
+pub async fn connect_with_retry<Connect, ConnectFuture, Connected, Notify>(
+    mut connect: Connect,
+    mut notify: Notify,
+) -> Result<Connected, String>
+where
+    Connect: FnMut() -> ConnectFuture,
+    ConnectFuture: Future<Output = Result<Connected, String>>,
+    Notify: FnMut(ReconnectNotice),
+{
+    let mut backoff = ReconnectBackoff::default();
+    let mut attempt = 1;
+    loop {
+        notify(ReconnectNotice::Attempt { attempt });
+        match connect().await {
+            Ok(daemon) => {
+                std::env::remove_var(REEXEC_BUILD_ENV);
+                return Ok(daemon);
+            }
+            Err(error) if is_incompatible_daemon_error(&error) => return Err(error),
+            Err(error) => {
+                let delay = backoff.next_delay();
+                notify(ReconnectNotice::Retry { attempt, error, delay });
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+pub fn warn_on_build_mismatch(daemon: &dyn DaemonHandle) {
+    if let Some(message) = build_mismatch(daemon) {
+        warn!(%message, "connected daemon and client builds differ");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn reconnect_backoff_doubles_and_caps_with_jitter() {
+        let mut backoff = ReconnectBackoff::default();
+        let delays: Vec<_> = (0..8).map(|_| backoff.next_delay_with_jitter(1.0)).collect();
+
+        assert_eq!(delays, vec![
+            Duration::from_millis(500),
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+            Duration::from_secs(4),
+            Duration::from_secs(8),
+            Duration::from_secs(16),
+            Duration::from_secs(30),
+            Duration::from_secs(30),
+        ]);
+
+        backoff.reset();
+        assert_eq!(backoff.next_delay_with_jitter(0.0), Duration::from_millis(250));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_until_connected_and_reports_attempts() {
+        let mut attempts = 0;
+        let mut notices = Vec::new();
+        let connected = connect_with_retry(
+            || {
+                attempts += 1;
+                async move { (attempts == 3).then_some("connected").ok_or_else(|| "unavailable".to_string()) }
+            },
+            |notice| notices.push(notice),
+        )
+        .await
+        .expect("third attempt connects");
+
+        assert_eq!(connected, "connected");
+        assert!(matches!(notices.as_slice(), [
+            ReconnectNotice::Attempt { attempt: 1 },
+            ReconnectNotice::Retry { attempt: 1, .. },
+            ReconnectNotice::Attempt { attempt: 2 },
+            ReconnectNotice::Retry { attempt: 2, .. },
+            ReconnectNotice::Attempt { attempt: 3 },
+        ]));
+    }
+}

--- a/crates/flotilla-client/src/reconnect.rs
+++ b/crates/flotilla-client/src/reconnect.rs
@@ -48,8 +48,7 @@ pub fn is_incompatible_daemon_error(error: &str) -> bool {
 
 pub fn build_mismatch(daemon: &dyn DaemonHandle) -> Option<String> {
     let daemon_build = daemon.build_id()?;
-    (daemon_build != flotilla_protocol::BUILD_ID)
-        .then(|| format!("daemon build {daemon_build} differs from this client ({})", flotilla_protocol::BUILD_ID))
+    (daemon_build != crate::BUILD_ID).then(|| format!("daemon build {daemon_build} differs from this client ({})", crate::BUILD_ID))
 }
 
 /// Connect to a daemon with the shared retry policy used by every long-lived

--- a/crates/flotilla-core/src/daemon.rs
+++ b/crates/flotilla-core/src/daemon.rs
@@ -37,6 +37,11 @@ impl Drop for QuerySubscription {
 /// Both InProcessDaemon and SocketDaemon implement this.
 #[async_trait]
 pub trait DaemonHandle: Send + Sync {
+    /// Build identity advertised by the connected daemon, when available.
+    fn build_id(&self) -> Option<&str> {
+        Some(flotilla_protocol::BUILD_ID)
+    }
+
     /// Subscribe to daemon events (snapshots, repo changes).
     fn subscribe(&self) -> broadcast::Receiver<DaemonEvent>;
 

--- a/crates/flotilla-core/src/daemon.rs
+++ b/crates/flotilla-core/src/daemon.rs
@@ -39,7 +39,7 @@ impl Drop for QuerySubscription {
 pub trait DaemonHandle: Send + Sync {
     /// Build identity advertised by the connected daemon, when available.
     fn build_id(&self) -> Option<&str> {
-        Some(flotilla_protocol::BUILD_ID)
+        None
     }
 
     /// Subscribe to daemon events (snapshots, repo changes).

--- a/crates/flotilla-daemon/build.rs
+++ b/crates/flotilla-daemon/build.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|output| output.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn main() {
+    println!("cargo::rerun-if-env-changed=FLOTILLA_BUILD_ID");
+    if let Some(head) = git_output(&["rev-parse", "--git-path", "HEAD"]) {
+        println!("cargo::rerun-if-changed={head}");
+    }
+    if let Some(reference) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+        if let Some(reference_path) = git_output(&["rev-parse", "--git-path", &reference]) {
+            println!("cargo::rerun-if-changed={reference_path}");
+        }
+    }
+
+    let build_id = std::env::var("FLOTILLA_BUILD_ID")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| git_output(&["rev-parse", "--short=12", "HEAD"]))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo::rustc-env=FLOTILLA_BUILD_ID={build_id}");
+}

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -515,7 +515,7 @@ async fn handle_client_session(
                     .write(Message::Hello {
                         protocol_version: PROTOCOL_VERSION,
                         node_id: daemon.node_id().clone(),
-                        display_name: daemon.host_name().to_string(),
+                        display_name: flotilla_protocol::hello_display_name(daemon.host_name().as_str()),
                         session_id: daemon.session_id(),
                         connection_role: Some(ConnectionRole::Client),
                         surface: None,

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -478,17 +478,19 @@ async fn handle_client_session(
 ) {
     let session = Arc::new(session);
     let first_msg = tokio::select! {
-        message_result = session.read() => {
-            match message_result {
-                Ok(msg) => msg,
-                Err(e) => {
-                    error!(err = %e, "error reading first message from client");
-                    None
+            message_result = session.read() => {
+                match message_result {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        error!(err = %e, "error reading first message from client");
+                        None
+                    }
                 }
             }
-        }
-        _ = shutdown_rx.changed() => None,
+            _ = shutdown_rx.changed() => None,
     };
+
+    const BUILD_ID: &str = env!("FLOTILLA_BUILD_ID");
 
     let Some(first_msg) = first_msg else {
         return;
@@ -515,7 +517,7 @@ async fn handle_client_session(
                     .write(Message::Hello {
                         protocol_version: PROTOCOL_VERSION,
                         node_id: daemon.node_id().clone(),
-                        display_name: flotilla_protocol::hello_display_name(daemon.host_name().as_str()),
+                        display_name: flotilla_protocol::hello_display_name(daemon.host_name().as_str(), BUILD_ID),
                         session_id: daemon.session_id(),
                         connection_role: Some(ConnectionRole::Client),
                         surface: None,

--- a/crates/flotilla-protocol/build.rs
+++ b/crates/flotilla-protocol/build.rs
@@ -1,0 +1,32 @@
+use std::process::Command;
+
+fn git_output(args: &[&str]) -> Option<String> {
+    Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|output| output.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn main() {
+    println!("cargo::rerun-if-env-changed=FLOTILLA_BUILD_ID");
+    if let Some(head) = git_output(&["rev-parse", "--git-path", "HEAD"]) {
+        println!("cargo::rerun-if-changed={head}");
+    }
+    if let Some(reference) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+        if let Some(reference_path) = git_output(&["rev-parse", "--git-path", &reference]) {
+            println!("cargo::rerun-if-changed={reference_path}");
+        }
+    }
+
+    let build_id = std::env::var("FLOTILLA_BUILD_ID")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| git_output(&["rev-parse", "--short=12", "HEAD"]))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo::rustc-env=FLOTILLA_BUILD_ID={build_id}");
+}

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -175,6 +175,20 @@ pub use snapshot::{
 pub struct ConfigLabel(pub String);
 
 pub const PROTOCOL_VERSION: u32 = 17;
+pub const BUILD_ID: &str = env!("FLOTILLA_BUILD_ID");
+
+const BUILD_ID_SEPARATOR: &str = "\u{1f}flotilla-build:";
+
+/// Add this binary's build identity to a Hello display name without changing
+/// the wire shape. Older peers continue to see an ordinary display name.
+pub fn hello_display_name(label: &str) -> String {
+    format!("{label}{BUILD_ID_SEPARATOR}{BUILD_ID}")
+}
+
+/// Extract the optional build identity advertised in a Hello display name.
+pub fn hello_build_id(display_name: &str) -> Option<&str> {
+    display_name.rsplit_once(BUILD_ID_SEPARATOR).map(|(_, build_id)| build_id).filter(|build_id| !build_id.is_empty())
+}
 
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -175,14 +175,13 @@ pub use snapshot::{
 pub struct ConfigLabel(pub String);
 
 pub const PROTOCOL_VERSION: u32 = 17;
-pub const BUILD_ID: &str = env!("FLOTILLA_BUILD_ID");
 
 const BUILD_ID_SEPARATOR: &str = "\u{1f}flotilla-build:";
 
 /// Add this binary's build identity to a Hello display name without changing
 /// the wire shape. Older peers continue to see an ordinary display name.
-pub fn hello_display_name(label: &str) -> String {
-    format!("{label}{BUILD_ID_SEPARATOR}{BUILD_ID}")
+pub fn hello_display_name(label: &str, build_id: &str) -> String {
+    format!("{label}{BUILD_ID_SEPARATOR}{build_id}")
 }
 
 /// Extract the optional build identity advertised in a Hello display name.

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -689,3 +689,11 @@ fn fetch_more_request_round_trips_parameterized_query() {
     assert!(encoded.contains("\"fetch_more\""));
     assert_eq!(serde_json::from_str::<Request>(&encoded).expect("deserialize fetch-more request"), request);
 }
+
+#[test]
+fn hello_display_name_carries_build_identity_without_changing_the_envelope() {
+    let display_name = hello_display_name("feta");
+    assert!(display_name.starts_with("feta"));
+    assert_eq!(hello_build_id(&display_name), Some(BUILD_ID));
+    assert_eq!(hello_build_id("legacy-daemon"), None);
+}

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -692,8 +692,8 @@ fn fetch_more_request_round_trips_parameterized_query() {
 
 #[test]
 fn hello_display_name_carries_build_identity_without_changing_the_envelope() {
-    let display_name = hello_display_name("feta");
+    let display_name = hello_display_name("feta", "abc123");
     assert!(display_name.starts_with("feta"));
-    assert_eq!(hello_build_id(&display_name), Some(BUILD_ID));
+    assert_eq!(hello_build_id(&display_name), Some("abc123"));
     assert_eq!(hello_build_id("legacy-daemon"), None);
 }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -749,6 +749,9 @@ impl App {
         self.acknowledged_dispatches.clear();
         self.pending_dispatch_acks = 0;
         self.recent_command_finishes.clear();
+        self.project_issue_start_batches.clear();
+        self.command_project_issue_starts.clear();
+        self.pending_cancel = None;
         self.subscriptions_dirty = true;
 
         let reconnect_note = flotilla_client::reconnect::build_mismatch(self.daemon.as_ref())

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -30,6 +30,7 @@ use flotilla_protocol::{
 use indexmap::IndexMap;
 pub use intent::Intent;
 pub use open_views::{OpenView, OpenViews, ViewTarget};
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tui_input::Input;
 use ui_state::PendingStatus;
@@ -42,7 +43,7 @@ use crate::{
     shared::Shared,
     theme::Theme,
     widgets::{
-        repo_page::{RepoData, RepoPage},
+        repo_page::{RepoData, RepoPage, RepoPageHandoff},
         section_table::IssueRow,
         split_table::SelectedRow,
     },
@@ -517,7 +518,67 @@ pub struct App {
     pub pending_attach_command: Option<String>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct AppHandoff {
+    views: OpenViews,
+    provisioning_target: ProvisioningTarget,
+    view_layout: RepoViewLayout,
+    status_keys_visible: bool,
+    dismissed_status_ids: HashSet<usize>,
+    show_debug: bool,
+    help_scroll: u16,
+    command_echo: Option<String>,
+    event_log: Vec<crate::event_log::HandoffLogEntry>,
+    repo_pages: Vec<(RepoIdentity, RepoPageHandoff)>,
+    issue_search_input: Option<String>,
+}
+
 impl App {
+    pub fn handoff(&self) -> AppHandoff {
+        AppHandoff {
+            views: self.views.clone(),
+            provisioning_target: self.ui.provisioning_target.clone(),
+            view_layout: self.ui.view_layout,
+            status_keys_visible: self.ui.status_bar.show_keys,
+            dismissed_status_ids: self.ui.status_bar.dismissed_status_ids.clone(),
+            show_debug: self.ui.show_debug,
+            help_scroll: self.ui.help_scroll,
+            command_echo: self.ui.command_echo.clone(),
+            event_log: crate::event_log::handoff_entries(),
+            repo_pages: self.screen.repo_pages.iter().map(|(identity, page)| (identity.clone(), page.handoff())).collect(),
+            issue_search_input: self
+                .screen
+                .modal_stack
+                .last()
+                .and_then(|widget| widget.as_any().downcast_ref::<crate::widgets::issue_search::IssueSearchWidget>())
+                .map(|widget| widget.input_value().to_string()),
+        }
+    }
+
+    pub fn restore_handoff(&mut self, handoff: AppHandoff) {
+        self.views = handoff.views;
+        self.ui.provisioning_target = handoff.provisioning_target;
+        self.ui.view_layout = handoff.view_layout;
+        self.ui.status_bar.show_keys = handoff.status_keys_visible;
+        self.ui.status_bar.dismissed_status_ids = handoff.dismissed_status_ids;
+        self.ui.show_debug = handoff.show_debug;
+        self.ui.help_scroll = handoff.help_scroll;
+        self.ui.command_echo = handoff.command_echo;
+        crate::event_log::restore_handoff_entries(handoff.event_log);
+        for (identity, page_handoff) in handoff.repo_pages {
+            if let Some(page) = self.screen.repo_pages.get_mut(&identity) {
+                page.restore_handoff(page_handoff);
+            }
+        }
+        if let Some(input) = handoff.issue_search_input {
+            let mut widget = crate::widgets::issue_search::IssueSearchWidget::new();
+            widget.prefill(&input);
+            self.screen.modal_stack.push(Box::new(widget));
+        }
+        self.subscriptions_dirty = true;
+        self.sync_active_view();
+    }
+
     pub fn new(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>, config: Arc<ConfigStore>, theme: Theme) -> Self {
         let app = Self::new_unreported(daemon, repos_info, config, theme);
         app.report_active_view_focus();
@@ -544,6 +605,7 @@ impl App {
         views.bind_repository_keys(&repository_keys);
         model.active_repo = views.active_repo_identity().cloned();
         let mut ui = UiState::new(&model.repo_order);
+        ui.command_echo = flotilla_client::reconnect::build_mismatch(daemon.as_ref());
         let loaded_config = config.load_config();
         ui.view_layout = match loaded_config.ui.preview.layout {
             RepoViewLayoutConfig::Auto => RepoViewLayout::Auto,
@@ -619,6 +681,79 @@ impl App {
     pub fn with_pm_connector(mut self, connector: Option<Arc<dyn PmConnector>>) -> Self {
         self.pm_connector = connector;
         self
+    }
+
+    /// Attach this UI session to a replacement daemon while retaining the
+    /// interaction state owned by the TUI. Daemon-derived caches are emptied
+    /// so the event loop's replay and query re-subscription repopulate them.
+    pub fn reconnect_daemon(&mut self, daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>) {
+        self.daemon = daemon;
+        self.session_id = uuid::Uuid::new_v4();
+        self._query_subscription = self.daemon.query_subscription(self.session_id);
+
+        let repo_order: Vec<_> = repos_info.iter().map(|info| info.identity.clone()).collect();
+        let current_repos: HashSet<_> = repos_info.iter().map(|info| info.identity.clone()).collect();
+        let removed: Vec<_> = self.model.repos.keys().filter(|identity| !current_repos.contains(*identity)).cloned().collect();
+        for identity in removed {
+            self.handle_repo_removed(&identity);
+        }
+        for info in repos_info {
+            if self.model.repos.contains_key(&info.identity) {
+                let identity = info.identity.clone();
+                let path = TuiModel::display_path(&identity, info.path);
+                if let Some(repo) = self.model.repos.get_mut(&identity) {
+                    repo.repository_key = info.repository_key;
+                    repo.path = path;
+                    repo.providers = Arc::new(ProviderData::default());
+                    repo.labels = info.labels;
+                    repo.provider_names = info.provider_names;
+                    repo.provider_health = info.provider_health;
+                    repo.loading = info.loading;
+                    repo.has_unseen_changes = false;
+                }
+                if let Some(data) = self.repo_data.get(&identity) {
+                    let repo = &self.model.repos[&identity];
+                    data.mutate(|data| {
+                        data.path = repo.path.clone();
+                        data.providers = Arc::new(ProviderData::default());
+                        data.labels = repo.labels.clone();
+                        data.provider_names = repo.provider_names.clone();
+                        data.provider_health = repo.provider_health.clone();
+                        data.work_items.clear();
+                        data.issue_rows.clear();
+                        data.issue_section_label.clear();
+                        data.loading = repo.loading;
+                    });
+                }
+                if let Some(page) = self.screen.repo_pages.get_mut(&identity) {
+                    page.pending_actions.clear();
+                }
+            } else {
+                self.handle_repo_added(info);
+            }
+        }
+        self.model.repo_order = repo_order;
+        let repository_keys =
+            self.model.repos.iter().filter_map(|(identity, repo)| repo.repository_key.clone().map(|key| (identity.clone(), key))).collect();
+        self.views.bind_repository_keys(&repository_keys);
+        self.sync_active_view();
+
+        self.model.provider_statuses.clear();
+        self.model.hosts.clear();
+        self.query_tables = QueryTableCache::default();
+        self.namespaces.clear();
+        self.query_seqs.clear();
+        self.pending_fetch_more.clear();
+        self.issue_views.clear();
+        self.in_flight.clear();
+        self.acknowledged_dispatches.clear();
+        self.pending_dispatch_acks = 0;
+        self.recent_command_finishes.clear();
+        self.subscriptions_dirty = true;
+
+        let reconnect_note = flotilla_client::reconnect::build_mismatch(self.daemon.as_ref())
+            .map_or_else(|| "Reconnected to daemon".to_string(), |mismatch| format!("Reconnected — {mismatch}"));
+        self.ui.command_echo = Some(reconnect_note);
     }
 
     /// Construct an `App` in scoped mode: exactly the one View at `address`,

--- a/crates/flotilla-tui/src/app/open_views.rs
+++ b/crates/flotilla-tui/src/app/open_views.rs
@@ -8,20 +8,21 @@ use std::collections::HashMap;
 
 use flotilla_core::config::OpenViewEntry;
 use flotilla_protocol::{QueryId, RepoIdentity, RepositoryKey, ViewAddress};
+use serde::{Deserialize, Serialize};
 
 use crate::table_view::{AuthoritativeRowUpdate, PendingRowContext, ProjectPanelKind, ProjectTableState, TableState};
 
 /// What an open tab points at: a parsed View address, or the raw entry that
 /// failed to parse. A broken entry renders an error view in place — it never
 /// invalidates the rest of the tab set (ADR 0013 loud-failure rule).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViewTarget {
     View(ViewAddress),
     Broken { raw: String, error: String },
 }
 
 /// One open View in this TUI instance.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenView {
     pub target: ViewTarget,
     /// User-set label. Display-only; never part of view identity.
@@ -33,7 +34,7 @@ pub struct OpenView {
     pub(crate) history: Vec<NavigationFrame>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct NavigationFrame {
     target: ViewTarget,
     table_state: TableState,
@@ -149,7 +150,7 @@ impl OpenView {
 /// Whether a set of open Views is the tabbed shell or a single scoped pane.
 /// This is the pinning policy: the tabbed shell pins the overview at index 0;
 /// a scoped pane pins its lone view.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TabSetMode {
     /// The full tab shell: pinned overview at index 0, user-managed tabs,
     /// persisted to `open-views.toml`.
@@ -160,6 +161,7 @@ pub enum TabSetMode {
 }
 
 /// The ordered set of open Views and the active tab.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct OpenViews {
     views: Vec<OpenView>,
     active: usize,

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -304,6 +304,17 @@ async fn reconnect_daemon_preserves_ui_state_and_clears_daemon_caches() {
     app.ui.show_debug = true;
     app.namespaces.insert("stale".into(), NamespaceModel::default());
     app.query_seqs.insert(flotilla_protocol::QueryId::Convoys, 42);
+    let batch_id = app.begin_project_issue_start_batch(1);
+    app.command_project_issue_starts.insert(1, ProjectIssueStartContext {
+        address: ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() },
+        row_id: crate::table_view::RowId::new("issue:1"),
+        issue: IssueRef {
+            source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+            id: "1".into(),
+        },
+        batch_id,
+    });
+    app.pending_cancel = Some(1);
     let daemon = Arc::clone(&app.daemon);
     let repos = daemon.list_repos().await.expect("list repos");
 
@@ -314,6 +325,9 @@ async fn reconnect_daemon_preserves_ui_state_and_clears_daemon_caches() {
     assert!(app.ui.show_debug);
     assert!(app.namespaces.is_empty());
     assert!(app.query_seqs.is_empty());
+    assert!(app.project_issue_start_batches.is_empty());
+    assert!(app.command_project_issue_starts.is_empty());
+    assert_eq!(app.pending_cancel, None);
     assert!(app.subscriptions_dirty);
     assert_eq!(app.ui.command_echo.as_deref(), Some("Reconnected to daemon"));
 }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -296,6 +296,60 @@ fn app_new_loads_layout_from_config() {
     assert_eq!(app.ui.view_layout, RepoViewLayout::Below);
 }
 
+#[tokio::test]
+async fn reconnect_daemon_preserves_ui_state_and_clears_daemon_caches() {
+    let mut app = stub_app();
+    app.views.open_or_focus(ViewAddress::Convoys { namespace: "flotilla".into() });
+    app.views.active_table_state_mut().filter = "needle".into();
+    app.ui.show_debug = true;
+    app.namespaces.insert("stale".into(), NamespaceModel::default());
+    app.query_seqs.insert(flotilla_protocol::QueryId::Convoys, 42);
+    let daemon = Arc::clone(&app.daemon);
+    let repos = daemon.list_repos().await.expect("list repos");
+
+    app.reconnect_daemon(daemon, repos);
+
+    assert_eq!(app.views.active_address(), Some(&ViewAddress::Convoys { namespace: "flotilla".into() }));
+    assert_eq!(app.views.active_table_state().filter, "needle");
+    assert!(app.ui.show_debug);
+    assert!(app.namespaces.is_empty());
+    assert!(app.query_seqs.is_empty());
+    assert!(app.subscriptions_dirty);
+    assert_eq!(app.ui.command_echo.as_deref(), Some("Reconnected to daemon"));
+}
+
+#[test]
+fn handoff_round_trip_preserves_navigation_table_and_ui_state() {
+    let mut source = stub_app();
+    source.views.open_or_focus(ViewAddress::Convoys { namespace: "flotilla".into() });
+    source.views.active_table_state_mut().filter = "mine".into();
+    source.views.drill("convoy/flotilla/demo".parse().expect("valid drill address"));
+    source.ui.show_debug = true;
+    source.ui.help_scroll = 7;
+    let mut search = crate::widgets::issue_search::IssueSearchWidget::new();
+    search.prefill("half typed");
+    source.screen.modal_stack.push(Box::new(search));
+
+    let encoded = serde_json::to_vec(&source.handoff()).expect("serialize handoff");
+    let handoff = serde_json::from_slice(&encoded).expect("deserialize handoff");
+    let mut restored = stub_app();
+    restored.restore_handoff(handoff);
+
+    assert_eq!(restored.views.active_address(), Some(&"convoy/flotilla/demo".parse().expect("valid address")));
+    assert!(restored.views.active().has_history());
+    assert!(restored.views.back());
+    assert_eq!(restored.views.active_table_state().filter, "mine");
+    assert!(restored.ui.show_debug);
+    assert_eq!(restored.ui.help_scroll, 7);
+    let restored_search = restored
+        .screen
+        .modal_stack
+        .last()
+        .and_then(|widget| widget.as_any().downcast_ref::<crate::widgets::issue_search::IssueSearchWidget>())
+        .expect("search input restored");
+    assert_eq!(restored_search.input_value(), "half typed");
+}
+
 #[test]
 fn persist_layout_writes_current_ui_state() {
     let dir = tempdir().unwrap();

--- a/crates/flotilla-tui/src/app/ui_state.rs
+++ b/crates/flotilla-tui/src/app/ui_state.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use flotilla_protocol::{HostName, IssueRef, ProvisioningTarget, RepoIdentity, ViewAddress, WorkItemIdentity};
 use ratatui::layout::Rect;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     status_bar::StatusBarTarget,
@@ -25,7 +26,7 @@ pub enum BranchInputKind {
     Generating,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RepoViewLayout {
     #[default]
     Auto,

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -694,20 +694,23 @@ fn print_bootstrap_events(events: &[DaemonEvent], replay_seqs: &mut HashMap<Stre
 }
 
 pub async fn run_watch(socket_path: &Path, format: OutputFormat) -> Result<(), String> {
-    let mut backoff = crate::pm_connect::ReconnectBackoff::default();
     loop {
-        match SocketDaemon::connect(socket_path).await {
-            Ok(daemon) => {
-                backoff.reset();
-                if let Err(error) = run_watch_connection(daemon, format).await {
-                    eprintln!("{error}; reconnecting...");
+        let daemon = flotilla_client::reconnect::connect_with_retry(
+            || SocketDaemon::connect(socket_path),
+            |notice| match notice {
+                flotilla_client::reconnect::ReconnectNotice::Attempt { attempt } => {
+                    eprintln!("connecting to daemon (attempt {attempt})...");
                 }
-            }
-            Err(error) if crate::pm_connect::is_incompatible_daemon_error(&error) => return Err(error),
-            Err(error) => eprintln!("cannot connect to daemon: {error}; retrying..."),
+                flotilla_client::reconnect::ReconnectNotice::Retry { error, delay, .. } => {
+                    eprintln!("cannot connect to daemon: {error}; retrying in {:.1}s...", delay.as_secs_f64());
+                }
+            },
+        )
+        .await?;
+        flotilla_client::reconnect::warn_on_build_mismatch(daemon.as_ref());
+        if let Err(error) = run_watch_connection(daemon, format).await {
+            eprintln!("{error}; reconnecting...");
         }
-
-        tokio::time::sleep(backoff.next_delay()).await;
     }
 }
 

--- a/crates/flotilla-tui/src/event_log.rs
+++ b/crates/flotilla-tui/src/event_log.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 
+use serde::{Deserialize, Serialize};
 use tracing_subscriber::{filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 /// Entry returned to the UI. Either a real log line or a retention marker.
@@ -19,6 +20,13 @@ pub struct LogEntry {
     /// Wall-clock hour, minute, second at time of logging.
     pub hms: (u8, u8, u8),
     pub level: tracing::Level,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffLogEntry {
+    pub hms: (u8, u8, u8),
+    pub level: String,
     pub message: String,
 }
 
@@ -187,6 +195,30 @@ static EVENT_LOG: LazyLock<Mutex<EventLog>> = LazyLock::new(|| Mutex::new(EventL
 /// Get display entries for the TUI, filtered by level, with retention markers.
 pub fn get_entries(filter: &tracing::Level) -> Vec<DisplayEntry> {
     EVENT_LOG.lock().unwrap().snapshot(filter)
+}
+
+pub fn handoff_entries() -> Vec<HandoffLogEntry> {
+    let log = EVENT_LOG.lock().expect("event log lock poisoned");
+    let mut entries: Vec<_> = [&log.error, &log.warn, &log.info, &log.debug, &log.trace]
+        .into_iter()
+        .flat_map(|bucket| bucket.entries.iter())
+        .map(|entry| {
+            (entry.seq, HandoffLogEntry { hms: entry.hms, level: entry.level.as_str().to_string(), message: entry.message.clone() })
+        })
+        .collect();
+    entries.sort_by_key(|(seq, _)| *seq);
+    entries.into_iter().map(|(_, entry)| entry).collect()
+}
+
+pub fn restore_handoff_entries(entries: Vec<HandoffLogEntry>) {
+    let mut log = EVENT_LOG.lock().expect("event log lock poisoned");
+    *log = EventLog::new();
+    for entry in entries {
+        let Ok(level) = entry.level.parse::<tracing::Level>() else { continue };
+        let seq = log.next_seq;
+        log.next_seq += 1;
+        log.bucket_mut(&level).push(LogEntry { seq, hms: entry.hms, level, message: entry.message });
+    }
 }
 
 /// Custom tracing layer that feeds the in-memory EventLog.

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -20,6 +20,7 @@ use std::{
     time::Duration,
 };
 
+pub use flotilla_client::reconnect::is_incompatible_daemon_error;
 use flotilla_core::daemon::DaemonHandle;
 use flotilla_manifest::{
     keys::REASSERT_INTERVAL_MS,
@@ -36,45 +37,9 @@ use flotilla_protocol::{
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, info, warn};
 
-const RECONNECT_INITIAL_DELAY: Duration = Duration::from_millis(500);
-const RECONNECT_MAX_DELAY: Duration = Duration::from_secs(30);
-
-pub struct ReconnectBackoff {
-    next_base: Duration,
-}
-
-impl Default for ReconnectBackoff {
-    fn default() -> Self {
-        Self { next_base: RECONNECT_INITIAL_DELAY }
-    }
-}
-
-impl ReconnectBackoff {
-    pub fn reset(&mut self) {
-        self.next_base = RECONNECT_INITIAL_DELAY;
-    }
-
-    pub fn next_delay(&mut self) -> Duration {
-        let random = uuid::Uuid::new_v4().as_u128() as u64;
-        self.next_delay_with_jitter(random as f64 / u64::MAX as f64)
-    }
-
-    fn next_delay_with_jitter(&mut self, unit: f64) -> Duration {
-        let base = self.next_base;
-        self.next_base = std::cmp::min(base.saturating_mul(2), RECONNECT_MAX_DELAY);
-        let factor = 0.5 + 0.5 * unit.clamp(0.0, 1.0);
-        Duration::from_secs_f64(base.as_secs_f64() * factor)
-    }
-}
-
-pub fn is_incompatible_daemon_error(error: &str) -> bool {
-    error.contains("protocol version mismatch")
-}
-
 async fn run_reconnecting<Connect, ConnectFuture, Connected, ConnectedFuture>(
     mut connect: Connect,
     mut run_connected: Connected,
-    mut backoff: ReconnectBackoff,
 ) -> Result<(), String>
 where
     Connect: FnMut() -> ConnectFuture,
@@ -83,21 +48,18 @@ where
     ConnectedFuture: Future<Output = Result<(), String>>,
 {
     loop {
-        match connect().await {
-            Ok(daemon) => {
-                backoff.reset();
-                info!("connected to daemon");
-                if let Err(error) = run_connected(daemon).await {
-                    info!(%error, "daemon connection ended; reconnecting");
-                }
+        let daemon = flotilla_client::reconnect::connect_with_retry(&mut connect, |notice| match notice {
+            flotilla_client::reconnect::ReconnectNotice::Attempt { attempt } => debug!(attempt, "connecting to daemon"),
+            flotilla_client::reconnect::ReconnectNotice::Retry { attempt, error, delay } => {
+                info!(attempt, %error, ?delay, "daemon unavailable; retrying")
             }
-            Err(error) if is_incompatible_daemon_error(&error) => return Err(error),
-            Err(error) => info!(%error, "daemon unavailable; retrying"),
+        })
+        .await?;
+        flotilla_client::reconnect::warn_on_build_mismatch(daemon.as_ref());
+        info!("connected to daemon");
+        if let Err(error) = run_connected(daemon).await {
+            info!(%error, "daemon connection ended; reconnecting");
         }
-
-        let delay = backoff.next_delay();
-        debug!(?delay, "waiting before daemon reconnect");
-        tokio::time::sleep(delay).await;
     }
 }
 
@@ -369,7 +331,6 @@ pub async fn run(
             .map(|daemon| daemon as Arc<dyn DaemonHandle>)
         },
         |daemon| run_connector(daemon, sink.clone(), mint.clone(), Duration::from_millis(REASSERT_INTERVAL_MS)),
-        ReconnectBackoff::default(),
     )
     .await
 }

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -303,27 +303,7 @@ fn resolve_pm_prefers_explicit_socket_then_environment_detection() {
     assert!(error.contains("no presentation manager detected"));
 }
 
-#[test]
-fn reconnect_backoff_doubles_and_caps_with_jitter() {
-    let mut backoff = ReconnectBackoff::default();
-    let delays: Vec<_> = (0..8).map(|_| backoff.next_delay_with_jitter(1.0)).collect();
-
-    assert_eq!(delays, vec![
-        Duration::from_millis(500),
-        Duration::from_secs(1),
-        Duration::from_secs(2),
-        Duration::from_secs(4),
-        Duration::from_secs(8),
-        Duration::from_secs(16),
-        Duration::from_secs(30),
-        Duration::from_secs(30),
-    ]);
-
-    backoff.reset();
-    assert_eq!(backoff.next_delay_with_jitter(0.0), Duration::from_millis(250));
-}
-
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn reconnect_loop_retries_unavailable_daemon_but_exits_for_incompatible_daemon() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let attempts_for_connect = Arc::clone(&attempts);
@@ -341,7 +321,6 @@ async fn reconnect_loop_retries_unavailable_daemon_but_exits_for_incompatible_da
             }
         },
         |_| async { Ok(()) },
-        ReconnectBackoff { next_base: Duration::ZERO },
     )
     .await;
 

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -5,6 +5,12 @@ use crossterm::{
     event::{EnableMouseCapture, KeyCode, KeyModifiers, MouseEventKind},
     execute,
 };
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::Style,
+    text::{Line, Text},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
 
 use crate::{
     app::{self, App},
@@ -12,10 +18,9 @@ use crate::{
     widgets::InteractiveWidget,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventLoopExit {
     Quit,
-    DaemonDisconnected,
+    DaemonDisconnected(Box<App>),
 }
 
 /// Run the TUI event loop: replay initial state, then process events until quit.
@@ -98,7 +103,7 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
                 }
                 Event::DaemonDisconnected => {
                     crate::terminal::restore_terminal();
-                    return Ok(EventLoopExit::DaemonDisconnected);
+                    return Ok(EventLoopExit::DaemonDisconnected(Box::new(app)));
                 }
                 Event::CommandDispatchCompleted { result, pending_ctx } => {
                     app::executor::handle_dispatch_completion(result, pending_ctx, &mut app);
@@ -207,6 +212,42 @@ fn render_frame(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> Resul
             query_tables: &app.query_tables,
         };
         app.screen.render(f, area, &mut ctx);
+    })?;
+    Ok(())
+}
+
+/// Draw the honest, minimal surface shown while the daemon is unavailable.
+pub fn render_reconnect_frame(
+    terminal: &mut ratatui::DefaultTerminal,
+    attempt: usize,
+    detail: Option<&str>,
+    theme: &crate::theme::Theme,
+) -> Result<()> {
+    terminal.draw(|frame| {
+        let area = frame.area();
+        frame.render_widget(Clear, area);
+        let popup = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Fill(1), Constraint::Length(7), Constraint::Fill(1)])
+            .split(area)[1];
+        let popup = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Fill(1), Constraint::Percentage(70), Constraint::Fill(1)])
+            .split(popup)[1];
+        let mut lines = vec![
+            Line::raw(""),
+            Line::styled(format!("Daemon disconnected — reconnecting (attempt {attempt})…"), Style::default().fg(theme.text).bold()),
+        ];
+        if let Some(detail) = detail {
+            lines.push(Line::raw(""));
+            lines.push(Line::styled(detail, Style::default().fg(theme.muted)));
+        }
+        frame.render_widget(
+            Paragraph::new(Text::from(lines))
+                .alignment(Alignment::Center)
+                .block(Block::default().borders(Borders::ALL).border_style(theme.block_style())),
+            popup,
+        );
     })?;
     Ok(())
 }

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -11,13 +11,14 @@ use flotilla_protocol::{
     IndependentRow, IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey, ResultSetCondition, ResultSetState, Salience,
     SessionPhase, ViewAddress,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     convoy_model::{ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase},
     pm_open::OpenInPmTarget,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct RowId(String);
 
 impl RowId {
@@ -29,7 +30,7 @@ impl RowId {
 /// Transient state for a row while a user action is being reconciled by an
 /// authoritative query. Surfaces render this state in their own idiom; the
 /// state itself contains no ratatui types.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RowState {
     Submitting { query: QueryId, description: String },
     Pending { query: QueryId, command_id: u64, description: String },
@@ -62,7 +63,7 @@ pub struct PendingRowContext {
     pub row_id: RowId,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, bon::Builder)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct TableState {
     selected: Option<RowId>,
     pub multi_selected: HashSet<RowId>,
@@ -206,7 +207,7 @@ impl TableState {
 /// Cursor and transient search state for the fixed Project composition. Each
 /// panel keeps the same tab-local state a standalone table owns; the page
 /// cursor selects which panel participates in keyboard actions.
-#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ProjectTableState {
     active: ProjectPanelKind,
     header_focused: bool,
@@ -447,7 +448,7 @@ pub struct TableView {
 /// One fixed panel in the Project composite View. The panel owns no layout or
 /// input policy: it is the same curated table projection a single-kind View
 /// renders, with the address its header expands into.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProjectPanelKind {
     Convoys,
     Checkouts,

--- a/crates/flotilla-tui/src/widgets/issue_search.rs
+++ b/crates/flotilla-tui/src/widgets/issue_search.rs
@@ -30,6 +30,10 @@ impl IssueSearchWidget {
     pub fn prefill(&mut self, text: &str) {
         self.input = Input::from(text);
     }
+
+    pub fn input_value(&self) -> &str {
+        self.input.value()
+    }
 }
 
 impl InteractiveWidget for IssueSearchWidget {

--- a/crates/flotilla-tui/src/widgets/repo_page.rs
+++ b/crates/flotilla-tui/src/widgets/repo_page.rs
@@ -13,6 +13,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     Frame,
 };
+use serde::{Deserialize, Serialize};
 
 use super::{
     preview_panel::PreviewPanel,
@@ -127,6 +128,18 @@ pub struct RepoPage {
     pub active_search_query: Option<String>,
     last_seen_generation: u64,
     double_click: DoubleClickState,
+    reconnect_selection: Option<(WorkItemIdentity, usize)>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct RepoPageHandoff {
+    selected: Option<WorkItemIdentity>,
+    multi_selected: HashSet<WorkItemIdentity>,
+    layout: RepoViewLayout,
+    show_providers: bool,
+    show_archived: bool,
+    active_search_query: Option<String>,
+    scroll_offset: usize,
 }
 
 impl RepoPage {
@@ -144,7 +157,29 @@ impl RepoPage {
             active_search_query: None,
             last_seen_generation: 0,
             double_click: DoubleClickState::default(),
+            reconnect_selection: None,
         }
+    }
+
+    pub(crate) fn handoff(&self) -> RepoPageHandoff {
+        RepoPageHandoff {
+            selected: self.table.selected_identity(),
+            multi_selected: self.multi_selected.clone(),
+            layout: self.layout,
+            show_providers: self.show_providers,
+            show_archived: self.show_archived,
+            active_search_query: self.active_search_query.clone(),
+            scroll_offset: self.table.reconnect_scroll_offset(),
+        }
+    }
+
+    pub(crate) fn restore_handoff(&mut self, handoff: RepoPageHandoff) {
+        self.multi_selected = handoff.multi_selected;
+        self.layout = handoff.layout;
+        self.show_providers = handoff.show_providers;
+        self.show_archived = handoff.show_archived;
+        self.active_search_query = handoff.active_search_query;
+        self.reconnect_selection = handoff.selected.map(|selected| (selected, handoff.scroll_offset));
     }
 
     /// Identity of the repo this page represents.
@@ -181,6 +216,9 @@ impl RepoPage {
 
         // Query-driven issues go into a native IssueRow section.
         self.table.update_issue_section(data.issue_section_label.clone(), data.issue_rows.clone());
+        if let Some((identity, scroll_offset)) = self.reconnect_selection.take() {
+            self.table.restore_reconnect_selection(&identity, scroll_offset);
+        }
 
         let current_identities: HashSet<WorkItemIdentity> = self.table.all_identities().collect();
         self.multi_selected.retain(|id| current_identities.contains(id));

--- a/crates/flotilla-tui/src/widgets/split_table.rs
+++ b/crates/flotilla-tui/src/widgets/split_table.rs
@@ -493,6 +493,30 @@ impl SplitTable {
         }
     }
 
+    pub fn reconnect_scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn restore_reconnect_selection(&mut self, identity: &WorkItemIdentity, scroll_offset: usize) {
+        let target = self.sections.iter().enumerate().find_map(|(section_idx, (_, section))| {
+            let item_idx = match section {
+                AnySection::WorkItems(table) => table.items.iter().position(|item| &item.identity == identity),
+                AnySection::Issues(table) => match identity {
+                    WorkItemIdentity::Issue(issue_id) => table.items.iter().position(|row| &row.id == issue_id),
+                    _ => None,
+                },
+            }?;
+            Some((section_idx, item_idx))
+        });
+        let Some((section_idx, item_idx)) = target else { return };
+        for (_, section) in &mut self.sections {
+            section.clear_selection();
+        }
+        self.active_section = section_idx;
+        self.sections[section_idx].1.select_idx(item_idx);
+        self.scroll_offset = scroll_offset;
+    }
+
     /// Iterate all selectable identities across all sections.
     pub fn all_identities(&self) -> impl Iterator<Item = WorkItemIdentity> + '_ {
         self.sections.iter().flat_map(|(_, section)| match section {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,9 @@
-use std::{future::Future, path::PathBuf, process::ExitStatus, sync::Arc};
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+    process::ExitStatus,
+    sync::Arc,
+};
 
 use clap::Parser;
 use color_eyre::Result;
@@ -291,7 +296,7 @@ async fn main() -> Result<()> {
     let format = OutputFormat::from_json_flag(cli.json);
     let command = cli.command.take();
 
-    match command {
+    let result = match command {
         Some(SubCommand::View { address }) => {
             // Parse before touching the terminal so a bad address in a
             // recipe fails loudly at the shell (ADR 0013).
@@ -345,6 +350,37 @@ async fn main() -> Result<()> {
         }
 
         None => run_tui(cli, None).await,
+    };
+
+    if let Err(error) = &result {
+        let message = format!("{error:?}");
+        let already_reexecuted = std::env::var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV).ok();
+        if should_reexec_for_incompatible_daemon(&message, already_reexecuted.as_deref()) {
+            std::env::set_var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV, flotilla_protocol::BUILD_ID);
+            reexec_current_process()?;
+        }
+    }
+    result
+}
+
+fn should_reexec_for_incompatible_daemon(error: &str, already_reexecuted_build: Option<&str>) -> bool {
+    flotilla_tui::socket::reconnect::is_incompatible_daemon_error(error) && already_reexecuted_build != Some(flotilla_protocol::BUILD_ID)
+}
+
+fn reexec_current_process() -> Result<()> {
+    let executable = std::env::current_exe()?;
+    let mut command = std::process::Command::new(executable);
+    command.args(std::env::args_os().skip(1));
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let error = command.exec();
+        Err(error.into())
+    }
+    #[cfg(not(unix))]
+    {
+        command.spawn()?;
+        std::process::exit(0);
     }
 }
 
@@ -442,22 +478,21 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     });
 
     show_startup_splash(scoped_view.as_ref(), || flotilla_tui::splash::show_splash(&mut terminal)).await?;
-    let mut daemon = match daemon_task.await {
+    let daemon = match daemon_task.await {
         Ok(Ok(daemon)) => {
+            std::env::remove_var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV);
             info!(elapsed = ?startup.elapsed(), "daemon ready");
             daemon
         }
         Ok(Err(e)) => {
             flotilla_tui::terminal::restore_terminal();
-            eprintln!("Error: {e}");
             eprintln!("  Check daemon log at {}", daemon_log_path.display());
             eprintln!("  Check panic log at {}", daemon_panic_log_path.display());
-            std::process::exit(1);
+            return Err(color_eyre::eyre::eyre!(e));
         }
         Err(e) => {
             flotilla_tui::terminal::restore_terminal();
-            eprintln!("Error: daemon initialization panicked: {e}");
-            std::process::exit(1);
+            return Err(color_eyre::eyre::eyre!("daemon initialization panicked: {e}"));
         }
     };
 
@@ -482,47 +517,85 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     }
 
     let pm_connector = flotilla_tui::pm_open::detect_connector();
-    loop {
-        let repos_info = daemon.list_repos().await.unwrap_or_default();
-        let app = match scoped_view.clone() {
-            Some(address) => app::App::new_scoped(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone(), address),
-            None => app::App::new(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone()),
-        }
-        .with_pm_connector(pm_connector.clone());
+    let repos_info = daemon.list_repos().await.unwrap_or_default();
+    let mut app = match scoped_view.clone() {
+        Some(address) => app::App::new_scoped(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone(), address),
+        None => app::App::new(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone()),
+    }
+    .with_pm_connector(pm_connector.clone());
+    restore_tui_handoff(&mut app);
 
+    loop {
         match flotilla_tui::run::run_event_loop(terminal, app).await? {
             flotilla_tui::run::EventLoopExit::Quit => return Ok(()),
-            flotilla_tui::run::EventLoopExit::DaemonDisconnected => {
+            flotilla_tui::run::EventLoopExit::DaemonDisconnected(disconnected_app) => {
                 info!("daemon disconnected; reconnecting TUI");
+                app = *disconnected_app;
             }
         }
 
-        let mut backoff = flotilla_tui::pm_connect::ReconnectBackoff::default();
-        loop {
-            match flotilla_tui::socket::connect_or_spawn(
-                &socket_path,
-                &resolved_config_dir,
-                config_dir_override.as_deref(),
-                socket_override.as_deref(),
-            )
-            .await
-            {
-                Ok(connected) => {
-                    info!("TUI reconnected to daemon");
-                    daemon = connected as Arc<dyn DaemonHandle>;
-                    terminal = ratatui::init();
-                    break;
+        terminal = ratatui::init();
+        let connected = match flotilla_tui::socket::reconnect::connect_with_retry(
+            || {
+                flotilla_tui::socket::connect_or_spawn(
+                    &socket_path,
+                    &resolved_config_dir,
+                    config_dir_override.as_deref(),
+                    socket_override.as_deref(),
+                )
+            },
+            |notice| {
+                let (attempt, detail) = match notice {
+                    flotilla_tui::socket::reconnect::ReconnectNotice::Attempt { attempt } => (attempt, None),
+                    flotilla_tui::socket::reconnect::ReconnectNotice::Retry { attempt, error, delay } => {
+                        (attempt, Some(format!("{error} — retrying in {:.1}s", delay.as_secs_f64())))
+                    }
+                };
+                if let Err(error) = flotilla_tui::run::render_reconnect_frame(&mut terminal, attempt, detail.as_deref(), &initial_theme) {
+                    tracing::warn!(%error, "failed to render daemon reconnect status");
                 }
-                Err(error) if flotilla_tui::pm_connect::is_incompatible_daemon_error(&error) => {
-                    return Err(color_eyre::eyre::eyre!(error));
+            },
+        )
+        .await
+        {
+            Ok(connected) => connected,
+            Err(error) => {
+                if let Err(handoff_error) = persist_tui_handoff(&app, paths.state_dir.as_path()) {
+                    tracing::warn!(error = %handoff_error, "failed to persist TUI state for re-exec");
                 }
-                Err(error) => {
-                    let delay = backoff.next_delay();
-                    info!(%error, ?delay, "daemon unavailable; retrying TUI connection");
-                    tokio::time::sleep(delay).await;
-                }
+                flotilla_tui::terminal::restore_terminal();
+                return Err(color_eyre::eyre::eyre!(error));
             }
+        };
+        info!("TUI reconnected to daemon");
+        let repos_info = connected.list_repos().await.unwrap_or_default();
+        app.reconnect_daemon(connected as Arc<dyn DaemonHandle>, repos_info);
+    }
+}
+
+const TUI_HANDOFF_ENV: &str = "FLOTILLA_TUI_HANDOFF";
+
+fn persist_tui_handoff(app: &app::App, state_dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(state_dir)?;
+    let path = state_dir.join(format!("tui-handoff-{}-{}.json", std::process::id(), uuid::Uuid::new_v4()));
+    std::fs::write(&path, serde_json::to_vec(&app.handoff())?)?;
+    std::env::set_var(TUI_HANDOFF_ENV, &path);
+    Ok(())
+}
+
+fn restore_tui_handoff(app: &mut app::App) {
+    let Some(path) = std::env::var_os(TUI_HANDOFF_ENV).map(PathBuf::from) else { return };
+    std::env::remove_var(TUI_HANDOFF_ENV);
+    let handoff = std::fs::read(&path)
+        .map_err(|error| error.to_string())
+        .and_then(|contents| serde_json::from_slice(&contents).map_err(|error| error.to_string()));
+    let _ = std::fs::remove_file(&path);
+    match handoff {
+        Ok(handoff) => {
+            app.restore_handoff(handoff);
+            app.ui.command_echo = Some("Re-executed and reconnected to daemon".to_string());
         }
+        Err(error) => tracing::warn!(%error, path = %path.display(), "could not restore TUI re-exec handoff"),
     }
 }
 
@@ -1399,14 +1472,22 @@ mod tests {
 
     use super::{
         attach_exit_disposition, provisioning_target_for_environment, run_replica_snapshot, select_host_target, select_startup_repo_roots,
-        show_startup_splash, AttachExitDisposition, Cli, ResourceApplyArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand,
-        SubCommand,
+        should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition, Cli, ResourceApplyArgs, ResourceGetArgs,
+        ResourceListArgs, ResourceSubCommand, SubCommand,
     };
 
     #[test]
     fn attach_exit_disposition_preserves_child_exit_code() {
         let status = Command::new("sh").args(["-c", "exit 42"]).status().expect("run child");
         assert_eq!(attach_exit_disposition(status), AttachExitDisposition::Code(42));
+    }
+
+    #[test]
+    fn incompatible_daemon_reexecs_once_per_client_build() {
+        let mismatch = "daemon protocol version mismatch: daemon has 18, client has 17";
+        assert!(should_reexec_for_incompatible_daemon(mismatch, None));
+        assert!(!should_reexec_for_incompatible_daemon(mismatch, Some(flotilla_protocol::BUILD_ID)));
+        assert!(!should_reexec_for_incompatible_daemon("daemon unavailable", None));
     }
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,7 +356,7 @@ async fn main() -> Result<()> {
         let message = format!("{error:?}");
         let already_reexecuted = std::env::var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV).ok();
         if should_reexec_for_incompatible_daemon(&message, already_reexecuted.as_deref()) {
-            std::env::set_var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV, flotilla_protocol::BUILD_ID);
+            std::env::set_var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV, flotilla_tui::socket::BUILD_ID);
             reexec_current_process()?;
         }
     }
@@ -364,7 +364,7 @@ async fn main() -> Result<()> {
 }
 
 fn should_reexec_for_incompatible_daemon(error: &str, already_reexecuted_build: Option<&str>) -> bool {
-    flotilla_tui::socket::reconnect::is_incompatible_daemon_error(error) && already_reexecuted_build != Some(flotilla_protocol::BUILD_ID)
+    flotilla_tui::socket::reconnect::is_incompatible_daemon_error(error) && already_reexecuted_build != Some(flotilla_tui::socket::BUILD_ID)
 }
 
 fn reexec_current_process() -> Result<()> {
@@ -1486,7 +1486,7 @@ mod tests {
     fn incompatible_daemon_reexecs_once_per_client_build() {
         let mismatch = "daemon protocol version mismatch: daemon has 18, client has 17";
         assert!(should_reexec_for_incompatible_daemon(mismatch, None));
-        assert!(!should_reexec_for_incompatible_daemon(mismatch, Some(flotilla_protocol::BUILD_ID)));
+        assert!(!should_reexec_for_incompatible_daemon(mismatch, Some(flotilla_tui::socket::BUILD_ID)));
         assert!(!should_reexec_for_incompatible_daemon("daemon unavailable", None));
     }
 


### PR DESCRIPTION
Closes #909

## Summary

- narrate TUI reconnect attempts in-terminal and show a post-reconnect status note
- retain the live `App` across daemon bounces while clearing and replaying daemon-derived caches
- share reconnect/backoff handling across the TUI, `watch`, and `pm connect`
- advertise build identity through the compatible Hello display field and surface same-wire stale-client mismatches
- self-re-exec once on wire incompatibility, carrying view/navigation/table/repo/search/event-log state through a JSON handoff

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`