### PR TITLE
fix: materialize remote convoy repositories

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -5,16 +5,16 @@ use flotilla_core::agent_adapter::{
     append_convoy_work_context, build_crew_brief_with_options, CrewAssignment, CrewBriefMember, CrewBriefTemplateResolver,
 };
 use flotilla_resources::{
-    clone_key,
+    canonicalize_repo_url, clone_key,
     controller::{
         delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
     },
     repository_workspace_slugs, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
     CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase,
     EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
-    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey, Resource,
-    ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase,
-    TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, CONVOY_LABEL, VESSEL_REF_LABEL,
+    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey,
+    RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionIdentity,
+    TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -309,7 +309,21 @@ impl Reconciler for VesselReconciler {
             let repository = match self.repositories.get(&convoy_repository.repo_ref.to_string()).await {
                 Ok(repository) => repository,
                 Err(ResourceError::NotFound { .. }) => {
-                    return Ok(VesselDeps::failed(format!("repository {} not found", convoy_repository.repo_ref)))
+                    let repository_spec = match canonicalize_repo_url(&convoy_repository.url).and_then(RepositorySpec::remote) {
+                        Ok(spec) => spec,
+                        Err(message) => {
+                            return Ok(VesselDeps::failed(format!(
+                                "convoy repository {} has invalid URL: {message}",
+                                convoy_repository.repo_ref
+                            )))
+                        }
+                    };
+                    if let Err(message) = repository_spec.verify_key(&convoy_repository.repo_ref) {
+                        return Ok(VesselDeps::failed(message));
+                    }
+                    actuations.push(Actuation::CreateRepository { key: convoy_repository.repo_ref.clone(), spec: repository_spec });
+                    waiting_for_checkouts = true;
+                    continue;
                 }
                 Err(err) => return Err(err),
             };

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -306,9 +306,11 @@ impl Reconciler for VesselReconciler {
         let mut checkout_paths = BTreeMap::new();
         let mut waiting_for_checkouts = false;
         for convoy_repository in convoy_repositories {
-            let repository = match self.repositories.get(&convoy_repository.repo_ref.to_string()).await {
-                Ok(repository) => repository,
+            let repository_spec = match self.repositories.get(&convoy_repository.repo_ref.to_string()).await {
+                Ok(repository) => repository.spec,
                 Err(ResourceError::NotFound { .. }) => {
+                    // Convoy URLs are clone transports and may use SCP-like SSH syntax.
+                    // Pre-canonicalize them before constructing the identity-bearing spec.
                     let repository_spec = match canonicalize_repo_url(&convoy_repository.url).and_then(RepositorySpec::remote) {
                         Ok(spec) => spec,
                         Err(message) => {
@@ -321,16 +323,15 @@ impl Reconciler for VesselReconciler {
                     if let Err(message) = repository_spec.verify_key(&convoy_repository.repo_ref) {
                         return Ok(VesselDeps::failed(message));
                     }
-                    actuations.push(Actuation::CreateRepository { key: convoy_repository.repo_ref.clone(), spec: repository_spec });
-                    waiting_for_checkouts = true;
-                    continue;
+                    actuations.push(Actuation::CreateRepository { key: convoy_repository.repo_ref.clone(), spec: repository_spec.clone() });
+                    repository_spec
                 }
                 Err(err) => return Err(err),
             };
-            if let Err(message) = repository.spec.verify_key(&convoy_repository.repo_ref) {
+            if let Err(message) = repository_spec.verify_key(&convoy_repository.repo_ref) {
                 return Ok(VesselDeps::failed(message));
             }
-            let canonical_repo = match repository.spec.identity() {
+            let canonical_repo = match repository_spec.identity() {
                 RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
                 RepositoryIdentity::Local { .. } => return Ok(VesselDeps::failed("convoy repository must have a transport remote")),
             };
@@ -360,7 +361,7 @@ impl Reconciler for VesselReconciler {
                             .iter()
                             .filter(|candidate| candidate.spec.key() != repository_key)
                             .map(|candidate| (candidate.spec.key(), &candidate.spec))
-                            .chain(std::iter::once((repository_key.clone(), &repository.spec)))
+                            .chain(std::iter::once((repository_key.clone(), &repository_spec)))
                             .collect::<Vec<_>>();
                         let clone_directory_slug = repository_workspace_slugs(keyed_repositories.iter().map(|(key, spec)| (key, *spec)))
                             .remove(&repository_key)

--- a/crates/flotilla-controllers/tests/clone_reconciler.rs
+++ b/crates/flotilla-controllers/tests/clone_reconciler.rs
@@ -21,6 +21,19 @@ impl CloneRuntime for FakeCloneRuntime {
     }
 }
 
+struct FailingCloneRuntime;
+
+#[async_trait]
+impl CloneRuntime for FailingCloneRuntime {
+    async fn clone_and_inspect(&self, _repo_url: &str, _target_path: &str) -> Result<Option<String>, String> {
+        Err("authentication failed".to_string())
+    }
+
+    async fn inspect_existing(&self, _target_path: &str) -> Result<Option<String>, String> {
+        Err("clone does not exist".to_string())
+    }
+}
+
 #[tokio::test]
 async fn mismatched_clone_name_fails() {
     let backend = ResourceBackend::InMemory(Default::default());
@@ -73,4 +86,36 @@ async fn alias_transport_uses_typed_repository_identity_for_clone_name() {
     let outcome = reconciler.reconcile(&clone, &deps, chrono::Utc::now());
 
     assert!(matches!(outcome.patch, Some(flotilla_resources::CloneStatusPatch::MarkReady { .. })));
+}
+
+#[tokio::test]
+async fn clone_failure_remains_an_honest_failure_after_repository_registration() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/private").expect("repository spec");
+    let repository_key = repository_spec.key();
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>("flotilla"), &repository_key, &repository_spec)
+        .await
+        .expect("repository create should succeed");
+    let env_ref = "host-direct-01HXYZ";
+    let clone_name = format!("clone-{}", clone_key("https://github.com/flotilla-org/private", env_ref));
+    let clone = backend
+        .clone()
+        .using::<flotilla_resources::Clone>("flotilla")
+        .create(&meta(&clone_name), &CloneSpec {
+            repo_ref: repository_key,
+            url: "git@github.com:flotilla-org/private.git".to_string(),
+            env_ref: env_ref.to_string(),
+            path: "/Users/alice/dev/private".to_string(),
+        })
+        .await
+        .expect("clone should create");
+    let reconciler = CloneReconciler::new(Arc::new(FailingCloneRuntime), backend.using("flotilla"));
+
+    let deps = reconciler.fetch_dependencies(&clone).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&clone, &deps, chrono::Utc::now());
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::CloneStatusPatch::MarkFailed { message }) if message == "authentication failed"
+    ));
 }

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -30,9 +30,10 @@ use flotilla_core::{
 };
 use flotilla_resources::{
     clone_key, controller::ControllerLoop, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone,
-    ClonePhase, CloneSpec, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec,
-    Host, HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation, PresentationPhase, PresentationSpec, ResourceBackend,
-    ResourceError, StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, CONVOY_LABEL, CREW_ORDINAL_LABEL,
+    ClonePhase, CloneSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerEnvironmentSpec,
+    Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host, HostDirectEnvironmentSpec, HostSpec,
+    HostStatus, Presentation, PresentationPhase, PresentationSpec, Repository, RepositorySpec, ResourceBackend, ResourceError, Stance,
+    StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, VesselRequirement, CONVOY_LABEL, CREW_ORDINAL_LABEL,
     VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
@@ -249,6 +250,103 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
         "steady-state reconciliation must not create new resource versions"
     );
     assert_eq!(steady.status.expect("steady workspace status").ready_at, status.ready_at);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn controller_materializes_a_missing_repository_for_a_multi_repository_convoy() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_host(&backend, "01HXYZ").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, "01HXYZ", "/Users/alice/dev/flotilla-repos").await;
+    create_host_direct_policy(&backend, NAMESPACE, "policy-multi", "01HXYZ", "cleat").await;
+
+    let known = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("known repository");
+    let missing = RepositorySpec::remote("https://github.com/flotilla-org/cleat").expect("missing repository");
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(NAMESPACE), &known.key(), &known)
+        .await
+        .expect("known repository should create");
+
+    let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+    let convoy = convoys
+        .create(&controller_meta().name("convoy-multi").call(), &ConvoySpec {
+            workflow_ref: "wf".to_string(),
+            dispatching_principal_ref: Default::default(),
+            inputs: BTreeMap::new(),
+            placement_policy: None,
+            repositories: vec![
+                ConvoyRepositorySpec::builder()
+                    .url("https://github.com/flotilla-org/flotilla".to_string())
+                    .repo_ref(known.key())
+                    .base_ref("main".to_string())
+                    .workspace_slug("flotilla".to_string())
+                    .subpaths(Vec::new())
+                    .build(),
+                ConvoyRepositorySpec::builder()
+                    .url("https://github.com/flotilla-org/cleat".to_string())
+                    .repo_ref(missing.key())
+                    .base_ref("main".to_string())
+                    .workspace_slug("cleat".to_string())
+                    .subpaths(Vec::new())
+                    .build(),
+            ],
+            r#ref: Some("fix/multi".to_string()),
+            project_ref: Some("flotilla-suite".to_string()),
+            adopted_checkout_refs: BTreeMap::new(),
+            issues: Vec::new(),
+            instruction: None,
+        })
+        .await
+        .expect("convoy should create");
+    convoys
+        .update_status("convoy-multi", &convoy.metadata.resource_version, &ConvoyStatus {
+            workflow_snapshot: Some(flotilla_resources::WorkflowSnapshot {
+                vessels: vec![VesselRequirement {
+                    name: "implement".to_string(),
+                    stance: Stance::Trusted,
+                    depends_on: Vec::new(),
+                    repository_refs: None,
+                    crew: vec![CrewSpec::builder()
+                        .role("coder".to_string())
+                        .source(CrewSource::Tool { command: "cargo test".to_string() })
+                        .build()],
+                }],
+            }),
+            ..Default::default()
+        })
+        .await
+        .expect("convoy status should update");
+    create_workspace(
+        &backend,
+        NAMESPACE,
+        "workspace-multi",
+        "convoy-multi",
+        "implement",
+        "policy-multi",
+        "https://github.com/flotilla-org/flotilla",
+    )
+    .await;
+
+    let harness = full_controller_harness(backend.clone());
+    let vessels = backend.clone().using::<Vessel>(NAMESPACE);
+    harness
+        .wait_until(Duration::from_secs(3), || {
+            let vessels = vessels.clone();
+            async move {
+                matches!(
+                    vessels.get("workspace-multi").await.ok().and_then(|vessel| vessel.status).map(|status| status.phase),
+                    Some(VesselPhase::Ready)
+                )
+            }
+        })
+        .await;
+
+    let repositories = backend.clone().using::<Repository>(NAMESPACE);
+    repositories.get(&known.key().to_string()).await.expect("known repository should remain registered");
+    repositories.get(&missing.key().to_string()).await.expect("missing repository should be materialized");
+    let clones = backend.clone().using::<Clone>(NAMESPACE).list().await.expect("clones should list");
+    assert_eq!(clones.items.len(), 2);
+    assert!(clones.items.iter().all(|clone| clone.status.as_ref().map(|status| status.phase) == Some(ClonePhase::Ready)));
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -29,12 +29,12 @@ use flotilla_core::{
     HostName,
 };
 use flotilla_resources::{
-    clone_key, controller::ControllerLoop, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone,
-    ClonePhase, CloneSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerEnvironmentSpec,
-    Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host, HostDirectEnvironmentSpec, HostSpec,
-    HostStatus, Presentation, PresentationPhase, PresentationSpec, Repository, RepositorySpec, ResourceBackend, ResourceError, Stance,
-    StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, VesselRequirement, CONVOY_LABEL, CREW_ORDINAL_LABEL,
-    VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    canonicalize_repo_url, clone_key, controller::ControllerLoop, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec,
+    CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec,
+    DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host,
+    HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation, PresentationPhase, PresentationSpec, Repository, RepositorySpec,
+    ResourceBackend, ResourceError, Stance, StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, VesselRequirement,
+    CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -208,17 +208,17 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
     create_ready_host(&backend, "01HXYZ").await;
     create_ready_host_direct_environment(&backend, NAMESPACE, "01HXYZ", "/Users/alice/dev/flotilla-repos").await;
     create_host_direct_policy(&backend, NAMESPACE, "policy-a", "01HXYZ", "cleat").await;
-    create_convoy_with_single_task(
-        &backend,
-        NAMESPACE,
-        "convoy-a",
-        "implement",
-        "git@github.com:flotilla-org/flotilla.git",
-        "feat/task-provisioning",
-    )
-    .await;
-    create_workspace(&backend, NAMESPACE, "workspace-a", "convoy-a", "implement", "policy-a", "git@github.com:flotilla-org/flotilla.git")
-        .await;
+    let repository_url = "git@github.com:flotilla-org/flotilla.git";
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-a", "implement", repository_url, "feat/task-provisioning").await;
+    let repository_spec = RepositorySpec::remote(canonicalize_repo_url(repository_url).expect("repository URL should canonicalize"))
+        .expect("repository spec");
+    backend
+        .clone()
+        .using::<Repository>(NAMESPACE)
+        .delete(&repository_spec.key().to_string())
+        .await
+        .expect("destination should start without the convoy repository");
+    create_workspace(&backend, NAMESPACE, "workspace-a", "convoy-a", "implement", "policy-a", repository_url).await;
 
     let harness = full_controller_harness(backend.clone());
 
@@ -242,6 +242,12 @@ async fn controller_loops_drive_host_direct_workspace_to_ready() {
     assert_eq!(status.environment_ref.as_deref(), Some("host-direct-01HXYZ"));
     assert_eq!(status.checkout_refs.values().next().map(String::as_str), Some("checkout-convoy-a"));
     assert_eq!(status.terminal_session_refs, vec!["terminal-workspace-a-coder".to_string()]);
+    backend
+        .clone()
+        .using::<Repository>(NAMESPACE)
+        .get(&repository_spec.key().to_string())
+        .await
+        .expect("missing repository should be materialized");
 
     tokio::time::sleep(Duration::from_millis(200)).await;
     let steady = workspaces.get("workspace-a").await.expect("ready workspace should remain readable");

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -69,6 +69,7 @@ impl<T: Resource> ReconcileOutcome<T> {
 
 #[derive(Debug, Clone)]
 pub enum Actuation {
+    CreateRepository { key: crate::RepositoryKey, spec: crate::RepositorySpec },
     CreateEnvironment { meta: InputMeta, spec: EnvironmentSpec },
     CreateClone { meta: InputMeta, spec: CloneSpec },
     CreateCheckout { meta: InputMeta, spec: CheckoutSpec },
@@ -278,6 +279,10 @@ impl<R: Reconciler> ControllerLoop<R> {
 
     async fn apply_actuation(backend: &ResourceBackend, namespace: &str, actuation: Actuation) -> Result<(), ResourceError> {
         match actuation {
+            Actuation::CreateRepository { key, spec } => {
+                let resolver = backend.using::<crate::Repository>(namespace);
+                crate::ensure_repository(&resolver, &key, &spec).await.map(|_| ())
+            }
             Actuation::CreateEnvironment { meta, spec } => {
                 let resolver = backend.using::<crate::Environment>(namespace);
                 Self::create_if_missing(&resolver, meta, spec).await


### PR DESCRIPTION
## Summary

- materialize missing destination Repository records from ConvoySpec repository URLs
- verify the reconstructed repository identity against the convoy repository key before provisioning
- cover a two-repository remote placement where one repository is already known and one is new
- preserve clone failures for inaccessible or unauthorized remotes

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1001
