### PR TITLE
feat: land unscoped TUI on project page

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4541,12 +4541,21 @@ impl InProcessDaemon {
             .items
             .into_iter()
             .map(|project| {
-                let mut repository_keys = project.spec.repositories.into_iter().map(|repository| repository.repo).collect::<Vec<_>>();
-                repository_keys.sort();
-                repository_keys.dedup();
-                let repositories = repository_keys
+                let mut project_repositories = BTreeMap::<RepositoryKey, BTreeSet<String>>::new();
+                for repository in project.spec.repositories {
+                    if let Some(subpath) = repository.subpath {
+                        project_repositories.entry(repository.repo).or_default().insert(subpath);
+                    } else {
+                        project_repositories.entry(repository.repo).or_default();
+                    }
+                }
+                let repositories = project_repositories
                     .into_iter()
-                    .map(|key| ProjectListRepository { slug: repository_slugs.get(&key).cloned(), key })
+                    .map(|(key, subpaths)| ProjectListRepository {
+                        slug: repository_slugs.get(&key).cloned(),
+                        key,
+                        subpaths: subpaths.into_iter().collect(),
+                    })
                     .collect::<Vec<_>>();
                 ProjectListEntry::builder()
                     .namespace(project.metadata.namespace.clone())

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -531,6 +531,8 @@ async fn project_list_query_returns_all_projects_with_addresses_and_repository_s
         "flotilla-org/cleat",
         "flotilla-org/flotilla"
     ]);
+    assert!(response.projects[1].repositories[0].subpaths.is_empty());
+    assert_eq!(response.projects[1].repositories[1].subpaths, vec!["crates/flotilla-core".to_string(), "crates/flotilla-tui".to_string()]);
     assert_eq!(response.projects[1].issue_source.as_ref().map(|source| source.scope.as_str()), Some("FLOT"));
     assert_eq!(response.projects[1].default_workflow_ref, "review-and-fix");
 }

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -142,6 +142,8 @@ pub struct ProjectListRepository {
     pub key: RepositoryKey,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subpaths: Vec<String>,
 }
 
 #[cfg(test)]
@@ -162,6 +164,7 @@ mod project_list_tests {
                 .repositories(vec![ProjectListRepository {
                     key: RepositoryKey("repo-key".into()),
                     slug: Some("flotilla-org/flotilla".into()),
+                    subpaths: vec![],
                 }])
                 .maybe_issue_source(Some(IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }))
                 .default_workflow_ref("single-agent-contained".to_string())

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -589,24 +589,45 @@ impl App {
     }
 
     pub fn new(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>, config: Arc<ConfigStore>, theme: Theme) -> Self {
-        let app = Self::new_unreported(daemon, repos_info, config, theme);
+        let app = Self::new_unreported(daemon, repos_info, config, theme, None);
         app.report_active_view_focus();
         app
     }
 
-    fn new_unreported(daemon: Arc<dyn DaemonHandle>, repos_info: Vec<RepoInfo>, config: Arc<ConfigStore>, theme: Theme) -> Self {
+    /// Construct the full TUI with an optional fresh-config landing View.
+    /// Persisted `open-views.toml` entries always take precedence.
+    pub fn new_with_default_landing(
+        daemon: Arc<dyn DaemonHandle>,
+        repos_info: Vec<RepoInfo>,
+        config: Arc<ConfigStore>,
+        theme: Theme,
+        landing: Option<(RepoIdentity, ViewAddress)>,
+    ) -> Self {
+        let app = Self::new_unreported(daemon, repos_info, config, theme, landing);
+        app.report_active_view_focus();
+        app
+    }
+
+    fn new_unreported(
+        daemon: Arc<dyn DaemonHandle>,
+        repos_info: Vec<RepoInfo>,
+        config: Arc<ConfigStore>,
+        theme: Theme,
+        landing: Option<(RepoIdentity, ViewAddress)>,
+    ) -> Self {
         let mut model = TuiModel::from_repo_info(repos_info);
-        // Open-view set: persisted if present, else seeded to match the
-        // pre-View tab bar (overview + convoys + one tab per tracked repo).
+        // Open-view set: persisted if present, else seeded with overview,
+        // convoys, and one landing View per tracked repo.
         // The seed isn't written back here — it is deterministic, and any
         // tab mutation persists the set (scoped mode must never write it).
         let mut views = match config.load_open_views() {
             Some(entries) => OpenViews::from_entries(entries),
-            None => OpenViews::seed_with_keys(
+            None => OpenViews::seed_with_landing(
                 model
                     .repo_order
                     .iter()
                     .filter_map(|identity| model.repos.get(identity).map(|repo| (identity.clone(), repo.repository_key.clone()))),
+                landing,
             ),
         };
         let repository_keys =
@@ -777,7 +798,7 @@ impl App {
         theme: Theme,
         address: ViewAddress,
     ) -> Self {
-        let mut app = Self::new_unreported(daemon, repos_info, config, theme);
+        let mut app = Self::new_unreported(daemon, repos_info, config, theme, None);
         app.views = OpenViews::scoped(address);
         app.subscriptions_dirty = true;
         app.sync_active_view();

--- a/crates/flotilla-tui/src/app/open_views.rs
+++ b/crates/flotilla-tui/src/app/open_views.rs
@@ -252,23 +252,38 @@ impl OpenViews {
     }
 
     pub fn seed_with_keys(repos: impl IntoIterator<Item = (RepoIdentity, Option<RepositoryKey>)>) -> Self {
+        Self::seed_with_landing(repos, None)
+    }
+
+    /// Build the fresh-config tab set, replacing the selected repo's Plane-A
+    /// tab with its composite landing View when one was resolved.
+    pub fn seed_with_landing(
+        repos: impl IntoIterator<Item = (RepoIdentity, Option<RepositoryKey>)>,
+        landing: Option<(RepoIdentity, ViewAddress)>,
+    ) -> Self {
         let mut entries = vec![OpenViewEntry { address: ViewAddress::Overview.to_string(), label: None }, OpenViewEntry {
             address: ViewAddress::Convoys { namespace: "flotilla".to_string() }.to_string(),
             label: None,
         }];
         entries.extend(repos.into_iter().map(|(identity, repository_key)| {
-            OpenViewEntry {
-                address: match repository_key {
+            let address = landing
+                .as_ref()
+                .filter(|(landing_identity, _)| landing_identity == &identity)
+                .map(|(_, address)| address.clone())
+                .unwrap_or_else(|| match repository_key {
                     Some(key) => ViewAddress::repo_with_key(identity, key),
                     None => ViewAddress::repo(identity),
-                }
-                .to_string(),
-                label: None,
-            }
+                });
+            OpenViewEntry { address: address.to_string(), label: None }
         }));
         let mut views = Self::from_entries(entries);
-        // Land on the first repo tab when there is one, like the old TUI did.
-        views.active = if views.views.len() > 2 { 2 } else { views.views.len() - 1 };
+        views.active = landing.as_ref().and_then(|(_, address)| views.find(address)).unwrap_or_else(|| {
+            if views.views.len() > 2 {
+                2
+            } else {
+                views.views.len() - 1
+            }
+        });
         views
     }
 
@@ -596,6 +611,29 @@ mod tests {
         let addresses: Vec<String> = views.iter().map(|view| view.address().expect("parsed").to_string()).collect();
         assert_eq!(addresses, vec!["overview", "convoys/flotilla", "repo/github.com/o/r"]);
         assert_eq!(views.active_index(), 2, "seed lands on the first repo tab");
+    }
+
+    #[test]
+    fn fresh_project_landing_replaces_only_its_seeded_repo_view() {
+        let selected = RepoIdentity { authority: "github.com".to_string(), path: "o/selected".to_string() };
+        let other = RepoIdentity { authority: "github.com".to_string(), path: "o/other".to_string() };
+        let project = addr("project/flotilla/selected");
+        let views =
+            OpenViews::seed_with_landing(vec![(other.clone(), None), (selected.clone(), None)], Some((selected.clone(), project.clone())));
+
+        let addresses = views.iter().map(|view| view.address().expect("parsed").to_string()).collect::<Vec<_>>();
+        assert_eq!(addresses, vec!["overview", "convoys/flotilla", "repo/github.com/o/other", "project/flotilla/selected"]);
+        assert_eq!(views.active_address(), Some(&project));
+        assert!(views.find(&ViewAddress::repo(selected)).is_none());
+    }
+
+    #[test]
+    fn explicit_repo_address_remains_openable_after_project_landing() {
+        let repo = RepoIdentity { authority: "github.com".to_string(), path: "o/r".to_string() };
+        let mut views = OpenViews::seed_with_landing(vec![(repo.clone(), None)], Some((repo.clone(), addr("project/flotilla/r"))));
+
+        assert!(views.open_or_focus(ViewAddress::repo(repo.clone())));
+        assert_eq!(views.active_address(), Some(&ViewAddress::repo(repo)));
     }
 
     #[test]

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -3,7 +3,7 @@ use std::{collections::VecDeque, path::Path, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use flotilla_core::{
-    config::ConfigStore,
+    config::{ConfigStore, OpenViewEntry},
     daemon::DaemonHandle,
     in_process::InProcessDaemon,
     providers::{
@@ -337,6 +337,31 @@ fn app_new_loads_layout_from_config() {
     let app = App::new(daemon, vec![repo_info("/tmp/repo-a", "repo-a", RepoLabels::default())], config, Theme::classic());
 
     assert_eq!(app.ui.view_layout, RepoViewLayout::Below);
+}
+
+#[test]
+fn persisted_open_views_take_precedence_over_a_fresh_project_landing() {
+    let dir = tempdir().expect("tempdir");
+    let config = Arc::new(ConfigStore::with_base(dir.path()));
+    config.save_open_views(&[OpenViewEntry { address: "overview".into(), label: None }, OpenViewEntry {
+        address: "repo/github.com/owner/repo-a".into(),
+        label: Some("saved".into()),
+    }]);
+    let daemon: Arc<dyn DaemonHandle> = Arc::new(test_support::StubDaemon::new());
+    let repo = repo_info("/tmp/repo-a", "repo-a", RepoLabels::default());
+
+    let app = App::new_with_default_landing(
+        daemon,
+        vec![repo.clone()],
+        config,
+        Theme::classic(),
+        Some((repo.identity, "project/flotilla/repo-a".parse().expect("project address"))),
+    );
+
+    assert_eq!(app.views.to_entries(), vec![OpenViewEntry { address: "overview".into(), label: None }, OpenViewEntry {
+        address: "repo/github.com/owner/repo-a".into(),
+        label: Some("saved".into())
+    },]);
 }
 
 #[tokio::test]

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -224,7 +224,7 @@ mod project_list_human {
     use crate::cli::format_project_list_human;
 
     fn repository(name: &str) -> ProjectListRepository {
-        ProjectListRepository { key: RepositoryKey(format!("key-{name}")), slug: Some(name.to_string()) }
+        ProjectListRepository { key: RepositoryKey(format!("key-{name}")), slug: Some(name.to_string()), subpaths: vec![] }
     }
 
     #[test]
@@ -274,6 +274,7 @@ mod project_list_human {
             .repositories(vec![ProjectListRepository {
                 key: RepositoryKey("umfdl0jvpivapi195j3h2n74gh69gbfub13294vogopginvd1m8g".to_string()),
                 slug: None,
+                subpaths: vec![],
             }])
             .maybe_issue_source(None)
             .default_workflow_ref("single-agent-contained".to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,10 +451,10 @@ fn default_project_landing(
     let project = projects
         .projects
         .iter()
-        .filter(|project| project.repositories.iter().any(|repository| &repository.key == repository_key))
-        .min_by_key(|project| {
-            (project.repositories.len() != 1, project.name != repo.name, project.namespace.as_str(), project.name.as_str())
-        })?;
+        .filter(|project| {
+            matches!(project.repositories.as_slice(), [repository] if &repository.key == repository_key && repository.subpaths.is_empty())
+        })
+        .min_by_key(|project| (project.name != repo.name, project.namespace.as_str(), project.name.as_str()))?;
     Some((repo.identity.clone(), project.address.clone()))
 }
 
@@ -549,7 +549,10 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
             .await
         {
             Ok(CommandValue::ProjectList(projects)) => default_project_landing(&repos_info, &startup_repo_roots, &projects),
-            Ok(_) => None,
+            Ok(value) => {
+                info!(?value, "default project query returned an unexpected result; using repo page");
+                None
+            }
             Err(error) => {
                 info!(%error, "could not resolve default project landing; using repo page");
                 None
@@ -1534,13 +1537,22 @@ mod tests {
         }
     }
 
-    fn landing_project(name: &str, repositories: &[&str]) -> ProjectListEntry {
+    fn landing_project(name: &str, repositories: &[(&str, Option<&str>)]) -> ProjectListEntry {
         ProjectListEntry::builder()
             .namespace("flotilla".to_string())
             .name(name.to_string())
             .display_name(name.to_string())
             .address(ViewAddress::Project { namespace: "flotilla".into(), name: name.into() })
-            .repositories(repositories.iter().map(|key| ProjectListRepository { key: RepositoryKey((*key).into()), slug: None }).collect())
+            .repositories(
+                repositories
+                    .iter()
+                    .map(|(key, subpath)| ProjectListRepository {
+                        key: RepositoryKey((*key).into()),
+                        slug: None,
+                        subpaths: subpath.iter().map(|subpath| (*subpath).to_string()).collect(),
+                    })
+                    .collect(),
+            )
             .default_workflow_ref("single-agent-contained".to_string())
             .build()
     }
@@ -1592,8 +1604,8 @@ mod tests {
         ];
         let projects = ProjectListResponse {
             projects: vec![
-                landing_project("presentation", &["repo-flotilla", "repo-other"]),
-                landing_project("flotilla", &["repo-flotilla"]),
+                landing_project("presentation", &[("repo-flotilla", None), ("repo-other", None)]),
+                landing_project("flotilla", &[("repo-flotilla", None)]),
             ],
         };
 
@@ -1608,9 +1620,25 @@ mod tests {
     #[test]
     fn fresh_landing_falls_back_when_detected_repo_has_no_project() {
         let repos = vec![landing_repo("/repos/plain", "plain", Some("repo-plain"))];
-        let projects = ProjectListResponse { projects: vec![landing_project("other", &["repo-other"])] };
+        let projects = ProjectListResponse { projects: vec![landing_project("other", &[("repo-other", None)])] };
 
         assert_eq!(default_project_landing(&repos, &[PathBuf::from("/repos/plain")], &projects), None);
+    }
+
+    #[test]
+    fn fresh_landing_does_not_confuse_a_subpath_project_for_the_whole_repo_project() {
+        let repos = vec![landing_repo("/repos/shared", "shared", Some("repo-shared"))];
+        let projects = ProjectListResponse {
+            projects: vec![
+                landing_project("docs", &[("repo-shared", Some("docs"))]),
+                landing_project("shared-a1b2c3d4", &[("repo-shared", None)]),
+            ],
+        };
+
+        assert_eq!(
+            default_project_landing(&repos, &[PathBuf::from("/repos/shared")], &projects),
+            Some((repos[0].identity.clone(), ViewAddress::Project { namespace: "flotilla".into(), name: "shared-a1b2c3d4".into() },))
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use flotilla_core::{
 };
 use flotilla_protocol::{
     commands::CommandValue, output::OutputFormat, AgentHookEvent, AttachableId, Command, CommandAction, EnvironmentId, HostName,
-    RepoSelector, StepStatus,
+    ProjectListResponse, RepoIdentity, RepoInfo, RepoSelector, StepStatus, ViewAddress,
 };
 use flotilla_tui::{app, event_log, theme};
 use tracing::info;
@@ -436,6 +436,28 @@ where
     Ok(())
 }
 
+fn default_project_landing(
+    repos: &[RepoInfo],
+    startup_repo_roots: &[PathBuf],
+    projects: &ProjectListResponse,
+) -> Option<(RepoIdentity, ViewAddress)> {
+    let repo = startup_repo_roots.iter().find_map(|root| {
+        let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+        repos
+            .iter()
+            .find(|repo| repo.path.as_ref().is_some_and(|path| std::fs::canonicalize(path).unwrap_or_else(|_| path.clone()) == root))
+    })?;
+    let repository_key = repo.repository_key.as_ref()?;
+    let project = projects
+        .projects
+        .iter()
+        .filter(|project| project.repositories.iter().any(|repository| &repository.key == repository_key))
+        .min_by_key(|project| {
+            (project.repositories.len() != 1, project.name != repo.name, project.namespace.as_str(), project.name.as_str())
+        })?;
+    Some((repo.identity.clone(), project.address.clone()))
+}
+
 /// Run the TUI. With `scoped_view`, run in scoped mode: exactly that View,
 /// no tab shell, no open-view persistence.
 async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) -> Result<()> {
@@ -496,7 +518,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
         }
     };
 
-    for root in startup_repo_roots {
+    for root in &startup_repo_roots {
         if let Err(e) = daemon
             .execute(flotilla_protocol::Command {
                 node_id: None,
@@ -518,9 +540,27 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
 
     let pm_connector = flotilla_tui::pm_open::detect_connector();
     let repos_info = daemon.list_repos().await.unwrap_or_default();
+    let default_landing = if scoped_view.is_none() && config.load_open_views().is_none() && !startup_repo_roots.is_empty() {
+        match daemon
+            .execute_query(
+                Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryProjectList {} },
+                uuid::Uuid::new_v4(),
+            )
+            .await
+        {
+            Ok(CommandValue::ProjectList(projects)) => default_project_landing(&repos_info, &startup_repo_roots, &projects),
+            Ok(_) => None,
+            Err(error) => {
+                info!(%error, "could not resolve default project landing; using repo page");
+                None
+            }
+        }
+    } else {
+        None
+    };
     let mut app = match scoped_view.clone() {
         Some(address) => app::App::new_scoped(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone(), address),
-        None => app::App::new(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone()),
+        None => app::App::new_with_default_landing(daemon.clone(), repos_info, Arc::clone(&config), initial_theme.clone(), default_landing),
     }
     .with_pm_connector(pm_connector.clone());
     restore_tui_handoff(&mut app);
@@ -1471,14 +1511,39 @@ mod tests {
 
     use clap::Parser;
     use flotilla_protocol::{
-        qualified_path::HostId, EnvironmentId, HostListEntry, HostName, NodeId, NodeInfo, PeerConnectionState, ProvisioningTarget,
+        qualified_path::HostId, EnvironmentId, HostListEntry, HostName, NodeId, NodeInfo, PeerConnectionState, ProjectListEntry,
+        ProjectListRepository, ProjectListResponse, ProvisioningTarget, RepoIdentity, RepoInfo, RepoLabels, RepositoryKey, ViewAddress,
     };
 
     use super::{
-        attach_exit_disposition, provisioning_target_for_environment, run_replica_snapshot, select_host_target, select_startup_repo_roots,
-        should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition, Cli, ResourceApplyArgs, ResourceGetArgs,
-        ResourceListArgs, ResourceSubCommand, SubCommand,
+        attach_exit_disposition, default_project_landing, provisioning_target_for_environment, run_replica_snapshot, select_host_target,
+        select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition, Cli,
+        ResourceApplyArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
     };
+
+    fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
+        RepoInfo {
+            identity: RepoIdentity { authority: "github.com".into(), path: format!("org/{name}") },
+            repository_key: key.map(|key| RepositoryKey(key.into())),
+            path: Some(PathBuf::from(path)),
+            name: name.into(),
+            labels: RepoLabels::default(),
+            provider_names: Default::default(),
+            provider_health: Default::default(),
+            loading: false,
+        }
+    }
+
+    fn landing_project(name: &str, repositories: &[&str]) -> ProjectListEntry {
+        ProjectListEntry::builder()
+            .namespace("flotilla".to_string())
+            .name(name.to_string())
+            .display_name(name.to_string())
+            .address(ViewAddress::Project { namespace: "flotilla".into(), name: name.into() })
+            .repositories(repositories.iter().map(|key| ProjectListRepository { key: RepositoryKey((*key).into()), slug: None }).collect())
+            .default_workflow_ref("single-agent-contained".to_string())
+            .build()
+    }
 
     #[test]
     fn attach_exit_disposition_preserves_child_exit_code() {
@@ -1517,6 +1582,35 @@ mod tests {
         let roots = select_startup_repo_roots(&explicit, None);
 
         assert_eq!(roots, vec![PathBuf::from("/repos/one"), PathBuf::from("/repos/two")]);
+    }
+
+    #[test]
+    fn fresh_landing_resolves_the_detected_repos_whole_repo_project() {
+        let repos = vec![
+            landing_repo("/repos/other", "other", Some("repo-other")),
+            landing_repo("/repos/flotilla", "flotilla", Some("repo-flotilla")),
+        ];
+        let projects = ProjectListResponse {
+            projects: vec![
+                landing_project("presentation", &["repo-flotilla", "repo-other"]),
+                landing_project("flotilla", &["repo-flotilla"]),
+            ],
+        };
+
+        let landing = default_project_landing(&repos, &[PathBuf::from("/repos/flotilla")], &projects);
+
+        assert_eq!(
+            landing,
+            Some((repos[1].identity.clone(), ViewAddress::Project { namespace: "flotilla".into(), name: "flotilla".into() },))
+        );
+    }
+
+    #[test]
+    fn fresh_landing_falls_back_when_detected_repo_has_no_project() {
+        let repos = vec![landing_repo("/repos/plain", "plain", Some("repo-plain"))];
+        let projects = ProjectListResponse { projects: vec![landing_project("other", &["repo-other"])] };
+
+        assert_eq!(default_project_landing(&repos, &[PathBuf::from("/repos/plain")], &projects), None);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- resolve a fresh unscoped launch to the detected repository's Project resource
- replace that repository's seeded Plane-A repo tab with the composite project page
- fall back to the repo page when no matching Project exists
- preserve existing `open-views.toml` entries exactly and keep repo addresses explicitly openable

## Why

The composite project page is now the primary control-plane surface. Fresh unscoped launches should enter through it while retaining the Plane-A repo page for comparison and explicit navigation.

## Impact

Running `flotilla` from a tracked repository now lands on its whole-repository project page. Saved tab sets are unchanged, and repositories without a Project continue to land on their repo page.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1033