### PR TITLE
feat: port hub-spoke compose topology tests

### DIFF
--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -23,7 +23,32 @@ jobs:
       - name: Install integration test dependencies
         run: python -m pip install ./tests/integration
       - name: Run real-boundary topology and wedge regressions
-        run: python -m pytest -v tests/integration
+        run: >-
+          python -m pytest -v
+          tests/integration/test_minimal_topology.py
+          tests/integration/test_wedge_regressions.py
       - name: Print compose logs
         if: failure()
         run: docker compose -f tests/integration/docker-compose.yml logs --no-color
+
+  hub-spoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tests/integration/pyproject.toml
+      - name: Install integration test dependencies
+        run: python -m pip install ./tests/integration
+      - name: Run hub-spoke topology regressions
+        run: python -m pytest -v tests/integration/test_hub_spoke_topology.py
+      - name: Print compose logs
+        if: failure()
+        run: >-
+          docker compose
+          -f tests/integration/docker-compose.hub-spoke.yml
+          logs --no-color

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,13 +13,26 @@ DAEMON_LOG = "~/.local/state/flotilla/daemon.log"
 
 
 def docker_exec(
-    service: str, cmd: str, timeout: int = 30
+    service: str,
+    cmd: str,
+    timeout: int = 30,
+    compose_file: str = COMPOSE_FILE,
 ) -> subprocess.CompletedProcess:
     """Run a command inside a container via docker compose exec."""
     return subprocess.run(
         [
-            "docker", "compose", "-f", COMPOSE_FILE,
-            "exec", "-T", "-u", "flotilla", service, "bash", "-c", cmd,
+            "docker",
+            "compose",
+            "-f",
+            compose_file,
+            "exec",
+            "-T",
+            "-u",
+            "flotilla",
+            service,
+            "bash",
+            "-c",
+            cmd,
         ],
         capture_output=True,
         text=True,
@@ -27,19 +40,33 @@ def docker_exec(
     )
 
 
-def compose(*args: str, timeout: int = 60) -> subprocess.CompletedProcess:
+def compose(
+    *args: str,
+    timeout: int = 60,
+    compose_file: str = COMPOSE_FILE,
+) -> subprocess.CompletedProcess:
     """Run docker compose against the integration topology."""
     return subprocess.run(
-        ["docker", "compose", "-f", COMPOSE_FILE, *args],
+        ["docker", "compose", "-f", compose_file, *args],
         capture_output=True,
         text=True,
         timeout=timeout,
     )
 
 
-def flotilla_json(service: str, args: str, timeout: int = 30) -> dict | list:
+def flotilla_json(
+    service: str,
+    args: str,
+    timeout: int = 30,
+    compose_file: str = COMPOSE_FILE,
+) -> dict | list:
     """Run a flotilla CLI command with --json and return parsed output."""
-    result = docker_exec(service, f"flotilla --json {args}", timeout=timeout)
+    result = docker_exec(
+        service,
+        f"flotilla --json {args}",
+        timeout=timeout,
+        compose_file=compose_file,
+    )
     assert result.returncode == 0, (
         f"flotilla {args} failed (rc={result.returncode}):\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
@@ -53,9 +80,7 @@ def flotilla_json(service: str, args: str, timeout: int = 30) -> dict | list:
         ) from e
 
 
-def wait_for(
-    predicate, description: str, timeout: int = 60, interval: float = 2.0
-):
+def wait_for(predicate, description: str, timeout: int = 60, interval: float = 2.0):
     """Poll until predicate returns True or timeout.
 
     AssertionError is re-raised immediately (hard failure, not transient).
@@ -78,17 +103,18 @@ def wait_for(
     raise TimeoutError(msg)
 
 
-def start_daemon(service: str):
+def start_daemon(service: str, compose_file: str = COMPOSE_FILE):
     """Start flotillad directly and record its PID for deterministic restarts."""
     result = docker_exec(
         service,
         "mkdir -p ~/.config/flotilla ~/.local/state/flotilla; "
         "tmux_env=$(tmux display-message -t integration -p "
         "'#{socket_path},#{pid},#{window_index}'); "
-        "nohup env TMUX=\"$tmux_env\" "
+        'nohup env TMUX="$tmux_env" '
         "RUST_LOG=flotilla_daemon=debug flotillad --timeout 0 "
         ">~/.config/flotilla/daemon-stdio.log 2>&1 & "
         "echo $! > ~/.config/flotilla/flotillad.pid",
+        compose_file=compose_file,
     )
     assert result.returncode == 0, (
         f"flotillad start failed on {service}:\n"
@@ -96,18 +122,19 @@ def start_daemon(service: str):
     )
 
 
-def stop_daemon(service: str):
+def stop_daemon(service: str, compose_file: str = COMPOSE_FILE):
     """Stop the recorded flotillad process, if it is still running."""
     result = docker_exec(
         service,
         "if test -f ~/.config/flotilla/flotillad.pid; then "
         "pid=$(cat ~/.config/flotilla/flotillad.pid); "
-        "kill \"$pid\" 2>/dev/null || true; "
+        'kill "$pid" 2>/dev/null || true; '
         "for attempt in $(seq 1 50); do "
-        "state=$(ps -o stat= -p \"$pid\" 2>/dev/null || true); "
+        'state=$(ps -o stat= -p "$pid" 2>/dev/null || true); '
         "case \"$state\" in ''|Z*) exit 0 ;; esac; sleep 0.1; "
         "done; exit 1; "
         "fi",
+        compose_file=compose_file,
     )
     assert result.returncode == 0, (
         f"flotillad stop failed on {service}:\n"
@@ -115,28 +142,29 @@ def stop_daemon(service: str):
     )
 
 
-def daemon_log(service: str) -> str:
+def daemon_log(service: str, compose_file: str = COMPOSE_FILE) -> str:
     """Read a node's structured daemon log."""
-    result = docker_exec(service, f"cat {DAEMON_LOG}")
+    result = docker_exec(service, f"cat {DAEMON_LOG}", compose_file=compose_file)
     return result.stdout if result.returncode == 0 else ""
 
 
 @pytest.fixture(scope="module")
 def topology():
     """Spin up 2-node topology, wait for peering, yield, tear down."""
-    result = compose(
-        "up", "-d", "--build", "--force-recreate", timeout=900
-    )
+    result = compose("up", "-d", "--build", "--force-recreate", timeout=900)
     assert result.returncode == 0, (
         f"compose up failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )
     try:
         # Wait for SSH readiness between nodes
         wait_for(
-            lambda: docker_exec(
-                "node-a",
-                "ssh -o StrictHostKeyChecking=no -o BatchMode=yes node-b true",
-            ).returncode == 0,
+            lambda: (
+                docker_exec(
+                    "node-a",
+                    "ssh -o StrictHostKeyChecking=no -o BatchMode=yes node-b true",
+                ).returncode
+                == 0
+            ),
             "SSH from node-a to node-b",
         )
 
@@ -150,41 +178,43 @@ def topology():
                 "cd /home/flotilla/repo && "
                 "git commit --allow-empty -m init",
             )
-            assert result.returncode == 0, (
-                f"git init failed on {node}: {result.stderr}"
-            )
+            assert result.returncode == 0, f"git init failed on {node}: {result.stderr}"
 
         # Write flotilla config: node-a is leader with node-b as peer
-        result = docker_exec("node-a", "\n".join([
-            "mkdir -p ~/.config/flotilla",
-            "cat > ~/.config/flotilla/hosts.toml << 'TOML'",
-            "[hosts.node-b]",
-            'hostname = "node-b"',
-            'expected_host_name = "node-b"',
-            'daemon_socket = "/home/flotilla/.config/flotilla/flotilla.sock"',
-            "TOML",
-        ]))
-        assert result.returncode == 0, (
-            f"hosts.toml write failed: {result.stderr}"
+        result = docker_exec(
+            "node-a",
+            "\n".join(
+                [
+                    "mkdir -p ~/.config/flotilla",
+                    "cat > ~/.config/flotilla/hosts.toml << 'TOML'",
+                    "[hosts.node-b]",
+                    'hostname = "node-b"',
+                    'expected_host_name = "node-b"',
+                    'daemon_socket = "/home/flotilla/.config/flotilla/flotilla.sock"',
+                    "TOML",
+                ]
+            ),
         )
+        assert result.returncode == 0, f"hosts.toml write failed: {result.stderr}"
 
         # Write flotilla config: node-b is follower
-        result = docker_exec("node-b", "\n".join([
-            "mkdir -p ~/.config/flotilla",
-            "cat > ~/.config/flotilla/daemon.toml << 'TOML'",
-            "follower = true",
-            "TOML",
-        ]))
-        assert result.returncode == 0, (
-            f"daemon.toml write failed: {result.stderr}"
+        result = docker_exec(
+            "node-b",
+            "\n".join(
+                [
+                    "mkdir -p ~/.config/flotilla",
+                    "cat > ~/.config/flotilla/daemon.toml << 'TOML'",
+                    "follower = true",
+                    "TOML",
+                ]
+            ),
         )
+        assert result.returncode == 0, f"daemon.toml write failed: {result.stderr}"
 
         # Give discovery a real presentation surface, then start the current
         # standalone daemon binary on both nodes.
         for node in ("node-a", "node-b"):
-            result = docker_exec(
-                node, "tmux new-session -d -s integration"
-            )
+            result = docker_exec(node, "tmux new-session -d -s integration")
             assert result.returncode == 0, (
                 f"tmux start failed on {node}: {result.stderr}"
             )
@@ -193,28 +223,21 @@ def topology():
         # Wait for daemon readiness on each node
         for node in ("node-a", "node-b"):
             wait_for(
-                lambda n=node: docker_exec(
-                    n, "flotilla status --json"
-                ).returncode == 0,
+                lambda n=node: docker_exec(n, "flotilla status --json").returncode == 0,
                 f"daemon ready on {node}",
                 timeout=30,
             )
 
         # Add repos via CLI
         for node in ("node-a", "node-b"):
-            result = docker_exec(
-                node, "flotilla repo add /home/flotilla/repo"
-            )
-            assert result.returncode == 0, (
-                f"repo add failed on {node}: {result.stderr}"
-            )
+            result = docker_exec(node, "flotilla repo add /home/flotilla/repo")
+            assert result.returncode == 0, f"repo add failed on {node}: {result.stderr}"
 
         # Wait for peering: node-a sees node-b as Connected
         def peers_connected():
             result = flotilla_json("node-a", "host list")
             return any(
-                h["host_name"] == "node-b"
-                and h["connection_status"] == "Connected"
+                h["host_name"] == "node-b" and h["connection_status"] == "Connected"
                 for h in result.get("hosts", [])
             )
 
@@ -228,9 +251,7 @@ def topology():
             log = daemon_log(node)
             if log:
                 print(f"\n=== {node} daemon log ===\n{log}")
-            stdio = docker_exec(
-                node, "cat ~/.config/flotilla/daemon-stdio.log"
-            )
+            stdio = docker_exec(node, "cat ~/.config/flotilla/daemon-stdio.log")
             if stdio.stdout:
                 print(f"\n=== {node} daemon stdio ===\n{stdio.stdout}")
 

--- a/tests/integration/docker-compose.hub-spoke.dev.yml
+++ b/tests/integration/docker-compose.hub-spoke.dev.yml
@@ -1,0 +1,11 @@
+# Override: use pre-built binaries from the host instead of building with cargo.
+# Usage:
+#   docker compose -f docker-compose.hub-spoke.yml \
+#     -f docker-compose.hub-spoke.dev.yml up -d --build
+#
+# The host binaries must be glibc-compatible with the container's Debian
+# trixie runtime (glibc 2.41).
+services:
+  flotilla-base:
+    build:
+      target: dev

--- a/tests/integration/docker-compose.hub-spoke.yml
+++ b/tests/integration/docker-compose.hub-spoke.yml
@@ -4,6 +4,7 @@
 # image, so the fixture builds flotilla-base before starting the topology.
 services:
   flotilla-base:
+    profiles: ["build-only"]
     build:
       context: ../..
       dockerfile: tests/integration/docker/base/Dockerfile

--- a/tests/integration/docker-compose.hub-spoke.yml
+++ b/tests/integration/docker-compose.hub-spoke.yml
@@ -1,0 +1,38 @@
+# 3-node hub-spoke topology: workstation (leader) + 2 followers.
+#
+# Role Dockerfiles layer heterogeneous tools onto the shared flotilla-base
+# image, so the fixture builds flotilla-base before starting the topology.
+services:
+  flotilla-base:
+    build:
+      context: ../..
+      dockerfile: tests/integration/docker/base/Dockerfile
+      target: full
+    image: flotilla-base
+
+  workstation:
+    build:
+      context: ../..
+      dockerfile: tests/integration/docker/workstation/Dockerfile
+    hostname: workstation
+    volumes:
+      - shared-keys:/shared-keys
+
+  homelab-1:
+    build:
+      context: ../..
+      dockerfile: tests/integration/docker/follower-codex/Dockerfile
+    hostname: homelab-1
+    volumes:
+      - shared-keys:/shared-keys
+
+  homelab-2:
+    build:
+      context: ../..
+      dockerfile: tests/integration/docker/follower-gemini/Dockerfile
+    hostname: homelab-2
+    volumes:
+      - shared-keys:/shared-keys
+
+volumes:
+  shared-keys:

--- a/tests/integration/docker/follower-gemini/Dockerfile
+++ b/tests/integration/docker/follower-gemini/Dockerfile
@@ -6,4 +6,4 @@ RUN npm install -g @google/gemini-cli
 FROM flotilla-base
 COPY --from=npm-installer /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=npm-installer /usr/local/bin/node /usr/local/bin/node
-RUN ln -s ../lib/node_modules/@google/gemini-cli/dist/index.js /usr/local/bin/gemini
+RUN ln -s ../lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/local/bin/gemini

--- a/tests/integration/test_hub_spoke_topology.py
+++ b/tests/integration/test_hub_spoke_topology.py
@@ -1,0 +1,399 @@
+"""Three-node hub-spoke topology coverage for the compose harness.
+
+The workstation peers directly with two heterogeneous followers:
+homelab-1 has codex and shpool, while homelab-2 has gemini and uses the
+passthrough terminal pool. Commands run through the real CLI/daemon/SSH
+boundary and assertions use the current JSON protocol.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from conftest import (
+    compose,
+    daemon_log,
+    docker_exec,
+    flotilla_json,
+    start_daemon,
+    stop_daemon,
+    wait_for,
+)
+
+COMPOSE_DIR = Path(__file__).parent
+HUB_SPOKE_COMPOSE = str(COMPOSE_DIR / "docker-compose.hub-spoke.yml")
+
+NODES = ("workstation", "homelab-1", "homelab-2")
+FOLLOWERS = ("homelab-1", "homelab-2")
+pytestmark = pytest.mark.timeout(900)
+
+
+def hub_exec(service: str, cmd: str, timeout: int = 30):
+    return docker_exec(
+        service,
+        cmd,
+        timeout=timeout,
+        compose_file=HUB_SPOKE_COMPOSE,
+    )
+
+
+def hub_json(service: str, args: str, timeout: int = 30) -> dict | list:
+    return flotilla_json(
+        service,
+        args,
+        timeout=timeout,
+        compose_file=HUB_SPOKE_COMPOSE,
+    )
+
+
+def hub_compose(*args: str, timeout: int = 60):
+    return compose(
+        *args,
+        timeout=timeout,
+        compose_file=HUB_SPOKE_COMPOSE,
+    )
+
+
+def hub_start_daemon(service: str):
+    start_daemon(service, compose_file=HUB_SPOKE_COMPOSE)
+
+
+def hub_stop_daemon(service: str):
+    stop_daemon(service, compose_file=HUB_SPOKE_COMPOSE)
+
+
+def wait_for_follower(follower: str):
+    wait_for(
+        lambda: (
+            next(
+                host
+                for host in hub_json("workstation", "host list")["hosts"]
+                if host["host_name"] == follower
+            )["connection_status"]
+            == "Connected"
+        ),
+        f"{follower} connected to workstation",
+        timeout=90,
+        interval=0.5,
+    )
+
+
+def wait_for_checkout_on_workstation(branch: str, source: str):
+    wait_for(
+        lambda: any(
+            item.get("branch") == branch and item.get("source") == source
+            for item in hub_json("workstation", "repo /home/flotilla/repo work")[
+                "work_items"
+            ]
+        ),
+        f"workstation sees {branch} from {source}",
+        timeout=30,
+        interval=1.0,
+    )
+
+
+@pytest.fixture(scope="module")
+def hub_spoke_topology():
+    """Start the three nodes, configure the star, and wait for replication."""
+    result = hub_compose("build", "flotilla-base", timeout=900)
+    assert result.returncode == 0, (
+        f"flotilla-base build failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    result = hub_compose(
+        "up",
+        "-d",
+        "--build",
+        "--force-recreate",
+        timeout=900,
+    )
+    assert result.returncode == 0, (
+        f"compose up failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    try:
+        for follower in FOLLOWERS:
+            wait_for(
+                lambda f=follower: (
+                    hub_exec(
+                        "workstation",
+                        f"ssh -o StrictHostKeyChecking=no -o BatchMode=yes {f} true",
+                    ).returncode
+                    == 0
+                ),
+                f"SSH from workstation to {follower}",
+            )
+
+        for node in NODES:
+            result = hub_exec(
+                node,
+                "git config --global user.email test@test.com && "
+                "git config --global user.name test && "
+                "git init /home/flotilla/repo && "
+                "cd /home/flotilla/repo && "
+                "git commit --allow-empty -m init",
+            )
+            assert result.returncode == 0, f"git init failed on {node}: {result.stderr}"
+
+        result = hub_exec(
+            "workstation",
+            "\n".join(
+                [
+                    "mkdir -p ~/.config/flotilla",
+                    "cat > ~/.config/flotilla/hosts.toml << 'TOML'",
+                    "[hosts.homelab-1]",
+                    'hostname = "homelab-1"',
+                    'expected_host_name = "homelab-1"',
+                    'daemon_socket = "/home/flotilla/.config/flotilla/flotilla.sock"',
+                    "",
+                    "[hosts.homelab-2]",
+                    'hostname = "homelab-2"',
+                    'expected_host_name = "homelab-2"',
+                    'daemon_socket = "/home/flotilla/.config/flotilla/flotilla.sock"',
+                    "TOML",
+                ]
+            ),
+        )
+        assert result.returncode == 0, f"hosts.toml write failed: {result.stderr}"
+
+        for follower in FOLLOWERS:
+            result = hub_exec(
+                follower,
+                "\n".join(
+                    [
+                        "mkdir -p ~/.config/flotilla",
+                        "cat > ~/.config/flotilla/daemon.toml << 'TOML'",
+                        "follower = true",
+                        "TOML",
+                    ]
+                ),
+            )
+            assert result.returncode == 0, (
+                f"daemon.toml write failed on {follower}: {result.stderr}"
+            )
+
+        for node in NODES:
+            result = hub_exec(node, "tmux new-session -d -s integration")
+            assert result.returncode == 0, (
+                f"tmux start failed on {node}: {result.stderr}"
+            )
+            hub_start_daemon(node)
+
+        for node in NODES:
+            wait_for(
+                lambda n=node: hub_exec(n, "flotilla status --json").returncode == 0,
+                f"daemon ready on {node}",
+                timeout=30,
+                interval=0.5,
+            )
+
+        for node in NODES:
+            result = hub_exec(node, "flotilla repo add /home/flotilla/repo")
+            assert result.returncode == 0, f"repo add failed on {node}: {result.stderr}"
+
+        for follower in FOLLOWERS:
+            wait_for_follower(follower)
+
+        yield
+    finally:
+        for node in NODES:
+            log = daemon_log(node, compose_file=HUB_SPOKE_COMPOSE)
+            if log:
+                print(f"\n=== {node} daemon log ===\n{log}")
+            stdio = hub_exec(node, "cat ~/.config/flotilla/daemon-stdio.log")
+            if stdio.stdout:
+                print(f"\n=== {node} daemon stdio ===\n{stdio.stdout}")
+
+        result = hub_compose("down", "-v", "--remove-orphans")
+        if result.returncode != 0:
+            print(
+                f"\n=== teardown failed (rc={result.returncode}) ===\n{result.stderr}"
+            )
+
+
+def test_all_daemons_running(hub_spoke_topology):
+    """All three daemons expose their locally tracked repository."""
+    for node in NODES:
+        result = hub_json(node, "status")
+        assert result["repos"]
+
+
+def test_topology_shows_star_shape(hub_spoke_topology):
+    """The workstation has two direct routes with no follower as next hop."""
+    result = hub_json("workstation", "topology")
+    assert result["local_node"]["display_name"] == "workstation"
+
+    routes = result["routes"]
+    for follower in FOLLOWERS:
+        route = next(
+            (route for route in routes if route["target"]["display_name"] == follower),
+            None,
+        )
+        assert route is not None, f"no route to {follower}: {routes}"
+        assert route["direct"]
+        assert route["connected"]
+        assert route["next_hop"]["display_name"] == follower
+
+
+def test_provider_heterogeneity(hub_spoke_topology):
+    """Each follower publishes its distinct real tool inventory."""
+    homelab_1 = hub_json("workstation", "host homelab-1 providers")
+    homelab_2 = hub_json("workstation", "host homelab-2 providers")
+
+    assert homelab_1["connection_status"] == "Connected"
+    assert homelab_2["connection_status"] == "Connected"
+
+    binaries_1 = {
+        binary["name"] for binary in homelab_1["summary"]["inventory"]["binaries"]
+    }
+    binaries_2 = {
+        binary["name"] for binary in homelab_2["summary"]["inventory"]["binaries"]
+    }
+    assert "codex" in binaries_1
+    assert "shpool" in binaries_1
+    assert "codex" not in binaries_2
+    assert "shpool" not in binaries_2
+    assert binaries_1 != binaries_2
+
+    gemini = hub_exec("homelab-2", "command -v gemini")
+    assert gemini.returncode == 0, gemini.stderr
+    no_gemini = hub_exec("homelab-1", "command -v gemini")
+    assert no_gemini.returncode != 0
+
+
+def test_work_correlation_across_three_hosts(hub_spoke_topology):
+    """Matching main branches retain all three sources on workstation."""
+
+    def all_nodes_visible():
+        result = hub_json("workstation", "repo /home/flotilla/repo work")
+        sources = {
+            item["source"]
+            for item in result["work_items"]
+            if item.get("branch") == "master" and item["is_main_checkout"]
+        }
+        return set(NODES) <= sources
+
+    wait_for(
+        all_nodes_visible,
+        "workstation sees the main checkout from all three nodes",
+        timeout=30,
+        interval=1.0,
+    )
+
+
+def test_followers_receive_leader_data(hub_spoke_topology):
+    """A follower sees a workstation checkout through peer publication."""
+    checkout = hub_json(
+        "workstation",
+        "repo /home/flotilla/repo checkout --fresh feat-leader-data",
+    )
+    assert checkout["kind"] == "checkout_created"
+
+    wait_for(
+        lambda: any(
+            item.get("branch") == "feat-leader-data"
+            and item.get("source") == "workstation"
+            for item in hub_json("homelab-1", "repo /home/flotilla/repo work")[
+                "work_items"
+            ]
+        ),
+        "homelab-1 sees workstation checkout feat-leader-data",
+        timeout=30,
+        interval=1.0,
+    )
+
+
+def test_shpool_attachable_set_survives_daemon_restart(
+    hub_spoke_topology,
+):
+    """A shpool-backed terminal keeps its durable set across restart."""
+    checkout = hub_json(
+        "homelab-1",
+        "repo /home/flotilla/repo checkout --fresh feat-shpool-persist",
+    )
+    assert checkout["kind"] == "checkout_created"
+    checkout_path = checkout["path"]["path"]
+    wait_for_checkout_on_workstation("feat-shpool-persist", "homelab-1")
+
+    prepared = hub_json(
+        "workstation",
+        f"host homelab-1 repo /home/flotilla/repo prepare-terminal {checkout_path}",
+        timeout=60,
+    )
+    assert prepared["kind"] == "terminal_prepared"
+    assert prepared["attachable_set_id"]
+
+    assert any(
+        arg.get("value", "").startswith("shpool ")
+        for command in prepared["commands"]
+        for arg in command["args"]
+    )
+
+    def attachable_registry():
+        registry = hub_exec(
+            "homelab-1",
+            "cat ~/.config/flotilla/attachables/registry.json",
+        )
+        assert registry.returncode == 0, registry.stderr
+        return json.loads(registry.stdout)
+
+    attachable_set_id = prepared["attachable_set_id"]
+    assert attachable_set_id in attachable_registry()["sets"]
+
+    hub_stop_daemon("homelab-1")
+    hub_start_daemon("homelab-1")
+    wait_for(
+        lambda: hub_exec("homelab-1", "flotilla status --json").returncode == 0,
+        "homelab-1 daemon restarted",
+        timeout=30,
+        interval=0.5,
+    )
+    wait_for_follower("homelab-1")
+    assert attachable_set_id in attachable_registry()["sets"]
+
+
+def test_terminal_without_shpool_uses_passthrough(hub_spoke_topology):
+    """The follower without shpool returns executable fallback commands."""
+    checkout = hub_json(
+        "homelab-2",
+        "repo /home/flotilla/repo checkout --fresh feat-no-shpool",
+    )
+    assert checkout["kind"] == "checkout_created"
+    checkout_path = checkout["path"]["path"]
+    wait_for_checkout_on_workstation("feat-no-shpool", "homelab-2")
+
+    prepared = hub_json(
+        "workstation",
+        f"host homelab-2 repo /home/flotilla/repo prepare-terminal {checkout_path}",
+        timeout=60,
+    )
+    assert prepared["kind"] == "terminal_prepared"
+    assert prepared["attachable_set_id"]
+    assert prepared["commands"]
+    assert all(
+        arg.get("value") != "shpool"
+        for command in prepared["commands"]
+        for arg in command["args"]
+    )
+
+
+def test_reprepare_reuses_attachable_identity(hub_spoke_topology):
+    """Repeated preparation keeps the checkout's attachable-set identity."""
+    checkout = hub_json(
+        "homelab-1",
+        "repo /home/flotilla/repo checkout --fresh feat-workspace-reprepare",
+    )
+    assert checkout["kind"] == "checkout_created"
+    checkout_path = checkout["path"]["path"]
+    wait_for_checkout_on_workstation("feat-workspace-reprepare", "homelab-1")
+    command = (
+        f"host homelab-1 repo /home/flotilla/repo prepare-terminal {checkout_path}"
+    )
+
+    first = hub_json("workstation", command, timeout=60)
+    second = hub_json("workstation", command, timeout=60)
+
+    assert first["kind"] == "terminal_prepared"
+    assert second["kind"] == "terminal_prepared"
+    assert first["attachable_set_id"] == second["attachable_set_id"]
+    assert first["commands"] == second["commands"]

--- a/tests/integration/test_hub_spoke_topology.py
+++ b/tests/integration/test_hub_spoke_topology.py
@@ -371,7 +371,7 @@ def test_terminal_without_shpool_uses_passthrough(hub_spoke_topology):
     assert prepared["attachable_set_id"]
     assert prepared["commands"]
     assert all(
-        arg.get("value") != "shpool"
+        "shpool" not in arg.get("value", "")
         for command in prepared["commands"]
         for arg in command["args"]
     )

--- a/tests/integration/test_hub_spoke_topology.py
+++ b/tests/integration/test_hub_spoke_topology.py
@@ -129,7 +129,7 @@ def hub_spoke_topology():
                 node,
                 "git config --global user.email test@test.com && "
                 "git config --global user.name test && "
-                "git init /home/flotilla/repo && "
+                "git init --initial-branch=master /home/flotilla/repo && "
                 "cd /home/flotilla/repo && "
                 "git commit --allow-empty -m init",
             )


### PR DESCRIPTION
## Summary
- revive the three-node workstation/homelab compose fixture with heterogeneous follower images
- forward-port eight current-schema hub-spoke scenarios while leaving restart/reconnect behavior to the existing wedge suite
- run the hub-spoke suite as an isolated nightly job and keep the existing two-node job scoped explicitly
- repair the Gemini CLI image link for the currently installed package layout

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `python -m pytest -q tests/integration/test_hub_spoke_topology.py` — 8 passed
- existing minimal + wedge compose suites — 14 passed
- compose configuration validation for production and dev overrides

## Local test note
`cargo test --workspace --locked` reaches the existing `flotilla-core` failure `adopted_checkout_with_explicit_transport_applies_fork_stance_config` (`inspection.spec.is_fork()`); it also fails in isolation on current `origin/main`. No Rust files are changed here.

Closes #1030
