### PR TITLE
feat: publish granular presentation facts

### DIFF
--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -6,6 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use chrono::Utc;
+use flotilla_manifest::keys::{KEY_CHANGE_REQUEST_NUMBER, KEY_CHECKOUT_BRANCH, KEY_CHECKOUT_PATH, KEY_CONVOY_NAME};
 use flotilla_protocol::{
     AwarenessCounts, AwarenessEntry, AwarenessFamily, AwarenessFamilySummary, AwarenessGrouping, AwarenessKind, AwarenessLimit,
     AwarenessNode, AwarenessPhase, AwarenessState, CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef,
@@ -82,7 +83,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .as_of(as_of)
                 .refs(vec![convoy.resource.clone()])
                 .issue_refs(convoy.issues.iter().map(|issue| issue.reference.clone()).collect())
-                .annotations(repo_fact_annotations(convoy.repo.as_ref()))
+                .annotations(convoy_annotations(convoy))
                 .build(),
             &input.salience,
             &project_ancestors,
@@ -155,7 +156,7 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .state(AwarenessState::Active)
                 .as_of(as_of)
                 .refs(vec![checkout.resource.clone()])
-                .annotations(repo_fact_annotations(checkout.repo_fact.as_ref()))
+                .annotations(checkout_annotations(checkout))
                 .build(),
             &input.salience,
             &project_ancestors,
@@ -241,6 +242,22 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
 
 fn repo_fact_annotations(repo: Option<&flotilla_protocol::RepoKey>) -> HashMap<String, String> {
     repo.map(|repo| HashMap::from([(REPO_FACT_ANNOTATION.to_string(), repo.0.clone())])).unwrap_or_default()
+}
+
+fn convoy_annotations(convoy: &ConvoyRow) -> HashMap<String, String> {
+    let mut annotations = repo_fact_annotations(convoy.repo.as_ref());
+    annotations.insert(KEY_CONVOY_NAME.to_owned(), convoy.name.clone());
+    if let Some(change_request) = &convoy.change_request {
+        annotations.insert(KEY_CHANGE_REQUEST_NUMBER.to_owned(), change_request.id.clone());
+    }
+    annotations
+}
+
+fn checkout_annotations(checkout: &CheckoutRow) -> HashMap<String, String> {
+    let mut annotations = repo_fact_annotations(checkout.repo_fact.as_ref());
+    annotations.insert(KEY_CHECKOUT_BRANCH.to_owned(), checkout.branch.clone());
+    annotations.insert(KEY_CHECKOUT_PATH.to_owned(), checkout.path.clone());
+    annotations
 }
 
 fn awareness_family_summaries(entries: &[AwarenessEntry]) -> Vec<AwarenessFamilySummary> {
@@ -435,7 +452,10 @@ fn entry_rank(entry: &AwarenessEntry) -> (u8, u8) {
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
-    use flotilla_protocol::{HostName, Issue, IssueRef, IssueSource, IssueState, RepositoryKey, ResourceRef, SessionPhase};
+    use flotilla_protocol::{
+        ChangeRequestStatus, ConvoyChangeRequest, HostName, Issue, IssueRef, IssueSource, IssueState, RepositoryKey, ResourceRef,
+        SessionPhase,
+    };
     use flotilla_resources::{DemandState, PrincipalRef, TerminalAttentionState};
 
     use super::*;
@@ -515,6 +535,40 @@ mod tests {
                 "repo grouping uses canonical fact value, not display label",
             );
         }
+    }
+
+    #[test]
+    fn composed_labels_retain_granular_convoy_and_checkout_annotations() {
+        let mut convoy = convoy(Some("flotilla/platform"), "ship-it", ConvoyPhase::Active);
+        convoy.change_request = Some(ConvoyChangeRequest {
+            id: "1044".into(),
+            status: ChangeRequestStatus::Open,
+            repository_key: RepositoryKey("repo-a".into()),
+        });
+        let (nodes, _) = project_awareness(AwarenessInput {
+            scope: Some(QueryScope::new("flotilla", "platform")),
+            convoys: vec![convoy],
+            checkouts: vec![CheckoutRow::builder()
+                .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", "checkout"))
+                .repo(RepositoryKey("repo-a".into()))
+                .repo_label("github.com/flotilla-org/flotilla")
+                .path("/work/flotilla")
+                .branch("main")
+                .host(HostName::new("local"))
+                .authority(flotilla_protocol::LifecycleAuthority::Observed)
+                .build()],
+            ..AwarenessInput::default()
+        });
+
+        let convoy = nodes[0].entries.iter().find(|entry| entry.kind == AwarenessKind::Convoy).expect("convoy entry");
+        assert_eq!(convoy.label, "ship-it · PR #1044");
+        assert_eq!(convoy.annotations.get("flotilla.convoy.name").map(String::as_str), Some("ship-it"));
+        assert_eq!(convoy.annotations.get("change_request.number").map(String::as_str), Some("1044"));
+
+        let checkout = nodes[0].entries.iter().find(|entry| entry.kind == AwarenessKind::Checkout).expect("checkout entry");
+        assert_eq!(checkout.label, "main · /work/flotilla");
+        assert_eq!(checkout.annotations.get("checkout.branch").map(String::as_str), Some("main"));
+        assert_eq!(checkout.annotations.get("checkout.path").map(String::as_str), Some("/work/flotilla"));
     }
 
     #[test]

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -59,12 +59,6 @@ pub const KEY_VESSEL_HOST: &str = "flotilla.vessel.host";
 pub const KEY_INDEPENDENT_HOST: &str = "flotilla.independent.host";
 pub const KEY_VESSEL_ENV: &str = "flotilla.vessel.env";
 pub const KEY_CREW_ROLES: &str = "flotilla.crew.roles";
-/// External change-request number without display decoration such as `PR #`.
-pub const KEY_CHANGE_REQUEST_NUMBER: &str = "change_request.number";
-/// Checkout branch without its path or other display decoration.
-pub const KEY_CHECKOUT_BRANCH: &str = "checkout.branch";
-/// Full checkout path without its branch or other display decoration.
-pub const KEY_CHECKOUT_PATH: &str = "checkout.path";
 
 // Cross-producer vocabulary (proposed for the Leg-1 freeze, design §6/§9).
 
@@ -87,6 +81,12 @@ pub const KEY_STATUS_ATTENTION: &str = "status.attention";
 pub const KEY_STATUS_CONNECTIVITY: &str = "status.connectivity";
 /// Short human summary line, e.g. "2/3 vessels done".
 pub const KEY_SUMMARY_TEXT: &str = "summary.text";
+/// External change-request number without display decoration such as `PR #`.
+pub const KEY_CHANGE_REQUEST_NUMBER: &str = "change_request.number";
+/// Checkout branch without its path or other display decoration.
+pub const KEY_CHECKOUT_BRANCH: &str = "checkout.branch";
+/// Full checkout path without its branch or other display decoration.
+pub const KEY_CHECKOUT_PATH: &str = "checkout.path";
 pub const KEY_COUNT_TOTAL: &str = "count.total";
 pub const KEY_COUNT_ISSUES: &str = "count.issues";
 pub const KEY_COUNT_CONVOYS: &str = "count.convoys";

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -59,6 +59,12 @@ pub const KEY_VESSEL_HOST: &str = "flotilla.vessel.host";
 pub const KEY_INDEPENDENT_HOST: &str = "flotilla.independent.host";
 pub const KEY_VESSEL_ENV: &str = "flotilla.vessel.env";
 pub const KEY_CREW_ROLES: &str = "flotilla.crew.roles";
+/// External change-request number without display decoration such as `PR #`.
+pub const KEY_CHANGE_REQUEST_NUMBER: &str = "change_request.number";
+/// Checkout branch without its path or other display decoration.
+pub const KEY_CHECKOUT_BRANCH: &str = "checkout.branch";
+/// Full checkout path without its branch or other display decoration.
+pub const KEY_CHECKOUT_PATH: &str = "checkout.path";
 
 // Cross-producer vocabulary (proposed for the Leg-1 freeze, design §6/§9).
 
@@ -97,6 +103,7 @@ pub const KEY_PRIMARY_ACTION_RECIPE: &str = "action.primary.recipe";
 /// Labels for facts used as grouping levels. Identity facts stay canonical;
 /// these are display-only companions selected through `label-key`.
 pub const KEY_REPO_NAME: &str = "vcs.repo.name";
+/// Human-readable convoy name without an associated change-request suffix.
 pub const KEY_CONVOY_NAME: &str = "flotilla.convoy.name";
 pub const KEY_VESSEL_NAME: &str = "flotilla.vessel.name";
 

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -17,12 +17,13 @@ use flotilla_protocol::{
 use crate::{
     entity::{self, EntityKind, EntityRef},
     keys::{
-        ARCHIPELAGO_ORDINAL, CATALOG_TTL_MS, KEY_CONVOY, KEY_CONVOY_MESSAGE, KEY_CONVOY_NAME, KEY_CONVOY_PHASE, KEY_CONVOY_WORKFLOW,
-        KEY_COUNT_CHECKOUTS, KEY_COUNT_CONVOYS, KEY_COUNT_INDEPENDENTS, KEY_COUNT_ISSUES, KEY_COUNT_TOTAL, KEY_COUNT_VESSELS,
-        KEY_CREW_ROLES, KEY_DISPLAY_LABEL, KEY_ENTITY_ID, KEY_ENTITY_KIND, KEY_INDEPENDENT_HOST, KEY_PRIMARY_ACTION_KEY,
-        KEY_PRIMARY_ACTION_LABEL, KEY_PRIMARY_ACTION_RECIPE, KEY_PRIMARY_ACTION_TARGET, KEY_PRIMARY_ACTION_VEHICLE, KEY_PROJECT_NAME,
-        KEY_REPO_NAME, KEY_SESSION, KEY_SOURCE, KEY_STATUS_ATTENTION, KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL, KEY_VESSEL_HOST,
-        KEY_VESSEL_NAME, KEY_WORK_PHASE, SEGMENT_CHECKOUT, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_REPO, SOURCE_CONNECTOR, SOURCE_FLOTILLA,
+        ARCHIPELAGO_ORDINAL, CATALOG_TTL_MS, KEY_CHANGE_REQUEST_NUMBER, KEY_CHECKOUT_BRANCH, KEY_CHECKOUT_PATH, KEY_CONVOY,
+        KEY_CONVOY_MESSAGE, KEY_CONVOY_NAME, KEY_CONVOY_PHASE, KEY_CONVOY_WORKFLOW, KEY_COUNT_CHECKOUTS, KEY_COUNT_CONVOYS,
+        KEY_COUNT_INDEPENDENTS, KEY_COUNT_ISSUES, KEY_COUNT_TOTAL, KEY_COUNT_VESSELS, KEY_CREW_ROLES, KEY_DISPLAY_LABEL, KEY_ENTITY_ID,
+        KEY_ENTITY_KIND, KEY_INDEPENDENT_HOST, KEY_PRIMARY_ACTION_KEY, KEY_PRIMARY_ACTION_LABEL, KEY_PRIMARY_ACTION_RECIPE,
+        KEY_PRIMARY_ACTION_TARGET, KEY_PRIMARY_ACTION_VEHICLE, KEY_PROJECT_NAME, KEY_REPO_NAME, KEY_SESSION, KEY_SOURCE,
+        KEY_STATUS_ATTENTION, KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL, KEY_VESSEL_HOST, KEY_VESSEL_NAME, KEY_WORK_PHASE,
+        SEGMENT_CHECKOUT, SEGMENT_ISSUE, SEGMENT_PROJECT, SEGMENT_REPO, SOURCE_CONNECTOR, SOURCE_FLOTILLA,
     },
     recipe::{Recipe, RecipeMint},
     wire::{MetadataPatch, MetadataTarget, MetadataValue, MetadataValueUpdate},
@@ -294,7 +295,13 @@ fn awareness_entry_entity(entry: &AwarenessEntry, convoys: &[ConvoyRow]) -> Opti
             let row = find_convoy(convoys, namespace, name);
             let origin = row.map(|row| entity::resource_origin(&row.resource)).unwrap_or_else(|| "fleet".to_owned());
             let entity = entity::convoy(namespace, name, &origin);
-            let facts = vec![(KEY_CONVOY, MetadataValue::text(entity.id.clone())), (KEY_CONVOY_NAME, MetadataValue::text(label.clone()))];
+            let mut facts = vec![
+                (KEY_CONVOY, MetadataValue::text(entity.id.clone())),
+                (KEY_CONVOY_NAME, MetadataValue::text(entry.annotations.get(KEY_CONVOY_NAME).cloned().unwrap_or_else(|| name.to_owned()))),
+            ];
+            if let Some(number) = entry.annotations.get(KEY_CHANGE_REQUEST_NUMBER) {
+                facts.push((KEY_CHANGE_REQUEST_NUMBER, MetadataValue::text(number.clone())));
+            }
             (entity, facts)
         }
         AwarenessKind::Vessel => {
@@ -339,7 +346,14 @@ fn awareness_entry_entity(entry: &AwarenessEntry, convoys: &[ConvoyRow]) -> Opti
         }
         AwarenessKind::Checkout => {
             let entity = entity::checkout(&entry.id);
-            (entity.clone(), vec![(SEGMENT_CHECKOUT, MetadataValue::text(entity.id.clone()))])
+            let mut facts = vec![(SEGMENT_CHECKOUT, MetadataValue::text(entity.id.clone()))];
+            if let Some(branch) = entry.annotations.get(KEY_CHECKOUT_BRANCH) {
+                facts.push((KEY_CHECKOUT_BRANCH, MetadataValue::text(branch.clone())));
+            }
+            if let Some(path) = entry.annotations.get(KEY_CHECKOUT_PATH) {
+                facts.push((KEY_CHECKOUT_PATH, MetadataValue::text(path.clone())));
+            }
+            (entity, facts)
         }
         AwarenessKind::Fleet | AwarenessKind::Project => return None,
     };
@@ -451,6 +465,9 @@ fn project_convoy(catalog: &mut Catalog, convoy: &ConvoyRow, mint: &dyn RecipeMi
         (KEY_CONVOY_WORKFLOW, MetadataValue::text(convoy.workflow_ref.clone())),
         (KEY_STATUS_STATE, MetadataValue::text(badge.state.as_str())),
     ]);
+    if let Some(change_request) = &convoy.change_request {
+        facts.push((KEY_CHANGE_REQUEST_NUMBER, MetadataValue::text(change_request.id.clone())));
+    }
     if let Some(message) = &convoy.message {
         facts.push((KEY_CONVOY_MESSAGE, MetadataValue::text(message.clone())));
     }

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -1,14 +1,15 @@
 use flotilla_protocol::{
     result_set::{AwarenessCounts, AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessState, CrewMemberSummary},
-    HostName, IssueRef, IssueSource, RepoKey, ResourceRef,
+    ChangeRequestStatus, ConvoyChangeRequest, HostName, IssueRef, IssueSource, RepoKey, RepositoryKey, ResourceRef,
 };
 
 use super::*;
 use crate::{
     entity::{self, EntityKind},
     keys::{
-        KEY_CONVOY, KEY_COUNT_ISSUES, KEY_COUNT_TOTAL, KEY_ENTITY_ID, KEY_ENTITY_KIND, KEY_PRIMARY_ACTION_RECIPE,
-        KEY_PRIMARY_ACTION_TARGET, KEY_SOURCE, KEY_STATUS_STATE, KEY_VESSEL, SEGMENT_PROJECT, SEGMENT_REPO,
+        KEY_CHANGE_REQUEST_NUMBER, KEY_CHECKOUT_BRANCH, KEY_CHECKOUT_PATH, KEY_CONVOY, KEY_CONVOY_NAME, KEY_COUNT_CHECKOUTS,
+        KEY_COUNT_ISSUES, KEY_COUNT_TOTAL, KEY_DISPLAY_LABEL, KEY_ENTITY_ID, KEY_ENTITY_KIND, KEY_PRIMARY_ACTION_RECIPE,
+        KEY_PRIMARY_ACTION_TARGET, KEY_SOURCE, KEY_STATUS_STATE, KEY_SUMMARY_TEXT, KEY_VESSEL, SEGMENT_PROJECT, SEGMENT_REPO,
     },
     recipe::FlotillaRecipes,
 };
@@ -53,6 +54,11 @@ fn raw_catalog_is_entities_only_with_canonical_flat_facts() {
         .phase(ConvoyPhase::Active)
         .project_ref("project/dev/platform")
         .repo(RepoKey("github.com:flotilla-org/flotilla".to_owned()))
+        .change_request(ConvoyChangeRequest {
+            id: "1044".to_owned(),
+            status: ChangeRequestStatus::Open,
+            repository_key: RepositoryKey("repo-flotilla".to_owned()),
+        })
         .vessels(vec![vessel().convoy(&reference).name("coder").phase(WorkPhase::Running).materialize("terminal-cutover-coder").call()])
         .build();
 
@@ -72,6 +78,7 @@ fn raw_catalog_is_entities_only_with_canonical_flat_facts() {
     assert_eq!(text(convoy_patch, SEGMENT_PROJECT), "dev/platform@kiwi");
     assert_eq!(text(convoy_patch, SEGMENT_REPO), "github.com:flotilla-org/flotilla");
     assert_eq!(text(convoy_patch, KEY_CONVOY), "dev/cutover@kiwi");
+    assert_eq!(text(convoy_patch, KEY_CHANGE_REQUEST_NUMBER), "1044");
     assert_eq!(text(vessel_patch, KEY_VESSEL), "dev/cutover/coder@feta");
     assert_eq!(
         text(convoy_patch, KEY_PRIMARY_ACTION_TARGET),
@@ -119,6 +126,60 @@ fn awareness_issues_are_recipe_less_entities_with_source_plus_id_identity() {
     );
     assert!(!issue_patch.set.contains_key(KEY_COUNT_ISSUES));
     assert!(!issue_patch.set.contains_key(KEY_PRIMARY_ACTION_RECIPE));
+}
+
+#[test]
+fn awareness_composed_text_is_unchanged_alongside_granular_facts() {
+    let convoy = AwarenessEntry::builder()
+        .id("convoy/dev/landing".to_owned())
+        .kind(AwarenessKind::Convoy)
+        .label("landing · PR #1044".to_owned())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .annotations(std::collections::HashMap::from([
+            (KEY_CONVOY_NAME.to_owned(), "landing".to_owned()),
+            (KEY_CHANGE_REQUEST_NUMBER.to_owned(), "1044".to_owned()),
+        ]))
+        .build();
+    let checkout = AwarenessEntry::builder()
+        .id("checkout/kiwi//work/flotilla".to_owned())
+        .kind(AwarenessKind::Checkout)
+        .label("main · /work/flotilla".to_owned())
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .annotations(std::collections::HashMap::from([
+            (KEY_CHECKOUT_BRANCH.to_owned(), "main".to_owned()),
+            (KEY_CHECKOUT_PATH.to_owned(), "/work/flotilla".to_owned()),
+        ]))
+        .build();
+    let node = AwarenessNode::builder()
+        .id("project/dev/platform".to_owned())
+        .kind(AwarenessKind::Project)
+        .label("platform".to_owned())
+        .scope(flotilla_protocol::QueryScope::new("dev", "platform"))
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .counts(AwarenessCounts::builder().total(2).convoys(1).checkouts(1).build())
+        .entries(vec![convoy, checkout])
+        .build();
+
+    let patches = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint()).reassert_patches();
+    let convoy = find_entity(&patches, &entity::convoy("dev", "landing", "fleet"));
+    assert_eq!(text(convoy, KEY_DISPLAY_LABEL), "landing · PR #1044");
+    assert_eq!(text(convoy, KEY_SUMMARY_TEXT), "landing · PR #1044");
+    assert_eq!(text(convoy, KEY_CONVOY_NAME), "landing");
+    assert_eq!(text(convoy, KEY_CHANGE_REQUEST_NUMBER), "1044");
+
+    let checkout = find_entity(&patches, &entity::checkout("checkout/kiwi//work/flotilla"));
+    assert_eq!(text(checkout, KEY_DISPLAY_LABEL), "main · /work/flotilla");
+    assert_eq!(text(checkout, KEY_SUMMARY_TEXT), "main · /work/flotilla");
+    assert_eq!(text(checkout, KEY_CHECKOUT_BRANCH), "main");
+    assert_eq!(text(checkout, KEY_CHECKOUT_PATH), "/work/flotilla");
+
+    let project = find_entity(&patches, &entity::project("dev", "platform", "fleet"));
+    assert_eq!(text(project, KEY_SUMMARY_TEXT), "2 entries · 0 issues · 0 vessels · 1 checkouts");
+    assert_eq!(project.set[KEY_COUNT_TOTAL].value, MetadataValue::Integer(2));
+    assert_eq!(project.set[KEY_COUNT_CHECKOUTS].value, MetadataValue::Integer(1));
 }
 
 #[test]

--- a/crates/flotilla-manifest/src/wire.rs
+++ b/crates/flotilla-manifest/src/wire.rs
@@ -23,6 +23,8 @@
 //! | `flotilla.crew.role` | One bound pane's crew role. |
 //! | `flotilla.attach.ref` | Address accepted by `flotilla attach`. |
 //! | `flotilla.project.name` | Human-readable name of a Project group. |
+//! | `flotilla.convoy.name` | Human-readable convoy name without an associated change-request suffix. |
+//! | `flotilla.vessel.name` | Human-readable vessel name. |
 //! | `flotilla.convoy.phase` | Raw [`flotilla_protocol::ConvoyPhase`] value. |
 //! | `flotilla.convoy.workflow` | WorkflowTemplate resource name used by a convoy. |
 //! | `flotilla.convoy.message` | Convoy lifecycle diagnostic. |
@@ -31,6 +33,10 @@
 //! | `flotilla.independent.host` | Host currently carrying an independent terminal session. |
 //! | `flotilla.vessel.env` | Execution-environment reference for a vessel. |
 //! | `flotilla.crew.roles` | Complete crew-role list aboard a vessel. |
+//! | `vcs.repo.name` | Human-readable Repository name. |
+//! | `change_request.number` | External change-request number without display decoration such as `PR #`. |
+//! | `checkout.branch` | Checkout branch without its path or other display decoration. |
+//! | `checkout.path` | Full checkout path without its branch or other display decoration. |
 //! | `entity.kind` | Canonical presentation entity kind. |
 //! | `entity.id` | Canonical id in that kind's single permitted dialect. |
 //! | `display.label` | Concise human label, never identity. |
@@ -38,6 +44,12 @@
 //! | `status.attention` | Boolean human-attention demand. |
 //! | `status.connectivity` | Connectivity annotation (`connected` or `disconnected`); reserved until emitted. |
 //! | `summary.text` | Short human summary, never an identity. |
+//! | `count.total` | Total awareness entries beneath a project or convoy entity. |
+//! | `count.issues` | Issue-entry count beneath a project or convoy entity. |
+//! | `count.convoys` | Convoy-entry count beneath a project entity. |
+//! | `count.vessels` | Vessel-entry count beneath a project or convoy entity. |
+//! | `count.checkouts` | Checkout-entry count beneath a project entity. |
+//! | `count.independents` | Independent-session count beneath a project entity. |
 //! | `action.primary.key` | Stable verb for the primary action. |
 //! | `action.primary.label` | Human label for the primary action. |
 //! | `action.primary.vehicle` | Execution vehicle for the action. |


### PR DESCRIPTION
## Summary

- preserve raw convoy names and change-request numbers beside composed convoy labels
- publish checkout branch and path facts beside composed checkout labels
- document identity and count keys in the entity-fact vocabulary
- preserve existing `display.label` and `summary.text` output

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-manifest --locked`
- `cargo test -p flotilla-core --locked` (1,144 passed; pre-existing macOS `/var` vs `/private/var` canonicalization failure in `adopted_checkout_with_explicit_transport_applies_fork_stance_config`)
- `cargo test --workspace --locked` (same single pre-existing macOS failure)
- andamento render harness: captured 17 connector patches before and after; both produced identical 150-line output

Closes #1062