### PR TITLE
feat: expose awareness projection truncation

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -365,6 +365,7 @@ fn merged_issue_state(issue_sets: &[(QueryScope, ResultSet)]) -> ResultSetState 
     let mut state = ResultSetState::default();
     for (_, set) in issue_sets {
         state.conditions.extend(set.state.conditions.clone());
+        state.truncated |= set.state.truncated;
         if let Some(demand) = &set.state.demand {
             state.demand = Some(match state.demand {
                 Some(existing) => flotilla_protocol::DemandBackedMetadata {
@@ -463,6 +464,7 @@ mod tests {
         state.replace_issues(&issue_query, generation, vec![issue_row("flotilla-org/flotilla", "862")], ResultSetState {
             demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: false }),
             conditions: vec![],
+            truncated: false,
         });
 
         let result = state.awareness_result_set(&None, AwarenessGrouping::Project, AwarenessLimit::default()).await;

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -191,6 +191,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
 
     let mut nodes = groups.into_values().collect::<Vec<_>>();
     nodes.sort_by(|left, right| group_rank(left).cmp(&group_rank(right)).then_with(|| left.label.cmp(&right.label)));
+    let mut truncated = nodes.len() > input.limit.groups;
     nodes.truncate(input.limit.groups);
     let rows = nodes
         .into_iter()
@@ -206,6 +207,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
             } else {
                 HashMap::new()
             };
+            truncated |= group.entries.len() > input.limit.entries;
             group.entries.truncate(input.limit.entries);
             AwarenessNode::builder()
                 .id(group.id)
@@ -223,7 +225,9 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .build()
         })
         .collect();
-    (rows, input.state)
+    let mut state = input.state;
+    state.truncated |= truncated;
+    (rows, state)
 }
 
 fn repo_fact_annotations(repo: Option<&flotilla_protocol::RepoKey>) -> HashMap<String, String> {
@@ -556,6 +560,52 @@ mod tests {
     }
 
     #[test]
+    fn awareness_state_distinguishes_projection_truncation_from_source_pagination() {
+        let source_state = ResultSetState {
+            demand: Some(flotilla_protocol::DemandBackedMetadata { as_of: Utc::now(), has_more: false }),
+            conditions: vec![],
+            truncated: false,
+        };
+        let (_, group_limited_state) = project_awareness(AwarenessInput {
+            grouping: AwarenessGrouping::Convoy,
+            limit: AwarenessLimit { groups: 1, entries: 32 },
+            convoys: vec![
+                convoy(Some("flotilla/platform"), "first", ConvoyPhase::Active),
+                convoy(Some("flotilla/platform"), "second", ConvoyPhase::Pending),
+            ],
+            state: source_state.clone(),
+            ..AwarenessInput::default()
+        });
+        let (_, entry_limited_state) = project_awareness(AwarenessInput {
+            grouping: AwarenessGrouping::Project,
+            limit: AwarenessLimit { groups: 1, entries: 1 },
+            convoys: vec![
+                convoy(Some("flotilla/platform"), "first", ConvoyPhase::Active),
+                convoy(Some("flotilla/platform"), "second", ConvoyPhase::Pending),
+            ],
+            state: source_state.clone(),
+            ..AwarenessInput::default()
+        });
+        let (_, complete_state) = project_awareness(AwarenessInput {
+            grouping: AwarenessGrouping::Convoy,
+            limit: AwarenessLimit { groups: 2, entries: 1 },
+            convoys: vec![
+                convoy(Some("flotilla/platform"), "first", ConvoyPhase::Active),
+                convoy(Some("flotilla/platform"), "second", ConvoyPhase::Pending),
+            ],
+            state: source_state,
+            ..AwarenessInput::default()
+        });
+
+        assert!(group_limited_state.truncated);
+        assert!(entry_limited_state.truncated);
+        assert!(!complete_state.truncated, "an exact limit does not truncate");
+        for state in [group_limited_state, entry_limited_state, complete_state] {
+            assert!(!state.demand.expect("source pagination metadata").has_more);
+        }
+    }
+
+    #[test]
     fn salience_is_joined_onto_entries_and_aggregated_to_their_node() {
         let base = Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).single().expect("timestamp");
         let demand_at = Utc.with_ymd_and_hms(2026, 7, 22, 12, 1, 0).single().expect("timestamp");
@@ -602,6 +652,7 @@ mod tests {
             state: ResultSetState {
                 demand: Some(flotilla_protocol::DemandBackedMetadata { as_of: base, has_more: false }),
                 conditions: Vec::new(),
+                truncated: false,
             },
             ..AwarenessInput::default()
         });

--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -246,6 +246,7 @@ fn unavailable_issues_result_set(query: QueryId) -> ResultSet {
                 source: None,
                 message: "issue source materialization is pending".to_string(),
             }],
+            truncated: false,
         },
     }
 }
@@ -335,7 +336,11 @@ mod tests {
         let query = issues("represented");
         registry.replace(Uuid::new_v4(), &[cursor(query.clone())]);
         let generation = registry.generation(&query);
-        let ready = ResultSetState { demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: true }), conditions: vec![] };
+        let ready = ResultSetState {
+            demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: true }),
+            conditions: vec![],
+            truncated: false,
+        };
         registry.replace_issues(&query, generation, vec![issue_row("809"), issue_row("810")], ready).expect("issue window");
 
         let represented = HashSet::from([IssueRef {
@@ -366,7 +371,11 @@ mod tests {
         let second_generation = registry.generation(&query);
 
         assert!(second_generation > first_generation);
-        let ready = ResultSetState { demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: false }), conditions: vec![] };
+        let ready = ResultSetState {
+            demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: false }),
+            conditions: vec![],
+            truncated: false,
+        };
         assert!(registry.replace_issues(&query, first_generation, vec![], ready.clone()).is_none());
         assert!(registry.replace_issues(&query, second_generation, vec![], ready).is_some());
     }
@@ -416,6 +425,7 @@ mod tests {
         registry.replace_issues(&query, registry.generation(&query), vec![], ResultSetState {
             demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: true }),
             conditions: vec![],
+            truncated: false,
         });
         let mut intents = registry.subscribe_fetch_more();
 
@@ -435,6 +445,7 @@ mod tests {
         registry.replace_issues(&query, first_generation, vec![], ResultSetState {
             demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: true }),
             conditions: vec![],
+            truncated: false,
         });
         registry.request_fetch_more(&query).expect("first lifetime accepts fetch-more");
 

--- a/crates/flotilla-core/src/scoped_store.rs
+++ b/crates/flotilla-core/src/scoped_store.rs
@@ -107,6 +107,7 @@ impl<R: ScopedStoreRow> MaterializedSet<R> {
             state: ResultSetState {
                 demand: None,
                 conditions: vec![ResultSetCondition::QueryScopeUnavailable { scope: scope.clone(), message }],
+                truncated: false,
             },
         }
     }

--- a/crates/flotilla-daemon/src/issue_materializer.rs
+++ b/crates/flotilla-daemon/src/issue_materializer.rs
@@ -530,7 +530,7 @@ async fn publish_awareness_sets(state: &AggregatorProjectionState, event_tx: &br
 }
 
 fn demand_state(has_more: bool, conditions: Vec<ResultSetCondition>) -> ResultSetState {
-    ResultSetState { demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more }), conditions }
+    ResultSetState { demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more }), conditions, truncated: false }
 }
 
 fn unavailable(source: Option<IssueSource>, message: impl Into<String>) -> ResultSetCondition {

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -270,11 +270,17 @@ pub struct ResultSetState {
     pub demand: Option<DemandBackedMetadata>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<ResultSetCondition>,
+    /// The query projection omitted rows after applying its own limit.
+    ///
+    /// This is independent of demand-backed [`DemandBackedMetadata::has_more`],
+    /// which reports whether the underlying source window can be expanded.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
 }
 
 impl ResultSetState {
     pub fn is_empty(&self) -> bool {
-        self.demand.is_none() && self.conditions.is_empty()
+        self.demand.is_none() && self.conditions.is_empty() && !self.truncated
     }
 }
 
@@ -875,8 +881,8 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use super::{
-        CheckoutRow, DemandBackedMetadata, IndependentRow, IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet,
-        ResultSetState, Rows, SessionPhase,
+        AwarenessGrouping, AwarenessLimit, CheckoutRow, DemandBackedMetadata, IndependentRow, IssueRow, QueryChanges, QueryId, QueryScope,
+        ResultDelta, ResultSet, ResultSetState, Rows, SessionPhase,
     };
     use crate::{provider_data::Issue, HostName, IssueRef, IssueSource, IssueState, LifecycleAuthority, RepositoryKey, ResourceRef};
 
@@ -956,6 +962,7 @@ mod tests {
                     scope: scope.clone(),
                     message: "repository definition is temporarily unavailable".into(),
                 }],
+                truncated: false,
             }),
         };
 
@@ -1044,6 +1051,7 @@ mod tests {
                 has_more: true,
             }),
             conditions: vec![],
+            truncated: false,
         };
         let delta = ResultDelta {
             seq: 2,
@@ -1055,5 +1063,24 @@ mod tests {
         let decoded = serde_json::from_str::<ResultDelta>(&json).expect("deserialize metadata delta");
         assert_eq!(decoded.state, Some(state));
         assert!(decoded.changes.is_empty());
+    }
+
+    #[test]
+    fn projection_truncation_round_trips_without_demand_metadata() {
+        let state = ResultSetState { truncated: true, ..ResultSetState::default() };
+        let set = ResultSet {
+            seq: 1,
+            rows: Rows::Awareness {
+                scope: None,
+                grouping: AwarenessGrouping::Project,
+                limit: AwarenessLimit { groups: 1, entries: 1 },
+                rows: vec![],
+            },
+            state: state.clone(),
+        };
+
+        let json = serde_json::to_string(&set).expect("serialize truncated projection");
+        assert!(json.contains(r#""state":{"truncated":true}"#));
+        assert_eq!(serde_json::from_str::<ResultSet>(&json).expect("deserialize truncated projection").state, state);
     }
 }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1939,6 +1939,7 @@ fn app_applies_materialized_issue_sets_and_deltas_to_the_typed_query_cache() {
                 has_more: true,
             }),
             conditions: vec![],
+            truncated: false,
         },
     })));
     assert_eq!(app.query_tables.issues[&query].rows[0].issue.reference.id, "LINEAR-1");
@@ -1961,6 +1962,7 @@ fn app_applies_materialized_issue_sets_and_deltas_to_the_typed_query_cache() {
                 has_more: false,
             }),
             conditions: vec![],
+            truncated: false,
         }),
     })));
 
@@ -2064,6 +2066,7 @@ async fn materialized_issue_scroll_requests_the_next_demand_backed_page() {
                 has_more: true,
             }),
             conditions: vec![],
+            truncated: false,
         },
     })));
 

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -1647,6 +1647,7 @@ mod tests {
         let state = ResultSetState {
             demand: Some(DemandBackedMetadata { as_of: "2026-07-20T12:00:00Z".parse().expect("timestamp"), has_more: true }),
             conditions: vec![ResultSetCondition::IssueSourceUnavailable { source: None, message: "one source is unavailable".into() }],
+            truncated: false,
         };
         let address: ViewAddress = "issues?project=flotilla%2Froadmap".parse().expect("issues address");
 

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -645,6 +645,7 @@ mod tests {
                 source: None,
                 message: "one source unavailable".into(),
             }],
+            truncated: false,
         };
         let view = table_view::project(&"issues?project=flotilla%2Froadmap".parse().expect("address"), &table_view::TableRows {
             issue_results: vec![table_view::QueryRows { query: &query, rows: std::slice::from_ref(&row), state: &state }],


### PR DESCRIPTION
Closes #880.

## Summary
- add projection-level `truncated` state independently of demand-backed `has_more`
- mark awareness results truncated when ranked group or entry limits discard rows
- preserve projection truncation through result-state composition and wire serialization
- cover group limits, entry limits, exact-limit completeness, and protocol round-tripping

## Verification
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`