### PR TITLE
fix: isolate tab clicks from page mouse handling

### DIFF
--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -331,6 +331,25 @@ fn left_click(x: u16, y: u16) -> MouseEvent {
     MouseEvent { kind: MouseEventKind::Down(MouseButton::Left), column: x, row: y, modifiers: KeyModifiers::NONE }
 }
 
+fn render_screen(app: &mut App) {
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 30)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            let mut ctx = crate::widgets::RenderContext {
+                model: &app.model,
+                views: &mut app.views,
+                ui: &mut app.ui,
+                theme: &app.theme,
+                keymap: &app.keymap,
+                in_flight: &app.in_flight,
+                namespaces: &app.namespaces,
+                query_tables: &app.query_tables,
+            };
+            app.screen.render(frame, frame.area(), &mut ctx);
+        })
+        .expect("draw");
+}
+
 // ── handle_key — top-level dispatch ──────────────────────────────
 
 #[test]
@@ -949,6 +968,7 @@ fn clicking_dismiss_status_target_hides_visible_error() {
 #[test]
 fn clicking_gear_icon_toggles_providers() {
     let mut app = stub_app();
+    render_screen(&mut app);
     // Place the gear hitbox on the active RepoPage's table
     let repo_key = app.model.repo_order[0].clone();
     app.screen.repo_pages.get_mut(&repo_key).expect("repo page").table.gear_area = Some(Rect::new(75, 2, 3, 1));

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -1088,6 +1088,7 @@ impl App {
     /// the model's active-repo scope, the unseen-changes badge, and the
     /// status bar's layout indicator.
     pub fn sync_active_view(&mut self) {
+        self.screen.invalidate_page_layout();
         self.model.active_repo = self.views.active_repo_identity().cloned();
         if let Some(identity) = self.model.active_repo.clone() {
             if let Some(rm) = self.model.repos.get_mut(&identity) {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2292,6 +2292,86 @@ fn selected_table_name(app: &App) -> Option<String> {
     app.views.active_table_state().selected_row(&view).map(|row| row.cells[name_column].text.clone())
 }
 
+fn render_app(app: &mut App, width: u16, height: u16) {
+    let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("terminal");
+    terminal
+        .draw(|frame| {
+            let mut ctx = crate::widgets::RenderContext {
+                model: &app.model,
+                views: &mut app.views,
+                ui: &mut app.ui,
+                theme: &app.theme,
+                keymap: &app.keymap,
+                in_flight: &app.in_flight,
+                namespaces: &app.namespaces,
+                query_tables: &app.query_tables,
+            };
+            app.screen.render(frame, frame.area(), &mut ctx);
+        })
+        .expect("draw");
+}
+
+#[test]
+fn mouse_does_not_use_a_freshly_activated_pages_stale_layout() {
+    let mut app = stub_app();
+    let project = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+    app.open_view(project.clone());
+    let project_tab = app.views.active_index();
+    render_app(&mut app, 80, 24);
+
+    app.switch_tab(0);
+    app.switch_tab(project_tab);
+    app.handle_mouse(MouseEvent { kind: MouseEventKind::Down(MouseButton::Left), column: 3, row: 1, modifiers: KeyModifiers::NONE });
+
+    assert_eq!(app.views.active_address(), Some(&project));
+    assert!(!app.views.active().has_history(), "mouse input must wait for the newly active page to render");
+}
+
+#[test]
+fn right_click_on_a_project_section_header_does_not_drill() {
+    let mut app = stub_app();
+    let project = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+    app.open_view(project.clone());
+    render_app(&mut app, 80, 24);
+
+    app.handle_mouse(MouseEvent { kind: MouseEventKind::Down(MouseButton::Right), column: 3, row: 1, modifiers: KeyModifiers::NONE });
+
+    assert_eq!(app.views.active_address(), Some(&project));
+    assert!(!app.views.active().has_history(), "right-click is reserved for action menus");
+}
+
+#[test]
+fn tab_bar_click_switches_to_project_without_dispatching_to_its_page() {
+    let mut app = stub_app();
+    let project = ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() };
+    app.open_view(project.clone());
+    let project_tab = app.views.active_index();
+    let project_state = app.views.active_project_table_state().clone();
+    app.switch_tab(0);
+    render_app(&mut app, 80, 24);
+    let tab_area = app.ui.layout.tab_areas[&crate::app::TabId::View(project_tab)];
+    let click =
+        MouseEvent { kind: MouseEventKind::Down(MouseButton::Left), column: tab_area.x, row: tab_area.y, modifiers: KeyModifiers::NONE };
+
+    let mut screen = std::mem::take(&mut app.screen);
+    let (outcome, actions) = {
+        let mut ctx = app.build_widget_context();
+        let outcome = screen.handle_mouse(click, &mut ctx);
+        (outcome, std::mem::take(&mut ctx.app_actions))
+    };
+    app.screen = screen;
+
+    assert!(matches!(outcome, crate::widgets::Outcome::Consumed));
+    assert!(matches!(actions.as_slice(), [crate::widgets::AppAction::SwitchToTab(index)] if *index == project_tab));
+    assert_eq!(app.views.active_index(), 0, "widgets queue the switch instead of mutating page dispatch state");
+    app.process_app_actions(actions);
+
+    assert_eq!(app.views.active_index(), project_tab);
+    assert_eq!(app.views.active_address(), Some(&project));
+    assert_eq!(app.views.active_project_table_state(), &project_state);
+    assert!(!app.views.active().has_history(), "the switching click must not reach the project header");
+}
+
 #[test]
 fn keyboard_uses_one_cursor_and_drills_with_tab_local_back_history() {
     let mut app = stub_app();

--- a/crates/flotilla-tui/src/widgets/project_page.rs
+++ b/crates/flotilla-tui/src/widgets/project_page.rs
@@ -463,7 +463,9 @@ impl InteractiveWidget for ProjectPageWidget {
             return Outcome::Ignored;
         };
         if line == layout.header_line {
-            ctx.app_actions.push(AppAction::DrillView(layout.panel.target.clone()));
+            if mouse.kind == MouseEventKind::Down(MouseButton::Left) {
+                ctx.app_actions.push(AppAction::DrillView(layout.panel.target.clone()));
+            }
             return Outcome::Consumed;
         }
         let row_index = line - layout.rows_start;

--- a/crates/flotilla-tui/src/widgets/screen.rs
+++ b/crates/flotilla-tui/src/widgets/screen.rs
@@ -61,6 +61,7 @@ pub struct Screen {
     pub table: TableWidget,
     pub project_page: ProjectPageWidget,
     view_header_area: Option<Rect>,
+    rendered_view: Option<ViewTarget>,
 }
 
 impl Default for Screen {
@@ -80,6 +81,7 @@ impl Screen {
             table: TableWidget::default(),
             project_page: ProjectPageWidget::default(),
             view_header_area: None,
+            rendered_view: None,
         }
     }
 
@@ -93,6 +95,11 @@ impl Screen {
     /// don't linger across context changes.
     pub fn dismiss_modals(&mut self) {
         self.modal_stack.clear();
+    }
+
+    /// Prevent page mouse dispatch until the active View has rendered again.
+    pub fn invalidate_page_layout(&mut self) {
+        self.rendered_view = None;
     }
 
     /// Apply a widget outcome from event dispatch.
@@ -354,6 +361,14 @@ impl InteractiveWidget for Screen {
             _ => {}
         }
 
+        // Page widgets retain hit-test areas from render. A tab can become
+        // active while several input events are already queued, before the
+        // next frame establishes that page's layout. Do not dispatch content
+        // input against the previously rendered View's coordinates.
+        if self.rendered_view.as_ref() != Some(&ctx.views.active().target) {
+            return Outcome::Consumed;
+        }
+
         // Dispatch to the active View's page for content area mouse events
         let outcome = match self.active_page(ctx.views.active(), &ctx.model.repos) {
             ActivePage::Overview => self.overview_page.handle_mouse(mouse, ctx),
@@ -373,6 +388,8 @@ impl InteractiveWidget for Screen {
     }
 
     fn render(&mut self, frame: &mut Frame, _area: Rect, ctx: &mut RenderContext) {
+        self.rendered_view = Some(ctx.views.active().target.clone());
+
         // Scoped mode: the pane is one View — no tab bar row.
         let view_header_height = u16::from(ctx.views.active().has_history());
         let constraints = if ctx.views.is_scoped() {


### PR DESCRIPTION
## What changed

- invalidate page mouse hit-testing whenever the active View changes, and re-enable it only after that View renders its own layout
- keep tab-bar mouse-down handling isolated as a queued `SwitchToTab` action that is consumed before page dispatch
- prevent right-clicks on project section headers from drilling; right-click remains reserved for action menus
- add regressions for tab-switch isolation, stale project-page layouts, and right-clicked section headers

## Root cause

Project page widgets retain their last rendered hit-test area. A View can become active while input events are already queued and before the next frame renders, allowing page mouse handling to use stale coordinates. On a project page, the stale top content row maps to the Convoys section header and drills immediately.

The screen now records which View produced the current page layout. Active-view synchronization invalidates that record, so shell controls such as the tab bar remain usable while page input is consumed until the newly active View renders.

## Impact

Clicking a TUI tab changes only the active tab. The switching click cannot reach the newly activated page, section headers cannot receive input against an old layout, and right-click never drills through a project header.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-tui --locked` (1,007 unit, 2 e2e, 1 high-fidelity, and 50 snapshot tests)

The exact workspace test command also ran; it reached an unrelated pre-existing `flotilla-core` failure in `in_process::tests::adopted_checkout_with_explicit_transport_applies_fork_stance_config`, which fails identically in isolation and is outside the unchanged TUI scope.

Closes #1068