### PR TITLE
fix: polish project page tables

### DIFF
--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -332,6 +332,7 @@ impl<R: Clone> QueryTableResult<R> {
 }
 
 pub fn table_rows<'a>(
+    model: &'a TuiModel,
     namespaces: &'a NamespaceMap,
     queries: &'a QueryTableCache,
     source_search: Option<&'a str>,
@@ -357,6 +358,11 @@ pub fn table_rows<'a>(
             .awareness
             .iter()
             .map(|(query, result)| crate::table_view::QueryRows { query, rows: &result.rows, state: &result.state })
+            .collect(),
+        host_home_dirs: model
+            .hosts
+            .values()
+            .filter_map(|host| host.summary.system.home_dir.as_deref().map(|home| (host.host_name.clone(), home)))
             .collect(),
         source_search,
     }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -362,7 +362,10 @@ pub fn table_rows<'a>(
         host_home_dirs: model
             .hosts
             .values()
-            .filter_map(|host| host.summary.system.home_dir.as_deref().map(|home| (host.host_name.clone(), home)))
+            .filter_map(|host| {
+                let resolved = model.resolve_host(&host.host_name).ok()?;
+                resolved.summary.system.home_dir.as_deref().map(|home| (resolved.host_name.clone(), home))
+            })
             .collect(),
         source_search,
     }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -222,6 +222,34 @@ fn scoped_pane_esc_navigates_back() {
 }
 
 #[test]
+fn scoped_pane_back_header_is_mouse_clickable() {
+    let mut app = stub_app();
+    app.views = crate::app::OpenViews::scoped("convoy/flotilla/alpha".parse().expect("valid address"));
+    app.sync_active_view();
+    app.open_view("vessel/flotilla/alpha/build".parse().expect("valid address"));
+    let mut terminal = Terminal::new(TestBackend::new(80, 12)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            let mut ctx = crate::widgets::RenderContext {
+                model: &app.model,
+                views: &mut app.views,
+                ui: &mut app.ui,
+                theme: &app.theme,
+                keymap: &app.keymap,
+                in_flight: &app.in_flight,
+                namespaces: &app.namespaces,
+                query_tables: &app.query_tables,
+            };
+            app.screen.render(frame, frame.area(), &mut ctx);
+        })
+        .expect("draw");
+
+    app.handle_mouse(MouseEvent { kind: MouseEventKind::Down(MouseButton::Left), column: 2, row: 0, modifiers: KeyModifiers::NONE });
+
+    assert_eq!(app.views.active_address(), Some(&"convoy/flotilla/alpha".parse().expect("valid address")));
+}
+
+#[test]
 fn command_queue_push_and_take_fifo() {
     let mut q = CommandQueue::default();
     q.push(Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::Refresh { repo: None } });
@@ -2070,7 +2098,7 @@ async fn materialized_issue_scroll_requests_the_next_demand_backed_page() {
         },
     })));
 
-    let rows = crate::app::table_rows(&app.namespaces, &app.query_tables, None);
+    let rows = crate::app::table_rows(&app.model, &app.namespaces, &app.query_tables, None);
     let view = crate::table_view::project(app.views.active_address().expect("active address"), &rows).expect("table");
     app.views.active_table_state_mut().reconcile(&view);
     app.views.active_table_state_mut().select_index(&view, 44);
@@ -2218,7 +2246,8 @@ fn selected_table_name(app: &App) -> Option<String> {
         ViewAddress::Issues { .. } | ViewAddress::Checkouts { .. } => 0,
         ViewAddress::Overview | ViewAddress::Repo { .. } => return None,
     };
-    let rows = crate::app::table_rows(&app.namespaces, &app.query_tables, app.views.active_table_state().source_search.as_deref());
+    let rows =
+        crate::app::table_rows(&app.model, &app.namespaces, &app.query_tables, app.views.active_table_state().source_search.as_deref());
     let view = crate::table_view::project(address, &rows).ok()?;
     app.views.active_table_state().selected_row(&view).map(|row| row.cells[name_column].text.clone())
 }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -76,6 +76,21 @@ fn non_local_test_host() -> &'static str {
     }
 }
 
+#[test]
+fn table_rows_omits_home_dirs_for_ambiguous_host_names() {
+    let mut app = stub_app();
+    let first = EnvironmentId::host(HostId::new("desktop-a"));
+    let second = EnvironmentId::host(HostId::new("desktop-b"));
+    insert_host(&mut app.model, "desktop", first.clone(), NodeId::new("node-a"), "Desktop A", false, PeerStatus::Connected);
+    insert_host(&mut app.model, "desktop", second.clone(), NodeId::new("node-b"), "Desktop B", false, PeerStatus::Connected);
+    app.model.hosts.get_mut(&first).expect("first host").summary.system.home_dir = Some("/home/first".into());
+    app.model.hosts.get_mut(&second).expect("second host").summary.system.home_dir = Some("/home/second".into());
+
+    let rows = table_rows(&app.model, &app.namespaces, &app.query_tables, None);
+
+    assert!(!rows.host_home_dirs.contains_key(&HostName::new("desktop")));
+}
+
 #[derive(Clone)]
 struct QueryStep {
     expected_page: u32,

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -4,6 +4,7 @@ use color_eyre::Result;
 use crossterm::{
     event::{EnableMouseCapture, KeyCode, KeyModifiers, MouseEventKind},
     execute,
+    terminal::SetTitle,
 };
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
@@ -45,6 +46,8 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
     resync_subscriptions(&mut app).await;
 
     execute!(stdout(), EnableMouseCapture)?;
+    let mut terminal_title = None;
+    sync_terminal_title(&app, &mut terminal_title)?;
     let mut events = event::EventHandler::new(Duration::from_millis(50));
     events.attach_daemon(daemon_rx);
 
@@ -155,6 +158,7 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
             events.pause_terminal_input().await;
             let (next_terminal, result) = crate::terminal::run_temporary_attach(&command);
             terminal = next_terminal;
+            terminal_title = None;
             events.resume_terminal_input();
             if let Err(message) = result {
                 app.set_status_message(Some(message));
@@ -173,12 +177,24 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
         }
 
         // ── Draw once ──
+        sync_terminal_title(&app, &mut terminal_title)?;
         render_frame(&mut terminal, &mut app)?;
     }
 
     app.daemon.unsubscribe_queries(app.session_id).await;
     crate::terminal::restore_terminal();
     Ok(EventLoopExit::Quit)
+}
+
+fn sync_terminal_title(app: &App, current: &mut Option<String>) -> Result<()> {
+    let next = app.views.is_scoped().then(|| crate::widgets::tabs::tab_label(app.views.active(), &app.model).trim().to_string());
+    if next != *current {
+        if let Some(title) = &next {
+            execute!(stdout(), SetTitle(format!("{title} — flotilla")))?;
+        }
+        *current = next;
+    }
+    Ok(())
 }
 
 /// Replace the daemon-side query subscription set with the union the open

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -4,7 +4,10 @@
 //! project query rows into semantic cells and intents; surfaces decide how to
 //! render and invoke them.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
 
 use flotilla_protocol::{
     result_set::Timestamp, AwarenessFamily, AwarenessGrouping, AwarenessLimit, AwarenessNode, ChangeRequestStatus, CheckoutRow, HostName,
@@ -531,6 +534,7 @@ pub struct TableRows<'a> {
     pub issue_results: Vec<QueryRows<'a, IssueRow>>,
     pub checkout_results: Vec<QueryRows<'a, CheckoutRow>>,
     pub awareness_results: Vec<QueryRows<'a, AwarenessNode>>,
+    pub host_home_dirs: HashMap<HostName, &'a Path>,
     pub source_search: Option<&'a str>,
 }
 
@@ -644,10 +648,29 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
                 .as_ref()
                 .map_or_else(|| "Checkouts · fleet".to_string(), |scope| format!("Checkouts · {}/{}", scope.namespace, scope.name));
             let mut view = checkout_spec().project(title, result.rows.iter().cloned());
+            polish_checkout_rows(&mut view, result.rows, &data.host_home_dirs);
             view.meta = result_set_meta(result.state);
             Ok(view)
         }
         ViewAddress::Overview | ViewAddress::Repo { .. } => Err(format!("view is not table-backed: {}", address.human_label())),
+    }
+}
+
+fn polish_checkout_rows(view: &mut TableView, rows: &[CheckoutRow], home_dirs: &HashMap<HostName, &Path>) {
+    let mut previous_host: Option<&HostName> = None;
+    let mut previous_repo: Option<&RepositoryKey> = None;
+    for (projected, row) in view.rows.iter_mut().zip(rows) {
+        let same_host = previous_host == Some(&row.host);
+        let same_repo = same_host && previous_repo == Some(&row.repo);
+        if same_host {
+            projected.cells[0].text.clear();
+        }
+        projected.cells[1].text = crate::ui_helpers::shorten_home_path(Path::new(&row.path), home_dirs.get(&row.host).copied());
+        if same_repo {
+            projected.cells[3].text.clear();
+        }
+        previous_host = Some(&row.host);
+        previous_repo = Some(&row.repo);
     }
 }
 
@@ -1704,6 +1727,45 @@ mod tests {
             "observed",
         ]);
         assert!(view.rows[0].actions.is_empty());
+    }
+
+    #[test]
+    fn checkout_table_shortens_home_paths_and_deduplicates_grouped_lines() {
+        let host = HostName::new("kiwi");
+        let first = CheckoutRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "widgets-main"))
+            .repo(RepositoryKey("repo_widgets".into()))
+            .repo_label("widgets")
+            .path("/home/dev/work/widgets")
+            .branch("main")
+            .host(host.clone())
+            .authority(LifecycleAuthority::Observed)
+            .build();
+        let second = CheckoutRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "widgets-feature"))
+            .repo(RepositoryKey("repo_widgets".into()))
+            .repo_label("widgets")
+            .path("/home/dev/work/widgets-feature-with-a-long-name")
+            .branch("feature")
+            .host(host.clone())
+            .authority(LifecycleAuthority::Observed)
+            .build();
+        let query = QueryId::Checkouts { scope: None };
+        let state = ResultSetState::default();
+        let rows = [first, second];
+        let view = project(&ViewAddress::Checkouts { scope: None }, &TableRows {
+            checkout_results: vec![QueryRows { query: &query, rows: &rows, state: &state }],
+            host_home_dirs: HashMap::from([(host, Path::new("/home/dev"))]),
+            ..TableRows::default()
+        })
+        .expect("checkout table");
+
+        assert_eq!(view.rows[0].cells[0].text, "kiwi");
+        assert_eq!(view.rows[0].cells[1].text, "~/work/widgets");
+        assert_eq!(view.rows[0].cells[3].text, "widgets");
+        assert_eq!(view.rows[1].cells[0].text, "");
+        assert_eq!(view.rows[1].cells[1].text, "~/work/widgets-feature-with-a-long-name");
+        assert_eq!(view.rows[1].cells[3].text, "");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -648,7 +648,7 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
                 .as_ref()
                 .map_or_else(|| "Checkouts · fleet".to_string(), |scope| format!("Checkouts · {}/{}", scope.namespace, scope.name));
             let mut view = checkout_spec().project(title, result.rows.iter().cloned());
-            polish_checkout_rows(&mut view, result.rows, &data.host_home_dirs);
+            shorten_checkout_paths(&mut view, result.rows, &data.host_home_dirs);
             view.meta = result_set_meta(result.state);
             Ok(view)
         }
@@ -656,21 +656,9 @@ pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView,
     }
 }
 
-fn polish_checkout_rows(view: &mut TableView, rows: &[CheckoutRow], home_dirs: &HashMap<HostName, &Path>) {
-    let mut previous_host: Option<&HostName> = None;
-    let mut previous_repo: Option<&RepositoryKey> = None;
+fn shorten_checkout_paths(view: &mut TableView, rows: &[CheckoutRow], home_dirs: &HashMap<HostName, &Path>) {
     for (projected, row) in view.rows.iter_mut().zip(rows) {
-        let same_host = previous_host == Some(&row.host);
-        let same_repo = same_host && previous_repo == Some(&row.repo);
-        if same_host {
-            projected.cells[0].text.clear();
-        }
-        projected.cells[1].text = crate::ui_helpers::shorten_home_path(Path::new(&row.path), home_dirs.get(&row.host).copied());
-        if same_repo {
-            projected.cells[3].text.clear();
-        }
-        previous_host = Some(&row.host);
-        previous_repo = Some(&row.repo);
+        projected.cells[1].text = crate::ui_helpers::shorten_against_home(Path::new(&row.path), home_dirs.get(&row.host).copied());
     }
 }
 
@@ -1730,7 +1718,7 @@ mod tests {
     }
 
     #[test]
-    fn checkout_table_shortens_home_paths_and_deduplicates_grouped_lines() {
+    fn checkout_table_shortens_home_paths_without_discarding_group_values() {
         let host = HostName::new("kiwi");
         let first = CheckoutRow::builder()
             .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "widgets-main"))
@@ -1763,9 +1751,9 @@ mod tests {
         assert_eq!(view.rows[0].cells[0].text, "kiwi");
         assert_eq!(view.rows[0].cells[1].text, "~/work/widgets");
         assert_eq!(view.rows[0].cells[3].text, "widgets");
-        assert_eq!(view.rows[1].cells[0].text, "");
+        assert_eq!(view.rows[1].cells[0].text, "kiwi");
         assert_eq!(view.rows[1].cells[1].text, "~/work/widgets-feature-with-a-long-name");
-        assert_eq!(view.rows[1].cells[3].text, "");
+        assert_eq!(view.rows[1].cells[3].text, "widgets");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/ui_helpers.rs
+++ b/crates/flotilla-tui/src/ui_helpers.rs
@@ -260,7 +260,7 @@ pub fn shorten_path(path: &Path, repo_root: &Path, col_width: usize, home_dir: O
     shorten_against_home(path, home_dir)
 }
 
-fn shorten_against_home(path: &Path, home_dir: Option<&Path>) -> String {
+pub(crate) fn shorten_against_home(path: &Path, home_dir: Option<&Path>) -> String {
     if let Some(home) = home_dir {
         if let Ok(rel) = path.strip_prefix(home) {
             let s = rel.to_string_lossy();
@@ -271,11 +271,6 @@ fn shorten_against_home(path: &Path, home_dir: Option<&Path>) -> String {
         }
     }
     path.display().to_string()
-}
-
-/// Shorten an arbitrary path against its host's home directory.
-pub fn shorten_home_path(path: &Path, home_dir: Option<&Path>) -> String {
-    shorten_against_home(path, home_dir)
 }
 
 /// Preserve both ends of long values, which is especially useful for paths

--- a/crates/flotilla-tui/src/ui_helpers.rs
+++ b/crates/flotilla-tui/src/ui_helpers.rs
@@ -67,18 +67,36 @@ pub fn render_popup_frame(
     (area, inner)
 }
 
-/// Render a full-width section divider: "── Label ──".
-pub fn render_section_divider(frame: &mut ratatui::Frame, label: &str, theme: &Theme, area: Rect, row_style: Style, label_style: Style) {
+/// Render a full-width section header with optional right-aligned metadata.
+pub fn render_section_header(
+    frame: &mut ratatui::Frame,
+    label: &str,
+    metadata: Option<&str>,
+    theme: &Theme,
+    area: Rect,
+    row_style: Style,
+    label_style: Style,
+) {
     let dashes_left = 2;
     let left = "\u{2500}".repeat(dashes_left);
-    let right_width = area.width.saturating_sub(dashes_left as u16 + label.chars().count() as u16 + 4);
+    let metadata_width = metadata.map_or(0, |value| value.chars().count() as u16 + 1);
+    let right_width = area.width.saturating_sub(dashes_left as u16 + label.chars().count() as u16 + metadata_width + 4);
     let right = "\u{2500}".repeat(right_width as usize);
-    let header_line = Line::from(vec![
+    let mut spans = vec![
         Span::styled(format!("{left} "), Style::default().fg(theme.muted)),
         Span::styled(label.to_string(), label_style),
         Span::styled(format!(" {right}"), Style::default().fg(theme.muted)),
-    ]);
+    ];
+    if let Some(metadata) = metadata {
+        spans.push(Span::styled(format!(" {metadata}"), Style::default().fg(theme.muted)));
+    }
+    let header_line = Line::from(spans);
     frame.render_widget(Paragraph::new(header_line).style(row_style), area);
+}
+
+/// Render a full-width section divider: "── Label ──".
+pub fn render_section_divider(frame: &mut ratatui::Frame, label: &str, theme: &Theme, area: Rect, row_style: Style, label_style: Style) {
+    render_section_header(frame, label, None, theme, area, row_style, label_style);
 }
 
 pub fn bottom_anchored_overlay(frame_area: Rect, reserved_top_rows: u16, requested_body_rows: u16) -> BottomAnchoredOverlayLayout {
@@ -253,6 +271,27 @@ fn shorten_against_home(path: &Path, home_dir: Option<&Path>) -> String {
         }
     }
     path.display().to_string()
+}
+
+/// Shorten an arbitrary path against its host's home directory.
+pub fn shorten_home_path(path: &Path, home_dir: Option<&Path>) -> String {
+    shorten_against_home(path, home_dir)
+}
+
+/// Preserve both ends of long values, which is especially useful for paths
+/// where the home/repository prefix and leaf checkout name both carry meaning.
+pub fn middle_elide(value: &str, width: usize) -> String {
+    let chars = value.chars().collect::<Vec<_>>();
+    if chars.len() <= width {
+        return value.to_string();
+    }
+    if width <= 1 {
+        return "…".chars().take(width).collect();
+    }
+    let available = width - 1;
+    let left = available.div_ceil(2);
+    let right = available - left;
+    chars[..left].iter().chain(std::iter::once(&'…')).chain(chars[chars.len() - right..].iter()).collect()
 }
 
 const BRAILLE_SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧'];
@@ -521,6 +560,12 @@ mod tests {
         let home = dirs::home_dir().expect("home dir");
         let root = home.join("dev/flotilla");
         assert_eq!(shorten_path(&root, &root, 40, Some(&home)), "~/dev/flotilla");
+    }
+
+    #[test]
+    fn middle_elision_preserves_path_prefix_and_leaf() {
+        assert_eq!(middle_elide("~/dev/projects/flotilla-feature", 16), "~/dev/pr…feature");
+        assert_eq!(middle_elide("short", 16), "short");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -9,7 +9,7 @@ use super::{
     Outcome, RenderContext, WidgetContext,
 };
 use crate::{
-    app::{NamespaceMap, QueryTableCache},
+    app::{NamespaceMap, QueryTableCache, TuiModel},
     binding_table::{BindingModeId, KeyBindingMode},
     keymap::Action,
     table_view::{self, AvailableAction, ProjectPanel, ProjectPanelKind, ProjectTableState, RowId, TableIntent, TableIssueStart},
@@ -60,24 +60,25 @@ impl ProjectPageWidget {
 
     fn project_panels(
         address: &ViewAddress,
+        model: &TuiModel,
         namespaces: &NamespaceMap,
         query_tables: &QueryTableCache,
         state: &ProjectTableState,
     ) -> Result<Vec<ProjectPanel>, String> {
-        let rows = crate::app::table_rows(namespaces, query_tables, state.issue_source_search());
+        let rows = crate::app::table_rows(model, namespaces, query_tables, state.issue_source_search());
         Self::filtered_panels(address, &rows, state)
     }
 
     fn panels(ctx: &WidgetContext<'_>) -> Result<Vec<ProjectPanel>, String> {
         let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
         let state = ctx.views.active_project_table_state();
-        Self::project_panels(address, ctx.namespaces, ctx.query_tables, state)
+        Self::project_panels(address, ctx.model, ctx.namespaces, ctx.query_tables, state)
     }
 
     fn render_panels(ctx: &RenderContext<'_>) -> Result<Vec<ProjectPanel>, String> {
         let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
         let state = ctx.views.active_project_table_state();
-        Self::project_panels(address, ctx.namespaces, ctx.query_tables, state)
+        Self::project_panels(address, ctx.model, ctx.namespaces, ctx.query_tables, state)
     }
 
     fn layouts(panels: &[ProjectPanel]) -> Vec<PanelLayout<'_>> {
@@ -181,7 +182,11 @@ impl ProjectPageWidget {
     }
 
     fn fetch_more_query(layouts: &[PanelLayout<'_>], state: &ProjectTableState, trigger: super::table::FetchTrigger) -> Option<QueryId> {
-        let layout = layouts.iter().find(|layout| layout.panel.kind == state.active())?;
+        let (index, layout) = layouts.iter().enumerate().find(|(_, layout)| layout.panel.kind == state.active())?;
+        let is_terminal = index + 1 == layouts.len();
+        if trigger == super::table::FetchTrigger::NearBottom && !is_terminal {
+            return None;
+        }
         if layout.panel.kind != ProjectPanelKind::Issues
             || !super::table::TablePanel::should_fetch_more(&layout.panel.table, state.table(layout.panel.kind), trigger)
         {
@@ -264,17 +269,15 @@ impl ProjectPageWidget {
         let layouts = Self::layouts(panels);
         Self::reconcile(&layouts, state);
         self.ensure_active_visible(&layouts, state);
-        for layout in &layouts {
+        for (index, layout) in layouts.iter().enumerate() {
             if let Some(header_area) = self.line_area(layout.header_line, state) {
                 let mut label = format!("{}  › {}", layout.panel.table.title, layout.panel.target.human_label());
                 if let Some(marker) = salience_marker(layout.panel.table.meta.salience) {
                     label = format!("{marker} {label}");
                 }
-                if let Some(as_of) = layout.panel.table.meta.as_of {
-                    label.push_str(&format!(" · as of {}", as_of.format("%Y-%m-%d %H:%M")));
-                }
                 if layout.panel.table.meta.has_more {
-                    label.push_str(" · more available");
+                    let is_terminal = index + 1 == layouts.len();
+                    label.push_str(if is_terminal { " · more available" } else { " · f fetch more" });
                 }
                 if layout.panel.table.meta.availability == table_view::TableAvailability::Loading {
                     label.push_str(" · loading");
@@ -291,7 +294,8 @@ impl ProjectPageWidget {
                 };
                 let style = if focused { style.add_modifier(Modifier::REVERSED) } else { style };
                 let row_style = if focused { style } else { Default::default() };
-                ui_helpers::render_section_divider(frame, &label, theme, header_area, row_style, style);
+                let timestamp = layout.panel.table.meta.as_of.map(|as_of| format!("as of {}", as_of.format("%Y-%m-%d %H:%M")));
+                ui_helpers::render_section_header(frame, &label, timestamp.as_deref(), theme, header_area, row_style, style);
             }
             if let Some(columns_area) = self.line_area(layout.columns_line, state) {
                 super::table::TablePanel::render_header(frame, columns_area, theme, &layout.panel.table);
@@ -606,7 +610,7 @@ mod tests {
         assert!(rendered.contains("issues?project=flotilla/roadmap"));
         assert!(!rendered.contains("%2F"));
         assert!(rendered.contains("as of 2026-07-21 12:30"));
-        assert!(rendered.contains("more available"));
+        assert!(rendered.contains("f fetch more"));
         assert!(rendered.contains("⚠ one source stale"));
     }
 
@@ -724,7 +728,7 @@ mod tests {
     }
 
     #[test]
-    fn panel_navigation_crosses_a_growing_issue_window_without_disabling_fetch_on_scroll() {
+    fn non_terminal_issue_panel_requires_explicit_fetch_more() {
         let mut panels = vec![
             panel(ProjectPanelKind::Issues, "Issues", "issues?project=flotilla%2Froadmap", "issue-0"),
             panel(ProjectPanelKind::Independents, "Independents", "independents?project=flotilla%2Froadmap", "governor"),
@@ -740,23 +744,25 @@ mod tests {
         state.set_active(ProjectPanelKind::Issues);
         state.focus_rows();
         state.table_mut(ProjectPanelKind::Issues).select_index(&panels[0].table, 0);
+        assert!(ProjectPageWidget::fetch_more_query(
+            &ProjectPageWidget::layouts(&panels),
+            &state,
+            crate::widgets::table::FetchTrigger::Explicit
+        )
+        .is_some());
 
-        for keypress in 0..20 {
+        for _ in 0..20 {
             let layouts = ProjectPageWidget::layouts(&panels);
             ProjectPageWidget::select_delta(&layouts, &mut state, 1);
-            if ProjectPageWidget::fetch_more_query(&layouts, &state, crate::widgets::table::FetchTrigger::NearBottom).is_some() {
-                let mut row = panels[0].table.rows[0].clone();
-                row.id = RowId::new(format!("fetched-{keypress}"));
-                panels[0].table.rows.push(row);
-            }
+            assert!(
+                ProjectPageWidget::fetch_more_query(&layouts, &state, crate::widgets::table::FetchTrigger::NearBottom).is_none(),
+                "a non-terminal panel must not auto-extend"
+            );
             ProjectPageWidget::reconcile(&ProjectPageWidget::layouts(&panels), &mut state);
         }
 
-        assert!(panels[0].table.rows.len() > 8, "near-bottom row navigation should still fetch more issues");
-        assert_eq!(state.active(), ProjectPanelKind::Issues, "the growing issue window should reproduce the row-navigation trap");
-        ProjectPageWidget::select_panel_delta(&ProjectPageWidget::layouts(&panels), &mut state, 1);
-        assert_eq!(state.active(), ProjectPanelKind::Independents);
-        assert!(state.header_focused());
+        assert_eq!(panels[0].table.rows.len(), 8);
+        assert_eq!(state.active(), ProjectPanelKind::Independents, "navigation should escape the finite issue window");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -60,6 +60,7 @@ pub struct Screen {
     pub overview_page: OverviewPage,
     pub table: TableWidget,
     pub project_page: ProjectPageWidget,
+    view_header_area: Option<Rect>,
 }
 
 impl Default for Screen {
@@ -78,6 +79,7 @@ impl Screen {
             overview_page: OverviewPage::new(),
             table: TableWidget::default(),
             project_page: ProjectPageWidget::default(),
+            view_header_area: None,
         }
     }
 
@@ -309,6 +311,11 @@ impl InteractiveWidget for Screen {
 
         match mouse.kind {
             MouseEventKind::Down(MouseButton::Left) => {
+                if self.view_header_area.is_some_and(|area| area.contains(ratatui::layout::Position::new(x, y))) {
+                    ctx.app_actions.push(AppAction::BackView);
+                    return Outcome::Consumed;
+                }
+
                 // Tab bar click
                 let tab_actions = self.tabs.handle_mouse(mouse);
                 if !tab_actions.is_empty() {
@@ -367,10 +374,11 @@ impl InteractiveWidget for Screen {
 
     fn render(&mut self, frame: &mut Frame, _area: Rect, ctx: &mut RenderContext) {
         // Scoped mode: the pane is one View — no tab bar row.
+        let view_header_height = u16::from(ctx.views.active().has_history());
         let constraints = if ctx.views.is_scoped() {
-            vec![Constraint::Length(0), Constraint::Min(0), Constraint::Length(1)]
+            vec![Constraint::Length(0), Constraint::Length(view_header_height), Constraint::Min(0), Constraint::Length(1)]
         } else {
-            vec![Constraint::Length(1), Constraint::Min(0), Constraint::Length(1)]
+            vec![Constraint::Length(1), Constraint::Length(view_header_height), Constraint::Min(0), Constraint::Length(1)]
         };
         let chunks = Layout::default().direction(Direction::Vertical).constraints(constraints).split(frame.area());
 
@@ -379,43 +387,57 @@ impl InteractiveWidget for Screen {
             self.tabs.render(ctx.views, ctx.model, ctx.ui, ctx.theme, frame, chunks[0]);
         }
 
-        // 2. Content: dispatch to the active View's page
+        // 2. Tab-local navigation header
+        self.view_header_area = (view_header_height == 1).then_some(chunks[1]);
+        if let Some(area) = self.view_header_area {
+            let path = ctx.views.active().breadcrumb_addresses().iter().map(ViewAddress::human_label).collect::<Vec<_>>().join("  ›  ");
+            frame.render_widget(
+                Paragraph::new(Line::styled(format!(" ← Back  {path}"), ratatui::style::Style::default().fg(ctx.theme.info))),
+                area,
+            );
+        }
+
+        // 3. Content: dispatch to the active View's page
         let active_page = self.active_page(ctx.views.active(), &ctx.model.repos);
         match &active_page {
             ActivePage::Table => {
                 let address = ctx.views.active_address().cloned().expect("table page has a parsed address");
                 let filter = ctx.views.active_table_state().filter.clone();
                 let source_search = ctx.views.active_table_state().source_search.as_deref();
-                let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
+                let rows = crate::app::table_rows(ctx.model, ctx.namespaces, ctx.query_tables, source_search);
                 match crate::table_view::project(&address, &rows).map(|view| view.filtered(&filter)) {
                     Ok(view) => {
-                        let breadcrumbs = ctx.views.active().breadcrumb_addresses();
-                        self.table.render_table(frame, chunks[1], ctx.theme, &view, ctx.views.active_table_state_mut(), &breadcrumbs);
+                        let breadcrumbs = if ctx.views.active().has_history() {
+                            Vec::new()
+                        } else {
+                            ctx.views.active().address().cloned().into_iter().collect()
+                        };
+                        self.table.render_table(frame, chunks[2], ctx.theme, &view, ctx.views.active_table_state_mut(), &breadcrumbs);
                     }
-                    Err(detail) => Self::render_error_page(frame, chunks[1], ctx.theme, "table view unavailable", &detail),
+                    Err(detail) => Self::render_error_page(frame, chunks[2], ctx.theme, "table view unavailable", &detail),
                 }
             }
-            ActivePage::Project => self.project_page.render(frame, chunks[1], ctx),
-            ActivePage::Overview => self.overview_page.render(frame, chunks[1], ctx),
+            ActivePage::Project => self.project_page.render(frame, chunks[2], ctx),
+            ActivePage::Overview => self.overview_page.render(frame, chunks[2], ctx),
             ActivePage::Repo(identity) => {
                 let identity = identity.clone();
                 match self.repo_pages.get_mut(&identity) {
-                    Some(page) => page.render(frame, chunks[1], ctx),
+                    Some(page) => page.render(frame, chunks[2], ctx),
                     None => Self::render_error_page(
                         frame,
-                        chunks[1],
+                        chunks[2],
                         ctx.theme,
                         &format!("no page for repo: {}/{}", identity.authority, identity.path),
                         "",
                     ),
                 }
             }
-            ActivePage::Error { title, detail } => Self::render_error_page(frame, chunks[1], ctx.theme, title, detail),
+            ActivePage::Error { title, detail } => Self::render_error_page(frame, chunks[2], ctx.theme, title, detail),
         }
 
-        // 3. Status bar — resolve all content, then call the pure renderer.
+        // 4. Status bar — resolve all content, then call the pure renderer.
 
-        // 3a. Resolve binding mode and status fragment.
+        // 4a. Resolve binding mode and status fragment.
         // Modal stack takes priority; otherwise the active View's kind
         // supplies its mode stack.
         let scoped = ctx.views.is_scoped();
@@ -441,7 +463,7 @@ impl InteractiveWidget for Screen {
 
         let active_mode = binding_mode.primary();
 
-        // 3b. Resolve key chips from binding mode via compiled binding table.
+        // 4b. Resolve key chips from binding mode via compiled binding table.
         //     Progress fragments suppress key chips (user can't interact during progress).
         let interactions = crate::interaction::InteractionContext::for_active_view(
             ctx.views.active_address(),
@@ -464,11 +486,11 @@ impl InteractiveWidget for Screen {
                 .collect()
         };
 
-        // 3c. Resolve status section from fragment (with fallback)
+        // 4c. Resolve status section from fragment (with fallback)
         let fallback_label = ": for commands";
         let status = status_bar_widget::resolve_status_section(&fragment, fallback_label);
 
-        // 3d. Task spinner — fragment progress takes priority over in-flight commands.
+        // 4d. Task spinner — fragment progress takes priority over in-flight commands.
         //     Only Normal/Overview modes show in-flight tasks.
         let task = status_bar_widget::resolve_task_from_fragment(&fragment).or_else(|| {
             if self.modal_stack.is_empty() {
@@ -478,14 +500,14 @@ impl InteractiveWidget for Screen {
             }
         });
 
-        // 3e. Error items — only override status in Normal mode (no modals)
+        // 4e. Error items — only override status in Normal mode (no modals)
         let error_items = if active_mode == BindingModeId::Normal && self.modal_stack.is_empty() {
             collect_visible_status_items(ctx.model, ctx.ui)
         } else {
             vec![]
         };
 
-        // 3f. Mode indicators — only for Normal mode (no modals, not config or issue search)
+        // 4f. Mode indicators — only for Normal mode (no modals, not config or issue search)
         let mode_indicators = if active_mode == BindingModeId::Normal && self.modal_stack.is_empty() {
             status_bar_widget::normal_mode_indicators(ctx.ui, ctx.namespaces)
         } else if active_mode == BindingModeId::CommandPalette {
@@ -495,15 +517,15 @@ impl InteractiveWidget for Screen {
             vec![]
         };
 
-        // 3g. show_keys flag
+        // 4g. show_keys flag
         let show_keys = ctx.ui.status_bar.show_keys;
 
-        // 3h. Status bar area — CommandPalette moves it to the overlay position
+        // 4h. Status bar area — CommandPalette moves it to the overlay position
         let is_command_palette = self.modal_stack.last().map(|w| w.binding_mode().primary()) == Some(BindingModeId::CommandPalette);
         let status_bar_area = if is_command_palette {
             ui_helpers::bottom_anchored_overlay(frame.area(), 1, crate::palette::MAX_PALETTE_ROWS as u16).status_row
         } else {
-            chunks[2]
+            chunks[3]
         };
 
         self.status_bar.render_bespoke(

--- a/crates/flotilla-tui/src/widgets/snapshots/flotilla_tui__widgets__table__tests__scoped_issue_metadata_and_condition_snapshot.snap
+++ b/crates/flotilla-tui/src/widgets/snapshots/flotilla_tui__widgets__table__tests__scoped_issue_metadata_and_condition_snapshot.snap
@@ -2,7 +2,7 @@
 source: crates/flotilla-tui/src/widgets/table.rs
 expression: terminal.backend()
 ---
-"┌ Issues · flotilla/roadmap · as of 2026-07-20 12:00 · more available · ⚠ one source unavailable ────────────┐"
+"┌ Issues · flotilla/roadmap · more available · ⚠ one source unavailable ───────────── as of 2026-07-20 12:00 ┐"
 "│issues?project=flotilla/roadmap                                                                             │"
 "│ISSUE          TITLE                                           SOURCE                  UPDATED              │"
 "│ENG-42         Fix pagination                                  test / owner/repo       2026-07-15 09:30     │"

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -58,6 +58,24 @@ impl TablePanel {
             && (trigger == FetchTrigger::Explicit || view.rows.len().saturating_sub(state.selected_index(view).unwrap_or(0) + 1) <= 5)
     }
 
+    fn rendered_cell_text(view: &TableView, row_index: usize, column_index: usize, width: usize) -> String {
+        let row = &view.rows[row_index];
+        let cell = &row.cells[column_index];
+        let column = &view.columns[column_index];
+        let repeated = row_index.checked_sub(1).and_then(|previous| view.rows.get(previous)).is_some_and(|previous| match column.id {
+            "host" => previous.cells[column_index].text == cell.text,
+            "repository" => previous.cells[0].text == row.cells[0].text && previous.cells[column_index].text == cell.text,
+            _ => false,
+        });
+        if repeated {
+            String::new()
+        } else if column.id == "path" {
+            crate::ui_helpers::middle_elide(&cell.text, width)
+        } else {
+            cell.text.clone()
+        }
+    }
+
     pub(crate) fn render_header(frame: &mut Frame, area: Rect, theme: &Theme, view: &TableView) {
         let header =
             Row::new(view.columns.iter().map(|column| Cell::from(Line::from(column.label).alignment(ratatui_alignment(column.alignment)))))
@@ -117,7 +135,7 @@ impl TablePanel {
                 _ => unreachable!("table width constraints are always resolved lengths"),
             })
             .collect::<Vec<_>>();
-        let rows = view.rows.iter().skip(first).take(count).map(|row| {
+        let rows = view.rows.iter().enumerate().skip(first).take(count).map(|(row_index, row)| {
             let selected = state.selected() == Some(&row.id);
             let multi = decorations.multi_selected.contains(&row.id);
             let row_state = state.row_state(&row.id);
@@ -129,8 +147,7 @@ impl TablePanel {
             });
             let mut offset = 0usize;
             let cells = row.cells.iter().zip(&view.columns).enumerate().map(|(index, (cell, column))| {
-                let mut text =
-                    if column.id == "path" { crate::ui_helpers::middle_elide(&cell.text, column_widths[index]) } else { cell.text.clone() };
+                let mut text = Self::rendered_cell_text(view, row_index, index, column_widths[index]);
                 if index == 0 {
                     if matches!(row_state, Some(RowState::Failed { .. })) {
                         text = format!("x {text}");
@@ -491,6 +508,48 @@ mod tests {
             }],
             meta: Default::default(),
         }
+    }
+
+    fn checkout_view() -> TableView {
+        let columns = [("host", "HOST"), ("path", "PATH"), ("branch", "BRANCH"), ("repository", "REPOSITORY")]
+            .into_iter()
+            .map(|(id, label)| ProjectedColumn {
+                id,
+                label,
+                width: WidthHint::Flexible { minimum: 8, weight: 1 },
+                alignment: Alignment::Left,
+            })
+            .collect();
+        let row = |id: &str, branch: &str| ProjectedRow {
+            id: RowId::new(id),
+            cells: vec![
+                CellValue { text: "kiwi".into(), tone: CellTone::Plain },
+                CellValue { text: format!("~/work/{id}"), tone: CellTone::Plain },
+                CellValue { text: branch.into(), tone: CellTone::Plain },
+                CellValue { text: "widgets".into(), tone: CellTone::Plain },
+            ],
+            drill: None,
+            describe: vec![],
+            actions: vec![],
+        };
+        TableView {
+            title: "Checkouts".into(),
+            columns,
+            rows: vec![row("main", "main"), row("feature", "feature/table-polish")],
+            meta: Default::default(),
+        }
+    }
+
+    #[test]
+    fn checkout_line_dedup_runs_after_filtering() {
+        let unfiltered = checkout_view();
+        assert_eq!(TablePanel::rendered_cell_text(&unfiltered, 1, 0, 20), "");
+        assert_eq!(TablePanel::rendered_cell_text(&unfiltered, 1, 3, 20), "");
+
+        let filtered = checkout_view().filtered("feature");
+        assert_eq!(filtered.rows.len(), 1);
+        assert_eq!(TablePanel::rendered_cell_text(&filtered, 0, 0, 20), "kiwi");
+        assert_eq!(TablePanel::rendered_cell_text(&filtered, 0, 3, 20), "widgets");
     }
 
     fn snapshot_view() -> TableView {

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -58,15 +58,20 @@ impl TablePanel {
             && (trigger == FetchTrigger::Explicit || view.rows.len().saturating_sub(state.selected_index(view).unwrap_or(0) + 1) <= 5)
     }
 
-    fn rendered_cell_text(view: &TableView, row_index: usize, column_index: usize, width: usize) -> String {
+    fn rendered_cell_text(view: &TableView, row_index: usize, first_visible: usize, column_index: usize, width: usize) -> String {
         let row = &view.rows[row_index];
         let cell = &row.cells[column_index];
         let column = &view.columns[column_index];
-        let repeated = row_index.checked_sub(1).and_then(|previous| view.rows.get(previous)).is_some_and(|previous| match column.id {
-            "host" => previous.cells[column_index].text == cell.text,
-            "repository" => previous.cells[0].text == row.cells[0].text && previous.cells[column_index].text == cell.text,
-            _ => false,
-        });
+        let host_column = view.columns.iter().position(|candidate| candidate.id == "host");
+        let repeated = (row_index > first_visible)
+            && row_index.checked_sub(1).and_then(|previous| view.rows.get(previous)).is_some_and(|previous| match column.id {
+                "host" => previous.cells[column_index].text == cell.text,
+                "repository" => {
+                    host_column.is_some_and(|host| previous.cells[host].text == row.cells[host].text)
+                        && previous.cells[column_index].text == cell.text
+                }
+                _ => false,
+            });
         if repeated {
             String::new()
         } else if column.id == "path" {
@@ -147,7 +152,7 @@ impl TablePanel {
             });
             let mut offset = 0usize;
             let cells = row.cells.iter().zip(&view.columns).enumerate().map(|(index, (cell, column))| {
-                let mut text = Self::rendered_cell_text(view, row_index, index, column_widths[index]);
+                let mut text = Self::rendered_cell_text(view, row_index, first, index, column_widths[index]);
                 if index == 0 {
                     if matches!(row_state, Some(RowState::Failed { .. })) {
                         text = format!("x {text}");
@@ -543,13 +548,21 @@ mod tests {
     #[test]
     fn checkout_line_dedup_runs_after_filtering() {
         let unfiltered = checkout_view();
-        assert_eq!(TablePanel::rendered_cell_text(&unfiltered, 1, 0, 20), "");
-        assert_eq!(TablePanel::rendered_cell_text(&unfiltered, 1, 3, 20), "");
+        assert_eq!(TablePanel::rendered_cell_text(&unfiltered, 1, 0, 0, 20), "");
+        assert_eq!(TablePanel::rendered_cell_text(&unfiltered, 1, 0, 3, 20), "");
 
         let filtered = checkout_view().filtered("feature");
         assert_eq!(filtered.rows.len(), 1);
-        assert_eq!(TablePanel::rendered_cell_text(&filtered, 0, 0, 20), "kiwi");
-        assert_eq!(TablePanel::rendered_cell_text(&filtered, 0, 3, 20), "widgets");
+        assert_eq!(TablePanel::rendered_cell_text(&filtered, 0, 0, 0, 20), "kiwi");
+        assert_eq!(TablePanel::rendered_cell_text(&filtered, 0, 0, 3, 20), "widgets");
+    }
+
+    #[test]
+    fn checkout_line_dedup_restarts_at_the_top_of_the_visible_window() {
+        let view = checkout_view();
+
+        assert_eq!(TablePanel::rendered_cell_text(&view, 1, 1, 0, 20), "kiwi");
+        assert_eq!(TablePanel::rendered_cell_text(&view, 1, 1, 3, 20), "widgets");
     }
 
     fn snapshot_view() -> TableView {

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -129,7 +129,8 @@ impl TablePanel {
             });
             let mut offset = 0usize;
             let cells = row.cells.iter().zip(&view.columns).enumerate().map(|(index, (cell, column))| {
-                let mut text = cell.text.clone();
+                let mut text =
+                    if column.id == "path" { crate::ui_helpers::middle_elide(&cell.text, column_widths[index]) } else { cell.text.clone() };
                 if index == 0 {
                     if matches!(row_state, Some(RowState::Failed { .. })) {
                         text = format!("x {text}");
@@ -173,7 +174,7 @@ impl TableWidget {
         let address = ctx.views.active_address().ok_or_else(|| "active view has no valid address".to_string())?;
         let filter = ctx.views.active_table_state().filter.clone();
         let source_search = ctx.views.active_table_state().source_search.as_deref();
-        let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
+        let rows = crate::app::table_rows(ctx.model, ctx.namespaces, ctx.query_tables, source_search);
         table_view::project(address, &rows).map(|view| view.filtered(&filter))
     }
 
@@ -222,9 +223,6 @@ impl TableWidget {
         if !state.filter.is_empty() {
             title.push_str(&format!(" · find \"{}\"", state.filter));
         }
-        if let Some(as_of) = view.meta.as_of {
-            title.push_str(&format!(" · as of {}", as_of.format("%Y-%m-%d %H:%M")));
-        }
         if view.meta.has_more {
             title.push_str(" · more available");
         }
@@ -234,7 +232,10 @@ impl TableWidget {
         if !view.meta.conditions.is_empty() {
             title.push_str(&format!(" · ⚠ {}", view.meta.conditions.join("; ")));
         }
-        let block = Block::bordered().style(theme.block_style()).title(format!(" {title} "));
+        let mut block = Block::bordered().style(theme.block_style()).title(format!(" {title} "));
+        if let Some(as_of) = view.meta.as_of {
+            block = block.title_top(Line::from(format!(" as of {} ", as_of.format("%Y-%m-%d %H:%M"))).right_aligned());
+        }
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
@@ -443,7 +444,7 @@ impl InteractiveWidget for TableWidget {
         let Some(address) = ctx.views.active_address().cloned() else { return };
         let filter = ctx.views.active_table_state().filter.clone();
         let source_search = ctx.views.active_table_state().source_search.as_deref();
-        let rows = crate::app::table_rows(ctx.namespaces, ctx.query_tables, source_search);
+        let rows = crate::app::table_rows(ctx.model, ctx.namespaces, ctx.query_tables, source_search);
         let Ok(view) = table_view::project(&address, &rows).map(|view| view.filtered(&filter)) else { return };
         let breadcrumbs = ctx.views.active().breadcrumb_addresses();
         self.render_table(frame, area, ctx.theme, &view, ctx.views.active_table_state_mut(), &breadcrumbs);


### PR DESCRIPTION
Closes #1013

## What changed

- set scoped-view terminal titles from the active tab/view label, including drill navigation
- add a visible, clickable `← Back` breadcrumb header for tab-local history
- shorten checkout paths against each host home, middle-elide long paths, and suppress repeated host/repository cells
- share section-header rendering and right-align freshness timestamps consistently
- require explicit `f` fetch-more for non-terminal project sections while preserving automatic extension for a terminal section

## Why

The composite project page worked functionally, but its pane identity and drill escape path were hard to discover, checkout rows were noisy, table headers were inconsistent, and automatic issue pagination could trap navigation before later sections.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`