### PR TITLE
Fix empty PM awareness catalog after daemon bootstrap

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6918,13 +6918,22 @@ impl DaemonHandle for InProcessDaemon {
         let state = self.aggregator_projection_state().await;
         let newly_materialized = state.replace_subscriber(subscriber_id, queries);
         let mut events = Vec::new();
+        let mut initial_row_counts = Vec::with_capacity(queries.len());
         for cursor in queries {
             let result_set =
                 state.result_set_for(&cursor.query).await.ok_or_else(|| format!("query is not materialized: {}", cursor.query))?;
+            initial_row_counts.push((cursor.query.clone(), result_set.rows.len()));
             if newly_materialized.contains(&cursor.query) || cursor.since.is_none_or(|seq| seq != result_set.seq) {
                 events.push(DaemonEvent::ResultSet(Box::new(result_set)));
             }
         }
+        info!(
+            subscriber = %subscriber_id,
+            queries = ?queries,
+            initial_row_counts = ?initial_row_counts,
+            replayed_result_sets = events.len(),
+            "query subscription initialized"
+        );
         Ok(events)
     }
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -7,12 +7,15 @@ use std::{
 use async_trait::async_trait;
 use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
-    result_set::{ConvoyPhase as WireConvoyPhase, ConvoyRow, IndependentRow, QueryId, ResultSet, Rows, SessionPhase},
+    result_set::{
+        AwarenessGrouping, AwarenessKind, AwarenessLimit, ConvoyPhase as WireConvoyPhase, ConvoyRow, DemandBackedMetadata, IndependentRow,
+        IssueRow, QueryId, ResultSet, ResultSetState, Rows, SessionPhase,
+    },
     test_support::TestIssue,
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent,
     CrewCommandContext, DaemonEvent, EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostProviderStatus, HostSummary, ImageId,
-    IssueRef, IssueSource, QueryCursor, QueryScope, RepoSelector, RepositoryKey, ResourceRef, ResultSetCondition, SystemInfo,
-    ToolInventory, TopologyRoute, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    Issue, IssueRef, IssueSource, IssueState, QueryCursor, QueryScope, RepoSelector, RepositoryKey, ResourceRef, ResultSetCondition,
+    SystemInfo, ToolInventory, TopologyRoute, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
@@ -4540,6 +4543,75 @@ async fn subscribe_queries_resends_result_set_when_client_seq_is_ahead() {
         })
         .expect("client ahead of daemon must still receive a result set");
     assert_eq!(result_set.seq, 2, "result set reflects the daemon's current seq, not the client's stale claim");
+}
+
+#[tokio::test]
+async fn fleet_awareness_subscription_replays_project_convoy_and_issue_rows() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    let state = daemon.aggregator_projection_state().await;
+    let project = QueryScope::new("flotilla", "roadmap");
+    state.replace_store_catalog(HashMap::new(), HashMap::from([(project.clone(), vec![])])).await;
+    let mut convoy = convoy_row("flotilla", "ship-it", WireConvoyPhase::Active, None);
+    convoy.project_ref = Some(project.name.clone());
+    set_local_convoy_rows(&daemon, 1, vec![convoy]).await;
+
+    let subscriber = uuid::Uuid::new_v4();
+    let awareness = QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, limit: AwarenessLimit::default() };
+    daemon
+        .subscribe_queries(subscriber, &[QueryCursor { query: awareness.clone(), since: None }])
+        .await
+        .expect("subscribe to fleet awareness");
+    let issue_query =
+        QueryId::Issues { scope: project.clone(), search: None, label: Some(flotilla_protocol::issue_query::READY_ISSUE_LABEL.into()) };
+    let generation = *state.subscribe_demand().borrow().get(&issue_query).expect("ready-issue demand");
+    let reference =
+        IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() }, id: "1054".into() };
+    state.replace_issues(
+        &issue_query,
+        generation,
+        vec![IssueRow {
+            reference: reference.clone(),
+            issue: Issue {
+                reference,
+                title: "Restore PM awareness catalog".into(),
+                body: None,
+                state: IssueState::Open,
+                labels: vec![flotilla_protocol::issue_query::READY_ISSUE_LABEL.into()],
+                as_of: Utc::now(),
+                observed_at: None,
+                association_keys: vec![],
+                provider_name: "github".into(),
+                provider_display_name: "GitHub".into(),
+            },
+        }],
+        ResultSetState { demand: Some(DemandBackedMetadata { as_of: Utc::now(), has_more: false }), conditions: vec![], truncated: false },
+    );
+
+    let events = daemon
+        .subscribe_queries(subscriber, &[QueryCursor { query: awareness.clone(), since: None }])
+        .await
+        .expect("replay populated fleet awareness");
+    let result_set = events
+        .into_iter()
+        .find_map(|event| match event {
+            DaemonEvent::ResultSet(result_set) if result_set.query() == awareness => Some(result_set),
+            _ => None,
+        })
+        .expect("fleet awareness result set");
+    let node = result_set
+        .rows
+        .as_awareness()
+        .expect("awareness rows")
+        .iter()
+        .find(|node| node.scope.as_ref() == Some(&project))
+        .expect("project awareness node");
+    assert!(node.entries.iter().any(|entry| entry.kind == AwarenessKind::Convoy));
+    assert!(node.entries.iter().any(|entry| entry.kind == AwarenessKind::Issue));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -355,6 +355,7 @@ impl Aggregator {
         self.emitted_queries.extend(QueryId::ALWAYS_MATERIALIZED.iter().cloned());
         let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.result_set().await)));
         let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(self.state.independents_result_set(&None).await)));
+        self.emit_awareness_result_sets().await;
 
         loop {
             let regard_expiry_delay = self.next_regard_expiry_delay();
@@ -1943,7 +1944,7 @@ mod tests {
     use flotilla_resources::{
         ConvoyRepositorySpec, ConvoySpec, CrewSpec, DemandKind, DemandSpec, DemandStatus, DemandTransition, EnvironmentSpec,
         HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta, ObservedCheckoutSpec, PlacementStatus, PresentationPhase,
-        PresentationSpec, PresentationStatus, PrincipalRef as AttentionPrincipalRef, RegardSource, RegardSpec, RegardStatus,
+        PresentationSpec, PresentationStatus, PrincipalRef as AttentionPrincipalRef, ProjectSpec, RegardSource, RegardSpec, RegardStatus,
         RepositorySpec, ResourceBackend, Stance, TerminalAttention, TerminalAttentionSource, TerminalSessionSource, TerminalSessionSpec,
         TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
     };
@@ -2141,7 +2142,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_bootstraps_materialization_from_the_store_replica_read_view() {
+    async fn subscribed_fleet_awareness_emits_when_project_catalog_changes() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+        let query = QueryId::Awareness {
+            scope: None,
+            grouping: flotilla_protocol::AwarenessGrouping::Project,
+            limit: flotilla_protocol::AwarenessLimit::default(),
+        };
+        state.replace_subscriber(Uuid::new_v4(), &[flotilla_protocol::QueryCursor { query: query.clone(), since: None }]);
+
+        aggregator.apply_project_event(WatchEvent::Added(project_object("widgets").await)).await;
+
+        let result_set = timeout(Duration::from_secs(1), async {
+            loop {
+                let event = event_rx.recv().await.expect("aggregator event");
+                if let DaemonEvent::ResultSet(result_set) = event {
+                    if result_set.query() == query {
+                        break result_set;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("project catalog change should publish fleet awareness");
+        assert_eq!(result_set.rows.as_awareness().expect("awareness rows")[0].label, "widgets");
+    }
+
+    #[tokio::test]
+    async fn run_bootstraps_materialization_and_subscribed_fleet_awareness() {
         let durable = ResourceBackend::InMemory(InMemoryBackend::default());
         let observed = ResourceBackend::InMemory(InMemoryBackend::observed());
         let mut convoy = convoy_with_vessel("convoy-a").await;
@@ -2168,8 +2198,21 @@ mod tests {
             )
             .await
             .expect("seed remote session replica");
+        let project = project_object("widgets").await;
+        durable
+            .clone()
+            .using::<Project>("flotilla")
+            .create(&InputMeta::builder().name(project.metadata.name).build(), &project.spec)
+            .await
+            .expect("seed project");
 
         let state = AggregatorProjectionState::new();
+        let awareness_query = QueryId::Awareness {
+            scope: None,
+            grouping: flotilla_protocol::AwarenessGrouping::Project,
+            limit: flotilla_protocol::AwarenessLimit::default(),
+        };
+        state.replace_subscriber(Uuid::new_v4(), &[flotilla_protocol::QueryCursor { query: awareness_query.clone(), since: None }]);
         let (event_tx, mut event_rx) = broadcast::channel(8);
         let (replica_tx, replica_rx) = broadcast::channel(1);
         let attach_resolver = Arc::new(CountingAttachResolver::with_origin("feta-node-id", "feta"));
@@ -2197,10 +2240,24 @@ mod tests {
                 .await
         });
 
-        let event = timeout(Duration::from_secs(1), event_rx.recv()).await.expect("aggregator bootstrap").expect("convoy result set");
-        let DaemonEvent::ResultSet(result) = event else { panic!("expected initial result set") };
-        let convoy = result.rows.as_convoys().expect("convoy rows").first().expect("local convoy");
+        let (convoy, awareness) = timeout(Duration::from_secs(1), async {
+            let mut convoy = None;
+            let mut awareness = None;
+            while convoy.is_none() || awareness.is_none() {
+                let event = event_rx.recv().await.expect("aggregator bootstrap event");
+                let DaemonEvent::ResultSet(result) = event else { continue };
+                if result.query() == QueryId::Convoys {
+                    convoy = result.rows.as_convoys().expect("convoy rows").first().cloned();
+                } else if result.query() == awareness_query {
+                    awareness = Some(result);
+                }
+            }
+            (convoy.expect("local convoy"), awareness.expect("fleet awareness"))
+        })
+        .await
+        .expect("aggregator bootstrap should publish convoy and fleet awareness result sets");
         assert_eq!(convoy.vessels[0].materialize.as_deref(), Some("terminal-convoy-a-implement-coder"));
+        assert!(awareness.rows.as_awareness().expect("awareness rows").iter().any(|node| node.label == "widgets"));
 
         drop(replica_tx);
         assert!(run
@@ -2553,6 +2610,22 @@ mod tests {
             )
             .await
             .expect("create scripted convoy")
+    }
+
+    async fn project_object(name: &str) -> ResourceObject<Project> {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        backend
+            .using::<Project>("flotilla")
+            .create(
+                &InputMeta::builder().name(name.to_string()).build(),
+                &ProjectSpec::builder()
+                    .display_name(name.to_string())
+                    .default_workflow_ref("scratch".to_string())
+                    .repositories(Vec::new())
+                    .build(),
+            )
+            .await
+            .expect("create scripted project")
     }
 
     async fn convoy_with_branch(name: &str) -> ResourceObject<Convoy> {


### PR DESCRIPTION
## Summary

- publish all subscribed awareness result sets once aggregator source recovery completes
- add structured subscription diagnostics for the subscriber, requested queries, initial row counts, and replay count
- cover startup recovery and fleet awareness replay with project, convoy, and issue regression tests

## Root cause

A PM connector can subscribe while the aggregator is still recovering its resource watches. Its immediate replay is therefore empty. Bootstrap suppresses intermediate result-set emissions, but the completion path only republished the always-materialized convoy and independent sets. The subscribed awareness result was never reasserted after projects, convoys, and issue demand had been recovered, leaving the connector with its initial empty catalog.

## Impact

Fresh PM connector sessions now receive the authoritative awareness snapshot after daemon bootstrap and can publish a non-empty entity catalog. Subscription initialization also leaves structured daemon-side evidence when a catalog is unexpectedly empty.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- manual connector-path check: a fresh awareness subscription rebuilt four tracked result sets into 26 PM catalog patches, confirming non-empty publication when rows are available

Closes #1054