### PR TITLE
fix: tolerate drifted replica snapshot records

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -661,7 +661,11 @@ struct ReplicaParseDiagnostics {
 
 impl ReplicaParseDiagnostics {
     fn record_skip(&mut self, path: impl std::fmt::Display, error: impl std::fmt::Display) {
-        self.skipped_records += 1;
+        self.record_skips(1, path, error);
+    }
+
+    fn record_skips(&mut self, count: usize, path: impl std::fmt::Display, error: impl std::fmt::Display) {
+        self.skipped_records += count;
         self.first_error.get_or_insert_with(|| format!("{path}: {error}"));
     }
 }
@@ -675,6 +679,8 @@ struct ParsedFleetReplicaSnapshot {
 fn result_set_records_mut(result_set: &mut serde_json::Value) -> Option<&mut Vec<serde_json::Value>> {
     let content = result_set.get_mut("rows")?.get_mut("rows")?;
     if content.is_array() {
+        // Tuple-style variants such as Rows::Convoys serialize their content
+        // directly as the record array.
         content.as_array_mut()
     } else {
         content.get_mut("rows")?.as_array_mut()
@@ -699,7 +705,7 @@ fn retain_parseable_result_set_records(
 
     let envelope = result_set.clone();
     if let Err(error) = serde_json::from_value::<ResultSet>(envelope.clone()) {
-        diagnostics.record_skip(format_args!("result_sets[{result_set_index}]"), error);
+        diagnostics.record_skips(records.len().max(1), format_args!("result_sets[{result_set_index}]"), error);
         return false;
     }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -677,14 +677,7 @@ struct ParsedFleetReplicaSnapshot {
 }
 
 fn result_set_records_mut(result_set: &mut serde_json::Value) -> Option<&mut Vec<serde_json::Value>> {
-    let content = result_set.get_mut("rows")?.get_mut("rows")?;
-    if content.is_array() {
-        // Tuple-style variants such as Rows::Convoys serialize their content
-        // directly as the record array.
-        content.as_array_mut()
-    } else {
-        content.get_mut("rows")?.as_array_mut()
-    }
+    result_set.get_mut("rows")?.get_mut("rows")?.get_mut("rows")?.as_array_mut()
 }
 
 fn retain_parseable_result_set_records(

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -653,6 +653,98 @@ fn replica_staleness(entry: &FleetReplicaCacheEntry, now: DateTime<Utc>) -> Flee
     }
 }
 
+#[derive(Debug, Default)]
+struct ReplicaParseDiagnostics {
+    skipped_records: usize,
+    first_error: Option<String>,
+}
+
+impl ReplicaParseDiagnostics {
+    fn record_skip(&mut self, path: impl std::fmt::Display, error: impl std::fmt::Display) {
+        self.skipped_records += 1;
+        self.first_error.get_or_insert_with(|| format!("{path}: {error}"));
+    }
+}
+
+#[derive(Debug)]
+struct ParsedFleetReplicaSnapshot {
+    snapshot: FleetReplicaSnapshot,
+    diagnostics: ReplicaParseDiagnostics,
+}
+
+fn result_set_records_mut(result_set: &mut serde_json::Value) -> Option<&mut Vec<serde_json::Value>> {
+    let content = result_set.get_mut("rows")?.get_mut("rows")?;
+    if content.is_array() {
+        content.as_array_mut()
+    } else {
+        content.get_mut("rows")?.as_array_mut()
+    }
+}
+
+fn retain_parseable_result_set_records(
+    result_set: &mut serde_json::Value,
+    result_set_index: usize,
+    diagnostics: &mut ReplicaParseDiagnostics,
+) -> bool {
+    let Some(records) = result_set_records_mut(result_set) else {
+        return match serde_json::from_value::<ResultSet>(result_set.clone()) {
+            Ok(_) => true,
+            Err(error) => {
+                diagnostics.record_skip(format_args!("result_sets[{result_set_index}]"), error);
+                false
+            }
+        };
+    };
+    let records = std::mem::take(records);
+
+    let envelope = result_set.clone();
+    if let Err(error) = serde_json::from_value::<ResultSet>(envelope.clone()) {
+        diagnostics.record_skip(format_args!("result_sets[{result_set_index}]"), error);
+        return false;
+    }
+
+    let mut retained = Vec::with_capacity(records.len());
+    for (record_index, record) in records.into_iter().enumerate() {
+        let mut candidate = envelope.clone();
+        result_set_records_mut(&mut candidate).expect("validated result set has a row array").push(record.clone());
+        match serde_json::from_value::<ResultSet>(candidate) {
+            Ok(_) => retained.push(record),
+            Err(error) => {
+                diagnostics.record_skip(format_args!("result_sets[{result_set_index}].rows[{record_index}]"), error);
+            }
+        }
+    }
+    *result_set_records_mut(result_set).expect("validated result set has a row array") = retained;
+    true
+}
+
+fn parse_fleet_replica_snapshot(input: &str) -> Result<ParsedFleetReplicaSnapshot, String> {
+    let mut value: serde_json::Value = serde_json::from_str(input).map_err(|error| format!("replica snapshot parse failed: {error}"))?;
+    let mut diagnostics = ReplicaParseDiagnostics::default();
+
+    if let Some(rows) = value.get_mut("rows").and_then(serde_json::Value::as_array_mut) {
+        let records = std::mem::take(rows);
+        for (index, record) in records.into_iter().enumerate() {
+            match serde_json::from_value::<FleetListRow>(record.clone()) {
+                Ok(_) => rows.push(record),
+                Err(error) => diagnostics.record_skip(format_args!("rows[{index}]"), error),
+            }
+        }
+    }
+
+    if let Some(result_sets) = value.get_mut("result_sets").and_then(serde_json::Value::as_array_mut) {
+        let records = std::mem::take(result_sets);
+        for (index, mut record) in records.into_iter().enumerate() {
+            if retain_parseable_result_set_records(&mut record, index, &mut diagnostics) {
+                result_sets.push(record);
+            }
+        }
+    }
+
+    let snapshot = serde_json::from_value(value).map_err(|error| format!("replica snapshot parse failed outside a record: {error}"))?;
+    Ok(ParsedFleetReplicaSnapshot { snapshot, diagnostics })
+}
+
 fn parse_and_validate_workflow_template_yaml(yaml: &str) -> Result<WorkflowTemplateSpec, String> {
     let spec: WorkflowTemplateSpec = serde_yml::from_str(yaml).map_err(|err| format!("invalid workflow template YAML: {err}"))?;
     flotilla_resources::validate(&spec).map_err(|errors| {
@@ -1085,6 +1177,8 @@ struct FleetReplicaCacheEntry {
     result_sets: Vec<ResultSet>,
     last_sync: Option<DateTime<Utc>>,
     generation: Option<String>,
+    skipped_records: usize,
+    first_parse_error: Option<String>,
     last_error: Option<String>,
 }
 
@@ -4719,6 +4813,8 @@ impl InProcessDaemon {
                         reachable: entry.last_error.is_none(),
                         last_sync: entry.last_sync,
                         generation: entry.generation.clone(),
+                        skipped_records: entry.skipped_records,
+                        first_parse_error: entry.first_parse_error.clone(),
                         message: entry.last_error.clone(),
                     });
                 }
@@ -4728,6 +4824,8 @@ impl InProcessDaemon {
                         reachable: false,
                         last_sync: None,
                         generation: None,
+                        skipped_records: 0,
+                        first_parse_error: None,
                         message: Some(format!("replica source '{label}' has not synced yet")),
                     });
                 }
@@ -5293,8 +5391,10 @@ impl InProcessDaemon {
             let multiplex = hosts.resolved_ssh_multiplex(label);
             let result = self.fetch_fleet_replica_snapshot(remote, multiplex, Arc::clone(&runner)).await;
             match result {
-                Ok(snapshot) => {
+                Ok(parsed) => {
                     let now = Utc::now();
+                    let diagnostics = parsed.diagnostics;
+                    let snapshot = parsed.snapshot;
                     let snapshot_host = snapshot.host;
                     let generation = snapshot.generation;
                     let result_sets = snapshot.result_sets.clone();
@@ -5316,6 +5416,8 @@ impl InProcessDaemon {
                         result_sets,
                         last_sync: Some(now),
                         generation,
+                        skipped_records: diagnostics.skipped_records,
+                        first_parse_error: diagnostics.first_error,
                         last_error: None,
                     });
                 }
@@ -5327,6 +5429,8 @@ impl InProcessDaemon {
                             result_sets: Vec::new(),
                             last_sync: None,
                             generation: None,
+                            skipped_records: 0,
+                            first_parse_error: None,
                             last_error: Some(message),
                         }
                     });
@@ -5342,7 +5446,7 @@ impl InProcessDaemon {
         remote: &RemoteHostConfig,
         multiplex: bool,
         runner: Arc<dyn CommandRunner>,
-    ) -> Result<FleetReplicaSnapshot, String> {
+    ) -> Result<ParsedFleetReplicaSnapshot, String> {
         let args = fleet_replica_ssh_args(remote, multiplex);
         let arg_refs: Vec<_> = args.iter().map(String::as_str).collect();
         let output =
@@ -5354,7 +5458,7 @@ impl InProcessDaemon {
             let message = if output.stderr.trim().is_empty() { output.stdout.trim() } else { output.stderr.trim() };
             return Err(format!("replica snapshot command failed: {message}"));
         }
-        serde_json::from_str(output.stdout.trim()).map_err(|err| format!("replica snapshot parse failed: {err}"))
+        parse_fleet_replica_snapshot(output.stdout.trim())
     }
 
     async fn local_fleet_rows(&self, namespace: &str) -> Result<(Vec<FleetListRow>, Option<String>), String> {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1912,7 +1912,7 @@ async fn replica_refresh_replaces_rows_when_generation_changes() {
 }
 
 #[tokio::test]
-async fn replica_refresh_skips_a_drifted_record_and_reports_the_parse_skew() {
+async fn replica_refresh_skips_drifted_records_and_reports_the_parse_skew() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -1940,13 +1940,23 @@ async fn replica_refresh_skips_a_drifted_record_and_reports_the_parse_skew() {
             state: Default::default(),
         }],
     };
-    let mut drifted_snapshot = serde_json::to_value(snapshot).expect("serialize replica snapshot");
-    drifted_snapshot["result_sets"][0]["rows"]["rows"]["rows"][0].as_object_mut().expect("checkout row object").remove("repo_label");
-    let runner = Arc::new(QueuedOutputRunner::new(vec![CommandOutput {
-        stdout: serde_json::to_string(&drifted_snapshot).expect("serialize drifted snapshot"),
-        stderr: String::new(),
-        success: true,
-    }]));
+    let snapshot = serde_json::to_value(snapshot).expect("serialize replica snapshot");
+    let mut drifted_record_snapshot = snapshot.clone();
+    drifted_record_snapshot["result_sets"][0]["rows"]["rows"]["rows"][0].as_object_mut().expect("checkout row object").remove("repo_label");
+    let mut drifted_envelope_snapshot = snapshot;
+    drifted_envelope_snapshot["result_sets"][0]["rows"]["rows"]["scope"] = serde_json::json!(42);
+    let runner = Arc::new(QueuedOutputRunner::new(vec![
+        CommandOutput {
+            stdout: serde_json::to_string(&drifted_record_snapshot).expect("serialize record-drifted snapshot"),
+            stderr: String::new(),
+            success: true,
+        },
+        CommandOutput {
+            stdout: serde_json::to_string(&drifted_envelope_snapshot).expect("serialize envelope-drifted snapshot"),
+            stderr: String::new(),
+            success: true,
+        },
+    ]));
     let mut discovery =
         fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(Arc::new(FakeTerminalPool::new())));
     discovery.runner = runner;
@@ -1968,6 +1978,23 @@ async fn replica_refresh_skips_a_drifted_record_and_reports_the_parse_skew() {
             .as_str()
             .is_some_and(|error| error.contains("result_sets[0].rows[0]") && error.contains("missing field `repo_label`")),
         "status should report the first parse error: {status}"
+    );
+
+    daemon.refresh_fleet_replicas_once().await.expect("envelope-drifted refresh should succeed");
+
+    let cached = daemon.cached_fleet_replica_snapshots().await;
+    assert!(cached[0].result_sets.is_empty(), "an unparseable result-set envelope cannot retain its rows");
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+    assert!(response.replicas[0].reachable);
+    assert_eq!(response.replicas[0].generation.as_deref(), Some("gen-drifted"));
+    assert_eq!(response.replicas[0].skipped_records, 2);
+    assert!(
+        response.replicas[0]
+            .first_parse_error
+            .as_deref()
+            .is_some_and(|error| error.contains("result_sets[0]") && error.contains("invalid type: integer `42`")),
+        "status should count every row dropped with an unparseable envelope: {:?}",
+        response.replicas[0]
     );
 }
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1930,10 +1930,21 @@ async fn replica_refresh_skips_drifted_records_and_reports_the_parse_skew() {
             .authority(LifecycleAuthority::Observed)
             .build()
     };
+    let fleet_row = |convoy: &str| {
+        FleetListRow::builder()
+            .convoy(convoy)
+            .vessel("implement")
+            .crew("implement/coder")
+            .crew_state("running")
+            .host(HostName::new("feta"))
+            .namespace("flotilla")
+            .staleness(FleetStaleness::Local)
+            .build()
+    };
     let snapshot = FleetReplicaSnapshot {
         host: HostName::new("feta"),
         generation: Some("gen-drifted".to_string()),
-        rows: vec![],
+        rows: vec![fleet_row("drifted-flat"), fleet_row("valid-flat")],
         result_sets: vec![ResultSet {
             seq: 4,
             rows: Rows::Checkouts { scope: None, rows: vec![checkout("drifted"), checkout("valid")] },
@@ -1943,8 +1954,10 @@ async fn replica_refresh_skips_drifted_records_and_reports_the_parse_skew() {
     let snapshot = serde_json::to_value(snapshot).expect("serialize replica snapshot");
     let mut drifted_record_snapshot = snapshot.clone();
     drifted_record_snapshot["result_sets"][0]["rows"]["rows"]["rows"][0].as_object_mut().expect("checkout row object").remove("repo_label");
-    let mut drifted_envelope_snapshot = snapshot;
+    let mut drifted_envelope_snapshot = snapshot.clone();
     drifted_envelope_snapshot["result_sets"][0]["rows"]["rows"]["scope"] = serde_json::json!(42);
+    let mut drifted_flat_snapshot = snapshot;
+    drifted_flat_snapshot["rows"][0].as_object_mut().expect("fleet row object").remove("namespace");
     let runner = Arc::new(QueuedOutputRunner::new(vec![
         CommandOutput {
             stdout: serde_json::to_string(&drifted_record_snapshot).expect("serialize record-drifted snapshot"),
@@ -1953,6 +1966,11 @@ async fn replica_refresh_skips_drifted_records_and_reports_the_parse_skew() {
         },
         CommandOutput {
             stdout: serde_json::to_string(&drifted_envelope_snapshot).expect("serialize envelope-drifted snapshot"),
+            stderr: String::new(),
+            success: true,
+        },
+        CommandOutput {
+            stdout: serde_json::to_string(&drifted_flat_snapshot).expect("serialize flat-record-drifted snapshot"),
             stderr: String::new(),
             success: true,
         },
@@ -1994,6 +2012,23 @@ async fn replica_refresh_skips_drifted_records_and_reports_the_parse_skew() {
             .as_deref()
             .is_some_and(|error| error.contains("result_sets[0]") && error.contains("invalid type: integer `42`")),
         "status should count every row dropped with an unparseable envelope: {:?}",
+        response.replicas[0]
+    );
+
+    daemon.refresh_fleet_replicas_once().await.expect("flat-record-drifted refresh should succeed");
+
+    let cached = daemon.cached_fleet_replica_snapshots().await;
+    assert!(matches!(cached[0].rows.as_slice(), [row] if row.convoy == "valid-flat"));
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+    assert!(response.replicas[0].reachable);
+    assert_eq!(response.replicas[0].generation.as_deref(), Some("gen-drifted"));
+    assert_eq!(response.replicas[0].skipped_records, 1);
+    assert!(
+        response.replicas[0]
+            .first_parse_error
+            .as_deref()
+            .is_some_and(|error| error.contains("rows[0]") && error.contains("missing field `namespace`")),
+        "status should report the drifted flat row: {:?}",
         response.replicas[0]
     );
 }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
     result_set::{
-        AwarenessGrouping, AwarenessKind, AwarenessLimit, ConvoyPhase as WireConvoyPhase, ConvoyRow, DemandBackedMetadata, IndependentRow,
-        IssueRow, QueryId, ResultSet, ResultSetState, Rows, SessionPhase,
+        AwarenessGrouping, AwarenessKind, AwarenessLimit, CheckoutRow, ConvoyPhase as WireConvoyPhase, ConvoyRow, DemandBackedMetadata,
+        IndependentRow, IssueRow, QueryId, ResultSet, ResultSetState, Rows, SessionPhase,
     },
     test_support::TestIssue,
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent,
@@ -1748,6 +1748,8 @@ async fn fleet_list_shows_simultaneous_convoys_on_kiwi_feta_and_udder() {
             result_sets: vec![],
             last_sync: Some(Utc::now()),
             generation: Some(format!("{host}-generation")),
+            skipped_records: 0,
+            first_parse_error: None,
             last_error: None,
         });
     }
@@ -1830,6 +1832,8 @@ async fn fleet_list_preserves_stale_rows_when_replica_is_unreachable() {
         result_sets: vec![],
         last_sync: Some(last_sync),
         generation: Some("gen-1".to_string()),
+        skipped_records: 0,
+        first_parse_error: None,
         last_error: Some("connection refused".to_string()),
     });
 
@@ -1905,6 +1909,66 @@ async fn replica_refresh_replaces_rows_when_generation_changes() {
     assert_eq!(response.replicas.len(), 1);
     assert!(response.replicas[0].reachable);
     assert_eq!(response.replicas[0].generation.as_deref(), Some("gen-2"));
+}
+
+#[tokio::test]
+async fn replica_refresh_skips_a_drifted_record_and_reports_the_parse_skew() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let checkout = |name: &str| {
+        CheckoutRow::builder()
+            .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "flotilla", name))
+            .repo(RepositoryKey("repo-key".to_string()))
+            .repo_label("flotilla-org/flotilla")
+            .path(format!("/work/{name}"))
+            .branch("main")
+            .host(HostName::new("feta"))
+            .authority(LifecycleAuthority::Observed)
+            .build()
+    };
+    let snapshot = FleetReplicaSnapshot {
+        host: HostName::new("feta"),
+        generation: Some("gen-drifted".to_string()),
+        rows: vec![],
+        result_sets: vec![ResultSet {
+            seq: 4,
+            rows: Rows::Checkouts { scope: None, rows: vec![checkout("drifted"), checkout("valid")] },
+            state: Default::default(),
+        }],
+    };
+    let mut drifted_snapshot = serde_json::to_value(snapshot).expect("serialize replica snapshot");
+    drifted_snapshot["result_sets"][0]["rows"]["rows"]["rows"][0].as_object_mut().expect("checkout row object").remove("repo_label");
+    let runner = Arc::new(QueuedOutputRunner::new(vec![CommandOutput {
+        stdout: serde_json::to_string(&drifted_snapshot).expect("serialize drifted snapshot"),
+        stderr: String::new(),
+        success: true,
+    }]));
+    let mut discovery =
+        fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_terminal_pool(Arc::new(FakeTerminalPool::new())));
+    discovery.runner = runner;
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), discovery, HostName::local()).await;
+
+    daemon.refresh_fleet_replicas_once().await.expect("refresh should succeed");
+
+    let cached = daemon.cached_fleet_replica_snapshots().await;
+    let checkouts = cached[0].result_sets[0].rows.as_checkouts().expect("checkout result set");
+    assert!(matches!(checkouts, [row] if row.resource.name == "valid"));
+
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+    assert!(response.replicas[0].reachable);
+    assert_eq!(response.replicas[0].generation.as_deref(), Some("gen-drifted"));
+    let status = serde_json::to_value(&response.replicas[0]).expect("serialize replica status");
+    assert_eq!(status["skipped_records"], 1);
+    assert!(
+        status["first_parse_error"]
+            .as_str()
+            .is_some_and(|error| error.contains("result_sets[0].rows[0]") && error.contains("missing field `repo_label`")),
+        "status should report the first parse error: {status}"
+    );
 }
 
 #[tokio::test]
@@ -2392,6 +2456,8 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
         result_sets: vec![],
         last_sync: Some(Utc::now() - chrono::Duration::seconds(FLEET_REPLICA_FRESH_SECS + 1)),
         generation: Some("gen-1".to_string()),
+        skipped_records: 0,
+        first_parse_error: None,
         last_error: Some("connection refused".to_string()),
     });
 
@@ -2513,6 +2579,8 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
             result_sets: vec![ResultSet { seq: 1, rows: Rows::Independents { scope: None, rows: vec![row] }, state: Default::default() }],
             last_sync: Some(Utc::now()),
             generation: Some(format!("gen-{host}")),
+            skipped_records: 0,
+            first_parse_error: None,
             last_error: None,
         });
     }
@@ -2572,6 +2640,8 @@ async fn attach_query_ignores_fleet_replica_hosts_that_are_not_configured() {
         result_sets: vec![],
         last_sync: Some(Utc::now()),
         generation: Some("gen-1".to_string()),
+        skipped_records: 0,
+        first_parse_error: None,
         last_error: None,
     });
 

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -1203,6 +1203,8 @@ mod tests {
                     reachable: false,
                     last_sync: None,
                     generation: None,
+                    skipped_records: 0,
+                    first_parse_error: None,
                     message: Some("not synced".into()),
                 }],
             })),

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -243,8 +243,16 @@ pub struct FleetReplicaStatus {
     pub last_sync: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub generation: Option<String>,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub skipped_records: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_parse_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+}
+
+fn is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -331,17 +331,35 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
         out.push('\n');
     }
 
-    if response.replicas.iter().any(|replica| !replica.reachable) {
+    if response.replicas.iter().any(|replica| !replica.reachable || replica.skipped_records > 0) {
         let mut table = Table::new();
         table.load_preset(UTF8_FULL_CONDENSED);
         table.set_header(vec!["Replica", "Status", "Last Sync", "Generation"]);
         for replica in &response.replicas {
-            if replica.reachable {
+            if replica.reachable && replica.skipped_records == 0 {
                 continue;
             }
+            let parse_skew = || {
+                let noun = if replica.skipped_records == 1 { "record" } else { "records" };
+                format!(
+                    "skipped {} {noun}: {}",
+                    replica.skipped_records,
+                    replica.first_parse_error.as_deref().unwrap_or("unknown parse error")
+                )
+            };
+            let status = if !replica.reachable {
+                let unreachable = replica.message.as_deref().unwrap_or("unreachable");
+                if replica.skipped_records > 0 {
+                    format!("{unreachable}; last sync {}", parse_skew())
+                } else {
+                    unreachable.to_string()
+                }
+            } else {
+                parse_skew()
+            };
             table.add_row(vec![
                 Cell::new(replica.host.as_str()),
-                Cell::new(replica.message.as_deref().unwrap_or("unreachable")),
+                Cell::new(status),
                 Cell::new(replica.last_sync.map(|ts| ts.to_rfc3339()).unwrap_or_else(|| "-".to_string())),
                 Cell::new(replica.generation.as_deref().unwrap_or("-")),
             ]);

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -611,13 +611,26 @@ mod command_result_human {
                 .namespace("dev")
                 .staleness(FleetStaleness::Unreachable { last_sync: None, message: "connection refused".to_string() })
                 .build()],
-            replicas: vec![FleetReplicaStatus {
-                host: HostName::new("feta"),
-                reachable: false,
-                last_sync: None,
-                generation: Some("gen-1".into()),
-                message: Some("connection refused".into()),
-            }],
+            replicas: vec![
+                FleetReplicaStatus {
+                    host: HostName::new("feta"),
+                    reachable: false,
+                    last_sync: None,
+                    generation: Some("gen-1".into()),
+                    skipped_records: 0,
+                    first_parse_error: None,
+                    message: Some("connection refused".into()),
+                },
+                FleetReplicaStatus {
+                    host: HostName::new("udder"),
+                    reachable: true,
+                    last_sync: None,
+                    generation: Some("gen-drifted".into()),
+                    skipped_records: 2,
+                    first_parse_error: Some("result_sets[0].rows[0]: missing field `repo_label`".into()),
+                    message: None,
+                },
+            ],
         }));
 
         let output = format_command_result(&result);
@@ -629,6 +642,10 @@ mod command_result_human {
         assert!(output.contains("unreachable"));
         assert!(output.contains("Replica status"));
         assert!(output.contains("connection refused"));
+        assert!(output.contains("udder"));
+        assert!(output.contains("skipped 2 records"));
+        assert!(output.contains("missing field `repo_label`"));
+        assert!(output.contains("gen-drifted"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- decode fleet replica snapshots record by record, including rows nested inside typed result sets
- retain valid records while counting skipped records and preserving the first path-qualified parse error
- expose parse skew in replica status without marking a partially synced replica unreachable
- render skipped count, first parse error, and generation in `flotilla ls`

## Root cause

Replica snapshot ingestion deserialized the entire JSON document directly into `FleetReplicaSnapshot`. A schema mismatch in any typed row therefore failed the whole document and left the remote host completely absent from the replica cache.

## Impact

Mixed-build fleets now degrade during rollouts: incompatible records are omitted, compatible records continue syncing, and operators see the exact skew in replica status.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-core --lib replica_refresh_ --locked --features test-support`
- `cargo test -p flotilla-tui --lib command_result_human::fleet_list --locked`
- `cargo test --workspace --locked` progressed through the workspace but is locally blocked by the unrelated existing `in_process::tests::adopted_checkout_with_explicit_transport_applies_fork_stance_config` assertion

Closes #1079