### PR TITLE
fix: keep peer generation counter monotonic across disconnects

### DIFF
--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -472,7 +472,11 @@ impl PeerManager {
     }
 
     fn generation_is_current(&self, name: &NodeId, generation: u64) -> bool {
-        generation != 0 && self.generations.get(name).copied() == Some(generation)
+        // Validity keys on the ACTIVE connection, not the mint counter: the
+        // counter must stay monotonic across disconnects (replicator
+        // supervision dedupes on it), while envelopes and hops from a
+        // disconnected generation must still be rejected.
+        generation != 0 && self.active_connections.get(name).map(|active| active.generation) == Some(generation)
     }
 
     fn install_direct_route(&mut self, host: &NodeId, generation: u64) {
@@ -1752,7 +1756,11 @@ impl PeerManager {
 
         self.senders.remove(name);
         self.active_connections.remove(name);
-        self.generations.remove(name);
+        // Deliberately NOT removing from self.generations: it is the
+        // monotonic mint counter. Resetting it made every reconnect mint
+        // generation 1 again, which the replicator supervisor rejected as
+        // a duplicate — wedging replication (and heartbeats) after any
+        // one-sided daemon restart.
         self.displaced_senders.retain(|(host, _), _| host != name);
         self.transport_peers.retain(|_, node_id| node_id != name);
         self.reverse_paths.retain(|_, hop| hop.next_hop != *name);

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -1424,3 +1424,26 @@ async fn failed_subscription_is_torn_down_diagnosed_and_retried() {
     assert!(route.connected);
     assert_eq!(route.last_error, None);
 }
+
+#[tokio::test]
+async fn reconnect_after_disconnect_mints_a_higher_generation() {
+    // Regression: disconnect_peer used to reset the mint counter, so every
+    // reconnect arrived as generation 1 and the replicator supervisor
+    // rejected its replicators as duplicates — wedging replication and
+    // heartbeats after any one-sided daemon restart.
+    let mut mgr = PeerManager::new(NodeId::new("local"));
+    let first_sender: Arc<dyn PeerSender> = Arc::new(MockPeerSender { sent: Arc::new(Mutex::new(Vec::new())) });
+    let second_sender: Arc<dyn PeerSender> = Arc::new(MockPeerSender { sent: Arc::new(Mutex::new(Vec::new())) });
+    let meta = || ConnectionMeta { direction: ConnectionDirection::Inbound, config_label: None, expected_peer: None, config_backed: false };
+
+    let gen1 = accepted_generation(mgr.activate_connection(NodeId::new("peer"), first_sender, meta()));
+    assert_eq!(gen1, 1);
+    let _ = mgr.disconnect_peer(&NodeId::new("peer"), gen1);
+
+    let gen2 = accepted_generation(mgr.activate_connection(NodeId::new("peer"), second_sender, meta()));
+    assert_eq!(gen2, 2, "reconnect after disconnect must mint a strictly higher generation");
+
+    // Validity still keys on the active connection: the disconnected
+    // generation is dead, the new one is current.
+    assert_eq!(mgr.current_generation(&NodeId::new("peer")), Some(gen2));
+}

--- a/scripts/run-daily-driver.sh
+++ b/scripts/run-daily-driver.sh
@@ -43,5 +43,5 @@ if [[ "$ZELLIJ_BIN" == "$ZELLIJ_NATIVE_ROOT/target/dev-opt/zellij" ]]; then
     fi
     "$ZELLIJ_NATIVE_ROOT/scripts/build-native-andamento"
 fi
-
+echo "Trying to run $ZELLIJ_BIN" 
 exec "$ZELLIJ_BIN" --layout "$FLOTILLA_ROOT/layouts/daily-driver.kdl"


### PR DESCRIPTION
Deploy-blocking regression observed live minutes after the #989 wave bounce: after kiwi's daemon restart, both peers wedged NOT-READY — the dead connection's replicators retried forever against the defunct transport while every reconnect minted generation=1 (disconnect_peer reset the counter) and got rejected by the supervisor's monotonic dedupe as 'stale or duplicate'.

Fix: the generations map becomes purely the monotonic mint counter (never removed); generation validity (generation_is_current) keys on active_connections instead, which is still removed on disconnect — so dead-connection envelopes and route hops stay rejected exactly as before, while reconnects mint strictly higher generations and the supervisor accepts them.

Regression test: activate → disconnect → activate asserts generation 2. Full workspace suite green locally; daemon lib 250 passed.

The counter reset predates #989 and was harmless until the supervisor started trusting monotonicity — the mismatch is the seam between the manager's lifecycle and the new supervision.