### PR TITLE
fix: show configured hosts during redial

### DIFF
--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -105,7 +105,7 @@ impl HostRegistry {
         host_entries.sort_by(|a, b| {
             b.is_local
                 .cmp(&a.is_local)
-                .then_with(|| a.node.node_id.cmp(&b.node.node_id))
+                .then_with(|| a.node.as_ref().map(|node| &node.node_id).cmp(&b.node.as_ref().map(|node| &node.node_id)))
                 .then_with(|| a.environment_id.cmp(&b.environment_id))
         });
 
@@ -728,12 +728,13 @@ fn build_host_list_entry_from_state(
         state.summary.as_ref().and_then(|summary| summary.host_name.clone()).unwrap_or_else(|| HostName::new(node.display_name.clone()));
 
     HostListEntry {
-        environment_id: state.environment_id.clone(),
+        environment_id: Some(state.environment_id.clone()),
         host_name,
-        node,
+        node: Some(node),
         is_local,
         configured: !is_local && configured.contains_key(&state.node_id),
         connection_status: connection_status_for_node(local_node, node_connectivity, &state.node_id),
+        reconnect: None,
         has_summary: state.summary.is_some(),
         repo_count: counts.repo_count,
         work_item_count: counts.work_item_count,
@@ -866,7 +867,7 @@ mod tests {
         registry.set_configured_peers(vec![NodeInfo::new(NodeId::new("peer-node"), "Build Box")], &HashMap::new(), &|_| {}).await;
 
         let hosts = registry.list_hosts(&HashMap::new()).await;
-        assert!(hosts.hosts.iter().all(|entry| entry.node.node_id != peer_node().node_id));
+        assert!(hosts.hosts.iter().all(|entry| entry.node.as_ref().is_none_or(|node| node.node_id != peer_node().node_id)));
     }
 
     #[tokio::test]
@@ -939,11 +940,11 @@ mod tests {
 
         let hosts = registry.list_hosts(&HashMap::new()).await;
         assert!(
-            hosts.hosts.iter().any(|entry| entry.environment_id == first_environment_id),
+            hosts.hosts.iter().any(|entry| entry.environment_id.as_ref() == Some(&first_environment_id)),
             "the first live environment should remain visible"
         );
         assert!(
-            hosts.hosts.iter().any(|entry| entry.environment_id == second_environment_id),
+            hosts.hosts.iter().any(|entry| entry.environment_id.as_ref() == Some(&second_environment_id)),
             "the second live environment should be visible even with a placeholder summary"
         );
     }
@@ -1010,7 +1011,7 @@ mod tests {
         registry.publish_peer_connection_status(&peer_node(), PeerConnectionState::Connected, &HashMap::new(), &|_| {}).await;
 
         let hosts = registry.list_hosts(&HashMap::new()).await;
-        assert!(hosts.hosts.iter().all(|entry| entry.node.node_id != peer_node().node_id));
+        assert!(hosts.hosts.iter().all(|entry| entry.node.as_ref().is_none_or(|node| node.node_id != peer_node().node_id)));
     }
 
     #[tokio::test]
@@ -1111,11 +1112,12 @@ mod tests {
         registry.publish_peer_summary(second_summary.clone(), &|_| {}).await;
 
         let hosts = registry.list_hosts(&HashMap::new()).await;
-        let peer_entries: Vec<_> = hosts.hosts.iter().filter(|entry| entry.node.node_id == peer.node_id).collect();
+        let peer_entries: Vec<_> =
+            hosts.hosts.iter().filter(|entry| entry.node.as_ref().is_some_and(|node| node.node_id == peer.node_id)).collect();
 
         assert_eq!(peer_entries.len(), 2, "a single node should be able to expose multiple host environments");
-        assert!(peer_entries.iter().any(|entry| entry.environment_id == first_summary.environment_id));
-        assert!(peer_entries.iter().any(|entry| entry.environment_id == second_summary.environment_id));
+        assert!(peer_entries.iter().any(|entry| entry.environment_id.as_ref() == Some(&first_summary.environment_id)));
+        assert!(peer_entries.iter().any(|entry| entry.environment_id.as_ref() == Some(&second_summary.environment_id)));
 
         let status_a =
             registry.get_host_status(&first_summary.environment_id, &HashMap::new()).await.expect("status for first environment");
@@ -1253,8 +1255,10 @@ mod tests {
         ]);
         let hosts = registry.list_hosts(&counts).await;
 
-        let first_entry = hosts.hosts.iter().find(|entry| entry.environment_id == first_environment_id).expect("first entry");
-        let second_entry = hosts.hosts.iter().find(|entry| entry.environment_id == second_environment_id).expect("second entry");
+        let first_entry =
+            hosts.hosts.iter().find(|entry| entry.environment_id.as_ref() == Some(&first_environment_id)).expect("first entry");
+        let second_entry =
+            hosts.hosts.iter().find(|entry| entry.environment_id.as_ref() == Some(&second_environment_id)).expect("second entry");
         assert_eq!((first_entry.repo_count, first_entry.work_item_count), (1, 2));
         assert_eq!((second_entry.repo_count, second_entry.work_item_count), (3, 5));
     }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -2742,8 +2742,11 @@ async fn list_hosts_does_not_materialize_configured_peers_without_host_environme
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
 
-    assert!(hosts.hosts.iter().any(|entry| entry.node.node_id == daemon.node_id().clone() && entry.is_local));
-    assert!(!hosts.hosts.iter().any(|entry| entry.node == test_node("remote")));
+    assert!(hosts
+        .hosts
+        .iter()
+        .any(|entry| { entry.node.as_ref().is_some_and(|node| node.node_id == daemon.node_id().clone()) && entry.is_local }));
+    assert!(!hosts.hosts.iter().any(|entry| entry.node == Some(test_node("remote"))));
 }
 
 #[tokio::test]
@@ -2765,7 +2768,7 @@ async fn get_host_providers_returns_local_summary_and_unmapped_remote_host_is_ab
         .expect("list hosts")
         .hosts
         .into_iter()
-        .any(|entry| entry.node.node_id == test_node("remote").node_id));
+        .any(|entry| entry.node.as_ref().is_some_and(|node| node.node_id == test_node("remote").node_id)));
 }
 
 #[tokio::test]
@@ -2905,7 +2908,7 @@ async fn list_hosts_counts_remote_repo_overlay_and_get_topology_returns_mirrored
     daemon.set_peer_providers(&repo, vec![(HostName::new("remote"), peer_data)], 0).await;
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
-    let remote = hosts.hosts.iter().find(|entry| entry.node == test_node("remote")).expect("remote host entry");
+    let remote = hosts.hosts.iter().find(|entry| entry.node == Some(test_node("remote"))).expect("remote host entry");
     assert_eq!(remote.repo_count, 1);
     assert!(remote.work_item_count >= 1, "remote overlay should contribute work items");
 
@@ -4157,10 +4160,10 @@ async fn set_peer_providers_reuses_existing_peer_host_environment_identity() {
     daemon.set_peer_providers(&repo, vec![(peer_host.clone(), ProviderData::default())], 0).await;
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
-    let peer_entry = hosts.hosts.iter().find(|entry| entry.node == test_node(peer_host.as_str())).expect("peer entry");
+    let peer_entry = hosts.hosts.iter().find(|entry| entry.node == Some(test_node(peer_host.as_str()))).expect("peer entry");
 
-    assert_eq!(peer_entry.environment_id, expected_environment_id);
-    assert!(peer_entry.environment_id.is_host());
+    assert_eq!(peer_entry.environment_id, Some(expected_environment_id));
+    assert!(peer_entry.environment_id.as_ref().is_some_and(EnvironmentId::is_host));
 }
 
 #[tokio::test]
@@ -4238,8 +4241,8 @@ async fn list_hosts_uses_environment_scoped_counts_for_multiple_hosts_on_same_no
     daemon.set_peer_providers(&repo_b, vec![(HostName::new("shared-peer"), providers_b)], 0).await;
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
-    let host_a = hosts.hosts.iter().find(|entry| entry.environment_id == env_a).expect("host a");
-    let host_b = hosts.hosts.iter().find(|entry| entry.environment_id == env_b).expect("host b");
+    let host_a = hosts.hosts.iter().find(|entry| entry.environment_id.as_ref() == Some(&env_a)).expect("host a");
+    let host_b = hosts.hosts.iter().find(|entry| entry.environment_id.as_ref() == Some(&env_b)).expect("host b");
 
     assert_eq!(host_a.repo_count, 1);
     assert_eq!(host_b.repo_count, 2);
@@ -4280,13 +4283,19 @@ async fn set_peer_providers_keeps_multiple_host_environments_visible_for_one_nod
     daemon.set_peer_providers(&repo, vec![(HostName::new("overlay-peer"), peer_data)], 0).await;
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
-    let peer_entries: Vec<_> = hosts.hosts.iter().filter(|entry| entry.node == test_node("overlay-peer")).collect();
+    let peer_entries: Vec<_> = hosts.hosts.iter().filter(|entry| entry.node == Some(test_node("overlay-peer"))).collect();
 
     assert_eq!(peer_entries.len(), 2);
-    assert_eq!(peer_entries.iter().find(|entry| entry.environment_id == env_a).expect("host a").host_name, HostName::new("overlay-peer-a"));
-    assert_eq!(peer_entries.iter().find(|entry| entry.environment_id == env_b).expect("host b").host_name, HostName::new("overlay-peer-b"));
-    assert!(peer_entries.iter().any(|entry| entry.environment_id == env_a));
-    assert!(peer_entries.iter().any(|entry| entry.environment_id == env_b));
+    assert_eq!(
+        peer_entries.iter().find(|entry| entry.environment_id.as_ref() == Some(&env_a)).expect("host a").host_name,
+        HostName::new("overlay-peer-a")
+    );
+    assert_eq!(
+        peer_entries.iter().find(|entry| entry.environment_id.as_ref() == Some(&env_b)).expect("host b").host_name,
+        HostName::new("overlay-peer-b")
+    );
+    assert!(peer_entries.iter().any(|entry| entry.environment_id.as_ref() == Some(&env_a)));
+    assert!(peer_entries.iter().any(|entry| entry.environment_id.as_ref() == Some(&env_b)));
 }
 
 #[tokio::test]
@@ -4312,7 +4321,7 @@ async fn set_peer_providers_without_canonical_host_name_does_not_emit_placeholde
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
     assert!(
-        hosts.hosts.iter().all(|entry| entry.environment_id != env),
+        hosts.hosts.iter().all(|entry| entry.environment_id.as_ref() != Some(&env)),
         "placeholder overlay data without a canonical host-facing name should not materialize a host entry"
     );
 
@@ -4332,7 +4341,7 @@ async fn set_peer_providers_without_environment_mapping_does_not_synthesize_host
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
     assert!(
-        hosts.hosts.iter().all(|entry| entry.node.display_name != peer_host.as_str()),
+        hosts.hosts.iter().all(|entry| entry.node.as_ref().is_none_or(|node| node.display_name != peer_host.as_str())),
         "peer host should not be materialized without a canonical environment id"
     );
 }
@@ -4360,7 +4369,7 @@ async fn set_peer_providers_without_environment_mapping_does_not_emit_host_snaps
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
     assert!(
-        hosts.hosts.iter().all(|entry| entry.node.display_name != overlay_host.as_str()),
+        hosts.hosts.iter().all(|entry| entry.node.as_ref().is_none_or(|node| node.display_name != overlay_host.as_str())),
         "overlay-only peer data should not synthesize host identity"
     );
 
@@ -4428,7 +4437,7 @@ async fn list_hosts_and_replay_drop_stale_non_configured_hosts() {
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
     assert!(
-        hosts.hosts.iter().any(|entry| entry.node == test_node(transient_host.as_str())),
+        hosts.hosts.iter().any(|entry| entry.node == Some(test_node(transient_host.as_str()))),
         "transient host should be visible while backed by state"
     );
 
@@ -4453,7 +4462,7 @@ async fn list_hosts_and_replay_drop_stale_non_configured_hosts() {
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
     assert!(
-        !hosts.hosts.iter().any(|entry| entry.node == test_node(transient_host.as_str())),
+        !hosts.hosts.iter().any(|entry| entry.node == Some(test_node(transient_host.as_str()))),
         "stale non-configured host should be pruned once summary, connection, and overlay data are gone"
     );
 

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -8,9 +8,9 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{
-    Command, CommandPeerEvent, CommandValue, ConfigLabel, EnvironmentId, GoodbyeReason, HostName, HostSummary, NodeId, NodeInfo,
-    PeerDataKind, PeerDataMessage, PeerWireMessage, ProviderData, RepoIdentity, RepositoryKey, RoutedPeerMessage, Step, StepOutcome,
-    StepStatus, TopologyRoute, VectorClock,
+    Command, CommandPeerEvent, CommandValue, ConfigLabel, EnvironmentId, GoodbyeReason, HostListEntry, HostListResponse, HostName,
+    HostSummary, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerReconnectStatus, PeerWireMessage, ProviderData,
+    RepoIdentity, RepositoryKey, RoutedPeerMessage, Step, StepOutcome, StepStatus, TopologyRoute, VectorClock,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -177,6 +177,13 @@ struct ConfiguredPeerTarget {
 struct PeerDialStatus {
     last_attempt: Option<DateTime<Utc>>,
     last_error: Option<String>,
+    reconnect_backoff: Option<ReconnectBackoff>,
+}
+
+#[derive(Debug, Clone)]
+struct ReconnectBackoff {
+    attempt: u32,
+    next_dial_at: Instant,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -383,7 +390,67 @@ impl PeerManager {
 
     pub fn note_dial_result(&mut self, label: &ConfigLabel, result: Result<(), &str>) {
         let status = self.peer_dial_status.entry(label.clone()).or_default();
+        let connected = result.is_ok();
         status.last_error = result.err().map(str::to_string);
+        if connected {
+            status.reconnect_backoff = None;
+        }
+    }
+
+    pub fn note_reconnect_backoff(&mut self, label: &ConfigLabel, attempt: u32, delay: Duration) {
+        self.peer_dial_status.entry(label.clone()).or_default().reconnect_backoff =
+            Some(ReconnectBackoff { attempt, next_dial_at: Instant::now() + delay });
+    }
+
+    pub fn project_host_list(&self, response: &mut HostListResponse) {
+        for (label, target) in &self.configured_targets {
+            let node_id =
+                self.transport_peers.get(label).or_else(|| self.learned_transport_peers.get(label)).or(target.expected_node_id.as_ref());
+            let reconnect = self.peer_dial_status.get(label).and_then(|status| status.reconnect_backoff.as_ref()).map(|backoff| {
+                let remaining = backoff.next_dial_at.saturating_duration_since(Instant::now());
+                let next_dial_in_seconds = remaining.as_secs() + u64::from(remaining.subsec_nanos() > 0);
+                PeerReconnectStatus { attempt: backoff.attempt, next_dial_in_seconds }
+            });
+            let connected = self.transport_peers.contains_key(label);
+            let connection_status = if connected {
+                PeerConnectionState::Connected
+            } else if reconnect.is_some() {
+                PeerConnectionState::Reconnecting
+            } else {
+                PeerConnectionState::Disconnected
+            };
+
+            let existing = node_id.and_then(|node_id| {
+                response.hosts.iter_mut().find(|entry| entry.node.as_ref().is_some_and(|node| node.node_id == *node_id))
+            });
+            if let Some(entry) = existing {
+                entry.configured = true;
+                entry.connection_status = connection_status;
+                entry.reconnect = reconnect;
+                continue;
+            }
+
+            response.hosts.push(HostListEntry {
+                environment_id: None,
+                host_name: target.expected_host_name.clone(),
+                node: node_id.map(|node_id| self.node_info_for(node_id)),
+                is_local: false,
+                configured: true,
+                connection_status,
+                reconnect,
+                has_summary: false,
+                repo_count: 0,
+                work_item_count: 0,
+            });
+        }
+
+        response.hosts.sort_by(|left, right| {
+            right
+                .is_local
+                .cmp(&left.is_local)
+                .then_with(|| left.host_name.cmp(&right.host_name))
+                .then_with(|| left.node.as_ref().map(|node| &node.node_id).cmp(&right.node.as_ref().map(|node| &node.node_id)))
+        });
     }
 
     /// Register or replace a sender for a connected peer.

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -420,13 +420,18 @@ impl PeerManager {
                 PeerConnectionState::Disconnected
             };
 
-            let existing = node_id.and_then(|node_id| {
-                response.hosts.iter_mut().find(|entry| entry.node.as_ref().is_some_and(|node| node.node_id == *node_id))
-            });
-            if let Some(entry) = existing {
+            let mut matched_existing = false;
+            for entry in response
+                .hosts
+                .iter_mut()
+                .filter(|entry| node_id.is_some_and(|node_id| entry.node.as_ref().is_some_and(|node| node.node_id == *node_id)))
+            {
+                matched_existing = true;
                 entry.configured = true;
-                entry.connection_status = connection_status;
-                entry.reconnect = reconnect;
+                entry.connection_status = connection_status.clone();
+                entry.reconnect = reconnect.clone();
+            }
+            if matched_existing {
                 continue;
             }
 

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -692,6 +692,46 @@ fn host_list_projection_includes_configured_target_in_redial_backoff() {
     assert_eq!(feta.reconnect, Some(flotilla_protocol::PeerReconnectStatus { attempt: 592, next_dial_in_seconds: 60 }));
 }
 
+#[test]
+fn host_list_projection_enriches_every_environment_row_for_configured_node() {
+    let mut mgr = PeerManager::new(NodeId::new("local"));
+    mgr.add_configured_target(
+        ConfigLabel("feta".into()),
+        HostName::new("feta"),
+        Some(NodeId::new("feta-node")),
+        Box::new(MockTransport::new()),
+    );
+    mgr.note_reconnect_backoff(&ConfigLabel("feta".into()), 8, Duration::from_secs(60));
+    let node = NodeInfo::new(NodeId::new("feta-node"), "feta");
+    let mut response = flotilla_protocol::HostListResponse {
+        hosts: ["feta-host", "feta-container"]
+            .into_iter()
+            .map(|environment_id| flotilla_protocol::HostListEntry {
+                environment_id: Some(EnvironmentId::host(HostId::new(environment_id))),
+                host_name: HostName::new("feta"),
+                node: Some(node.clone()),
+                is_local: false,
+                configured: false,
+                connection_status: PeerConnectionState::Disconnected,
+                reconnect: None,
+                has_summary: true,
+                repo_count: 0,
+                work_item_count: 0,
+            })
+            .collect(),
+    };
+
+    mgr.project_host_list(&mut response);
+
+    assert_eq!(response.hosts.len(), 2, "canonical rows should be enriched, not duplicated");
+    assert!(response.hosts.iter().all(|entry| entry.configured));
+    assert!(response.hosts.iter().all(|entry| entry.connection_status == PeerConnectionState::Reconnecting));
+    assert!(response
+        .hosts
+        .iter()
+        .all(|entry| entry.reconnect == Some(flotilla_protocol::PeerReconnectStatus { attempt: 8, next_dial_in_seconds: 60 })));
+}
+
 #[tokio::test]
 async fn reconnect_target_uses_handshake_node_identity() {
     let mut mgr = PeerManager::new(NodeId::new("z"));

--- a/crates/flotilla-daemon/src/peer/manager/tests.rs
+++ b/crates/flotilla-daemon/src/peer/manager/tests.rs
@@ -672,6 +672,26 @@ async fn configured_targets_are_stored_separately_from_established_peers() {
     assert!(established.is_empty(), "configured targets should not look established before handshake");
 }
 
+#[test]
+fn host_list_projection_includes_configured_target_in_redial_backoff() {
+    let mut mgr = PeerManager::new(NodeId::new("local"));
+    add_configured_transport(&mut mgr, "feta", "feta", MockTransport::new());
+    mgr.note_reconnect_backoff(&ConfigLabel("feta".into()), 592, Duration::from_secs(60));
+    let mut response = flotilla_protocol::HostListResponse { hosts: vec![] };
+
+    mgr.project_host_list(&mut response);
+
+    let [feta] = response.hosts.as_slice() else {
+        panic!("expected one configured host row, got {:?}", response.hosts);
+    };
+    assert_eq!(feta.host_name, HostName::new("feta"));
+    assert_eq!(feta.environment_id, None);
+    assert_eq!(feta.node, None);
+    assert!(feta.configured);
+    assert_eq!(feta.connection_status, PeerConnectionState::Reconnecting);
+    assert_eq!(feta.reconnect, Some(flotilla_protocol::PeerReconnectStatus { attempt: 592, next_dial_in_seconds: 60 }));
+}
+
 #[tokio::test]
 async fn reconnect_target_uses_handshake_node_identity() {
     let mut mgr = PeerManager::new(NodeId::new("z"));

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -253,6 +253,10 @@ impl PeerRuntime {
                                 daemon_for_cleanup.publish_peer_connection_status(peer, PeerConnectionState::Reconnecting).await;
                             }
                             let delay = SshTransport::backoff_delay(attempt);
+                            {
+                                let mut pm = pm.lock().await;
+                                pm.note_reconnect_backoff(&target_label, attempt, delay);
+                            }
                             info!(target = %target_label.0, %attempt, delay_secs = delay.as_secs(), "reconnecting after backoff");
                             tokio::time::sleep(delay).await;
 

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -249,13 +249,13 @@ impl PeerRuntime {
                                 attempt = 1;
                                 continue;
                             }
-                            if let Some(peer) = current_peer.as_ref() {
-                                daemon_for_cleanup.publish_peer_connection_status(peer, PeerConnectionState::Reconnecting).await;
-                            }
                             let delay = SshTransport::backoff_delay(attempt);
                             {
                                 let mut pm = pm.lock().await;
                                 pm.note_reconnect_backoff(&target_label, attempt, delay);
+                            }
+                            if let Some(peer) = current_peer.as_ref() {
+                                daemon_for_cleanup.publish_peer_connection_status(peer, PeerConnectionState::Reconnecting).await;
                             }
                             info!(target = %target_label.0, %attempt, delay_secs = delay.as_secs(), "reconnecting after backoff");
                             tokio::time::sleep(delay).await;

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -246,7 +246,11 @@ impl RemoteCommandRouter {
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
 
         if target_node_id == *self.daemon.node_id() {
-            return self.daemon.execute_query(command, session_id).await;
+            let mut value = self.daemon.execute_query(command, session_id).await?;
+            if let CommandValue::HostList(response) = &mut value {
+                self.peer_manager.lock().await.project_host_list(response);
+            }
+            return Ok(value);
         }
 
         let request_id = {

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -246,11 +246,7 @@ impl RemoteCommandRouter {
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
 
         if target_node_id == *self.daemon.node_id() {
-            let mut value = self.daemon.execute_query(command, session_id).await?;
-            if let CommandValue::HostList(response) = &mut value {
-                self.peer_manager.lock().await.project_host_list(response);
-            }
-            return Ok(value);
+            return self.execute_projected_query(command, session_id).await;
         }
 
         let request_id = {
@@ -296,6 +292,14 @@ impl RemoteCommandRouter {
         };
 
         result
+    }
+
+    async fn execute_projected_query(&self, command: Command, session_id: uuid::Uuid) -> Result<CommandValue, String> {
+        let mut value = self.daemon.execute_query(command, session_id).await?;
+        if let CommandValue::HostList(response) = &mut value {
+            self.peer_manager.lock().await.project_host_list(response);
+        }
+        Ok(value)
     }
 
     pub(super) async fn dispatch_cancel(&self, command_id: u64) -> Result<(), String> {
@@ -626,7 +630,7 @@ impl RemoteCommandRouter {
         // result back directly without subscribing to the event stream.
         if command.action.is_query() {
             let query_session = session_id.unwrap_or(uuid::Uuid::nil());
-            let result = match self.daemon.execute_query(command, query_session).await {
+            let result = match self.execute_projected_query(command, query_session).await {
                 Ok(value) => value,
                 Err(message) => CommandValue::Error { message },
             };

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -633,7 +633,7 @@ async fn dispatch_host_query_methods_round_trip() {
     // Host queries now go through execute() via CommandAction::Query* variants.
     // Test the internal methods directly to validate the data path.
     let hosts = daemon.list_hosts_internal().await.expect("list hosts");
-    assert!(hosts.hosts.iter().any(|entry| entry.node.node_id == *daemon.node_id()));
+    assert!(hosts.hosts.iter().any(|entry| entry.node.as_ref().is_some_and(|node| node.node_id == *daemon.node_id())));
 
     let status = daemon.get_host_status_internal(&local_environment_id).await.expect("host status");
     assert!(status.is_local);
@@ -855,7 +855,10 @@ async fn sync_peer_query_state_mirrors_host_summaries_and_routes_into_daemon() {
     sync_peer_query_state(&peer_manager, &daemon).await;
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts after sync");
-    assert!(hosts.hosts.iter().any(|entry| entry.node.node_id == node("remote") && entry.has_summary));
+    assert!(hosts
+        .hosts
+        .iter()
+        .any(|entry| entry.node.as_ref().is_some_and(|node_info| node_info.node_id == node("remote")) && entry.has_summary));
 
     let topology = daemon.get_topology().await.expect("topology after sync");
     assert!(topology.routes.iter().any(|route| route.target.node_id == node("remote") && route.next_hop.node_id == node("remote")));
@@ -893,7 +896,8 @@ async fn sync_peer_query_state_preserves_multiple_host_summaries_for_one_node() 
     sync_peer_query_state(&peer_manager, &daemon).await;
 
     let hosts = daemon.list_hosts_internal().await.expect("list hosts after sync");
-    let remote_hosts: Vec<_> = hosts.hosts.into_iter().filter(|entry| entry.node.node_id == node("remote")).collect();
+    let remote_hosts: Vec<_> =
+        hosts.hosts.into_iter().filter(|entry| entry.node.as_ref().is_some_and(|node_info| node_info.node_id == node("remote"))).collect();
     assert_eq!(remote_hosts.len(), 2, "both host environments for the same node should remain visible");
 }
 

--- a/crates/flotilla-daemon/tests/socket_roundtrip.rs
+++ b/crates/flotilla-daemon/tests/socket_roundtrip.rs
@@ -244,7 +244,10 @@ async fn query_commands_roundtrip() {
     let (local_node_id, local_environment_id) = match hosts_result {
         CommandValue::HostList(hosts) => {
             let entry = hosts.hosts.iter().find(|entry| entry.is_local).expect("expected local host entry");
-            (entry.node.node_id.clone(), entry.environment_id.clone())
+            (
+                entry.node.as_ref().expect("local host should have node identity").node_id.clone(),
+                entry.environment_id.clone().expect("local host should have environment identity"),
+            )
         }
         other => panic!("expected HostList, got {other:?}"),
     };
@@ -334,9 +337,13 @@ async fn execute_refresh_all_roundtrip_emits_lifecycle_events() {
 
     let mut rx = client.subscribe();
     let local_node_id = match run_query(&*client, CommandAction::QueryHostList {}).await {
-        CommandValue::HostList(hosts) => {
-            hosts.hosts.iter().find(|entry| entry.is_local).map(|entry| entry.node.node_id.clone()).expect("expected local host entry")
-        }
+        CommandValue::HostList(hosts) => hosts
+            .hosts
+            .iter()
+            .find(|entry| entry.is_local)
+            .and_then(|entry| entry.node.as_ref())
+            .map(|node| node.node_id.clone())
+            .expect("expected local host entry"),
         other => panic!("expected HostList, got {other:?}"),
     };
     let command_id = client

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -1125,12 +1125,13 @@ mod tests {
             })),
             CommandValue::HostList(Box::new(HostListResponse {
                 hosts: vec![HostListEntry {
-                    environment_id: EnvironmentId::host(HostId::new("desktop-host")),
+                    environment_id: Some(EnvironmentId::host(HostId::new("desktop-host"))),
                     host_name: crate::HostName::new("desktop"),
-                    node: NodeInfo::new(NodeId::new("desktop"), "Desktop"),
+                    node: Some(NodeInfo::new(NodeId::new("desktop"), "Desktop")),
                     is_local: true,
                     configured: true,
                     connection_status: PeerConnectionState::Connected,
+                    reconnect: None,
                     has_summary: true,
                     repo_count: 1,
                     work_item_count: 3,

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -120,9 +120,9 @@ pub use provider_data::{
 };
 pub use query::{
     CrewCommandContext, CrewListMember, CrewListResponse, DiscoveryEntry, FleetListResponse, FleetListRow, FleetReplicaSnapshot,
-    FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse, ProjectListEntry,
-    ProjectListRepository, ProjectListResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse, RepoProvidersResponse, RepoSummary,
-    RepoWorkResponse, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
+    FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse, PeerReconnectStatus,
+    ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse,
+    RepoProvidersResponse, RepoSummary, RepoWorkResponse, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
 };
 pub use repository::{RepositoryRelation, RepositoryUpstream};
 pub use resource_ref::ResourceRef;

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -268,18 +268,32 @@ pub struct HostListResponse {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostListEntry {
-    pub environment_id: crate::EnvironmentId,
+    /// Canonical host environment identity, when the peer has supplied one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<crate::EnvironmentId>,
     pub host_name: HostName,
-    pub node: NodeInfo,
+    /// Canonical node identity, when the configured target has connected at
+    /// least once or pins an expected node id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node: Option<NodeInfo>,
     pub is_local: bool,
     /// `true` only for non-local hosts that appear in `hosts.toml`.
     pub configured: bool,
     pub connection_status: PeerConnectionState,
+    /// Live redial details when `connection_status` is `Reconnecting`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reconnect: Option<PeerReconnectStatus>,
     /// Indicates whether `get_host_status` would be able to return a
     /// non-`None` summary for this host.
     pub has_summary: bool,
     pub repo_count: usize,
     pub work_item_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PeerReconnectStatus {
+    pub attempt: u32,
+    pub next_dial_in_seconds: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -409,12 +423,13 @@ mod tests {
     fn host_list_response_roundtrips_without_summary_data() {
         let response = HostListResponse {
             hosts: vec![HostListEntry {
-                environment_id: EnvironmentId::host(HostId::new("remote-laptop-host")),
+                environment_id: Some(EnvironmentId::host(HostId::new("remote-laptop-host"))),
                 host_name: HostName::new("remote-laptop"),
-                node: NodeInfo::new(NodeId::new("node-remote-1"), "Remote Laptop"),
+                node: Some(NodeInfo::new(NodeId::new("node-remote-1"), "Remote Laptop")),
                 is_local: false,
                 configured: true,
                 connection_status: PeerConnectionState::Disconnected,
+                reconnect: None,
                 has_summary: false,
                 repo_count: 0,
                 work_item_count: 0,

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -138,10 +138,15 @@ fn format_host_list_human(response: &flotilla_protocol::HostListResponse) -> Str
     for host in &response.hosts {
         table.add_row(vec![
             Cell::new(host.host_name.as_str()),
-            Cell::new(node_label(&host.node)),
+            Cell::new(host.node.as_ref().map(node_label).unwrap_or("-")),
             Cell::new(if host.is_local { "yes" } else { "no" }),
             Cell::new(if host.configured { "yes" } else { "no" }),
-            Cell::new(format_connection_status(&host.connection_status)),
+            Cell::new(match &host.reconnect {
+                Some(reconnect) => {
+                    format!("reconnecting (attempt {}, next dial in {}s)", reconnect.attempt, reconnect.next_dial_in_seconds)
+                }
+                None => format_connection_status(&host.connection_status).to_string(),
+            }),
             Cell::new(if host.has_summary { "yes" } else { "no" }),
             Cell::new(host.repo_count),
             Cell::new(host.work_item_count),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -119,23 +119,25 @@ mod status_human {
         let response = HostListResponse {
             hosts: vec![
                 HostListEntry {
-                    environment_id: EnvironmentId::host(HostId::new("local-env")),
+                    environment_id: Some(EnvironmentId::host(HostId::new("local-env"))),
                     host_name: HostName::new("local"),
-                    node: NodeInfo::new(NodeId::new("local"), "local"),
+                    node: Some(NodeInfo::new(NodeId::new("local"), "local")),
                     is_local: true,
                     configured: false,
                     connection_status: PeerConnectionState::Connected,
+                    reconnect: None,
                     has_summary: true,
                     repo_count: 2,
                     work_item_count: 5,
                 },
                 HostListEntry {
-                    environment_id: EnvironmentId::host(HostId::new("remote-env")),
+                    environment_id: Some(EnvironmentId::host(HostId::new("remote-env"))),
                     host_name: HostName::new("remote"),
-                    node: NodeInfo::new(NodeId::new("remote"), "remote"),
+                    node: Some(NodeInfo::new(NodeId::new("remote"), "remote")),
                     is_local: false,
                     configured: true,
-                    connection_status: PeerConnectionState::Disconnected,
+                    connection_status: PeerConnectionState::Reconnecting,
+                    reconnect: Some(flotilla_protocol::PeerReconnectStatus { attempt: 592, next_dial_in_seconds: 37 }),
                     has_summary: false,
                     repo_count: 0,
                     work_item_count: 0,
@@ -145,7 +147,7 @@ mod status_human {
 
         let output = format_host_list_human(&response);
         assert!(output.contains("remote"));
-        assert!(output.contains("disconnected"));
+        assert!(output.contains("reconnecting (attempt 592, next dial in 37s)"));
         assert!(output.contains("5"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1073,10 +1073,22 @@ fn select_host_target(
         0 => Err(color_eyre::eyre::eyre!("unknown host: {subject}")),
         1 => {
             let entry = matches.pop().expect("single host match");
-            Ok((entry.environment_id.clone(), entry.node.node_id.clone()))
+            let environment_id = entry
+                .environment_id
+                .clone()
+                .ok_or_else(|| color_eyre::eyre::eyre!("host {subject} is configured but has no known environment identity"))?;
+            let node_id = entry
+                .node
+                .as_ref()
+                .map(|node| node.node_id.clone())
+                .ok_or_else(|| color_eyre::eyre::eyre!("host {subject} is configured but has no known node identity"))?;
+            Ok((environment_id, node_id))
         }
         _ => {
-            let mut ids: Vec<_> = matches.iter().map(|entry| entry.environment_id.canonical_string()).collect();
+            let mut ids: Vec<_> = matches
+                .iter()
+                .map(|entry| entry.environment_id.as_ref().map(EnvironmentId::canonical_string).unwrap_or_else(|| "configured".into()))
+                .collect();
             ids.sort();
             Err(color_eyre::eyre::eyre!("ambiguous host: {subject} ({})", ids.join(", ")))
         }
@@ -1101,17 +1113,20 @@ async fn resolve_environment_target(
     };
 
     for entry in response.hosts {
-        if entry.environment_id == *target_environment_id {
-            return Ok((provisioning_target_for_environment(&entry.host_name, &entry.environment_id), entry.node.node_id));
+        let (Some(environment_id), Some(node)) = (entry.environment_id, entry.node) else {
+            continue;
+        };
+        if environment_id == *target_environment_id {
+            return Ok((provisioning_target_for_environment(&entry.host_name, &environment_id), node.node_id));
         }
 
         let status = daemon
             .execute_query(
                 Command {
-                    node_id: Some(entry.node.node_id.clone()),
+                    node_id: Some(node.node_id.clone()),
                     provisioning_target: None,
                     context_repo: None,
-                    action: CommandAction::QueryHostStatus { target_environment_id: entry.environment_id.clone() },
+                    action: CommandAction::QueryHostStatus { target_environment_id: environment_id.clone() },
                 },
                 uuid::Uuid::new_v4(),
             )
@@ -1123,8 +1138,8 @@ async fn resolve_environment_target(
             Err(err) => {
                 info!(
                     host = %entry.host_name,
-                    environment_id = %entry.environment_id,
-                    node_id = %entry.node.node_id,
+                    %environment_id,
+                    node_id = %node.node_id,
                     error = %err,
                     "skipping host while resolving environment target"
                 );
@@ -1139,7 +1154,7 @@ async fn resolve_environment_target(
         if response.visible_environments.iter().any(|environment| environment.environment_id() == target_environment_id) {
             return Ok((
                 flotilla_protocol::ProvisioningTarget::ExistingEnvironment { host: entry.host_name, env_id: target_environment_id.clone() },
-                entry.node.node_id,
+                node.node_id,
             ));
         }
     }
@@ -1925,12 +1940,13 @@ mod tests {
     #[test]
     fn host_target_selection_uses_host_facing_name() {
         let hosts = vec![HostListEntry {
-            environment_id: EnvironmentId::host(HostId::new("desktop-a")),
+            environment_id: Some(EnvironmentId::host(HostId::new("desktop-a"))),
             host_name: HostName::new("desktop"),
-            node: NodeInfo::new(NodeId::new("node-a"), "Builder"),
+            node: Some(NodeInfo::new(NodeId::new("node-a"), "Builder")),
             is_local: false,
             configured: true,
             connection_status: PeerConnectionState::Connected,
+            reconnect: None,
             has_summary: true,
             repo_count: 0,
             work_item_count: 0,
@@ -1945,23 +1961,25 @@ mod tests {
     fn host_target_selection_reports_ambiguity_for_duplicate_host_names() {
         let hosts = vec![
             HostListEntry {
-                environment_id: EnvironmentId::host(HostId::new("desktop-a")),
+                environment_id: Some(EnvironmentId::host(HostId::new("desktop-a"))),
                 host_name: HostName::new("desktop"),
-                node: NodeInfo::new(NodeId::new("node-a"), "Desktop"),
+                node: Some(NodeInfo::new(NodeId::new("node-a"), "Desktop")),
                 is_local: false,
                 configured: true,
                 connection_status: PeerConnectionState::Connected,
+                reconnect: None,
                 has_summary: true,
                 repo_count: 0,
                 work_item_count: 0,
             },
             HostListEntry {
-                environment_id: EnvironmentId::host(HostId::new("desktop-b")),
+                environment_id: Some(EnvironmentId::host(HostId::new("desktop-b"))),
                 host_name: HostName::new("desktop"),
-                node: NodeInfo::new(NodeId::new("node-b"), "Desktop"),
+                node: Some(NodeInfo::new(NodeId::new("node-b"), "Desktop")),
                 is_local: false,
                 configured: true,
                 connection_status: PeerConnectionState::Connected,
+                reconnect: None,
                 has_summary: true,
                 repo_count: 0,
                 work_item_count: 0,


### PR DESCRIPTION
## Summary

- project every configured peer target into `host list`, even before it has a canonical node or environment identity
- surface the peer runtime's current retry attempt and deadline as `reconnecting (attempt N, next dial in Ns)`
- keep canonical host snapshots unchanged and make config-only row identities explicitly optional
- add host-list projection and human-format coverage

## Root cause

`host list` was built only from canonical host snapshots. When a peer disconnected, its summary and canonical host row were removed even though the daemon's peer runtime still owned the configured target and was actively redialing it.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-daemon --locked host_list_projection_includes_configured_target_in_redial_backoff`
- `cargo test -p flotilla-tui --locked host_list_shows_hosts_and_counts`
- `cargo check --workspace --all-targets --locked`
- `cargo test --workspace --locked` runs the changed coverage successfully, but the local macOS run has one unrelated reproducible failure in `in_process::tests::adopted_checkout_with_explicit_transport_applies_fork_stance_config`

Closes #1073