### PR TITLE
fix: re-resolve peer socket paths between retries

### DIFF
--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashMap,
-    future::Future,
-    path::PathBuf,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{collections::HashMap, future::Future, path::PathBuf, sync::Arc, time::Duration};
 
 use chrono::Utc;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
@@ -13,6 +7,7 @@ use flotilla_resources::{
     HttpBackend, K8sWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, WatchStart,
 };
 use futures::StreamExt;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -46,20 +41,32 @@ struct ActiveGeneration {
 /// from a dead forwarded socket, or from no socket, to the live transport.
 #[derive(Clone)]
 struct SocketPathSource {
-    path: Arc<RwLock<Option<PathBuf>>>,
+    path: watch::Sender<Option<PathBuf>>,
 }
 
 impl SocketPathSource {
     fn new(path: Option<PathBuf>) -> Self {
-        Self { path: Arc::new(RwLock::new(path)) }
+        let (path, _) = watch::channel(path);
+        Self { path }
     }
 
-    fn resolve(&self) -> Option<PathBuf> {
-        self.path.read().expect("socket path source read lock").clone()
+    async fn resolve(&self) -> Result<PathBuf, String> {
+        let mut path = self.path.subscribe();
+        loop {
+            if let Some(path) = path.borrow_and_update().clone() {
+                return Ok(path);
+            }
+            path.changed().await.map_err(|_| "peer resource socket path source closed".to_string())?;
+        }
+    }
+
+    #[cfg(test)]
+    fn current(&self) -> Option<PathBuf> {
+        self.path.borrow().clone()
     }
 
     fn update(&self, path: PathBuf) {
-        *self.path.write().expect("socket path source write lock") = Some(path);
+        self.path.send_replace(Some(path));
     }
 }
 
@@ -156,9 +163,8 @@ fn spawn_kind<T: Resource>(
                     cancellation,
                     REPLICATION_RETRY,
                     move || {
-                        socket_path_source
-                            .resolve()
-                            .ok_or_else(|| "peer has no forwarded resource socket; waiting for an outbound SSH connection".to_string())
+                        let socket_path_source = socket_path_source.clone();
+                        async move { socket_path_source.resolve().await }
                     },
                     move |path| {
                         let daemon = Arc::clone(&run_daemon);
@@ -181,7 +187,7 @@ fn spawn_kind<T: Resource>(
                     T::API_PATHS.kind,
                     cancellation,
                     REPLICATION_RETRY,
-                    || Ok(()),
+                    || async { Ok(()) },
                     move |()| {
                         let router = router.clone();
                         let daemon = Arc::clone(&run_daemon);
@@ -195,7 +201,7 @@ fn spawn_kind<T: Resource>(
     });
 }
 
-async fn supervise_kind<I, S, F, Fut>(
+async fn supervise_kind<I, S, SourceFut, F, Fut>(
     peer: NodeId,
     generation: u64,
     kind: &'static str,
@@ -204,7 +210,8 @@ async fn supervise_kind<I, S, F, Fut>(
     mut source: S,
     mut run: F,
 ) where
-    S: FnMut() -> Result<I, String>,
+    S: FnMut() -> SourceFut,
+    SourceFut: Future<Output = Result<I, String>>,
     F: FnMut(I) -> Fut,
     Fut: Future<Output = Result<(), String>>,
 {
@@ -215,7 +222,7 @@ async fn supervise_kind<I, S, F, Fut>(
             biased;
             _ = cancellation.cancelled() => return,
             result = async {
-                let input = source()?;
+                let input = source().await?;
                 run(input).await
             } => result,
         };
@@ -421,7 +428,10 @@ mod tests {
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
             {
                 let source = source.clone();
-                move || source.resolve().ok_or_else(|| "peer has no forwarded resource socket".to_string())
+                move || {
+                    let source = source.clone();
+                    async move { source.resolve().await }
+                }
             },
             {
                 let attempted_paths = Arc::clone(&attempted_paths);
@@ -448,8 +458,9 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn missing_socket_path_retries_until_the_source_resolves() {
+    async fn missing_socket_path_waits_until_the_source_resolves() {
         let source = SocketPathSource::new(None);
+        let resolutions = Arc::new(AtomicUsize::new(0));
         let attempted_paths = Arc::new(Mutex::new(Vec::new()));
         let cancellation = CancellationToken::new();
         let task = tokio::spawn(supervise_kind(
@@ -460,7 +471,12 @@ mod tests {
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
             {
                 let source = source.clone();
-                move || source.resolve().ok_or_else(|| "peer has no forwarded resource socket".to_string())
+                let resolutions = Arc::clone(&resolutions);
+                move || {
+                    let source = source.clone();
+                    resolutions.fetch_add(1, Ordering::SeqCst);
+                    async move { source.resolve().await }
+                }
             },
             {
                 let attempted_paths = Arc::clone(&attempted_paths);
@@ -473,9 +489,13 @@ mod tests {
 
         tokio::task::yield_now().await;
         assert!(attempted_paths.lock().expect("attempted paths lock").is_empty());
+        assert_eq!(resolutions.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(resolutions.load(Ordering::SeqCst), 1, "an unavailable source should wait instead of polling and warning");
 
         source.update(PathBuf::from("/tmp/ready.sock"));
-        tokio::time::advance(Duration::from_secs(1)).await;
         tokio::task::yield_now().await;
         assert_eq!(*attempted_paths.lock().expect("attempted paths lock"), vec![PathBuf::from("/tmp/ready.sock")]);
 
@@ -493,7 +513,7 @@ mod tests {
             Convoy::API_PATHS.kind,
             cancellation.clone(),
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
-            || Ok(()),
+            || async { Ok(()) },
             {
                 let attempts = Arc::clone(&attempts);
                 move |()| {
@@ -530,7 +550,7 @@ mod tests {
             Convoy::API_PATHS.kind,
             old_cancellation,
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
-            || Ok(()),
+            || async { Ok(()) },
             {
                 let attempts = Arc::clone(&attempts);
                 move |()| {
@@ -562,7 +582,7 @@ mod tests {
             Convoy::API_PATHS.kind,
             cancellation.clone(),
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(8), reset_after: Duration::from_secs(5) },
-            || Ok(()),
+            || async { Ok(()) },
             {
                 let attempts = Arc::clone(&attempts);
                 move |()| {
@@ -603,7 +623,7 @@ mod tests {
         assert!(supervisors.begin_generation(&peer, 4, Some(PathBuf::from("/tmp/current.sock"))).is_none());
         assert!(supervisors.begin_generation(&peer, 3, Some(PathBuf::from("/tmp/stale.sock"))).is_none());
         assert_eq!(
-            source.resolve(),
+            source.current(),
             Some(PathBuf::from("/tmp/current.sock")),
             "same-generation reconnects refresh the live source, while stale notices cannot replace it"
         );

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, future::Future, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    future::Future,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use chrono::Utc;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
@@ -31,6 +37,30 @@ pub(super) struct PeerReplicatorSupervisors {
 struct ActiveGeneration {
     generation: u64,
     cancellation: CancellationToken,
+    socket_path_source: SocketPathSource,
+}
+
+/// Generation-scoped source refreshed by same-generation reconnect notices.
+///
+/// Replication attempts resolve this value after each backoff so they can move
+/// from a dead forwarded socket, or from no socket, to the live transport.
+#[derive(Clone)]
+struct SocketPathSource {
+    path: Arc<RwLock<Option<PathBuf>>>,
+}
+
+impl SocketPathSource {
+    fn new(path: Option<PathBuf>) -> Self {
+        Self { path: Arc::new(RwLock::new(path)) }
+    }
+
+    fn resolve(&self) -> Option<PathBuf> {
+        self.path.read().expect("socket path source read lock").clone()
+    }
+
+    fn update(&self, path: PathBuf) {
+        *self.path.write().expect("socket path source write lock") = Some(path);
+    }
 }
 
 impl PeerReplicatorSupervisors {
@@ -42,25 +72,35 @@ impl PeerReplicatorSupervisors {
         generation: u64,
         resource_socket_path: Option<PathBuf>,
     ) {
-        let Some(cancellation) = self.begin_generation(&peer, generation) else {
+        let Some((cancellation, socket_path_source)) = self.begin_generation(&peer, generation, resource_socket_path.clone()) else {
             return;
         };
         let transport = match resource_socket_path {
-            Some(path) => ReplicationTransport::Http(path),
+            Some(_) => ReplicationTransport::Http(socket_path_source),
             #[cfg(feature = "test-support")]
             None => ReplicationTransport::Routed(router),
             #[cfg(not(feature = "test-support"))]
             None => {
                 debug!(%peer, generation, "peer has no forwarded resource socket; replication waits for an outbound SSH connection");
-                return;
+                ReplicationTransport::Http(socket_path_source)
             }
         };
         flotilla_resources::for_each_registered_resource!(spawn_kind, &daemon, &peer, generation, &transport, &cancellation)
     }
 
-    fn begin_generation(&mut self, peer: &NodeId, generation: u64) -> Option<CancellationToken> {
+    fn begin_generation(
+        &mut self,
+        peer: &NodeId,
+        generation: u64,
+        resource_socket_path: Option<PathBuf>,
+    ) -> Option<(CancellationToken, SocketPathSource)> {
         if let Some(active) = self.generations.get(peer) {
             if generation <= active.generation {
+                if generation == active.generation {
+                    if let Some(path) = resource_socket_path {
+                        active.socket_path_source.update(path);
+                    }
+                }
                 debug!(
                     %peer,
                     generation,
@@ -73,14 +113,19 @@ impl PeerReplicatorSupervisors {
         }
 
         let cancellation = CancellationToken::new();
-        self.generations.insert(peer.clone(), ActiveGeneration { generation, cancellation: cancellation.clone() });
-        Some(cancellation)
+        let socket_path_source = SocketPathSource::new(resource_socket_path);
+        self.generations.insert(peer.clone(), ActiveGeneration {
+            generation,
+            cancellation: cancellation.clone(),
+            socket_path_source: socket_path_source.clone(),
+        });
+        Some((cancellation, socket_path_source))
     }
 }
 
 #[derive(Clone)]
 enum ReplicationTransport {
-    Http(PathBuf),
+    Http(SocketPathSource),
     #[cfg(feature = "test-support")]
     Routed(RemoteCommandRouter),
 }
@@ -100,34 +145,67 @@ fn spawn_kind<T: Resource>(
     let transport = transport.clone();
     let cancellation = cancellation.clone();
     tokio::spawn(async move {
-        supervise_kind(peer.clone(), generation, T::API_PATHS.kind, cancellation, REPLICATION_RETRY, || {
-            let transport = transport.clone();
-            let daemon = Arc::clone(&daemon);
-            let peer = peer.clone();
-            async move {
-                match transport {
-                    ReplicationTransport::Http(path) => {
-                        let http = HttpBackend::from_unix_socket(path).map_err(|error| error.to_string())?;
-                        replicate_kind_over_http::<T>(http, &daemon, &peer).await
-                    }
-                    #[cfg(feature = "test-support")]
-                    ReplicationTransport::Routed(router) => replicate_kind_over_routed_watch::<T>(&router, &daemon, &peer).await,
-                }
+        match transport {
+            ReplicationTransport::Http(socket_path_source) => {
+                let run_daemon = Arc::clone(&daemon);
+                let run_peer = peer.clone();
+                supervise_kind(
+                    peer,
+                    generation,
+                    T::API_PATHS.kind,
+                    cancellation,
+                    REPLICATION_RETRY,
+                    move || {
+                        socket_path_source
+                            .resolve()
+                            .ok_or_else(|| "peer has no forwarded resource socket; waiting for an outbound SSH connection".to_string())
+                    },
+                    move |path| {
+                        let daemon = Arc::clone(&run_daemon);
+                        let peer = run_peer.clone();
+                        async move {
+                            let http = HttpBackend::from_unix_socket(path).map_err(|error| error.to_string())?;
+                            replicate_kind_over_http::<T>(http, &daemon, &peer).await
+                        }
+                    },
+                )
+                .await;
             }
-        })
-        .await;
+            #[cfg(feature = "test-support")]
+            ReplicationTransport::Routed(router) => {
+                let run_daemon = Arc::clone(&daemon);
+                let run_peer = peer.clone();
+                supervise_kind(
+                    peer,
+                    generation,
+                    T::API_PATHS.kind,
+                    cancellation,
+                    REPLICATION_RETRY,
+                    || Ok(()),
+                    move |()| {
+                        let router = router.clone();
+                        let daemon = Arc::clone(&run_daemon);
+                        let peer = run_peer.clone();
+                        async move { replicate_kind_over_routed_watch::<T>(&router, &daemon, &peer).await }
+                    },
+                )
+                .await;
+            }
+        }
     });
 }
 
-async fn supervise_kind<F, Fut>(
+async fn supervise_kind<I, S, F, Fut>(
     peer: NodeId,
     generation: u64,
     kind: &'static str,
     cancellation: CancellationToken,
     retry: RetryBackoff,
+    mut source: S,
     mut run: F,
 ) where
-    F: FnMut() -> Fut,
+    S: FnMut() -> Result<I, String>,
+    F: FnMut(I) -> Fut,
     Fut: Future<Output = Result<(), String>>,
 {
     let mut backoff = retry.initial;
@@ -136,7 +214,10 @@ async fn supervise_kind<F, Fut>(
         let result = tokio::select! {
             biased;
             _ = cancellation.cancelled() => return,
-            result = run() => result,
+            result = async {
+                let input = source()?;
+                run(input).await
+            } => result,
         };
         if started_at.elapsed() >= retry.reset_after {
             backoff = retry.initial;
@@ -319,13 +400,88 @@ async fn apply_response<T: Resource>(
 mod tests {
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex,
     };
 
     use flotilla_resources::Convoy;
     use serde_json::json;
 
     use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn socket_path_source_changes_are_resolved_between_retries() {
+        let source = SocketPathSource::new(Some(PathBuf::from("/tmp/first.sock")));
+        let attempted_paths = Arc::new(Mutex::new(Vec::new()));
+        let cancellation = CancellationToken::new();
+        let task = tokio::spawn(supervise_kind(
+            NodeId::new("peer"),
+            1,
+            Convoy::API_PATHS.kind,
+            cancellation.clone(),
+            RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
+            {
+                let source = source.clone();
+                move || source.resolve().ok_or_else(|| "peer has no forwarded resource socket".to_string())
+            },
+            {
+                let attempted_paths = Arc::clone(&attempted_paths);
+                move |path| {
+                    attempted_paths.lock().expect("attempted paths lock").push(path);
+                    async { Err("transient watch failure".to_string()) }
+                }
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(*attempted_paths.lock().expect("attempted paths lock"), vec![PathBuf::from("/tmp/first.sock")]);
+
+        source.update(PathBuf::from("/tmp/second.sock"));
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(*attempted_paths.lock().expect("attempted paths lock"), vec![
+            PathBuf::from("/tmp/first.sock"),
+            PathBuf::from("/tmp/second.sock")
+        ]);
+
+        cancellation.cancel();
+        task.await.expect("replicator supervisor task");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn missing_socket_path_retries_until_the_source_resolves() {
+        let source = SocketPathSource::new(None);
+        let attempted_paths = Arc::new(Mutex::new(Vec::new()));
+        let cancellation = CancellationToken::new();
+        let task = tokio::spawn(supervise_kind(
+            NodeId::new("peer"),
+            1,
+            Convoy::API_PATHS.kind,
+            cancellation.clone(),
+            RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
+            {
+                let source = source.clone();
+                move || source.resolve().ok_or_else(|| "peer has no forwarded resource socket".to_string())
+            },
+            {
+                let attempted_paths = Arc::clone(&attempted_paths);
+                move |path| {
+                    attempted_paths.lock().expect("attempted paths lock").push(path);
+                    async { Err("transient watch failure".to_string()) }
+                }
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        assert!(attempted_paths.lock().expect("attempted paths lock").is_empty());
+
+        source.update(PathBuf::from("/tmp/ready.sock"));
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(*attempted_paths.lock().expect("attempted paths lock"), vec![PathBuf::from("/tmp/ready.sock")]);
+
+        cancellation.cancel();
+        task.await.expect("replicator supervisor task");
+    }
 
     #[tokio::test(start_paused = true)]
     async fn malformed_event_failure_retries_the_kind() {
@@ -337,9 +493,10 @@ mod tests {
             Convoy::API_PATHS.kind,
             cancellation.clone(),
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
+            || Ok(()),
             {
                 let attempts = Arc::clone(&attempts);
-                move || {
+                move |()| {
                     let attempts = Arc::clone(&attempts);
                     async move {
                         attempts.fetch_add(1, Ordering::SeqCst);
@@ -365,7 +522,7 @@ mod tests {
     async fn newer_generation_cancels_a_replicator_during_backoff() {
         let peer = NodeId::new("peer");
         let mut supervisors = PeerReplicatorSupervisors::default();
-        let old_cancellation = supervisors.begin_generation(&peer, 7).expect("start old generation");
+        let (old_cancellation, _) = supervisors.begin_generation(&peer, 7, None).expect("start old generation");
         let attempts = Arc::new(AtomicUsize::new(0));
         let task = tokio::spawn(supervise_kind(
             peer.clone(),
@@ -373,9 +530,10 @@ mod tests {
             Convoy::API_PATHS.kind,
             old_cancellation,
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(4), reset_after: Duration::from_secs(60) },
+            || Ok(()),
             {
                 let attempts = Arc::clone(&attempts);
-                move || {
+                move |()| {
                     let attempts = Arc::clone(&attempts);
                     async move {
                         attempts.fetch_add(1, Ordering::SeqCst);
@@ -387,7 +545,7 @@ mod tests {
 
         tokio::task::yield_now().await;
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
-        supervisors.begin_generation(&peer, 8).expect("start new generation");
+        supervisors.begin_generation(&peer, 8, None).expect("start new generation");
         task.await.expect("cancelled old supervisor");
         tokio::time::advance(Duration::from_secs(4)).await;
         tokio::task::yield_now().await;
@@ -404,9 +562,10 @@ mod tests {
             Convoy::API_PATHS.kind,
             cancellation.clone(),
             RetryBackoff { initial: Duration::from_secs(1), maximum: Duration::from_secs(8), reset_after: Duration::from_secs(5) },
+            || Ok(()),
             {
                 let attempts = Arc::clone(&attempts);
-                move || {
+                move |()| {
                     let attempts = Arc::clone(&attempts);
                     async move {
                         let attempt = attempts.fetch_add(1, Ordering::SeqCst);
@@ -439,14 +598,18 @@ mod tests {
         let mut supervisors = PeerReplicatorSupervisors::default();
         let mut applications = 0;
 
-        for generation in [4, 4, 3] {
-            if supervisors.begin_generation(&peer, generation).is_some() {
-                applications += 1;
-            }
-        }
+        let (_, source) = supervisors.begin_generation(&peer, 4, None).expect("start generation");
+        applications += 1;
+        assert!(supervisors.begin_generation(&peer, 4, Some(PathBuf::from("/tmp/current.sock"))).is_none());
+        assert!(supervisors.begin_generation(&peer, 3, Some(PathBuf::from("/tmp/stale.sock"))).is_none());
+        assert_eq!(
+            source.resolve(),
+            Some(PathBuf::from("/tmp/current.sock")),
+            "same-generation reconnects refresh the live source, while stale notices cannot replace it"
+        );
         assert_eq!(applications, 1, "one generation may apply only once despite duplicate or stale notices");
 
-        if supervisors.begin_generation(&peer, 5).is_some() {
+        if supervisors.begin_generation(&peer, 5, None).is_some() {
             applications += 1;
         }
         assert_eq!(applications, 2, "a newer generation starts exactly one new application stream");


### PR DESCRIPTION
## What changed

- keep a generation-scoped live source for each peer's forwarded resource socket path
- refresh that source on same-generation reconnect notices without spawning duplicate replicators
- resolve the current path before every replication attempt
- keep replicators retrying when a generation starts before a forwarded socket exists
- cover changed and initially-missing socket sources at the replicator retry seam

## Why

Transport-level SSH reconnects can preserve the logical peer connection generation while replacing the forwarded resource socket. Replicators previously retained the path supplied when they spawned, and a generation that started without a socket returned without scheduling retries. Either case could strand replication and heartbeat updates until a daemon restart.

## Impact

A one-sided peer daemon restart can heal replication on the next backoff attempt without minting a new connection generation or restarting either daemon. Peers whose outbound forwarded socket appears after replication supervision starts also recover automatically.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #998