### PR TITLE
tui: project-scope the convoys view address

### DIFF
--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -73,7 +73,7 @@ fn no_subscriptions() -> Arc<QuerySet> {
 }
 
 fn convoys_subscription() -> Arc<QuerySet> {
-    Arc::new(std::sync::RwLock::new(HashSet::from([QueryId::Convoys])))
+    Arc::new(std::sync::RwLock::new(HashSet::from([QueryId::Convoys { scope: None }])))
 }
 
 fn request_harness() -> RequestHarness {
@@ -1150,11 +1150,11 @@ async fn recover_from_gap_handles_empty_replay() {
 // --- Query result stream gap detection ---
 
 fn make_result_set(seq: u64) -> ResultSet {
-    ResultSet { seq, rows: Rows::Convoys(vec![]), state: Default::default() }
+    ResultSet { seq, rows: Rows::Convoys { scope: None, rows: vec![] }, state: Default::default() }
 }
 
 fn make_result_delta(seq: u64) -> ResultDelta {
-    ResultDelta { seq, changes: QueryChanges::Convoys { changed: vec![], removed: vec![] }, state: None }
+    ResultDelta { seq, changes: QueryChanges::Convoys { scope: None, changed: vec![], removed: vec![] }, state: None }
 }
 
 #[tokio::test]
@@ -1171,13 +1171,16 @@ async fn handle_event_result_set_updates_local_seq_and_forwards() {
 
     let event = event_rx.try_recv().expect("should receive ResultSet");
     assert!(matches!(event, DaemonEvent::ResultSet(_)));
-    assert_eq!(local_seqs.read().expect("sequence lock").get(&StreamKey::Query { query: QueryId::Convoys }).copied(), Some(5));
+    assert_eq!(
+        local_seqs.read().expect("sequence lock").get(&StreamKey::Query { query: QueryId::Convoys { scope: None } }).copied(),
+        Some(5)
+    );
 }
 
 #[tokio::test]
 async fn handle_event_result_delta_happy_path_applies_and_forwards() {
     let local_seqs: Arc<SeqMap> = Arc::new(std::sync::RwLock::new(HashMap::new()));
-    local_seqs.write().expect("sequence lock").insert(StreamKey::Query { query: QueryId::Convoys }, 1);
+    local_seqs.write().expect("sequence lock").insert(StreamKey::Query { query: QueryId::Convoys { scope: None } }, 1);
     let recovering: Arc<std::sync::Mutex<HashMap<RepoIdentity, Vec<DaemonEvent>>>> = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let (event_tx, mut event_rx) = broadcast::channel(16);
     let (session, pending, next_id, _server) = event_harness();
@@ -1190,7 +1193,10 @@ async fn handle_event_result_delta_happy_path_applies_and_forwards() {
 
     let event = event_rx.try_recv().expect("should receive ResultDelta");
     assert!(matches!(event, DaemonEvent::ResultDelta(_)));
-    assert_eq!(local_seqs.read().expect("sequence lock").get(&StreamKey::Query { query: QueryId::Convoys }).copied(), Some(2));
+    assert_eq!(
+        local_seqs.read().expect("sequence lock").get(&StreamKey::Query { query: QueryId::Convoys { scope: None } }).copied(),
+        Some(2)
+    );
 }
 
 #[tokio::test]
@@ -1198,7 +1204,7 @@ async fn handle_event_result_delta_stale_seq_is_ignored() {
     let local_seqs: Arc<SeqMap> = Arc::new(std::sync::RwLock::new(HashMap::new()));
     // Local seq is 5 — a delta at seq 5 is already covered by the current
     // result set (e.g. it raced ahead of the subscribe replay).
-    local_seqs.write().expect("sequence lock").insert(StreamKey::Query { query: QueryId::Convoys }, 5);
+    local_seqs.write().expect("sequence lock").insert(StreamKey::Query { query: QueryId::Convoys { scope: None } }, 5);
     let recovering: Arc<std::sync::Mutex<HashMap<RepoIdentity, Vec<DaemonEvent>>>> = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let (event_tx, mut event_rx) = broadcast::channel(16);
     let (session, pending, next_id, _server) = event_harness();
@@ -1209,14 +1215,17 @@ async fn handle_event_result_delta_stale_seq_is_ignored() {
     );
 
     assert!(event_rx.try_recv().is_err(), "stale delta must not be forwarded");
-    assert_eq!(local_seqs.read().expect("sequence lock").get(&StreamKey::Query { query: QueryId::Convoys }).copied(), Some(5));
+    assert_eq!(
+        local_seqs.read().expect("sequence lock").get(&StreamKey::Query { query: QueryId::Convoys { scope: None } }).copied(),
+        Some(5)
+    );
 }
 
 #[tokio::test]
 async fn handle_event_result_delta_seq_gap_triggers_resubscribe() {
     let local_seqs: Arc<SeqMap> = Arc::new(std::sync::RwLock::new(HashMap::new()));
     // Local seq is 1, but incoming delta seq is 3 — seq 2 was dropped.
-    local_seqs.write().expect("sequence lock").insert(StreamKey::Query { query: QueryId::Convoys }, 1);
+    local_seqs.write().expect("sequence lock").insert(StreamKey::Query { query: QueryId::Convoys { scope: None } }, 1);
     let recovering: Arc<std::sync::Mutex<HashMap<RepoIdentity, Vec<DaemonEvent>>>> = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let (event_tx, _event_rx) = broadcast::channel(16);
     let (session, pending, next_id, server) = event_harness();
@@ -1235,7 +1244,7 @@ async fn handle_event_result_delta_seq_gap_triggers_resubscribe() {
     let Request::SubscribeQueries { queries } = request else {
         panic!("result seq gap should trigger a SubscribeQueries request, got: {request:?}");
     };
-    assert_eq!(queries, vec![QueryCursor { query: QueryId::Convoys, since: Some(1) }]);
+    assert_eq!(queries, vec![QueryCursor { query: QueryId::Convoys { scope: None }, since: Some(1) }]);
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -39,7 +39,7 @@ impl QueryRow for ConvoyRow {
     }
 
     fn into_rows(rows: Vec<Self>) -> Rows {
-        Rows::Convoys(rows)
+        Rows::Convoys { scope: None, rows }
     }
 }
 
@@ -149,6 +149,13 @@ impl AggregatorProjectionState {
 
     pub async fn result_set(&self) -> ResultSet {
         self.convoys.read().await.result_set()
+    }
+
+    pub async fn convoy_result_set(&self, scope: &Option<QueryScope>) -> ResultSet {
+        let set = self.result_set().await;
+        let Rows::Convoys { rows, .. } = set.rows else { unreachable!("convoy projection must produce convoy rows") };
+        let rows = rows.into_iter().filter(|row| scope.as_ref().is_none_or(|scope| convoy_matches_scope(row, scope))).collect();
+        ResultSet { seq: set.seq, rows: Rows::Convoys { scope: scope.clone(), rows }, state: set.state }
     }
 
     pub async fn seq(&self) -> u64 {
@@ -282,7 +289,7 @@ impl AggregatorProjectionState {
     /// The current fleet-merged result set for one named query.
     pub async fn result_set_for(&self, query: &QueryId) -> Option<ResultSet> {
         match query {
-            QueryId::Convoys => Some(self.result_set().await),
+            QueryId::Convoys { scope } => Some(self.convoy_result_set(scope).await),
             QueryId::Independents { scope } => Some(self.independents_result_set(scope).await),
             QueryId::Issues { .. } => self.demand_backed.result_set(query),
             QueryId::Checkouts { scope } => Some(self.checkouts.write().await.result_set(scope)),
@@ -302,7 +309,7 @@ impl AggregatorProjectionState {
         let convoys = {
             let set = self.result_set().await;
             let rows = match set.rows {
-                Rows::Convoys(rows) => rows,
+                Rows::Convoys { rows, .. } => rows,
                 _ => Vec::new(),
             };
             rows.into_iter().filter(|row| scope.as_ref().is_none_or(|scope| convoy_matches_scope(row, scope))).collect::<Vec<_>>()
@@ -548,6 +555,26 @@ mod tests {
         assert_eq!(empty_node.state, flotilla_protocol::AwarenessState::Idle);
         assert_eq!(empty_node.counts, flotilla_protocol::AwarenessCounts::default());
         assert!(empty_node.entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn convoy_result_sets_filter_by_optional_project_scope_without_changing_the_global_set() {
+        let state = AggregatorProjectionState::new();
+        let roadmap = convoy_row("flotilla", "roadmap-work", "roadmap");
+        let other_project = convoy_row("flotilla", "other-work", "other");
+        let other_namespace = convoy_row("platform", "roadmap-work", "roadmap");
+        {
+            let mut convoys = state.write().await;
+            convoys.local_rows =
+                [roadmap.clone(), other_project, other_namespace].into_iter().map(|row| (row.resource.clone(), row)).collect();
+            convoys.seq = 1;
+        }
+
+        let scoped = state.result_set_for(&QueryId::Convoys { scope: Some(scope("roadmap")) }).await.expect("scoped convoy result set");
+        assert_eq!(scoped.rows.as_convoys().expect("scoped convoy rows"), &[roadmap]);
+
+        let global = state.result_set_for(&QueryId::Convoys { scope: None }).await.expect("global convoy result set");
+        assert_eq!(global.rows.as_convoys().expect("global convoy rows").len(), 3);
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -558,7 +558,7 @@ fn append_crewless_convoy_rows(
 ) {
     let mut convoys_with_crew: HashSet<String> = rows.iter().map(|row| row.convoy.clone()).collect();
     for result_set in result_sets {
-        let Rows::Convoys(convoys) = &result_set.rows else { continue };
+        let Rows::Convoys { rows: convoys, .. } = &result_set.rows else { continue };
         for row in convoys {
             if row.resource.namespace != target_namespace {
                 continue;
@@ -2177,7 +2177,7 @@ impl InProcessDaemon {
         };
 
         let result_set = self.aggregator_projection_state().await.result_set().await;
-        let Rows::Convoys(rows) = result_set.rows else {
+        let Rows::Convoys { rows, .. } = result_set.rows else {
             return Ok(None);
         };
         let mut hosts = rows

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -577,7 +577,7 @@ fn convoy_row(namespace: &str, name: &str, phase: WireConvoyPhase, message: Opti
 }
 
 fn convoy_result_set(seq: u64, rows: Vec<ConvoyRow>) -> ResultSet {
-    ResultSet { seq, rows: Rows::Convoys(rows), state: Default::default() }
+    ResultSet { seq, rows: Rows::Convoys { scope: None, rows }, state: Default::default() }
 }
 
 async fn set_local_convoy_rows(daemon: &InProcessDaemon, seq: u64, rows: Vec<ConvoyRow>) {
@@ -4595,13 +4595,13 @@ async fn subscribe_queries_replays_result_set_from_aggregator_state() {
     set_local_convoy_rows(&daemon, 7, vec![convoy_row("flotilla", "convoy-1", WireConvoyPhase::Active, None)]).await;
 
     let events = daemon
-        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys, since: None }])
+        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys { scope: None }, since: None }])
         .await
         .expect("subscribe_queries should succeed");
     let result_set = events
         .iter()
         .find_map(|e| match e {
-            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys => Some(result_set.clone()),
+            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys { scope: None } => Some(result_set.clone()),
             _ => None,
         })
         .expect("expected ResultSet in subscribe replay");
@@ -4623,7 +4623,7 @@ async fn subscribe_queries_skips_replay_when_cursor_matches_seq() {
     set_local_convoy_rows(&daemon, 7, vec![convoy_row("flotilla", "convoy-1", WireConvoyPhase::Active, None)]).await;
 
     let events = daemon
-        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys, since: Some(7) }])
+        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys { scope: None }, since: Some(7) }])
         .await
         .expect("subscribe_queries should succeed");
     assert!(!events.iter().any(|event| matches!(event, DaemonEvent::ResultSet(_))));
@@ -4647,13 +4647,13 @@ async fn subscribe_queries_resends_result_set_when_client_seq_is_ahead() {
 
     // Client's cursor is ahead of the daemon's seq — simulates daemon restart.
     let events = daemon
-        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys, since: Some(99) }])
+        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys { scope: None }, since: Some(99) }])
         .await
         .expect("subscribe_queries should succeed");
     let result_set = events
         .iter()
         .find_map(|e| match e {
-            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys => Some(result_set.clone()),
+            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys { scope: None } => Some(result_set.clone()),
             _ => None,
         })
         .expect("client ahead of daemon must still receive a result set");

--- a/crates/flotilla-core/src/query_registry.rs
+++ b/crates/flotilla-core/src/query_registry.rs
@@ -235,7 +235,7 @@ fn issue_demand_query(query: &QueryId) -> Option<QueryId> {
         QueryId::Awareness { scope: Some(scope), .. } => {
             Some(QueryId::Issues { scope: scope.clone(), search: None, label: Some(READY_ISSUE_LABEL.into()) })
         }
-        QueryId::Convoys | QueryId::Independents { .. } | QueryId::Checkouts { .. } | QueryId::Awareness { scope: None, .. } => None,
+        QueryId::Convoys { .. } | QueryId::Independents { .. } | QueryId::Checkouts { .. } | QueryId::Awareness { scope: None, .. } => None,
     }
 }
 

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1185,12 +1185,13 @@ impl Aggregator {
         if self.bootstrapping {
             return;
         }
-        if self.emitted_queries.contains(&QueryId::Convoys) {
+        if self.emitted_queries.contains(&QueryId::Convoys { scope: None }) {
             self.emit_delta(changed, removed).await;
         } else {
-            self.emitted_queries.insert(QueryId::Convoys);
+            self.emitted_queries.insert(QueryId::Convoys { scope: None });
             let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
         }
+        self.emit_scoped_convoy_result_sets().await;
         let represented = self.state.represented_issue_refs().await;
         for delta in self.state.suppress_issues(&represented) {
             let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(delta)));
@@ -1411,7 +1412,7 @@ impl Aggregator {
             let mut checkout_rows = Vec::new();
             for result_set in snapshot.result_sets {
                 match result_set.rows {
-                    Rows::Convoys(_) | Rows::Independents { .. } => {}
+                    Rows::Convoys { .. } | Rows::Independents { .. } => {}
                     Rows::Issues { .. } => {
                         tracing::warn!(host = %host, "ignoring demand-backed issues in fleet replica snapshot");
                     }
@@ -1438,9 +1439,20 @@ impl Aggregator {
 
     async fn emit_delta(&self, changed: Vec<ConvoyRow>, removed: Vec<ResourceRef>) {
         let seq = self.state.seq().await;
-        let changes = QueryChanges::Convoys { changed, removed };
+        let changes = QueryChanges::Convoys { scope: None, changed, removed };
         let _ = self.event_tx.send(DaemonEvent::ResultDelta(Box::new(ResultDelta { seq, changes, state: None })));
         self.emit_awareness_result_sets().await;
+    }
+
+    async fn emit_scoped_convoy_result_sets(&self) {
+        for query in self.state.subscribed_queries() {
+            if !matches!(query, QueryId::Convoys { scope: Some(_) }) {
+                continue;
+            }
+            if let Some(result_set) = self.state.result_set_for(&query).await {
+                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
+            }
+        }
     }
 
     async fn rebuild_salience_projection(&self) -> bool {
@@ -2246,7 +2258,7 @@ mod tests {
             while convoy.is_none() || awareness.is_none() {
                 let event = event_rx.recv().await.expect("aggregator bootstrap event");
                 let DaemonEvent::ResultSet(result) = event else { continue };
-                if result.query() == QueryId::Convoys {
+                if result.query() == (QueryId::Convoys { scope: None }) {
                     convoy = result.rows.as_convoys().expect("convoy rows").first().cloned();
                 } else if result.query() == awareness_query {
                     awareness = Some(result);
@@ -2878,10 +2890,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn convoy_row_insert_and_removal_are_not_blocked_by_change_request_enrichment() {
+    async fn convoy_row_insert_and_removal_update_global_and_scoped_queries_without_waiting_for_change_request_enrichment() {
         let state = AggregatorProjectionState::new();
+        let scoped_query = QueryId::Convoys { scope: Some(QueryScope::new("flotilla", "roadmap")) };
+        state.replace_subscriber(Uuid::new_v4(), &[flotilla_protocol::QueryCursor { query: scoped_query.clone(), since: None }]);
         let (event_tx, mut event_rx) = broadcast::channel(8);
-        let convoy = convoy_with_branch("convoy-a").await;
+        let mut convoy = convoy_with_branch("convoy-a").await;
+        convoy.spec.project_ref = Some("roadmap".into());
         let mut deleting_convoy = convoy.clone();
         deleting_convoy.metadata.deletion_timestamp = Some(Utc::now());
         let durable_convoys = ScriptedSource::new(vec![empty_list()], vec![Ok(watch_events(vec![
@@ -2905,24 +2920,32 @@ mod tests {
         tokio::select! {
             result = &mut run => panic!("aggregator stopped before row lifecycle events: {result:?}"),
             () = async {
-                let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy result set").await;
+                let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial convoy result set").await;
                 let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial result set") };
                 assert!(initial.rows.is_empty());
 
-                let inserted = recv_query_event(&mut event_rx, QueryId::Convoys, "convoy insert delta").await;
+                let inserted = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "convoy insert delta").await;
                 let DaemonEvent::ResultDelta(inserted) = inserted else { panic!("expected insert delta") };
-                let QueryChanges::Convoys { changed, removed } = &inserted.changes else { panic!("expected convoy changes") };
+                let QueryChanges::Convoys { changed, removed, .. } = &inserted.changes else { panic!("expected convoy changes") };
                 assert_eq!(changed.iter().map(|row| row.name.as_str()).collect::<Vec<_>>(), vec!["convoy-a"]);
                 assert!(removed.is_empty());
 
-                let removed = recv_query_event(&mut event_rx, QueryId::Convoys, "convoy removal delta").await;
+                let scoped = recv_query_event(&mut event_rx, scoped_query.clone(), "scoped convoy insert result set").await;
+                let DaemonEvent::ResultSet(scoped) = scoped else { panic!("expected scoped result set") };
+                assert_eq!(scoped.rows.as_convoys().expect("scoped convoy rows")[0].name, "convoy-a");
+
+                let removed = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "convoy removal delta").await;
                 let DaemonEvent::ResultDelta(removed) = removed else { panic!("expected removal delta") };
-                let QueryChanges::Convoys { changed, removed } = &removed.changes else { panic!("expected convoy changes") };
+                let QueryChanges::Convoys { changed, removed, .. } = &removed.changes else { panic!("expected convoy changes") };
                 assert!(changed.is_empty());
                 assert_eq!(
                     removed.iter().map(|resource| resource.name.as_str()).collect::<Vec<_>>(),
                     vec!["convoy-a"]
                 );
+
+                let scoped = recv_query_event(&mut event_rx, scoped_query, "scoped convoy removal result set").await;
+                let DaemonEvent::ResultSet(scoped) = scoped else { panic!("expected scoped result set") };
+                assert!(scoped.rows.is_empty());
             } => {}
         }
     }
@@ -3054,7 +3077,7 @@ mod tests {
         tokio::select! {
             result = &mut run => panic!("aggregator stopped during route transition test: {result:?}"),
             () = async {
-                let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy set").await;
+                let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial convoy set").await;
                 let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial result set") };
                 assert_eq!(
                     initial.rows.as_convoys().expect("convoy rows")[0].vessels[0].materialize.as_deref(),
@@ -3066,7 +3089,7 @@ mod tests {
                     node_id: flotilla_protocol::NodeId::new("feta"),
                     status: flotilla_protocol::PeerConnectionState::Disconnected,
                 });
-                let disconnected = recv_query_event(&mut event_rx, QueryId::Convoys, "disconnect should retract recipe").await;
+                let disconnected = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "disconnect should retract recipe").await;
                 let DaemonEvent::ResultDelta(disconnected) = disconnected else { panic!("expected disconnect delta") };
                 assert_eq!(disconnected.changes.as_convoys().expect("convoy changes")[0].vessels[0].materialize, None);
 
@@ -3075,7 +3098,7 @@ mod tests {
                     node_id: flotilla_protocol::NodeId::new("feta"),
                     status: flotilla_protocol::PeerConnectionState::Connected,
                 });
-                let reconnected = recv_query_event(&mut event_rx, QueryId::Convoys, "reconnect should restore recipe").await;
+                let reconnected = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "reconnect should restore recipe").await;
                 let DaemonEvent::ResultDelta(reconnected) = reconnected else { panic!("expected reconnect delta") };
                 assert_eq!(
                     reconnected.changes.as_convoys().expect("convoy changes")[0].vessels[0].materialize.as_deref(),
@@ -3262,9 +3285,9 @@ mod tests {
         tokio::select! {
             result = &mut run => panic!("aggregator stopped before refresh: {result:?}"),
             () = async {
-                let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy result set").await;
+                let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial convoy result set").await;
                 assert!(matches!(initial, DaemonEvent::ResultSet(_)));
-                let initial_change_request = recv_query_event(&mut event_rx, QueryId::Convoys, "initial change request delta").await;
+                let initial_change_request = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial change request delta").await;
                 assert!(matches!(initial_change_request, DaemonEvent::ResultDelta(_)));
                 event_tx
                     .send(DaemonEvent::RepoRefreshCompleted {
@@ -3276,7 +3299,7 @@ mod tests {
                     })
                     .expect("publish provider refresh");
 
-                let refreshed = recv_query_event(&mut event_rx, QueryId::Convoys, "refreshed convoy delta").await;
+                let refreshed = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "refreshed convoy delta").await;
                 let DaemonEvent::ResultDelta(delta) = refreshed else { panic!("expected refreshed result delta") };
                 assert_eq!(
                     delta.changes.as_convoys().expect("convoy changes")[0]
@@ -3332,11 +3355,11 @@ mod tests {
             result = &mut run => panic!("aggregator stopped before refresh: {result:?}"),
             () = async {
                 assert!(matches!(
-                    recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy result set").await,
+                    recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial convoy result set").await,
                     DaemonEvent::ResultSet(_)
                 ));
                 assert!(matches!(
-                    recv_query_event(&mut event_rx, QueryId::Convoys, "initial change request delta").await,
+                    recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial change request delta").await,
                     DaemonEvent::ResultDelta(_)
                 ));
                 for repo_identity in [
@@ -3351,7 +3374,7 @@ mod tests {
                         .expect("publish provider refresh");
                 }
                 assert!(matches!(
-                    recv_query_event(&mut event_rx, QueryId::Convoys, "related repository refresh delta").await,
+                    recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "related repository refresh delta").await,
                     DaemonEvent::ResultDelta(_)
                 ));
             } => {}
@@ -3477,9 +3500,9 @@ mod tests {
         tokio::select! {
             result = &mut run => panic!("aggregator stopped before repo snapshot: {result:?}"),
             () = async {
-                let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial convoy result set").await;
+                let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial convoy result set").await;
                 assert!(matches!(initial, DaemonEvent::ResultSet(_)));
-                let initial_change_request = recv_query_event(&mut event_rx, QueryId::Convoys, "initial change request delta").await;
+                let initial_change_request = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial change request delta").await;
                 assert!(matches!(initial_change_request, DaemonEvent::ResultDelta(_)));
                 let mut providers = flotilla_protocol::ProviderData::default();
                 providers.change_requests.insert("815".into(), flotilla_protocol::ChangeRequest {
@@ -3508,7 +3531,7 @@ mod tests {
                     })))
                     .expect("publish repo snapshot");
 
-                let refreshed = recv_query_event(&mut event_rx, QueryId::Convoys, "refreshed convoy delta").await;
+                let refreshed = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "refreshed convoy delta").await;
                 let DaemonEvent::ResultDelta(delta) = refreshed else { panic!("expected refreshed result delta") };
                 assert_eq!(
                     delta.changes.as_convoys().expect("convoy changes")[0]
@@ -3807,11 +3830,11 @@ mod tests {
             .await
         });
 
-        let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial result set timeout").await;
+        let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial result set timeout").await;
         let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial result set") };
         assert_eq!(convoy_names(&initial.rows), vec!["deleted-while-watch-expired"]);
 
-        let removal = recv_query_event(&mut event_rx, QueryId::Convoys, "relist delta timeout").await;
+        let removal = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "relist delta timeout").await;
         let DaemonEvent::ResultDelta(removal) = removal else { panic!("expected relist delta") };
         let removed = removal.changes.removed_resources().expect("convoy removals");
         assert_eq!(removed.len(), 1);
@@ -3918,7 +3941,7 @@ mod tests {
             .await
         });
 
-        let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial result set timeout").await;
+        let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial result set timeout").await;
         let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial result set") };
         assert!(initial.rows.is_empty(), "failed watch attempt must not publish its stale list");
         assert!(state.result_set().await.rows.is_empty());
@@ -3965,12 +3988,12 @@ mod tests {
             .await
         });
 
-        let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial result set timeout").await;
+        let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial result set timeout").await;
         let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial result set") };
         let initial_row = initial.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
         assert_eq!(initial_row.vessels.first().expect("vessel row").attach.as_deref(), Some("workspace-1"));
 
-        let update = recv_query_event(&mut event_rx, QueryId::Convoys, "relist delta timeout").await;
+        let update = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "relist delta timeout").await;
         let DaemonEvent::ResultDelta(update) = update else { panic!("expected relist delta") };
         let changed = update.changes.as_convoys().expect("changed convoy rows").first().expect("changed convoy row");
         assert_eq!(changed.vessels.first().expect("changed vessel row").attach, None);
@@ -4036,7 +4059,7 @@ mod tests {
             .await
         });
 
-        let initial = recv_query_event(&mut event_rx, QueryId::Convoys, "initial result set timeout").await;
+        let initial = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "initial result set timeout").await;
         let DaemonEvent::ResultSet(initial) = initial else { panic!("expected initial result set") };
         let row = initial.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
         assert_eq!(row.vessels.first().expect("vessel row").attach, None);

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -3134,7 +3134,7 @@ async fn handle_client_session_filters_query_events_until_subscribed() {
     let result_delta = |seq| {
         DaemonEvent::ResultDelta(Box::new(ResultDelta {
             seq,
-            changes: QueryChanges::Convoys { changed: vec![], removed: vec![] },
+            changes: QueryChanges::Convoys { scope: None, changed: vec![], removed: vec![] },
             state: None,
         }))
     };
@@ -3162,14 +3162,14 @@ async fn handle_client_session_filters_query_events_until_subscribed() {
     client_session
         .write(Message::Request {
             id: 2,
-            request: Request::SubscribeQueries { queries: vec![QueryCursor { query: QueryId::Convoys, since: None }] },
+            request: Request::SubscribeQueries { queries: vec![QueryCursor { query: QueryId::Convoys { scope: None }, since: None }] },
         })
         .await
         .expect("write subscribe request");
     match ok_response(read_session_message(&client_session).await, 2) {
         Response::SubscribeQueries(events) => {
             assert!(
-                matches!(events.as_slice(), [DaemonEvent::ResultSet(result_set)] if result_set.query() == QueryId::Convoys),
+                matches!(events.as_slice(), [DaemonEvent::ResultSet(result_set)] if result_set.query() == QueryId::Convoys { scope: None }),
                 "subscribe should replay one convoys result set, got {events:?}"
             );
         }
@@ -3181,7 +3181,7 @@ async fn handle_client_session_filters_query_events_until_subscribed() {
     match read_session_message(&client_session).await {
         Message::Event { event } => match *event {
             DaemonEvent::ResultDelta(delta) => {
-                assert_eq!(delta.query(), QueryId::Convoys);
+                assert_eq!(delta.query(), QueryId::Convoys { scope: None });
                 assert_eq!(delta.seq, 2);
             }
             other => panic!("expected ResultDelta after subscribing, got {other:?}"),

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -482,7 +482,7 @@ async fn aggregator_emits_result_set_events() {
     let found = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Ok(DaemonEvent::ResultSet(result_set)) if result_set.query() == QueryId::Convoys => {
+                Ok(DaemonEvent::ResultSet(result_set)) if result_set.query() == QueryId::Convoys { scope: None } => {
                     return result_set;
                 }
                 Ok(_) => continue,
@@ -669,13 +669,13 @@ async fn running_convoyless_session_emits_attachable_independent_row() {
         "convoy-bound terminal sessions surface on vessel rows, never in independents",
     );
     let convoy_replay = daemon
-        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys, since: None }])
+        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys { scope: None }, since: None }])
         .await
         .expect("subscribe to convoys query");
     let convoy_rows = convoy_replay
         .iter()
         .find_map(|event| match event {
-            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys => Some(convoy_rows(result_set)),
+            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys { scope: None } => Some(convoy_rows(result_set)),
             _ => None,
         })
         .expect("convoys replay result set");
@@ -866,7 +866,7 @@ async fn subscribe_queries_replays_result_set_after_seq() {
     let result_set_after_a = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Ok(DaemonEvent::ResultSet(result_set)) if result_set.query() == QueryId::Convoys => return result_set,
+                Ok(DaemonEvent::ResultSet(result_set)) if result_set.query() == QueryId::Convoys { scope: None } => return result_set,
                 Ok(_) => continue,
                 Err(err) => panic!("recv error waiting for result set: {err}"),
             }
@@ -884,7 +884,7 @@ async fn subscribe_queries_replays_result_set_after_seq() {
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Convoys => return delta,
+                Ok(DaemonEvent::ResultDelta(delta)) if delta.query() == QueryId::Convoys { scope: None } => return delta,
                 Ok(_) => continue,
                 Err(err) => panic!("recv error waiting for delta: {err}"),
             }
@@ -895,7 +895,7 @@ async fn subscribe_queries_replays_result_set_after_seq() {
 
     // Step 3: SubscribeQueries with the cursor from step 1.
     let replay_events = daemon
-        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys, since: Some(cursor_seq) }])
+        .subscribe_queries(uuid::Uuid::nil(), &[QueryCursor { query: QueryId::Convoys { scope: None }, since: Some(cursor_seq) }])
         .await
         .expect("subscribe_queries");
 
@@ -904,7 +904,7 @@ async fn subscribe_queries_replays_result_set_after_seq() {
     let result_set = replay_events
         .iter()
         .find_map(|e| match e {
-            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys => Some(result_set),
+            DaemonEvent::ResultSet(result_set) if result_set.query() == QueryId::Convoys { scope: None } => Some(result_set),
             _ => None,
         })
         .expect("expected a ResultSet for the convoys query in subscribe replay");

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -614,13 +614,18 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
         })
         .vessels(vec![implement, review])
         .build();
-    let event = DaemonEvent::ResultSet(Box::new(ResultSet { seq: 7, rows: Rows::Convoys(vec![row]), state: Default::default() }));
+    let scope = QueryScope::new("flotilla", "roadmap");
+    let event = DaemonEvent::ResultSet(Box::new(ResultSet {
+        seq: 7,
+        rows: Rows::Convoys { scope: Some(scope.clone()), rows: vec![row] },
+        state: Default::default(),
+    }));
 
     let encoded = serde_json::to_string(&event).expect("serialize result set");
     let decoded: DaemonEvent = serde_json::from_str(&encoded).expect("deserialize result set");
     let DaemonEvent::ResultSet(result_set) = decoded else { panic!("expected ResultSet") };
     assert_eq!(result_set.seq, 7);
-    assert_eq!(result_set.query(), QueryId::Convoys);
+    assert_eq!(result_set.query(), QueryId::Convoys { scope: Some(scope.clone()) });
     let rows = result_set.rows.as_convoys().expect("convoy rows");
     assert_eq!(rows[0].vessels[1].depends_on, vec![rows[0].vessels[0].name.clone()]);
     assert!(rows[0].vessels[0].attach.is_some(), "presentation join surfaces as attach capability");
@@ -629,7 +634,7 @@ fn result_set_round_trips_a_resource_backed_vessel_dag() {
     assert!(rows[0].vessels[0].complete_work);
     assert!(!rows[0].vessels[1].complete_work, "capabilities default closed");
     assert_eq!(rows[0].change_request.as_ref().expect("change request").id, "815");
-    assert_eq!(StreamKey::Query { query: QueryId::Convoys }, StreamKey::Query { query: result_set.query() });
+    assert_eq!(StreamKey::Query { query: QueryId::Convoys { scope: Some(scope) } }, StreamKey::Query { query: result_set.query() });
 }
 
 #[test]
@@ -671,7 +676,7 @@ fn subscribe_queries_request_round_trips_cursors() {
     use crate::result_set::QueryId;
 
     let request = Request::SubscribeQueries {
-        queries: vec![QueryCursor { query: QueryId::Convoys, since: Some(41) }, QueryCursor {
+        queries: vec![QueryCursor { query: QueryId::Convoys { scope: None }, since: Some(41) }, QueryCursor {
             query: QueryId::Independents { scope: None },
             since: None,
         }],

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -1,7 +1,7 @@
 //! Named-query result sets — the Aggregator's data plane.
 //!
 //! The Aggregator maintains incrementally-updated result sets for a small set
-//! of named queries (e.g. [`QueryId::Convoys`]: all Convoys, durable ∪
+//! of named queries (e.g. [`QueryId::Convoys`]: Convoys, durable ∪
 //! observed, fleet-merged, joined with Presentation attach state). Clients
 //! subscribe per query and receive a full [`ResultSet`] followed by
 //! [`ResultDelta`]s. Rows are typed per query; presentation concerns
@@ -27,9 +27,10 @@ pub type Timestamp = DateTime<Utc>;
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryId {
-    /// All Convoys — durable ∪ observed, fleet-merged, joined with
-    /// Presentation attach state. Rows are [`ConvoyRow`].
-    Convoys,
+    /// Convoys — durable ∪ observed, fleet-merged, joined with Presentation
+    /// attach state — fleet-wide (`None`) or in one Project.
+    /// Rows are [`ConvoyRow`].
+    Convoys { scope: Option<QueryScope> },
     /// TerminalSessions with no Convoy association. Rows are
     /// [`IndependentRow`].
     Independents { scope: Option<QueryScope> },
@@ -76,11 +77,11 @@ impl QueryId {
     /// Finite query families that are always materialized. Parameterized
     /// demand-backed queries cannot appear in a static list.
     pub const ALWAYS_MATERIALIZED: &'static [QueryId] =
-        &[QueryId::Convoys, QueryId::Independents { scope: None }, QueryId::Checkouts { scope: None }];
+        &[QueryId::Convoys { scope: None }, QueryId::Independents { scope: None }, QueryId::Checkouts { scope: None }];
 
     pub fn family(&self) -> &'static str {
         match self {
-            Self::Convoys => "convoys",
+            Self::Convoys { .. } => "convoys",
             Self::Independents { .. } => "independents",
             Self::Issues { .. } => "issues",
             Self::Checkouts { .. } => "checkouts",
@@ -140,6 +141,7 @@ impl ResultDelta {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum QueryChanges {
     Convoys {
+        scope: Option<QueryScope>,
         changed: Vec<ConvoyRow>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         removed: Vec<ResourceRef>,
@@ -179,7 +181,7 @@ pub enum QueryChanges {
 impl QueryChanges {
     pub fn query(&self) -> QueryId {
         match self {
-            Self::Convoys { .. } => QueryId::Convoys,
+            Self::Convoys { scope, .. } => QueryId::Convoys { scope: scope.clone() },
             Self::Independents { scope, .. } => QueryId::Independents { scope: scope.clone() },
             Self::Issues { scope, search, label, .. } => {
                 QueryId::Issues { scope: scope.clone(), search: search.clone(), label: label.clone() }
@@ -312,7 +314,10 @@ pub enum ResultSetCondition {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "rows", rename_all = "snake_case")]
 pub enum Rows {
-    Convoys(Vec<ConvoyRow>),
+    Convoys {
+        scope: Option<QueryScope>,
+        rows: Vec<ConvoyRow>,
+    },
     Independents {
         scope: Option<QueryScope>,
         rows: Vec<IndependentRow>,
@@ -340,7 +345,7 @@ pub enum Rows {
 impl Rows {
     pub fn query(&self) -> QueryId {
         match self {
-            Self::Convoys(_) => QueryId::Convoys,
+            Self::Convoys { scope, .. } => QueryId::Convoys { scope: scope.clone() },
             Self::Independents { scope, .. } => QueryId::Independents { scope: scope.clone() },
             Self::Issues { scope, search, label, .. } => {
                 QueryId::Issues { scope: scope.clone(), search: search.clone(), label: label.clone() }
@@ -354,7 +359,7 @@ impl Rows {
 
     pub fn len(&self) -> usize {
         match self {
-            Self::Convoys(rows) => rows.len(),
+            Self::Convoys { rows, .. } => rows.len(),
             Self::Independents { rows, .. } => rows.len(),
             Self::Issues { rows, .. } => rows.len(),
             Self::Checkouts { rows, .. } => rows.len(),
@@ -368,7 +373,7 @@ impl Rows {
 
     pub fn as_convoys(&self) -> Option<&[ConvoyRow]> {
         match self {
-            Self::Convoys(rows) => Some(rows),
+            Self::Convoys { rows, .. } => Some(rows),
             _ => None,
         }
     }

--- a/crates/flotilla-protocol/src/view_address.rs
+++ b/crates/flotilla-protocol/src/view_address.rs
@@ -31,8 +31,8 @@ const QUERY_COMPONENT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').r
 pub enum ViewAddress {
     /// The overview/home view: registered repos, hosts, config.
     Overview,
-    /// All convoys in one namespace.
-    Convoys { namespace: String },
+    /// All convoys in one namespace, fleet-wide or narrowed to one Project.
+    Convoys { namespace: String, scope: Option<QueryScope> },
     /// All terminal sessions that are not associated with a Convoy.
     Independents { scope: Option<QueryScope> },
     /// One convoy: its vessel DAG, phases, and intents.
@@ -85,7 +85,10 @@ impl ViewAddress {
     pub fn human_label(&self) -> String {
         match self {
             Self::Overview => "overview".to_string(),
-            Self::Convoys { namespace } => format!("convoys/{namespace}"),
+            Self::Convoys { namespace, scope: Some(scope) } => {
+                format!("convoys/{namespace}?project={}/{}", scope.namespace, scope.name)
+            }
+            Self::Convoys { namespace, scope: None } => format!("convoys/{namespace}"),
             Self::Independents { scope: Some(scope) } => {
                 format!("independents?project={}/{}", scope.namespace, scope.name)
             }
@@ -120,7 +123,13 @@ impl fmt::Display for ViewAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Overview => f.write_str("overview"),
-            Self::Convoys { namespace } => write!(f, "convoys/{}", encode(namespace)),
+            Self::Convoys { namespace, scope } => {
+                write!(f, "convoys/{}", encode(namespace))?;
+                if let Some(scope) = scope {
+                    write!(f, "?project={}", encode_query_component(&format!("{}/{}", scope.namespace, scope.name)))?;
+                }
+                Ok(())
+            }
             Self::Independents { scope: Some(scope) } => {
                 write!(f, "independents?project={}", encode_query_component(&format!("{}/{}", scope.namespace, scope.name)))
             }
@@ -183,7 +192,10 @@ impl FromStr for ViewAddress {
                 _ => Err(format!("overview takes no parameters: {s}")),
             },
             "convoys" => match segments[1..] {
-                [namespace] => Ok(Self::Convoys { namespace: decode(namespace)? }),
+                [namespace] => {
+                    let scope = parameters.remove("project").map(parse_project_scope).transpose()?;
+                    Ok(Self::Convoys { namespace: decode(namespace)?, scope })
+                }
                 _ => Err(format!("convoys takes exactly one parameter (namespace): {s}")),
             },
             kind if kind.eq_ignore_ascii_case("independents") => match segments.len() {
@@ -298,9 +310,13 @@ mod tests {
 
     #[test]
     fn convoys_round_trips() {
-        let addr = ViewAddress::Convoys { namespace: "flotilla".to_string() };
-        assert_eq!(addr.to_string(), "convoys/flotilla");
-        assert_eq!("convoys/flotilla".parse::<ViewAddress>().expect("parse"), addr);
+        let fleet = ViewAddress::Convoys { namespace: "flotilla".to_string(), scope: None };
+        assert_eq!(fleet.to_string(), "convoys/flotilla");
+        assert_eq!("convoys/flotilla".parse::<ViewAddress>().expect("parse fleet convoys"), fleet);
+
+        let project = ViewAddress::Convoys { namespace: "flotilla".to_string(), scope: Some(QueryScope::new("flotilla", "roadmap")) };
+        assert_eq!("convoys/flotilla?project=flotilla%2froadmap".parse::<ViewAddress>().expect("parse project convoys"), project);
+        assert_eq!(project.to_string(), "convoys/flotilla?project=flotilla%2Froadmap");
     }
 
     #[test]
@@ -430,7 +446,7 @@ mod tests {
 
     #[test]
     fn segments_percent_encode_reserved_characters() {
-        let addr = ViewAddress::Convoys { namespace: "with/slash and space".to_string() };
+        let addr = ViewAddress::Convoys { namespace: "with/slash and space".to_string(), scope: None };
         let rendered = addr.to_string();
         assert_eq!(rendered, "convoys/with%2Fslash%20and%20space");
         assert_eq!(rendered.parse::<ViewAddress>().expect("parse"), addr);

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -403,14 +403,14 @@ mod tests {
         let daemon = Arc::new(StubDaemon::builder().execute_gate(Arc::clone(&execute_gate)).build());
         let mut app =
             stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
-        let address = ViewAddress::Convoys { namespace: "flotilla".into() };
+        let address = ViewAddress::Convoys { namespace: "flotilla".into(), scope: None };
         app.open_view(address.clone());
         let row_id = crate::table_view::RowId::new("flotilla/delete-me");
         let pending_ctx = PendingActionContext::table_row(
             crate::table_view::PendingRowContext {
                 address,
                 panel: None,
-                query: flotilla_protocol::QueryId::Convoys,
+                query: flotilla_protocol::QueryId::Convoys { scope: None },
                 row_id: row_id.clone(),
             },
             "Delete convoy".into(),
@@ -449,6 +449,7 @@ mod tests {
         app.handle_daemon_event(flotilla_protocol::DaemonEvent::ResultDelta(Box::new(flotilla_protocol::ResultDelta {
             seq: 1,
             changes: flotilla_protocol::QueryChanges::Convoys {
+                scope: None,
                 changed: vec![],
                 removed: vec![flotilla_protocol::ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "delete-me")],
             },
@@ -463,14 +464,14 @@ mod tests {
         let daemon = Arc::new(StubDaemon::builder().execute_result(Err("delete failed".into())).build());
         let mut app =
             stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
-        let address = ViewAddress::Convoys { namespace: "flotilla".into() };
+        let address = ViewAddress::Convoys { namespace: "flotilla".into(), scope: None };
         app.open_view(address.clone());
         let row_id = crate::table_view::RowId::new("flotilla/delete-me");
         let pending_ctx = PendingActionContext::table_row(
             crate::table_view::PendingRowContext {
                 address,
                 panel: None,
-                query: flotilla_protocol::QueryId::Convoys,
+                query: flotilla_protocol::QueryId::Convoys { scope: None },
                 row_id: row_id.clone(),
             },
             "Delete convoy".into(),
@@ -496,14 +497,14 @@ mod tests {
         let daemon = Arc::new(StubDaemon::new());
         let mut app =
             stub_app_with_daemon(daemon, vec![repo_info("/tmp/test-repo", "test-repo", flotilla_protocol::RepoLabels::default())]);
-        let address = ViewAddress::Convoys { namespace: "flotilla".into() };
+        let address = ViewAddress::Convoys { namespace: "flotilla".into(), scope: None };
         app.open_view(address.clone());
         let row_id = crate::table_view::RowId::new("flotilla/delete-me");
         let pending_ctx = PendingActionContext::table_row(
             crate::table_view::PendingRowContext {
                 address,
                 panel: None,
-                query: flotilla_protocol::QueryId::Convoys,
+                query: flotilla_protocol::QueryId::Convoys { scope: None },
                 row_id: row_id.clone(),
             },
             "Delete convoy".into(),
@@ -684,13 +685,13 @@ mod tests {
     #[test]
     fn table_row_cancellation_before_ack_stops_shimmering() {
         let mut app = stub_app();
-        let address = ViewAddress::Convoys { namespace: "flotilla".into() };
+        let address = ViewAddress::Convoys { namespace: "flotilla".into(), scope: None };
         app.open_view(address.clone());
         let row_id = crate::table_view::RowId::new("flotilla/delete-me");
         let row_ctx = crate::table_view::PendingRowContext {
             address,
             panel: None,
-            query: flotilla_protocol::QueryId::Convoys,
+            query: flotilla_protocol::QueryId::Convoys { scope: None },
             row_id: row_id.clone(),
         };
         let pending_ctx = PendingActionContext::table_row(row_ctx.clone(), "Delete convoy".into());

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -443,7 +443,7 @@ impl App {
                 let panel = matches!(&address, flotilla_protocol::ViewAddress::Project { .. })
                     .then(|| self.views.active_project_table_state().active());
                 let pending = PendingActionContext::table_row(
-                    PendingRowContext { address, panel, query: flotilla_protocol::QueryId::Convoys, row_id },
+                    PendingRowContext { address, panel, query: flotilla_protocol::QueryId::Convoys { scope: None }, row_id },
                     "Delete convoy".into(),
                 );
                 self.screen.modal_stack.push(Box::new(ConvoyDeleteConfirmWidget::new(command, pending)));

--- a/crates/flotilla-tui/src/app/key_handlers/tests.rs
+++ b/crates/flotilla-tui/src/app/key_handlers/tests.rs
@@ -196,7 +196,7 @@ fn dispatch_confirmation_warns_for_non_ready_issue_and_cancel_queues_nothing() {
 fn convoy_delete_table_intent_confirms_then_routes_to_origin_host() {
     let mut app = stub_app();
     insert_peer_host(&mut app.model, "remote-host");
-    app.open_view(flotilla_protocol::ViewAddress::Convoys { namespace: "other-team".into() });
+    app.open_view(flotilla_protocol::ViewAddress::Convoys { namespace: "other-team".into(), scope: None });
     let row_id = crate::table_view::RowId::new("other-team/failed-convoy@remote-host");
 
     app.execute_table_intent(TableIntent::DeleteConvoy {

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -289,6 +289,7 @@ pub struct NamespaceModel {
 /// window it subscribed to.
 #[derive(Default)]
 pub struct QueryTableCache {
+    pub convoys: HashMap<flotilla_protocol::QueryId, QueryTableResult<crate::convoy_model::ConvoySummary>>,
     pub independents: HashMap<flotilla_protocol::QueryId, QueryTableResult<flotilla_protocol::IndependentRow>>,
     pub issues: HashMap<flotilla_protocol::QueryId, QueryTableResult<flotilla_protocol::IssueRow>>,
     pub checkouts: HashMap<flotilla_protocol::QueryId, QueryTableResult<flotilla_protocol::CheckoutRow>>,
@@ -339,6 +340,11 @@ pub fn table_rows<'a>(
 ) -> crate::table_view::TableRows<'a> {
     crate::table_view::TableRows {
         convoys: namespaces.values().flat_map(|namespace| namespace.convoys.values()).collect(),
+        convoy_results: queries
+            .convoys
+            .iter()
+            .map(|(query, result)| crate::table_view::QueryRows { query, rows: &result.rows, state: &result.state })
+            .collect(),
         independent_results: queries
             .independents
             .iter()
@@ -1714,16 +1720,21 @@ impl App {
                 self.query_seqs.insert(query.clone(), result_set.seq);
                 self.views.reconcile_authoritative_rows(&query, &crate::table_view::AuthoritativeRowUpdate::Full);
                 match &result_set.rows {
-                    flotilla_protocol::Rows::Convoys(rows) => {
-                        for namespace in self.namespaces.values_mut() {
-                            namespace.convoys.clear();
-                        }
-                        for row in rows {
-                            let convoy = ConvoySummary::from(row);
-                            let namespace = convoy.namespace.clone();
-                            let entry = self.namespaces.entry(namespace).or_default();
-                            entry.convoys.insert(convoy.id.clone(), convoy);
-                            entry.last_seq = result_set.seq;
+                    flotilla_protocol::Rows::Convoys { rows, .. } => {
+                        let convoys = rows.iter().map(ConvoySummary::from).collect::<Vec<_>>();
+                        self.query_tables
+                            .convoys
+                            .insert(query.clone(), QueryTableResult { rows: convoys.clone(), state: result_set.state.clone() });
+                        if matches!(query, flotilla_protocol::QueryId::Convoys { scope: None }) {
+                            for namespace in self.namespaces.values_mut() {
+                                namespace.convoys.clear();
+                            }
+                            for convoy in convoys {
+                                let namespace = convoy.namespace.clone();
+                                let entry = self.namespaces.entry(namespace).or_default();
+                                entry.convoys.insert(convoy.id.clone(), convoy);
+                                entry.last_seq = result_set.seq;
+                            }
                         }
                     }
                     flotilla_protocol::Rows::Independents { rows, .. } => {
@@ -1749,24 +1760,34 @@ impl App {
                 self.pending_fetch_more.remove(&query);
                 self.query_seqs.insert(query.clone(), delta.seq);
                 match &delta.changes {
-                    flotilla_protocol::QueryChanges::Convoys { changed, removed } => {
+                    flotilla_protocol::QueryChanges::Convoys { changed, removed, .. } => {
                         let updated = changed
                             .iter()
                             .map(|row| crate::table_view::RowId::new(ConvoyId::for_resource(&row.resource).as_str()))
                             .chain(removed.iter().map(|resource| crate::table_view::RowId::new(ConvoyId::for_resource(resource).as_str())))
                             .collect();
                         self.views.reconcile_authoritative_rows(&query, &crate::table_view::AuthoritativeRowUpdate::Rows(updated));
-                        for row in changed {
-                            let convoy = ConvoySummary::from(row);
-                            let namespace = convoy.namespace.clone();
-                            let entry = self.namespaces.entry(namespace).or_default();
-                            entry.convoys.insert(convoy.id.clone(), convoy);
-                            entry.last_seq = delta.seq;
-                        }
-                        for removed in removed {
-                            if let Some(entry) = self.namespaces.get_mut(&removed.namespace) {
-                                entry.convoys.shift_remove(&ConvoyId::for_resource(removed));
+                        let changed_convoys = changed.iter().map(ConvoySummary::from).collect::<Vec<_>>();
+                        let removed_ids = removed.iter().map(ConvoyId::for_resource).collect::<Vec<_>>();
+                        self.query_tables.convoys.entry(query.clone()).or_default().apply_delta(
+                            &changed_convoys,
+                            &removed_ids,
+                            delta.state.as_ref(),
+                            |row| row.id.clone(),
+                            |left, right| left.id.as_str().cmp(right.id.as_str()),
+                        );
+                        if matches!(query, flotilla_protocol::QueryId::Convoys { scope: None }) {
+                            for convoy in changed_convoys {
+                                let namespace = convoy.namespace.clone();
+                                let entry = self.namespaces.entry(namespace).or_default();
+                                entry.convoys.insert(convoy.id.clone(), convoy);
                                 entry.last_seq = delta.seq;
+                            }
+                            for removed in removed {
+                                if let Some(entry) = self.namespaces.get_mut(&removed.namespace) {
+                                    entry.convoys.shift_remove(&ConvoyId::for_resource(removed));
+                                    entry.last_seq = delta.seq;
+                                }
                             }
                         }
                     }

--- a/crates/flotilla-tui/src/app/navigation/tests.rs
+++ b/crates/flotilla-tui/src/app/navigation/tests.rs
@@ -19,7 +19,7 @@ fn active_address(app: &App) -> ViewAddress {
 }
 
 fn convoys_address() -> ViewAddress {
-    ViewAddress::Convoys { namespace: "flotilla".to_string() }
+    ViewAddress::Convoys { namespace: "flotilla".to_string(), scope: None }
 }
 
 #[tokio::test]

--- a/crates/flotilla-tui/src/app/open_views.rs
+++ b/crates/flotilla-tui/src/app/open_views.rs
@@ -262,7 +262,7 @@ impl OpenViews {
         landing: Option<(RepoIdentity, ViewAddress)>,
     ) -> Self {
         let mut entries = vec![OpenViewEntry { address: ViewAddress::Overview.to_string(), label: None }, OpenViewEntry {
-            address: ViewAddress::Convoys { namespace: "flotilla".to_string() }.to_string(),
+            address: ViewAddress::Convoys { namespace: "flotilla".to_string(), scope: None }.to_string(),
             label: None,
         }];
         entries.extend(repos.into_iter().map(|(identity, repository_key)| {
@@ -558,6 +558,8 @@ fn bind_repository_key(target: &mut ViewTarget, keys: &HashMap<RepoIdentity, Rep
 
 #[cfg(test)]
 mod tests {
+    use flotilla_protocol::QueryScope;
+
     use super::*;
 
     fn addr(s: &str) -> ViewAddress {
@@ -602,6 +604,18 @@ mod tests {
         let entries = views.to_entries();
         assert_eq!(entries[1].address, "workflow/ns/w");
         assert_eq!(entries[2].address, "garbage");
+    }
+
+    #[test]
+    fn project_scoped_convoys_round_trip_through_open_view_entries() {
+        let entries = vec![entry("overview"), entry("convoys/flotilla?project=flotilla%2Froadmap")];
+        let views = OpenViews::from_entries(entries.clone());
+
+        assert_eq!(views.to_entries(), entries);
+        assert_eq!(
+            views.get(1).and_then(OpenView::address),
+            Some(&ViewAddress::Convoys { namespace: "flotilla".into(), scope: Some(QueryScope::new("flotilla", "roadmap")) })
+        );
     }
 
     #[test]

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -367,11 +367,11 @@ fn persisted_open_views_take_precedence_over_a_fresh_project_landing() {
 #[tokio::test]
 async fn reconnect_daemon_preserves_ui_state_and_clears_daemon_caches() {
     let mut app = stub_app();
-    app.views.open_or_focus(ViewAddress::Convoys { namespace: "flotilla".into() });
+    app.views.open_or_focus(ViewAddress::Convoys { namespace: "flotilla".into(), scope: None });
     app.views.active_table_state_mut().filter = "needle".into();
     app.ui.show_debug = true;
     app.namespaces.insert("stale".into(), NamespaceModel::default());
-    app.query_seqs.insert(flotilla_protocol::QueryId::Convoys, 42);
+    app.query_seqs.insert(flotilla_protocol::QueryId::Convoys { scope: None }, 42);
     let batch_id = app.begin_project_issue_start_batch(1);
     app.command_project_issue_starts.insert(1, ProjectIssueStartContext {
         address: ViewAddress::Project { namespace: "flotilla".into(), name: "roadmap".into() },
@@ -388,7 +388,7 @@ async fn reconnect_daemon_preserves_ui_state_and_clears_daemon_caches() {
 
     app.reconnect_daemon(daemon, repos);
 
-    assert_eq!(app.views.active_address(), Some(&ViewAddress::Convoys { namespace: "flotilla".into() }));
+    assert_eq!(app.views.active_address(), Some(&ViewAddress::Convoys { namespace: "flotilla".into(), scope: None }));
     assert_eq!(app.views.active_table_state().filter, "needle");
     assert!(app.ui.show_debug);
     assert!(app.namespaces.is_empty());
@@ -403,7 +403,7 @@ async fn reconnect_daemon_preserves_ui_state_and_clears_daemon_caches() {
 #[test]
 fn handoff_round_trip_preserves_navigation_table_and_ui_state() {
     let mut source = stub_app();
-    source.views.open_or_focus(ViewAddress::Convoys { namespace: "flotilla".into() });
+    source.views.open_or_focus(ViewAddress::Convoys { namespace: "flotilla".into(), scope: None });
     source.views.active_table_state_mut().filter = "mine".into();
     source.views.drill("convoy/flotilla/demo".parse().expect("valid drill address"));
     source.ui.show_debug = true;
@@ -1781,7 +1781,19 @@ fn result_set_event(snapshot: impl AsRef<crate::convoy_model::ConvoyFixtureSnaps
     let snapshot = snapshot.as_ref().clone();
     flotilla_protocol::DaemonEvent::ResultSet(Box::new(ResultSet {
         seq: snapshot.seq,
-        rows: Rows::Convoys(snapshot.convoys.into_iter().map(wire_convoy_row).collect()),
+        rows: Rows::Convoys { scope: None, rows: snapshot.convoys.into_iter().map(wire_convoy_row).collect() },
+        state: Default::default(),
+    }))
+}
+
+fn scoped_convoy_result_set(
+    seq: u64,
+    scope: flotilla_protocol::QueryScope,
+    convoys: Vec<crate::convoy_model::ConvoySummary>,
+) -> flotilla_protocol::DaemonEvent {
+    flotilla_protocol::DaemonEvent::ResultSet(Box::new(flotilla_protocol::ResultSet {
+        seq,
+        rows: flotilla_protocol::Rows::Convoys { scope: Some(scope), rows: convoys.into_iter().map(wire_convoy_row).collect() },
         state: Default::default(),
     }))
 }
@@ -1796,6 +1808,7 @@ fn result_delta_event(delta: impl AsRef<crate::convoy_model::ConvoyFixtureDelta>
     flotilla_protocol::DaemonEvent::ResultDelta(Box::new(ResultDelta {
         seq: delta.seq,
         changes: QueryChanges::Convoys {
+            scope: None,
             changed: delta.changed.into_iter().map(wire_convoy_row).collect(),
             removed: delta
                 .removed
@@ -1910,6 +1923,27 @@ fn empty_panel_snapshot_clears_convoys() {
     app.handle_daemon_event(result_set_event(Box::new(ConvoyFixtureSnapshot { seq: 2, namespace: "flotilla".into(), convoys: vec![] })));
 
     assert!(app.convoys("flotilla").is_empty());
+}
+
+#[test]
+fn app_keeps_global_and_project_convoy_results_separate() {
+    use crate::convoy_model::{ConvoyFixtureSnapshot, ConvoyPhase};
+
+    let mut app = stub_app();
+    let global = test_convoy("flotilla", "global", ConvoyPhase::Active, false);
+    app.handle_daemon_event(result_set_event(Box::new(ConvoyFixtureSnapshot {
+        seq: 1,
+        namespace: "flotilla".into(),
+        convoys: vec![global],
+    })));
+
+    let scope = flotilla_protocol::QueryScope::new("flotilla", "roadmap");
+    let mut scoped = test_convoy("flotilla", "scoped", ConvoyPhase::Active, false);
+    scoped.project_ref = Some("roadmap".into());
+    app.handle_daemon_event(scoped_convoy_result_set(1, scope.clone(), vec![scoped]));
+
+    assert_eq!(app.convoys("flotilla").iter().map(|convoy| convoy.name.as_str()).collect::<Vec<_>>(), vec!["global"]);
+    assert_eq!(app.query_tables.convoys[&flotilla_protocol::QueryId::Convoys { scope: Some(scope) }].rows[0].name, "scoped");
 }
 
 #[test]
@@ -2653,12 +2687,12 @@ fn escape_clears_a_table_find_before_navigating_back() {
 fn table_refresh_requests_a_fresh_named_query_snapshot() {
     let mut app = stub_app();
     app.switch_tab(1);
-    app.query_seqs.insert(flotilla_protocol::QueryId::Convoys, 42);
+    app.query_seqs.insert(flotilla_protocol::QueryId::Convoys { scope: None }, 42);
     app.subscriptions_dirty = false;
 
     app.handle_key(key(KeyCode::Char('r')));
 
-    assert!(!app.query_seqs.contains_key(&flotilla_protocol::QueryId::Convoys));
+    assert!(!app.query_seqs.contains_key(&flotilla_protocol::QueryId::Convoys { scope: None }));
     assert!(app.subscriptions_dirty);
     assert!(app.proto_commands.take_next().is_none(), "table refresh resubscribes instead of dispatching a repo command");
 }

--- a/crates/flotilla-tui/src/app/view_kind.rs
+++ b/crates/flotilla-tui/src/app/view_kind.rs
@@ -14,7 +14,8 @@ use crate::binding_table::{BindingModeId, KeyBindingMode};
 /// set. Repo views ride the Plane-A repo streams and return None.
 pub(crate) fn queries(address: &ViewAddress, source_search: Option<&str>) -> Vec<QueryId> {
     match address {
-        ViewAddress::Convoys { .. } | ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. } => vec![QueryId::Convoys],
+        ViewAddress::Convoys { scope, .. } => vec![QueryId::Convoys { scope: scope.clone() }],
+        ViewAddress::Convoy { .. } | ViewAddress::Vessel { .. } => vec![QueryId::Convoys { scope: None }],
         ViewAddress::Project { namespace, name } => {
             vec![
                 QueryId::Awareness {
@@ -22,7 +23,7 @@ pub(crate) fn queries(address: &ViewAddress, source_search: Option<&str>) -> Vec
                     grouping: AwarenessGrouping::Project,
                     limit: AwarenessLimit::default(),
                 },
-                QueryId::Convoys,
+                QueryId::Convoys { scope: Some(QueryScope::new(namespace, name)) },
                 QueryId::Checkouts { scope: Some(QueryScope::new(namespace, name)) },
                 QueryId::Issues {
                     scope: QueryScope::new(namespace, name),
@@ -98,12 +99,21 @@ mod tests {
                 grouping: AwarenessGrouping::Project,
                 limit: AwarenessLimit::default(),
             },
-            QueryId::Convoys,
+            QueryId::Convoys { scope: Some(QueryScope::new("flotilla", "roadmap")) },
             QueryId::Checkouts { scope: Some(QueryScope::new("flotilla", "roadmap")) },
             QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None, label: None },
             QueryId::Independents { scope: Some(QueryScope::new("flotilla", "roadmap")) },
         ]);
         assert_eq!(kind_modes(Some(&address)), vec![BindingModeId::Convoys, BindingModeId::DemandTable, BindingModeId::Project]);
+    }
+
+    #[test]
+    fn convoy_views_subscribe_to_their_address_scope() {
+        let global: ViewAddress = "convoys/flotilla".parse().expect("global convoys address");
+        assert_eq!(queries(&global, None), vec![QueryId::Convoys { scope: None }]);
+
+        let project: ViewAddress = "convoys/flotilla?project=flotilla%2Froadmap".parse().expect("project-scoped convoys address");
+        assert_eq!(queries(&project, None), vec![QueryId::Convoys { scope: Some(QueryScope::new("flotilla", "roadmap")) }]);
     }
 
     #[test]

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -1175,7 +1175,7 @@ mod result_set_event_formatting {
 
     #[test]
     fn result_set_formatting() {
-        let result_set = ResultSet { seq: 7, rows: Rows::Convoys(vec![]), state: Default::default() };
+        let result_set = ResultSet { seq: 7, rows: Rows::Convoys { scope: None, rows: vec![] }, state: Default::default() };
         let event = DaemonEvent::ResultSet(Box::new(result_set));
         let line = format_event_human(&event);
         assert!(line.contains("[query]"), "should have query tag");
@@ -1189,6 +1189,7 @@ mod result_set_event_formatting {
         let delta = ResultDelta {
             seq: 12,
             changes: QueryChanges::Convoys {
+                scope: None,
                 changed: vec![],
                 removed: vec![ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "old-convoy")],
             },
@@ -1215,13 +1216,13 @@ mod watch_dedupe_query {
     use crate::cli::event_stream_seq;
 
     fn result_set(seq: u64) -> DaemonEvent {
-        DaemonEvent::ResultSet(Box::new(ResultSet { seq, rows: Rows::Convoys(vec![]), state: Default::default() }))
+        DaemonEvent::ResultSet(Box::new(ResultSet { seq, rows: Rows::Convoys { scope: None, rows: vec![] }, state: Default::default() }))
     }
 
     fn result_delta(seq: u64) -> DaemonEvent {
         DaemonEvent::ResultDelta(Box::new(ResultDelta {
             seq,
-            changes: QueryChanges::Convoys { changed: vec![], removed: vec![] },
+            changes: QueryChanges::Convoys { scope: None, changed: vec![], removed: vec![] },
             state: None,
         }))
     }
@@ -1252,14 +1253,14 @@ mod watch_dedupe_query {
     fn event_stream_seq_returns_query_key_for_result_set() {
         let event = result_set(5);
         let result = event_stream_seq(&event);
-        assert_eq!(result, Some((StreamKey::Query { query: QueryId::Convoys }, 5)));
+        assert_eq!(result, Some((StreamKey::Query { query: QueryId::Convoys { scope: None } }, 5)));
     }
 
     #[test]
     fn event_stream_seq_returns_query_key_for_delta() {
         let event = result_delta(9);
         let result = event_stream_seq(&event);
-        assert_eq!(result, Some((StreamKey::Query { query: QueryId::Convoys }, 9)));
+        assert_eq!(result, Some((StreamKey::Query { query: QueryId::Convoys { scope: None } }, 9)));
     }
 
     #[test]

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -136,7 +136,10 @@ impl ConnectorState {
             return Applied::Ignored;
         }
         match &set.rows {
-            Rows::Convoys(rows) => self.convoys = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect(),
+            Rows::Convoys { scope: None, rows } => {
+                self.convoys = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect();
+            }
+            Rows::Convoys { scope: Some(_), .. } => return Applied::Ignored,
             Rows::Independents { scope: None, rows } => {
                 self.independents = rows.iter().map(|row| (row.resource.clone(), row.clone())).collect();
             }
@@ -162,7 +165,7 @@ impl ConnectorState {
             return Applied::Gap(query);
         }
         match &delta.changes {
-            QueryChanges::Convoys { changed: rows, removed } => {
+            QueryChanges::Convoys { scope: None, changed: rows, removed } => {
                 for row in rows {
                     self.convoys.insert(row.resource.clone(), row.clone());
                 }
@@ -170,6 +173,7 @@ impl ConnectorState {
                     self.convoys.remove(removed);
                 }
             }
+            QueryChanges::Convoys { scope: Some(_), .. } => return Applied::Ignored,
             QueryChanges::Independents { scope: None, changed: rows, removed } => {
                 for row in rows {
                     self.independents.insert(row.resource.clone(), row.clone());

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -40,7 +40,7 @@ fn independents_delta(seq: u64, changed: Vec<IndependentRow>, removed: Vec<Resou
 }
 
 fn convoys_set(seq: u64) -> DaemonEvent {
-    DaemonEvent::ResultSet(Box::new(ResultSet { seq, rows: Rows::Convoys(vec![]), state: Default::default() }))
+    DaemonEvent::ResultSet(Box::new(ResultSet { seq, rows: Rows::Convoys { scope: None, rows: vec![] }, state: Default::default() }))
 }
 
 fn awareness_set(seq: u64, rows: Vec<AwarenessNode>) -> DaemonEvent {
@@ -108,7 +108,7 @@ fn gaps_and_unseeded_deltas_request_resubscription() {
     let cursors = state.cursors();
     let independents = cursors.iter().find(|cursor| cursor.query == (QueryId::Independents { scope: None })).expect("independents cursor");
     assert_eq!(independents.since, Some(1));
-    let convoys = cursors.iter().find(|cursor| cursor.query == QueryId::Convoys).expect("convoys cursor");
+    let convoys = cursors.iter().find(|cursor| cursor.query == QueryId::Convoys { scope: None }).expect("convoys cursor");
     assert_eq!(convoys.since, None, "never-seen queries subscribe from scratch");
     assert!(
         cursors.iter().any(|cursor| matches!(cursor.query, QueryId::Awareness { scope: None, grouping: AwarenessGrouping::Project, .. })),

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -532,6 +532,7 @@ struct ScopedIssueProjection {
 #[derive(Default, bon::Builder)]
 pub struct TableRows<'a> {
     pub convoys: Vec<&'a ConvoySummary>,
+    pub convoy_results: Vec<QueryRows<'a, ConvoySummary>>,
     pub independent_results: Vec<QueryRows<'a, IndependentRow>>,
     pub issue_results: Vec<QueryRows<'a, IssueRow>>,
     pub checkout_results: Vec<QueryRows<'a, CheckoutRow>>,
@@ -551,6 +552,7 @@ pub struct QueryRows<'a, R> {
 /// curated table families to prevent subscription/projection drift.
 pub fn query_for(address: &ViewAddress, source_search: Option<&str>) -> Option<QueryId> {
     match address {
+        ViewAddress::Convoys { scope, .. } => Some(QueryId::Convoys { scope: scope.clone() }),
         ViewAddress::Issues { scope } => Some(QueryId::Issues {
             scope: scope.clone(),
             search: source_search.filter(|search| !search.is_empty()).map(str::to_owned),
@@ -564,8 +566,23 @@ pub fn query_for(address: &ViewAddress, source_search: Option<&str>) -> Option<Q
 
 pub fn project(address: &ViewAddress, data: &TableRows<'_>) -> Result<TableView, String> {
     match address {
-        ViewAddress::Convoys { namespace } => {
-            let rows = data.convoys.iter().copied().filter(|convoy| &convoy.namespace == namespace).cloned();
+        ViewAddress::Convoys { namespace, scope } => {
+            let query = query_for(address, data.source_search).expect("convoys address has a query");
+            let query_rows = data.convoy_results.iter().find(|result| *result.query == query).map(|result| result.rows);
+            let rows = query_rows
+                .into_iter()
+                .flatten()
+                .chain(query_rows.is_none().then_some(data.convoys.as_slice()).into_iter().flatten().copied())
+                .filter(|convoy| &convoy.namespace == namespace)
+                .filter(|convoy| {
+                    scope.as_ref().is_none_or(|scope| {
+                        convoy
+                            .project_ref
+                            .as_deref()
+                            .is_some_and(|project| project == scope.name || project == format!("{}/{}", scope.namespace, scope.name))
+                    })
+                })
+                .cloned();
             Ok(convoy_spec().project(format!("Convoys · {namespace}"), rows))
         }
         ViewAddress::Independents { scope } => {
@@ -672,14 +689,8 @@ pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec
         return Err(format!("view is not project-backed: {}", address.human_label()));
     };
     let scope = QueryScope::new(namespace, name);
-    let convoys = convoy_spec().project(
-        "Convoys".to_string(),
-        data.convoys
-            .iter()
-            .copied()
-            .filter(|convoy| &convoy.namespace == namespace && convoy.project_ref.as_deref() == Some(name))
-            .cloned(),
-    );
+    let convoys_address = ViewAddress::Convoys { namespace: namespace.clone(), scope: Some(scope.clone()) };
+    let convoys = project(&convoys_address, data).unwrap_or_else(|_| pending_project_table(&convoys_address));
     let checkouts_address = ViewAddress::Checkouts { scope: Some(scope.clone()) };
     let issues_address = ViewAddress::Issues { scope: scope.clone() };
     let independents_address = ViewAddress::Independents { scope: Some(scope) };
@@ -712,7 +723,7 @@ pub fn project_panels(address: &ViewAddress, data: &TableRows<'_>) -> Result<Vec
     }
 
     Ok(vec![
-        ProjectPanel { kind: ProjectPanelKind::Convoys, target: ViewAddress::Convoys { namespace: namespace.clone() }, table: convoys },
+        ProjectPanel { kind: ProjectPanelKind::Convoys, target: convoys_address, table: convoys },
         ProjectPanel { kind: ProjectPanelKind::Checkouts, target: checkouts_address, table: checkouts },
         ProjectPanel { kind: ProjectPanelKind::Issues, target: issues_address, table: issues },
         ProjectPanel { kind: ProjectPanelKind::Independents, target: independents_address, table: independents },
@@ -1609,7 +1620,7 @@ mod tests {
             ProjectPanelKind::Independents,
         ]);
         assert_eq!(panels.iter().map(|panel| panel.target.to_string()).collect::<Vec<_>>(), vec![
-            "convoys/flotilla",
+            "convoys/flotilla?project=flotilla%2Froadmap",
             "checkouts?project=flotilla%2Froadmap",
             "issues?project=flotilla%2Froadmap",
             "independents?project=flotilla%2Froadmap",
@@ -1819,12 +1830,12 @@ mod tests {
         let pending = RowId::new("dev/tables");
         let unrelated = RowId::new("dev/other");
 
-        state.begin_pending(QueryId::Convoys, pending.clone(), "Delete convoy".into()).expect("row should become pending");
-        state.reconcile_authoritative(&QueryId::Convoys, &AuthoritativeRowUpdate::Rows(HashSet::from([unrelated])));
+        state.begin_pending(QueryId::Convoys { scope: None }, pending.clone(), "Delete convoy".into()).expect("row should become pending");
+        state.reconcile_authoritative(&QueryId::Convoys { scope: None }, &AuthoritativeRowUpdate::Rows(HashSet::from([unrelated])));
 
         assert!(matches!(state.row_state(&pending), Some(RowState::Submitting { .. })));
 
-        state.reconcile_authoritative(&QueryId::Convoys, &AuthoritativeRowUpdate::Rows(HashSet::from([pending.clone()])));
+        state.reconcile_authoritative(&QueryId::Convoys { scope: None }, &AuthoritativeRowUpdate::Rows(HashSet::from([pending.clone()])));
 
         assert!(state.row_state(&pending).is_none());
     }
@@ -1835,10 +1846,12 @@ mod tests {
         let convoy = RowId::new("dev/tables");
         let issue = RowId::new("issue:809");
         let issues_query = QueryId::Issues { scope: QueryScope::new("flotilla", "roadmap"), search: None, label: None };
-        state.begin_pending(QueryId::Convoys, convoy.clone(), "Delete convoy".into()).expect("convoy should become pending");
+        state
+            .begin_pending(QueryId::Convoys { scope: None }, convoy.clone(), "Delete convoy".into())
+            .expect("convoy should become pending");
         state.begin_pending(issues_query.clone(), issue.clone(), "Start convoy".into()).expect("issue should become pending");
 
-        state.reconcile_authoritative(&QueryId::Convoys, &AuthoritativeRowUpdate::Full);
+        state.reconcile_authoritative(&QueryId::Convoys { scope: None }, &AuthoritativeRowUpdate::Full);
 
         assert!(state.row_state(&convoy).is_none());
         assert!(matches!(state.row_state(&issue), Some(RowState::Submitting { .. })));
@@ -1849,9 +1862,9 @@ mod tests {
         let mut state = TableState::default();
         let pending = RowId::new("dev/pending");
         let failed = RowId::new("dev/failed");
-        state.begin_pending(QueryId::Convoys, pending.clone(), "Delete convoy".into()).expect("row should submit");
+        state.begin_pending(QueryId::Convoys { scope: None }, pending.clone(), "Delete convoy".into()).expect("row should submit");
         state.mark_pending(&pending, 1);
-        state.begin_pending(QueryId::Convoys, failed.clone(), "Delete convoy".into()).expect("row should submit");
+        state.begin_pending(QueryId::Convoys { scope: None }, failed.clone(), "Delete convoy".into()).expect("row should submit");
         state.mark_failed(&failed, "delete failed".into());
 
         state.mark_pending(&pending, 2);

--- a/crates/flotilla-tui/src/widgets/table.rs
+++ b/crates/flotilla-tui/src/widgets/table.rs
@@ -655,7 +655,7 @@ mod tests {
         let view = view();
         let row_id = view.rows[0].id.clone();
         let mut state = TableState::default();
-        state.begin_pending(flotilla_protocol::QueryId::Convoys, row_id, "Delete convoy".into()).expect("pending row");
+        state.begin_pending(flotilla_protocol::QueryId::Convoys { scope: None }, row_id, "Delete convoy".into()).expect("pending row");
         terminal
             .draw(|frame| {
                 TablePanel::render_rows_at(

--- a/crates/flotilla-tui/src/widgets/tabs.rs
+++ b/crates/flotilla-tui/src/widgets/tabs.rs
@@ -69,8 +69,8 @@ fn repo_label(identity: &flotilla_protocol::RepoIdentity, model: &TuiModel, leve
 fn default_label(view: &OpenView, model: &TuiModel, level: usize) -> String {
     match &view.target {
         ViewTarget::View(ViewAddress::Overview) => " ⚓ flotilla ".to_string(),
-        ViewTarget::View(ViewAddress::Convoys { namespace }) if namespace == "flotilla" && level == 0 => " 🚢 convoys ".to_string(),
-        ViewTarget::View(ViewAddress::Convoys { namespace }) => format!(" 🚢 {namespace} "),
+        ViewTarget::View(ViewAddress::Convoys { namespace, .. }) if namespace == "flotilla" && level == 0 => " 🚢 convoys ".to_string(),
+        ViewTarget::View(ViewAddress::Convoys { namespace, .. }) => format!(" 🚢 {namespace} "),
         ViewTarget::View(ViewAddress::Independents { scope: Some(scope) }) => match level {
             0 => format!("⛵ {} independents", scope.name),
             _ => format!("⛵ {}/{} independents", scope.namespace, scope.name),

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -229,7 +229,7 @@ async fn generated_table_action_completes_work() {
     }
 
     // Switch the TUI into the Convoys tab and drive the keybinding flow.
-    app.open_view(flotilla_protocol::ViewAddress::Convoys { namespace: "flotilla".to_string() });
+    app.open_view(flotilla_protocol::ViewAddress::Convoys { namespace: "flotilla".to_string(), scope: None });
 
     fn key(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty())

--- a/docs/adr/0013-views-are-the-addressable-unit.md
+++ b/docs/adr/0013-views-are-the-addressable-unit.md
@@ -111,14 +111,17 @@ concept (see CONTEXT.md: **View**).
 
 ## Amendment: curated query-family Views (2026-07-20)
 
-Issues, checkouts, and independents are addressable as single-table Views.
-Their canonical grammar is `issues?project=<namespace%2Fname>`,
+Issues, convoys, checkouts, and independents are addressable as scoped
+single-table Views. Their canonical grammar is
+`issues?project=<namespace%2Fname>`,
+`convoys/<namespace>?project=<namespace%2Fname>`,
 `checkouts?project=<namespace%2Fname>`, and
 `independents?project=<namespace%2Fname>`. Bare `checkouts` and
-`independents` are their Fleet-wide forms; bare `issues` is invalid. Family
-names and percent escapes render canonically in lowercase/uppercase
-respectively, and parsed addresses deduplicate by their typed identity. The
-earlier experimental `?repo=` form is not part of the contract.
+`independents`, plus `convoys/<namespace>` without the query parameter, are
+their Fleet-wide forms; bare `issues` is invalid. Family names and percent
+escapes render canonically in lowercase/uppercase respectively, and parsed
+addresses deduplicate by their typed identity. The earlier experimental
+`?repo=` form is not part of the contract.
 
 The client-visible query scope is Project-only: Repository membership is an
 Aggregator implementation detail. Source search is transient state of an


### PR DESCRIPTION
## Summary

- add optional Project scope to Convoys view addresses and query identities
- filter scoped Convoys result sets in the Aggregator while preserving the global set
- make Project panels subscribe to and drill into their scoped Convoys view
- keep scoped and global Convoys caches isolated in the TUI

## Tests

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked`

Closes #1069
