### PR TITLE
feat: open standing checkouts in a terminal

### DIFF
--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -9,8 +9,8 @@ use chrono::Utc;
 use flotilla_manifest::keys::{KEY_CHANGE_REQUEST_NUMBER, KEY_CHECKOUT_BRANCH, KEY_CHECKOUT_PATH, KEY_CONVOY_NAME};
 use flotilla_protocol::{
     AwarenessCounts, AwarenessEntry, AwarenessFamily, AwarenessFamilySummary, AwarenessGrouping, AwarenessKind, AwarenessLimit,
-    AwarenessNode, AwarenessPhase, AwarenessState, CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow, QueryScope, ResourceRef,
-    ResultSetState, Salience, WorkPhase, UNKNOWN_REPOSITORY_LABEL,
+    AwarenessLink, AwarenessNode, AwarenessPhase, AwarenessState, CheckoutRow, ConvoyPhase, ConvoyRow, IndependentRow, IssueRow,
+    QueryScope, ResourceRef, ResultSetState, Salience, WorkPhase, AWARENESS_REL_FOR_CONVOY, UNKNOWN_REPOSITORY_LABEL,
 };
 use flotilla_resources::{api_version, Project, Resource};
 
@@ -156,6 +156,13 @@ pub fn project_awareness(input: AwarenessInput) -> (Vec<AwarenessNode>, ResultSe
                 .state(AwarenessState::Active)
                 .as_of(as_of)
                 .refs(vec![checkout.resource.clone()])
+                .links(
+                    checkout
+                        .for_convoy
+                        .iter()
+                        .map(|convoy| AwarenessLink { rel: AWARENESS_REL_FOR_CONVOY.to_owned(), target: convoy.clone() })
+                        .collect(),
+                )
                 .annotations(checkout_annotations(checkout))
                 .build(),
             &input.salience,
@@ -556,6 +563,7 @@ mod tests {
                 .branch("main")
                 .host(HostName::new("local"))
                 .authority(flotilla_protocol::LifecycleAuthority::Observed)
+                .for_convoy("ship-it")
                 .build()],
             ..AwarenessInput::default()
         });
@@ -569,6 +577,7 @@ mod tests {
         assert_eq!(checkout.label, "main · /work/flotilla");
         assert_eq!(checkout.annotations.get("checkout.branch").map(String::as_str), Some("main"));
         assert_eq!(checkout.annotations.get("checkout.path").map(String::as_str), Some("/work/flotilla"));
+        assert_eq!(checkout.links, vec![flotilla_protocol::AwarenessLink { rel: "for-convoy".to_owned(), target: "ship-it".to_owned() }]);
     }
 
     #[test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -20,7 +20,7 @@ use flotilla_protocol::{
     arg::{flatten, Arg},
     commands::RepositoryIdentityChange,
     qualified_path::{HostId, QualifiedPath},
-    result_set::{ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
+    result_set::{CheckoutRow, ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
     AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, CorrelationKey, CrewCommandContext, CrewListMember,
     CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId, FleetListResponse, FleetListRow, FleetReplicaSnapshot, FleetReplicaStatus,
     FleetStaleness, HostListResponse, HostName, HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId,
@@ -435,6 +435,7 @@ fn fleet_row_attach_reference_label(row: &FleetListRow) -> String {
 enum AttachTarget {
     Local(Box<flotilla_resources::ResourceObject<ResourceTerminalSession>>),
     Replica { row: Box<FleetListRow> },
+    Checkout(Box<CheckoutRow>),
 }
 
 impl AttachTarget {
@@ -471,6 +472,17 @@ impl AttachTarget {
                     .maybe_role(role)
                     .build();
                 Ok(ResolvedAttach { command, binding: Some(binding) })
+            }
+            Self::Checkout(row) => {
+                if !transient {
+                    return Err(format!("checkout '{}' is only available as a transient attach target", row.path));
+                }
+                let command = if row.host == daemon.host_name {
+                    daemon.local_checkout_terminal_command(row).await?
+                } else {
+                    daemon.recursive_attach_command_for_remote(&row.host, reference, true).await?
+                };
+                Ok(ResolvedAttach { command, binding: None })
             }
         }
     }
@@ -5720,6 +5732,21 @@ impl InProcessDaemon {
             });
         }
 
+        let checkout_set = self
+            .aggregator_projection_state()
+            .await
+            .result_set_for(&flotilla_protocol::QueryId::Checkouts { scope: None })
+            .await
+            .expect("checkout query is always materialized");
+        if let Rows::Checkouts { rows, .. } = checkout_set.rows {
+            candidates.extend(rows.into_iter().filter(|row| row.for_convoy.is_none()).map(|row| AttachCandidate {
+                label: format!("{} ({})", row.path, row.host),
+                references: vec![row.path.clone()],
+                host: row.host.clone(),
+                target: AttachTarget::Checkout(Box::new(row)),
+            }));
+        }
+
         let configured_replica_hosts: HashSet<HostName> = self
             .config
             .load_hosts()
@@ -5785,6 +5812,30 @@ impl InProcessDaemon {
         }
         drop(cache);
         Ok(AttachCandidateIndex::new(candidates))
+    }
+
+    async fn local_checkout_terminal_command(&self, checkout: &CheckoutRow) -> Result<String, String> {
+        let cwd = ExecutionEnvironmentPath::new(&checkout.path);
+        let discovery = discover_repo_for_environment(
+            &self.environment_manager,
+            &self.discovery,
+            &self.config,
+            &self.local_environment_id,
+            &self.local_environment_id,
+            cwd.as_path(),
+        )
+        .await
+        .map_err(|error| format!("checkout {} provider discovery failed: {error}", checkout.path))?;
+        let pool = discovery
+            .registry
+            .terminal_pools
+            .preferred()
+            .cloned()
+            .ok_or_else(|| format!("no terminal pool available for checkout {}", checkout.path))?;
+        let session_name = transient_checkout_session_name(checkout);
+        let command = "${SHELL:-/bin/sh}";
+        pool.ensure_session(&session_name, command, &cwd, &Vec::new(), &[]).await?;
+        pool.attach_command(&session_name, command, &cwd, &Vec::new()).await
     }
 
     /// Resolve the attach command for a locally-known session, returning it
@@ -6884,6 +6935,15 @@ impl InProcessDaemon {
 
         Ok(id)
     }
+}
+
+fn transient_checkout_session_name(checkout: &CheckoutRow) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(checkout.host.as_str().as_bytes());
+    hasher.update([0]);
+    hasher.update(checkout.path.as_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    format!("flotilla-checkout-{}", &digest[..32])
 }
 
 async fn execute_local_remote_step_batch(

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2681,6 +2681,102 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
 }
 
 #[tokio::test]
+async fn transient_attach_resolves_standing_checkout_paths_locally_and_deterministically() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let checkout_path = temp.path().join("standing-checkout");
+    std::fs::create_dir_all(&checkout_path).expect("create checkout");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(&config_base).await;
+    let row = CheckoutRow::builder()
+        .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "dev", "standing").on_host(HostName::new(TEST_LOCAL_ATTACH_HOST)))
+        .repo(RepositoryKey("repo-standing".to_owned()))
+        .repo_label("standing")
+        .path(checkout_path.display().to_string())
+        .branch("main")
+        .host(HostName::new(TEST_LOCAL_ATTACH_HOST))
+        .authority(LifecycleAuthority::Observed)
+        .build();
+    daemon.aggregator_projection_state().await.replace_local_checkout_rows(vec![row]).await;
+
+    let mut resolved = Vec::new();
+    for _ in 0..2 {
+        let result = daemon
+            .execute_query(
+                Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::AttachTransient {
+                        reference: checkout_path.display().to_string(),
+                        host: Some(HostName::new(TEST_LOCAL_ATTACH_HOST)),
+                    },
+                },
+                uuid::Uuid::new_v4(),
+            )
+            .await
+            .expect("transient attach query should execute");
+        let CommandValue::AttachCommandResolved { command, binding } = result else {
+            panic!("expected attach command, got {result:?}");
+        };
+        assert!(binding.is_none(), "standing checkout terminals are deliberately not stamped as convoy sessions");
+        resolved.push(command);
+    }
+    assert_eq!(resolved[0], resolved[1], "the same checkout must resolve to the same terminal target");
+    let ensured = terminal_pool.ensured.lock().await;
+    assert_eq!(ensured.len(), 1, "re-opening a checkout reuses its terminal-pool session");
+    assert_eq!(ensured[0].cwd.as_path(), checkout_path);
+    assert_eq!(ensured[0].command, "${SHELL:-/bin/sh}");
+}
+
+#[tokio::test]
+async fn transient_attach_routes_standing_checkout_paths_to_the_displayed_remote_host() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let (remote_host, _) = non_local_attach_hosts();
+    let remote_hostname = format!("{remote_host}.local");
+    write_attach_hosts_config(&config_base, &[(remote_host, &remote_hostname, Some("alice"))]);
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let row = CheckoutRow::builder()
+        .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "dev", "standing").on_host(HostName::new(remote_host)))
+        .repo(RepositoryKey("repo-standing".to_owned()))
+        .repo_label("standing")
+        .path("/work/standing")
+        .branch("main")
+        .host(HostName::new(remote_host))
+        .authority(LifecycleAuthority::Observed)
+        .build();
+    daemon
+        .aggregator_projection_state()
+        .await
+        .replace_checkout_replica_rows(HashMap::from([(HostName::new(remote_host), vec![row])]))
+        .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::AttachTransient { reference: "/work/standing".to_owned(), host: Some(HostName::new(remote_host)) },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("transient attach query should execute");
+    let CommandValue::AttachCommandResolved { command, binding } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert!(binding.is_none());
+    assert!(command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")));
+    assert!(command.contains("--transient"));
+    assert!(command.contains("/work/standing"));
+}
+
+#[tokio::test]
 async fn attach_query_ignores_fleet_replica_hosts_that_are_not_configured() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1325,6 +1325,7 @@ impl Aggregator {
                     .branch(spec.r#ref.clone())
                     .host(self.local_host.clone())
                     .authority(authority)
+                    .maybe_for_convoy(checkout.metadata.labels.get(CONVOY_LABEL).cloned())
                     .build())
             })
             .collect::<Result<Vec<_>, ResourceError>>()?;

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -141,7 +141,11 @@ async fn scoped_checkout_queries_emit_observed_rows_and_removal_deltas() {
     let checkouts = observed.using::<Checkout>("flotilla");
     let checkout = checkouts
         .create(
-            &InputMeta::builder().name("checkout-widgets".to_string()).build().with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &InputMeta::builder()
+                .name("checkout-widgets".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "ship-it".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
             &CheckoutSpec::Observed(
                 ObservedCheckoutSpec::builder()
                     .r#ref("feature/query".to_string())
@@ -174,11 +178,16 @@ async fn scoped_checkout_queries_emit_observed_rows_and_removal_deltas() {
         assert_eq!(rows[0].branch, "feature/query");
         assert_eq!(rows[0].authority, LifecycleAuthority::Adopted);
         assert_eq!(rows[0].host, HostName::new("local"));
+        assert_eq!(rows[0].for_convoy.as_deref(), Some("ship-it"));
     }
 
     let checkout = checkouts
         .update(
-            &InputMeta::builder().name(checkout.metadata.name.clone()).build().with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &InputMeta::builder()
+                .name(checkout.metadata.name.clone())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "ship-it".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
             &checkout.metadata.resource_version,
             &CheckoutSpec::Observed(
                 ObservedCheckoutSpec::builder()
@@ -208,6 +217,7 @@ async fn scoped_checkout_queries_emit_observed_rows_and_removal_deltas() {
         let rows = modifications.get(query).expect("scoped modification").changes.as_checkouts().expect("checkout changes");
         assert_eq!(rows[0].path, "/work/widgets-revised");
         assert_eq!(rows[0].branch, "feature/revised");
+        assert_eq!(rows[0].for_convoy.as_deref(), Some("ship-it"));
     }
 
     let stale_replay = daemon

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -11,7 +11,7 @@ use flotilla_protocol::{
         AwarenessCounts, AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessPhase, AwarenessState, ConvoyPhase, ConvoyRow,
         IndependentRow, SessionPhase, VesselRow, WorkPhase,
     },
-    ViewAddress,
+    ViewAddress, AWARENESS_REL_FOR_CONVOY,
 };
 
 use crate::{
@@ -376,6 +376,15 @@ fn awareness_project_recipe(node: &AwarenessNode, mint: &dyn RecipeMint) -> Opti
 fn awareness_entry_recipe(entry: &AwarenessEntry, convoys: &[ConvoyRow], mint: &dyn RecipeMint) -> Option<(Recipe, EntityRef)> {
     if matches!(entry.kind, AwarenessKind::Issue) {
         return None;
+    }
+    if matches!(entry.kind, AwarenessKind::Checkout) {
+        if entry.links.iter().any(|link| link.rel == AWARENESS_REL_FOR_CONVOY) {
+            return None;
+        }
+        let path = entry.annotations.get(KEY_CHECKOUT_PATH)?;
+        let host = entry.refs.iter().find_map(|reference| reference.host.as_ref())?;
+        let target = entity::checkout(&entry.id);
+        return mint.checkout_terminal(path, host).map(|recipe| (recipe, target));
     }
     match entry.id.parse().ok()? {
         ViewAddress::Project { namespace, name } => {

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -1,5 +1,5 @@
 use flotilla_protocol::{
-    result_set::{AwarenessCounts, AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessState, CrewMemberSummary},
+    result_set::{AwarenessCounts, AwarenessEntry, AwarenessKind, AwarenessLink, AwarenessNode, AwarenessState, CrewMemberSummary},
     ChangeRequestStatus, ConvoyChangeRequest, HostName, IssueRef, IssueSource, RepoKey, RepositoryKey, ResourceRef,
 };
 
@@ -180,6 +180,47 @@ fn awareness_composed_text_is_unchanged_alongside_granular_facts() {
     assert_eq!(text(project, KEY_SUMMARY_TEXT), "2 entries · 0 issues · 0 vessels · 1 checkouts");
     assert_eq!(project.set[KEY_COUNT_TOTAL].value, MetadataValue::Integer(2));
     assert_eq!(project.set[KEY_COUNT_CHECKOUTS].value, MetadataValue::Integer(1));
+}
+
+#[test]
+fn standing_checkout_mints_a_transient_terminal_action_but_convoy_checkout_does_not() {
+    let checkout = |id: &str, path: &str, links: Vec<AwarenessLink>| {
+        AwarenessEntry::builder()
+            .id(id.to_owned())
+            .kind(AwarenessKind::Checkout)
+            .label(format!("main · {path}"))
+            .state(AwarenessState::Active)
+            .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+            .refs(vec![ResourceRef::new("flotilla.work/v1", "Checkout", "dev", id).on_host(HostName::new("kiwi"))])
+            .links(links)
+            .annotations(std::collections::HashMap::from([
+                (KEY_CHECKOUT_BRANCH.to_owned(), "main".to_owned()),
+                (KEY_CHECKOUT_PATH.to_owned(), path.to_owned()),
+            ]))
+            .build()
+    };
+    let standing = checkout("standing", "/work/standing", vec![]);
+    let convoy_owned =
+        checkout("convoy-owned", "/work/convoy", vec![AwarenessLink { rel: "for-convoy".to_owned(), target: "dev/ship-it".to_owned() }]);
+    let node = AwarenessNode::builder()
+        .id("project/dev/platform".to_owned())
+        .kind(AwarenessKind::Project)
+        .label("platform".to_owned())
+        .scope(flotilla_protocol::QueryScope::new("dev", "platform"))
+        .state(AwarenessState::Active)
+        .as_of(flotilla_protocol::result_set::Timestamp::UNIX_EPOCH)
+        .counts(AwarenessCounts::builder().total(2).checkouts(2).build())
+        .entries(vec![standing, convoy_owned])
+        .build();
+
+    let patches = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint()).reassert_patches();
+    let standing = find_entity(&patches, &entity::checkout("standing"));
+    assert_eq!(text(standing, KEY_PRIMARY_ACTION_RECIPE), "flotilla attach --transient --host 'kiwi' '/work/standing'");
+    assert_eq!(text(standing, KEY_PRIMARY_ACTION_TARGET), entity::checkout("standing").action_target());
+
+    let convoy_owned = find_entity(&patches, &entity::checkout("convoy-owned"));
+    assert!(!convoy_owned.set.contains_key(KEY_PRIMARY_ACTION_RECIPE));
+    assert!(!convoy_owned.set.contains_key(KEY_PRIMARY_ACTION_TARGET));
 }
 
 #[test]

--- a/crates/flotilla-manifest/src/recipe.rs
+++ b/crates/flotilla-manifest/src/recipe.rs
@@ -29,6 +29,8 @@ pub trait RecipeMint: Send + Sync {
     /// running session into a workspace; `attach_ref` is any reference the
     /// daemon accepts (rows expose it as a capability fact).
     fn attach(&self, attach_ref: &str, host: &HostName) -> Option<Recipe>;
+    /// Recipe opening a transient shell rooted at a standing checkout.
+    fn checkout_terminal(&self, path: &str, host: &HostName) -> Option<Recipe>;
     /// Recipe materialising a scoped view of an entity with no live session.
     fn scoped_view(&self, target: &flotilla_protocol::ViewAddress) -> Option<Recipe>;
 }
@@ -48,6 +50,15 @@ impl FlotillaRecipes {
 impl RecipeMint for FlotillaRecipes {
     fn attach(&self, attach_ref: &str, host: &HostName) -> Option<Recipe> {
         Some(Recipe::Command(format!("{} attach --host {} {}", self.flotilla_bin, shell_quote(host.as_str()), shell_quote(attach_ref))))
+    }
+
+    fn checkout_terminal(&self, path: &str, host: &HostName) -> Option<Recipe> {
+        Some(Recipe::Command(format!(
+            "{} attach --transient --host {} {}",
+            self.flotilla_bin,
+            shell_quote(host.as_str()),
+            shell_quote(path)
+        )))
     }
 
     fn scoped_view(&self, target: &flotilla_protocol::ViewAddress) -> Option<Recipe> {
@@ -73,6 +84,10 @@ mod tests {
                 vessel: "implement".to_owned(),
             }),
             Some(Recipe::Command("flotilla view 'vessel/dev/manifest-extraction/implement'".to_owned()))
+        );
+        assert_eq!(
+            mint.checkout_terminal("/work/flotilla's checkout", &HostName::new("kiwi")),
+            Some(Recipe::Command("flotilla attach --transient --host 'kiwi' '/work/flotilla'\\''s checkout'".to_owned()))
         );
     }
 }

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -130,7 +130,7 @@ pub use result_set::{
     AwarenessCounts, AwarenessEntry, AwarenessFamily, AwarenessFamilySummary, AwarenessGrouping, AwarenessKind, AwarenessLimit,
     AwarenessLink, AwarenessNode, AwarenessPhase, AwarenessState, CheckoutRow, ConvoyChangeRequest, ConvoyPhase, ConvoyRow,
     CrewMemberSummary, DemandBackedMetadata, IndependentRow, IssueRow, QueryChanges, QueryId, QueryScope, ResultDelta, ResultSet,
-    ResultSetCondition, ResultSetState, Rows, Salience, SessionPhase, VesselRow, WorkPhase,
+    ResultSetCondition, ResultSetState, Rows, Salience, SessionPhase, VesselRow, WorkPhase, AWARENESS_REL_FOR_CONVOY,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -535,6 +535,8 @@ pub struct AwarenessLink {
     pub target: String,
 }
 
+pub const AWARENESS_REL_FOR_CONVOY: &str = "for-convoy";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct AwarenessEntry {
     pub id: String,
@@ -636,6 +638,10 @@ pub struct CheckoutRow {
     pub branch: String,
     pub host: HostName,
     pub authority: LifecycleAuthority,
+    /// Convoy this checkout serves, when it is part of convoy work rather
+    /// than a standing checkout available for independent use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub for_convoy: Option<String>,
 }
 
 /// Lifecycle phase of an independent terminal session.
@@ -893,7 +899,7 @@ mod tests {
     use crate::{provider_data::Issue, HostName, IssueRef, IssueSource, IssueState, LifecycleAuthority, RepositoryKey, ResourceRef};
 
     #[test]
-    fn fleet_checkout_result_set_round_trip_preserves_host_and_authority() {
+    fn fleet_checkout_result_set_round_trip_preserves_host_authority_and_convoy_relationship() {
         let set = ResultSet {
             seq: 7,
             rows: Rows::Checkouts {
@@ -906,6 +912,7 @@ mod tests {
                     .branch("feature/query")
                     .host(HostName::new("kiwi"))
                     .authority(LifecycleAuthority::Adopted)
+                    .for_convoy("ship-it")
                     .build()],
             },
             state: ResultSetState::default(),


### PR DESCRIPTION
## Summary

- project checkout ownership into awareness so convoy-managed checkouts can be distinguished
- mint terminal actions only for standing checkouts
- resolve transient checkout attaches locally or through the owning host with deterministic session reuse

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1063