### PR TITLE
fix: suppress dispatch regard for no-attach convoys

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -21,13 +21,14 @@ use flotilla_protocol::{
     commands::RepositoryIdentityChange,
     qualified_path::{HostId, QualifiedPath},
     result_set::{ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
-    AttachBinding, Command, CommandAction, CommandValue, CorrelationKey, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent,
-    DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse,
-    HostName, HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState,
-    PrincipalRef, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta,
-    RepoDetailResponse, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedPaneCommand,
-    ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo,
-    ToolInventory, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, CorrelationKey, CrewCommandContext, CrewListMember,
+    CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus,
+    FleetStaleness, HostListResponse, HostName, HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId,
+    NodeInfo, PeerConnectionState, PrincipalRef, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo,
+    QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse,
+    ResolvedPaneCommand, ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey,
+    SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY,
+    TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
@@ -2339,6 +2340,7 @@ impl InProcessDaemon {
             .maybe_placement_policy_name(placement_policy_name)
             .maybe_placement_policy_spec(placement_policy_spec)
             .auto_attach(self.should_auto_attach(intent.auto_attach))
+            .dispatch_regard(intent.auto_attach.into())
             .build())
     }
 
@@ -3686,15 +3688,23 @@ impl InProcessDaemon {
         dispatching_principal_ref: &PrincipalRef,
     ) -> Result<String, String> {
         let admission = self.prepare_convoy_admission(namespace, intent, dispatching_principal_ref).await?;
-        self.create_convoy_with_regard(namespace, &admission.name, &admission.spec).await?;
+        self.create_convoy(namespace, &admission.name, &admission.spec, intent.auto_attach.into()).await?;
         Ok(admission.name)
     }
 
-    async fn create_convoy_with_regard(&self, namespace: &str, name: &str, spec: &ConvoySpec) -> Result<(), String> {
+    async fn create_convoy(
+        &self,
+        namespace: &str,
+        name: &str,
+        spec: &ConvoySpec,
+        dispatch_regard: ConvoyDispatchRegard,
+    ) -> Result<(), String> {
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
         convoys.create(&InputMeta::builder().name(name.to_string()).build(), spec).await.map_err(|error| error.to_string())?;
-        if let Err(error) = self.emit_implicit_convoy_regard(namespace, name, &spec.dispatching_principal_ref).await {
-            warn!(%error, %namespace, %name, "failed to emit convoy dispatch regard");
+        if dispatch_regard == ConvoyDispatchRegard::Emit {
+            if let Err(error) = self.emit_implicit_convoy_regard(namespace, name, &spec.dispatching_principal_ref).await {
+                warn!(%error, %namespace, %name, "failed to emit convoy dispatch regard");
+            }
         }
         Ok(())
     }
@@ -3843,7 +3853,7 @@ impl InProcessDaemon {
         if let Some((name, spec)) = placement_spec {
             ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, &spec).await?;
         }
-        self.create_convoy_with_regard(&namespace, &start.name, &convoy_spec).await
+        self.create_convoy(&namespace, &start.name, &convoy_spec, start.dispatch_regard).await
     }
 
     async fn supervise_convoy_start(&self, task: ConvoyStartTask) {
@@ -6530,7 +6540,7 @@ impl InProcessDaemon {
                 issues: Vec::new(),
                 instruction: None,
             };
-            let result = match self.create_convoy_with_regard(&namespace, name, &spec).await {
+            let result = match self.create_convoy(&namespace, name, &spec, ConvoyDispatchRegard::Emit).await {
                 Ok(()) => flotilla_protocol::CommandValue::ConvoyCreated { name: name.clone() },
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             };

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1322,6 +1322,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     );
     discovery.factories.ai_utilities.push(Box::new(CountingConvoyAiUtilityFactory { utility: Arc::clone(&utility) }));
     let (temp, _repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    daemon.connect_surface(uuid::Uuid::new_v4(), flotilla_protocol::SurfaceDeclaration::ambient_for_namespace("flotilla"));
     let backend = daemon.resource_backend();
     let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
     backend
@@ -1394,16 +1395,50 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     assert_eq!(persisted.spec.repositories.len(), 1);
     assert_eq!(persisted.spec.instruction.as_deref(), Some("Keep the snapshot durable."));
     let regards = backend.using::<Regard>("flotilla").list().await.expect("list dispatcher regards");
-    let regard = regards.items.iter().find(|regard| regard.spec.target.name == "issue-732").expect("implicit dispatcher regard");
-    assert_eq!(regard.spec.principal_ref, persisted.spec.dispatching_principal_ref);
-    assert_eq!(regard.spec.source, RegardSource::Implicit { policy: "convoy-dispatch".to_string() });
-    assert_eq!(regard.spec.expiry, RegardExpiryPolicy::Decaying { expires_after_seconds: 300 });
+    assert!(
+        regards.items.iter().all(|regard| regard.spec.target.name != "issue-732"),
+        "--no-attach must leave the convoy outside the dispatching principal's searchlight"
+    );
     let persisted_issue = persisted.spec.issues.first().expect("issue snapshot");
     assert_eq!(persisted_issue.reference, reference);
     assert_eq!(persisted_issue.repository_ref, Some(repository.key()));
     assert_eq!(persisted_issue.snapshot.title, issue.title);
     assert_eq!(persisted_issue.snapshot.body, issue.body);
     assert_eq!(utility.calls.load(Ordering::SeqCst), 0, "fully specified admission must not call AI");
+
+    let default_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".into(),
+                    issues: Vec::new(),
+                    name: Some("default-regard".into()),
+                    branch: Some("fix/default-regard".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Default,
+                }),
+            },
+        })
+        .await
+        .expect("default start command accepted");
+    assert_eq!(recv_command_finished(&mut events, default_id).await, CommandValue::ConvoyStarted {
+        name: "default-regard".into(),
+        attach_command: None,
+        binding: None
+    });
+    let regards = backend.using::<Regard>("flotilla").list().await.expect("list default dispatcher regard");
+    let regard =
+        regards.items.iter().find(|regard| regard.spec.target.name == "default-regard").expect("default implicit dispatcher regard");
+    assert_eq!(regard.spec.principal_ref, persisted.spec.dispatching_principal_ref);
+    assert_eq!(regard.spec.source, RegardSource::Implicit { policy: "convoy-dispatch".to_string() });
+    assert_eq!(regard.spec.expiry, RegardExpiryPolicy::Decaying { expires_after_seconds: 300 });
 
     let batch_id = daemon
         .execute(Command {
@@ -1446,6 +1481,11 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     let batch = backend.using::<ResourceConvoy>("flotilla").get("batch-732-733").await.expect("batch convoy");
     assert_eq!(batch.spec.issues.iter().map(|issue| &issue.reference).collect::<Vec<_>>(), vec![&reference, &reference_two]);
     assert_eq!(batch.spec.instruction.as_deref(), Some("Fix both issues in one convoy."));
+    let regards = backend.using::<Regard>("flotilla").list().await.expect("list batch dispatcher regards");
+    assert!(
+        regards.items.iter().all(|regard| regard.spec.target.name != "batch-732-733"),
+        "batch --no-attach must not add a dispatch regard"
+    );
 
     utility.fail.store(true, Ordering::SeqCst);
     let fallback_id = daemon

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1433,10 +1433,11 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
         attach_command: None,
         binding: None
     });
+    let default_convoy = backend.using::<ResourceConvoy>("flotilla").get("default-regard").await.expect("default convoy");
     let regards = backend.using::<Regard>("flotilla").list().await.expect("list default dispatcher regard");
     let regard =
         regards.items.iter().find(|regard| regard.spec.target.name == "default-regard").expect("default implicit dispatcher regard");
-    assert_eq!(regard.spec.principal_ref, persisted.spec.dispatching_principal_ref);
+    assert_eq!(regard.spec.principal_ref, default_convoy.spec.dispatching_principal_ref);
     assert_eq!(regard.spec.source, RegardSource::Implicit { policy: "convoy-dispatch".to_string() });
     assert_eq!(regard.spec.expiry, RegardExpiryPolicy::Decaying { expires_after_seconds: 300 });
 

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -148,6 +148,23 @@ pub enum ConvoyAutoAttach {
     Never,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConvoyDispatchRegard {
+    #[default]
+    Emit,
+    Suppress,
+}
+
+impl From<ConvoyAutoAttach> for ConvoyDispatchRegard {
+    fn from(auto_attach: ConvoyAutoAttach) -> Self {
+        match auto_attach {
+            ConvoyAutoAttach::Never => Self::Suppress,
+            ConvoyAutoAttach::Default | ConvoyAutoAttach::Always => Self::Emit,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoyStartIntent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -194,6 +211,9 @@ pub struct PreparedConvoyStart {
     #[builder(default)]
     #[serde(default)]
     pub auto_attach: bool,
+    #[builder(default)]
+    #[serde(default)]
+    pub dispatch_regard: ConvoyDispatchRegard,
 }
 
 /// Commands the client can send to the daemon.
@@ -1596,5 +1616,12 @@ mod tests {
     fn issue_page_value_roundtrip() {
         let val = CommandValue::IssuePage(crate::issue_query::IssueResultPage { items: vec![], total: Some(10), has_more: true });
         assert_json_roundtrip(&val);
+    }
+
+    #[test]
+    fn only_no_attach_suppresses_the_dispatch_regard() {
+        assert_eq!(ConvoyDispatchRegard::from(ConvoyAutoAttach::Never), ConvoyDispatchRegard::Suppress);
+        assert_eq!(ConvoyDispatchRegard::from(ConvoyAutoAttach::Default), ConvoyDispatchRegard::Emit);
+        assert_eq!(ConvoyDispatchRegard::from(ConvoyAutoAttach::Always), ConvoyDispatchRegard::Emit);
     }
 }

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -108,8 +108,8 @@ pub(crate) mod test_helpers {
 
 pub use commands::{
     AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyAutoAttach,
-    ConvoyStartIntent, IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand,
-    ResourceJsonResponse, ResourceWatchCursor, ResourceWatchResponse, StepStatus,
+    ConvoyDispatchRegard, ConvoyStartIntent, IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector,
+    ResolvedPaneCommand, ResourceJsonResponse, ResourceWatchCursor, ResourceWatchResponse, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{


### PR DESCRIPTION
## Summary

- suppress the implicit `convoy-dispatch` regard when `auto_attach` is `Never`
- preserve the dispatch-regard decision across prepared remote convoy starts
- cover no-attach searchlight behavior with an ambient presentation surface while retaining default and explicit attach policy coverage

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1099