### PR TITLE
feat: enact fork repository stance

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -305,6 +305,7 @@ impl Reconciler for VesselReconciler {
         let mut checkout_refs = BTreeMap::new();
         let mut checkout_paths = BTreeMap::new();
         let mut waiting_for_checkouts = false;
+        let mut fork_stance = false;
         for convoy_repository in convoy_repositories {
             let repository_spec = match self.repositories.get(&convoy_repository.repo_ref.to_string()).await {
                 Ok(repository) => repository.spec,
@@ -331,6 +332,7 @@ impl Reconciler for VesselReconciler {
             if let Err(message) = repository_spec.verify_key(&convoy_repository.repo_ref) {
                 return Ok(VesselDeps::failed(message));
             }
+            fork_stance |= repository_spec.is_fork();
             let canonical_repo = match repository_spec.identity() {
                 RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
                 RepositoryIdentity::Local { .. } => return Ok(VesselDeps::failed("convoy repository must have a transport remote")),
@@ -651,10 +653,11 @@ impl Reconciler for VesselReconciler {
                                 None if !convoy.spec.issues.is_empty() => CrewAssignment::CarriedIssue,
                                 None => CrewAssignment::Unassigned,
                             };
-                            let render_options = self.brief_templates.render_options(
+                            let render_options = self.brief_templates.render_options_with_fork_stance(
                                 brief_template.as_deref(),
                                 convoy.spec.project_ref.as_deref(),
                                 checkout_paths.values().map(PathBuf::from),
+                                fork_stance,
                             );
                             let mut brief = match build_crew_brief_with_options(
                                 &context,

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -20,6 +20,8 @@ pub const TRUSTED_IMPLICIT_STANCE: &str = "trusted-implicit";
 pub const DEFAULT_CREW_BRIEF_TEMPLATE: &str = "crew.md";
 const BUILTIN_CREW_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/crew.md");
 const BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/interactive-session.md");
+const BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/diff-review.md");
+const BUILTIN_FORK_STANCE_BRIEF_LAYER: &str = include_str!("agent_adapter/templates/fork-stance.md");
 const BRIEF_TEMPLATE_DIR: &str = "brief-templates";
 
 pub fn crew_brief_path(role: &str) -> String {
@@ -69,9 +71,20 @@ impl CrewBriefTemplateResolver {
         project_ref: Option<&str>,
         repo_roots: impl IntoIterator<Item = PathBuf>,
     ) -> CrewBriefRenderOptions {
+        self.render_options_with_fork_stance(template, project_ref, repo_roots, false)
+    }
+
+    pub fn render_options_with_fork_stance(
+        &self,
+        template: Option<&str>,
+        project_ref: Option<&str>,
+        repo_roots: impl IntoIterator<Item = PathBuf>,
+        fork_stance: bool,
+    ) -> CrewBriefRenderOptions {
         let template = template.filter(|template| !template.trim().is_empty()).unwrap_or(DEFAULT_CREW_BRIEF_TEMPLATE);
         let override_filename = match template {
             "interactive-session" => "interactive-session.md",
+            "diff-review" => "diff-review.md",
             other => other,
         };
         let mut overrides = Vec::new();
@@ -87,7 +100,7 @@ impl CrewBriefTemplateResolver {
         for repo_root in repo_roots {
             push_template_override(&mut overrides, repo_root.join(".flotilla").join(BRIEF_TEMPLATE_DIR).join(override_filename));
         }
-        CrewBriefRenderOptions { template: template.to_string(), overrides }
+        CrewBriefRenderOptions { template: template.to_string(), overrides, fork_stance }
     }
 }
 
@@ -103,11 +116,12 @@ fn push_template_override(overrides: &mut Vec<CrewBriefTemplateOverride>, path: 
 pub struct CrewBriefRenderOptions {
     pub template: String,
     pub overrides: Vec<CrewBriefTemplateOverride>,
+    pub fork_stance: bool,
 }
 
 impl Default for CrewBriefRenderOptions {
     fn default() -> Self {
-        Self { template: DEFAULT_CREW_BRIEF_TEMPLATE.to_string(), overrides: Vec::new() }
+        Self { template: DEFAULT_CREW_BRIEF_TEMPLATE.to_string(), overrides: Vec::new(), fork_stance: false }
     }
 }
 
@@ -175,10 +189,13 @@ fn render_crew_brief_template(options: &CrewBriefRenderOptions, context: &CrewBr
         .map_err(|err| format!("load built-in crew brief template: {err}"))?;
     env.add_template(BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME, BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE)
         .map_err(|err| format!("load built-in interactive-session brief template: {err}"))?;
+    env.add_template(BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE_NAME, BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE)
+        .map_err(|err| format!("load built-in diff-review brief template: {err}"))?;
     let mut skip_overrides = 0;
     let mut current_template = match options.template.as_str() {
         DEFAULT_CREW_BRIEF_TEMPLATE => BUILTIN_CREW_BRIEF_TEMPLATE_NAME.to_string(),
         "interactive-session" | "interactive-session.md" => BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME.to_string(),
+        "diff-review" | "diff-review.md" => BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE_NAME.to_string(),
         custom if !options.overrides.is_empty() => {
             let first = &options.overrides[0];
             if is_block_only_override(&first.source) {
@@ -200,6 +217,12 @@ fn render_crew_brief_template(options: &CrewBriefRenderOptions, context: &CrewBr
             .map_err(|err| format!("load crew brief template {}: {err}", template_override.path.display()))?;
         current_template = name;
     }
+    if options.fork_stance {
+        let name = format!("builtin/fork-stance/{}", options.template);
+        let source = format!("{{% extends \"{current_template}\" %}}\n{BUILTIN_FORK_STANCE_BRIEF_LAYER}");
+        env.add_template_owned(name.clone(), source).map_err(|err| format!("load built-in fork-stance brief layer: {err}"))?;
+        current_template = name;
+    }
     env.get_template(&current_template)
         .and_then(|template| template.render(context))
         .map_err(|err| format!("render crew brief template {}: {err}", options.template))
@@ -207,6 +230,7 @@ fn render_crew_brief_template(options: &CrewBriefRenderOptions, context: &CrewBr
 
 const BUILTIN_CREW_BRIEF_TEMPLATE_NAME: &str = "builtin/crew.md";
 const BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME: &str = "builtin/interactive-session.md";
+const BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE_NAME: &str = "builtin/diff-review.md";
 
 fn layered_override_source(parent: &str, source: &str) -> String {
     if !is_block_only_override(source) {
@@ -731,7 +755,7 @@ mod tests {
             "driver",
             CrewAssignment::Prompt("Pair with the user."),
             &[CrewBriefMember { role: "driver".to_string(), state: "active".to_string(), is_agent: true }],
-            &CrewBriefRenderOptions { template: "interactive-session.md".to_string(), overrides: Vec::new() },
+            &CrewBriefRenderOptions { template: "interactive-session.md".to_string(), overrides: Vec::new(), fork_stance: false },
         )
         .expect("render selected template")
         .content;
@@ -739,6 +763,34 @@ mod tests {
         assert!(selected.contains("For interactive sessions, keep the user-facing loop tight"));
         assert!(selected.contains("## Assignment\n\nPair with the user."));
         assert!(!default.contains("For interactive sessions"));
+    }
+
+    #[test]
+    fn diff_review_template_and_fork_layer_define_review_settlement() {
+        let brief = build_crew_brief_with_options(
+            &TerminalCrewContext {
+                namespace: "flotilla".to_string(),
+                convoy: "zellij-9".to_string(),
+                vessel_ref: "zellij-9-work".to_string(),
+            },
+            "work",
+            "reviewer",
+            CrewAssignment::CarriedIssue,
+            &[CrewBriefMember { role: "coder".to_string(), state: "handed-off".to_string(), is_agent: true }, CrewBriefMember {
+                role: "reviewer".to_string(),
+                state: "active".to_string(),
+                is_agent: true,
+            }],
+            &CrewBriefRenderOptions { template: "diff-review".to_string(), overrides: Vec::new(), fork_stance: true },
+        )
+        .expect("render fork review brief")
+        .content;
+
+        assert!(brief.contains("flotilla crew coder handoff --message"));
+        assert!(brief.contains("sign off on the fork PR"));
+        assert!(brief.contains("Never add a git remote"));
+        assert!(brief.contains("Never open issues, pull requests, or comments against the upstream repository"));
+        assert!(brief.contains("base set to the stack branch named in the dispatch inputs"));
     }
 
     #[test]
@@ -790,6 +842,7 @@ mod tests {
                     path: "pairing.md".into(),
                     source: "{% block delivery %}Pairing-specific delivery gate.{% endblock %}".to_string(),
                 }],
+                fork_stance: false,
             },
         )
         .expect("render custom block-only template");

--- a/crates/flotilla-core/src/agent_adapter/templates/diff-review.md
+++ b/crates/flotilla-core/src/agent_adapter/templates/diff-review.md
@@ -1,0 +1,2 @@
+{% extends "builtin/crew.md" %}
+{% block delivery %}Review the implementation diff and the fork PR against the assignment. Send actionable findings to the coder with `flotilla crew coder handoff --message '...'`, then re-review the resulting changes. When the implementation is sound, sign off on the fork PR and complete with `flotilla crew complete --message '<PR URL>'`. Do not merge the PR; the human owns merge.{% endblock %}

--- a/crates/flotilla-core/src/agent_adapter/templates/fork-stance.md
+++ b/crates/flotilla-core/src/agent_adapter/templates/fork-stance.md
@@ -1,0 +1,5 @@
+{% block operating_instructions %}{{ super() }}Fork-stance constraints:
+- Never add a git remote. Provisioned checkouts intentionally contain only the fork remote (`origin`).
+- Never open issues, pull requests, or comments against the upstream repository.
+- Open the fork PR with its base set to the stack branch named in the dispatch inputs.
+{% endblock %}

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -4,7 +4,8 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use flotilla_protocol::{IssueSource, NodeId};
+use flotilla_protocol::{IssueSource, NodeId, RepositoryRelation};
+use flotilla_resources::RepositorySpec;
 use serde::{Deserialize, Serialize};
 
 use crate::path_context::{DaemonHostPath, ExecutionEnvironmentPath};
@@ -215,6 +216,10 @@ pub struct RepoFileConfig {
     pub vcs: RepoVcsConfig,
     #[serde(default)]
     pub issue_tracker: RepoIssueTrackerConfig,
+    #[serde(default)]
+    pub upstream: Option<RepoUpstreamConfig>,
+    #[serde(default)]
+    pub workflow: RepoWorkflowConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -240,6 +245,18 @@ pub struct RepoIssueTrackerConfig {
 #[derive(Debug, Default, Deserialize)]
 pub struct RepoForgejoIssueTrackerConfig {
     pub scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RepoUpstreamConfig {
+    pub url: String,
+    pub relation: RepositoryRelation,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct RepoWorkflowConfig {
+    #[serde(default)]
+    pub allow_reviewless: bool,
 }
 
 /// Global SSH settings for remote host connections.
@@ -610,6 +627,20 @@ impl ConfigStore {
             return None;
         };
         Some(IssueSource { service, scope })
+    }
+
+    pub fn configure_repository_spec(
+        &self,
+        repo_root: &ExecutionEnvironmentPath,
+        mut spec: RepositorySpec,
+    ) -> Result<RepositorySpec, String> {
+        let Some(repo_cfg) = self.load_repo_file_config(repo_root) else {
+            return Ok(spec);
+        };
+        if let Some(upstream) = repo_cfg.upstream {
+            spec = spec.with_upstream(upstream.url, upstream.relation)?;
+        }
+        Ok(spec.with_allow_reviewless_workflows(repo_cfg.workflow.allow_reviewless))
     }
 
     fn load_repo_file_config(&self, repo_root: &ExecutionEnvironmentPath) -> Option<RepoFileConfig> {

--- a/crates/flotilla-core/src/config/tests.rs
+++ b/crates/flotilla-core/src/config/tests.rs
@@ -122,6 +122,32 @@ fn resolve_repo_issue_source_reads_forgejo_binding() {
 }
 
 #[test]
+fn configure_repository_spec_reads_fork_stance_and_reviewless_override() {
+    let dir = tempdir().expect("create config tempdir");
+    let base = dir.path();
+    let repo = make_dir(base, "zellij");
+    let content = format!(
+        "path = \"{}\"\n[upstream]\nurl = \"https://github.com/zellij-org/zellij.git\"\nrelation = \"fork\"\n[workflow]\nallow_reviewless = true\n",
+        repo.display()
+    );
+    write_repo_file(base, &format!("{}.toml", repo_file_key(&repo)), &content);
+
+    let store = ConfigStore::with_base(base);
+    let configured = store
+        .configure_repository_spec(&ee(repo), RepositorySpec::remote("https://forgejo.lab/fork-issues/zellij").expect("fork repository"))
+        .expect("repository config");
+
+    assert_eq!(
+        configured.upstream(),
+        Some(&flotilla_protocol::RepositoryUpstream {
+            url: "https://github.com/zellij-org/zellij".to_string(),
+            relation: flotilla_protocol::RepositoryRelation::Fork,
+        })
+    );
+    assert!(configured.allows_reviewless_workflows());
+}
+
+#[test]
 fn resolve_repo_issue_source_requires_global_forgejo_service_url() {
     let dir = tempdir().expect("create config tempdir");
     let base = dir.path();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1696,7 +1696,10 @@ impl InProcessDaemon {
     }
 
     pub async fn inspect_repository_path(&self, path: &Path, remote: Option<&str>) -> Result<RepositoryInspection, String> {
-        self.repository_inspector().await?.inspect_path(path, remote).await
+        let mut inspection = self.repository_inspector().await?.inspect_path(path, remote).await?;
+        inspection.spec =
+            self.config.configure_repository_spec(&ExecutionEnvironmentPath::new(&inspection.checkout.path), inspection.spec)?;
+        Ok(inspection)
     }
 
     pub async fn repository_key_for_path(&self, path: &Path) -> Option<RepositoryKey> {
@@ -3042,11 +3045,17 @@ fn repository_matches_target(repository: &ResourceObject<Repository>, target: &s
 
 async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
     let templates = backend.clone().using::<WorkflowTemplate>(namespace);
-    let meta = InputMeta::builder().name("single-agent-contained".to_string()).build();
-    match templates.create(&meta, &flotilla_resources::single_agent_contained_workflow_spec()).await {
-        Ok(_) | Err(ResourceError::Conflict { .. }) => Ok(()),
-        Err(error) => Err(error.to_string()),
+    for (name, spec) in [
+        ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
+        ("implement-review", flotilla_resources::implement_review_workflow_spec()),
+    ] {
+        let meta = InputMeta::builder().name(name.to_string()).build();
+        match templates.create(&meta, &spec).await {
+            Ok(_) | Err(ResourceError::Conflict { .. }) => {}
+            Err(error) => return Err(error.to_string()),
+        }
     }
+    Ok(())
 }
 
 fn prepared_snapshot_name(convoy_name: &str, kind: &str, spec: &serde_json::Value) -> Result<String, String> {
@@ -3200,6 +3209,40 @@ fn required_admission_value<'a>(value: &'a str, field: &str) -> Result<&'a str, 
     } else {
         Ok(value)
     }
+}
+
+fn workflow_has_in_crew_review(workflow: &WorkflowTemplateSpec) -> bool {
+    workflow.vessels.iter().any(|vessel| {
+        let agent_count = vessel.crew.iter().filter(|crew| matches!(crew.source, CrewSource::Agent { .. })).count();
+        agent_count > 1
+            && vessel.crew.iter().any(|crew| {
+                matches!(
+                    &crew.source,
+                    CrewSource::Agent { selector, .. } if matches!(selector.capability.as_str(), "review" | "code-review")
+                )
+            })
+    })
+}
+
+async fn validate_fork_workflow_admission(
+    backend: &ResourceBackend,
+    namespace: &str,
+    repositories: &[ConvoyRepositorySpec],
+    workflow_ref: &str,
+    workflow: &WorkflowTemplateSpec,
+) -> Result<(), String> {
+    if workflow_has_in_crew_review(workflow) {
+        return Ok(());
+    }
+    let resolver = backend.clone().using::<Repository>(namespace);
+    for repository in repositories {
+        let repository =
+            resolver.get(&repository.repo_ref.to_string()).await.map_err(|error| format!("repository {}: {error}", repository.repo_ref))?;
+        if repository.spec.is_fork() && !repository.spec.allows_reviewless_workflows() {
+            return Err(format!("workflow {workflow_ref} not permitted for fork-stance repository — use implement-review"));
+        }
+    }
+    Ok(())
 }
 
 async fn validate_workflow_agent_adapters(
@@ -3452,6 +3495,7 @@ impl InProcessDaemon {
             .get(&workflow_ref)
             .await
             .map_err(|error| format!("workflow template {workflow_ref}: {error}"))?;
+        validate_fork_workflow_admission(&self.resource_backend, namespace, &repositories, &workflow_ref, &workflow.spec).await?;
 
         let fallback_slug = convoy_issues_fallback_slug(&issues, &project.spec.display_name, project_ref);
         let generated = if intent.name.is_none() || intent.branch.is_none() {
@@ -3906,9 +3950,16 @@ impl InProcessDaemon {
         let repository_spec = &inspection.spec;
         let repository_key = repository_spec.key();
         ensure_repository_and_default_project_workflow(&self.resource_backend, &namespace, &repository_key, repository_spec).await?;
+        let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
+        let stored = repositories.get(&repository_key.to_string()).await.map_err(|error| error.to_string())?;
+        if stored.spec != *repository_spec {
+            repositories
+                .update(&InputMeta::from(&stored.metadata), &stored.metadata.resource_version, repository_spec)
+                .await
+                .map_err(|error| error.to_string())?;
+        }
 
         let projects = self.resource_backend.clone().using::<Project>(&namespace);
-        let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
         let repository_objects = repositories.list().await.map_err(|error| error.to_string())?.items;
         let repository_specs = repository_objects
             .iter()
@@ -4146,19 +4197,21 @@ impl InProcessDaemon {
         let repo = self.resolve_repo_selector(repo).await?;
         let identity = self.tracked_repo_identity_for_path(&repo).await.ok_or_else(|| format!("repo not tracked: {}", repo.display()))?;
         let identity_change = match self.inspect_repository_path(&repo, None).await {
-            Ok(inspection) if self.repository_keys_by_path.read().await.get(&repo) != Some(&inspection.key()) => {
+            Ok(inspection) => {
+                let key_changed = self.repository_keys_by_path.read().await.get(&repo) != Some(&inspection.key());
                 let identity_change = self.reconcile_whole_repository_project(&inspection).await?;
-                {
-                    let _reconciliation = self.observed_checkout_reconciliation.lock().await;
-                    if self.tracked_repo_identity_for_path(&repo).await.as_ref() != Some(&identity) {
-                        return Err(format!("repo not tracked: {}", repo.display()));
+                if key_changed {
+                    {
+                        let _reconciliation = self.observed_checkout_reconciliation.lock().await;
+                        if self.tracked_repo_identity_for_path(&repo).await.as_ref() != Some(&identity) {
+                            return Err(format!("repo not tracked: {}", repo.display()));
+                        }
+                        self.repository_keys_by_path.write().await.insert(repo.clone(), inspection.key());
                     }
-                    self.repository_keys_by_path.write().await.insert(repo.clone(), inspection.key());
+                    self.publish_repo_info_update(&identity).await;
                 }
-                self.publish_repo_info_update(&identity).await;
                 identity_change
             }
-            Ok(_) => None,
             Err(error) => {
                 warn!(repo = %repo.display(), %error, "repository identity is unavailable during refresh");
                 None
@@ -4427,6 +4480,17 @@ impl InProcessDaemon {
 
     pub async fn get_repo_detail_internal(&self, repo: &flotilla_protocol::RepoSelector) -> Result<RepoDetailResponse, String> {
         let repo_path = self.resolve_repo_selector(repo).await?;
+        let upstream = match self.repository_keys_by_path.read().await.get(&repo_path).cloned() {
+            Some(key) => self
+                .resource_backend
+                .clone()
+                .using::<Repository>(&self.provisioning_namespace().await)
+                .get(&key.to_string())
+                .await
+                .ok()
+                .and_then(|repository| repository.spec.upstream().cloned()),
+            None => None,
+        };
         let identity =
             self.tracked_repo_identity_for_path(&repo_path).await.ok_or_else(|| format!("repo not found: {}", repo_path.display()))?;
         let peer_overlay = self.peer_providers.read().await.get(&identity).cloned();
@@ -4443,6 +4507,7 @@ impl InProcessDaemon {
         Ok(RepoDetailResponse {
             path: state.preferred_path().to_path_buf(),
             slug: state.slug().map(str::to_string),
+            upstream,
             provider_health: snapshot.provider_health.clone(),
             work_items: snapshot.work_items.clone(),
             errors: snapshot.errors.clone(),
@@ -5014,8 +5079,20 @@ impl InProcessDaemon {
                 };
                 let current = self.crew_list_internal(requested).await?;
                 let repo_roots = crew_brief_repo_roots(&self.resource_backend, &context.namespace, &convoy, &repository_refs).await;
+                let repositories = self.resource_backend.clone().using::<Repository>(&context.namespace);
+                let mut fork_stance = false;
+                for repository_ref in &repository_refs {
+                    if let Ok(repository) = repositories.get(&repository_ref.to_string()).await {
+                        fork_stance |= repository.spec.is_fork();
+                    }
+                }
                 let render_options = crate::agent_adapter::CrewBriefTemplateResolver::with_config_dir(self.config.base_path().as_path())
-                    .render_options(brief_template.as_deref(), convoy.spec.project_ref.as_deref(), repo_roots);
+                    .render_options_with_fork_stance(
+                        brief_template.as_deref(),
+                        convoy.spec.project_ref.as_deref(),
+                        repo_roots,
+                        fork_stance,
+                    );
                 let brief =
                     handoff_crew_brief(&context, &convoy, target, prompt.as_deref(), &current.members, &repository_refs, &render_options)?;
                 sessions

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3043,7 +3043,7 @@ fn repository_matches_target(repository: &ResourceObject<Repository>, target: &s
     repository.metadata.name == target || repository.spec.matches_catalog_target(target)
 }
 
-async fn ensure_single_agent_contained_workflow(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
+async fn ensure_default_workflows(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
     let templates = backend.clone().using::<WorkflowTemplate>(namespace);
     for (name, spec) in [
         ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
@@ -3134,7 +3134,7 @@ async fn ensure_repository_and_default_project_workflow(
     flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(namespace), repository_key, repository_spec)
         .await
         .map_err(|error| error.to_string())?;
-    ensure_single_agent_contained_workflow(backend, namespace).await
+    ensure_default_workflows(backend, namespace).await
 }
 
 fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: String) -> Result<ProjectSpec, String> {
@@ -3953,6 +3953,9 @@ impl InProcessDaemon {
         let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
         let stored = repositories.get(&repository_key.to_string()).await.map_err(|error| error.to_string())?;
         if stored.spec != *repository_spec {
+            // This path is authoritative for per-repository config, so it may
+            // intentionally clear provenance that identity-only observations
+            // preserve in `ensure_repository`.
             repositories
                 .update(&InputMeta::from(&stored.metadata), &stored.metadata.resource_version, repository_spec)
                 .await
@@ -4122,6 +4125,27 @@ impl InProcessDaemon {
         Err(format!("could not allocate a deterministic Project name for repository {repository_key}"))
     }
 
+    async fn reconcile_repository_config(
+        &self,
+        namespace: &str,
+        repository_key: &RepositoryKey,
+        repository_spec: &RepositorySpec,
+    ) -> Result<(), String> {
+        let repositories = self.resource_backend.clone().using::<Repository>(namespace);
+        let stored = flotilla_resources::ensure_repository(&repositories, repository_key, repository_spec)
+            .await
+            .map_err(|error| error.to_string())?;
+        if stored.spec != *repository_spec {
+            // Unlike identity-only observations, the current per-repository
+            // config is authoritative and may remove a previously set stance.
+            repositories
+                .update(&InputMeta::from(&stored.metadata), &stored.metadata.resource_version, repository_spec)
+                .await
+                .map_err(|error| error.to_string())?;
+        }
+        Ok(())
+    }
+
     pub async fn materialize_tracked_repo_projects(&self) -> Result<(), String> {
         for repo_path in self.tracked_repo_paths().await {
             let inspection = match self.inspect_repository_path(&repo_path, None).await {
@@ -4199,7 +4223,13 @@ impl InProcessDaemon {
         let identity_change = match self.inspect_repository_path(&repo, None).await {
             Ok(inspection) => {
                 let key_changed = self.repository_keys_by_path.read().await.get(&repo) != Some(&inspection.key());
-                let identity_change = self.reconcile_whole_repository_project(&inspection).await?;
+                let identity_change = if key_changed {
+                    self.reconcile_whole_repository_project(&inspection).await?
+                } else {
+                    let namespace = self.provisioning_namespace().await;
+                    self.reconcile_repository_config(&namespace, &inspection.key(), &inspection.spec).await?;
+                    None
+                };
                 if key_changed {
                     {
                         let _reconciliation = self.observed_checkout_reconciliation.lock().await;

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1717,9 +1717,10 @@ impl InProcessDaemon {
         git_ref: Option<&str>,
     ) -> Result<RepositoryInspection, String> {
         if let (Some(repository_url), Some(git_ref)) = (repository_url, git_ref) {
-            if let Ok(spec) = RepositorySpec::remote(repository_url) {
+            if let Ok(mut spec) = RepositorySpec::remote(repository_url) {
                 let path = std::fs::canonicalize(path)
                     .map_err(|error| format!("adopted checkout path {} cannot be resolved: {error}", path.display()))?;
+                spec = self.config.configure_repository_spec(&ExecutionEnvironmentPath::new(&path), spec)?;
                 let host_ref = self.local_host_id().ok_or_else(|| "local Host identity is unavailable".to_string())?.to_string();
                 return Ok(RepositoryInspection {
                     spec,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1048,6 +1048,94 @@ async fn handoff_brief_for_demo_repository_scope(repository_refs: Option<Vec<Rep
 }
 
 #[tokio::test]
+async fn fork_review_handoff_launches_reviewer_with_diff_review_and_fork_brief() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, _) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+
+    let repository = RepositorySpec::remote("https://forgejo.lab/fork-issues/zellij")
+        .expect("fork repository")
+        .with_upstream("https://github.com/zellij-org/zellij", flotilla_protocol::RepositoryRelation::Fork)
+        .expect("upstream");
+    flotilla_resources::ensure_repository(&daemon.resource_backend().using::<Repository>("flotilla"), &repository.key(), &repository)
+        .await
+        .expect("repository create");
+    let convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    let convoy = convoys.get("demo").await.expect("convoy");
+    let mut spec = convoy.spec.clone();
+    spec.repositories = vec![ConvoyRepositorySpec::builder()
+        .url("https://forgejo.lab/fork-issues/zellij".to_string())
+        .repo_ref(repository.key())
+        .base_ref("stack/base".to_string())
+        .workspace_slug("zellij".to_string())
+        .subpaths(Vec::new())
+        .build()];
+    let convoy =
+        convoys.update(&input_meta_from_resource(&convoy), &convoy.metadata.resource_version, &spec).await.expect("convoy spec update");
+    let mut status = convoy.status.expect("convoy status");
+    let reviewer = status
+        .workflow_snapshot
+        .as_mut()
+        .expect("workflow snapshot")
+        .vessels
+        .iter_mut()
+        .find(|vessel| vessel.name == "implement")
+        .expect("implement vessel")
+        .crew
+        .iter_mut()
+        .find(|crew| crew.role == "reviewer")
+        .expect("reviewer");
+    let CrewSource::Agent { brief_template, .. } = &mut reviewer.source else {
+        panic!("reviewer should be an agent");
+    };
+    *brief_template = Some("diff-review".to_string());
+    convoys.update_status("demo", &convoy.metadata.resource_version, &status).await.expect("convoy status update");
+
+    daemon
+        .crew_handoff_internal(
+            &CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
+            "reviewer",
+            "Review the fork PR",
+        )
+        .await
+        .expect("review handoff");
+    let reviewer = daemon
+        .resource_backend()
+        .using::<ResourceTerminalSession>("flotilla")
+        .get("terminal-demo-implement-reviewer")
+        .await
+        .expect("reviewer session");
+    let TerminalSessionSource::Agent { selector, brief, message, .. } = reviewer.spec.source else {
+        panic!("reviewer should be agent-backed");
+    };
+    assert_eq!(selector.capability, "review");
+    assert_eq!(message.as_ref().map(|message| message.text.as_str()), Some("handoff from coder@implement\n\nReview the fork PR"));
+    assert!(brief.content.contains("sign off on the fork PR"));
+    assert!(brief.content.contains("Never add a git remote"));
+    assert!(brief.content.contains("Never open issues, pull requests, or comments against the upstream repository"));
+
+    daemon
+        .crew_complete_internal(
+            &CrewCommandContext {
+                namespace: Some("flotilla".into()),
+                convoy: Some("demo".into()),
+                vessel_ref: Some("demo-implement".into()),
+                role: Some("reviewer".into()),
+                ..Default::default()
+            },
+            Some("https://forgejo.lab/fork-issues/zellij/pulls/9".into()),
+        )
+        .await
+        .expect("reviewer sign-off completion");
+    let convoy = convoys.get("demo").await.expect("completed convoy");
+    let reviewer_work = &convoy.status.expect("convoy status").crew_work["implement"]["reviewer"];
+    assert_eq!(reviewer_work.phase, CrewWorkPhase::Done);
+    assert_eq!(reviewer_work.message.as_deref(), Some("https://forgejo.lab/fork-issues/zellij/pulls/9"));
+}
+
+#[tokio::test]
 async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
     let temp = tempfile::tempdir().expect("tempdir");
     std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -135,6 +135,31 @@ async fn convoy_auto_attach_config_overrides_presence_heuristic() {
     assert!(enabled.should_auto_attach(flotilla_protocol::ConvoyAutoAttach::Default));
 }
 
+#[tokio::test]
+async fn adopted_checkout_with_explicit_transport_applies_fork_stance_config() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"adopted-fork-test\"\n").expect("write daemon config");
+    overwrite_single_saved_repo_config(
+        &config_base,
+        &repo,
+        format!("path = \"{}\"\n\n[upstream]\nurl = \"https://github.com/upstream/repo\"\nrelation = \"fork\"\n", repo.display()),
+    );
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(config_base)), fake_discovery(false), HostName::local()).await;
+
+    let inspection = daemon
+        .inspect_adopted_checkout(&repo, Some("https://github.com/fork/repo"), Some("stack/feature"))
+        .await
+        .expect("inspect adopted checkout");
+
+    assert!(inspection.spec.is_fork());
+    assert_eq!(inspection.spec.upstream().expect("upstream").url, "https://github.com/upstream/repo");
+}
+
 #[test]
 fn configured_repo_identity_prefers_repo_file_forgejo_binding() {
     let temp = tempfile::tempdir().expect("create tempdir");

--- a/crates/flotilla-core/src/providers/vcs/provisioning.rs
+++ b/crates/flotilla-core/src/providers/vcs/provisioning.rs
@@ -137,6 +137,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fork_clone_uses_only_the_fork_url_and_never_adds_an_upstream_remote() {
+        let runner = Arc::new(RecordingRunner::with_responses(vec![Ok(String::new())]));
+        let provisioner = super::GitCloneProvisioner::new(runner.clone());
+
+        provisioner
+            .clone_repo("https://forgejo.lab/fork-issues/zellij", &ExecutionEnvironmentPath::new("/tmp/zellij"))
+            .await
+            .expect("clone should succeed");
+
+        assert_eq!(runner.calls(), vec![(
+            "git".to_string(),
+            vec!["clone".to_string(), "https://forgejo.lab/fork-issues/zellij".to_string(), "/tmp/zellij".to_string()],
+            PathBuf::from("/")
+        )]);
+    }
+
+    #[tokio::test]
     async fn inspect_clone_prefers_origin_head_for_default_branch() {
         let runner = Arc::new(RecordingRunner::with_responses(vec![Ok("origin/main\n".to_string())]));
         let provisioner = super::GitCloneProvisioner::new(runner);

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -2679,6 +2679,39 @@ async fn daemon_for_fake_repo() -> (tempfile::TempDir, PathBuf, Arc<InProcessDae
     (temp, repo, daemon, identity)
 }
 
+#[tokio::test]
+async fn refresh_syncs_fork_stance_without_whole_project_migration_and_clears_removed_config() {
+    let (temp, repo, daemon, _identity) = daemon_for_fake_repo().await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
+    ConfigStore::with_base(temp.path().join("config")).save_repo(&ExecutionEnvironmentPath::new(repo.clone()));
+    let repo_config = std::fs::read_dir(temp.path().join("config/repos"))
+        .expect("repo config directory")
+        .find_map(|entry| {
+            let path = entry.ok()?.path();
+            (path.extension().is_some_and(|extension| extension == "toml")).then_some(path)
+        })
+        .expect("persisted repo config");
+    let path = repo.to_string_lossy();
+    std::fs::write(
+        &repo_config,
+        format!("path = \"{path}\"\n\n[upstream]\nurl = \"https://github.com/upstream/repo\"\nrelation = \"fork\"\n"),
+    )
+    .expect("write fork config");
+
+    daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh fork config");
+
+    let repository = RepositorySpec::remote("https://github.com/owner/repo").expect("repository spec");
+    let repositories = daemon.resource_backend().using::<Repository>("flotilla");
+    let stored = repositories.get(&repository.key().to_string()).await.expect("stored repository");
+    assert!(stored.spec.is_fork(), "refresh should apply fork provenance without changing repository identity");
+
+    std::fs::write(&repo_config, format!("path = \"{path}\"\n")).expect("remove fork config");
+    daemon.refresh(&RepoSelector::Path(repo)).await.expect("refresh removed fork config");
+
+    let stored = repositories.get(&repository.key().to_string()).await.expect("stored repository");
+    assert!(stored.spec.upstream().is_none(), "authoritative per-repository config removal should clear previously stored fork provenance");
+}
+
 async fn daemon_for_duplicate_fake_repos() -> (tempfile::TempDir, PathBuf, PathBuf, Arc<InProcessDaemon>) {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo_a = temp.path().join("repo-a");

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -46,13 +46,14 @@ use flotilla_protocol::{
     RepoIdentity, RepoSelector, StepStatus, StreamKey, SystemInfo, ToolInventory, TopologyRoute, WorkItemKind,
 };
 use flotilla_resources::{
-    apply_status_patch, controller_patches as convoy_controller_patches, single_agent_contained_workflow_spec,
-    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
-    DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec,
-    HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
-    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositorySpec, Stance, TypedResolver, WorkPhase, WorkState,
-    WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, REPO_KEY_LABEL, REPO_LABEL,
+    apply_status_patch, controller_patches as convoy_controller_patches, implement_review_workflow_spec,
+    single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase,
+    CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Convoy as ResourceConvoy, ConvoyPhase,
+    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy,
+    PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository,
+    RepositoryRelation, RepositorySpec, Stance, TypedResolver, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
+    AGENT_ADAPTERS_CAPABILITY, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -919,6 +920,104 @@ async fn create_test_convoy_project(backend: &flotilla_resources::ResourceBacken
         })
         .await
         .expect("project create");
+}
+
+#[tokio::test]
+async fn fork_stance_refuses_reviewless_dispatch_and_admits_implement_review() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let daemon =
+        InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
+    let backend = daemon.resource_backend();
+    let repository = RepositorySpec::remote("https://forgejo.lab/fork-issues/zellij")
+        .expect("fork repository")
+        .with_upstream("https://github.com/zellij-org/zellij", RepositoryRelation::Fork)
+        .expect("upstream");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository.key().to_string()).build(), &repository)
+        .await
+        .expect("repository create");
+    for (name, workflow) in
+        [("single-agent-contained", single_agent_contained_workflow_spec()), ("implement-review", implement_review_workflow_spec())]
+    {
+        backend
+            .clone()
+            .using::<WorkflowTemplate>("flotilla")
+            .create(&InputMeta::builder().name(name.to_string()).build(), &workflow)
+            .await
+            .expect("workflow create");
+    }
+    create_test_contained_policy(&backend, "flotilla-test", BTreeSet::from(["codex".to_string(), "claude-code".to_string()])).await;
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("zellij".to_string()).build(), &ProjectSpec {
+            display_name: "Zellij".into(),
+            default_workflow_ref: "single-agent-contained".into(),
+            issue_source: Some(IssueSource { service: "https://forgejo.lab".into(), scope: "fork-issues/zellij".into() }),
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project create");
+
+    let mut events = daemon.subscribe();
+    let start = |name: &str, workflow_ref: &str| Command {
+        node_id: None,
+        provisioning_target: None,
+        context_repo: None,
+        action: CommandAction::ConvoyStart {
+            intent: Box::new(ConvoyStartIntent {
+                namespace: None,
+                project_ref: "zellij".into(),
+                issues: Vec::new(),
+                name: Some(name.to_string()),
+                branch: Some(format!("stack/{name}")),
+                workflow_ref: Some(workflow_ref.to_string()),
+                inputs: Vec::new(),
+                instruction: None,
+                placement_policy: Some("docker-test".into()),
+                auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
+            }),
+        },
+    };
+    let rejected_id = daemon.execute(start("reviewless", "single-agent-contained")).await.expect("dispatch command");
+    assert_eq!(recv_command_finished(&mut events, rejected_id).await, CommandValue::Error {
+        message: "workflow single-agent-contained not permitted for fork-stance repository — use implement-review".to_string()
+    });
+
+    let repositories = backend.clone().using::<Repository>("flotilla");
+    let stored = repositories.get(&repository.key().to_string()).await.expect("fork repository");
+    repositories
+        .update(
+            &InputMeta::from(&stored.metadata),
+            &stored.metadata.resource_version,
+            &repository.clone().with_allow_reviewless_workflows(true),
+        )
+        .await
+        .expect("explicit reviewless override");
+    let overridden_id = daemon.execute(start("overridden", "single-agent-contained")).await.expect("override dispatch command");
+    assert_eq!(recv_command_finished(&mut events, overridden_id).await, CommandValue::ConvoyStarted {
+        name: "overridden".into(),
+        attach_command: None,
+        binding: None
+    });
+
+    let admitted_id = daemon.execute(start("reviewed", "implement-review")).await.expect("dispatch command");
+    assert_eq!(recv_command_finished(&mut events, admitted_id).await, CommandValue::ConvoyStarted {
+        name: "reviewed".into(),
+        attach_command: None,
+        binding: None
+    });
+    let convoy = backend.using::<ResourceConvoy>("flotilla").get("reviewed").await.expect("reviewed convoy");
+    assert_eq!(convoy.spec.workflow_ref, "implement-review");
+    let workflow = backend.using::<WorkflowTemplate>("flotilla").get("implement-review").await.expect("implement-review workflow");
+    assert_eq!(workflow.spec.vessels[0].crew.len(), 2);
+    assert!(matches!(
+        &workflow.spec.vessels[0].crew[1].source,
+        flotilla_resources::CrewSource::Agent { selector, brief_template: Some(template), .. }
+            if selector.capability == "code-review" && template == "diff-review"
+    ));
 }
 
 async fn create_test_host_direct_policy(

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -304,6 +304,7 @@ fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
                     .build()])
                 .build(),
         ),
+        ("implement-review", flotilla_resources::implement_review_workflow_spec()),
         ("interactive-single", flotilla_resources::interactive_single_workflow_spec()),
         ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
     ]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -1105,6 +1105,7 @@ mod tests {
             CommandValue::RepoDetail(Box::new(RepoDetailResponse {
                 path: PathBuf::from("/repo"),
                 slug: Some("owner/repo".into()),
+                upstream: None,
                 provider_health: Default::default(),
                 work_items: vec![],
                 errors: vec![],

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -124,6 +124,7 @@ pub use query::{
     ProjectListRepository, ProjectListResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse, RepoProvidersResponse, RepoSummary,
     RepoWorkResponse, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
 };
+pub use repository::{RepositoryRelation, RepositoryUpstream};
 pub use resource_ref::ResourceRef;
 pub use result_set::{
     AwarenessCounts, AwarenessEntry, AwarenessFamily, AwarenessFamilySummary, AwarenessGrouping, AwarenessKind, AwarenessLimit,

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     snapshot::{ProviderError, WorkItem},
-    EnvironmentInfo, HostName, HostSummary, IssueSource, NodeInfo, PeerConnectionState, RepositoryKey, ViewAddress,
+    EnvironmentInfo, HostName, HostSummary, IssueSource, NodeInfo, PeerConnectionState, RepositoryKey, RepositoryUpstream, ViewAddress,
 };
 
 /// Provider health across categories. Outer key: category (e.g. "vcs",
@@ -71,6 +71,8 @@ pub struct RepoSummary {
 pub struct RepoDetailResponse {
     pub path: PathBuf,
     pub slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<RepositoryUpstream>,
     pub provider_health: ProviderHealthMap,
     pub work_items: Vec<WorkItem>,
     pub errors: Vec<ProviderError>,

--- a/crates/flotilla-protocol/src/repository.rs
+++ b/crates/flotilla-protocol/src/repository.rs
@@ -4,6 +4,26 @@ use serde::{Deserialize, Serialize};
 
 pub const UNKNOWN_REPOSITORY_LABEL: &str = "Unknown repository";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RepositoryRelation {
+    Fork,
+}
+
+impl std::fmt::Display for RepositoryRelation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fork => f.write_str("fork"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryUpstream {
+    pub url: String,
+    pub relation: RepositoryRelation,
+}
+
 /// Storage-safe key of a Repository resource.
 ///
 /// The key is opaque on the wire. Its derivation and referent verification

--- a/crates/flotilla-resources/src/crds/repository.crd.yaml
+++ b/crates/flotilla-resources/src/crds/repository.crd.yaml
@@ -43,6 +43,17 @@ spec:
                       type: string
                     repository:
                       type: string
+                upstream:
+                  type: object
+                  required: [url, relation]
+                  properties:
+                    url:
+                      type: string
+                    relation:
+                      type: string
+                      enum: [fork]
+                allow_reviewless_workflows:
+                  type: boolean
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -74,7 +74,7 @@ pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaC
 pub use repository::{
     ensure_repository, repository_display_labels, repository_workspace_slugs, resolve_default_branch, DefaultBranchObservation,
     DefaultBranchProvenance, ForgeIdentity, Repository, RepositoryCheckoutKind, RepositoryCheckoutRef, RepositoryIdentity, RepositoryKey,
-    RepositorySpec, RepositoryStatus, RepositoryStatusPatch,
+    RepositoryRelation, RepositorySpec, RepositoryStatus, RepositoryStatusPatch, RepositoryUpstream,
 };
 pub use resource::{
     api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,
@@ -113,7 +113,7 @@ macro_rules! for_each_registered_resource {
     }};
 }
 pub use workflow_template::{
-    interactive_single_workflow_spec, single_agent_contained_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition,
-    InterpolationField, InterpolationLocation, Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate,
+    implement_review_workflow_spec, interactive_single_workflow_spec, single_agent_contained_workflow_spec, validate, CrewSource, CrewSpec,
+    InputDefinition, InterpolationField, InterpolationLocation, Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate,
     WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -1,13 +1,20 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-pub use flotilla_protocol::RepositoryKey;
+pub use flotilla_protocol::{RepositoryKey, RepositoryRelation, RepositoryUpstream};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     resource::define_resource, status_patch::StatusPatch, InputMeta, LifecycleAuthority, ResourceError, ResourceObject, TypedResolver,
 };
 
-define_resource!(Repository, "repositories", RepositorySpec, RepositoryStatus, RepositoryStatusPatch, immutable_spec);
+define_resource!(
+    Repository,
+    "repositories",
+    RepositorySpec,
+    RepositoryStatus,
+    RepositoryStatusPatch,
+    validate_spec_update = validate_repository_spec_update
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -27,6 +34,10 @@ pub struct RepositorySpec {
     identity: RepositoryIdentity,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     forge: Option<ForgeIdentity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    upstream: Option<RepositoryUpstream>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    allow_reviewless_workflows: bool,
 }
 
 impl RepositorySpec {
@@ -37,7 +48,12 @@ impl RepositorySpec {
         }
         let canonical_remote = crate::canonicalize_repo_url(&remote)?;
         let forge = forge_from_canonical_remote(&canonical_remote)?;
-        Ok(Self { identity: RepositoryIdentity::Remote { canonical_remote }, forge: Some(forge) })
+        Ok(Self {
+            identity: RepositoryIdentity::Remote { canonical_remote },
+            forge: Some(forge),
+            upstream: None,
+            allow_reviewless_workflows: false,
+        })
     }
 
     pub fn local(host_ref: impl Into<String>, git_common_dir: impl Into<String>) -> Result<Self, String> {
@@ -51,7 +67,12 @@ impl RepositorySpec {
             return Err("local repository git_common_dir must be absolute".to_string());
         }
         let normalized = normalize_absolute_path(path)?;
-        Ok(Self { identity: RepositoryIdentity::Local { host_ref, git_common_dir: normalized }, forge: None })
+        Ok(Self {
+            identity: RepositoryIdentity::Local { host_ref, git_common_dir: normalized },
+            forge: None,
+            upstream: None,
+            allow_reviewless_workflows: false,
+        })
     }
 
     pub fn key(&self) -> RepositoryKey {
@@ -69,6 +90,29 @@ impl RepositorySpec {
 
     pub fn forge(&self) -> Option<&ForgeIdentity> {
         self.forge.as_ref()
+    }
+
+    pub fn upstream(&self) -> Option<&RepositoryUpstream> {
+        self.upstream.as_ref()
+    }
+
+    pub fn is_fork(&self) -> bool {
+        self.upstream.as_ref().is_some_and(|upstream| upstream.relation == RepositoryRelation::Fork)
+    }
+
+    pub fn allows_reviewless_workflows(&self) -> bool {
+        self.allow_reviewless_workflows
+    }
+
+    pub fn with_upstream(mut self, url: impl Into<String>, relation: RepositoryRelation) -> Result<Self, String> {
+        let url = crate::canonicalize_repo_url(&url.into())?;
+        self.upstream = Some(RepositoryUpstream { url, relation });
+        Ok(self)
+    }
+
+    pub fn with_allow_reviewless_workflows(mut self, allow: bool) -> Self {
+        self.allow_reviewless_workflows = allow;
+        self
     }
 
     pub fn verify_key(&self, key: &RepositoryKey) -> Result<(), String> {
@@ -234,7 +278,15 @@ pub async fn ensure_repository(
     };
     repository.spec.verify_key(key).map_err(ResourceError::invalid)?;
     if repository.spec != *spec {
-        return Err(ResourceError::invalid(format!("repository key {key} already refers to a different canonical identity")));
+        if repository.spec.identity != spec.identity || repository.spec.forge != spec.forge {
+            return Err(ResourceError::invalid(format!("repository key {key} already refers to a different canonical identity")));
+        }
+        // Identity-only observations are common during provisioning and must not
+        // erase provenance supplied by the per-repository config authority.
+        if spec.upstream.is_none() && !spec.allow_reviewless_workflows {
+            return Ok(repository);
+        }
+        return repositories.update(&InputMeta::from(&repository.metadata), &repository.metadata.resource_version, spec).await;
     }
     Ok(repository)
 }
@@ -249,10 +301,14 @@ impl<'de> Deserialize<'de> for RepositorySpec {
             identity: RepositoryIdentity,
             #[serde(default)]
             forge: Option<ForgeIdentity>,
+            #[serde(default)]
+            upstream: Option<RepositoryUpstream>,
+            #[serde(default)]
+            allow_reviewless_workflows: bool,
         }
 
         let stored = StoredRepositorySpec::deserialize(deserializer)?;
-        let normalized = match &stored.identity {
+        let mut normalized = match &stored.identity {
             RepositoryIdentity::Remote { canonical_remote } => RepositorySpec::remote(canonical_remote),
             RepositoryIdentity::Local { host_ref, git_common_dir } => RepositorySpec::local(host_ref, git_common_dir),
         }
@@ -263,8 +319,25 @@ impl<'de> Deserialize<'de> for RepositorySpec {
         if normalized.forge != stored.forge {
             return Err(serde::de::Error::custom("repository forge must be the identity-derived forge"));
         }
+        if let Some(upstream) = stored.upstream {
+            normalized = normalized.with_upstream(&upstream.url, upstream.relation).map_err(serde::de::Error::custom)?;
+            if normalized.upstream.as_ref() != Some(&upstream) {
+                return Err(serde::de::Error::custom("repository upstream URL must be canonical"));
+            }
+        }
+        normalized.allow_reviewless_workflows = stored.allow_reviewless_workflows;
         Ok(normalized)
     }
+}
+
+fn validate_repository_spec_update(current: &RepositorySpec, requested: &RepositorySpec) -> Result<(), ResourceError> {
+    if current.identity != requested.identity {
+        return Err(ResourceError::invalid("Repository identity is immutable after creation"));
+    }
+    if current.forge != requested.forge {
+        return Err(ResourceError::invalid("Repository forge is immutable and identity-derived"));
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -11,6 +11,23 @@ use crate::{
 };
 
 macro_rules! define_resource {
+    ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty, validate_spec_update = $validator:path) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub struct $name;
+
+        impl $crate::resource::Resource for $name {
+            type Spec = $spec;
+            type Status = $status;
+            type StatusPatch = $patch;
+
+            const API_PATHS: $crate::resource::ApiPaths =
+                $crate::resource::ApiPaths { group: "flotilla.work", version: "v1", plural: $plural, kind: stringify!($name) };
+
+            fn validate_spec_update(current: &Self::Spec, requested: &Self::Spec) -> Result<(), $crate::ResourceError> {
+                $validator(current, requested)
+            }
+        }
+    };
     ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty, replication = $replication:expr) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct $name;

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -140,6 +140,29 @@ pub fn interactive_single_workflow_spec() -> WorkflowTemplateSpec {
         .build()
 }
 
+pub fn implement_review_workflow_spec() -> WorkflowTemplateSpec {
+    WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Contained)
+            .crew(vec![
+                CrewSpec::builder()
+                    .role("coder".to_string())
+                    .source(CrewSource::Agent { selector: Selector { capability: "code".to_string() }, prompt: None, brief_template: None })
+                    .build(),
+                CrewSpec::builder()
+                    .role("reviewer".to_string())
+                    .source(CrewSource::Agent {
+                        selector: Selector { capability: "code-review".to_string() },
+                        prompt: None,
+                        brief_template: Some("diff-review".to_string()),
+                    })
+                    .build(),
+            ])
+            .build()])
+        .build()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
     DuplicateVesselName { name: String },

--- a/crates/flotilla-resources/tests/repository_in_memory.rs
+++ b/crates/flotilla-resources/tests/repository_in_memory.rs
@@ -1,7 +1,7 @@
 use flotilla_resources::{
     normalize_project_spec, repository_display_labels, resolve_project_issue_sources, DefaultBranchObservation, DefaultBranchProvenance,
     InMemoryBackend, InputMeta, IssueSource, IssueSourceResolution, IssueSourceUnavailable, ProjectRepositorySpec, ProjectSpec, Repository,
-    RepositoryIdentity, RepositoryKey, RepositorySpec, ResourceBackend, SqliteBackend,
+    RepositoryIdentity, RepositoryKey, RepositoryRelation, RepositorySpec, ResourceBackend, SqliteBackend,
 };
 
 #[tokio::test]
@@ -105,6 +105,23 @@ async fn repository_roundtrips_and_is_immutable_in_local_backends() {
             .await;
         assert!(update.expect_err("repository identity must be immutable").to_string().contains("immutable"));
     }
+}
+
+#[tokio::test]
+async fn repository_fork_provenance_roundtrips_and_can_enrich_identity() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let repositories = backend.using::<Repository>("flotilla");
+    let identity = RepositorySpec::remote("https://forgejo.lab/fork-issues/zellij").expect("fork identity");
+    let key = identity.key();
+    repositories.create(&InputMeta::builder().name(key.to_string()).build(), &identity).await.expect("repository should create");
+    let fork =
+        identity.with_upstream("https://github.com/zellij-org/zellij.git", RepositoryRelation::Fork).expect("upstream should normalize");
+
+    let enriched = flotilla_resources::ensure_repository(&repositories, &key, &fork).await.expect("provenance should enrich");
+
+    assert_eq!(enriched.spec, fork);
+    assert!(enriched.spec.is_fork());
+    assert_eq!(enriched.spec.upstream().expect("upstream").url, "https://github.com/zellij-org/zellij");
 }
 
 #[test]

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -594,6 +594,9 @@ fn format_repo_detail_human(detail: &RepoDetailResponse) -> String {
     if let Some(slug) = &detail.slug {
         out.push_str(&format!("Slug: {slug}\n"));
     }
+    if let Some(upstream) = &detail.upstream {
+        out.push_str(&format!("Upstream: {} ({})\n", upstream.url, upstream.relation));
+    }
     out.push('\n');
 
     if !detail.work_items.is_empty() {

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -772,7 +772,7 @@ mod work_items_table {
 mod repo_detail_human {
     use std::{collections::HashMap, path::PathBuf};
 
-    use flotilla_protocol::{snapshot::ProviderError, RepoDetailResponse};
+    use flotilla_protocol::{snapshot::ProviderError, RepoDetailResponse, RepositoryRelation, RepositoryUpstream};
 
     use super::make_work_item;
     use crate::cli::format_repo_detail_human;
@@ -782,6 +782,7 @@ mod repo_detail_human {
         let detail = RepoDetailResponse {
             path: PathBuf::from("/tmp/my-repo"),
             slug: None,
+            upstream: None,
             provider_health: HashMap::new(),
             work_items: vec![],
             errors: vec![],
@@ -798,6 +799,7 @@ mod repo_detail_human {
         let detail = RepoDetailResponse {
             path: PathBuf::from("/tmp/my-repo"),
             slug: Some("org/my-repo".into()),
+            upstream: None,
             provider_health: HashMap::new(),
             work_items: vec![],
             errors: vec![],
@@ -807,10 +809,27 @@ mod repo_detail_human {
     }
 
     #[test]
+    fn with_fork_provenance() {
+        let detail = RepoDetailResponse {
+            path: PathBuf::from("/tmp/zellij"),
+            slug: Some("fork-issues/zellij".into()),
+            upstream: Some(RepositoryUpstream { url: "https://github.com/zellij-org/zellij".into(), relation: RepositoryRelation::Fork }),
+            provider_health: HashMap::new(),
+            work_items: vec![],
+            errors: vec![],
+        };
+
+        let output = format_repo_detail_human(&detail);
+
+        assert!(output.contains("Upstream: https://github.com/zellij-org/zellij (fork)"));
+    }
+
+    #[test]
     fn with_work_items() {
         let detail = RepoDetailResponse {
             path: PathBuf::from("/tmp/my-repo"),
             slug: None,
+            upstream: None,
             provider_health: HashMap::new(),
             work_items: vec![make_work_item(flotilla_protocol::snapshot::WorkItemKind::Checkout, Some("feat"), "My feature")],
             errors: vec![],
@@ -825,6 +844,7 @@ mod repo_detail_human {
         let detail = RepoDetailResponse {
             path: PathBuf::from("/tmp/my-repo"),
             slug: None,
+            upstream: None,
             provider_health: HashMap::new(),
             work_items: vec![],
             errors: vec![ProviderError { category: "change_request".into(), provider: "GitHub".into(), message: "rate limited".into() }],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,32 @@ Stored in `~/.config/flotilla/`:
 
 Repos are added interactively from within flotilla using the `a` key.
 
+### Fork provenance
+
+Repositories that are maintained as forks declare their upstream provenance in
+the tracked repo's TOML file:
+
+```toml
+path = "/home/alice/dev/zellij"
+
+[upstream]
+url = "https://github.com/zellij-org/zellij"
+relation = "fork"
+
+[issue_tracker.forgejo]
+scope = "fork-issues/zellij"
+```
+
+Fork-stance provisioning clones only the repository's own URL as `origin`; it
+does not add the upstream as a remote. Convoy admission requires a workflow
+with an in-crew reviewer, such as `implement-review`. A deliberate per-repo
+override can admit review-less workflows:
+
+```toml
+[workflow]
+allow_reviewless = true
+```
+
 ## Convoy start attachment
 
 By default, `flotilla convoy start` attaches to the new convoy only when the


### PR DESCRIPTION
Closes #1032

## Summary

- model configured fork provenance on repository resources and expose it through repository detail output
- enforce reviewed workflow admission for fork-stance repositories, with an explicit per-repository override
- register the two-crew `implement-review` workflow and fork-safe coder/reviewer brief layers
- preserve fork-only clone provenance and cover admission, handoff, settlement, and Forgejo-backed dispatch behavior

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`