### PR TITLE
feat: make convoy auto-attach presence-aware

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use flotilla_protocol::{Command, CommandAction, ConvoyStartIntent, IssueRef, IssueSelector, IssueSource};
+use flotilla_protocol::{Command, CommandAction, ConvoyAutoAttach, ConvoyStartIntent, IssueRef, IssueSelector, IssueSource};
 
 use crate::{
     quote::quote_value,
@@ -86,8 +86,11 @@ pub enum ConvoyVerb {
         #[arg(long = "placement-policy")]
         placement_policy: Option<String>,
         /// Create the convoy without attaching the caller to its first crew session
-        #[arg(long, default_value_t = false)]
+        #[arg(long, conflicts_with = "attach")]
         no_attach: bool,
+        /// Attach to the convoy's first crew session even when a presentation surface is connected
+        #[arg(long, conflicts_with = "no_attach")]
+        attach: bool,
     },
     /// Create a convoy from a workflow template
     Create {
@@ -232,6 +235,7 @@ impl ConvoyNoun {
                 instruction,
                 placement_policy,
                 no_attach,
+                attach,
             } => {
                 if self.subject.is_some() {
                     return Err("convoy start does not take a positional convoy name; use --name".to_string());
@@ -265,7 +269,12 @@ impl ConvoyNoun {
                                 inputs,
                                 instruction,
                                 placement_policy,
-                                auto_attach: !no_attach,
+                                auto_attach: match (attach, no_attach) {
+                                    (true, false) => ConvoyAutoAttach::Always,
+                                    (false, true) => ConvoyAutoAttach::Never,
+                                    (false, false) => ConvoyAutoAttach::Default,
+                                    (true, true) => unreachable!("clap rejects conflicting attach flags"),
+                                },
                             }),
                         },
                     },
@@ -292,7 +301,7 @@ impl ConvoyNoun {
                                     inputs,
                                     instruction: None,
                                     placement_policy,
-                                    auto_attach: false,
+                                    auto_attach: ConvoyAutoAttach::Never,
                                 }),
                             },
                         },
@@ -375,6 +384,7 @@ impl std::fmt::Display for ConvoyNoun {
                 instruction,
                 placement_policy,
                 no_attach,
+                attach,
             } => {
                 write!(f, " start --project {}", quote_value(project))?;
                 if let Some(issue) = issue {
@@ -407,6 +417,9 @@ impl std::fmt::Display for ConvoyNoun {
                 if *no_attach {
                     write!(f, " --no-attach")?;
                 }
+                if *attach {
+                    write!(f, " --attach")?;
+                }
             }
             ConvoyVerb::Create { template, inputs, repository_url, r#ref, project_ref, placement_policy, adopted_checkout } => {
                 write!(f, " create --template {}", quote_value(template))?;
@@ -437,7 +450,7 @@ impl std::fmt::Display for ConvoyNoun {
 #[cfg(test)]
 mod tests {
     use clap::Parser;
-    use flotilla_protocol::{Command, CommandAction, ConvoyStartIntent, IssueRef, IssueSelector, IssueSource};
+    use flotilla_protocol::{Command, CommandAction, ConvoyAutoAttach, ConvoyStartIntent, IssueRef, IssueSelector, IssueSource};
 
     use super::ConvoyNoun;
     use crate::{
@@ -608,7 +621,7 @@ mod tests {
                         inputs: vec![],
                         instruction: Some("Preserve the public API.".into()),
                         placement_policy: None,
-                        auto_attach: false,
+                        auto_attach: ConvoyAutoAttach::Never,
                     }),
                 },
             },
@@ -639,7 +652,7 @@ mod tests {
                         inputs: vec![],
                         instruction: None,
                         placement_policy: None,
-                        auto_attach: true,
+                        auto_attach: ConvoyAutoAttach::Default,
                     }),
                 },
             },
@@ -668,13 +681,31 @@ mod tests {
                         inputs: vec![],
                         instruction: None,
                         placement_policy: None,
-                        auto_attach: true,
+                        auto_attach: ConvoyAutoAttach::Default,
                     }),
                 },
             },
             repo: RepoContext::None,
             host: HostResolution::Local,
         });
+    }
+
+    #[test]
+    fn convoy_start_attach_flags_are_explicit_overrides() {
+        for (flag, expected) in [("--attach", ConvoyAutoAttach::Always), ("--no-attach", ConvoyAutoAttach::Never)] {
+            let Resolved::NeedsContext { command, .. } =
+                parse(&["convoy", "start", "--project", "flotilla", flag]).resolve().expect("resolve attach override")
+            else {
+                panic!("expected daemon command");
+            };
+            let CommandAction::ConvoyStart { intent } = command.action else { panic!("expected convoy start") };
+            assert_eq!(intent.auto_attach, expected);
+        }
+
+        assert!(
+            ConvoyNoun::try_parse_from(["convoy", "start", "--project", "flotilla", "--attach", "--no-attach"]).is_err(),
+            "opposing attach flags must conflict"
+        );
     }
 
     #[test]
@@ -769,7 +800,7 @@ mod tests {
                 inputs: Vec::new(),
                 instruction: None,
                 placement_policy: None,
-                auto_attach: false,
+                auto_attach: ConvoyAutoAttach::Never,
             }),
         });
     }

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -90,6 +90,16 @@ pub struct FlotillaConfig {
     pub presentation_manager: PresentationManagerConfig,
     #[serde(default)]
     pub terminal_pool: TerminalPoolConfig,
+    #[serde(default)]
+    pub convoy: ConvoyConfig,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ConvoyConfig {
+    /// Override presence-aware auto-attach for convoy starts without an
+    /// explicit `--attach` or `--no-attach`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_attach: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/crates/flotilla-core/src/config/tests.rs
+++ b/crates/flotilla-core/src/config/tests.rs
@@ -300,6 +300,16 @@ fn load_config_parses_full_overrides() {
 }
 
 #[test]
+fn load_config_parses_convoy_auto_attach_override() {
+    let dir = tempdir().expect("create config tempdir");
+    std::fs::write(dir.path().join("config.toml"), "[convoy]\nauto_attach = false\n").expect("write config");
+
+    let store = ConfigStore::with_base(dir.path());
+
+    assert_eq!(store.load_config().convoy.auto_attach, Some(false));
+}
+
+#[test]
 fn load_config_partial_override_keeps_defaults() {
     let dir = tempdir().unwrap();
     std::fs::write(dir.path().join("config.toml"), "[vcs.git]\ncheckout_strategy = \"worktree\"\n").unwrap();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1918,6 +1918,16 @@ impl InProcessDaemon {
         self.regard_lifecycle.principal_for_surface(surface_id)
     }
 
+    fn should_auto_attach(&self, requested: flotilla_protocol::ConvoyAutoAttach) -> bool {
+        match requested {
+            flotilla_protocol::ConvoyAutoAttach::Always => true,
+            flotilla_protocol::ConvoyAutoAttach::Never => false,
+            flotilla_protocol::ConvoyAutoAttach::Default => {
+                self.config.load_config().convoy.auto_attach.unwrap_or_else(|| !self.regard_lifecycle.has_ambient_surface())
+            }
+        }
+    }
+
     pub async fn disconnect_surface(&self, surface_id: uuid::Uuid) -> Result<(), String> {
         self.regard_lifecycle.disconnect_surface(surface_id).await
     }
@@ -2231,7 +2241,7 @@ impl InProcessDaemon {
             .workflow_spec(workflow_value)
             .maybe_placement_policy_name(placement_policy_name)
             .maybe_placement_policy_spec(placement_policy_spec)
-            .auto_attach(intent.auto_attach)
+            .auto_attach(self.should_auto_attach(intent.auto_attach))
             .build())
     }
 
@@ -3591,8 +3601,9 @@ impl InProcessDaemon {
                 message: format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"),
             };
         }
+        let auto_attach = self.should_auto_attach(intent.auto_attach);
         match self.admit_convoy_start(&namespace, &intent, &dispatching_principal_ref).await {
-            Ok(name) if intent.auto_attach => match self.wait_for_convoy_attach(&namespace, &name).await {
+            Ok(name) if auto_attach => match self.wait_for_convoy_attach(&namespace, &name).await {
                 Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
                     name,
                     attach_command: Some(resolved.command),

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -91,6 +91,50 @@ fn convoy_branch_validation_rejects_refs_that_checkout_cannot_create() {
     validate_convoy_branch("fix/issue-732").expect("normal branch should be accepted");
 }
 
+async fn daemon_for_auto_attach_config(config: Option<bool>) -> (tempfile::TempDir, Arc<InProcessDaemon>) {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"auto-attach-test\"\n").expect("write daemon config");
+    if let Some(auto_attach) = config {
+        std::fs::write(config_base.join("config.toml"), format!("[convoy]\nauto_attach = {auto_attach}\n")).expect("write flotilla config");
+    }
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), fake_discovery(false), HostName::local()).await;
+    (temp, daemon)
+}
+
+#[tokio::test]
+async fn convoy_auto_attach_default_tracks_ambient_surface_presence_and_explicit_modes_win() {
+    let (_temp, daemon) = daemon_for_auto_attach_config(None).await;
+    let tui_id = uuid::Uuid::new_v4();
+    let connector_id = uuid::Uuid::new_v4();
+
+    assert!(daemon.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Default));
+    daemon.connect_surface(tui_id, flotilla_protocol::SurfaceDeclaration::focal_for_namespace("flotilla"));
+    assert!(
+        daemon.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Default),
+        "a TUI client alone is not a presentation-manager connector"
+    );
+    daemon.connect_surface(connector_id, flotilla_protocol::SurfaceDeclaration::ambient_for_namespace("flotilla"));
+    assert!(!daemon.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Default));
+    assert!(daemon.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Always));
+    assert!(!daemon.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Never));
+
+    daemon.disconnect_surface(connector_id).await.expect("disconnect ambient connector");
+    assert!(daemon.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Default));
+}
+
+#[tokio::test]
+async fn convoy_auto_attach_config_overrides_presence_heuristic() {
+    let (_disabled_temp, disabled) = daemon_for_auto_attach_config(Some(false)).await;
+    assert!(!disabled.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Default));
+
+    let (_enabled_temp, enabled) = daemon_for_auto_attach_config(Some(true)).await;
+    enabled.connect_surface(uuid::Uuid::new_v4(), flotilla_protocol::SurfaceDeclaration::ambient_for_namespace("flotilla"));
+    assert!(enabled.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Default));
+}
+
 #[test]
 fn configured_repo_identity_prefers_repo_file_forgejo_binding() {
     let temp = tempfile::tempdir().expect("create tempdir");

--- a/crates/flotilla-core/src/regard_lifecycle.rs
+++ b/crates/flotilla-core/src/regard_lifecycle.rs
@@ -75,6 +75,16 @@ impl RegardLifecycle {
             .map(|surface| surface.declaration.principal_ref.clone()))
     }
 
+    /// Whether a headless presentation connector is currently projecting
+    /// daemon state into a presentation manager.
+    pub fn has_ambient_surface(&self) -> bool {
+        self.surfaces
+            .lock()
+            .expect("regard surfaces lock poisoned")
+            .values()
+            .any(|surface| surface.declaration.character == SurfaceCharacter::Ambient)
+    }
+
     pub async fn emit_expressed(&self, principal: &PrincipalRef, target: &ResourceRef) -> Result<(), String> {
         self.record_regard(principal, target, RegardSource::Expressed).await
     }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1012,7 +1012,7 @@ async fn bare_convoy_start_uses_the_viable_local_host_direct_policy() {
                     inputs: Vec::new(),
                     instruction: None,
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1084,7 +1084,7 @@ async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
                     inputs: Vec::new(),
                     instruction: None,
                     placement_policy: Some("docker-test".into()),
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1215,7 +1215,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                     inputs: vec![("review".into(), "required".into())],
                     instruction: Some("Keep the snapshot durable.".into()),
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1274,7 +1274,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                     inputs: Vec::new(),
                     instruction: Some("Fix both issues in one convoy.".into()),
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1313,7 +1313,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                     inputs: Vec::new(),
                     instruction: None,
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1366,7 +1366,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                     inputs: Vec::new(),
                     instruction: None,
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1401,7 +1401,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                     inputs: Vec::new(),
                     instruction: None,
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1440,7 +1440,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                     inputs: Vec::new(),
                     instruction: None,
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1516,7 +1516,7 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
                     inputs: Vec::new(),
                     instruction: Some("Implement the admission snapshot.".into()),
                     placement_policy: None,
-                    auto_attach: false,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                 }),
             },
         })
@@ -1568,7 +1568,7 @@ async fn convoy_start_acknowledges_while_admission_is_in_flight() {
                             inputs: Vec::new(),
                             instruction: None,
                             placement_policy: None,
-                            auto_attach: false,
+                            auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                         }),
                     },
                 })
@@ -1632,7 +1632,7 @@ async fn convoy_start_rejects_the_same_project_start_while_admission_is_in_fligh
                 inputs: Vec::new(),
                 instruction: Some("Implement issue 782".into()),
                 placement_policy: None,
-                auto_attach: false,
+                auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
             }),
         },
     };
@@ -1682,7 +1682,14 @@ async fn convoy_start_worker_panic_finishes_the_command_and_allows_retry() {
         node_id: None,
         provisioning_target: None,
         context_repo: None,
-        action: CommandAction::ConvoyStart { intent: Box::new(ConvoyStartIntent::builder().project_ref("flotilla".to_string()).build()) },
+        action: CommandAction::ConvoyStart {
+            intent: Box::new(
+                ConvoyStartIntent::builder()
+                    .project_ref("flotilla".to_string())
+                    .auto_attach(flotilla_protocol::ConvoyAutoAttach::Never)
+                    .build(),
+            ),
+        },
     };
     let mut events = daemon.subscribe();
 
@@ -1719,7 +1726,7 @@ async fn convoy_start_reports_failed_work_without_waiting_for_auto_attach_timeou
                     inputs: Vec::new(),
                     instruction: None,
                     placement_policy: None,
-                    auto_attach: true,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Always,
                 }),
             },
         })

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1070,6 +1070,7 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
                     .name("remote-work".to_string())
                     .branch("feat/remote-work".to_string())
                     .placement_policy(remote_policy_name.clone())
+                    .auto_attach(flotilla_protocol::ConvoyAutoAttach::Never)
                     .build(),
             ),
         })

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -505,6 +505,7 @@ async fn convoy_start_uses_live_peer_route_when_presentation_membership_is_stale
                         .name("remote-work".to_string())
                         .branch("fix/remote-work".to_string())
                         .placement_policy(placement_policy)
+                        .auto_attach(flotilla_protocol::ConvoyAutoAttach::Never)
                         .build(),
                 ),
             },

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -135,6 +135,19 @@ pub enum IssueSelector {
 ///
 /// This type lives in protocol rather than resources because incomplete
 /// intent must never enter the resource store.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvoyAutoAttach {
+    /// Let the dispatching daemon choose from configuration and connected
+    /// presentation-surface presence.
+    #[default]
+    Default,
+    /// Attach even when a presentation surface is connected.
+    Always,
+    /// Leave the convoy latent even when no presentation surface is connected.
+    Never,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoyStartIntent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -158,7 +171,7 @@ pub struct ConvoyStartIntent {
     pub placement_policy: Option<String>,
     #[builder(default)]
     #[serde(default)]
-    pub auto_attach: bool,
+    pub auto_attach: ConvoyAutoAttach,
 }
 
 /// A convoy launch admitted by the presentation host and ready to be

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -107,8 +107,8 @@ pub(crate) mod test_helpers {
 }
 
 pub use commands::{
-    AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyStartIntent,
-    IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand,
+    AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyAutoAttach,
+    ConvoyStartIntent, IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand,
     ResourceJsonResponse, ResourceWatchCursor, ResourceWatchResponse, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -482,7 +482,7 @@ impl App {
                         inputs: Vec::new(),
                         instruction: None,
                         placement_policy: None,
-                        auto_attach: true,
+                        auto_attach: flotilla_protocol::ConvoyAutoAttach::Default,
                     }),
                 }));
                 return;
@@ -502,7 +502,7 @@ impl App {
                             inputs: Vec::new(),
                             instruction: None,
                             placement_policy: None,
-                            auto_attach: false,
+                            auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
                         }),
                     });
                     let pending_ctx = PendingActionContext::project_issue_start(
@@ -537,7 +537,7 @@ impl App {
                         inputs: Vec::new(),
                         instruction: None,
                         placement_policy: None,
-                        auto_attach: true,
+                        auto_attach: flotilla_protocol::ConvoyAutoAttach::Default,
                     }),
                 }));
                 if let Some(index) = self.views.find(&address) {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2393,7 +2393,10 @@ fn project_issue_bulk_start_queues_one_convoy_start_per_issue() {
 
     assert_eq!(queued.len(), 3);
     assert_eq!(queued.iter().map(|(_, id, _)| id.as_str()).collect::<Vec<_>>(), vec!["809", "810", "811"]);
-    assert!(queued.iter().all(|(_, _, auto_attach)| !auto_attach), "bulk convoy starts should not auto-attach one selected issue");
+    assert!(
+        queued.iter().all(|(_, _, auto_attach)| *auto_attach == flotilla_protocol::ConvoyAutoAttach::Never),
+        "bulk convoy starts should not auto-attach one selected issue"
+    );
     assert_eq!(app.model.status_message.as_deref(), Some("Starting 3 convoys..."));
 }
 
@@ -2432,7 +2435,11 @@ fn project_issue_batch_start_queues_one_convoy_for_all_issues() {
             .collect::<Vec<_>>(),
         vec!["809", "810", "811"]
     );
-    assert!(intent.auto_attach, "batch convoy start should auto-attach the single created convoy");
+    assert_eq!(
+        intent.auto_attach,
+        flotilla_protocol::ConvoyAutoAttach::Default,
+        "batch convoy start should use the presence-aware attach default"
+    );
     assert_eq!(app.model.status_message.as_deref(), Some("Starting batch convoy for 3 issues..."));
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,20 @@ Stored in `~/.config/flotilla/`:
 
 Repos are added interactively from within flotilla using the `a` key.
 
+## Convoy start attachment
+
+By default, `flotilla convoy start` attaches to the new convoy only when the
+daemon has no presentation-manager connector (`flotilla pm connect`) connected.
+`--attach` and `--no-attach` always override that heuristic.
+
+To override the default for every convoy start that omits those flags, set
+`auto_attach` in `~/.config/flotilla/config.toml`:
+
+```toml
+[convoy]
+auto_attach = false
+```
+
 ## Dependencies
 
 Flotilla auto-detects available tools. Nothing is strictly required beyond git, but more tools unlock more features.


### PR DESCRIPTION
Closes #1009

## What changed

- represent convoy-start attachment as a tri-state default/always/never intent
- resolve the default on the dispatching daemon from connected ambient presentation surfaces
- keep `--attach` and `--no-attach` decisive regardless of connector presence
- make the TUI start-convoy flows use the same presence-aware default
- add a global `[convoy] auto_attach = true|false` override and document it

## Why

A connected `flotilla pm connect` session already provides convoy visibility, so opening a multiplexer tab automatically is disruptive. Without that connector, auto-attach remains the only immediate visibility and stays enabled.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`