### PR TITLE
fix: refresh connected peer host heartbeats

### DIFF
--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -854,6 +854,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connected_peer_summaries_only_returns_live_routes() {
+        let registry = HostRegistry::new(local_node(), minimal_summary(&local_node()));
+        let peer = peer_node();
+        let summary = minimal_summary(&peer);
+        registry.publish_peer_summary(summary.clone(), &|_| {}).await;
+
+        assert!(registry.connected_peer_summaries().await.is_empty(), "a disconnected peer must not receive heartbeat refreshes");
+
+        registry.publish_peer_connection_status(&peer, PeerConnectionState::Connected, &HashMap::new(), &|_| {}).await;
+        assert_eq!(registry.connected_peer_summaries().await, vec![summary]);
+
+        registry.publish_peer_connection_status(&peer, PeerConnectionState::Disconnected, &HashMap::new(), &|_| {}).await;
+        assert!(registry.connected_peer_summaries().await.is_empty(), "a disconnected peer must stop receiving heartbeat refreshes");
+    }
+
+    #[tokio::test]
     async fn replay_uses_environment_id_stream_keys() {
         let registry = HostRegistry::new(local_node(), minimal_summary(&local_node()));
         registry.publish_peer_summary(minimal_summary(&peer_node()), &|_| {}).await;

--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -91,6 +91,19 @@ impl HostRegistry {
         connection_status_for_node(&self.local_node, &node_connectivity, node_id)
     }
 
+    pub(crate) async fn connected_peer_summaries(&self) -> Vec<HostSummary> {
+        let node_connectivity = self.node_connectivity.read().await;
+        let hosts = self.hosts.read().await;
+        hosts
+            .values()
+            .filter(|state| !state.removed && state.node_id != self.local_node.node_id)
+            .filter(|state| {
+                connection_status_for_node(&self.local_node, &node_connectivity, &state.node_id) == PeerConnectionState::Connected
+            })
+            .filter_map(|state| state.summary.clone())
+            .collect()
+    }
+
     pub(crate) async fn list_hosts(&self, counts: &HashMap<EnvironmentId, HostCounts>) -> HostListResponse {
         let configured = self.configured_peers.read().await.clone();
         let node_connectivity = self.node_connectivity.read().await.clone();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2158,11 +2158,12 @@ impl InProcessDaemon {
     }
 
     /// Keep locally materialized peer hosts ready while their transport route is live.
-    pub async fn refresh_connected_peer_host_heartbeats(&self) -> Result<(), String> {
+    pub async fn refresh_connected_peer_host_heartbeats(&self) {
         for summary in self.host_registry.connected_peer_summaries().await {
-            self.materialize_peer_host_direct_placement(&summary).await?;
+            if let Err(error) = self.materialize_peer_host_direct_placement(&summary).await {
+                warn!(peer = %summary.node.node_id, %error, "failed to refresh connected peer host heartbeat");
+            }
         }
-        Ok(())
     }
 
     async fn materialize_peer_host_direct_placement(&self, summary: &HostSummary) -> Result<(), String> {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2157,6 +2157,14 @@ impl InProcessDaemon {
             .await;
     }
 
+    /// Keep locally materialized peer hosts ready while their transport route is live.
+    pub async fn refresh_connected_peer_host_heartbeats(&self) -> Result<(), String> {
+        for summary in self.host_registry.connected_peer_summaries().await {
+            self.materialize_peer_host_direct_placement(&summary).await?;
+        }
+        Ok(())
+    }
+
     async fn materialize_peer_host_direct_placement(&self, summary: &HostSummary) -> Result<(), String> {
         let Some(host_id) = summary.environment_id.host_id() else {
             return Ok(());

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -575,7 +575,8 @@ async fn apply_host_heartbeat(daemon: &Arc<InProcessDaemon>, namespace: &str, pr
     let status =
         HostStatus { capabilities: host_capabilities(&summary, profile), heartbeat_at: Some(Utc::now()), ready: true, resource_store };
     hosts.update_status(&profile.host_id, &host.metadata.resource_version, &status).await.map_err(|err| err.to_string())?;
-    daemon.refresh_connected_peer_host_heartbeats().await
+    daemon.refresh_connected_peer_host_heartbeats().await;
+    Ok(())
 }
 
 fn host_capabilities(_summary: &HostSummary, profile: &LocalProvisioningProfile) -> BTreeMap<String, serde_json::Value> {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -574,7 +574,8 @@ async fn apply_host_heartbeat(daemon: &Arc<InProcessDaemon>, namespace: &str, pr
     }
     let status =
         HostStatus { capabilities: host_capabilities(&summary, profile), heartbeat_at: Some(Utc::now()), ready: true, resource_store };
-    hosts.update_status(&profile.host_id, &host.metadata.resource_version, &status).await.map(|_| ()).map_err(|err| err.to_string())
+    hosts.update_status(&profile.host_id, &host.metadata.resource_version, &status).await.map_err(|err| err.to_string())?;
+    daemon.refresh_connected_peer_host_heartbeats().await
 }
 
 fn host_capabilities(_summary: &HostSummary, profile: &LocalProvisioningProfile) -> BTreeMap<String, serde_json::Value> {
@@ -2401,6 +2402,71 @@ mod tests {
             status.resource_store.expect("heartbeat should publish resource store diagnostics").event_log_within_retention(),
             "heartbeat should report a bounded resource event log"
         );
+
+        heartbeat.abort();
+        let _ = heartbeat.await;
+    }
+
+    #[tokio::test]
+    async fn heartbeat_task_advances_connected_peer_host_status_after_restart() {
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path()));
+        let daemon = in_memory_daemon(Vec::new(), config).await;
+        let local_host_id = daemon.local_host_id().expect("local host id").to_string();
+        let peer_node = flotilla_protocol::NodeInfo::new(flotilla_protocol::NodeId::new("feta-node"), "feta");
+        daemon
+            .publish_peer_summary(
+                HostSummary::builder()
+                    .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new("feta-host")))
+                    .host_name(flotilla_protocol::HostName::new("feta"))
+                    .node(peer_node.clone())
+                    .system(flotilla_protocol::SystemInfo::default())
+                    .providers(Vec::new())
+                    .build(),
+            )
+            .await;
+        daemon.publish_peer_connection_status(&peer_node, flotilla_protocol::PeerConnectionState::Connected).await;
+
+        let hosts = daemon.resource_backend().using::<Host>(NAMESPACE);
+        let peer = hosts.get("feta-host").await.expect("peer host should be materialized");
+        let stale_heartbeat = Utc::now() - chrono::Duration::seconds(61);
+        hosts
+            .update_status(&peer.metadata.name, &peer.metadata.resource_version, &HostStatus {
+                capabilities: BTreeMap::new(),
+                heartbeat_at: Some(stale_heartbeat),
+                ready: true,
+                resource_store: None,
+            })
+            .await
+            .expect("seed stale peer heartbeat");
+
+        let heartbeat = spawn_heartbeat_task(
+            Arc::clone(&daemon),
+            NAMESPACE.to_string(),
+            manual_profile(&local_host_id, false),
+            Duration::from_millis(20),
+        );
+        wait_until(|| {
+            let hosts = hosts.clone();
+            async move {
+                hosts
+                    .get("feta-host")
+                    .await
+                    .ok()
+                    .and_then(|host| host.status)
+                    .is_some_and(|status| status.heartbeat_at.is_some_and(|heartbeat| heartbeat > stale_heartbeat))
+            }
+        })
+        .await;
+
+        assert_eq!(
+            daemon.peer_connection_status(&peer_node.node_id).await,
+            flotilla_protocol::PeerConnectionState::Connected,
+            "the peer transport should remain connected"
+        );
+        let mut status = hosts.get("feta-host").await.expect("peer host").status.expect("peer status");
+        status.apply_heartbeat_readiness(Utc::now());
+        assert!(status.ready, "a connected peer should remain ready for placement");
 
         heartbeat.abort();
         let _ = heartbeat.await;


### PR DESCRIPTION
## Summary

- refresh locally materialized peer `Host` status on every daemon heartbeat tick while the peer route is `Connected`
- stop refreshing disconnected peers so the existing heartbeat TTL continues to mark them unready
- add an `InProcessDaemon` regression covering a restarted heartbeat publisher with a connected peer whose `ResourceHost` status had gone stale

## Root cause

A peer's locally materialized `ResourceHost` heartbeat was stamped only when its `HostSummary` arrived. The periodic heartbeat publisher updated only the local host, so a healthy peer connection could remain connected while the peer host row aged past the 60-second placement-readiness TTL.

## Impact

After a local daemon restart, connected peers keep advancing their materialized host heartbeat and remain eligible for placement. Connectivity and placement readiness now derive from the same live peer-route signal instead of diverging indefinitely.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1092