### PR TITLE
fix: retract stale awareness issue demands

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -210,10 +210,6 @@ impl AggregatorProjectionState {
         self.demand_backed.replace(subscriber, cursors)
     }
 
-    pub async fn replace_subscriber_expanding_awareness(&self, subscriber: Uuid, cursors: &[QueryCursor]) -> HashSet<QueryId> {
-        self.replace_subscriber(subscriber, cursors)
-    }
-
     pub fn remove_subscriber(&self, subscriber: Uuid) {
         self.demand_backed.remove(subscriber);
     }
@@ -429,7 +425,7 @@ mod tests {
             .await;
 
         let awareness = QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
-        state.replace_subscriber_expanding_awareness(Uuid::new_v4(), &[QueryCursor { query: awareness, since: None }]).await;
+        state.replace_subscriber(Uuid::new_v4(), &[QueryCursor { query: awareness, since: None }]);
 
         assert!(state.subscribe_demand().borrow().contains_key(&QueryId::Issues {
             scope: project,
@@ -448,7 +444,7 @@ mod tests {
 
         let subscriber = Uuid::new_v4();
         let awareness = QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
-        state.replace_subscriber_expanding_awareness(subscriber, &[QueryCursor { query: awareness.clone(), since: None }]).await;
+        state.replace_subscriber(subscriber, &[QueryCursor { query: awareness.clone(), since: None }]);
         let retained_issues = QueryId::Issues { scope: retained.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) };
         let removed_issues = QueryId::Issues { scope: removed.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) };
         assert_eq!(
@@ -459,12 +455,10 @@ mod tests {
         state.replace_store_catalog(repositories.clone(), HashMap::from([(retained, vec![])])).await;
         assert_eq!(state.subscribe_demand().borrow().keys().cloned().collect::<HashSet<_>>(), HashSet::from([retained_issues]));
 
-        state
-            .replace_subscriber_expanding_awareness(subscriber, &[QueryCursor { query: awareness, since: None }, QueryCursor {
-                query: removed_issues.clone(),
-                since: None,
-            }])
-            .await;
+        state.replace_subscriber(subscriber, &[QueryCursor { query: awareness, since: None }, QueryCursor {
+            query: removed_issues.clone(),
+            since: None,
+        }]);
         state.replace_store_catalog(repositories, HashMap::new()).await;
         assert_eq!(state.subscribe_demand().borrow().keys().cloned().collect::<HashSet<_>>(), HashSet::from([removed_issues]));
     }

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -172,7 +172,7 @@ impl AggregatorProjectionState {
         let mut deltas = self.independents.write().await.replace_catalog(repositories.clone(), projects.clone());
         deltas.extend(self.checkouts.write().await.replace_catalog(repositories, projects));
         let scopes = self.checkouts.read().await.project_scopes();
-        self.demand_backed.expand_fleet_awareness_demands(&scopes);
+        self.demand_backed.replace_fleet_awareness_scopes(&scopes);
         deltas
     }
 
@@ -211,16 +211,7 @@ impl AggregatorProjectionState {
     }
 
     pub async fn replace_subscriber_expanding_awareness(&self, subscriber: Uuid, cursors: &[QueryCursor]) -> HashSet<QueryId> {
-        let mut expanded = cursors.to_vec();
-        if cursors.iter().any(|cursor| matches!(cursor.query, QueryId::Awareness { scope: None, .. })) {
-            for scope in self.checkouts.read().await.project_scopes() {
-                let query = QueryId::Issues { scope, search: None, label: Some(READY_ISSUE_LABEL.into()) };
-                if !expanded.iter().any(|cursor| cursor.query == query) {
-                    expanded.push(QueryCursor { query, since: None });
-                }
-            }
-        }
-        self.replace_subscriber(subscriber, &expanded)
+        self.replace_subscriber(subscriber, cursors)
     }
 
     pub fn remove_subscriber(&self, subscriber: Uuid) {
@@ -445,6 +436,37 @@ mod tests {
             search: None,
             label: Some(READY_ISSUE_LABEL.into()),
         }));
+    }
+
+    #[tokio::test]
+    async fn fleet_awareness_subscription_retracts_removed_project_issue_windows_but_preserves_explicit_demand() {
+        let state = AggregatorProjectionState::new();
+        let retained = scope("retained");
+        let removed = scope("removed");
+        let repositories = HashMap::from([(RepositoryKey("repo-a".into()), "a".to_string())]);
+        state.replace_store_catalog(repositories.clone(), HashMap::from([(retained.clone(), vec![]), (removed.clone(), vec![])])).await;
+
+        let subscriber = Uuid::new_v4();
+        let awareness = QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
+        state.replace_subscriber_expanding_awareness(subscriber, &[QueryCursor { query: awareness.clone(), since: None }]).await;
+        let retained_issues = QueryId::Issues { scope: retained.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) };
+        let removed_issues = QueryId::Issues { scope: removed.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) };
+        assert_eq!(
+            state.subscribe_demand().borrow().keys().cloned().collect::<HashSet<_>>(),
+            HashSet::from([retained_issues.clone(), removed_issues.clone()])
+        );
+
+        state.replace_store_catalog(repositories.clone(), HashMap::from([(retained, vec![])])).await;
+        assert_eq!(state.subscribe_demand().borrow().keys().cloned().collect::<HashSet<_>>(), HashSet::from([retained_issues]));
+
+        state
+            .replace_subscriber_expanding_awareness(subscriber, &[QueryCursor { query: awareness, since: None }, QueryCursor {
+                query: removed_issues.clone(),
+                since: None,
+            }])
+            .await;
+        state.replace_store_catalog(repositories, HashMap::new()).await;
+        assert_eq!(state.subscribe_demand().borrow().keys().cloned().collect::<HashSet<_>>(), HashSet::from([removed_issues]));
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6853,7 +6853,7 @@ impl DaemonHandle for InProcessDaemon {
 
     async fn subscribe_queries(&self, subscriber_id: uuid::Uuid, queries: &[QueryCursor]) -> Result<Vec<DaemonEvent>, String> {
         let state = self.aggregator_projection_state().await;
-        let newly_materialized = state.replace_subscriber_expanding_awareness(subscriber_id, queries).await;
+        let newly_materialized = state.replace_subscriber(subscriber_id, queries);
         let mut events = Vec::new();
         for cursor in queries {
             let result_set =

--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -24,6 +24,7 @@ pub struct QueryRegistry {
 #[derive(Default, Debug)]
 struct RegistryState {
     subscribers: HashMap<Uuid, HashSet<QueryId>>,
+    fleet_awareness_scopes: HashSet<flotilla_protocol::QueryScope>,
     demand_backed: HashMap<QueryId, ResultSet>,
     generations: HashMap<QueryId, u64>,
     next_generation: u64,
@@ -51,16 +52,11 @@ impl QueryRegistry {
         created
     }
 
-    pub fn expand_fleet_awareness_demands(&self, scopes: &[flotilla_protocol::QueryScope]) -> HashSet<QueryId> {
+    /// Replace the catalog scopes from which fleet-awareness issue demand is
+    /// derived. Explicit subscriber queries remain independently owned.
+    pub fn replace_fleet_awareness_scopes(&self, scopes: &[flotilla_protocol::QueryScope]) -> HashSet<QueryId> {
         let mut state = self.inner.lock().expect("query registry lock poisoned");
-        for queries in state.subscribers.values_mut() {
-            if !queries.iter().any(|query| matches!(query, QueryId::Awareness { scope: None, .. })) {
-                continue;
-            }
-            for scope in scopes {
-                queries.insert(QueryId::Issues { scope: scope.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) });
-            }
-        }
+        state.fleet_awareness_scopes = scopes.iter().cloned().collect();
         let created = reconcile_demand(&mut state);
         self.publish_demand(&state);
         created
@@ -209,7 +205,15 @@ impl QueryRegistry {
 }
 
 fn reconcile_demand(state: &mut RegistryState) -> HashSet<QueryId> {
-    let demanded: HashSet<QueryId> = state.subscribers.values().flat_map(|queries| queries.iter().filter_map(issue_demand_query)).collect();
+    let mut demanded: HashSet<QueryId> =
+        state.subscribers.values().flat_map(|queries| queries.iter().filter_map(issue_demand_query)).collect();
+    if state.subscribers.values().any(|queries| queries.iter().any(|query| matches!(query, QueryId::Awareness { scope: None, .. }))) {
+        demanded.extend(state.fleet_awareness_scopes.iter().cloned().map(|scope| QueryId::Issues {
+            scope,
+            search: None,
+            label: Some(READY_ISSUE_LABEL.into()),
+        }));
+    }
     state.demand_backed.retain(|query, _| demanded.contains(query));
     state.generations.retain(|query, _| demanded.contains(query));
     let mut created = HashSet::new();


### PR DESCRIPTION
Closes #879.

## Summary
- keep fleet-awareness catalog scopes separate from explicit subscriber queries
- reconcile derived ready-issue demand against the current catalog so removed projects tear down their materializers
- preserve an explicit issue subscription when it overlaps a removed derived demand

## Verification
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`