### PR TITLE
fix: surface codex workspace trust prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "toml_edit 0.22.27",
  "tracing",
  "urlencoding",
  "uuid",

--- a/crates/flotilla-core/Cargo.toml
+++ b/crates/flotilla-core/Cargo.toml
@@ -24,6 +24,7 @@ indexmap = { workspace = true }
 color-eyre = { workspace = true }
 dirs = "6"
 toml = "0.8"
+toml_edit = "0.22"
 reqwest = { workspace = true, features = ["charset", "http2", "json", "system-proxy"] }
 http = "1"
 bytes = "1"

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -6,8 +6,10 @@ use std::{
 
 use async_trait::async_trait;
 use flotilla_protocol::arg::{flatten, Arg};
-use flotilla_resources::TerminalBrief;
+use flotilla_resources::{TerminalAttentionState, TerminalBrief};
 use serde::Serialize;
+use tokio::sync::Mutex;
+use toml_edit::{value, DocumentMut, Item, Table};
 
 use crate::{
     path_context::ExecutionEnvironmentPath,
@@ -321,6 +323,9 @@ pub trait AgentAdapter: Send + Sync {
     fn deliver_brief(&self, brief: &TerminalBrief) -> String {
         format!("Read your crew brief at {} and follow it.", brief.path)
     }
+    fn classify_screen_attention(&self, _screen: &str) -> Option<TerminalAttentionState> {
+        None
+    }
     fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String>;
 }
 
@@ -329,6 +334,13 @@ struct CliAgentAdapter {
     binary: String,
     runner: Arc<dyn CommandRunner>,
     autonomy_args: &'static [&'static str],
+    trust_config: Option<CodexTrustConfig>,
+}
+
+#[derive(Clone)]
+struct CodexTrustConfig {
+    path: PathBuf,
+    lock: Arc<Mutex<()>>,
 }
 
 impl CliAgentAdapter {
@@ -350,6 +362,13 @@ impl AgentAdapter for CliAgentAdapter {
     }
 
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
+        if self.id == "codex" {
+            let config = self
+                .trust_config
+                .as_ref()
+                .ok_or_else(|| "cannot determine Codex config path because neither CODEX_HOME nor HOME was detected".to_string())?;
+            seed_codex_workspace_trust(&*self.runner, cwd.as_path(), config).await?;
+        }
         self.runner.write_file(&cwd.as_path().join(&brief.path), &brief.content).await?;
         ensure_flotilla_git_exclude(&*self.runner, cwd.as_path()).await
     }
@@ -358,9 +377,54 @@ impl AgentAdapter for CliAgentAdapter {
         remove_agent_brief(&*self.runner, cwd.as_path(), brief).await
     }
 
+    fn classify_screen_attention(&self, screen: &str) -> Option<TerminalAttentionState> {
+        (self.id == "codex" && codex_screen_needs_input(screen)).then_some(TerminalAttentionState::NeedsInput)
+    }
+
     fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String> {
         Ok(AgentLaunchPlan { command: self.command(request), env: Vec::new(), stance: TRUSTED_IMPLICIT_STANCE.into() })
     }
+}
+
+fn codex_screen_needs_input(screen: &str) -> bool {
+    let approval_prompt = [
+        "Do you trust the contents of this directory?",
+        "Would you like to run the following command?",
+        "Do you want to approve network access to ",
+        "Would you like to grant these permissions?",
+        "Would you like to make the following edits?",
+        " needs your approval.",
+    ]
+    .iter()
+    .any(|prompt| screen.contains(prompt));
+    let user_question = screen.contains("Question ") && (screen.contains(" to submit answer") || screen.contains(" to submit all"));
+    approval_prompt || user_question
+}
+
+async fn seed_codex_workspace_trust(runner: &dyn CommandRunner, cwd: &Path, config: &CodexTrustConfig) -> Result<(), String> {
+    let _guard = config.lock.lock().await;
+    let canonical_cwd = match runner.run_output("pwd", &["-P"], cwd, &ChannelLabel::Noop).await {
+        Ok(output) if output.success && !output.stdout.trim().is_empty() => output.stdout.trim().to_string(),
+        _ => cwd.display().to_string(),
+    };
+    let source = runner.ensure_file(&config.path, "").await?;
+    let mut document = source.parse::<DocumentMut>().map_err(|error| format!("parse Codex config {}: {error}", config.path.display()))?;
+    let projects = document
+        .as_table_mut()
+        .entry("projects")
+        .or_insert_with(|| Item::Table(Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| format!("Codex config {} has a non-table `projects` value", config.path.display()))?;
+    let project = projects
+        .entry(&canonical_cwd)
+        .or_insert_with(|| Item::Table(Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| format!("Codex config {} has a non-table project entry for {canonical_cwd}", config.path.display()))?;
+    if project.get("trust_level").and_then(Item::as_str) == Some("trusted") {
+        return Ok(());
+    }
+    project["trust_level"] = value("trusted");
+    runner.write_file(&config.path, &document.to_string()).await
 }
 
 async fn ensure_flotilla_git_exclude(runner: &dyn CommandRunner, cwd: &Path) -> Result<(), String> {
@@ -413,14 +477,21 @@ impl AgentAdapterRegistry {
                 binary: binary.as_path().display().to_string(),
                 runner: Arc::clone(&runner),
                 autonomy_args: &["--dangerously-skip-permissions"],
+                trust_config: None,
             }));
         }
         if let Some(binary) = env.find_binary("codex") {
+            let config_path = env
+                .find_env_var("CODEX_HOME")
+                .map(PathBuf::from)
+                .or_else(|| env.find_env_var("HOME").map(|home| PathBuf::from(home).join(".codex")))
+                .map(|home| home.join("config.toml"));
             registry.insert(Arc::new(CliAgentAdapter {
                 id: "codex",
                 binary: binary.as_path().display().to_string(),
                 runner,
                 autonomy_args: &["--dangerously-bypass-approvals-and-sandbox"],
+                trust_config: config_path.map(|path| CodexTrustConfig { path, lock: Arc::new(Mutex::new(())) }),
             }));
         }
         registry
@@ -447,8 +518,9 @@ mod tests {
     use flotilla_protocol::{IssueRef, IssueSource, IssueState};
     use flotilla_resources::{
         single_agent_contained_workflow_spec, Convoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, CrewSource, IssueSnapshot, ObjectMeta,
-        RepositoryKey, ResourceObject, TerminalCrewContext,
+        RepositoryKey, ResourceObject, TerminalAttentionState, TerminalCrewContext,
     };
+    use toml_edit::DocumentMut;
 
     use crate::{
         agent_adapter::{
@@ -465,9 +537,13 @@ mod tests {
 
     fn discovered_registry() -> AgentAdapterRegistry {
         let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("HOME", "/home/test"))
             .with(EnvironmentAssertion::binary("claude", "/tools/claude"))
             .with(EnvironmentAssertion::binary("codex", "/tools/codex"));
-        AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(vec![Ok(".git/info/exclude\n".into()), Ok(String::new())])))
+        AgentAdapterRegistry::discover(
+            &env,
+            Arc::new(MockRunner::new(vec![Ok("/workspace\n".into()), Ok(".git/info/exclude\n".into()), Ok(String::new())])),
+        )
     }
 
     #[test]
@@ -796,6 +872,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_prepare_preserves_config_while_trusting_the_canonical_workspace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let codex_home = temp.path().join("codex-home");
+        std::fs::create_dir_all(&codex_home).expect("codex home");
+        std::fs::write(
+            codex_home.join("config.toml"),
+            "# keep this comment\nmodel = \"gpt-5.6-sol\"\n\n[projects.\"/existing\"]\ntrust_level = \"trusted\"\n",
+        )
+        .expect("initial Codex config");
+        let workspace = temp.path().join(r#"quote"and\slash"#);
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("CODEX_HOME", codex_home.display().to_string()))
+            .with(EnvironmentAssertion::binary("codex", "/tools/codex"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
+        let codex = registry.get("codex").expect("codex adapter");
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: String::new(), copies: Vec::new() };
+        codex.prepare(&ExecutionEnvironmentPath::new(&workspace), &brief).await.expect("prepare Codex workspace");
+
+        let config = std::fs::read_to_string(codex_home.join("config.toml")).expect("Codex config");
+        assert!(config.contains("# keep this comment"));
+        let parsed = config.parse::<DocumentMut>().expect("parse updated Codex config");
+        let canonical_workspace = workspace.canonicalize().expect("canonical workspace").display().to_string();
+        assert_eq!(parsed["model"].as_str(), Some("gpt-5.6-sol"));
+        assert_eq!(parsed["projects"]["/existing"]["trust_level"].as_str(), Some("trusted"));
+        assert_eq!(parsed["projects"][&canonical_workspace]["trust_level"].as_str(), Some("trusted"));
+    }
+
+    #[test]
+    fn codex_classifies_interactive_trust_and_approval_prompts_as_needing_input() {
+        let registry = discovered_registry();
+        let codex = registry.get("codex").expect("codex adapter");
+
+        for screen in [
+            "Do you trust the contents of this directory?\n› 1. Yes, continue\n  2. No, quit\n\nPress enter to continue",
+            "Would you like to run the following command?\n\n$ cargo test\n\n› 1. Yes, proceed\n  2. No, tell Codex what to do differently",
+            "Do you want to approve network access to \"github.com\"?\n\n› 1. Approve once\n  2. Deny",
+            "Would you like to grant these permissions?\n\n› 1. Yes\n  2. No",
+            "Would you like to make the following edits?\n\n› 1. Yes\n  2. No",
+            "github needs your approval.\n\n› 1. Approve\n  2. Deny",
+            "Question 1/2 (2 unanswered)\n\nWhich environment?\n\n› 1. Staging\n  2. Production\n\nenter to submit answer",
+        ] {
+            assert_eq!(codex.classify_screen_attention(screen), Some(TerminalAttentionState::NeedsInput), "{screen}");
+        }
+    }
+
+    #[test]
+    fn codex_does_not_treat_its_normal_composer_as_an_interactive_prompt() {
+        let registry = discovered_registry();
+        let codex = registry.get("codex").expect("codex adapter");
+        let screen = "• Working (57s • esc to interrupt)\n\n› Run /review on my current changes\n\ngpt-5.6-sol high · /workspace";
+
+        assert_eq!(codex.classify_screen_attention(screen), None);
+    }
+
+    #[tokio::test]
     async fn prepare_excludes_flotilla_brief_from_git_status() {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
@@ -826,7 +959,9 @@ mod tests {
             .expect("git commit")
             .success());
 
-        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("codex", "/tools/codex"));
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("CODEX_HOME", temp.path().join("codex-home").display().to_string()))
+            .with(EnvironmentAssertion::binary("codex", "/tools/codex"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
         let brief = flotilla_resources::TerminalBrief {
             path: ".flotilla/briefs/coder.md".into(),

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -403,10 +403,17 @@ fn codex_screen_needs_input(screen: &str) -> bool {
 
 async fn seed_codex_workspace_trust(runner: &dyn CommandRunner, cwd: &Path, config: &CodexTrustConfig) -> Result<(), String> {
     let _guard = config.lock.lock().await;
-    let canonical_cwd = match runner.run_output("pwd", &["-P"], cwd, &ChannelLabel::Noop).await {
-        Ok(output) if output.success && !output.stdout.trim().is_empty() => output.stdout.trim().to_string(),
-        _ => cwd.display().to_string(),
-    };
+    let output = runner
+        .run_output("pwd", &["-P"], cwd, &ChannelLabel::Noop)
+        .await
+        .map_err(|error| format!("resolve canonical Codex workspace {}: {error}", cwd.display()))?;
+    if !output.success {
+        return Err(format!("resolve canonical Codex workspace {}: {}", cwd.display(), output.stderr.trim()));
+    }
+    let canonical_cwd = output.stdout.trim();
+    if canonical_cwd.is_empty() {
+        return Err(format!("resolve canonical Codex workspace {}: `pwd -P` returned an empty path", cwd.display()));
+    }
     let source = runner.ensure_file(&config.path, "").await?;
     let mut document = source.parse::<DocumentMut>().map_err(|error| format!("parse Codex config {}: {error}", config.path.display()))?;
     let projects = document
@@ -416,7 +423,7 @@ async fn seed_codex_workspace_trust(runner: &dyn CommandRunner, cwd: &Path, conf
         .as_table_mut()
         .ok_or_else(|| format!("Codex config {} has a non-table `projects` value", config.path.display()))?;
     let project = projects
-        .entry(&canonical_cwd)
+        .entry(canonical_cwd)
         .or_insert_with(|| Item::Table(Table::new()))
         .as_table_mut()
         .ok_or_else(|| format!("Codex config {} has a non-table project entry for {canonical_cwd}", config.path.display()))?;

--- a/crates/flotilla-core/src/providers/discovery/detectors/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/mod.rs
@@ -15,6 +15,8 @@ pub fn default_host_detectors() -> Vec<Box<dyn HostDetector>> {
         Box::new(claude::ClaudeDetector),
         Box::new(codex::CodexAuthDetector),
         Box::new(CommandDetector::new("codex", &["--version"], parse_first_dotted_version)),
+        Box::new(EnvVarDetector::new("HOME")),
+        Box::new(EnvVarDetector::new("CODEX_HOME")),
         Box::new(EnvVarDetector::new("ANTHROPIC_API_KEY")),
         Box::new(EnvVarDetector::new("CURSOR_API_KEY")),
         Box::new(CommandDetector::new("agent", &["--version"], parse_first_dotted_version)),
@@ -117,10 +119,19 @@ mod tests {
             .on_run("codex", &["--version"], Ok("codex-cli 0.5.0\n".into()))
             .on_run("claude", &["--version"], Ok("1.0.0 (Claude Code)\n".into()))
             .build();
-        let bag = run_host_detectors(&default_host_detectors(), &runner, &TestEnvVars::default()).await;
+        let bag = run_host_detectors(&default_host_detectors(), &runner, &TestEnvVars::new([("HOME", "/mock/home")])).await;
 
         assert!(bag.find_binary("codex").is_some(), "codex binary must be detected for its agent adapter to register");
+        assert_eq!(bag.find_env_var("HOME"), Some("/mock/home"), "Codex config discovery needs the detected home directory");
         let adapters = crate::agent_adapter::AgentAdapterRegistry::discover(&bag, Arc::new(runner));
-        assert!(adapters.get("codex").is_some(), "codex agent adapter should register when the binary is present");
+        let codex = adapters.get("codex").expect("codex agent adapter should register when the binary is present");
+        codex
+            .prepare(&crate::path_context::ExecutionEnvironmentPath::new("/workspace"), &flotilla_resources::TerminalBrief {
+                path: ".flotilla/briefs/coder.md".into(),
+                content: "Implement the issue.".into(),
+                copies: Vec::new(),
+            })
+            .await
+            .expect("production-shaped discovery should supply Codex config location");
     }
 }

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -793,6 +793,7 @@ pub struct FakeTerminalPool {
     pub killed: Arc<TokioMutex<Vec<String>>>,
     pub delivered: Arc<TokioMutex<Vec<(String, String, bool)>>>,
     pub ensured: Arc<TokioMutex<Vec<EnsuredTerminalSession>>>,
+    pub captured_screens: Arc<TokioMutex<HashMap<String, String>>>,
 }
 
 pub struct EnsuredTerminalSession {
@@ -815,6 +816,7 @@ impl FakeTerminalPool {
             killed: Arc::new(TokioMutex::new(Vec::new())),
             delivered: Arc::new(TokioMutex::new(Vec::new())),
             ensured: Arc::new(TokioMutex::new(Vec::new())),
+            captured_screens: Arc::new(TokioMutex::new(HashMap::new())),
         }
     }
 
@@ -824,6 +826,10 @@ impl FakeTerminalPool {
 
     pub async fn remove_session(&self, session_name: &str) {
         self.sessions.lock().await.retain(|session| session.session_name != session_name);
+    }
+
+    pub async fn set_captured_screen(&self, session_name: &str, screen: &str) {
+        self.captured_screens.lock().await.insert(session_name.to_string(), screen.to_string());
     }
 }
 
@@ -879,6 +885,10 @@ impl TerminalPool for FakeTerminalPool {
         self.killed.lock().await.push(session_name.to_string());
         self.sessions.lock().await.retain(|session| session.session_name != session_name);
         Ok(())
+    }
+
+    async fn capture_screen(&self, session_name: &str) -> Result<Option<String>, String> {
+        Ok(self.captured_screens.lock().await.get(session_name).cloned())
     }
 
     async fn deliver(&self, session_name: &str, text: &str, submit: bool) -> Result<(), String> {

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -242,6 +242,9 @@ impl EnvVars for TestEnvVars {
 impl CommandRunner for DiscoveryMockRunner {
     async fn run(&self, cmd: &str, args: &[&str], cwd: &Path, _label: &ChannelLabel) -> Result<String, String> {
         self.seen_cwds.lock().expect("lock poisoned").push(cwd.to_path_buf());
+        if cmd == "pwd" && args == ["-P"] {
+            return Ok(format!("{}\n", cwd.display()));
+        }
         let key = (cmd.to_string(), args.join(" "));
         let mut map = self.responses.lock().expect("lock poisoned");
         if let Some(queue) = map.get_mut(&key) {

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -141,6 +141,10 @@ impl TerminalPool for CleatTerminalPool {
         Ok(())
     }
 
+    async fn capture_screen(&self, session_name: &str) -> Result<Option<String>, String> {
+        run!(self.runner, &self.binary, &["capture", session_name], Path::new("/")).map(Some)
+    }
+
     async fn deliver(&self, session_name: &str, text: &str, submit: bool) -> Result<(), String> {
         let mut args = vec!["send", session_name, text];
         if submit {
@@ -182,6 +186,18 @@ mod tests {
         assert!(sessions[1].command.is_none());
         assert_eq!(sessions[1].working_directory.as_ref().map(|p| p.as_path()), Some(Path::new("/other")));
         assert_eq!(sessions[1].screen_activity, Some(ScreenActivity::Stable));
+    }
+
+    #[tokio::test]
+    async fn capture_screen_reads_the_rendered_terminal() {
+        let runner = Arc::new(MockRunner::new(vec![Ok("Do you trust the contents of this directory?\n".into())]));
+        let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
+
+        assert_eq!(
+            pool.capture_screen("terminal-demo-work-coder").await.expect("capture screen").as_deref(),
+            Some("Do you trust the contents of this directory?\n")
+        );
+        assert_eq!(runner.calls()[0], ("cleat".to_string(), vec!["capture".to_string(), "terminal-demo-work-coder".to_string()]));
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/providers/terminal/mod.rs
+++ b/crates/flotilla-core/src/providers/terminal/mod.rs
@@ -125,6 +125,13 @@ pub trait TerminalPool: Send + Sync {
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String>;
 
+    /// Capture the currently rendered terminal screen when the pool has a
+    /// functional VT engine. This is level-triggered observation for prompts
+    /// that do not emit a harness hook event.
+    async fn capture_screen(&self, _session_name: &str) -> Result<Option<String>, String> {
+        Ok(None)
+    }
+
     /// Deliver text to a running session. This trait grows only for concrete
     /// flotilla consumers; it is not intended to mirror a pool backend's API.
     async fn deliver(&self, _session_name: &str, _text: &str, _submit: bool) -> Result<(), String> {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1357,6 +1357,29 @@ impl TerminalRuntime for TerminalControllerRuntime {
             return Ok(None);
         };
         let Some(activity) = session.screen_activity else { return Ok(None) };
+        if activity == ScreenActivity::Stable {
+            if let TerminalSessionSource::Agent { selector, .. } = &spec.source {
+                let requirement = CapabilityTable::seeded().resolve(&selector.capability)?.clone();
+                let registry = self.registry_for_env(&spec.env_ref)?;
+                let adapter = registry
+                    .agent_adapters
+                    .get(&requirement.adapter)
+                    .ok_or_else(|| format!("agent adapter {} unavailable for environment {}", requirement.adapter, spec.env_ref))?;
+                match pool.capture_screen(session_id).await {
+                    Ok(Some(screen))
+                        if adapter.classify_screen_attention(&screen) == Some(flotilla_resources::TerminalAttentionState::NeedsInput) =>
+                    {
+                        return Ok(Some(flotilla_resources::TerminalAttention {
+                            state: flotilla_resources::TerminalAttentionState::NeedsInput,
+                            as_of: Utc::now(),
+                            source: flotilla_resources::TerminalAttentionSource::Screen,
+                        }));
+                    }
+                    Ok(_) => {}
+                    Err(error) => tracing::debug!(%session_id, %error, "could not capture terminal screen for attention observation"),
+                }
+            }
+        }
         let state = match activity {
             ScreenActivity::Active => flotilla_resources::TerminalAttentionState::Working,
             ScreenActivity::Stable => flotilla_resources::TerminalAttentionState::Idle,
@@ -1497,8 +1520,9 @@ mod tests {
     use flotilla_resources::{
         Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
         CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
-        ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, RepositorySpec, Selector, SqliteBackend, TerminalSession,
-        TerminalSessionPhase, TypedResolver, VesselRequirement, WorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+        ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, RepositorySpec, Selector, SqliteBackend,
+        TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WorkPhase, WorkflowTemplate,
+        WorkflowTemplateSpec,
     };
     use tempfile::TempDir;
 
@@ -2085,6 +2109,7 @@ mod tests {
 
     async fn crew_daemon_with_process_runner(config: Arc<ConfigStore>) -> (Arc<InProcessDaemon>, Arc<FakeTerminalPool>) {
         let pool = Arc::new(FakeTerminalPool::new());
+        let codex_home = config.base_path().join("codex-home");
         let mut discovery = fake_discovery_with_provider_set(
             FakeDiscoveryProviders::new()
                 .with_terminal_pool(Arc::clone(&pool) as Arc<dyn flotilla_core::providers::terminal::TerminalPool>),
@@ -2095,6 +2120,7 @@ mod tests {
             .replace_local_environment_bag_for_test(
                 EnvironmentBag::new()
                     .with(EnvironmentAssertion::env_var("HOME", "/Users/tester"))
+                    .with(EnvironmentAssertion::env_var("CODEX_HOME", codex_home.to_string()))
                     .with(EnvironmentAssertion::binary("git", "/usr/bin/git"))
                     .with(EnvironmentAssertion::binary("codex", "/tools/codex"))
                     .with(EnvironmentAssertion::binary("claude", "/tools/claude")),
@@ -2647,6 +2673,71 @@ mod tests {
         runtime.kill_session(session_name, &spec).await.expect("teardown should resolve the persisted session pool");
 
         assert_eq!(pool.killed.lock().await.as_slice(), &[session_name.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn codex_interactive_prompt_is_observed_as_needing_input() {
+        let temp = TempDir::new().expect("tempdir");
+        let config_path = temp.path().join("config");
+        std::fs::create_dir_all(&config_path).expect("config dir");
+        std::fs::write(config_path.join("daemon.toml"), "machine_id = \"dinghy-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_path));
+        let (daemon, pool) = crew_daemon(Arc::clone(&config)).await;
+        let local_registry = probe_local_provider_registry(&daemon, &config).await.expect("crew provider registry");
+        let profile = build_local_profile(&daemon, &local_registry).expect("local profile");
+        let runtime = TerminalControllerRuntime {
+            state: Arc::new(ControllerRuntimeState::new(
+                Arc::clone(&daemon),
+                config,
+                local_registry,
+                None,
+                profile.host_id.clone(),
+                None,
+                profile.host_direct_environment_name(),
+            )),
+        };
+        let session_name = "terminal-demo-work-coder";
+        pool.add_sessions(vec![flotilla_core::providers::terminal::TerminalSession {
+            session_name: session_name.to_string(),
+            status: TerminalStatus::Running,
+            command: Some("codex".to_string()),
+            working_directory: Some(ExecutionEnvironmentPath::new("/workspace")),
+            screen_activity: Some(ScreenActivity::Stable),
+        }])
+        .await;
+        pool.set_captured_screen(
+            session_name,
+            "Do you trust the contents of this directory?\n› 1. Yes, continue\n  2. No, quit\n\nPress enter to continue",
+        )
+        .await;
+        let spec = flotilla_resources::TerminalSessionSpec {
+            env_ref: profile.host_direct_environment_name(),
+            role: "coder".to_string(),
+            source: TerminalSessionSource::Agent {
+                selector: Selector { capability: "coding".to_string() },
+                brief: flotilla_resources::TerminalBrief {
+                    path: ".flotilla/briefs/coder.md".to_string(),
+                    content: "Implement the issue.".to_string(),
+                    copies: Vec::new(),
+                },
+                context: flotilla_resources::TerminalCrewContext {
+                    namespace: NAMESPACE.to_string(),
+                    convoy: "demo".to_string(),
+                    vessel_ref: "demo-work".to_string(),
+                },
+                message: None,
+            },
+            cwd: "/workspace".to_string(),
+            pool: "fake-terminals".to_string(),
+        };
+
+        let attention = runtime.observe_attention(session_name, &spec).await.expect("observe prompt").expect("attention observation");
+        assert_eq!(attention.state, TerminalAttentionState::NeedsInput);
+
+        pool.set_captured_screen(session_name, "› Ask Codex to do something\n\ngpt-5.6-sol high · /workspace").await;
+        let attention =
+            runtime.observe_attention(session_name, &spec).await.expect("observe normal composer").expect("attention observation");
+        assert_eq!(attention.state, TerminalAttentionState::Idle);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- pre-seed the canonical workspace path as trusted in Codex config before launching crew agents
- capture stable cleat screens and classify current Codex trust, approval, permission, edit, network, and question prompts as NeedsInput
- preserve existing Codex config formatting/comments and cover live attention observation with regression tests

## Testing

- `cargo +nightly-2026-03-12 fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1002