### PR TITLE
fix: assert canonical repo path round trip

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4163,7 +4163,8 @@ impl InProcessDaemon {
     ///
     /// If `path` is a git worktree, the main repo root is resolved via
     /// `git rev-parse --path-format=absolute --git-common-dir` and tracked
-    /// instead. `resolved_from` is `Some(original_path)` in that case.
+    /// instead. The returned `tracked_path` is canonicalized, and
+    /// `resolved_from` is `Some(original_path)` when the repo root changes.
     pub async fn add_repo(&self, path: &Path) -> Result<AddRepoOutcome, String> {
         let (path, resolved_from) = self.normalize_repo_path(path).await;
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4163,8 +4163,9 @@ impl InProcessDaemon {
     ///
     /// If `path` is a git worktree, the main repo root is resolved via
     /// `git rev-parse --path-format=absolute --git-common-dir` and tracked
-    /// instead. The returned `tracked_path` is canonicalized, and
-    /// `resolved_from` is `Some(original_path)` when the repo root changes.
+    /// instead. When the path resolves to a git repo root, the returned
+    /// `tracked_path` is canonicalized and `resolved_from` is
+    /// `Some(original_path)` when the repo root changes.
     pub async fn add_repo(&self, path: &Path) -> Result<AddRepoOutcome, String> {
         let (path, resolved_from) = self.normalize_repo_path(path).await;
 

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -489,10 +489,8 @@ async fn dispatch_add_list_remove_repo_round_trip() {
         other => panic!("expected list repos response, got {:?}", other),
     };
     assert_eq!(listed.len(), 1);
-    assert_eq!(
-        listed[0].path.as_ref().map(|path| path.canonicalize().expect("canonical listed repo path")),
-        Some(repo_path.canonicalize().expect("canonical requested repo path"))
-    );
+    let canonical_repo_path = repo_path.canonicalize().expect("canonical requested repo path");
+    assert_eq!(listed[0].path.as_deref(), Some(canonical_repo_path.as_path()));
 
     let remove = dispatch_request_test(&daemon, 12, Request::RemoveRepo {
         path: listed[0].path.clone().expect("tracked repo should have local path"),


### PR DESCRIPTION
## Summary

- assert that the daemon lists the canonical form of a tracked repository path
- keep the complete path round-trip assertion so unrelated path regressions still fail
- pin canonicalization to the daemon layer instead of canonicalizing the daemon's output inside the assertion

## Root cause

On macOS, `TMPDIR` may use the `/var/...` spelling while repository-path normalization resolves that symlink to `/private/var/...`. The original test compared the daemon's canonical path with the lexical tempfile path. A later incidental change canonicalized both sides during comparison, which avoided the failure but no longer asserted that the daemon itself owns canonicalization.

This change computes only the expected canonical path and compares the listed path to it exactly.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (macOS)

Closes #868