### PR TITLE
fix: reply to peer keepalive pings

### DIFF
--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -717,7 +717,11 @@ impl PeerManager {
                     HandleResult::ReconnectSuppressed { peer: env.connection_peer }
                 }
             },
-            PeerWireMessage::Ping { .. } | PeerWireMessage::Pong { .. } => HandleResult::Ignored,
+            PeerWireMessage::Ping { timestamp } => {
+                self.queue_send_to(&env.connection_peer, PeerWireMessage::Pong { timestamp });
+                HandleResult::Ignored
+            }
+            PeerWireMessage::Pong { .. } => HandleResult::Ignored,
         }
     }
 

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -461,6 +461,32 @@ async fn send_to_reaches_registered_sender() {
 }
 
 #[tokio::test]
+async fn handle_ping_replies_with_matching_pong() {
+    let mut mgr = PeerManager::new(NodeId::new("local"));
+    let sent = Arc::new(Mutex::new(Vec::new()));
+    let sender: Arc<dyn PeerSender> = Arc::new(MockPeerSender { sent: Arc::clone(&sent) });
+    let peer = NodeId::new("peer");
+    let generation = accepted_generation(mgr.activate_connection(peer.clone(), sender, ConnectionMeta {
+        direction: ConnectionDirection::Inbound,
+        config_label: None,
+        expected_peer: None,
+        config_backed: false,
+    }));
+
+    let result = mgr
+        .handle_inbound(InboundPeerEnvelope {
+            msg: PeerWireMessage::Ping { timestamp: 42 },
+            connection_generation: generation,
+            connection_peer: peer,
+        })
+        .await;
+    dispatch_pending_sends(mgr.take_pending_sends()).await;
+
+    assert_eq!(result, HandleResult::Ignored);
+    assert!(matches!(sent.lock().expect("lock").as_slice(), [PeerWireMessage::Pong { timestamp: 42 }]));
+}
+
+#[tokio::test]
 async fn activate_connection_rejects_same_direction_duplicate_sender() {
     let mut mgr = PeerManager::new(NodeId::new("local"));
     let first_sent = Arc::new(Mutex::new(Vec::new()));

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -337,6 +337,26 @@ impl PeerSender for FailingPeerSender {
     }
 }
 
+struct PongingPeerSender {
+    inbound_tx: mpsc::Sender<PeerWireMessage>,
+    ping_count: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl PeerSender for PongingPeerSender {
+    async fn send(&self, msg: PeerWireMessage) -> Result<(), String> {
+        if let PeerWireMessage::Ping { timestamp } = msg {
+            self.ping_count.fetch_add(1, Ordering::SeqCst);
+            self.inbound_tx.send(PeerWireMessage::Pong { timestamp }).await.map_err(|_| "inbound channel closed".to_string())?;
+        }
+        Ok(())
+    }
+
+    async fn retire(&self, _reason: flotilla_protocol::GoodbyeReason) -> Result<(), String> {
+        Ok(())
+    }
+}
+
 struct FailingPeerTransport;
 
 #[async_trait::async_trait]
@@ -3217,6 +3237,37 @@ async fn forward_with_keepalive_times_out_after_silence() {
     assert!(matches!(result, ForwardResult::KeepaliveTimeout));
     let sent = sent.lock().expect("lock");
     assert!(sent.iter().any(|msg| matches!(msg, PeerWireMessage::Ping { .. })), "keepalive loop should send ping messages");
+}
+
+#[tokio::test(start_paused = true)]
+async fn forward_with_keepalive_stays_connected_when_pongs_arrive() {
+    let (peer_data_tx, _peer_data_rx) = mpsc::channel(4);
+    let (inbound_tx, mut inbound_rx) = mpsc::channel(4);
+    let ping_count = Arc::new(AtomicUsize::new(0));
+    let sender: Arc<dyn PeerSender> = Arc::new(PongingPeerSender { inbound_tx, ping_count: Arc::clone(&ping_count) });
+
+    let task = tokio::spawn(async move {
+        forward_with_keepalive_for_test(
+            &peer_data_tx,
+            &mut inbound_rx,
+            &NodeId::new("remote-host"),
+            1,
+            sender,
+            Duration::from_secs(30),
+            Duration::from_secs(90),
+        )
+        .await
+    });
+    tokio::task::yield_now().await;
+
+    for _ in 0..4 {
+        tokio::time::advance(Duration::from_secs(31)).await;
+        tokio::task::yield_now().await;
+    }
+
+    assert!(!task.is_finished(), "keepalive loop should stay connected while pongs arrive");
+    assert_eq!(ping_count.load(Ordering::SeqCst), 4);
+    task.abort();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- reply to inbound peer `Ping` messages with a same-timestamp `Pong`
- keep replies generation-aware by handling them after the existing stale-connection guard
- cover responsive idle links and silent dead links with deterministic watchdog tests

## Root cause

The dialing peer already sent a keepalive `Ping` every 30 seconds, but the accepting peer ignored it without replying. The dialer therefore received no traffic and forced a reconnect after the 90-second watchdog window even though the transport remained healthy.

With `Pong` replies, quiet links produce bidirectional keepalive traffic, preserving peer connection state and host readiness. A genuinely dead transport still produces no reply and follows the existing watchdog timeout path.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1016