### PR TITLE
Revive compose integration coverage for multi-host wedge regressions

### DIFF
--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -1,0 +1,29 @@
+name: Compose integration
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  wedge-regressions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tests/integration/pyproject.toml
+      - name: Install integration test dependencies
+        run: python -m pip install ./tests/integration
+      - name: Run real-boundary topology and wedge regressions
+        run: python -m pytest -v tests/integration
+      - name: Print compose logs
+        if: failure()
+        run: docker compose -f tests/integration/docker-compose.yml logs --no-color

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .codex-tmp/
 .idea/
 __pycache__/
+*.egg-info/
 .playwright-mcp/
 .claude/worktrees/
 .worktrees/

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -196,6 +196,7 @@ impl PeerRuntime {
                             current_peer = Some(initial_connection.node.clone());
                             let mut inbound_rx = initial_connection.inbound_rx;
                             let generation = initial_connection.generation;
+                            info!(peer = %peer_name, generation, "connected successfully");
                             let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
                                 peer: peer_name.clone(),
                                 generation,
@@ -266,7 +267,7 @@ impl PeerRuntime {
                                     current_peer = Some(connection.node.clone());
                                     let generation = connection.generation;
                                     let mut inbound_rx = connection.inbound_rx;
-                                    info!(peer = %peer_name, "reconnected successfully");
+                                    info!(peer = %peer_name, generation, "reconnected successfully");
                                     last_known_session_id =
                                         handle_remote_restart_if_needed(&pm, &daemon_for_cleanup, &peer_name, last_known_session_id).await;
                                     sync_peer_query_state(&pm, &daemon_for_cleanup).await;

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -83,7 +83,7 @@ def start_daemon(service: str):
     result = docker_exec(
         service,
         "mkdir -p ~/.config/flotilla ~/.local/state/flotilla; "
-        "tmux_env=$(tmux display-message -p "
+        "tmux_env=$(tmux display-message -t integration -p "
         "'#{socket_path},#{pid},#{window_index}'); "
         "nohup env TMUX=\"$tmux_env\" "
         "RUST_LOG=flotilla_daemon=debug flotillad --timeout 0 "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 COMPOSE_DIR = Path(__file__).parent
 COMPOSE_FILE = str(COMPOSE_DIR / "docker-compose.yml")
+DAEMON_LOG = "~/.local/state/flotilla/daemon.log"
 
 
 def docker_exec(
@@ -26,9 +27,19 @@ def docker_exec(
     )
 
 
+def compose(*args: str, timeout: int = 60) -> subprocess.CompletedProcess:
+    """Run docker compose against the integration topology."""
+    return subprocess.run(
+        ["docker", "compose", "-f", COMPOSE_FILE, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
 def flotilla_json(service: str, args: str, timeout: int = 30) -> dict | list:
     """Run a flotilla CLI command with --json and return parsed output."""
-    result = docker_exec(service, f"flotilla {args} --json", timeout=timeout)
+    result = docker_exec(service, f"flotilla --json {args}", timeout=timeout)
     assert result.returncode == 0, (
         f"flotilla {args} failed (rc={result.returncode}):\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
@@ -67,14 +78,57 @@ def wait_for(
     raise TimeoutError(msg)
 
 
-@pytest.fixture(scope="session")
+def start_daemon(service: str):
+    """Start flotillad directly and record its PID for deterministic restarts."""
+    result = docker_exec(
+        service,
+        "mkdir -p ~/.config/flotilla ~/.local/state/flotilla; "
+        "tmux_env=$(tmux display-message -p "
+        "'#{socket_path},#{pid},#{window_index}'); "
+        "nohup env TMUX=\"$tmux_env\" "
+        "RUST_LOG=flotilla_daemon=debug flotillad --timeout 0 "
+        ">~/.config/flotilla/daemon-stdio.log 2>&1 & "
+        "echo $! > ~/.config/flotilla/flotillad.pid",
+    )
+    assert result.returncode == 0, (
+        f"flotillad start failed on {service}:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def stop_daemon(service: str):
+    """Stop the recorded flotillad process, if it is still running."""
+    result = docker_exec(
+        service,
+        "if test -f ~/.config/flotilla/flotillad.pid; then "
+        "pid=$(cat ~/.config/flotilla/flotillad.pid); "
+        "kill \"$pid\" 2>/dev/null || true; "
+        "for attempt in $(seq 1 50); do "
+        "state=$(ps -o stat= -p \"$pid\" 2>/dev/null || true); "
+        "case \"$state\" in ''|Z*) exit 0 ;; esac; sleep 0.1; "
+        "done; exit 1; "
+        "fi",
+    )
+    assert result.returncode == 0, (
+        f"flotillad stop failed on {service}:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def daemon_log(service: str) -> str:
+    """Read a node's structured daemon log."""
+    result = docker_exec(service, f"cat {DAEMON_LOG}")
+    return result.stdout if result.returncode == 0 else ""
+
+
+@pytest.fixture(scope="module")
 def topology():
     """Spin up 2-node topology, wait for peering, yield, tear down."""
-    subprocess.run(
-        ["docker", "compose", "-f", COMPOSE_FILE, "up", "-d", "--build",
-         "--force-recreate"],
-        check=True,
-        timeout=600,
+    result = compose(
+        "up", "-d", "--build", "--force-recreate", timeout=900
+    )
+    assert result.returncode == 0, (
+        f"compose up failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
     try:
         # Wait for SSH readiness between nodes
@@ -125,12 +179,16 @@ def topology():
             f"daemon.toml write failed: {result.stderr}"
         )
 
-        # Start daemons (backgrounded, reparented to container PID 1)
+        # Give discovery a real presentation surface, then start the current
+        # standalone daemon binary on both nodes.
         for node in ("node-a", "node-b"):
-            docker_exec(
-                node,
-                "nohup flotilla daemon >/dev/null 2>~/.config/flotilla/daemon-panic.log &",
+            result = docker_exec(
+                node, "tmux new-session -d -s integration"
             )
+            assert result.returncode == 0, (
+                f"tmux start failed on {node}: {result.stderr}"
+            )
+            start_daemon(node)
 
         # Wait for daemon readiness on each node
         for node in ("node-a", "node-b"):
@@ -155,7 +213,7 @@ def topology():
         def peers_connected():
             result = flotilla_json("node-a", "host list")
             return any(
-                h["host"] == "node-b"
+                h["host_name"] == "node-b"
                 and h["connection_status"] == "Connected"
                 for h in result.get("hosts", [])
             )
@@ -167,22 +225,16 @@ def topology():
     finally:
         # Print daemon logs for debugging (daemon writes to state_dir/daemon.log)
         for node in ("node-a", "node-b"):
-            result = docker_exec(node, "cat ~/.local/state/flotilla/daemon.log")
-            if result.stdout:
-                print(f"\n=== {node} daemon log ===\n{result.stdout}")
-            panic_result = docker_exec(node, "cat ~/.config/flotilla/daemon-panic.log")
-            if panic_result.stdout:
-                print(f"\n=== {node} daemon panic log ===\n{panic_result.stdout}")
+            log = daemon_log(node)
+            if log:
+                print(f"\n=== {node} daemon log ===\n{log}")
+            stdio = docker_exec(
+                node, "cat ~/.config/flotilla/daemon-stdio.log"
+            )
+            if stdio.stdout:
+                print(f"\n=== {node} daemon stdio ===\n{stdio.stdout}")
 
-        result = subprocess.run(
-            [
-                "docker", "compose", "-f", COMPOSE_FILE,
-                "down", "-v", "--remove-orphans",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+        result = compose("down", "-v", "--remove-orphans")
         if result.returncode != 0:
             print(f"\n=== teardown failed (rc={result.returncode}) ===")
             print(result.stderr)

--- a/tests/integration/docker/base/Dockerfile
+++ b/tests/integration/docker/base/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-server \
     openssh-client \
     git \
+    tmux \
     ca-certificates \
     libssl3t64 \
     gosu \
@@ -48,7 +49,9 @@ CMD ["sleep", "infinity"]
 # --- Full build target (default): cargo-built binary ---
 FROM runtime-base AS full
 COPY --from=builder /app/target/release/flotilla /usr/local/bin/flotilla
+COPY --from=builder /app/target/release/flotillad /usr/local/bin/flotillad
 
 # --- Dev target: pre-built binary from host ---
 FROM runtime-base AS dev
 COPY target/release/flotilla /usr/local/bin/flotilla
+COPY target/release/flotillad /usr/local/bin/flotillad

--- a/tests/integration/test_minimal_topology.py
+++ b/tests/integration/test_minimal_topology.py
@@ -22,7 +22,7 @@ def test_host_list_shows_peer(topology):
     # Should see at least local host + node-b
     assert len(hosts) >= 2
 
-    peer = next((h for h in hosts if h["host"] == "node-b"), None)
+    peer = next((h for h in hosts if h["host_name"] == "node-b"), None)
     assert peer is not None, f"node-b not in host list: {hosts}"
     assert peer["connection_status"] == "Connected"
     assert not peer["is_local"]
@@ -34,37 +34,40 @@ def test_host_list_shows_local(topology):
     result = flotilla_json(topology["node-a"], "host list")
     local = next((h for h in result["hosts"] if h["is_local"]), None)
     assert local is not None, "no local host in host list"
-    assert local["host"] == "node-a"
+    assert local["host_name"] == "node-a"
 
 
 def test_topology_shows_direct_route(topology):
     """Topology shows a direct, connected route to node-b."""
     result = flotilla_json(topology["node-a"], "topology")
-    assert result["local_host"] == "node-a"
+    assert result["local_node"]["display_name"] == "node-a"
 
     routes = result["routes"]
     node_b_route = next(
-        (r for r in routes if r["target"] == "node-b"), None
+        (r for r in routes if r["target"]["display_name"] == "node-b"), None
     )
     assert node_b_route is not None, f"no route to node-b: {routes}"
     assert node_b_route["direct"]
     assert node_b_route["connected"]
-    assert node_b_route["next_hop"] == "node-b"
+    assert node_b_route["next_hop"]["display_name"] == "node-b"
 
 
 def test_host_status_peer(topology):
     """Can query node-b's status from node-a."""
     result = flotilla_json(topology["node-a"], "host node-b status")
-    assert result["host"] == "node-b"
+    assert result["host_name"] == "node-b"
     assert result["connection_status"] == "Connected"
-    assert not result["is_local"]
-    assert result["repo_count"] >= 1
+    # The query executes on node-b, so the returned status is local from
+    # node-b's point of view.
+    assert result["is_local"]
+    assert result["summary"]["host_name"] == "node-b"
+    assert result["visible_environments"]
 
 
 def test_host_providers_peer(topology):
     """Can query node-b's providers from node-a."""
     result = flotilla_json(topology["node-a"], "host node-b providers")
-    assert result["host"] == "node-b"
+    assert result["host_name"] == "node-b"
     assert result["connection_status"] == "Connected"
 
     summary = result["summary"]
@@ -83,10 +86,15 @@ def test_status_shows_repos(topology):
     assert "work_item_count" in repo
 
 
-def test_peer_repo_visible_via_host_status(topology):
-    """node-b's tracked repo is visible from node-a via host status."""
-    result = flotilla_json(topology["node-a"], "host node-b status")
-    assert result["repo_count"] >= 1
+def test_peer_repo_visible_in_merged_repo_work(topology):
+    """node-b's tracked repo is visible in node-a's merged repo work."""
+    result = flotilla_json(
+        topology["node-a"], "repo /home/flotilla/repo work"
+    )
+    assert any(
+        item.get("source") == "node-b"
+        for item in result.get("work_items", [])
+    )
 
 
 def test_remote_prepare_terminal_returns_attachable_set_id(topology):
@@ -95,13 +103,14 @@ def test_remote_prepare_terminal_returns_attachable_set_id(topology):
         topology["node-b"],
         "repo /home/flotilla/repo checkout --fresh feat-prepare",
     )
-    assert checkout["status"] == "checkout_created"
-    checkout_path = checkout["path"]
+    assert checkout["kind"] == "checkout_created"
+    checkout_path = checkout["path"]["path"]
 
     def checkout_visible_on_node_a():
         result = flotilla_json(topology["node-a"], "repo /home/flotilla/repo work")
         return any(
-            item.get("branch") == "feat-prepare" and item.get("host") == "node-b"
+            item.get("branch") == "feat-prepare"
+            and item.get("source") == "node-b"
             for item in result.get("work_items", [])
         )
 
@@ -117,7 +126,7 @@ def test_remote_prepare_terminal_returns_attachable_set_id(topology):
         f"host node-b repo /home/flotilla/repo prepare-terminal {checkout_path}",
         timeout=60,
     )
-    assert prepared["status"] == "terminal_prepared"
+    assert prepared["kind"] == "terminal_prepared"
     assert prepared.get("attachable_set_id"), (
         "remote prepare-terminal should include attachable_set_id"
     )

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -1,0 +1,259 @@
+"""Real-boundary regressions for the multi-host wedge family."""
+
+import json
+import re
+import time
+
+from conftest import (
+    compose,
+    daemon_log,
+    docker_exec,
+    flotilla_json,
+    start_daemon,
+    stop_daemon,
+    wait_for,
+)
+
+GENERATION_RE = re.compile(r"\bgeneration=(\d+)\b")
+RECONNECT_MESSAGES = (
+    "SSH connection dropped, will reconnect",
+    "reconnecting after backoff",
+    "reconnected successfully",
+)
+
+
+def peer_entry():
+    hosts = flotilla_json("node-a", "host list")["hosts"]
+    return next(host for host in hosts if host["host_name"] == "node-b")
+
+
+def peer_generations() -> list[int]:
+    generations = []
+    for line in daemon_log("node-a").splitlines():
+        if "connected successfully" not in line:
+            continue
+        match = GENERATION_RE.search(line)
+        if match:
+            generations.append(int(match.group(1)))
+    return generations
+
+
+def replicated_peer_host() -> dict:
+    peer = peer_entry()
+    peer_node_id = peer["node"]["node_id"]
+    peer_host_id = peer["environment_id"].removeprefix("host:")
+    listed = flotilla_json(
+        "node-a", "resource list hosts --include-replicas"
+    )
+    for item in listed["items"]:
+        annotations = item["metadata"].get("annotations", {})
+        if (
+            item["metadata"]["name"] == peer_host_id
+            and peer_node_id in annotations.values()
+        ):
+            return item
+    raise LookupError(
+        f"no replicated Host from peer {peer_node_id}: "
+        f"{json.dumps(listed, indent=2)}"
+    )
+
+
+def replicated_host_by_identity(name: str, origin: str) -> dict:
+    listed = flotilla_json(
+        "node-a", "resource list hosts --include-replicas"
+    )
+    for item in listed["items"]:
+        annotations = item["metadata"].get("annotations", {})
+        if (
+            item["metadata"]["name"] == name
+            and origin in annotations.values()
+        ):
+            return item
+    raise LookupError(
+        f"replicated Host {name} from {origin} disappeared: "
+        f"{json.dumps(listed, indent=2)}"
+    )
+
+
+def heartbeat_at() -> str:
+    return replicated_peer_host()["status"]["heartbeat_at"]
+
+
+def wait_connected():
+    wait_for(
+        lambda: peer_entry()["connection_status"] == "Connected",
+        "node-a reports node-b connected",
+        timeout=30,
+        interval=0.5,
+    )
+
+
+def test_01_one_sided_daemon_restart_recovers(topology):
+    """#992: a restarted peer gets a new generation and resumes replication."""
+    initial_generation = max(peer_generations())
+    initial_heartbeat = heartbeat_at()
+    stale_warning_count = daemon_log("node-a").count(
+        "ignoring stale or duplicate peer replicator generation"
+    )
+
+    stop_daemon("node-b")
+    start_daemon("node-b")
+    wait_for(
+        lambda: docker_exec(
+            "node-b", "flotilla status --json"
+        ).returncode == 0,
+        "restarted node-b daemon",
+        timeout=30,
+        interval=0.5,
+    )
+    wait_connected()
+    wait_for(
+        lambda: max(peer_generations(), default=0) > initial_generation,
+        "node-a mints a higher connection generation",
+        timeout=15,
+        interval=0.25,
+    )
+    wait_for(
+        lambda: heartbeat_at() > initial_heartbeat,
+        "restarted node-b heartbeat replicates to node-a",
+        timeout=15,
+        interval=0.5,
+    )
+
+    resumed_heartbeat = heartbeat_at()
+    wait_for(
+        lambda: heartbeat_at() > resumed_heartbeat,
+        "periodic node-b heartbeats continue after restart",
+        timeout=40,
+        interval=1.0,
+    )
+    assert daemon_log("node-a").count(
+        "ignoring stale or duplicate peer replicator generation"
+    ) == stale_warning_count
+
+
+def test_02_transport_death_re_resolves_forwarded_socket(topology):
+    """#1008: killing only SSH recovers the same daemon session promptly."""
+    initial_generation = max(peer_generations())
+    remote_pid = docker_exec(
+        "node-b", "cat ~/.config/flotilla/flotillad.pid"
+    ).stdout.strip()
+    initial_log = daemon_log("node-a")
+    killed_at = time.monotonic()
+    killed = docker_exec(
+        "node-a", "pkill -f '^ssh -N -L '"
+    )
+    assert killed.returncode == 0, (
+        "expected a live SSH forwarding process\n"
+        f"stdout: {killed.stdout}\nstderr: {killed.stderr}"
+    )
+
+    wait_for(
+        lambda: max(peer_generations(), default=0) > initial_generation,
+        "SSH transport reconnects with a new forwarded socket",
+        timeout=10,
+        interval=0.25,
+    )
+    assert time.monotonic() - killed_at < 5, (
+        "transport should recover within the first one-second backoff"
+    )
+    wait_connected()
+    assert docker_exec(
+        "node-b", "cat ~/.config/flotilla/flotillad.pid"
+    ).stdout.strip() == remote_pid
+    recovery_log = daemon_log("node-a")[len(initial_log):]
+    assert "reconnection failed" not in recovery_log
+
+    document = "\n".join([
+        "apiVersion: flotilla.work/v1",
+        "kind: Host",
+        "metadata:",
+        "  name: transport-recovery",
+        "  namespace: flotilla",
+        "spec: {}",
+        "",
+    ])
+    applied = docker_exec(
+        "node-b",
+        "cat > /tmp/transport-recovery.yaml <<'YAML'\n"
+        f"{document}"
+        "YAML\n"
+        "flotilla resource apply "
+        "-f /tmp/transport-recovery.yaml --json",
+    )
+    assert applied.returncode == 0, applied.stderr
+
+    def template_replicated():
+        listed = flotilla_json(
+            "node-a",
+            "resource list hosts --include-replicas",
+        )
+        return any(
+            item["metadata"]["name"] == "transport-recovery"
+            for item in listed["items"]
+        )
+
+    wait_for(
+        template_replicated,
+        "replicators re-resolve the replacement forwarded socket",
+        timeout=10,
+        interval=0.5,
+    )
+
+
+def test_03_idle_link_survives_three_ping_windows(topology):
+    """#1016: a quiet mesh remains connected across three keepalive pings."""
+    generation = max(peer_generations())
+    log = daemon_log("node-a")
+    reconnect_counts = {
+        message: log.count(message) for message in RECONNECT_MESSAGES
+    }
+
+    time.sleep(95)
+
+    assert peer_entry()["connection_status"] == "Connected"
+    assert replicated_peer_host()["status"]["ready"] is True
+    assert max(peer_generations()) == generation
+    final_log = daemon_log("node-a")
+    assert {
+        message: final_log.count(message) for message in RECONNECT_MESSAGES
+    } == reconnect_counts
+
+
+def test_04_stopped_host_becomes_not_ready(topology):
+    """#976: TTL expiry is honest even before the peer route disappears."""
+    remote_host = replicated_peer_host()
+    host_id = remote_host["metadata"]["name"]
+    origin = next(
+        value
+        for key, value in remote_host["metadata"]["annotations"].items()
+        if key.endswith("/origin-root")
+    )
+    result = compose("stop", "node-b")
+    assert result.returncode == 0, result.stderr
+
+    wait_for(
+        lambda: replicated_host_by_identity(
+            host_id, origin
+        )["status"]["ready"] is False,
+        "node-b Host replica becomes not-ready after heartbeat TTL",
+        timeout=70,
+        interval=1.0,
+    )
+
+    refused = docker_exec(
+        "node-a",
+        "flotilla convoy start --project repo "
+        "--name readiness-refusal --branch readiness-refusal "
+        f"--placement-policy host-direct-{host_id} "
+        "--no-attach --json",
+    )
+    assert refused.returncode != 0, (
+        "dispatch unexpectedly succeeded against a stopped host"
+    )
+    error = json.loads(refused.stdout)
+    assert error == {
+        "kind": "error",
+        "message": f"peer host {host_id} is not connected",
+    }
+    assert "\n" not in error["message"]


### PR DESCRIPTION
## Summary

- revive the real two-node Docker Compose harness against the current standalone daemon and CLI schemas
- add deterministic regressions for one-sided daemon restart, SSH tunnel death, idle keepalive stability, and stopped-host readiness expiry
- add a nightly/manual GitHub Actions workflow for the compose suite
- include connection generations in peer runtime logs so reconnect behavior is observable at the real boundary

## Why

The compose harness had drifted from the current binaries and JSON contracts, leaving issues #992, #1008, #1016, and #976 without reliable real-boundary regression coverage. The revived harness runs actual daemons, SSH forwarding, replication, heartbeat TTL handling, and dispatch refusal across two containers.

## Impact

Maintainers can reproduce and continuously exercise the multi-host wedge family. The runtime behavior is unchanged apart from adding generation fields to successful peer-connection logs.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `python -m pytest -v tests/integration` — 13 passed
- `python -m py_compile tests/integration/conftest.py tests/integration/test_minimal_topology.py tests/integration/test_wedge_regressions.py`
- `git diff --check`

Closes #1023