### PR TITLE
fix: provision claude hooks for managed crew and stop reporting latent crew as working

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ flotilla host <name> repo <args>                  # route repo commands to a hos
 
 ### Agent hooks
 
+Convoy crew sessions provision their own hooks at launch, so these commands are only needed
+for Claude Code sessions you start yourself.
+
 ```
 flotilla hooks install <harness> [--user|--project|--local]
 flotilla hooks install <harness> --plugin         # show plugin marketplace instructions

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -590,10 +590,9 @@ impl Reconciler for VesselReconciler {
             })
             .collect::<Vec<_>>();
 
-        let first_agent_index = requirement.crew.iter().position(|process| matches!(process.source, CrewSource::Agent { .. }));
         let mut terminal_refs = Vec::new();
         for (crew_index, process) in requirement.crew.iter().enumerate() {
-            let should_start = matches!(process.source, CrewSource::Tool { .. }) || first_agent_index == Some(crew_index);
+            let should_start = requirement.starts_eagerly(crew_index);
             let identity = TerminalSessionIdentity::builder()
                 .vessel_ref(obj.metadata.name.clone())
                 .convoy(obj.spec.convoy_ref.clone())
@@ -643,12 +642,7 @@ impl Reconciler for VesselReconciler {
                                 .enumerate()
                                 .map(|(index, member)| CrewBriefMember {
                                     role: member.role.clone(),
-                                    state: if matches!(member.source, CrewSource::Tool { .. }) || first_agent_index == Some(index) {
-                                        "active"
-                                    } else {
-                                        "latent"
-                                    }
-                                    .to_string(),
+                                    state: if requirement.starts_eagerly(index) { "active" } else { "latent" }.to_string(),
                                     is_agent: matches!(member.source, CrewSource::Agent { .. }),
                                 })
                                 .collect::<Vec<_>>();

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -329,12 +329,58 @@ pub trait AgentAdapter: Send + Sync {
     fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String>;
 }
 
+/// Where a managed Claude Code session's Flotilla settings overlay is written,
+/// relative to the session's working directory. It lives under `.flotilla/`
+/// alongside the brief so it inherits the same git exclusion and teardown.
+pub const CLAUDE_MANAGED_SETTINGS_PATH: &str = ".flotilla/claude-settings.json";
+
 struct CliAgentAdapter {
-    id: &'static str,
     binary: String,
     runner: Arc<dyn CommandRunner>,
-    autonomy_args: &'static [&'static str],
-    trust_config: Option<CodexTrustConfig>,
+    flavor: AdapterFlavor,
+}
+
+/// Per-harness behaviour. Each CLI agent gates autonomy differently and needs a
+/// different thing seeded before it will run unattended, so the differences are
+/// named here rather than inferred from an id string.
+enum AdapterFlavor {
+    /// `--dangerously-skip-permissions` clears Claude Code's directory-trust and
+    /// tool-approval gates outright, so there is no persisted trust to pre-seed
+    /// for either a convoy checkout or a multi-repo workspace root. What a
+    /// managed session *does* need is Flotilla's hooks: without them the crew
+    /// runs, but no phase or attention signal ever leaves the pane. `--settings`
+    /// layers them on for this invocation only, leaving the user's own settings
+    /// untouched — which also means a crew works on a host where nobody has run
+    /// `flotilla hooks install`.
+    ClaudeCode,
+    /// Codex gates on a persisted per-project trust level, so the workspace has
+    /// to be marked trusted in its config before launch.
+    Codex { trust_config: Option<CodexTrustConfig> },
+}
+
+impl AdapterFlavor {
+    fn id(&self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::Codex { .. } => "codex",
+        }
+    }
+
+    fn autonomy_args(&self) -> &'static [&'static str] {
+        match self {
+            Self::ClaudeCode => &["--dangerously-skip-permissions"],
+            Self::Codex { .. } => &["--dangerously-bypass-approvals-and-sandbox"],
+        }
+    }
+
+    /// Files the adapter writes into the working directory and must remove on
+    /// teardown, beyond the brief itself.
+    fn managed_files(&self) -> &'static [&'static str] {
+        match self {
+            Self::ClaudeCode => &[CLAUDE_MANAGED_SETTINGS_PATH],
+            Self::Codex { .. } => &[],
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -346,7 +392,10 @@ struct CodexTrustConfig {
 impl CliAgentAdapter {
     fn command(&self, request: &AgentLaunchRequest) -> String {
         let mut args = vec![Arg::Literal(self.binary.clone())];
-        args.extend(self.autonomy_args.iter().map(|arg| Arg::Literal((*arg).into())));
+        args.extend(self.flavor.autonomy_args().iter().map(|arg| Arg::Literal((*arg).into())));
+        if matches!(self.flavor, AdapterFlavor::ClaudeCode) {
+            args.extend([Arg::Literal("--settings".into()), Arg::Literal(CLAUDE_MANAGED_SETTINGS_PATH.into())]);
+        }
         if let Some(model) = &request.model {
             args.extend([Arg::Literal("--model".into()), Arg::Literal(model.clone())]);
         }
@@ -358,27 +407,38 @@ impl CliAgentAdapter {
 #[async_trait]
 impl AgentAdapter for CliAgentAdapter {
     fn id(&self) -> &'static str {
-        self.id
+        self.flavor.id()
     }
 
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
-        if self.id == "codex" {
-            let config = self
-                .trust_config
-                .as_ref()
-                .ok_or_else(|| "cannot determine Codex config path because neither CODEX_HOME nor HOME was detected".to_string())?;
-            seed_codex_workspace_trust(&*self.runner, cwd.as_path(), config).await?;
+        match &self.flavor {
+            AdapterFlavor::ClaudeCode => {
+                let settings = serde_json::to_string_pretty(&crate::agents::claude_code_hook_settings())
+                    .map_err(|error| format!("render Claude Code settings overlay: {error}"))?;
+                self.runner.write_file(&cwd.as_path().join(CLAUDE_MANAGED_SETTINGS_PATH), &settings).await?;
+            }
+            AdapterFlavor::Codex { trust_config } => {
+                let config = trust_config
+                    .as_ref()
+                    .ok_or_else(|| "cannot determine Codex config path because neither CODEX_HOME nor HOME was detected".to_string())?;
+                seed_codex_workspace_trust(&*self.runner, cwd.as_path(), config).await?;
+            }
         }
         self.runner.write_file(&cwd.as_path().join(&brief.path), &brief.content).await?;
         ensure_flotilla_git_exclude(&*self.runner, cwd.as_path()).await
     }
 
     async fn cleanup(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
-        remove_agent_brief(&*self.runner, cwd.as_path(), brief).await
+        remove_agent_files(&*self.runner, cwd.as_path(), brief, self.flavor.managed_files()).await
     }
 
     fn classify_screen_attention(&self, screen: &str) -> Option<TerminalAttentionState> {
-        (self.id == "codex" && codex_screen_needs_input(screen)).then_some(TerminalAttentionState::NeedsInput)
+        match self.flavor {
+            // Claude Code reports its own permission prompts through the hook
+            // path, which is more precise than matching rendered text.
+            AdapterFlavor::ClaudeCode => None,
+            AdapterFlavor::Codex { .. } => codex_screen_needs_input(screen).then_some(TerminalAttentionState::NeedsInput),
+        }
     }
 
     fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String> {
@@ -454,18 +514,31 @@ async fn ensure_flotilla_git_exclude(runner: &dyn CommandRunner, cwd: &Path) -> 
     Ok(())
 }
 
-async fn remove_agent_brief(runner: &dyn CommandRunner, cwd: &Path, brief: &TerminalBrief) -> Result<(), String> {
-    let path = cwd.join(&brief.path);
-    let path_str = path.to_str().ok_or_else(|| format!("brief path is not valid UTF-8: {}", path.display()))?;
-    runner.run("rm", &["-f", path_str], Path::new("/"), &ChannelLabel::Noop).await?;
+/// Removes everything the adapter wrote into the working directory, then prunes
+/// the `.flotilla` scaffolding it left behind. Directories are pruned deepest
+/// first so an outer directory becomes empty in time to be removed.
+async fn remove_agent_files(runner: &dyn CommandRunner, cwd: &Path, brief: &TerminalBrief, managed_files: &[&str]) -> Result<(), String> {
+    let paths =
+        std::iter::once(brief.path.as_str()).chain(managed_files.iter().copied()).map(|relative| cwd.join(relative)).collect::<Vec<_>>();
 
-    for parent in [path.parent(), path.parent().and_then(Path::parent)].into_iter().flatten() {
-        if parent != cwd {
-            let Some(parent) = parent.to_str() else {
-                continue;
-            };
-            let _ = runner.run("rmdir", &[parent], Path::new("/"), &ChannelLabel::Noop).await;
-        }
+    for path in &paths {
+        let path_str = path.to_str().ok_or_else(|| format!("agent file path is not valid UTF-8: {}", path.display()))?;
+        runner.run("rm", &["-f", path_str], Path::new("/"), &ChannelLabel::Noop).await?;
+    }
+
+    let mut directories = paths
+        .iter()
+        // Strictly below cwd: an absolute or escaping relative path must never
+        // walk the prune up into directories the adapter did not create.
+        .flat_map(|path| path.ancestors().skip(1).take_while(|ancestor| *ancestor != cwd && ancestor.starts_with(cwd)))
+        .collect::<Vec<_>>();
+    directories.sort_by_key(|directory| std::cmp::Reverse(directory.components().count()));
+    directories.dedup();
+    for directory in directories {
+        let Some(directory) = directory.to_str() else {
+            continue;
+        };
+        let _ = runner.run("rmdir", &[directory], Path::new("/"), &ChannelLabel::Noop).await;
     }
     Ok(())
 }
@@ -480,11 +553,9 @@ impl AgentAdapterRegistry {
         let mut registry = Self::default();
         if let Some(binary) = env.find_binary("claude") {
             registry.insert(Arc::new(CliAgentAdapter {
-                id: "claude-code",
                 binary: binary.as_path().display().to_string(),
                 runner: Arc::clone(&runner),
-                autonomy_args: &["--dangerously-skip-permissions"],
-                trust_config: None,
+                flavor: AdapterFlavor::ClaudeCode,
             }));
         }
         if let Some(binary) = env.find_binary("codex") {
@@ -494,11 +565,11 @@ impl AgentAdapterRegistry {
                 .or_else(|| env.find_env_var("HOME").map(|home| PathBuf::from(home).join(".codex")))
                 .map(|home| home.join("config.toml"));
             registry.insert(Arc::new(CliAgentAdapter {
-                id: "codex",
                 binary: binary.as_path().display().to_string(),
                 runner,
-                autonomy_args: &["--dangerously-bypass-approvals-and-sandbox"],
-                trust_config: config_path.map(|path| CodexTrustConfig { path, lock: Arc::new(Mutex::new(())) }),
+                flavor: AdapterFlavor::Codex {
+                    trust_config: config_path.map(|path| CodexTrustConfig { path, lock: Arc::new(Mutex::new(())) }),
+                },
             }));
         }
         registry
@@ -873,9 +944,76 @@ mod tests {
             claude.launch(&AgentLaunchRequest { role: "reviewer".into(), model: Some("opus".into()), brief }).expect("claude launch plan");
         assert_eq!(
             plan.command,
-            "/tools/claude --dangerously-skip-permissions --model opus 'Read your crew brief at .flotilla/briefs/coder.md and follow it.'"
+            "/tools/claude --dangerously-skip-permissions --settings .flotilla/claude-settings.json --model opus 'Read your crew brief at .flotilla/briefs/coder.md and follow it.'"
         );
         assert!(!plan.command.contains("Implement the issue"));
+    }
+
+    #[tokio::test]
+    async fn claude_prepare_writes_a_settings_overlay_the_launch_command_loads() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
+        let claude = registry.get("claude-code").expect("claude adapter");
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
+
+        claude.prepare(&ExecutionEnvironmentPath::new(&workspace), &brief).await.expect("prepare claude workspace");
+
+        // The launch command names this path relatively, so it must resolve
+        // against the session's working directory.
+        let plan = claude.launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief: brief.clone() }).expect("launch plan");
+        assert!(plan.command.contains("--settings .flotilla/claude-settings.json"), "{}", plan.command);
+
+        let settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(workspace.join(".flotilla/claude-settings.json")).expect("read settings"))
+                .expect("parse settings");
+        assert_eq!(settings["hooks"]["SessionStart"][0]["hooks"][0]["command"], "flotilla hook claude-code session-start");
+        assert_eq!(settings["hooks"]["Notification"][0]["matcher"], "permission_prompt");
+        // The overlay carries hooks only: anything else would silently override
+        // the user's own settings for the managed session.
+        assert_eq!(settings.as_object().expect("settings object").keys().collect::<Vec<_>>(), vec!["hooks"]);
+
+        claude.cleanup(&ExecutionEnvironmentPath::new(&workspace), &brief).await.expect("cleanup");
+        assert!(!workspace.join(".flotilla/claude-settings.json").exists(), "settings overlay should be removed");
+        assert!(!workspace.join(".flotilla").exists(), "settings overlay should not keep .flotilla alive");
+    }
+
+    #[tokio::test]
+    async fn claude_needs_no_workspace_trust_seeding_for_any_checkout_shape() {
+        // `--dangerously-skip-permissions` clears the directory-trust gate, so
+        // unlike Codex there is nothing to pre-seed — and preparing a workspace
+        // root that is not a git checkout (the multi-repo shape from #1002) must
+        // still succeed.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_root = temp.path().join("multi-repo-workspace");
+        std::fs::create_dir_all(workspace_root.join("repo-a")).expect("repo a");
+        std::fs::create_dir_all(workspace_root.join("repo-b")).expect("repo b");
+        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
+
+        registry
+            .get("claude-code")
+            .expect("claude adapter")
+            .prepare(&ExecutionEnvironmentPath::new(&workspace_root), &brief)
+            .await
+            .expect("prepare multi-repo workspace root");
+
+        assert_eq!(std::fs::read_to_string(workspace_root.join(".flotilla/briefs/coder.md")).expect("brief"), "brief");
+        assert!(workspace_root.join(".flotilla/claude-settings.json").exists());
+    }
+
+    #[test]
+    fn claude_leaves_screen_classification_to_its_hook_path() {
+        let registry = discovered_registry();
+        let claude = registry.get("claude-code").expect("claude adapter");
+
+        // Codex's prompt vocabulary must not be matched against Claude screens.
+        assert_eq!(claude.classify_screen_attention("Do you trust the contents of this directory?"), None);
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/agents/hooks.rs
+++ b/crates/flotilla-core/src/agents/hooks.rs
@@ -99,6 +99,57 @@ impl HarnessHookParser for ClaudeCodeParser {
     }
 }
 
+/// The Claude Code hook events Flotilla subscribes to: the native hook name, the
+/// matcher that narrows it, and the `flotilla hook claude-code <event>` argument
+/// it dispatches to.
+///
+/// This table lives next to [`ClaudeCodeParser`] on purpose. It is the only
+/// producer of Flotilla's hook configuration — both the `flotilla hooks install`
+/// CLI and the managed-crew adapter render from it — so a subscription can never
+/// drift away from the parser arm that has to handle it. The
+/// `every_subscription_has_a_parser_arm` test enforces that.
+const CLAUDE_CODE_HOOK_SUBSCRIPTIONS: &[ClaudeCodeHookSubscription] = &[
+    ClaudeCodeHookSubscription { hook: "SessionStart", matcher: "", event: "session-start" },
+    ClaudeCodeHookSubscription { hook: "SessionEnd", matcher: "", event: "session-end" },
+    ClaudeCodeHookSubscription { hook: "UserPromptSubmit", matcher: "", event: "user-prompt-submit" },
+    ClaudeCodeHookSubscription { hook: "Stop", matcher: "", event: "stop" },
+    ClaudeCodeHookSubscription { hook: "Notification", matcher: "permission_prompt", event: "notification" },
+];
+
+struct ClaudeCodeHookSubscription {
+    hook: &'static str,
+    matcher: &'static str,
+    event: &'static str,
+}
+
+/// Marks a hook command as Flotilla's, so installers can recognise entries they
+/// own without re-parsing the command line.
+pub const CLAUDE_CODE_HOOK_COMMAND_PREFIX: &str = "flotilla hook claude-code";
+
+/// The `hooks` object Flotilla installs into Claude Code settings.
+pub fn claude_code_hook_entries() -> serde_json::Value {
+    let mut entries = serde_json::Map::new();
+    for subscription in CLAUDE_CODE_HOOK_SUBSCRIPTIONS {
+        entries.insert(
+            subscription.hook.to_string(),
+            serde_json::json!([{
+                "matcher": subscription.matcher,
+                "hooks": [{ "type": "command", "command": format!("{CLAUDE_CODE_HOOK_COMMAND_PREFIX} {}", subscription.event) }],
+            }]),
+        );
+    }
+    serde_json::Value::Object(entries)
+}
+
+/// A complete Claude Code settings document carrying only Flotilla's hooks.
+///
+/// Managed crew sessions load this through `claude --settings <path>`, which
+/// layers on top of the user's own settings for one invocation instead of
+/// mutating them.
+pub fn claude_code_hook_settings() -> serde_json::Value {
+    serde_json::json!({ "hooks": claude_code_hook_entries() })
+}
+
 /// Look up the parser for a given harness name.
 pub fn parser_for_harness(harness: &str) -> Result<(AgentHarness, Box<dyn HarnessHookParser>), String> {
     match harness {
@@ -198,6 +249,34 @@ mod tests {
         assert_eq!(AgentEventType::Idle.to_status(), Some(AgentStatus::Idle));
         assert_eq!(AgentEventType::WaitingForPermission.to_status(), Some(AgentStatus::WaitingForPermission));
         assert_eq!(AgentEventType::NoChange.to_status(), None);
+    }
+
+    #[test]
+    fn every_subscription_has_a_parser_arm() {
+        let parser = ClaudeCodeParser;
+        let payload = serde_json::json!({ "session_id": "sess-abc" }).to_string();
+        for subscription in CLAUDE_CODE_HOOK_SUBSCRIPTIONS {
+            parser
+                .parse_event(subscription.event, payload.as_bytes())
+                .unwrap_or_else(|err| panic!("subscription `{}` has no parser arm: {err}", subscription.hook));
+        }
+    }
+
+    #[test]
+    fn hook_settings_dispatch_every_subscription_through_the_flotilla_cli() {
+        let settings = claude_code_hook_settings();
+        let hooks = settings["hooks"].as_object().expect("hooks object");
+
+        assert_eq!(hooks.len(), CLAUDE_CODE_HOOK_SUBSCRIPTIONS.len());
+        for subscription in CLAUDE_CODE_HOOK_SUBSCRIPTIONS {
+            let entry = &hooks[subscription.hook][0];
+            assert_eq!(entry["matcher"], subscription.matcher);
+            assert_eq!(entry["hooks"][0]["type"], "command");
+            assert_eq!(entry["hooks"][0]["command"], format!("flotilla hook claude-code {}", subscription.event));
+        }
+        // The permission prompt is what turns a stalled crew into visible
+        // attention rather than a healthy-looking phase.
+        assert_eq!(hooks["Notification"][0]["matcher"], "permission_prompt");
     }
 
     #[test]

--- a/crates/flotilla-core/src/agents/mod.rs
+++ b/crates/flotilla-core/src/agents/mod.rs
@@ -1,7 +1,10 @@
 pub mod hooks;
 pub mod store;
 
-pub use hooks::{parser_for_harness, HarnessHookParser, ParsedHookEvent};
+pub use hooks::{
+    claude_code_hook_entries, claude_code_hook_settings, parser_for_harness, HarnessHookParser, ParsedHookEvent,
+    CLAUDE_CODE_HOOK_COMMAND_PREFIX,
+};
 
 /// Allocate a fresh attachable ID for an agent in an unmanaged terminal.
 ///

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2922,7 +2922,11 @@ mod tests {
         ]);
         let initial_status = convoys.get("crew-convoy").await.expect("crew convoy").status.expect("convoy status");
         assert_eq!(initial_status.crew_work["implement"]["coder"].phase, flotilla_resources::CrewWorkPhase::Working);
-        assert_eq!(initial_status.crew_work["implement"]["reviewer"].phase, flotilla_resources::CrewWorkPhase::Working);
+        // The reviewer is latent above and has no terminal session yet, so the
+        // convoy status has to agree rather than report a crew member that was
+        // never launched as working.
+        assert_eq!(initial_status.crew_work["implement"]["reviewer"].phase, flotilla_resources::CrewWorkPhase::Pending);
+        assert_eq!(initial_status.crew_work["implement"]["reviewer"].started_at, None);
         assert!(!initial_status.crew_work["implement"].contains_key("watcher"));
 
         let mut rx = daemon.subscribe();

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -255,6 +255,9 @@ pub enum ConvoyStatusPatch {
     WorkRunning {
         work: String,
         started_at: DateTime<Utc>,
+        /// Crew whose sessions the vessel actually launched. Latent agents are
+        /// absent and stay `Pending` until a handoff starts them.
+        launched_roles: BTreeSet<String>,
     },
     ForceWorkCompleted {
         work: String,
@@ -388,13 +391,18 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                     state.placement = Some(placement.clone());
                 }
             }
-            Self::WorkRunning { work, started_at } => {
+            Self::WorkRunning { work, started_at, launched_roles } => {
                 if let Some(state) = status.work.get_mut(work) {
                     state.phase = WorkPhase::Running;
                     state.completion_authority = WorkCompletionAuthority::CrewRollup;
                 }
                 if let Some(crew) = status.crew_work.get_mut(work) {
-                    for state in crew.values_mut().filter(|state| state.phase == CrewWorkPhase::Pending) {
+                    // Only the crew the vessel launched are working. A latent
+                    // agent has no session yet, so it stays Pending until a
+                    // handoff starts it.
+                    for (_, state) in
+                        crew.iter_mut().filter(|(role, state)| state.phase == CrewWorkPhase::Pending && launched_roles.contains(*role))
+                    {
                         state.phase = CrewWorkPhase::Working;
                         state.started_at.get_or_insert(*started_at);
                     }
@@ -571,8 +579,8 @@ pub mod provisioning_patches {
         ConvoyStatusPatch::WorkLaunching { work, started_at, placement }
     }
 
-    pub fn work_running(work: String, started_at: DateTime<Utc>) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::WorkRunning { work, started_at }
+    pub fn work_running(work: String, started_at: DateTime<Utc>, launched_roles: BTreeSet<String>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::WorkRunning { work, started_at, launched_roles }
     }
 }
 

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -357,11 +357,13 @@ fn backfill_crew_work_outcome(status: &super::ConvoyStatus) -> Option<InternalRe
         let missing_crew = vessel
             .crew
             .iter()
-            .filter(|member| matches!(member.source, CrewSource::Agent { .. }))
-            .filter(|member| existing.is_none_or(|crew| !crew.contains_key(&member.role)))
-            .map(|member| {
+            .enumerate()
+            .filter(|(_, member)| matches!(member.source, CrewSource::Agent { .. }))
+            .filter(|(_, member)| existing.is_none_or(|crew| !crew.contains_key(&member.role)))
+            .map(|(index, member)| {
                 let mut state = CrewWorkState::builder().phase(CrewWorkPhase::Pending).build();
-                if work.is_some_and(|work| work.phase == WorkPhase::Running) {
+                // A latent agent has no session even once the vessel is running.
+                if work.is_some_and(|work| work.phase == WorkPhase::Running) && vessel.starts_eagerly(index) {
                     state.phase = CrewWorkPhase::Working;
                     state.started_at = work.and_then(|work| work.started_at);
                 }
@@ -609,7 +611,11 @@ fn vessel_outcome(
                     }
                     if vessel.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Ready) {
                         return InternalReconcileOutcome {
-                            patch: Some(provisioning_patches::work_running(requirement.name.clone(), now)),
+                            patch: Some(provisioning_patches::work_running(
+                                requirement.name.clone(),
+                                now,
+                                requirement.eagerly_started_roles(),
+                            )),
                             actuations,
                             events: vec![ConvoyEvent::WorkPhaseChanged {
                                 work: requirement.name.clone(),

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -35,6 +35,31 @@ pub struct VesselRequirement {
     pub crew: Vec<CrewSpec>,
 }
 
+impl VesselRequirement {
+    /// Whether this crew member's session is created when the vessel starts.
+    ///
+    /// Tool processes all start. Among agents only the first does: the rest are
+    /// *latent*, and their session is created on demand when someone hands work
+    /// off to them. Reporting is the reason this rule has to be shared rather
+    /// than re-derived — a latent agent that is described as working looks like
+    /// a healthy crew when in fact nothing has been launched.
+    pub fn starts_eagerly(&self, crew_index: usize) -> bool {
+        self.crew.get(crew_index).is_some_and(|member| match member.source {
+            CrewSource::Tool { .. } => true,
+            CrewSource::Agent { .. } => self.first_agent_index() == Some(crew_index),
+        })
+    }
+
+    /// The roles whose sessions the vessel creates up front.
+    pub fn eagerly_started_roles(&self) -> BTreeSet<String> {
+        self.crew.iter().enumerate().filter(|(index, _)| self.starts_eagerly(*index)).map(|(_, member)| member.role.clone()).collect()
+    }
+
+    fn first_agent_index(&self) -> Option<usize> {
+        self.crew.iter().position(|member| matches!(member.source, CrewSource::Agent { .. }))
+    }
+}
+
 /// The minimum isolation guarantee required while a vessel runs.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -446,10 +471,50 @@ fn push_error(errors: &mut Vec<ValidationError>, error: ValidationError) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::{
         validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation, Selector, ValidationError,
         VesselRequirement, WorkflowTemplateSpec,
     };
+
+    fn crew(role: &str, source: CrewSource) -> CrewSpec {
+        CrewSpec::builder().role(role.to_string()).source(source).build()
+    }
+
+    fn agent(capability: &str) -> CrewSource {
+        CrewSource::Agent { selector: Selector { capability: capability.to_string() }, prompt: None, brief_template: None }
+    }
+
+    #[test]
+    fn only_the_first_agent_starts_with_the_vessel() {
+        let vessel = VesselRequirement::builder()
+            .name("implement".to_string())
+            .crew(vec![
+                crew("watcher", CrewSource::Tool { command: "tail -f log".to_string() }),
+                crew("coder", agent("code")),
+                crew("reviewer", agent("code-review")),
+            ])
+            .build();
+
+        // Tools all start; the reviewer stays latent until a handoff creates its
+        // session, so nothing may describe it as running.
+        assert!(vessel.starts_eagerly(0), "tool process");
+        assert!(vessel.starts_eagerly(1), "first agent");
+        assert!(!vessel.starts_eagerly(2), "second agent is latent");
+        assert!(!vessel.starts_eagerly(3), "out of range");
+        assert_eq!(vessel.eagerly_started_roles(), BTreeSet::from(["watcher".to_string(), "coder".to_string()]));
+    }
+
+    #[test]
+    fn a_tool_before_an_agent_does_not_consume_the_agent_slot() {
+        let vessel = VesselRequirement::builder()
+            .name("implement".to_string())
+            .crew(vec![crew("build", CrewSource::Tool { command: "cargo test".to_string() }), crew("coder", agent("code"))])
+            .build();
+
+        assert_eq!(vessel.eagerly_started_roles(), BTreeSet::from(["build".to_string(), "coder".to_string()]));
+    }
 
     fn valid_spec() -> WorkflowTemplateSpec {
         WorkflowTemplateSpec::builder()

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{TimeZone, Utc};
 use flotilla_resources::{
@@ -272,12 +272,52 @@ fn running_vessel_work_starts_pending_agents_without_reopening_done_agents() {
         observed_workflows: Some(BTreeMap::new()),
     };
 
-    provisioning_patches::work_running("implement".to_string(), ts(12)).apply(&mut status);
+    provisioning_patches::work_running("implement".to_string(), ts(12), BTreeSet::from(["coder".to_string()])).apply(&mut status);
 
     assert_eq!(status.work["implement"].phase, WorkPhase::Running);
     assert_eq!(status.crew_work["implement"]["coder"].phase, CrewWorkPhase::Working);
     assert_eq!(status.crew_work["implement"]["coder"].started_at, Some(ts(12)));
     assert_eq!(status.crew_work["implement"]["reviewer"].phase, CrewWorkPhase::Done);
+}
+
+#[test]
+fn running_vessel_work_leaves_latent_agents_pending() {
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Active,
+        workflow_snapshot: Some(sample_snapshot()),
+        work: BTreeMap::from([("implement".to_string(), WorkState {
+            phase: WorkPhase::Launching,
+            completion_authority: WorkCompletionAuthority::CrewRollup,
+            ready_at: Some(ts(8)),
+            started_at: Some(ts(9)),
+            finished_at: None,
+            message: None,
+            placement: None,
+        })]),
+        crew_work: BTreeMap::from([(
+            "implement".to_string(),
+            // Bootstrapped crew, neither started yet.
+            BTreeMap::from([
+                ("coder".to_string(), CrewWorkState::builder().phase(CrewWorkPhase::Pending).build()),
+                ("reviewer".to_string(), CrewWorkState::builder().phase(CrewWorkPhase::Pending).build()),
+            ]),
+        )]),
+        message: None,
+        started_at: Some(ts(1)),
+        finished_at: None,
+        observed_workflow_ref: Some("review-and-fix".to_string()),
+        observed_workflows: Some(BTreeMap::new()),
+    };
+
+    // The vessel launches only the first agent; `reviewer` has no session until
+    // someone hands off to it, so reporting it as Working would describe a crew
+    // member that does not exist yet.
+    provisioning_patches::work_running("implement".to_string(), ts(12), BTreeSet::from(["coder".to_string()])).apply(&mut status);
+
+    assert_eq!(status.crew_work["implement"]["coder"].phase, CrewWorkPhase::Working);
+    assert_eq!(status.crew_work["implement"]["coder"].started_at, Some(ts(12)));
+    assert_eq!(status.crew_work["implement"]["reviewer"].phase, CrewWorkPhase::Pending);
+    assert_eq!(status.crew_work["implement"]["reviewer"].started_at, None, "a latent agent has not started");
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -403,7 +403,11 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                 let crew = status.crew_work.get_mut("implement").and_then(|crew| crew.get_mut("coder")).expect("coder work");
                 crew.phase = CrewWorkPhase::Working;
                 let before = crew_timestamps(&status);
-                let patch = ConvoyStatusPatch::WorkRunning { work: "implement".to_string(), started_at: ts(30) };
+                let patch = ConvoyStatusPatch::WorkRunning {
+                    work: "implement".to_string(),
+                    started_at: ts(30),
+                    launched_roles: BTreeSet::from(["coder".to_string()]),
+                };
                 apply_and_replay(&mut status, &patch);
                 (before, crew_timestamps(&status))
             },

--- a/docs/architecture/cli-agent-hooks-design.md
+++ b/docs/architecture/cli-agent-hooks-design.md
@@ -122,6 +122,18 @@ five hook events. Auto-discovered by Claude Code.
 **Phase 2 — CLI installer:** `flotilla hooks install claude-code` writes hook entries into
 settings idempotently. Supports `uninstall`. Extends to other harnesses.
 
+**Phase 3 — managed crew sessions self-provision.** Convoy crew must not depend on a human
+having run the installer on whichever host the vessel lands on: without hooks the crew runs
+normally but no phase or attention signal ever leaves the pane, and the failure is silent.
+The Claude Code adapter therefore writes `.flotilla/claude-settings.json` into the session's
+working directory and launches with `claude --settings .flotilla/claude-settings.json`, which
+layers the hooks on for that invocation only. User settings are never modified, and the
+overlay is removed with the brief at teardown.
+
+The subscription table in `flotilla-core/src/agents/hooks.rs` is the single producer for both
+the installer and the adapter, so a hook Flotilla subscribes to cannot drift from the parser
+arm that handles it.
+
 ### Cloud Agent Refactor
 
 Separate track, can ship after CLI agent hooks:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1408,16 +1408,6 @@ fn resolve_settings_scope(user: bool, project: bool, local: bool) -> Result<Sett
     }
 }
 
-fn claude_code_hook_entries() -> serde_json::Value {
-    serde_json::json!({
-        "SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "flotilla hook claude-code session-start"}]}],
-        "SessionEnd": [{"matcher": "", "hooks": [{"type": "command", "command": "flotilla hook claude-code session-end"}]}],
-        "UserPromptSubmit": [{"matcher": "", "hooks": [{"type": "command", "command": "flotilla hook claude-code user-prompt-submit"}]}],
-        "Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "flotilla hook claude-code stop"}]}],
-        "Notification": [{"matcher": "permission_prompt", "hooks": [{"type": "command", "command": "flotilla hook claude-code notification"}]}]
-    })
-}
-
 fn install_claude_code_hooks(path: &std::path::Path) -> Result<()> {
     let mut settings: serde_json::Value = if path.exists() {
         let content = std::fs::read_to_string(path).map_err(|e| color_eyre::eyre::eyre!("failed to read {}: {e}", path.display()))?;
@@ -1427,12 +1417,12 @@ fn install_claude_code_hooks(path: &std::path::Path) -> Result<()> {
     };
 
     let hooks = settings.as_object_mut().expect("settings is object").entry("hooks").or_insert_with(|| serde_json::json!({}));
-    let new_entries = claude_code_hook_entries();
+    let new_entries = agents::claude_code_hook_entries();
     for (event, matchers) in new_entries.as_object().expect("entries is object") {
         let event_hooks = hooks.as_object_mut().expect("hooks is object").entry(event).or_insert_with(|| serde_json::json!([]));
         let existing_arr = event_hooks.as_array().expect("event hooks is array");
         // Check if flotilla hooks are already present
-        let already_installed = existing_arr.iter().any(|m| m.to_string().contains("flotilla hook claude-code"));
+        let already_installed = existing_arr.iter().any(|m| m.to_string().contains(agents::CLAUDE_CODE_HOOK_COMMAND_PREFIX));
         if !already_installed {
             let arr = event_hooks.as_array_mut().expect("array");
             for entry in matchers.as_array().expect("matchers array") {
@@ -1460,7 +1450,7 @@ fn uninstall_claude_code_hooks(path: &std::path::Path) -> Result<()> {
     if let Some(hooks) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) {
         for (_event, matchers) in hooks.iter_mut() {
             if let Some(arr) = matchers.as_array_mut() {
-                arr.retain(|m| !m.to_string().contains("flotilla hook claude-code"));
+                arr.retain(|m| !m.to_string().contains(agents::CLAUDE_CODE_HOOK_COMMAND_PREFIX));
             }
         }
         // Remove empty event arrays


### PR DESCRIPTION
Closes #1003.

Exercised by running the probe *as* a claude-code crew: this branch was written by a claude-code coder driving convoy `claude-code-e2e-probe` on kiwi, brief → work → PR.

## What the run surfaced

**1. Managed claude crews had no hook path, silently.** Preflight on kiwi: `~/.claude/settings.json` had `hooks: null`. The crew launched, read its brief and worked normally — but no phase or attention signal ever left the pane. Only after manually running `flotilla hooks install claude-code --user` did `SessionStart`/`UserPromptSubmit` produce `TerminalAttention source=hook`. That prerequisite was undocumented, host-local, and its absence undetectable from the control plane: exactly the failure class #1002 named, where a stalled crew reports a healthy-looking phase.

Managed sessions now provision their own hooks. The adapter writes `.flotilla/claude-settings.json` beside the brief and launches with `claude --settings .flotilla/claude-settings.json`, which loads *additional* settings for that invocation. Nothing in the user's config is modified, the overlay is removed with the brief at teardown, and a crew works on any host regardless of whether a human ever ran the installer.

The hook subscription table moves into `flotilla-core/src/agents/hooks.rs` and is now the single producer for both the `flotilla hooks install` CLI and the adapter, sitting next to the parser it feeds. A test asserts every subscription has a parser arm, so the two lists cannot drift.

**2. Latent crew reported `Working`.** A vessel launches only its first agent; later agents are latent, and their session is created on demand when someone hands off to them. But the `WorkRunning` status patch flipped *every* crew member to `Working` with a `started_at`. In the two-crew probe the reviewer had no terminal session at all and still reported as working — while `flotilla crew list` correctly reported it `latent`. Two views of the same crew disagreeing, with the wrong one being the one the control plane rolls up.

The launch rule now lives in one place, `VesselRequirement::starts_eagerly`, used by the vessel reconciler (session creation and brief `active`/`latent` state) and by the convoy status patch. Latent agents stay `Pending` until something actually starts them.

**3. Adapter shape.** `CliAgentAdapter` distinguished harnesses with `if self.id == "codex"`. It now carries an `AdapterFlavor` enum, so each harness's autonomy flag, pre-launch seeding, managed files and screen classification are named rather than inferred from a string.

## Trust parity with #1002

Verified, and no seeding is needed. Codex gates on a *persisted* per-project `trust_level`, which is why it needs `config.toml` pre-seeded. Claude's `--dangerously-skip-permissions` clears the directory-trust and tool-approval gates outright, for the convoy checkout and the multi-repo workspace root alike — covered by a test that prepares a non-git multi-repo workspace root (the #1002 shape). Claude also now returns `None` from `classify_screen_attention` explicitly: its permission prompts arrive through the hook path, which is more precise than matching rendered text, and Codex's prompt vocabulary must not be matched against Claude screens.

## Acceptance

- [x] **A convoy with a claude-code coder completes: brief → work → PR → shepherd → Done, recorded in cleat** — this PR. Session `terminal-claude-code-e2e-probe-work-coder` in cleat, adapter `claude-code`, stance `trusted-implicit`, no trust prompt on launch.
- [x] **Model selection honored** — the `review` role alias resolved to `claude-code` + `opus`; live launch command was `claude --dangerously-skip-permissions --model opus '...'`.
- [x] **A two-crew test (codex coder + claude-code reviewer) launches both sessions correctly** — convoy `mixed-crew-e2e-probe` completed with both crew `Done`; the claude-code reviewer read its brief from a multi-repo workspace root. Note this is the *latent* model working as designed: the reviewer's session is created at handoff, not at vessel start. What was broken was its reported phase, fixed here.
- [x] **Phase/attention reporting works for claude sessions (hooks path)** — A/B against a clean `CLAUDE_CONFIG_DIR` with no user hooks: without the overlay, zero hook events reached the daemon; with it, four (`Started`, `Active`, `Idle`, `Ended`).

## Verification

Live A/B of the overlay in isolation, plus `cargo +nightly-2026-03-12 fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked` all clean.

## Note for review

One property becomes *visible* rather than new: if a coder completes without handing off, a two-agent vessel's work never rolls up to `Complete`, because roll-up requires every crew member `Done`. That was already true — the latent reviewer just sat at `Working` instead of `Pending`. I left roll-up semantics alone deliberately: making latent crew skippable would silently allow bypassing a reviewer, which points against #978's mandatory in-crew review. If latent crew should be skippable, that belongs in an explicit workflow policy rather than falling out of phase bookkeeping.