### PR TITLE
feat: capture pm connector patches for the render harness

### DIFF
--- a/layouts/daily-driver-wasm.kdl
+++ b/layouts/daily-driver-wasm.kdl
@@ -1,0 +1,85 @@
+// Daily-driver layout: zellij + andamento + the flotilla manifest connector.
+//
+// This is the composed layout the PM-capability daily driver runs
+// (flotilla-org/flotilla#708). It is derived from andamento's own
+// layouts/andamento.kdl — which deliberately stays flotilla-free (the
+// git-watcher is the manifest architecture's independence proof) — plus one
+// pane running `flotilla pm connect`, the catalog half of the connector.
+//
+// Launch via scripts/run-daily-driver.sh, which sets the env vars used
+// below: ANDAMENTO_ROOT, FLOTILLA_BIN.
+
+// Native (Rust-linked) andamento plugins — the wasm plugin path has
+// unacceptable serde/runtime overhead for daily driving. Requires the
+// spike/native-plugins zellij built with native-plugins-all (see
+// scripts/run-daily-driver.sh); plugin names resolve via the native registry.
+plugins {
+    andamento-controller location="file:/Users/robert/dev/andamento/target/wasm32-wasip1/release/andamento-controller.wasm" {
+        rail_structure "joined-cells"
+        rail_sizing "active-large"
+        rail_grouping "directory"
+        rail_segment_between_color "#282c34"
+        template_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
+        grouping_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
+    }
+    andamento-rail location="file:/Users/robert/dev/andamento/target/wasm32-wasip1/release/andamento-rail.wasm" {
+        controller_plugin_url "andamento-controller"
+        config_plugin_url "andamento-config"
+        rail_placement "left"
+    }
+    andamento-config location="file:/Users/robert/dev/andamento/target/wasm32-wasip1/release/andamento-config.wasm"
+}
+
+load_plugins {
+    andamento-controller
+}
+
+layout {
+    default_tab_template {
+        pane split_direction="vertical" {
+            pane size="23%" borderless=true {
+                plugin location="andamento-rail"
+            }
+            children
+        }
+        pane size=2 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+
+    new_tab_template {
+        pane split_direction="vertical" {
+            pane size="23%" borderless=true {
+                plugin location="andamento-rail"
+            }
+            pane
+        }
+        pane size=2 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+
+    tab name="main" {
+        pane split_direction="vertical" {
+            pane
+            pane split_direction="horizontal" {
+                pane size="40%" {
+                    plugin location="andamento-config" {
+                        close_on_hidden "false"
+                    }
+                }
+                pane command="$ANDAMENTO_ROOT/scripts/andamento-git-watcher.py" cwd="$ANDAMENTO_ROOT" {
+                    args "--interval" "5"
+                }
+                // The manifest metadata-patch connector: subscribes to the
+                // local daemon's named queries and publishes the catalog
+                // (projects/convoys/vessels, live + latent, badges) into
+                // andamento's metadata plane. Recipes it mints reference
+                // $FLOTILLA_BIN so activation works from fresh panes.
+                pane command="$FLOTILLA_BIN" {
+                    args "pm" "connect" "--flotilla-bin" "$FLOTILLA_BIN"
+                }
+            }
+        }
+    }
+}

--- a/scripts/capture-pm-patches.py
+++ b/scripts/capture-pm-patches.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Capture the manifest connector's patch stream to JSONL, headless.
+
+Serves a unix socket, runs `flotilla pm connect --wheelhouse-socket` against it
+for a few seconds, writes one JSON patch per line. The other half of the local
+presentation harness (render side: `cargo run -p andamento-controller` in the
+andamento repo). Born from the andamento#37 postmortem: never debug the
+composed pipeline through zellij relaunches again."""
+import json, os, socket, subprocess, sys, tempfile, threading, time
+
+flotilla_bin = os.environ.get("FLOTILLA_BIN", os.path.expanduser("~/dev/flotilla/target/debug/flotilla"))
+out_path = sys.argv[1] if len(sys.argv) > 1 else "pm-patches.jsonl"
+seconds = float(sys.argv[2]) if len(sys.argv) > 2 else 8.0
+
+sock_path = os.path.join(tempfile.mkdtemp(), "wh.sock")
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(sock_path)
+server.listen(64)
+server.settimeout(0.5)
+lines = []
+stop = threading.Event()
+
+def serve():
+    while not stop.is_set():
+        try:
+            conn, _ = server.accept()
+        except socket.timeout:
+            continue
+        with conn:
+            buf = b""
+            conn.settimeout(1.0)
+            try:
+                while True:
+                    chunk = conn.recv(65536)
+                    if not chunk:
+                        break
+                    buf += chunk
+            except socket.timeout:
+                pass
+            for line in buf.decode(errors="replace").splitlines():
+                if line.strip():
+                    lines.append(line)
+
+t = threading.Thread(target=serve, daemon=True)
+t.start()
+proc = subprocess.Popen([flotilla_bin, "pm", "connect", "--flotilla-bin", flotilla_bin, "--wheelhouse-socket", sock_path],
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+time.sleep(seconds)
+proc.terminate()
+stop.set(); t.join(timeout=2)
+seen, out = set(), []
+for l in lines:
+    try:
+        key = json.dumps(json.loads(l), sort_keys=True)
+    except Exception:
+        key = l
+    if key not in seen:
+        seen.add(key); out.append(l)
+with open(out_path, "w") as f:
+    f.write("\n".join(out) + ("\n" if out else ""))
+print(f"captured {len(lines)} patches ({len(out)} unique) -> {out_path}")


### PR DESCRIPTION
Tooling half of the presentation debug loop (pairs with flotilla-org/andamento#39; rulings in #1056):

- `scripts/capture-pm-patches.py <out.jsonl> <seconds>` — runs `flotilla pm connect` against a local unix-socket sink and writes deduplicated metadata patches as JSONL, the fixture the andamento render harness replays. Capture once, iterate offline.
- `layouts/daily-driver-wasm.kdl` — daily-driver layout pointed at the wasm plugin builds, for bisecting native-plugin issues against the wasm path.

https://claude.ai/code/session_019iE3vGfKm6bZh7B6i1CUuY