### PR TITLE
docs: add ProjectSpec reaction fixtures

### DIFF
--- a/prototypes/1035-1041/README.md
+++ b/prototypes/1035-1041/README.md
@@ -38,6 +38,8 @@ Project only declares how it uses that repository.
   must not silently imply one another.
 - `issue_sources` — ordered, explicit tracker bindings. `primary` is the
   default dispatch source; `associated` sources are visible and selectable.
+- `important_refs` — named branches or revisions the Project treats as
+  durable working topology in addition to the membership's current `ref`.
 - `relevance.default: all` — records the current v1 rule that every member and
   reference is materialized. A later placement decision may narrow this set.
 

--- a/prototypes/1035-1041/README.md
+++ b/prototypes/1035-1041/README.md
@@ -1,0 +1,55 @@
+# ProjectSpec fixtures for the roles and overlap grills
+
+These are deliberately forward-looking `ProjectSpec` bodies for the four real
+projects named in #1041. They are reaction fixtures, not definitions accepted
+by `flotilla project apply` today. The current schema has one `issue_source`
+and repository entries containing only `repo`, `subpath`, and
+`default_branch`; every other field below is a candidate contract.
+
+The fixtures use readable Repository resource references rather than opaque
+content-derived keys. A reference names the repository we mean, while source
+and fork provenance remain properties of that Repository resource. In
+particular, `rjwittams/zellij` is expected to resolve to a Repository whose
+spec records:
+
+```yaml
+upstream:
+  url: https://github.com/zellij-org/zellij
+  relation: fork
+```
+
+That follows the #978 ruling: provenance has one home on `Repository`, and a
+Project only declares how it uses that repository.
+
+## Candidate vocabulary
+
+- `role: member` — project work may modify the repository.
+- `role: reference` — materialize and read/pin it, but do not modify it for
+  this project.
+- `role: vendored` — consume a snapshot rather than a live checkout.
+- `claim: controller` — this is the repository (or slice) membership that
+  owns reconciliation and default issue attribution. There must be at most
+  one controller for a claimed scope across all Projects.
+- `claim: association` — a deliberately weak, overlapping membership. It may
+  make work visible and dispatchable without stealing ownership from the
+  controller Project.
+- `slices` — explicit path scopes. A slice can narrow or override its parent
+  repository role and claim. Whole-repository membership and slice membership
+  must not silently imply one another.
+- `issue_sources` — ordered, explicit tracker bindings. `primary` is the
+  default dispatch source; `associated` sources are visible and selectable.
+- `relevance.default: all` — records the current v1 rule that every member and
+  reference is materialized. A later placement decision may narrow this set.
+
+## Questions these shapes force
+
+1. Is controller/association a Project membership field, or should the
+   Repository hold one `primary_project_ref` plus weak association refs?
+2. Can a view-like Project such as `roberts-daily-surface` legitimately have
+   no controller claims?
+3. Does a member slice inside a reference repository work, or must `jackstay`
+   become a Repository before the push can be represented?
+4. Are issue-source bindings ordered Project data, repo-derived data, or both?
+   What happens when the same source is associated with several Projects?
+5. Should fork stance affect every Project containing the fork (as these
+   workflows assume), even when the fork membership is only an association?

--- a/prototypes/1035-1041/jackstay-push.yaml
+++ b/prototypes/1035-1041/jackstay-push.yaml
@@ -1,0 +1,59 @@
+# The post-extraction push described by #1006. The source subtree is retained
+# here to expose the slice-vs-new-Repository decision rather than hiding it.
+display_name: Jackstay push
+default_workflow_ref: implement-review
+
+issue_sources:
+  - role: primary
+    source:
+      service: https://github.com
+      scope: flotilla-org/porthole
+    repository_ref: github.com/flotilla-org/porthole
+  - role: associated
+    source:
+      service: https://github.com
+      scope: flotilla-org/cleat
+    repository_ref: github.com/flotilla-org/cleat
+
+relevance:
+  default: all
+
+repositories:
+  # Porthole is historical/read-only context except for the extracted source
+  # scope. If extraction has completed, this slice should instead be a
+  # standalone jackstay Repository with extraction provenance on Repository.
+  - repo: github.com/flotilla-org/porthole
+    role: reference
+    claim: association
+    ref:
+      branch: main
+    slices:
+      - path: jackstay
+        role: member
+        claim: controller
+
+  - repo: github.com/rjwittams/katzensteg
+    role: member
+    claim: association
+    ref:
+      branch: main
+
+  - repo: github.com/flotilla-org/cleat
+    role: member
+    claim: association
+    ref:
+      branch: main
+
+  # This logical Repository ref remains stable across uishell -> wheelhouse.
+  - repo: uishell
+    role: member
+    claim: association
+    ref:
+      branch: main
+
+  # Fork provenance and upstream guardrails resolve from Repository, not here.
+  - repo: github.com/rjwittams/zellij
+    role: member
+    claim: association
+    ref:
+      branch: feat/kitty-image-plumbing

--- a/prototypes/1035-1041/presentation.yaml
+++ b/prototypes/1035-1041/presentation.yaml
@@ -1,0 +1,31 @@
+# The live "presentation" project without the hand-applied, schema-v0 shape.
+display_name: Presentation
+default_workflow_ref: single-agent-contained
+
+issue_sources:
+  - role: primary
+    source:
+      service: https://github.com
+      scope: flotilla-org/flotilla
+    repository_ref: github.com/flotilla-org/flotilla
+  - role: associated
+    source:
+      service: https://github.com
+      scope: flotilla-org/andamento
+    repository_ref: github.com/flotilla-org/andamento
+
+relevance:
+  default: all
+
+repositories:
+  - repo: github.com/flotilla-org/flotilla
+    role: member
+    claim: association
+    ref:
+      branch: main
+
+  - repo: github.com/flotilla-org/andamento
+    role: member
+    claim: controller
+    ref:
+      branch: main

--- a/prototypes/1035-1041/presentation.yaml
+++ b/prototypes/1035-1041/presentation.yaml
@@ -18,6 +18,8 @@ relevance:
   default: all
 
 repositories:
+  # Flotilla supplies the work queue without surrendering its whole-repo
+  # controller Project; this Project controls andamento's presentation work.
   - repo: github.com/flotilla-org/flotilla
     role: member
     claim: association

--- a/prototypes/1035-1041/roberts-daily-surface.yaml
+++ b/prototypes/1035-1041/roberts-daily-surface.yaml
@@ -1,0 +1,45 @@
+# Robert's actual cross-project working surface. It intentionally owns no
+# repository: its value is the durable aggregate and its tracker bindings.
+display_name: Robert's daily surface
+default_workflow_ref: implement-review
+
+issue_sources:
+  - role: primary
+    source:
+      service: https://forgejo.lab.flotilla.work
+      scope: fork-issues/zellij
+    repository_ref: github.com/rjwittams/zellij
+  - role: associated
+    source:
+      service: https://github.com
+      scope: flotilla-org/flotilla
+    repository_ref: github.com/flotilla-org/flotilla
+  - role: associated
+    source:
+      service: https://github.com
+      scope: flotilla-org/andamento
+    repository_ref: github.com/flotilla-org/andamento
+
+relevance:
+  default: all
+
+repositories:
+  - repo: github.com/flotilla-org/andamento
+    role: member
+    claim: association
+    ref:
+      branch: main
+
+  - repo: github.com/flotilla-org/flotilla
+    role: member
+    claim: association
+    ref:
+      branch: main
+
+  # Association is still fork stance: dispatch must use implement-review and
+  # must never expose or act against the upstream forge.
+  - repo: github.com/rjwittams/zellij
+    role: member
+    claim: association
+    ref:
+      branch: feat/kitty-image-plumbing

--- a/prototypes/1035-1041/zellij-fork.yaml
+++ b/prototypes/1035-1041/zellij-fork.yaml
@@ -1,0 +1,27 @@
+# A single-repository Project still needs the Repository's fork stance to
+# change admission, brief selection, remotes, review, and settlement (#978).
+display_name: Zellij fork
+default_workflow_ref: implement-review
+
+issue_sources:
+  - role: primary
+    source:
+      service: https://forgejo.lab.flotilla.work
+      scope: fork-issues/zellij
+    repository_ref: github.com/rjwittams/zellij
+
+relevance:
+  default: all
+
+repositories:
+  # The referenced Repository owns:
+  # upstream: { url: https://github.com/zellij-org/zellij, relation: fork }
+  # Provisioning therefore exposes only our fork remote to a crew.
+  - repo: github.com/rjwittams/zellij
+    role: member
+    claim: controller
+    ref:
+      branch: main
+    important_refs:
+      - branch: main
+      - branch: feat/kitty-image-plumbing


### PR DESCRIPTION
## Summary

- add four candidate ProjectSpec YAMLs for the real presentation, jackstay-push, zellij-fork, and daily-surface cases
- make member/reference roles, slice overrides, controller/association claims, tracker bindings, relevance, and refs concrete
- keep zellij upstream provenance on Repository per the #978 ruling
- record the questions these shapes force for the roles and overlap grills

Artifact for #1041, part of #1035. This intentionally does not auto-close the prototype ticket: wayfinding prototypes settle only after HITL reaction.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `git diff --check`
