### PR TITLE
feat: add change request merge verb

### DIFF
--- a/crates/flotilla-commands/src/commands/cr.rs
+++ b/crates/flotilla-commands/src/commands/cr.rs
@@ -22,6 +22,12 @@ pub enum CrVerb {
     Open,
     /// Close a change request
     Close,
+    /// Merge a change request using the repository's squash convention
+    Merge {
+        /// Confirm the merge without prompting
+        #[arg(long)]
+        yes: bool,
+    },
     /// Link issues to a change request
     LinkIssues { issue_ids: Vec<String> },
 }
@@ -49,6 +55,16 @@ impl CrNoun {
                 repo: RepoContext::Inferred,
                 host: HostResolution::ProviderHost,
             }),
+            CrVerb::Merge { yes } => Ok(Resolved::NeedsContext {
+                command: Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::MergeChangeRequest { id: self.subject, confirmed: yes },
+                },
+                repo: RepoContext::Inferred,
+                host: HostResolution::ProviderHost,
+            }),
             CrVerb::LinkIssues { issue_ids } => Ok(Resolved::NeedsContext {
                 command: Command {
                     node_id: None,
@@ -69,6 +85,12 @@ impl std::fmt::Display for CrNoun {
         match &self.verb {
             CrVerb::Open => write!(f, " open")?,
             CrVerb::Close => write!(f, " close")?,
+            CrVerb::Merge { yes } => {
+                write!(f, " merge")?;
+                if *yes {
+                    write!(f, " --yes")?;
+                }
+            }
             CrVerb::LinkIssues { issue_ids } => {
                 write!(f, " link-issues")?;
                 for id in issue_ids {
@@ -127,6 +149,36 @@ mod tests {
     }
 
     #[test]
+    fn cr_merge_requires_surface_confirmation() {
+        let resolved = parse(&["cr", "42", "merge"]).resolve().unwrap();
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::MergeChangeRequest { id: "42".into(), confirmed: false }
+            },
+            repo: RepoContext::Inferred,
+            host: HostResolution::ProviderHost,
+        });
+    }
+
+    #[test]
+    fn cr_merge_yes_records_explicit_confirmation() {
+        let resolved = parse(&["cr", "42", "merge", "--yes"]).resolve().unwrap();
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::MergeChangeRequest { id: "42".into(), confirmed: true }
+            },
+            repo: RepoContext::Inferred,
+            host: HostResolution::ProviderHost,
+        });
+    }
+
+    #[test]
     fn cr_link_issues() {
         let resolved = parse(&["cr", "42", "link-issues", "1", "5", "7"]).resolve().unwrap();
         assert_eq!(resolved, Resolved::NeedsContext {
@@ -169,6 +221,12 @@ mod tests {
     #[test]
     fn round_trip_close() {
         assert_round_trip::<CrNoun>(&["cr", "42", "close"]);
+    }
+
+    #[test]
+    fn round_trip_merge() {
+        assert_round_trip::<CrNoun>(&["cr", "42", "merge"]);
+        assert_round_trip::<CrNoun>(&["cr", "42", "merge", "--yes"]);
     }
 
     #[test]

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -325,6 +325,17 @@ pub async fn build_plan(
             action: StepAction::CloseChangeRequest { id },
         }])),
 
+        CommandAction::MergeChangeRequest { id, confirmed } => {
+            if !confirmed {
+                return Err(CommandValue::Error { message: format!("merging change request {id} requires explicit confirmation") });
+            }
+            Ok(StepPlan::new(vec![Step {
+                description: format!("Merge change request {id}"),
+                host: StepExecutionContext::Host(target_node_id.clone()),
+                action: StepAction::MergeChangeRequest { id },
+            }]))
+        }
+
         CommandAction::OpenIssue { id } => Ok(StepPlan::new(vec![Step {
             description: format!("Open issue {id}"),
             host: StepExecutionContext::Host(target_node_id.clone()),
@@ -1088,6 +1099,16 @@ impl StepResolver for ExecutorStepResolver {
                 if let Some(cr) = self.registry.change_requests.preferred() {
                     let _ = cr.close_change_request(self.repo.root.as_path(), &id).await;
                 }
+                Ok(StepOutcome::Completed)
+            }
+            StepAction::MergeChangeRequest { id } => {
+                debug!(%id, "merging change request");
+                let cr = self
+                    .registry
+                    .change_requests
+                    .preferred()
+                    .ok_or_else(|| "no change request provider is active for this repository".to_string())?;
+                cr.merge_change_request(self.repo.root.as_path(), &id).await?;
                 Ok(StepOutcome::Completed)
             }
             StepAction::OpenIssue { id } => {

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -207,6 +207,37 @@ impl ChangeRequestTracker for MockChangeRequestTracker {
     async fn close_change_request(&self, _repo_root: &Path, _id: &str) -> Result<(), String> {
         Ok(())
     }
+    async fn merge_change_request(&self, _repo_root: &Path, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+    async fn list_merged_branch_names(&self, _repo_root: &Path, _limit: usize) -> Result<Vec<String>, String> {
+        Ok(vec![])
+    }
+}
+
+struct MergeChangeRequestTracker {
+    calls: tokio::sync::Mutex<Vec<String>>,
+    result: Result<(), String>,
+}
+
+#[async_trait]
+impl ChangeRequestTracker for MergeChangeRequestTracker {
+    async fn list_change_requests(&self, _repo_root: &Path, _limit: usize) -> Result<Vec<(String, ChangeRequest)>, String> {
+        Ok(vec![])
+    }
+    async fn get_change_request(&self, _repo_root: &Path, _id: &str) -> Result<(String, ChangeRequest), String> {
+        Err("not implemented".to_string())
+    }
+    async fn open_in_browser(&self, _repo_root: &Path, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+    async fn close_change_request(&self, _repo_root: &Path, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+    async fn merge_change_request(&self, _repo_root: &Path, id: &str) -> Result<(), String> {
+        self.calls.lock().await.push(id.to_string());
+        self.result.clone()
+    }
     async fn list_merged_branch_names(&self, _repo_root: &Path, _limit: usize) -> Result<Vec<String>, String> {
         Ok(vec![])
     }
@@ -1526,6 +1557,74 @@ async fn close_change_request_with_provider() {
         run_build_plan_to_completion(CommandAction::CloseChangeRequest { id: "42".to_string() }, registry, empty_data(), runner).await;
 
     assert_ok(result);
+}
+
+// -----------------------------------------------------------------------
+// Tests: MergeChangeRequest
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn merge_change_request_requires_confirmation() {
+    let result = run_build_plan_to_completion(
+        CommandAction::MergeChangeRequest { id: "42".to_string(), confirmed: false },
+        empty_registry(),
+        empty_data(),
+        runner_ok(),
+    )
+    .await;
+
+    assert_error_contains(result, "confirmation");
+}
+
+#[tokio::test]
+async fn merge_change_request_requires_provider() {
+    let result = run_build_plan_to_completion(
+        CommandAction::MergeChangeRequest { id: "42".to_string(), confirmed: true },
+        empty_registry(),
+        empty_data(),
+        runner_ok(),
+    )
+    .await;
+
+    assert_error_contains(result, "change request provider");
+}
+
+#[tokio::test]
+async fn merge_change_request_calls_provider() {
+    let provider = Arc::new(MergeChangeRequestTracker { calls: tokio::sync::Mutex::new(Vec::new()), result: Ok(()) });
+    let mut registry = empty_registry();
+    registry.change_requests.insert("github", desc("github"), provider.clone());
+
+    let result = run_build_plan_to_completion(
+        CommandAction::MergeChangeRequest { id: "42".to_string(), confirmed: true },
+        registry,
+        empty_data(),
+        runner_ok(),
+    )
+    .await;
+
+    assert_ok(result);
+    assert_eq!(provider.calls.lock().await.as_slice(), ["42"]);
+}
+
+#[tokio::test]
+async fn merge_change_request_surfaces_provider_failure() {
+    let provider = Arc::new(MergeChangeRequestTracker {
+        calls: tokio::sync::Mutex::new(Vec::new()),
+        result: Err("merge blocked by required checks".to_string()),
+    });
+    let mut registry = empty_registry();
+    registry.change_requests.insert("github", desc("github"), provider);
+
+    let result = run_build_plan_to_completion(
+        CommandAction::MergeChangeRequest { id: "42".to_string(), confirmed: true },
+        registry,
+        empty_data(),
+        runner_ok(),
+    )
+    .await;
+
+    assert_error_eq(result, "merge blocked by required checks");
 }
 
 // -----------------------------------------------------------------------

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -21,13 +21,13 @@ use flotilla_protocol::{
     commands::RepositoryIdentityChange,
     qualified_path::{HostId, QualifiedPath},
     result_set::{ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
-    AttachBinding, Command, CommandValue, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry,
-    EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
-    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PrincipalRef,
-    ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse,
-    RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand, ResourceJsonResponse,
-    ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory,
-    TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    AttachBinding, Command, CommandAction, CommandValue, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent,
+    DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse,
+    HostName, HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState,
+    PrincipalRef, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta,
+    RepoDetailResponse, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand,
+    ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo,
+    ToolInventory, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
@@ -2427,6 +2427,7 @@ impl InProcessDaemon {
             CommandAction::FetchCheckoutStatus { .. }
             | CommandAction::OpenChangeRequest { .. }
             | CommandAction::CloseChangeRequest { .. }
+            | CommandAction::MergeChangeRequest { .. }
             | CommandAction::OpenIssue { .. }
             | CommandAction::LinkIssuesToChangeRequest { .. }
             | CommandAction::ArchiveSession { .. }
@@ -2441,6 +2442,33 @@ impl InProcessDaemon {
             }
             _ => Err("command does not resolve to a single repo".to_string()),
         }
+    }
+
+    async fn repository_action_policy_error(&self, command: &Command, repo: &Path) -> Option<String> {
+        let CommandAction::MergeChangeRequest { id, .. } = &command.action else {
+            return None;
+        };
+        let repository_key = match self.repository_keys_by_path.read().await.get(repo).cloned() {
+            Some(key) => key,
+            None => {
+                return Some(format!(
+                    "cannot determine whether merging change request {id} is permitted: repository policy is unavailable"
+                ));
+            }
+        };
+        let namespace = self.provisioning_namespace().await;
+        let repository = match self.resource_backend.clone().using::<Repository>(&namespace).get(&repository_key.to_string()).await {
+            Ok(repository) => repository,
+            Err(error) => {
+                return Some(format!(
+                    "cannot determine whether merging change request {id} is permitted: repository policy is unavailable: {error}"
+                ));
+            }
+        };
+        repository
+            .spec
+            .is_fork()
+            .then(|| format!("merging change request {id} is forbidden for fork-stance repository; landing is human-only"))
     }
 
     /// Get the local-only provider data for a repo (without peer overlay).
@@ -6597,6 +6625,7 @@ impl InProcessDaemon {
 
         // Gather what the spawned task needs — validate repo before broadcasting
         let repo = self.resolve_repo_for_command(&command).await?;
+        let repository_action_policy_error = self.repository_action_policy_error(&command, &repo).await;
         let runner = Arc::clone(&self.discovery.runner);
         let env = Arc::clone(&self.discovery.env);
         let event_tx = self.event_tx.clone();
@@ -6657,18 +6686,23 @@ impl InProcessDaemon {
             let resolver_repo = executor::RepoExecutionContext { identity: repo_identity.clone(), root: ee_repo_path.clone() };
             let daemon_socket_dhp = daemon_socket_path.map(DaemonHostPath::new);
 
-            let plan = executor::build_plan(
-                command,
-                executor::RepoExecutionContext { identity: repo_identity.clone(), root: ee_repo_path },
-                registry,
-                providers_data,
-                config_base,
-                attachable_store,
-                daemon_socket_dhp.clone(),
-                local_node_id.clone(),
-                local_host,
-            )
-            .await;
+            let plan = match repository_action_policy_error {
+                Some(message) => Err(CommandValue::Error { message }),
+                None => {
+                    executor::build_plan(
+                        command,
+                        executor::RepoExecutionContext { identity: repo_identity.clone(), root: ee_repo_path },
+                        registry,
+                        providers_data,
+                        config_base,
+                        attachable_store,
+                        daemon_socket_dhp.clone(),
+                        local_node_id.clone(),
+                        local_host,
+                    )
+                    .await
+                }
+            };
 
             match plan {
                 Err(result) => {

--- a/crates/flotilla-core/src/model/tests.rs
+++ b/crates/flotilla-core/src/model/tests.rs
@@ -100,6 +100,9 @@ impl ChangeRequestTracker for StubChangeRequestTracker {
     async fn close_change_request(&self, _: &Path, _: &str) -> Result<(), String> {
         Ok(())
     }
+    async fn merge_change_request(&self, _: &Path, _: &str) -> Result<(), String> {
+        Ok(())
+    }
     async fn list_merged_branch_names(&self, _: &Path, _: usize) -> Result<Vec<String>, String> {
         Ok(vec![])
     }

--- a/crates/flotilla-core/src/providers/change_request/fixtures/github_merge.yaml
+++ b/crates/flotilla-core/src/providers/change_request/fixtures/github_merge.yaml
@@ -1,0 +1,12 @@
+interactions:
+- channel: command
+  cmd: gh
+  args:
+  - pr
+  - merge
+  - '42'
+  - --squash
+  cwd: /test/repo
+  stdout: ''
+  stderr: null
+  exit_code: 0

--- a/crates/flotilla-core/src/providers/change_request/github.rs
+++ b/crates/flotilla-core/src/providers/change_request/github.rs
@@ -167,6 +167,11 @@ impl super::ChangeRequestTracker for GitHubChangeRequest {
         Ok(())
     }
 
+    async fn merge_change_request(&self, repo_root: &Path, id: &str) -> Result<(), String> {
+        run!(self.runner, "gh", &["pr", "merge", id, "--squash"], repo_root)?;
+        Ok(())
+    }
+
     async fn list_merged_branch_names(&self, repo_root: &Path, limit: usize) -> Result<Vec<String>, String> {
         let per_page = clamp_per_page(limit);
         let endpoint = format!("repos/{}/pulls?state=closed&sort=updated&direction=desc&per_page={}", self.repo_slug, per_page);
@@ -241,6 +246,20 @@ mod tests {
         for name in &branches {
             assert!(!name.is_empty());
         }
+
+        session.finish();
+    }
+
+    #[tokio::test]
+    async fn replay_merge_change_request_uses_squash() {
+        // Merging is destructive on a live forge, so this interaction is
+        // intentionally replay-only rather than recordable in place.
+        let session = replay::Session::replaying(fixture("github_merge.yaml"), Masks::new());
+        let repo_root = PathBuf::from("/test/repo");
+        let (api, runner) = build_api_and_runner(&session);
+        let provider = GitHubChangeRequest::new("github".into(), "rjwittams/flotilla".into(), api, runner);
+
+        provider.merge_change_request(&repo_root, "42").await.expect("merge change request");
 
         session.finish();
     }

--- a/crates/flotilla-core/src/providers/change_request/mod.rs
+++ b/crates/flotilla-core/src/providers/change_request/mod.rs
@@ -20,5 +20,6 @@ pub trait ChangeRequestTracker: Send + Sync {
     async fn get_change_request(&self, repo_root: &Path, id: &str) -> Result<(String, ChangeRequest), String>;
     async fn open_in_browser(&self, repo_root: &Path, id: &str) -> Result<(), String>;
     async fn close_change_request(&self, repo_root: &Path, id: &str) -> Result<(), String>;
+    async fn merge_change_request(&self, repo_root: &Path, id: &str) -> Result<(), String>;
     async fn list_merged_branch_names(&self, repo_root: &Path, limit: usize) -> Result<Vec<String>, String>;
 }

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -942,6 +942,16 @@ impl ChangeRequestTracker for FakeChangeRequest {
         }
     }
 
+    async fn merge_change_request(&self, _repo_root: &Path, id: &str) -> Result<(), String> {
+        let mut store = self.change_requests.lock().await;
+        if let Some((_, cr)) = store.iter_mut().find(|(cr_id, _)| cr_id == id) {
+            cr.status = ChangeRequestStatus::Merged;
+            Ok(())
+        } else {
+            Err(format!("change request {id} not found"))
+        }
+    }
+
     async fn list_merged_branch_names(&self, _repo_root: &Path, limit: usize) -> Result<Vec<String>, String> {
         let store = self.merged_branches.lock().await;
         Ok(store.iter().take(limit).cloned().collect())

--- a/crates/flotilla-core/src/refresh/tests.rs
+++ b/crates/flotilla-core/src/refresh/tests.rs
@@ -110,6 +110,10 @@ impl ChangeRequestTracker for MockChangeRequestTracker {
         Ok(())
     }
 
+    async fn merge_change_request(&self, _repo_root: &Path, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+
     async fn list_merged_branch_names(&self, _repo_root: &Path, _limit: usize) -> Result<Vec<String>, String> {
         self.merged_result.clone()
     }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -23,9 +23,9 @@ use flotilla_core::{
         discovery::{
             test_support::{
                 fake_discovery, fake_discovery_with_provider_set, fake_discovery_with_providers, fake_vcs_discovery, git_process_discovery,
-                init_git_repo, init_git_repo_with_remote, DiscoveryMockRunner, FakeCheckoutManager, FakeCheckoutManagerFactory,
-                FakeDiscoveryProviders, FakeIssueProvider, FakePresentationManager, FakeTerminalPool, FakeVcsFactory, FakeVcsState,
-                TestEnvVars,
+                init_git_repo, init_git_repo_with_remote, DiscoveryMockRunner, FakeChangeRequest, FakeCheckoutManager,
+                FakeCheckoutManagerFactory, FakeDiscoveryProviders, FakeIssueProvider, FakePresentationManager, FakeTerminalPool,
+                FakeVcsFactory, FakeVcsState, TestEnvVars,
             },
             DiscoveryRuntime, EnvironmentAssertion, EnvironmentBag, Factory, HostDetector, HostPlatform, ProviderCategory,
             ProviderDescriptor, RepoDetector, UnmetRequirement,
@@ -640,6 +640,10 @@ impl ChangeRequestTracker for FailingChangeRequestTracker {
         Ok(())
     }
 
+    async fn merge_change_request(&self, _: &Path, _: &str) -> Result<(), String> {
+        Ok(())
+    }
+
     async fn list_merged_branch_names(&self, _: &Path, _: usize) -> Result<Vec<String>, String> {
         Err("merged branch listing failed".into())
     }
@@ -1018,6 +1022,54 @@ async fn fork_stance_refuses_reviewless_dispatch_and_admits_implement_review() {
         flotilla_resources::CrewSource::Agent { selector, brief_template: Some(template), .. }
             if selector.capability == "code-review" && template == "diff-review"
     ));
+}
+
+#[tokio::test]
+async fn fork_stance_refuses_change_request_merge_without_calling_provider() {
+    let provider = Arc::new(FakeChangeRequest::new());
+    provider
+        .add_change_requests(vec![("42".to_string(), ChangeRequest {
+            title: "Keep landing human-owned".to_string(),
+            branch: "stack/fork-fix".to_string(),
+            status: flotilla_protocol::ChangeRequestStatus::Open,
+            body: None,
+            correlation_keys: Vec::new(),
+            association_keys: Vec::new(),
+            provider_name: "fake-cr".to_string(),
+            provider_display_name: "Fake PRs".to_string(),
+        })])
+        .await;
+    let discovery = fake_discovery_with_provider_set(
+        FakeDiscoveryProviders::new().with_change_request(provider.clone() as Arc<dyn ChangeRequestTracker>),
+    );
+    let (_temp, repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("reconcile repository identity");
+    let repository_key = daemon.repository_key_for_path(&repo).await.expect("tracked repository key");
+    let repositories = daemon.resource_backend().using::<Repository>("flotilla");
+    let stored = repositories.get(&repository_key.to_string()).await.expect("stored repository");
+    let fork_spec =
+        stored.spec.clone().with_upstream("https://github.com/upstream/repo", RepositoryRelation::Fork).expect("fork provenance");
+    repositories
+        .update(&InputMeta::from(&stored.metadata), &stored.metadata.resource_version, &fork_spec)
+        .await
+        .expect("apply fork stance");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: Some(RepoSelector::Path(repo)),
+            action: CommandAction::MergeChangeRequest { id: "42".to_string(), confirmed: true },
+        })
+        .await
+        .expect("dispatch merge command");
+
+    assert_eq!(recv_command_finished(&mut events, command_id).await, CommandValue::Error {
+        message: "merging change request 42 is forbidden for fork-stance repository; landing is human-only".to_string(),
+    });
+    let (_, request) = provider.get_change_request(Path::new("/unused"), "42").await.expect("change request should remain available");
+    assert_eq!(request.status, flotilla_protocol::ChangeRequestStatus::Open);
 }
 
 async fn create_test_host_direct_policy(

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -256,6 +256,11 @@ pub enum CommandAction {
     CloseChangeRequest {
         id: String,
     },
+    MergeChangeRequest {
+        id: String,
+        #[serde(default, skip_serializing_if = "is_false")]
+        confirmed: bool,
+    },
     OpenIssue {
         id: String,
     },
@@ -472,6 +477,7 @@ impl Command {
             CommandAction::FetchCheckoutStatus { .. } => "Fetching checkout status...",
             CommandAction::OpenChangeRequest { .. } => "Opening in browser...",
             CommandAction::CloseChangeRequest { .. } => "Closing PR...",
+            CommandAction::MergeChangeRequest { .. } => "Merging change request...",
             CommandAction::OpenIssue { .. } => "Opening in browser...",
             CommandAction::LinkIssuesToChangeRequest { .. } => "Linking issues...",
             CommandAction::ArchiveSession { .. } => "Archiving session...",
@@ -803,6 +809,12 @@ mod tests {
                 provisioning_target: None,
                 context_repo: Some(RepoSelector::Query("owner/repo".into())),
                 action: CommandAction::CloseChangeRequest { id: "99".into() },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: Some(RepoSelector::Query("owner/repo".into())),
+                action: CommandAction::MergeChangeRequest { id: "99".into(), confirmed: true },
             },
             Command {
                 node_id: None,
@@ -1448,6 +1460,12 @@ mod tests {
                 provisioning_target: None,
                 context_repo: Some(RepoSelector::Path(PathBuf::from("/tmp"))),
                 action: CommandAction::CloseChangeRequest { id: "1".into() },
+            },
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: Some(RepoSelector::Path(PathBuf::from("/tmp"))),
+                action: CommandAction::MergeChangeRequest { id: "1".into(), confirmed: true },
             },
             Command {
                 node_id: None,

--- a/crates/flotilla-protocol/src/step.rs
+++ b/crates/flotilla-protocol/src/step.rs
@@ -120,6 +120,9 @@ pub enum StepAction {
     CloseChangeRequest {
         id: String,
     },
+    MergeChangeRequest {
+        id: String,
+    },
     OpenIssue {
         id: String,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1214,6 +1214,7 @@ fn confirm_command(
         *confirmed = true;
         Ok(true)
     } else {
+        writeln!(output, "Merge cancelled.").map_err(|error| error.to_string())?;
         Ok(false)
     }
 }
@@ -1998,6 +1999,7 @@ mod tests {
 
         assert!(!confirm_command(&mut command, true, &mut input, &mut output).expect("confirmation prompt"));
         assert!(matches!(command.action, flotilla_protocol::CommandAction::MergeChangeRequest { confirmed: false, .. }));
+        assert_eq!(String::from_utf8(output).expect("utf8 prompt"), "Merge change request 42 using squash? [y/N] Merge cancelled.\n");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1190,6 +1190,47 @@ fn inject_repo_context(cmd: &mut Command, cli: &Cli) -> Result<()> {
     Ok(())
 }
 
+fn confirm_command(
+    command: &mut Command,
+    interactive: bool,
+    input: &mut dyn std::io::BufRead,
+    output: &mut dyn std::io::Write,
+) -> Result<bool, String> {
+    let CommandAction::MergeChangeRequest { id, confirmed } = &mut command.action else {
+        return Ok(true);
+    };
+    if *confirmed {
+        return Ok(true);
+    }
+    if !interactive {
+        return Err("merging a change request non-interactively requires --yes".to_string());
+    }
+
+    write!(output, "Merge change request {id} using squash? [y/N] ").map_err(|error| error.to_string())?;
+    output.flush().map_err(|error| error.to_string())?;
+    let mut response = String::new();
+    input.read_line(&mut response).map_err(|error| error.to_string())?;
+    if matches!(response.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        *confirmed = true;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+async fn run_confirmed_control_command(cli: &Cli, mut command: Command, format: OutputFormat) -> Result<()> {
+    use std::io::IsTerminal;
+
+    let stdin = std::io::stdin();
+    let interactive = stdin.is_terminal();
+    let mut input = stdin.lock();
+    let mut output = std::io::stderr().lock();
+    if !confirm_command(&mut command, interactive, &mut input, &mut output).map_err(color_eyre::eyre::Report::msg)? {
+        return Ok(());
+    }
+    run_control_command(cli, command, format).await
+}
+
 async fn dispatch(resolved: flotilla_commands::Resolved, cli: &Cli, format: OutputFormat) -> Result<()> {
     use flotilla_commands::{resolved::HostQueryKind, RepoContext, Resolved};
     reset_sigpipe();
@@ -1200,10 +1241,14 @@ async fn dispatch(resolved: flotilla_commands::Resolved, cli: &Cli, format: Outp
                 HostQueryKind::Status => CommandAction::QueryHostStatus { target_environment_id: environment_id },
                 HostQueryKind::Providers => CommandAction::QueryHostProviders { target_environment_id: environment_id },
             };
-            run_control_command(cli, Command { node_id: Some(node_id), provisioning_target: None, context_repo: None, action }, format)
-                .await
+            run_confirmed_control_command(
+                cli,
+                Command { node_id: Some(node_id), provisioning_target: None, context_repo: None, action },
+                format,
+            )
+            .await
         }
-        Resolved::Ready(cmd) => run_control_command(cli, cmd, format).await,
+        Resolved::Ready(cmd) => run_confirmed_control_command(cli, cmd, format).await,
         Resolved::NeedsContext { mut command, repo, host } => {
             match repo {
                 RepoContext::None => {}
@@ -1225,7 +1270,7 @@ async fn dispatch(resolved: flotilla_commands::Resolved, cli: &Cli, format: Outp
                     _ => {}
                 }
             }
-            run_control_command(cli, command, format).await
+            run_confirmed_control_command(cli, command, format).await
         }
     }
 }
@@ -1519,9 +1564,9 @@ mod tests {
     };
 
     use super::{
-        attach_exit_disposition, default_project_landing, provisioning_target_for_environment, run_replica_snapshot, select_host_target,
-        select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition, Cli,
-        ResourceApplyArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
+        attach_exit_disposition, confirm_command, default_project_landing, provisioning_target_for_environment, run_replica_snapshot,
+        select_host_target, select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition,
+        Cli, ResourceApplyArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
     };
 
     fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
@@ -1920,6 +1965,54 @@ mod tests {
     fn cli_no_subcommand_is_none() {
         let cli = Cli::try_parse_from(["flotilla"]).expect("bare cli should parse");
         assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn interactive_merge_confirmation_marks_command_confirmed() {
+        let mut command = flotilla_protocol::Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: flotilla_protocol::CommandAction::MergeChangeRequest { id: "42".into(), confirmed: false },
+        };
+        let mut input = std::io::Cursor::new(b"yes\n");
+        let mut output = Vec::new();
+
+        let proceed = confirm_command(&mut command, true, &mut input, &mut output).expect("confirmation prompt");
+
+        assert!(proceed);
+        assert!(matches!(command.action, flotilla_protocol::CommandAction::MergeChangeRequest { confirmed: true, .. }));
+        assert_eq!(String::from_utf8(output).expect("utf8 prompt"), "Merge change request 42 using squash? [y/N] ");
+    }
+
+    #[test]
+    fn interactive_merge_decline_does_not_dispatch() {
+        let mut command = flotilla_protocol::Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: flotilla_protocol::CommandAction::MergeChangeRequest { id: "42".into(), confirmed: false },
+        };
+        let mut input = std::io::Cursor::new(b"n\n");
+        let mut output = Vec::new();
+
+        assert!(!confirm_command(&mut command, true, &mut input, &mut output).expect("confirmation prompt"));
+        assert!(matches!(command.action, flotilla_protocol::CommandAction::MergeChangeRequest { confirmed: false, .. }));
+    }
+
+    #[test]
+    fn non_interactive_merge_requires_yes_flag() {
+        let mut command = flotilla_protocol::Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: flotilla_protocol::CommandAction::MergeChangeRequest { id: "42".into(), confirmed: false },
+        };
+
+        let error = confirm_command(&mut command, false, &mut std::io::empty(), &mut std::io::sink())
+            .expect_err("non-interactive merge must require explicit confirmation");
+
+        assert_eq!(error, "merging a change request non-interactively requires --yes");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add the canonical `flotilla cr <id> merge` command with interactive confirmation and `--yes` for non-interactive use
- carry merge through the protocol, executor, and change-request provider using squash semantics
- refuse merge for fork-stance repositories where landing is human-only
- cover CLI confirmation, protocol round-trips, executor behavior, fork policy, and GitHub replay behavior

## Impact

Operators can merge a change request from the CLI without adding a TUI action. Destructive execution remains confirmation-gated, and fork-stance repositories fail closed.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- focused CLI, protocol, executor, provider replay, and in-process fork-policy tests
- documented repo-local `TMPDIR` rerun for the macOS temp-path-sensitive fork configuration test

Closes #1078