### PR TITLE
fix: emit empty projects in awareness

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -116,6 +116,12 @@ struct SalienceProjection {
     revision: u64,
 }
 
+#[derive(Debug, Default)]
+struct ProjectCatalogProjection {
+    projects: HashMap<QueryScope, Vec<RepositoryKey>>,
+    revision: u64,
+}
+
 #[derive(Debug, Default, Clone, bon::Builder)]
 pub struct AggregatorProjectionState {
     convoys: Arc<RwLock<QueryProjection<ConvoyRow>>>,
@@ -125,6 +131,8 @@ pub struct AggregatorProjectionState {
     checkouts: Arc<RwLock<ScopedCheckoutProjection>>,
     #[builder(skip)]
     salience: Arc<RwLock<SalienceProjection>>,
+    #[builder(skip)]
+    project_catalog: Arc<RwLock<ProjectCatalogProjection>>,
     /// Subscriber ownership and demand-backed materializations belong to the
     /// Aggregator state, shared with the daemon's subscription transport.
     demand_backed: QueryRegistry,
@@ -169,10 +177,17 @@ impl AggregatorProjectionState {
         repositories: HashMap<RepositoryKey, String>,
         projects: HashMap<QueryScope, Vec<RepositoryKey>>,
     ) -> Vec<ResultDelta> {
+        let project_scopes = {
+            let mut catalog = self.project_catalog.write().await;
+            if catalog.projects != projects {
+                catalog.projects = projects.clone();
+                catalog.revision = catalog.revision.saturating_add(1);
+            }
+            sorted_project_scopes(&catalog.projects)
+        };
         let mut deltas = self.independents.write().await.replace_catalog(repositories.clone(), projects.clone());
         deltas.extend(self.checkouts.write().await.replace_catalog(repositories, projects));
-        let scopes = self.checkouts.read().await.project_scopes();
-        self.demand_backed.replace_fleet_awareness_scopes(&scopes);
+        self.demand_backed.replace_fleet_awareness_scopes(&project_scopes);
         deltas
     }
 
@@ -276,6 +291,14 @@ impl AggregatorProjectionState {
     }
 
     pub async fn awareness_result_set(&self, scope: &Option<QueryScope>, grouping: AwarenessGrouping, limit: AwarenessLimit) -> ResultSet {
+        let (projects, project_catalog_revision) = {
+            let catalog = self.project_catalog.read().await;
+            let projects = sorted_project_scopes(&catalog.projects)
+                .into_iter()
+                .filter(|project| scope.as_ref().is_none_or(|scope| project == scope))
+                .collect::<Vec<_>>();
+            (projects, catalog.revision)
+        };
         let convoys = {
             let set = self.result_set().await;
             let rows = match set.rows {
@@ -305,11 +328,12 @@ impl AggregatorProjectionState {
                 .into_iter()
                 .max()
                 .unwrap_or(0);
-        let seq = base_seq.saturating_add(salience_revision);
+        let seq = base_seq.saturating_add(project_catalog_revision).saturating_add(salience_revision);
         let (rows, state) = project_awareness(AwarenessInput {
             scope: scope.clone(),
             grouping,
             limit,
+            projects,
             convoys,
             issues,
             checkouts,
@@ -323,7 +347,7 @@ impl AggregatorProjectionState {
     async fn issue_sets_for_awareness(&self, scope: &Option<QueryScope>) -> Vec<(QueryScope, ResultSet)> {
         let scopes = match scope {
             Some(scope) => vec![scope.clone()],
-            None => self.checkouts.read().await.project_scopes(),
+            None => sorted_project_scopes(&self.project_catalog.read().await.projects),
         };
         scopes
             .into_iter()
@@ -334,6 +358,12 @@ impl AggregatorProjectionState {
             })
             .collect()
     }
+}
+
+fn sorted_project_scopes(projects: &HashMap<QueryScope, Vec<RepositoryKey>>) -> Vec<QueryScope> {
+    let mut scopes = projects.keys().cloned().collect::<Vec<_>>();
+    scopes.sort_by(|left, right| (&left.namespace, &left.name).cmp(&(&right.namespace, &right.name)));
+    scopes
 }
 
 fn convoy_phase_represents_issues(phase: ConvoyPhase) -> bool {
@@ -491,6 +521,46 @@ mod tests {
                 && node.scope.as_ref() == Some(&project)
                 && node.entries.iter().any(|entry| entry.kind == AwarenessKind::Issue)
         }));
+    }
+
+    #[tokio::test]
+    async fn fleet_awareness_emits_every_catalogued_project_including_empty_projects() {
+        let state = AggregatorProjectionState::new();
+        let active = scope("active");
+        let empty = scope("empty");
+        state
+            .replace_store_catalog(
+                HashMap::from([(RepositoryKey("repo-a".into()), "a".to_string())]),
+                HashMap::from([(active.clone(), vec![]), (empty.clone(), vec![])]),
+            )
+            .await;
+        let active_convoy = convoy_row("flotilla", "ship-it", "active");
+        {
+            let mut convoys = state.write().await;
+            convoys.local_rows.insert(active_convoy.resource.clone(), active_convoy);
+        }
+
+        let result = state.awareness_result_set(&None, AwarenessGrouping::Project, AwarenessLimit::default()).await;
+        let Rows::Awareness { rows, .. } = result.rows else { panic!("awareness rows") };
+
+        assert_eq!(rows.len(), 2);
+        let empty_node = rows.iter().find(|node| node.scope.as_ref() == Some(&empty)).expect("empty project awareness node");
+        assert_eq!(empty_node.state, flotilla_protocol::AwarenessState::Idle);
+        assert_eq!(empty_node.counts, flotilla_protocol::AwarenessCounts::default());
+        assert!(empty_node.entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_project_catalog_changes_advance_awareness_sequence() {
+        let state = AggregatorProjectionState::new();
+        state.write().await.seq = 10;
+        let before = state.awareness_result_set(&None, AwarenessGrouping::Project, AwarenessLimit::default()).await;
+
+        state.replace_store_catalog(HashMap::new(), HashMap::from([(scope("empty"), vec![])])).await;
+
+        let after = state.awareness_result_set(&None, AwarenessGrouping::Project, AwarenessLimit::default()).await;
+        assert!(after.seq > before.seq);
+        assert_eq!(after.rows.as_awareness().expect("awareness rows").len(), 1);
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -22,6 +22,7 @@ pub struct AwarenessInput {
     pub scope: Option<QueryScope>,
     pub grouping: AwarenessGrouping,
     pub limit: AwarenessLimit,
+    pub projects: Vec<QueryScope>,
     pub convoys: Vec<ConvoyRow>,
     pub issues: Vec<ScopedIssueRow>,
     pub checkouts: Vec<CheckoutRow>,
@@ -51,6 +52,14 @@ struct Group {
 pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSetState) {
     let as_of = input.state.demand.as_ref().map_or_else(Utc::now, |metadata| metadata.as_of);
     let mut groups = BTreeMap::<String, Group>::new();
+
+    if input.grouping == AwarenessGrouping::Project || input.scope.is_some() {
+        for project in input.projects.iter().filter(|project| input.scope.as_ref().is_none_or(|scope| *project == scope)) {
+            let key = group_key_for_scope(project);
+            let group = groups.entry(key.id.clone()).or_insert_with(|| Group::new(key, AwarenessKind::Project));
+            group.refs.push(project_resource_ref(&project.namespace, &project.name));
+        }
+    }
 
     for convoy in &input.convoys {
         let key = input.scope.as_ref().map(group_key_for_scope).unwrap_or_else(|| group_key_for_convoy(input.grouping, convoy));
@@ -297,7 +306,7 @@ impl Group {
             refs: Vec::new(),
             entries: Vec::new(),
             counts: AwarenessCounts::default(),
-            state: AwarenessState::Unknown,
+            state: AwarenessState::Idle,
         }
     }
 
@@ -316,9 +325,9 @@ impl Group {
             AwarenessState::Active => self.counts.active += 1,
             AwarenessState::Done => self.counts.done += 1,
             AwarenessState::Failed => self.counts.failed += 1,
-            AwarenessState::Unknown | AwarenessState::Pending | AwarenessState::Cancelled => {}
+            AwarenessState::Unknown | AwarenessState::Idle | AwarenessState::Pending | AwarenessState::Cancelled => {}
         }
-        self.state = stronger_state(self.state, entry.state);
+        self.state = if self.entries.is_empty() { entry.state } else { stronger_state(self.state, entry.state) };
         self.entries.push(entry);
     }
 }
@@ -339,21 +348,23 @@ fn group_kind_for_query(scope: Option<&QueryScope>, grouping: AwarenessGrouping)
 
 fn group_key_for_convoy(grouping: AwarenessGrouping, convoy: &ConvoyRow) -> GroupKey {
     match grouping {
-        AwarenessGrouping::Project => convoy.project_ref.as_deref().map(project_ref_key).unwrap_or_else(|| {
-            convoy
-                .repo
-                .as_ref()
-                .map_or_else(|| GroupKey::new("unparented", "Unparented"), |repo| GroupKey::new(format!("repo/{}", repo.0), repo.0.clone()))
-        }),
+        AwarenessGrouping::Project => {
+            convoy.project_ref.as_deref().map(|project| project_ref_key(&convoy.resource.namespace, project)).unwrap_or_else(|| {
+                convoy.repo.as_ref().map_or_else(
+                    || GroupKey::new("unparented", "Unparented"),
+                    |repo| GroupKey::new(format!("repo/{}", repo.0), repo.0.clone()),
+                )
+            })
+        }
         AwarenessGrouping::Convoy => GroupKey::new(format!("convoy/{}/{}", convoy.resource.namespace, convoy.name), convoy.name.clone()),
     }
 }
 
-fn project_ref_key(value: &str) -> GroupKey {
+fn project_ref_key(default_namespace: &str, value: &str) -> GroupKey {
     if let Some((namespace, name)) = value.split_once('/') {
         return GroupKey::scoped(QueryScope::new(namespace, name));
     }
-    GroupKey::new(format!("project/{value}"), value.to_string())
+    GroupKey::scoped(QueryScope::new(default_namespace, value))
 }
 
 fn convoy_label(convoy: &ConvoyRow) -> String {
@@ -402,12 +413,12 @@ fn state_rank(state: AwarenessState) -> u8 {
         AwarenessState::Active => 3,
         AwarenessState::Pending => 2,
         AwarenessState::Unknown => 1,
-        AwarenessState::Done | AwarenessState::Cancelled => 0,
+        AwarenessState::Idle | AwarenessState::Done | AwarenessState::Cancelled => 0,
     }
 }
 
-fn group_rank(group: &Group) -> (u8, std::cmp::Reverse<usize>, String) {
-    (std::cmp::Reverse(state_rank(group.state)).0, std::cmp::Reverse(group.counts.total), group.label.clone())
+fn group_rank(group: &Group) -> (std::cmp::Reverse<u8>, std::cmp::Reverse<usize>, String) {
+    (std::cmp::Reverse(state_rank(group.state)), std::cmp::Reverse(group.counts.total), group.label.clone())
 }
 
 fn entry_rank(entry: &AwarenessEntry) -> (u8, u8) {
@@ -524,6 +535,42 @@ mod tests {
 
         assert_eq!(nodes[0].label, "github.com/flotilla-org/flotilla");
         assert_eq!(nodes[0].annotations.get(REPO_FACT_ANNOTATION).map(String::as_str), Some("flotilla-org/flotilla"),);
+    }
+
+    #[test]
+    fn project_grouping_emits_idle_projects_without_children_within_the_group_limit() {
+        let active = QueryScope::new("flotilla", "active");
+        let empty = QueryScope::new("flotilla", "empty");
+        let overflow = QueryScope::new("flotilla", "overflow");
+
+        let (nodes, state) = project_awareness(AwarenessInput {
+            grouping: AwarenessGrouping::Project,
+            limit: AwarenessLimit { groups: 2, entries: 32 },
+            projects: vec![empty.clone(), active.clone(), overflow],
+            convoys: vec![convoy(Some("flotilla/active"), "ship-it", ConvoyPhase::Active)],
+            ..AwarenessInput::default()
+        });
+
+        assert_eq!(nodes.len(), 2);
+        assert!(state.truncated, "project inventory remains subject to the awareness group window");
+        assert_eq!(nodes[0].scope.as_ref(), Some(&active), "active projects rank ahead of idle projects");
+        let empty_node = nodes.iter().find(|node| node.scope.as_ref() == Some(&empty)).expect("empty project node");
+        assert_eq!(empty_node.kind, AwarenessKind::Project);
+        assert_eq!(empty_node.state, AwarenessState::Idle);
+        assert_eq!(empty_node.counts, AwarenessCounts::default());
+        assert!(empty_node.entries.is_empty());
+        assert_eq!(empty_node.refs, vec![project_resource_ref("flotilla", "empty")]);
+    }
+
+    #[test]
+    fn convoy_grouping_does_not_turn_empty_projects_into_convoy_nodes() {
+        let (nodes, _) = project_awareness(AwarenessInput {
+            grouping: AwarenessGrouping::Convoy,
+            projects: vec![QueryScope::new("flotilla", "empty")],
+            ..AwarenessInput::default()
+        });
+
+        assert!(nodes.is_empty());
     }
 
     #[test]

--- a/crates/flotilla-core/src/scoped_store.rs
+++ b/crates/flotilla-core/src/scoped_store.rs
@@ -189,12 +189,6 @@ impl<R: ScopedStoreRow> ScopedStoreProjection<R> {
         vec![MaterializedSet { seq, rows, state: ResultSetState::default() }.result_set(&scope)]
     }
 
-    pub fn project_scopes(&self) -> Vec<QueryScope> {
-        let mut scopes = self.projects.keys().cloned().collect::<Vec<_>>();
-        scopes.sort_by(|left, right| (&left.namespace, &left.name).cmp(&(&right.namespace, &right.name)));
-        scopes
-    }
-
     fn recompute_all(&mut self) -> Vec<ResultDelta> {
         let mut scopes = self.sets.keys().cloned().collect::<HashSet<_>>();
         scopes.insert(None);

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -398,7 +398,7 @@ fn find_vessel<'a>(convoys: &'a [ConvoyRow], namespace: &str, convoy_name: &str,
 
 fn awareness_state(state: AwarenessState) -> &'static str {
     match state {
-        AwarenessState::Unknown | AwarenessState::Pending | AwarenessState::Cancelled => "idle",
+        AwarenessState::Unknown | AwarenessState::Idle | AwarenessState::Pending | AwarenessState::Cancelled => "idle",
         AwarenessState::Waiting => "waiting",
         AwarenessState::Active => "active",
         AwarenessState::Done => "done",

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -7,8 +7,8 @@ use super::*;
 use crate::{
     entity::{self, EntityKind},
     keys::{
-        KEY_CONVOY, KEY_COUNT_ISSUES, KEY_ENTITY_ID, KEY_ENTITY_KIND, KEY_PRIMARY_ACTION_RECIPE, KEY_PRIMARY_ACTION_TARGET, KEY_SOURCE,
-        KEY_VESSEL, SEGMENT_PROJECT, SEGMENT_REPO,
+        KEY_CONVOY, KEY_COUNT_ISSUES, KEY_COUNT_TOTAL, KEY_ENTITY_ID, KEY_ENTITY_KIND, KEY_PRIMARY_ACTION_RECIPE,
+        KEY_PRIMARY_ACTION_TARGET, KEY_SOURCE, KEY_STATUS_STATE, KEY_VESSEL, SEGMENT_PROJECT, SEGMENT_REPO,
     },
     recipe::FlotillaRecipes,
 };
@@ -119,6 +119,25 @@ fn awareness_issues_are_recipe_less_entities_with_source_plus_id_identity() {
     );
     assert!(!issue_patch.set.contains_key(KEY_COUNT_ISSUES));
     assert!(!issue_patch.set.contains_key(KEY_PRIMARY_ACTION_RECIPE));
+}
+
+#[test]
+fn empty_project_is_an_idle_zero_count_latent_that_opens_its_scoped_view() {
+    let node = AwarenessNode::builder()
+        .id("project/dev/empty".to_owned())
+        .kind(AwarenessKind::Project)
+        .label("empty".to_owned())
+        .scope(flotilla_protocol::QueryScope::new("dev", "empty"))
+        .state(AwarenessState::Idle)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .build();
+
+    let patches = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint()).reassert_patches();
+    let project = find_entity(&patches, &entity::project("dev", "empty", "fleet"));
+
+    assert_eq!(text(project, KEY_STATUS_STATE), "idle");
+    assert_eq!(project.set[KEY_COUNT_TOTAL].value, MetadataValue::Integer(0));
+    assert_eq!(text(project, KEY_PRIMARY_ACTION_RECIPE), "flotilla view 'project/dev/empty'");
 }
 
 #[test]

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -449,6 +449,7 @@ pub enum AwarenessFamily {
 pub enum AwarenessState {
     #[default]
     Unknown,
+    Idle,
     Pending,
     Waiting,
     Active,


### PR DESCRIPTION
## What

- seed project-grouped awareness output from the complete Project catalog, so projects remain eligible even when they have no convoys, ready issues, checkouts, or independent sessions
- represent empty project nodes with explicit `idle` state, zero counts, their Project resource ref, and the existing scoped-view action recipe
- retain awareness group windowing, ranking active projects ahead of empty projects when the group limit truncates output
- advance awareness sequence numbers when the Project catalog changes
- canonicalize unqualified convoy project refs with the convoy namespace so child rows join the catalogued Project node

## Why

The aggregator previously created awareness groups only while processing child rows. Tracked Projects with no children therefore disappeared before presentation templates could apply their `show-empty` policy. The producer now emits the complete eligible data set, while surface grouping templates remain responsible for visibility.

## Impact

Daemon awareness queries include all catalogued Projects within the configured awareness limit. Empty Projects are idle latents and open their scoped TUI with `flotilla view project/<namespace>/<name>`.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1000