### PR TITLE
fix: confirm issue convoy dispatches

### DIFF
--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -157,6 +157,8 @@ pub struct KeysConfig {
     #[serde(default)]
     pub close_confirm: HashMap<String, String>,
     #[serde(default)]
+    pub dispatch_confirm: HashMap<String, String>,
+    #[serde(default)]
     pub command_palette: HashMap<String, String>,
     #[serde(default)]
     pub file_picker: HashMap<String, String>,

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -6,7 +6,7 @@ use crate::{
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
     table_view::{PendingRowContext, TableIntent},
-    widgets::{convoy_delete_confirm::ConvoyDeleteConfirmWidget, InteractiveWidget},
+    widgets::{convoy_delete_confirm::ConvoyDeleteConfirmWidget, dispatch_confirm::DispatchConfirmWidget, InteractiveWidget},
 };
 
 impl App {
@@ -470,22 +470,39 @@ impl App {
             TableIntent::ForceCompleteWork { convoy, vessel, host } => {
                 (self.command(CommandAction::ConvoyWorkForceComplete { convoy, work: vessel, message: None }), host)
             }
+            intent @ (TableIntent::StartConvoy { .. } | TableIntent::StartConvoys { .. } | TableIntent::StartBatchConvoy { .. }) => {
+                self.screen.modal_stack.push(Box::new(DispatchConfirmWidget::new(intent)));
+                return;
+            }
+        };
+        let node_id = match self.panel_target_node(&host) {
+            Ok(node_id) => node_id,
+            Err(message) => {
+                self.set_status_message(Some(message));
+                return;
+            }
+        };
+        command.node_id = node_id;
+        self.proto_commands.push(command);
+    }
+
+    pub(super) fn execute_confirmed_convoy_dispatch(&mut self, intent: TableIntent, instruction: Option<String>) {
+        match intent {
             TableIntent::StartConvoy { namespace, project, issue } => {
                 self.proto_commands.push(self.command(CommandAction::ConvoyStart {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: Some(namespace),
                         project_ref: project,
-                        issues: vec![IssueSelector::Reference(issue)],
+                        issues: vec![IssueSelector::Reference(issue.issue)],
                         name: None,
                         branch: None,
                         workflow_ref: None,
                         inputs: Vec::new(),
-                        instruction: None,
+                        instruction,
                         placement_policy: None,
                         auto_attach: true,
                     }),
                 }));
-                return;
             }
             TableIntent::StartConvoys { namespace, project, issues } => {
                 let Some(address) = self.views.active_address().cloned() else { return };
@@ -500,7 +517,7 @@ impl App {
                             branch: None,
                             workflow_ref: None,
                             inputs: Vec::new(),
-                            instruction: None,
+                            instruction: instruction.clone(),
                             placement_policy: None,
                             auto_attach: false,
                         }),
@@ -521,7 +538,6 @@ impl App {
                         view.project_table_state.table_mut(crate::table_view::ProjectPanelKind::Issues).multi_selected.clear();
                     }
                 }
-                return;
             }
             TableIntent::StartBatchConvoy { namespace, project, issues } => {
                 let Some(address) = self.views.active_address().cloned() else { return };
@@ -535,7 +551,7 @@ impl App {
                         branch: None,
                         workflow_ref: None,
                         inputs: Vec::new(),
-                        instruction: None,
+                        instruction,
                         placement_policy: None,
                         auto_attach: true,
                     }),
@@ -546,18 +562,9 @@ impl App {
                     }
                 }
                 self.set_status_message(Some(format!("Starting batch convoy for {issue_count} issues...")));
-                return;
             }
-        };
-        let node_id = match self.panel_target_node(&host) {
-            Ok(node_id) => node_id,
-            Err(message) => {
-                self.set_status_message(Some(message));
-                return;
-            }
-        };
-        command.node_id = node_id;
-        self.proto_commands.push(command);
+            _ => unreachable!("dispatch confirmation only returns convoy-start table intents"),
+        }
     }
 
     fn table_action_repo(&self, hint: Option<&RepoKey>) -> Option<RepoIdentity> {

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -112,19 +112,84 @@ fn setup_native_issue_rows(app: &mut App, issue_ids: &[&str]) {
 }
 
 #[test]
-fn project_issue_start_preserves_the_selected_namespace() {
+fn project_issue_start_requires_confirmation_and_preserves_guidance_and_namespace() {
     let mut app = stub_app();
     let issue = flotilla_protocol::IssueRef {
         source: flotilla_protocol::IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
         id: "732".into(),
     };
-    app.execute_table_intent(TableIntent::StartConvoy { namespace: "other-team".into(), project: "roadmap".into(), issue: issue.clone() });
+    app.execute_table_intent(TableIntent::StartConvoy {
+        namespace: "other-team".into(),
+        project: "roadmap".into(),
+        issue: crate::table_view::TableIssueStart {
+            row_id: crate::table_view::RowId::new("issue:732"),
+            issue: issue.clone(),
+            title: "Protect the API".into(),
+            ready: true,
+        },
+    });
+
+    assert!(app.proto_commands.take_next().is_none(), "opening the dispatch action must not queue a command");
+    assert_eq!(
+        app.screen.modal_stack.last().expect("dispatch confirmation").binding_mode(),
+        KeyBindingMode::from(BindingModeId::DispatchConfirm)
+    );
+    for character in "Keep the API stable".chars() {
+        app.handle_key(key(KeyCode::Char(character)));
+    }
+    app.handle_key(key(KeyCode::Enter));
 
     let (command, _) = app.proto_commands.take_next().expect("start command");
     let flotilla_protocol::CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
     assert_eq!(intent.namespace.as_deref(), Some("other-team"));
     assert_eq!(intent.project_ref, "roadmap");
     assert_eq!(intent.issues, vec![flotilla_protocol::IssueSelector::Reference(issue)]);
+    assert_eq!(intent.instruction.as_deref(), Some("Keep the API stable"));
+}
+
+#[test]
+fn dispatch_confirmation_warns_for_non_ready_issue_and_cancel_queues_nothing() {
+    let mut app = stub_app();
+    let issue = flotilla_protocol::IssueRef {
+        source: flotilla_protocol::IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() },
+        id: "1012".into(),
+    };
+    app.execute_table_intent(TableIntent::StartConvoy {
+        namespace: "flotilla".into(),
+        project: "roadmap".into(),
+        issue: crate::table_view::TableIssueStart {
+            row_id: crate::table_view::RowId::new("issue:1012"),
+            issue,
+            title: "Confirm expensive dispatches".into(),
+            ready: false,
+        },
+    });
+
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(100, 30)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            let mut ctx = crate::widgets::RenderContext {
+                model: &app.model,
+                views: &mut app.views,
+                ui: &mut app.ui,
+                theme: &app.theme,
+                keymap: &app.keymap,
+                in_flight: &app.in_flight,
+                namespaces: &app.namespaces,
+                query_tables: &app.query_tables,
+            };
+            app.screen.render(frame, frame.area(), &mut ctx);
+        })
+        .expect("draw");
+    let rendered: String = terminal.backend().buffer().content().iter().map(|cell| cell.symbol()).collect();
+    assert!(rendered.contains("#1012 Confirm expensive dispatches"));
+    assert!(rendered.contains("Target project: flotilla/roadmap"));
+    assert!(rendered.contains("Placement:"));
+    assert!(rendered.contains("Workflow:"));
+    assert!(rendered.contains("Issue is not marked ready"));
+
+    app.handle_key(key(KeyCode::Esc));
+    assert!(app.proto_commands.take_next().is_none());
 }
 
 #[test]

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -1443,6 +1443,9 @@ impl App {
                 AppAction::ExecuteTableIntent(intent) => {
                     self.execute_table_intent(intent);
                 }
+                AppAction::ConfirmConvoyDispatch { intent, instruction } => {
+                    self.execute_confirmed_convoy_dispatch(intent, instruction);
+                }
                 AppAction::SetTableFilter(filter) => {
                     self.views.active_table_state_mut().filter = filter;
                 }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2379,9 +2379,13 @@ fn project_issue_bulk_start_queues_one_convoy_start_per_issue() {
             .map(|id| crate::table_view::TableIssueStart {
                 row_id: crate::table_view::RowId::new(format!("issue:{id}")),
                 issue: IssueRef { source: source.clone(), id: id.into() },
+                title: format!("Issue {id}"),
+                ready: true,
             })
             .collect(),
     });
+    assert!(app.proto_commands.take_next().is_none(), "bulk start must wait for confirmation");
+    app.handle_key(key(KeyCode::Enter));
 
     let mut queued = Vec::new();
     while let Some((command, ctx)) = app.proto_commands.take_next() {
@@ -2412,9 +2416,13 @@ fn project_issue_batch_start_queues_one_convoy_for_all_issues() {
             .map(|id| crate::table_view::TableIssueStart {
                 row_id: crate::table_view::RowId::new(format!("issue:{id}")),
                 issue: IssueRef { source: source.clone(), id: id.into() },
+                title: format!("Issue {id}"),
+                ready: true,
             })
             .collect(),
     });
+    assert!(app.proto_commands.take_next().is_none(), "batch start must wait for confirmation");
+    app.handle_key(key(KeyCode::Enter));
 
     let (command, ctx) = app.proto_commands.take_next().expect("expected command");
     assert!(app.proto_commands.take_next().is_none(), "batch start should queue exactly one command");

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2385,6 +2385,9 @@ fn project_issue_bulk_start_queues_one_convoy_start_per_issue() {
             .collect(),
     });
     assert!(app.proto_commands.take_next().is_none(), "bulk start must wait for confirmation");
+    for character in "Keep each fix focused".chars() {
+        app.handle_key(key(KeyCode::Char(character)));
+    }
     app.handle_key(key(KeyCode::Enter));
 
     let mut queued = Vec::new();
@@ -2392,12 +2395,13 @@ fn project_issue_bulk_start_queues_one_convoy_start_per_issue() {
         let CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
         let ctx = ctx.expect("pending context");
         let project_ctx = ctx.project_issue_start_context().expect("project context");
-        queued.push((intent.issues, project_ctx.issue.id.clone(), intent.auto_attach));
+        queued.push((intent.issues, project_ctx.issue.id.clone(), intent.auto_attach, intent.instruction));
     }
 
     assert_eq!(queued.len(), 3);
-    assert_eq!(queued.iter().map(|(_, id, _)| id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
-    assert!(queued.iter().all(|(_, _, auto_attach)| !auto_attach), "bulk convoy starts should not auto-attach one selected issue");
+    assert_eq!(queued.iter().map(|(_, id, _, _)| id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
+    assert!(queued.iter().all(|(_, _, auto_attach, _)| !auto_attach), "bulk convoy starts should not auto-attach one selected issue");
+    assert!(queued.iter().all(|(_, _, _, instruction)| instruction.as_deref() == Some("Keep each fix focused")));
     assert_eq!(app.model.status_message.as_deref(), Some("Starting 3 convoys..."));
 }
 
@@ -2422,6 +2426,9 @@ fn project_issue_batch_start_queues_one_convoy_for_all_issues() {
             .collect(),
     });
     assert!(app.proto_commands.take_next().is_none(), "batch start must wait for confirmation");
+    for character in "Preserve shared behavior".chars() {
+        app.handle_key(key(KeyCode::Char(character)));
+    }
     app.handle_key(key(KeyCode::Enter));
 
     let (command, ctx) = app.proto_commands.take_next().expect("expected command");
@@ -2441,6 +2448,7 @@ fn project_issue_batch_start_queues_one_convoy_for_all_issues() {
         vec!["809", "810", "811"]
     );
     assert!(intent.auto_attach, "batch convoy start should auto-attach the single created convoy");
+    assert_eq!(intent.instruction.as_deref(), Some("Preserve shared behavior"));
     assert_eq!(app.model.status_message.as_deref(), Some("Starting batch convoy for 3 issues..."));
 }
 

--- a/crates/flotilla-tui/src/binding_table.rs
+++ b/crates/flotilla-tui/src/binding_table.rs
@@ -43,6 +43,7 @@ pub enum BindingModeId {
     ActionMenu,
     DeleteConfirm,
     CloseConfirm,
+    DispatchConfirm,
     BranchInput,
     FindInput,
     CommandPalette,
@@ -214,6 +215,9 @@ pub static BINDINGS: &[Binding] = &[
     h(BindingModeId::CloseConfirm, "y", Action::Confirm, "Yes"),
     h(BindingModeId::CloseConfirm, "n", Action::Dismiss, "No"),
     b(BindingModeId::CloseConfirm, "q", Action::Dismiss),
+    // ── DispatchConfirm ──
+    hk(BindingModeId::DispatchConfirm, "enter", "ENT", Action::Confirm, "Dispatch"),
+    hk(BindingModeId::DispatchConfirm, "esc", "ESC", Action::Dismiss, "Cancel"),
     // ── BranchInput ──
     hk(BindingModeId::BranchInput, "enter", "ENT", Action::Confirm, "Create"),
     hk(BindingModeId::BranchInput, "esc", "ESC", Action::Dismiss, "Cancel"),

--- a/crates/flotilla-tui/src/keymap.rs
+++ b/crates/flotilla-tui/src/keymap.rs
@@ -314,6 +314,7 @@ impl Keymap {
             (&config.action_menu, BindingModeId::ActionMenu),
             (&config.delete_confirm, BindingModeId::DeleteConfirm),
             (&config.close_confirm, BindingModeId::CloseConfirm),
+            (&config.dispatch_confirm, BindingModeId::DispatchConfirm),
             (&config.command_palette, BindingModeId::CommandPalette),
             (&config.file_picker, BindingModeId::FilePicker),
         ];

--- a/crates/flotilla-tui/src/keymap/tests.rs
+++ b/crates/flotilla-tui/src/keymap/tests.rs
@@ -263,6 +263,13 @@ fn close_confirm_has_y_n_bindings() {
 }
 
 #[test]
+fn dispatch_confirm_has_enter_and_escape_bindings() {
+    let km = Keymap::defaults();
+    assert_eq!(km.resolve(&KeyBindingMode::from(BindingModeId::DispatchConfirm), crokey::key!(enter)), Some(Action::Confirm));
+    assert_eq!(km.resolve(&KeyBindingMode::from(BindingModeId::DispatchConfirm), crokey::key!(esc)), Some(Action::Dismiss));
+}
+
+#[test]
 fn help_mode_toggle_with_h() {
     let km = Keymap::defaults();
     // h maps to ToggleHelp in TabPage (composed with top-level tabs) and in Help mode.

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -409,7 +409,7 @@ pub enum TableIntent {
     DeleteConvoy { row_id: RowId, namespace: String, name: String, host: Option<HostName> },
     OpenChangeRequest { id: String, repository_key: RepositoryKey, host: Option<HostName> },
     ForceCompleteWork { convoy: String, vessel: String, host: HostName },
-    StartConvoy { namespace: String, project: String, issue: IssueRef },
+    StartConvoy { namespace: String, project: String, issue: TableIssueStart },
     StartConvoys { namespace: String, project: String, issues: Vec<TableIssueStart> },
     StartBatchConvoy { namespace: String, project: String, issues: Vec<TableIssueStart> },
 }
@@ -418,6 +418,8 @@ pub enum TableIntent {
 pub struct TableIssueStart {
     pub row_id: RowId,
     pub issue: IssueRef,
+    pub title: String,
+    pub ready: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
@@ -1176,7 +1178,12 @@ fn start_scoped_issue(row: &ScopedIssueProjection) -> Option<TableIntent> {
     Some(TableIntent::StartConvoy {
         namespace: row.scope.namespace.clone(),
         project: row.scope.name.clone(),
-        issue: row.row.reference.clone(),
+        issue: TableIssueStart {
+            row_id: scoped_issue_id(row),
+            issue: row.row.reference.clone(),
+            title: row.row.issue.title.clone(),
+            ready: row.row.issue.labels.iter().any(|label| label == "ready"),
+        },
     })
 }
 
@@ -1614,7 +1621,12 @@ mod tests {
         assert_eq!(panels[2].table.rows[0].actions[0].intent, TableIntent::StartConvoy {
             namespace: "flotilla".into(),
             project: "roadmap".into(),
-            issue: issue_row.reference,
+            issue: TableIssueStart {
+                row_id: issue_row_id(&scope, &issue_row.reference),
+                issue: issue_row.reference,
+                title: "Composite project issue".into(),
+                ready: false,
+            },
         });
         assert_eq!(panels[3].table.rows[0].actions[0].intent, TableIntent::AttachPane {
             reference: "terminal-governor".into(),
@@ -1663,7 +1675,12 @@ mod tests {
         assert_eq!(view.rows[0].actions[0].intent, TableIntent::StartConvoy {
             namespace: "flotilla".into(),
             project: "roadmap".into(),
-            issue: row.reference,
+            issue: TableIssueStart {
+                row_id: issue_row_id(&scope, &row.reference),
+                issue: row.reference,
+                title: "Start convoy from scoped issue".into(),
+                ready: false,
+            },
         });
         assert_eq!(view.meta.as_of, state.demand.as_ref().map(|metadata| metadata.as_of));
         assert!(view.meta.has_more);

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -7,9 +7,9 @@
 use std::collections::{HashMap, HashSet};
 
 use flotilla_protocol::{
-    result_set::Timestamp, AwarenessFamily, AwarenessGrouping, AwarenessLimit, AwarenessNode, ChangeRequestStatus, CheckoutRow, HostName,
-    IndependentRow, IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey, ResultSetCondition, ResultSetState, Salience,
-    SessionPhase, ViewAddress,
+    issue_query::READY_ISSUE_LABEL, result_set::Timestamp, AwarenessFamily, AwarenessGrouping, AwarenessLimit, AwarenessNode,
+    ChangeRequestStatus, CheckoutRow, HostName, IndependentRow, IssueRef, IssueRow, QueryId, QueryScope, RepoKey, RepositoryKey,
+    ResultSetCondition, ResultSetState, Salience, SessionPhase, ViewAddress,
 };
 use serde::{Deserialize, Serialize};
 
@@ -1182,7 +1182,7 @@ fn start_scoped_issue(row: &ScopedIssueProjection) -> Option<TableIntent> {
             row_id: scoped_issue_id(row),
             issue: row.row.reference.clone(),
             title: row.row.issue.title.clone(),
-            ready: row.row.issue.labels.iter().any(|label| label == "ready"),
+            ready: row.row.issue.labels.iter().any(|label| label == READY_ISSUE_LABEL),
         },
     })
 }

--- a/crates/flotilla-tui/src/widgets/dispatch_confirm.rs
+++ b/crates/flotilla-tui/src/widgets/dispatch_confirm.rs
@@ -1,0 +1,140 @@
+use std::any::Any;
+
+use crossterm::event::KeyEvent;
+use ratatui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::{Block, Clear, Paragraph, Wrap},
+    Frame,
+};
+use tui_input::{backend::crossterm::EventHandler as InputEventHandler, Input};
+
+use super::{AppAction, InteractiveWidget, Outcome, RenderContext, WidgetContext};
+use crate::{
+    binding_table::{BindingModeId, KeyBindingMode, StatusContent, StatusFragment},
+    keymap::Action,
+    table_view::{TableIntent, TableIssueStart},
+    ui_helpers,
+};
+
+/// The single confirmation barrier for every issue-table convoy dispatch.
+pub struct DispatchConfirmWidget {
+    intent: TableIntent,
+    instruction: Input,
+}
+
+impl DispatchConfirmWidget {
+    pub fn new(intent: TableIntent) -> Self {
+        assert!(
+            matches!(intent, TableIntent::StartConvoy { .. } | TableIntent::StartConvoys { .. } | TableIntent::StartBatchConvoy { .. }),
+            "dispatch confirmation requires a convoy-start table intent"
+        );
+        Self { intent, instruction: Input::default() }
+    }
+
+    fn dispatch_details(&self) -> (&str, &str, &[TableIssueStart], &str) {
+        match &self.intent {
+            TableIntent::StartConvoy { namespace, project, issue } => (namespace, project, std::slice::from_ref(issue), "One convoy"),
+            TableIntent::StartConvoys { namespace, project, issues } => (namespace, project, issues, "One convoy per issue"),
+            TableIntent::StartBatchConvoy { namespace, project, issues } => (namespace, project, issues, "One convoy for all issues"),
+            _ => unreachable!("constructor validates the table intent"),
+        }
+    }
+
+    pub fn instruction(&self) -> &str {
+        self.instruction.value()
+    }
+}
+
+impl InteractiveWidget for DispatchConfirmWidget {
+    fn handle_action(&mut self, action: Action, ctx: &mut WidgetContext) -> Outcome {
+        match action {
+            Action::Confirm => {
+                let instruction = self.instruction.value().trim();
+                ctx.app_actions.push(AppAction::ConfirmConvoyDispatch {
+                    intent: self.intent.clone(),
+                    instruction: (!instruction.is_empty()).then(|| instruction.to_string()),
+                });
+                Outcome::Finished
+            }
+            Action::Dismiss => Outcome::Finished,
+            _ => Outcome::Ignored,
+        }
+    }
+
+    fn handle_raw_key(&mut self, key: KeyEvent, _ctx: &mut WidgetContext) -> Outcome {
+        self.instruction.handle_event(&crossterm::event::Event::Key(key));
+        Outcome::Consumed
+    }
+
+    fn render(&mut self, frame: &mut Frame, area: Rect, ctx: &mut RenderContext) {
+        let (namespace, project, issues, dispatch_shape) = self.dispatch_details();
+        let popup = ui_helpers::popup_area(area, 72, 58);
+        frame.render_widget(Clear, popup);
+
+        let theme = ctx.theme;
+        let mut lines = vec![
+            Line::from(vec![Span::raw("Target project: "), Span::styled(format!("{namespace}/{project}"), Style::default().bold())]),
+            Line::from(vec![
+                Span::raw("Placement:      "),
+                Span::styled("Automatic (resolved on dispatch)", Style::default().fg(theme.muted)),
+            ]),
+            Line::from(vec![Span::raw("Workflow:       "), Span::styled("Project default", Style::default().fg(theme.muted))]),
+            Line::from(vec![Span::raw("Dispatch:       "), Span::raw(dispatch_shape)]),
+            Line::from(""),
+        ];
+
+        for issue in issues.iter().take(4) {
+            lines.push(Line::from(vec![
+                Span::styled(format!("#{} ", issue.issue.id), Style::default().bold()),
+                Span::raw(issue.title.clone()),
+            ]));
+        }
+        if issues.len() > 4 {
+            lines.push(Line::from(format!("… and {} more", issues.len() - 4)));
+        }
+        if issues.iter().any(|issue| !issue.ready) {
+            lines.push(Line::from(""));
+            let warning = if issues.len() == 1 { "⚠ Issue is not marked ready" } else { "⚠ One or more issues are not marked ready" };
+            lines.push(Line::from(Span::styled(warning, Style::default().fg(theme.status_error).bold())));
+        }
+
+        lines.extend([
+            Line::from(""),
+            Line::from("Optional guidance (appended to the crew brief):"),
+            Line::from(vec![
+                Span::styled("> ", Style::default().fg(theme.input_text)),
+                Span::raw(self.instruction.value().to_string()),
+                Span::styled("▏", Style::default().fg(theme.input_text)),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled("Enter: dispatch    Esc: cancel", Style::default().fg(theme.muted))),
+        ]);
+
+        let paragraph = Paragraph::new(lines)
+            .block(Block::bordered().style(theme.block_style()).title(" Confirm convoy dispatch "))
+            .wrap(Wrap { trim: false });
+        frame.render_widget(paragraph, popup);
+    }
+
+    fn binding_mode(&self) -> KeyBindingMode {
+        BindingModeId::DispatchConfirm.into()
+    }
+
+    fn captures_raw_keys(&self) -> bool {
+        true
+    }
+
+    fn status_fragment(&self) -> StatusFragment {
+        StatusFragment { status: Some(StatusContent::Label("CONFIRM DISPATCH".into())) }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/crates/flotilla-tui/src/widgets/mod.rs
+++ b/crates/flotilla-tui/src/widgets/mod.rs
@@ -6,6 +6,7 @@ pub mod command_palette;
 pub mod convoy_delete_confirm;
 pub mod delete_confirm;
 pub mod describe;
+pub mod dispatch_confirm;
 pub mod event_log;
 pub mod file_picker;
 pub mod help;
@@ -84,6 +85,10 @@ pub enum AppAction {
     /// Pop the active tab's in-place navigation history.
     BackView,
     ExecuteTableIntent(crate::table_view::TableIntent),
+    ConfirmConvoyDispatch {
+        intent: crate::table_view::TableIntent,
+        instruction: Option<String>,
+    },
     SetTableFilter(String),
     SetSourceSearch(Option<String>),
     FetchMore(flotilla_protocol::QueryId),

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -517,7 +517,7 @@ impl InteractiveWidget for ProjectPageWidget {
 
 fn issue_start_from_row(row: &table_view::ProjectedRow) -> Option<TableIssueStart> {
     row.actions.iter().find_map(|action| match &action.intent {
-        TableIntent::StartConvoy { issue, .. } => Some(TableIssueStart { row_id: row.id.clone(), issue: issue.clone() }),
+        TableIntent::StartConvoy { issue, .. } => Some(issue.clone()),
         _ => None,
     })
 }
@@ -571,7 +571,16 @@ mod tests {
                 id: "start",
                 label: "Start convoy",
                 key: 'c',
-                intent: TableIntent::StartConvoy { namespace: "flotilla".into(), project: "roadmap".into(), issue },
+                intent: TableIntent::StartConvoy {
+                    namespace: "flotilla".into(),
+                    project: "roadmap".into(),
+                    issue: TableIssueStart {
+                        row_id: RowId::new(format!("issue:flotilla:roadmap:https://github.com:flotilla-org/flotilla:{id}")),
+                        issue,
+                        title: format!("Issue {id}"),
+                        ready: true,
+                    },
+                },
             }],
         }
     }


### PR DESCRIPTION
## Summary

- route every issue-table convoy start through one confirmation modal
- show issue details, target project, placement/workflow defaults, and a non-ready warning
- accept optional guidance and pass it through to the convoy instruction/crew brief
- preserve confirmation for fan-out and batch multi-issue dispatches

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1012
