### PR TITLE
fix: select a viable local default convoy placement

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -753,25 +753,59 @@ async fn persist_adopted_checkout(
     }
 }
 
-async fn default_convoy_placement_policy(backend: &ResourceBackend, namespace: &str, contained: bool) -> Option<String> {
+async fn default_convoy_placement_policy(
+    backend: &ResourceBackend,
+    namespace: &str,
+    workflow: &WorkflowTemplateSpec,
+    local_host_ref: Option<&str>,
+) -> Result<Option<ResourceObject<PlacementPolicy>>, String> {
+    let contained = workflow.vessels.iter().any(|vessel| vessel.stance == flotilla_resources::Stance::Contained);
     let mut policies = match backend.clone().using::<PlacementPolicy>(namespace).list().await {
         Ok(list) => list.items,
         Err(err) => {
             warn!(%namespace, error = %err, "failed to list placement policies; convoy will remain Pending until one is registered");
-            return None;
+            return Ok(None);
         }
     };
     policies.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
-    let policy = if contained {
-        policies.iter().find(|policy| policy.spec.docker_per_vessel.is_some())
-    } else {
-        policies.iter().find(|policy| policy.metadata.name.starts_with("host-direct-")).or_else(|| policies.first())
+    let candidates = policies.into_iter().filter(|policy| !contained || policy.spec.docker_per_vessel.is_some()).collect::<Vec<_>>();
+    let candidate_names = candidates.iter().map(|policy| policy.metadata.name.clone()).collect::<Vec<_>>();
+    let mut viable = Vec::new();
+    for policy in candidates {
+        if validate_workflow_agent_adapters(backend, namespace, workflow, Some(&policy)).await.is_ok() {
+            viable.push(policy);
+        }
     }
-    .map(|policy| policy.metadata.name.clone());
-    if policy.is_none() {
+    viable.sort_by_key(|policy| {
+        let target_host = policy
+            .spec
+            .host_direct
+            .as_ref()
+            .map(|spec| spec.host_ref.as_str())
+            .or_else(|| policy.spec.docker_per_vessel.as_ref().map(|spec| spec.host_ref.as_str()));
+        let is_local = local_host_ref.is_some_and(|local| target_host == Some(local));
+        let is_host_direct = policy.spec.host_direct.is_some();
+        (!is_local, !is_host_direct, policy.metadata.name.clone())
+    });
+    if let Some(policy) = viable.into_iter().next() {
+        return Ok(Some(policy));
+    }
+
+    let required_adapters = required_workflow_agent_adapters(workflow)?;
+    if !required_adapters.is_empty() {
+        let requirement = if required_adapters.len() == 1 {
+            format!("adapter `{}`", required_adapters.first().expect("one required adapter"))
+        } else {
+            format!("adapters {}", required_adapters.iter().map(|adapter| format!("`{adapter}`")).collect::<Vec<_>>().join(", "))
+        };
+        let candidates = if candidate_names.is_empty() { "(none)".to_string() } else { candidate_names.join(", ") };
+        return Err(format!("no placement policy satisfies {requirement}; candidates: {candidates}"));
+    }
+
+    if candidate_names.is_empty() {
         warn!(%namespace, "no placement policy found; convoy will remain Pending until one is registered");
     }
-    policy
+    Ok(None)
 }
 
 fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {
@@ -3164,41 +3198,13 @@ async fn validate_workflow_agent_adapters(
     workflow: &WorkflowTemplateSpec,
     placement: Option<&ResourceObject<PlacementPolicy>>,
 ) -> Result<(), String> {
-    let capabilities = CapabilityTable::seeded();
-    let mut required_adapters = BTreeSet::new();
-    for crew in workflow.vessels.iter().flat_map(|vessel| &vessel.crew) {
-        if let CrewSource::Agent { selector, .. } = &crew.source {
-            required_adapters.insert(capabilities.resolve(&selector.capability)?.adapter.clone());
-        }
-    }
+    let required_adapters = required_workflow_agent_adapters(workflow)?;
 
     for adapter in required_adapters {
         let Some(placement) = placement else {
             return Err(format!("workflow requires agent adapter `{adapter}`, but no placement is available"));
         };
-        let (available_adapters, detail) = if let Some(docker) = &placement.spec.docker_per_vessel {
-            (docker.agent_adapters.clone(), format!("image `{}`", docker.image))
-        } else if let Some(host_direct) = &placement.spec.host_direct {
-            let host = backend.clone().using::<ResourceHost>(namespace).get(&host_direct.host_ref).await.map_err(|error| {
-                format!("placement `{}` host `{}` is not ready: {error}", placement.metadata.name, host_direct.host_ref)
-            })?;
-            let mut status = host
-                .status
-                .ok_or_else(|| format!("placement `{}` host `{}` has no observed status", placement.metadata.name, host_direct.host_ref))?;
-            status.apply_heartbeat_readiness(Utc::now());
-            if !status.ready {
-                return Err(format!("placement `{}` host `{}` is not ready", placement.metadata.name, host_direct.host_ref));
-            }
-            let available_adapters = status.agent_adapters().map_err(|error| {
-                format!(
-                    "placement `{}` host `{}` has invalid agent adapter capabilities: {error}",
-                    placement.metadata.name, host_direct.host_ref
-                )
-            })?;
-            (available_adapters, format!("host `{}`", host_direct.host_ref))
-        } else {
-            (BTreeSet::new(), "unknown target environment".to_string())
-        };
+        let (available_adapters, detail) = placement_agent_adapters(backend, namespace, placement).await?;
         if available_adapters.contains(&adapter) {
             continue;
         }
@@ -3209,6 +3215,48 @@ async fn validate_workflow_agent_adapters(
     }
 
     Ok(())
+}
+
+fn required_workflow_agent_adapters(workflow: &WorkflowTemplateSpec) -> Result<BTreeSet<String>, String> {
+    let capabilities = CapabilityTable::seeded();
+    let mut required_adapters = BTreeSet::new();
+    for crew in workflow.vessels.iter().flat_map(|vessel| &vessel.crew) {
+        if let CrewSource::Agent { selector, .. } = &crew.source {
+            required_adapters.insert(capabilities.resolve(&selector.capability)?.adapter.clone());
+        }
+    }
+    Ok(required_adapters)
+}
+
+async fn placement_agent_adapters(
+    backend: &ResourceBackend,
+    namespace: &str,
+    placement: &ResourceObject<PlacementPolicy>,
+) -> Result<(BTreeSet<String>, String), String> {
+    if let Some(docker) = &placement.spec.docker_per_vessel {
+        Ok((docker.agent_adapters.clone(), format!("image `{}`", docker.image)))
+    } else if let Some(host_direct) = &placement.spec.host_direct {
+        let host =
+            backend.clone().using::<ResourceHost>(namespace).get(&host_direct.host_ref).await.map_err(|error| {
+                format!("placement `{}` host `{}` is not ready: {error}", placement.metadata.name, host_direct.host_ref)
+            })?;
+        let mut status = host
+            .status
+            .ok_or_else(|| format!("placement `{}` host `{}` has no observed status", placement.metadata.name, host_direct.host_ref))?;
+        status.apply_heartbeat_readiness(Utc::now());
+        if !status.ready {
+            return Err(format!("placement `{}` host `{}` is not ready", placement.metadata.name, host_direct.host_ref));
+        }
+        let available_adapters = status.agent_adapters().map_err(|error| {
+            format!(
+                "placement `{}` host `{}` has invalid agent adapter capabilities: {error}",
+                placement.metadata.name, host_direct.host_ref
+            )
+        })?;
+        Ok((available_adapters, format!("host `{}`", host_direct.host_ref)))
+    } else {
+        Ok((BTreeSet::new(), "unknown target environment".to_string()))
+    }
 }
 
 fn convoy_fallback_slug(title: &str, id: &str) -> String {
@@ -3513,21 +3561,18 @@ impl InProcessDaemon {
                 Some(resolved)
             }
             None => {
-                let policy = default_convoy_placement_policy(&self.resource_backend, namespace, contained).await;
-                if contained && policy.is_none() {
+                let local_host_id = self.local_host_id();
+                let placement = default_convoy_placement_policy(
+                    &self.resource_backend,
+                    namespace,
+                    workflow,
+                    local_host_id.as_ref().map(HostId::as_str),
+                )
+                .await?;
+                if contained && placement.is_none() {
                     return Err("contained workflow requires an available docker placement policy".to_string());
                 }
-                match policy {
-                    Some(policy) => Some(
-                        self.resource_backend
-                            .clone()
-                            .using::<PlacementPolicy>(namespace)
-                            .get(&policy)
-                            .await
-                            .map_err(|error| format!("placement policy {policy}: {error}"))?,
-                    ),
-                    None => None,
-                }
+                placement
             }
         };
         validate_workflow_agent_adapters(&self.resource_backend, namespace, workflow, placement.as_ref()).await?;

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -259,6 +259,82 @@ async fn agent_adapter_admission_rejects_a_host_with_stale_heartbeat() {
     assert_eq!(error, "placement `host-direct-test` host `host-test` is not ready");
 }
 
+async fn create_host_direct_placement(backend: &ResourceBackend, policy_name: &str, host_ref: &str, agent_adapters: BTreeSet<String>) {
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = hosts.create(&empty_input_meta(host_ref), &HostSpec {}).await.expect("host create");
+    hosts
+        .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
+            capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(agent_adapters))].into_iter().collect(),
+            heartbeat_at: Some(Utc::now()),
+            ready: true,
+            resource_store: None,
+        })
+        .await
+        .expect("host status update");
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta(policy_name),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: host_ref.to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("placement create");
+}
+
+fn trusted_codex_workflow() -> WorkflowTemplateSpec {
+    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
+    workflow.vessels[0].stance = Stance::Trusted;
+    workflow
+}
+
+#[tokio::test]
+async fn default_placement_prefers_the_viable_local_host() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_host_direct_placement(&backend, "host-direct-a-remote", "remote-host", BTreeSet::from(["codex".to_string()])).await;
+    create_host_direct_placement(&backend, "host-direct-z-local", "local-host", BTreeSet::from(["codex".to_string()])).await;
+
+    let placement = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("local-host"))
+        .await
+        .expect("default placement")
+        .expect("viable placement");
+
+    assert_eq!(placement.metadata.name, "host-direct-z-local");
+}
+
+#[tokio::test]
+async fn default_placement_never_selects_a_host_without_the_required_adapter() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_host_direct_placement(&backend, "host-direct-a-no-adapters", "empty-host", BTreeSet::new()).await;
+    create_host_direct_placement(&backend, "host-direct-z-codex", "codex-host", BTreeSet::from(["codex".to_string()])).await;
+
+    let placement = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("unrelated-local-host"))
+        .await
+        .expect("default placement")
+        .expect("viable placement");
+
+    assert_eq!(placement.metadata.name, "host-direct-z-codex");
+}
+
+#[tokio::test]
+async fn default_placement_no_viable_candidate_error_names_the_adapter_and_candidates() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_host_direct_placement(&backend, "host-direct-a", "host-a", BTreeSet::new()).await;
+    create_host_direct_placement(&backend, "host-direct-b", "host-b", BTreeSet::from(["claude-code".to_string()])).await;
+
+    let error = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("host-a"))
+        .await
+        .expect_err("no candidate should admit codex");
+
+    assert_eq!(error, "no placement policy satisfies adapter `codex`; candidates: host-direct-a, host-direct-b");
+}
+
 #[tokio::test]
 async fn peer_summary_materializes_an_admissible_host_direct_placement_target() {
     let temp = tempfile::tempdir().expect("create tempdir");

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -49,9 +49,10 @@ use flotilla_resources::{
     apply_status_patch, controller_patches as convoy_controller_patches, single_agent_contained_workflow_spec,
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
-    DockerPerVesselPlacementPolicySpec, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
-    ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositorySpec, TypedResolver, WorkPhase,
-    WorkState, WorkflowSnapshot, WorkflowTemplate, REPO_KEY_LABEL, REPO_LABEL,
+    DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec,
+    HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
+    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositorySpec, Stance, TypedResolver, WorkPhase, WorkState,
+    WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -918,6 +919,120 @@ async fn create_test_convoy_project(backend: &flotilla_resources::ResourceBacken
         })
         .await
         .expect("project create");
+}
+
+async fn create_test_host_direct_policy(
+    backend: &flotilla_resources::ResourceBackend,
+    policy_name: &str,
+    host_ref: &str,
+    agent_adapters: BTreeSet<String>,
+) {
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = hosts.create(&InputMeta::builder().name(host_ref.to_string()).build(), &HostSpec {}).await.expect("host create");
+    hosts
+        .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
+            capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(agent_adapters))].into_iter().collect(),
+            heartbeat_at: Some(chrono::Utc::now()),
+            ready: true,
+            resource_store: None,
+        })
+        .await
+        .expect("host status update");
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &InputMeta::builder().name(policy_name.to_string()).build(),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: host_ref.to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("host-direct policy create");
+}
+
+#[tokio::test]
+async fn bare_convoy_start_uses_the_viable_local_host_direct_policy() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"local-host\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), fake_discovery(false), HostName::local()).await;
+    let local_host_ref = daemon.local_host_id().expect("local host id").to_string();
+    let backend = daemon.resource_backend();
+    let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository.key().to_string()).build(), &repository)
+        .await
+        .expect("repository create");
+    let mut workflow = single_agent_contained_workflow_spec();
+    workflow.vessels[0].stance = Stance::Trusted;
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("single-agent-trusted".to_string()).build(), &workflow)
+        .await
+        .expect("workflow create");
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
+            display_name: "Flotilla".into(),
+            default_workflow_ref: "single-agent-trusted".into(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project create");
+    create_test_host_direct_policy(&backend, "host-direct-a-empty", "empty-host", BTreeSet::new()).await;
+    create_test_host_direct_policy(&backend, "host-direct-b-remote", "remote-host", BTreeSet::from(["codex".to_string()])).await;
+    create_test_host_direct_policy(&backend, "host-direct-z-local", &local_host_ref, BTreeSet::from(["codex".to_string()])).await;
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".into(),
+                    issues: Vec::new(),
+                    name: Some("local-default".into()),
+                    branch: Some("fix/local-default".into()),
+                    workflow_ref: None,
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: false,
+                }),
+            },
+        })
+        .await
+        .expect("start command accepted");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events.recv().await {
+                Ok(DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => break result,
+                Ok(_) => {}
+                Err(error) => panic!("command event receive failed: {error:?}"),
+            }
+        }
+    })
+    .await
+    .expect("start command should finish");
+    assert_eq!(result, CommandValue::ConvoyStarted { name: "local-default".into(), attach_command: None, binding: None });
+    let convoy = backend.using::<ResourceConvoy>("flotilla").get("local-default").await.expect("persisted convoy");
+    assert_eq!(convoy.spec.placement_policy.as_deref(), Some("host-direct-z-local"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #840

## What changed

- evaluate every stance-compatible placement policy with the same agent-adapter admission check used after selection
- prefer viable policies targeting the local host, while retaining deterministic host-direct/name ordering
- report the required adapter(s) and the complete candidate list when no default policy is viable
- cover selection behavior and a bare `convoy start` command that persists the viable local placement

## Root cause

Default selection sorted the materialized placement policies and chose the first host-direct policy before checking workflow adapter requirements. With peer host-direct policies present, an alphabetically earlier host advertising no adapters could be selected and then rejected by admission.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`