### PR TITLE
Wire definitions-class Project replication

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -914,6 +914,7 @@ mod tests {
                 finalizers: Vec::new(),
                 deletion_timestamp: None,
                 creation_timestamp: Utc::now(),
+                merge: None,
             },
             spec: ConvoySpec {
                 workflow_ref: "workflow".to_string(),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -34,7 +34,7 @@ use flotilla_resources::{
     apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
     list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
     resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
-    watch_resource_kind_including_replicas, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
+    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
     CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, ConditionValue,
     Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CrewSource,
     Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
@@ -142,6 +142,7 @@ struct ResourceWatchCommandContext {
     namespace: String,
     kind: String,
     include_replicas: bool,
+    replica_sources: bool,
     cursor: Option<flotilla_protocol::ResourceWatchCursor>,
     command_id: u64,
     node_id: NodeId,
@@ -155,11 +156,13 @@ async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> Com
         Some(generation) => WatchStart::FromVersionInGeneration { generation, resource_version: cursor.resource_version },
         None => WatchStart::FromVersion(cursor.resource_version),
     });
-    let result = match (context.include_replicas, start) {
-        (true, Some(_)) => Err(ResourceError::invalid("include-replicas watches cannot resume from an origin resourceVersion")),
-        (true, None) => watch_resource_kind_including_replicas(&context.backend, &context.namespace, &context.kind).await,
-        (false, Some(start)) => watch_resource_kind_from(&context.backend, &context.namespace, &context.kind, start).await,
-        (false, None) => watch_resource_kind(&context.backend, &context.namespace, &context.kind).await,
+    let result = match (context.replica_sources, context.include_replicas, start) {
+        (true, _, Some(_)) => Err(ResourceError::invalid("replica-source watches cannot resume from an origin resourceVersion")),
+        (true, _, None) => watch_resource_kind_replica_sources(&context.backend, &context.namespace, &context.kind).await,
+        (false, true, Some(_)) => Err(ResourceError::invalid("include-replicas watches cannot resume from an origin resourceVersion")),
+        (false, true, None) => watch_resource_kind_including_replicas(&context.backend, &context.namespace, &context.kind).await,
+        (false, false, Some(start)) => watch_resource_kind_from(&context.backend, &context.namespace, &context.kind, start).await,
+        (false, false, None) => watch_resource_kind(&context.backend, &context.namespace, &context.kind).await,
     };
     let watch = match result {
         Ok(watch) => watch,
@@ -1580,6 +1583,7 @@ impl InProcessDaemon {
         let local_node_id = resolve_local_node_id(config.base_path().as_path(), config_machine_id, &*discovery.runner)
             .await
             .expect("failed to resolve local node id");
+        let resource_backend = resource_backend.with_local_root(local_node_id.clone());
         let local_environment_id =
             resolve_or_create_environment_id(&local_environment_state_dir).expect("failed to resolve local direct environment id");
         let local_host_id = resolve_local_host_id(config.state_dir().as_path(), config_machine_id, &*discovery.runner)
@@ -1871,7 +1875,7 @@ impl InProcessDaemon {
         let project = self
             .resource_backend
             .clone()
-            .using::<Project>(&scope.namespace)
+            .definitions::<Project>(&scope.namespace)
             .get(&scope.name)
             .await
             .map_err(|error| format!("project {}/{}: {error}", scope.namespace, scope.name))?;
@@ -3594,7 +3598,7 @@ impl InProcessDaemon {
         let project = self
             .resource_backend
             .clone()
-            .using::<Project>(namespace)
+            .definitions::<Project>(namespace)
             .get(project_ref)
             .await
             .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
@@ -3908,7 +3912,7 @@ impl InProcessDaemon {
         let project = self
             .resource_backend
             .clone()
-            .using::<Project>(namespace)
+            .definitions::<Project>(namespace)
             .get(project_ref)
             .await
             .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
@@ -4037,7 +4041,7 @@ impl InProcessDaemon {
         let default_name = normalize_project_name(&repository_spec.leaf_slug())?;
         let project_name = explicit_name.map(str::to_string).unwrap_or(default_name.clone());
         validate_project_name(&project_name)?;
-        let projects = self.resource_backend.clone().using::<Project>(&namespace);
+        let projects = self.resource_backend.clone().definitions::<Project>(&namespace);
         match projects.get(&project_name).await {
             Ok(existing) => {
                 let same_whole_repository = matches!(
@@ -4060,7 +4064,7 @@ impl InProcessDaemon {
         }
 
         let spec = whole_repository_project_spec(key, explicit_display_name.map(str::to_string).unwrap_or(default_name))?;
-        projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
+        projects.apply(&InputMeta::builder().name(project_name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
         Ok(project_name)
     }
 
@@ -4084,7 +4088,7 @@ impl InProcessDaemon {
                 .map_err(|error| error.to_string())?;
         }
 
-        let projects = self.resource_backend.clone().using::<Project>(&namespace);
+        let projects = self.resource_backend.clone().definitions::<Project>(&namespace);
         let repository_objects = repositories.list().await.map_err(|error| error.to_string())?.items;
         let repository_specs = repository_objects
             .iter()
@@ -4132,7 +4136,7 @@ impl InProcessDaemon {
             .collect::<BTreeSet<_>>();
         let migratable_keys = superseded_keys.difference(&other_tracked_keys).cloned().collect::<BTreeSet<_>>();
 
-        let mut project_objects = projects.list().await.map_err(|error| error.to_string())?.items;
+        let mut project_objects = projects.list().await.map_err(|error| error.to_string())?;
         let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
         let mut generated_names = whole_repository_project_names(repository_spec)?.into_iter().collect::<BTreeSet<_>>();
         let mut generated_display_names = BTreeSet::from([display_name.clone()]);
@@ -4154,10 +4158,7 @@ impl InProcessDaemon {
             }
             if changed {
                 updated = normalize_project_spec(updated)?;
-                projects
-                    .update(&InputMeta::from(&project.metadata), &project.metadata.resource_version, &updated)
-                    .await
-                    .map_err(|error| error.to_string())?;
+                projects.apply(&InputMeta::from(&project.metadata), &updated).await.map_err(|error| error.to_string())?;
                 project.spec = updated;
                 migrated_project_names.insert(project.metadata.name.clone());
             }
@@ -4193,7 +4194,7 @@ impl InProcessDaemon {
             }
         }
 
-        let remaining_projects = projects.list().await.map_err(|error| error.to_string())?.items;
+        let remaining_projects = projects.list().await.map_err(|error| error.to_string())?;
         let durable_checkouts =
             self.resource_backend.clone().using::<ResourceCheckout>(&namespace).list().await.map_err(|error| error.to_string())?.items;
         for old_key in &migratable_keys {
@@ -4745,7 +4746,7 @@ impl InProcessDaemon {
 
     pub async fn list_projects_internal(&self) -> Result<ProjectListResponse, String> {
         let namespace = self.provisioning_namespace().await;
-        let projects = self.resource_backend.clone().using::<Project>(&namespace).list().await.map_err(|error| error.to_string())?;
+        let projects = self.resource_backend.clone().definitions::<Project>(&namespace).list().await.map_err(|error| error.to_string())?;
         let repositories = self.resource_backend.clone().using::<Repository>(&namespace).list().await.map_err(|error| error.to_string())?;
         let repositories = repositories
             .items
@@ -4755,9 +4756,9 @@ impl InProcessDaemon {
         let repository_slugs = repository_display_labels(repositories.iter().map(|(key, repository)| (key, &repository.spec)));
 
         let mut entries = projects
-            .items
             .into_iter()
             .map(|project| {
+                let conflicts = project.metadata.merge.as_ref().map(|merge| merge.conflicts.keys().cloned().collect()).unwrap_or_default();
                 let mut project_repositories = BTreeMap::<RepositoryKey, BTreeSet<String>>::new();
                 for repository in project.spec.repositories {
                     if let Some(subpath) = repository.subpath {
@@ -4782,6 +4783,7 @@ impl InProcessDaemon {
                     .repositories(repositories)
                     .maybe_issue_source(project.spec.issue_source)
                     .default_workflow_ref(project.spec.default_workflow_ref)
+                    .conflicts(conflicts)
                     .build()
             })
             .collect::<Vec<_>>();
@@ -6053,7 +6055,9 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ResourceWatch { namespace, kind, include_replicas, cursor } = command.action {
+        if let flotilla_protocol::CommandAction::ResourceWatch { namespace, kind, include_replicas, replica_sources, cursor } =
+            command.action
+        {
             let repo_identity = empty_repo_identity();
             let description = format!("watch resource {namespace}/{kind}");
             let token = CancellationToken::new();
@@ -6079,6 +6083,7 @@ impl InProcessDaemon {
                         .namespace(namespace)
                         .kind(kind)
                         .include_replicas(include_replicas)
+                        .replica_sources(replica_sources)
                         .maybe_cursor(cursor)
                         .command_id(id)
                         .node_id(command_node_id.clone())
@@ -6613,16 +6618,12 @@ impl InProcessDaemon {
                 description: command.description().to_string(),
             });
             let namespace = self.provisioning_namespace().await;
-            let projects = self.resource_backend.clone().using::<Project>(&namespace);
+            let projects = self.resource_backend.clone().definitions::<Project>(&namespace);
             let result = match validate_project_name(name).and_then(|_| parse_project_yaml(spec_yaml)) {
                 Ok(spec) => match normalize_project_spec(spec) {
                     Ok(spec) => {
                         let meta = InputMeta::builder().name(name.clone()).build();
-                        let outcome = match projects.get(name).await {
-                            Ok(existing) => projects.update(&meta, &existing.metadata.resource_version, &spec).await.map(|_| ()),
-                            Err(ResourceError::NotFound { .. }) => projects.create(&meta, &spec).await.map(|_| ()),
-                            Err(err) => Err(err),
-                        };
+                        let outcome = projects.apply(&meta, &spec).await.map(|_| ());
                         match outcome {
                             Ok(()) => flotilla_protocol::CommandValue::ProjectApplied { name: name.clone() },
                             Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -787,6 +787,7 @@ async fn resource_watch_emits_initial_resources_as_wire_events() {
                 namespace: "flotilla".to_string(),
                 kind: "convoys".to_string(),
                 include_replicas: false,
+                replica_sources: false,
                 cursor: None,
             },
         })
@@ -835,6 +836,7 @@ async fn resource_watch_resumes_after_a_stored_cursor_without_relisting() {
                 namespace: "flotilla".to_string(),
                 kind: "convoys".to_string(),
                 include_replicas: false,
+                replica_sources: false,
                 cursor: Some(flotilla_protocol::ResourceWatchCursor { resource_version: cursor, generation: None }),
             },
         })

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -43,7 +43,7 @@ pub struct AggregatorResolvers {
     durable_environments: TypedResolver<Environment>,
     durable_presentations: TypedResolver<Presentation>,
     durable_sessions: ReplicaReadResolver<TerminalSession>,
-    durable_projects: TypedResolver<Project>,
+    durable_projects: ReplicaReadResolver<Project>,
     durable_repositories: TypedResolver<Repository>,
     durable_regards: TypedResolver<Regard>,
     observed_convoys: TypedResolver<Convoy>,
@@ -59,7 +59,7 @@ struct AggregatorSourceRefs<'a> {
     durable_environments: &'a dyn AggregatorWatchSource<Environment>,
     durable_presentations: &'a dyn AggregatorWatchSource<Presentation>,
     durable_sessions: &'a dyn AggregatorReplicaWatchSource<TerminalSession>,
-    durable_projects: &'a dyn AggregatorWatchSource<Project>,
+    durable_projects: &'a dyn AggregatorReplicaWatchSource<Project>,
     durable_repositories: &'a dyn AggregatorWatchSource<Repository>,
     durable_regards: &'a dyn AggregatorWatchSource<Regard>,
     observed_convoys: &'a dyn AggregatorWatchSource<Convoy>,
@@ -641,14 +641,18 @@ impl Aggregator {
 
     async fn recover_project_watch(
         &mut self,
-        resolver: &dyn AggregatorWatchSource<Project>,
-    ) -> Result<WatchStream<Project>, ResourceError> {
-        loop {
-            match self.list_and_watch_projects(resolver).await {
-                Err(ResourceError::WatchExpired { .. }) => tokio::time::sleep(Self::WATCH_RESTART_BACKOFF).await,
-                result => return result,
-            }
-        }
+        resolver: &dyn AggregatorReplicaWatchSource<Project>,
+    ) -> Result<BoxStream<'static, Result<ReadWatchEvent<Project>, ResourceError>>, ResourceError> {
+        let (items, watch) = Self::recover_replica_watch(resolver).await?;
+        self.projects = items
+            .into_iter()
+            .map(|project| {
+                let object = project.object;
+                ((object.metadata.namespace.clone(), object.metadata.name.clone()), object)
+            })
+            .collect();
+        self.rebuild_store_catalog().await;
+        Ok(watch)
     }
 
     async fn recover_repository_watch(
@@ -767,21 +771,6 @@ impl Aggregator {
         let start = WatchStart::resuming_from(&listed);
         let watch = resolver.watch(start).await?;
         self.replace_session_source(source, listed.items).await;
-        Ok(watch)
-    }
-
-    async fn list_and_watch_projects(
-        &mut self,
-        resolver: &dyn AggregatorWatchSource<Project>,
-    ) -> Result<WatchStream<Project>, ResourceError> {
-        let listed = resolver.list().await?;
-        let watch = resolver.watch(WatchStart::resuming_from(&listed)).await?;
-        self.projects = listed
-            .items
-            .into_iter()
-            .map(|project| ((project.metadata.namespace.clone(), project.metadata.name.clone()), project))
-            .collect();
-        self.rebuild_store_catalog().await;
         Ok(watch)
     }
 
@@ -1249,12 +1238,14 @@ impl Aggregator {
         self.rebuild_local_projection().await;
     }
 
-    async fn apply_project_event(&mut self, event: WatchEvent<Project>) {
+    async fn apply_project_event(&mut self, event: ReadWatchEvent<Project>) {
         match event {
-            WatchEvent::Added(project) | WatchEvent::Modified(project) => {
+            ReadWatchEvent::Added(project) | ReadWatchEvent::Modified(project) => {
+                let project = project.object;
                 self.projects.insert((project.metadata.namespace.clone(), project.metadata.name.clone()), project);
             }
-            WatchEvent::Deleted(project) => {
+            ReadWatchEvent::Deleted(project) => {
+                let project = project.object;
                 self.projects.remove(&(project.metadata.namespace, project.metadata.name));
             }
         }
@@ -2165,7 +2156,7 @@ mod tests {
         };
         state.replace_subscriber(Uuid::new_v4(), &[flotilla_protocol::QueryCursor { query: query.clone(), since: None }]);
 
-        aggregator.apply_project_event(WatchEvent::Added(project_object("widgets").await)).await;
+        aggregator.apply_project_event(local_read_event(WatchEvent::Added(project_object("widgets").await))).await;
 
         let result_set = timeout(Duration::from_secs(1), async {
             loop {
@@ -2239,7 +2230,7 @@ mod tests {
                         .durable_environments(durable.clone().using::<Environment>("flotilla"))
                         .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
                         .durable_sessions(durable.including_replicas::<TerminalSession>("flotilla"))
-                        .durable_projects(durable.using::<Project>("flotilla"))
+                        .durable_projects(durable.including_replicas::<Project>("flotilla"))
                         .durable_repositories(durable.using::<Repository>("flotilla"))
                         .durable_regards(durable.using::<Regard>("flotilla"))
                         .observed_convoys(observed.clone().using::<Convoy>("flotilla"))
@@ -2380,6 +2371,7 @@ mod tests {
             finalizers: Vec::new(),
             deletion_timestamp: None,
             creation_timestamp,
+            merge: None,
         }
     }
 
@@ -3624,6 +3616,7 @@ mod tests {
                 finalizers: Vec::new(),
                 deletion_timestamp: None,
                 creation_timestamp: Utc::now(),
+                merge: None,
             },
             spec: ConvoySpec::builder().workflow_ref("scratch".to_string()).build(),
             status: Some(ConvoyStatus {
@@ -3779,7 +3772,7 @@ mod tests {
                     .durable_environments(durable.clone().using::<Environment>("flotilla"))
                     .durable_presentations(durable.clone().using::<Presentation>("flotilla"))
                     .durable_sessions(durable.including_replicas::<TerminalSession>("flotilla"))
-                    .durable_projects(durable.using::<Project>("flotilla"))
+                    .durable_projects(durable.including_replicas::<Project>("flotilla"))
                     .durable_repositories(durable.using::<Repository>("flotilla"))
                     .durable_regards(durable.using::<Regard>("flotilla"))
                     .observed_convoys(observed.clone().using::<Convoy>("flotilla"))

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -873,7 +873,7 @@ fn spawn_aggregator_task(
                             .durable_environments(durable.clone().using::<Environment>(&namespace))
                             .durable_presentations(durable.using::<Presentation>(&namespace))
                             .durable_sessions(durable.including_replicas::<flotilla_resources::TerminalSession>(&namespace))
-                            .durable_projects(durable.using::<Project>(&namespace))
+                            .durable_projects(durable.including_replicas::<Project>(&namespace))
                             .durable_repositories(durable.using::<Repository>(&namespace))
                             .durable_regards(durable.using::<Regard>(&namespace))
                             .observed_convoys(observed.clone().using::<Convoy>(&namespace))

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -4,7 +4,8 @@ use chrono::Utc;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, NodeId, ResourceWatchCursor, ResourceWatchResponse};
 use flotilla_resources::{
-    HttpBackend, K8sWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, WatchStart,
+    HttpBackend, K8sWatchEvent, ReadWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject,
+    ResourceProvenance, WatchEvent, WatchStart,
 };
 use futures::StreamExt;
 use tokio::sync::watch;
@@ -144,8 +145,64 @@ fn spawn_kind<T: Resource>(
     transport: &ReplicationTransport,
     cancellation: &CancellationToken,
 ) {
-    if T::REPLICATION_CLASS != ReplicationClass::HomeBoundRuntime {
+    if T::REPLICATION_CLASS == ReplicationClass::None {
         return;
+    }
+    match transport.clone() {
+        ReplicationTransport::Http(socket_path_source) => {
+            let relay_daemon = Arc::clone(daemon);
+            let relay_peer = peer.clone();
+            let relay_cancellation = cancellation.clone();
+            tokio::spawn(async move {
+                let run_daemon = Arc::clone(&relay_daemon);
+                let run_peer = relay_peer.clone();
+                supervise_kind(
+                    relay_peer,
+                    generation,
+                    T::API_PATHS.kind,
+                    relay_cancellation,
+                    REPLICATION_RETRY,
+                    move || {
+                        let socket_path_source = socket_path_source.clone();
+                        async move { socket_path_source.resolve().await }
+                    },
+                    move |path| {
+                        let daemon = Arc::clone(&run_daemon);
+                        let peer = run_peer.clone();
+                        async move {
+                            let http = HttpBackend::from_unix_socket(path).map_err(|error| error.to_string())?;
+                            replicate_relay_over_http::<T>(http, &daemon, &peer).await
+                        }
+                    },
+                )
+                .await;
+            });
+        }
+        #[cfg(feature = "test-support")]
+        ReplicationTransport::Routed(router) => {
+            let relay_daemon = Arc::clone(daemon);
+            let relay_peer = peer.clone();
+            let relay_cancellation = cancellation.clone();
+            tokio::spawn(async move {
+                let run_daemon = Arc::clone(&relay_daemon);
+                let run_peer = relay_peer.clone();
+                supervise_kind(
+                    relay_peer,
+                    generation,
+                    T::API_PATHS.kind,
+                    relay_cancellation,
+                    REPLICATION_RETRY,
+                    || async { Ok(()) },
+                    move |()| {
+                        let router = router.clone();
+                        let daemon = Arc::clone(&run_daemon);
+                        let peer = run_peer.clone();
+                        async move { replicate_relay_over_routed_watch::<T>(&router, &daemon, &peer).await }
+                    },
+                )
+                .await;
+            });
+        }
     }
     let daemon = Arc::clone(daemon);
     let peer = peer.clone();
@@ -199,6 +256,45 @@ fn spawn_kind<T: Resource>(
             }
         }
     });
+}
+
+async fn replicate_relay_over_http<T: Resource>(http: HttpBackend, daemon: &Arc<InProcessDaemon>, peer: &NodeId) -> Result<(), String> {
+    let mut watch = http.watch_replica_sources_typed::<T>(REPLICATION_NAMESPACE).await.map_err(|error| error.to_string())?;
+    while let Some(event) = watch.next().await {
+        let event = event.map_err(|error| error.to_string())?;
+        let (kind, mut source) = match event {
+            ReadWatchEvent::Added(source) => (StoredRelayEventKind::Added, source),
+            ReadWatchEvent::Modified(source) => (StoredRelayEventKind::Modified, source),
+            ReadWatchEvent::Deleted(source) => (StoredRelayEventKind::Deleted, source),
+        };
+        let ResourceProvenance::Replica { origin_root, last_synced_at } = source.provenance else {
+            continue;
+        };
+        if &origin_root == daemon.node_id() || &origin_root == peer {
+            continue;
+        }
+        source.object.metadata.annotations.remove("flotilla.work/origin-root");
+        source.object.metadata.annotations.remove("flotilla.work/last-synced-at");
+        let event = match kind {
+            StoredRelayEventKind::Added => WatchEvent::Added(source.object),
+            StoredRelayEventKind::Modified => WatchEvent::Modified(source.object),
+            StoredRelayEventKind::Deleted => WatchEvent::Deleted(source.object),
+        };
+        daemon
+            .resource_backend()
+            .replica_writer::<T>(origin_root, REPLICATION_NAMESPACE)
+            .apply(event, last_synced_at)
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum StoredRelayEventKind {
+    Added,
+    Modified,
+    Deleted,
 }
 
 async fn supervise_kind<I, S, SourceFut, F, Fut>(
@@ -322,6 +418,7 @@ async fn run_routed_watch<T: Resource>(
                     namespace: REPLICATION_NAMESPACE.to_string(),
                     kind: T::API_PATHS.plural.to_string(),
                     include_replicas: false,
+                    replica_sources: false,
                     cursor: protocol_cursor,
                 },
             },
@@ -362,6 +459,108 @@ async fn run_routed_watch<T: Resource>(
             Err(tokio::sync::broadcast::error::RecvError::Closed) => return Err("daemon event stream closed".to_string()),
         }
     }
+}
+
+#[cfg(feature = "test-support")]
+async fn replicate_relay_over_routed_watch<T: Resource>(
+    router: &RemoteCommandRouter,
+    daemon: &Arc<InProcessDaemon>,
+    peer: &NodeId,
+) -> Result<(), String> {
+    let mut events = daemon.subscribe();
+    let command_id = router
+        .dispatch_execute_for_principal(
+            Command {
+                node_id: Some(peer.clone()),
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ResourceWatch {
+                    namespace: REPLICATION_NAMESPACE.to_string(),
+                    kind: T::API_PATHS.plural.to_string(),
+                    include_replicas: false,
+                    replica_sources: true,
+                    cursor: None,
+                },
+            },
+            None,
+        )
+        .await?;
+    loop {
+        match events.recv().await {
+            Ok(DaemonEvent::CommandStepUpdate {
+                command_id: event_command_id,
+                status: flotilla_protocol::StepStatus::Produced { value },
+                ..
+            }) if event_command_id == command_id => {
+                let CommandValue::ResourceWatchEvent(response) = *value else {
+                    continue;
+                };
+                if response.kind == T::API_PATHS.kind && response.event["type"] != "BOOKMARK" {
+                    apply_relay_response::<T>(daemon, peer, *response).await?;
+                }
+            }
+            Ok(DaemonEvent::CommandFinished { command_id: event_command_id, result, .. }) if event_command_id == command_id => {
+                return match result {
+                    CommandValue::Cancelled | CommandValue::Ok => Ok(()),
+                    CommandValue::Error { message } => Err(message),
+                    other => Err(format!("resource relay watch ended unexpectedly: {other:?}")),
+                };
+            }
+            Ok(_) => {}
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                warn!(%peer, kind = T::API_PATHS.kind, skipped, "resource relay lagged; reconnect will relist");
+                return Err("resource relay event subscriber lagged".to_string());
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return Err("daemon event stream closed".to_string()),
+        }
+    }
+}
+
+#[cfg(feature = "test-support")]
+async fn apply_relay_response<T: Resource>(
+    daemon: &Arc<InProcessDaemon>,
+    peer: &NodeId,
+    response: ResourceWatchResponse,
+) -> Result<(), String> {
+    let event: K8sWatchEvent<T> =
+        serde_json::from_value(response.event).map_err(|error| format!("decode relayed {} event: {error}", T::API_PATHS.kind))?;
+    let event = event.into_watch_event().map_err(|error| error.to_string())?;
+    let object = match &event {
+        WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => object,
+    };
+    let Some(origin) = object.metadata.annotations.get("flotilla.work/origin-root") else {
+        return Ok(());
+    };
+    let origin = NodeId::new(origin.clone());
+    if &origin == daemon.node_id() || &origin == peer {
+        return Ok(());
+    }
+    let synced_at = object
+        .metadata
+        .annotations
+        .get("flotilla.work/last-synced-at")
+        .ok_or_else(|| "relayed resource is missing last-synced-at".to_string())
+        .and_then(|value| {
+            chrono::DateTime::parse_from_rfc3339(value)
+                .map(|value| value.with_timezone(&Utc))
+                .map_err(|error| format!("decode relayed sync timestamp: {error}"))
+        })?;
+    let strip = |mut object: ResourceObject<T>| {
+        object.metadata.annotations.remove("flotilla.work/origin-root");
+        object.metadata.annotations.remove("flotilla.work/last-synced-at");
+        object
+    };
+    let event = match event {
+        WatchEvent::Added(object) => WatchEvent::Added(strip(object)),
+        WatchEvent::Modified(object) => WatchEvent::Modified(strip(object)),
+        WatchEvent::Deleted(object) => WatchEvent::Deleted(strip(object)),
+    };
+    daemon
+        .resource_backend()
+        .replica_writer::<T>(origin, REPLICATION_NAMESPACE)
+        .apply(event, synced_at)
+        .await
+        .map_err(|error| error.to_string())
 }
 
 #[cfg(feature = "test-support")]

--- a/crates/flotilla-daemon/src/server/resource_http.rs
+++ b/crates/flotilla-daemon/src/server/resource_http.rs
@@ -1,8 +1,9 @@
 use std::collections::BTreeMap;
 
 use flotilla_resources::{
-    list_resource_kind, list_resource_kind_including_replicas, watch_resource_kind, watch_resource_kind_from,
-    watch_resource_kind_including_replicas, DynamicResourceWatch, ResourceBackend, ResourceError, WatchStart,
+    list_resource_kind, list_resource_kind_including_replicas, list_resource_kind_replica_sources, watch_resource_kind,
+    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceWatch,
+    ResourceBackend, ResourceError, WatchStart,
 };
 use futures::StreamExt;
 use tokio::{
@@ -43,10 +44,13 @@ pub(super) async fn serve_resource_http(mut stream: UnixStream, first_byte: u8, 
     let query = parse_query(raw_query);
     let include_replicas =
         ["includeReplicas", "include-replicas", "include_replicas"].iter().filter_map(|key| query.get(*key)).any(|value| value == "true");
+    let replica_sources = query.get("replicaSources").is_some_and(|value| value == "true");
     let watch = query.get("watch").is_some_and(|value| value == "true");
 
     if !watch {
-        let listed = if include_replicas {
+        let listed = if replica_sources {
+            list_resource_kind_replica_sources(&backend, namespace, kind).await
+        } else if include_replicas {
             list_resource_kind_including_replicas(&backend, namespace, kind).await
         } else {
             list_resource_kind(&backend, namespace, kind).await
@@ -57,7 +61,13 @@ pub(super) async fn serve_resource_http(mut stream: UnixStream, first_byte: u8, 
         };
     }
 
-    let watched = if include_replicas {
+    let watched = if replica_sources {
+        if query.contains_key("resourceVersion") {
+            Err(ResourceError::invalid("replica-source watches do not support resourceVersion resume"))
+        } else {
+            watch_resource_kind_replica_sources(&backend, namespace, kind).await
+        }
+    } else if include_replicas {
         if query.contains_key("resourceVersion") {
             Err(ResourceError::invalid("include-replicas watches do not support resourceVersion resume"))
         } else {

--- a/crates/flotilla-daemon/src/server/resource_http.rs
+++ b/crates/flotilla-daemon/src/server/resource_http.rs
@@ -42,9 +42,8 @@ pub(super) async fn serve_resource_http(mut stream: UnixStream, first_byte: u8, 
         return write_error(&mut stream, 404, "unknown resource API path").await;
     };
     let query = parse_query(raw_query);
-    let include_replicas =
-        ["includeReplicas", "include-replicas", "include_replicas"].iter().filter_map(|key| query.get(*key)).any(|value| value == "true");
-    let replica_sources = query.get("replicaSources").is_some_and(|value| value == "true");
+    let include_replicas = query_flag(&query, &["includeReplicas", "include-replicas", "include_replicas"]);
+    let replica_sources = query_flag(&query, &["replicaSources", "replica-sources", "replica_sources"]);
     let watch = query.get("watch").is_some_and(|value| value == "true");
 
     if !watch {
@@ -98,6 +97,10 @@ fn parse_query(raw_query: &str) -> BTreeMap<String, String> {
         .map(|pair| pair.split_once('=').unwrap_or((pair, "")))
         .map(|(key, value)| (key.to_string(), value.to_string()))
         .collect()
+}
+
+fn query_flag(query: &BTreeMap<String, String>, names: &[&str]) -> bool {
+    names.iter().filter_map(|name| query.get(*name)).any(|value| value == "true")
 }
 
 async fn stream_watch(stream: &mut UnixStream, mut watch: DynamicResourceWatch) -> Result<(), String> {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -984,6 +984,7 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
                 namespace: "flotilla".into(),
                 kind: "convoys".into(),
                 include_replicas: false,
+                replica_sources: false,
                 cursor: None,
             },
         })
@@ -1007,6 +1008,7 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
                     namespace: "flotilla".into(),
                     kind: "convoys".into(),
                     include_replicas: false,
+                    replica_sources: false,
                     cursor: None,
                 }
             });

--- a/crates/flotilla-daemon/tests/overlay_replication.rs
+++ b/crates/flotilla-daemon/tests/overlay_replication.rs
@@ -346,3 +346,82 @@ async fn a_peer_relays_another_origins_project_definition() {
     );
     drop(feta_gouda);
 }
+
+#[tokio::test]
+async fn a_peer_relays_another_origins_home_bound_runtime_resource() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let kiwi = daemon(temp.path().join("kiwi"), "kiwi-root", "kiwi").await;
+    let feta = daemon(temp.path().join("feta"), "feta-root", "feta").await;
+    let gouda = daemon(temp.path().join("gouda"), "gouda-root", "gouda").await;
+    kiwi.resource_backend()
+        .using::<TerminalSession>("flotilla")
+        .create(
+            &InputMeta::builder().name("kiwi-session".to_string()).build(),
+            &TerminalSessionSpec::builder()
+                .env_ref("env".to_string())
+                .role("coder".to_string())
+                .source(TerminalSessionSource::Tool { command: "true".to_string() })
+                .cwd("/tmp".to_string())
+                .pool("passthrough".to_string())
+                .build(),
+        )
+        .await
+        .expect("create TerminalSession on kiwi");
+
+    let kiwi_feta = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("connect kiwi and feta");
+    let kiwi_origin = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let sessions =
+                feta.resource_backend().including_replicas::<TerminalSession>("flotilla").list().await.expect("list feta sessions");
+            if let Some(session) = sessions.items.into_iter().find(|session| session.object.metadata.name == "kiwi-session") {
+                match session.provenance {
+                    ResourceProvenance::Replica { origin_root, .. } => break origin_root,
+                    ResourceProvenance::Local => panic!("kiwi TerminalSession must be a replica on feta"),
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("kiwi-to-feta TerminalSession replication timed out");
+    drop(kiwi_feta);
+
+    let feta_gouda = spawn_in_memory_request_topology(Arc::clone(&feta), Arc::clone(&gouda)).await.expect("connect feta and gouda");
+    let relayed_origin = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let sessions =
+                gouda.resource_backend().including_replicas::<TerminalSession>("flotilla").list().await.expect("list gouda sessions");
+            if let Some(session) = sessions.items.into_iter().find(|session| session.object.metadata.name == "kiwi-session") {
+                match session.provenance {
+                    ResourceProvenance::Replica { origin_root, .. } => break origin_root,
+                    ResourceProvenance::Local => panic!("relayed TerminalSession must remain a replica"),
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("feta did not relay kiwi TerminalSession to gouda");
+    assert_eq!(relayed_origin, kiwi_origin, "relay must preserve the first hop's origin");
+    assert!(
+        gouda
+            .resource_backend()
+            .using::<TerminalSession>("flotilla")
+            .list()
+            .await
+            .expect("gouda local TerminalSession log")
+            .items
+            .is_empty(),
+        "relay must not re-author the TerminalSession on gouda"
+    );
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let mut raw_session_watch = watch_resource_kind_replica_sources(&feta.resource_backend(), "flotilla", "terminalsessions")
+        .await
+        .expect("watch raw TerminalSession replica sources");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), raw_session_watch.stream.next()).await.is_err(),
+        "peers must not echo an unchanged third-origin TerminalSession indefinitely"
+    );
+    drop(feta_gouda);
+}

--- a/crates/flotilla-daemon/tests/overlay_replication.rs
+++ b/crates/flotilla-daemon/tests/overlay_replication.rs
@@ -4,9 +4,10 @@ use flotilla_core::{config::ConfigStore, in_process::InProcessDaemon, providers:
 use flotilla_daemon::server::test_support::spawn_in_memory_request_topology;
 use flotilla_protocol::HostName;
 use flotilla_resources::{
-    Convoy, ConvoySpec, InMemoryBackend, InputMeta, ResourceBackend, ResourceProvenance, TerminalSession, TerminalSessionSource,
-    TerminalSessionSpec, Vessel, VesselSpec,
+    watch_resource_kind_replica_sources, Convoy, ConvoySpec, InMemoryBackend, InputMeta, Project, ProjectSpec, ResourceBackend,
+    ResourceProvenance, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec,
 };
+use futures::StreamExt;
 
 fn config(path: std::path::PathBuf, machine_id: &str) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&path).expect("create config");
@@ -191,4 +192,157 @@ async fn connected_daemons_replicate_home_bound_runtime_kinds_and_deletes() {
     .await
     .expect("reconnect replication timed out");
     drop(reconnected);
+}
+
+fn project_spec(display_name: &str, workflow: &str) -> ProjectSpec {
+    ProjectSpec::builder()
+        .display_name(display_name.to_string())
+        .default_workflow_ref(workflow.to_string())
+        .repositories(Vec::new())
+        .build()
+}
+
+#[tokio::test]
+async fn connected_daemons_causally_merge_project_definitions() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let kiwi = daemon(temp.path().join("kiwi"), "kiwi-root", "kiwi").await;
+    let feta = daemon(temp.path().join("feta"), "feta-root", "feta").await;
+    let meta = InputMeta::builder().name("widgets".to_string()).build();
+    kiwi.resource_backend()
+        .definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Widgets", "default"))
+        .await
+        .expect("create Project on kiwi");
+
+    let topology = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("connect topology");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if feta
+                .resource_backend()
+                .definitions::<Project>("flotilla")
+                .get("widgets")
+                .await
+                .is_ok_and(|project| project.spec.display_name == "Widgets")
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("initial Project replication timed out");
+    drop(topology);
+
+    kiwi.resource_backend()
+        .definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Kiwi Widgets", "default"))
+        .await
+        .expect("offline edit on kiwi");
+    feta.resource_backend()
+        .definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Feta Widgets", "feta-flow"))
+        .await
+        .expect("offline edit on feta");
+
+    let reconnected = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("reconnect topology");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let kiwi_project = kiwi.resource_backend().definitions::<Project>("flotilla").get("widgets").await;
+            let feta_project = feta.resource_backend().definitions::<Project>("flotilla").get("widgets").await;
+            if let (Ok(kiwi_project), Ok(feta_project)) = (kiwi_project, feta_project) {
+                let kiwi_merge = kiwi_project.metadata.merge.as_ref().expect("kiwi merge metadata");
+                let feta_merge = feta_project.metadata.merge.as_ref().expect("feta merge metadata");
+                if kiwi_project.spec.default_workflow_ref == "feta-flow"
+                    && feta_project.spec.default_workflow_ref == "feta-flow"
+                    && kiwi_merge.conflicts.contains_key("spec.display_name")
+                    && feta_merge.conflicts.contains_key("spec.display_name")
+                {
+                    break;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("concurrent Project replication timed out");
+    let listed = kiwi.list_projects_internal().await.expect("list conflicted Projects");
+    let widgets = listed.projects.iter().find(|project| project.name == "widgets").expect("widgets Project in list");
+    assert_eq!(widgets.conflicts, vec!["spec.display_name"], "Project list should expose a compact conflict badge");
+
+    kiwi.resource_backend()
+        .definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Resolved Widgets", "feta-flow"))
+        .await
+        .expect("resolve Project conflict");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let resolved = feta.resource_backend().definitions::<Project>("flotilla").get("widgets").await;
+            if resolved.is_ok_and(|project| {
+                project.spec.display_name == "Resolved Widgets" && project.metadata.merge.is_some_and(|merge| merge.conflicts.is_empty())
+            }) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("Project conflict resolution replication timed out");
+    drop(reconnected);
+}
+
+#[tokio::test]
+async fn a_peer_relays_another_origins_project_definition() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let kiwi = daemon(temp.path().join("kiwi"), "kiwi-root", "kiwi").await;
+    let feta = daemon(temp.path().join("feta"), "feta-root", "feta").await;
+    let gouda = daemon(temp.path().join("gouda"), "gouda-root", "gouda").await;
+    kiwi.resource_backend()
+        .definitions::<Project>("flotilla")
+        .apply(&InputMeta::builder().name("widgets".to_string()).build(), &project_spec("Widgets", "default"))
+        .await
+        .expect("create Project on kiwi");
+
+    let kiwi_feta = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("connect kiwi and feta");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if feta.resource_backend().definitions::<Project>("flotilla").get("widgets").await.is_ok() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("kiwi-to-feta replication timed out");
+    drop(kiwi_feta);
+
+    let feta_gouda = spawn_in_memory_request_topology(Arc::clone(&feta), Arc::clone(&gouda)).await.expect("connect feta and gouda");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if gouda
+                .resource_backend()
+                .definitions::<Project>("flotilla")
+                .get("widgets")
+                .await
+                .is_ok_and(|project| project.spec.display_name == "Widgets")
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("feta did not relay kiwi Project to gouda");
+    assert!(
+        gouda.resource_backend().using::<Project>("flotilla").list().await.expect("gouda local Project log").items.is_empty(),
+        "relay must preserve the kiwi origin instead of re-authoring on gouda"
+    );
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let mut raw_project_watch = watch_resource_kind_replica_sources(&feta.resource_backend(), "flotilla", "projects")
+        .await
+        .expect("watch raw Project replica sources");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(150), raw_project_watch.stream.next()).await.is_err(),
+        "peers must not echo an unchanged third-origin Project indefinitely"
+    );
+    drop(feta_gouda);
 }

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -227,10 +227,10 @@ async fn retracking_path_after_remote_appears_migrates_repository_identity() {
         }),
     });
 
-    let projects = backend.using::<Project>("flotilla").list().await.expect("project list");
-    assert_eq!(projects.items.len(), 1, "identity migration must not leave a disambiguated twin");
-    assert_eq!(projects.items[0].metadata.name, "andamento");
-    assert_eq!(projects.items[0].spec.repositories[0].repo, remote_key);
+    let projects = backend.definitions::<Project>("flotilla").list().await.expect("project list");
+    assert_eq!(projects.len(), 1, "identity migration must not leave a disambiguated twin");
+    assert_eq!(projects[0].metadata.name, "andamento");
+    assert_eq!(projects[0].spec.repositories[0].repo, remote_key);
     let repositories = backend.using::<Repository>("flotilla").list().await.expect("repository list");
     assert_eq!(repositories.items.len(), 1, "superseded repository identities should be garbage-collected");
     assert_eq!(repositories.items[0].metadata.name, remote_key.to_string());
@@ -364,11 +364,11 @@ async fn identity_change_preserves_migrated_project_when_local_and_remote_names_
         .expect("repo add after remote appears");
     assert!(matches!(await_command_result(&mut rx, second_id).await, CommandValue::RepoTracked { .. }));
 
-    let projects = backend.using::<Project>("flotilla").list().await.expect("project list");
-    assert_eq!(projects.items.len(), 1, "the pre-existing remote twin should be removed");
-    assert_eq!(projects.items[0].metadata.name, "z-local-name", "the migrated Project should retain its identity");
-    assert_eq!(projects.items[0].spec.display_name, "z-local-name");
-    assert_eq!(projects.items[0].spec.repositories[0].repo, remote_key);
+    let projects = backend.definitions::<Project>("flotilla").list().await.expect("project list");
+    assert_eq!(projects.len(), 1, "the pre-existing remote twin should be removed");
+    assert_eq!(projects[0].metadata.name, "z-local-name", "the migrated Project should retain its identity");
+    assert_eq!(projects[0].spec.display_name, "z-local-name");
+    assert_eq!(projects[0].spec.repositories[0].repo, remote_key);
 }
 
 #[tokio::test]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -429,6 +429,8 @@ pub enum CommandAction {
         kind: String,
         #[serde(default, skip_serializing_if = "is_false")]
         include_replicas: bool,
+        #[serde(default, skip_serializing_if = "is_false")]
+        replica_sources: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cursor: Option<ResourceWatchCursor>,
     },
@@ -1001,6 +1003,7 @@ mod tests {
                     namespace: "flotilla".into(),
                     kind: "convoys".into(),
                     include_replicas: false,
+                    replica_sources: false,
                     cursor: None,
                 },
             },

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -137,6 +137,9 @@ pub struct ProjectListEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issue_source: Option<IssueSource>,
     pub default_workflow_ref: String,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conflicts: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -5,6 +5,7 @@ use flotilla_protocol::NodeId;
 use futures::{stream, StreamExt};
 
 use crate::{
+    definition::DefinitionResolver,
     error::ResourceError,
     http::HttpBackend,
     in_memory::InMemoryBackend,
@@ -33,8 +34,28 @@ pub enum ResourceBackend {
 }
 
 impl ResourceBackend {
+    pub fn with_local_root(self, local_root: NodeId) -> Self {
+        match self {
+            Self::InMemory(backend) => Self::InMemory(backend.with_local_root(local_root)),
+            Self::Http(backend) => Self::Http(backend),
+            Self::Sqlite(backend) => Self::Sqlite(backend.with_local_root(local_root)),
+        }
+    }
+
+    pub(crate) fn local_root(&self) -> Result<NodeId, ResourceError> {
+        match self {
+            Self::InMemory(backend) => Ok(backend.local_root()),
+            Self::Sqlite(backend) => Ok(backend.local_root()),
+            Self::Http(_) => Err(ResourceError::invalid("HTTP backends cannot author definitions")),
+        }
+    }
+
     pub fn using<T: Resource>(&self, namespace: &str) -> TypedResolver<T> {
         TypedResolver { backend: self.clone(), namespace: namespace.to_string(), _marker: PhantomData }
+    }
+
+    pub fn definitions<T: Resource>(&self, namespace: &str) -> DefinitionResolver<T> {
+        DefinitionResolver::new(self.clone(), namespace.to_string())
     }
 
     /// A read-only union of locally-authored objects and durable replicas.
@@ -71,6 +92,25 @@ impl<T: Resource> ReplicaReadResolver<T> {
         if let ResourceBackend::Http(backend) = &self.backend {
             return backend.list_including_replicas_typed::<T>(&self.namespace).await;
         }
+        if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+            let items = self
+                .backend
+                .definitions::<T>(&self.namespace)
+                .list()
+                .await?
+                .into_iter()
+                .map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local })
+                .collect();
+            return Ok(ReadResourceList { items });
+        }
+        self.list_sources().await
+    }
+
+    pub(crate) async fn list_sources(&self) -> Result<ReadResourceList<T>, ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        if matches!(&self.backend, ResourceBackend::Http(_)) {
+            return Err(ResourceError::invalid("HTTP replica-source lists use the resource API"));
+        }
         let local = self.backend.using::<T>(&self.namespace).list().await?;
         let mut items =
             local.items.into_iter().map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local }).collect::<Vec<_>>();
@@ -98,6 +138,38 @@ impl<T: Resource> ReplicaReadResolver<T> {
         ensure_replication_enabled::<T>()?;
         if let ResourceBackend::Http(backend) = &self.backend {
             return backend.watch_including_replicas_typed::<T>(&self.namespace).await;
+        }
+        let raw = self.watch_sources().await?;
+        if T::REPLICATION_CLASS != crate::ReplicationClass::Definitions {
+            return Ok(raw);
+        }
+        let backend = self.backend.clone();
+        let namespace = self.namespace.clone();
+        Ok(raw
+            .then(move |event| {
+                let backend = backend.clone();
+                let namespace = namespace.clone();
+                async move {
+                    let event = event?;
+                    let fallback = match event {
+                        ReadWatchEvent::Added(object) | ReadWatchEvent::Modified(object) | ReadWatchEvent::Deleted(object) => object,
+                    };
+                    match backend.definitions::<T>(&namespace).get(&fallback.object.metadata.name).await {
+                        Ok(object) => Ok(ReadWatchEvent::Modified(ReadResourceObject { object, provenance: ResourceProvenance::Local })),
+                        Err(ResourceError::NotFound { .. }) => Ok(ReadWatchEvent::Deleted(fallback)),
+                        Err(error) => Err(error),
+                    }
+                }
+            })
+            .boxed())
+    }
+
+    pub(crate) async fn watch_sources(
+        &self,
+    ) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        if matches!(&self.backend, ResourceBackend::Http(_)) {
+            return Err(ResourceError::invalid("HTTP replica-source watches use the resource API"));
         }
         let replicas = match &self.backend {
             ResourceBackend::InMemory(backend) => backend.watch_replicas_typed::<T>(&self.namespace).await?,
@@ -160,7 +232,7 @@ impl<T: Resource> ReplicaWriter<T> {
 }
 
 fn ensure_replication_enabled<T: Resource>() -> Result<(), ResourceError> {
-    if T::REPLICATION_CLASS == crate::ReplicationClass::HomeBoundRuntime {
+    if T::REPLICATION_CLASS != crate::ReplicationClass::None {
         Ok(())
     } else {
         Err(ResourceError::invalid(format!("{} is not enabled for overlay replication", T::API_PATHS.kind)))
@@ -194,10 +266,22 @@ impl<T: Resource> TypedResolver<T> {
     }
 
     pub async fn create(&self, meta: &InputMeta, spec: &T::Spec) -> Result<ResourceObject<T>, ResourceError> {
+        if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+            return self.backend.definitions::<T>(&self.namespace).create(meta, spec).await;
+        }
         dispatch_backend!(self, create_typed, meta, spec)
     }
 
     pub async fn update(&self, meta: &InputMeta, resource_version: &str, spec: &T::Spec) -> Result<ResourceObject<T>, ResourceError> {
+        if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+            let definitions = self.backend.definitions::<T>(&self.namespace);
+            let current = definitions.get(&meta.name).await?;
+            let local_version_matches = self.get(&meta.name).await.is_ok_and(|local| local.metadata.resource_version == resource_version);
+            if current.metadata.resource_version != resource_version && !local_version_matches {
+                return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
+            }
+            return definitions.apply(meta, spec).await;
+        }
         dispatch_backend!(self, update_typed, meta, resource_version, spec)
     }
 
@@ -206,6 +290,9 @@ impl<T: Resource> TypedResolver<T> {
     }
 
     pub async fn delete(&self, name: &str) -> Result<(), ResourceError> {
+        if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+            return self.backend.definitions::<T>(&self.namespace).delete(name).await;
+        }
         dispatch_backend!(self, delete_typed, name)
     }
 

--- a/crates/flotilla-resources/src/definition.rs
+++ b/crates/flotilla-resources/src/definition.rs
@@ -92,11 +92,18 @@ impl<T: Resource> DefinitionResolver<T> {
         let next_counter = context.get(&local_root).copied().unwrap_or_default().saturating_add(1);
         let dot = CausalDot { author_root: local_root.clone(), author_counter: next_counter };
         let now = Utc::now();
+        let has_value_changes =
+            requested.iter().any(|(field, value)| current_spec.as_ref().and_then(|current| current.get(field)) != Some(value));
+        let resolves_existing_view = current.is_some() && !has_value_changes;
 
         for (field, value) in &requested {
             let path = format!("spec.{field}");
             let value_changed = current_spec.as_ref().and_then(|current| current.get(field)) != Some(value);
-            let resolves_conflict = merge.conflicts.contains_key(&path);
+            // A full-spec apply cannot distinguish an echoed merged value from
+            // an intentional choice of that sibling. Treat a pure no-op apply
+            // as conflict resolution, but do not let an edit to one field
+            // silently collapse conflicts in untouched fields.
+            let resolves_conflict = resolves_existing_view && merge.conflicts.contains_key(&path);
             if value_changed || resolves_conflict || current.is_none() {
                 changed = true;
                 merge.fields.insert(path, FieldMergeMetadata { dot: dot.clone(), seen: context.clone(), written_at: now });

--- a/crates/flotilla-resources/src/definition.rs
+++ b/crates/flotilla-resources/src/definition.rs
@@ -1,0 +1,382 @@
+use std::{collections::BTreeMap, marker::PhantomData};
+
+use chrono::{DateTime, Utc};
+use flotilla_protocol::NodeId;
+use serde_json::{Map, Value};
+
+use crate::{
+    CausalDot, FieldMergeMetadata, InputMeta, MergeConflictSibling, MergeMetadata, ReplicationClass, Resource, ResourceBackend,
+    ResourceError, ResourceObject, ResourceProvenance,
+};
+
+const DELETION_FIELD: &str = "$deleted";
+
+#[derive(Debug)]
+struct DefinitionSource<T: Resource> {
+    object: ResourceObject<T>,
+    origin: NodeId,
+    synced_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+struct FieldCandidate {
+    value: Value,
+    metadata: FieldMergeMetadata,
+}
+
+/// Read/write view for a definitions-class resource kind.
+///
+/// Reads merge the locally-authored record with every durable origin replica.
+/// Writes always append to this root's local authority after the store stamps
+/// causal context derived from that merged view.
+#[derive(Debug, Clone)]
+pub struct DefinitionResolver<T: Resource> {
+    backend: ResourceBackend,
+    namespace: String,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Resource> DefinitionResolver<T> {
+    pub(crate) fn new(backend: ResourceBackend, namespace: String) -> Self {
+        Self { backend, namespace, _marker: PhantomData }
+    }
+
+    pub async fn get(&self, name: &str) -> Result<ResourceObject<T>, ResourceError> {
+        self.list().await?.into_iter().find(|object| object.metadata.name == name).ok_or_else(|| ResourceError::not_found(name))
+    }
+
+    pub async fn list(&self) -> Result<Vec<ResourceObject<T>>, ResourceError> {
+        ensure_definitions::<T>()?;
+        let mut by_name = BTreeMap::<String, Vec<DefinitionSource<T>>>::new();
+        for source in self.sources().await? {
+            by_name.entry(source.object.metadata.name.clone()).or_default().push(source);
+        }
+        let mut merged = Vec::with_capacity(by_name.len());
+        for sources in by_name.into_values() {
+            let object = merge_sources(&sources)?;
+            let deleted = object
+                .metadata
+                .merge
+                .as_ref()
+                .and_then(|merge| merge.fields.get(DELETION_FIELD))
+                .is_some_and(|_| object.metadata.deletion_timestamp.is_some());
+            if !deleted || object.metadata.merge.as_ref().is_some_and(|merge| merge.conflicts.contains_key(DELETION_FIELD)) {
+                merged.push(object);
+            }
+        }
+        Ok(merged)
+    }
+
+    pub async fn create(&self, meta: &InputMeta, spec: &T::Spec) -> Result<ResourceObject<T>, ResourceError> {
+        match self.get(&meta.name).await {
+            Ok(_) => Err(ResourceError::conflict(&meta.name, "resource already exists")),
+            Err(ResourceError::NotFound { .. }) => self.apply(meta, spec).await,
+            Err(error) => Err(error),
+        }
+    }
+
+    pub async fn apply(&self, meta: &InputMeta, spec: &T::Spec) -> Result<ResourceObject<T>, ResourceError> {
+        ensure_definitions::<T>()?;
+        let local_root = self.backend.local_root()?;
+        let sources = self.sources_for_name(&meta.name).await?;
+        let current = (!sources.is_empty()).then(|| merge_sources(&sources)).transpose()?;
+        let requested = spec_object(spec)?;
+        let current_spec = current.as_ref().map(|object| spec_object(&object.spec)).transpose()?;
+        let mut changed = current_spec.is_none();
+        let mut merge = current.as_ref().and_then(|object| object.metadata.merge.clone()).unwrap_or_else(|| MergeMetadata {
+            fields: BTreeMap::new(),
+            seen: BTreeMap::new(),
+            conflicts: BTreeMap::new(),
+        });
+        let context = causal_context(&sources);
+        let next_counter = context.get(&local_root).copied().unwrap_or_default().saturating_add(1);
+        let dot = CausalDot { author_root: local_root.clone(), author_counter: next_counter };
+        let now = Utc::now();
+
+        for (field, value) in &requested {
+            let path = format!("spec.{field}");
+            let value_changed = current_spec.as_ref().and_then(|current| current.get(field)) != Some(value);
+            let resolves_conflict = merge.conflicts.contains_key(&path);
+            if value_changed || resolves_conflict || current.is_none() {
+                changed = true;
+                merge.fields.insert(path, FieldMergeMetadata { dot: dot.clone(), seen: context.clone(), written_at: now });
+            }
+        }
+        if merge.conflicts.contains_key(DELETION_FIELD)
+            || current.as_ref().is_some_and(|object| object.metadata.deletion_timestamp.is_some())
+        {
+            changed = true;
+        }
+        if !changed {
+            return current.ok_or_else(|| ResourceError::not_found(&meta.name));
+        }
+
+        merge.fields.insert(DELETION_FIELD.to_string(), FieldMergeMetadata { dot: dot.clone(), seen: context.clone(), written_at: now });
+        merge.seen = context;
+        merge.seen.insert(local_root, next_counter);
+        merge.conflicts.clear();
+
+        let mut admitted_meta = meta.clone();
+        admitted_meta.deletion_timestamp = None;
+        match self.backend.using::<T>(&self.namespace).get(&meta.name).await {
+            Ok(local) => match &self.backend {
+                ResourceBackend::InMemory(backend) => {
+                    backend
+                        .update_definition_typed::<T>(&self.namespace, &admitted_meta, &local.metadata.resource_version, spec, merge)
+                        .await?;
+                }
+                ResourceBackend::Sqlite(backend) => {
+                    backend
+                        .update_definition_typed::<T>(&self.namespace, &admitted_meta, &local.metadata.resource_version, spec, merge)
+                        .await?;
+                }
+                ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP backends cannot author definitions")),
+            },
+            Err(ResourceError::NotFound { .. }) => match &self.backend {
+                ResourceBackend::InMemory(backend) => {
+                    backend.create_definition_typed::<T>(&self.namespace, &admitted_meta, spec, merge).await?;
+                }
+                ResourceBackend::Sqlite(backend) => {
+                    backend.create_definition_typed::<T>(&self.namespace, &admitted_meta, spec, merge).await?;
+                }
+                ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP backends cannot author definitions")),
+            },
+            Err(error) => return Err(error),
+        }
+        self.get(&meta.name).await
+    }
+
+    pub async fn delete(&self, name: &str) -> Result<(), ResourceError> {
+        ensure_definitions::<T>()?;
+        let local_root = self.backend.local_root()?;
+        let sources = self.sources_for_name(name).await?;
+        if sources.is_empty() {
+            return Err(ResourceError::not_found(name));
+        }
+        let current = merge_sources(&sources)?;
+        let context = causal_context(&sources);
+        let next_counter = context.get(&local_root).copied().unwrap_or_default().saturating_add(1);
+        let dot = CausalDot { author_root: local_root.clone(), author_counter: next_counter };
+        let mut merge = current.metadata.merge.clone().unwrap_or_else(|| MergeMetadata {
+            fields: BTreeMap::new(),
+            seen: BTreeMap::new(),
+            conflicts: BTreeMap::new(),
+        });
+        merge.fields.insert(DELETION_FIELD.to_string(), FieldMergeMetadata { dot, seen: context.clone(), written_at: Utc::now() });
+        merge.seen = context;
+        merge.seen.insert(local_root, next_counter);
+        merge.conflicts.clear();
+        let mut meta = InputMeta::from(&current.metadata);
+        meta.deletion_timestamp = Some(Utc::now());
+
+        match self.backend.using::<T>(&self.namespace).get(name).await {
+            Ok(local) => match &self.backend {
+                ResourceBackend::InMemory(backend) => {
+                    backend
+                        .update_definition_typed::<T>(&self.namespace, &meta, &local.metadata.resource_version, &current.spec, merge)
+                        .await?;
+                }
+                ResourceBackend::Sqlite(backend) => {
+                    backend
+                        .update_definition_typed::<T>(&self.namespace, &meta, &local.metadata.resource_version, &current.spec, merge)
+                        .await?;
+                }
+                ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP backends cannot author definitions")),
+            },
+            Err(ResourceError::NotFound { .. }) => match &self.backend {
+                ResourceBackend::InMemory(backend) => {
+                    backend.create_definition_typed::<T>(&self.namespace, &meta, &current.spec, merge).await?;
+                }
+                ResourceBackend::Sqlite(backend) => {
+                    backend.create_definition_typed::<T>(&self.namespace, &meta, &current.spec, merge).await?;
+                }
+                ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP backends cannot author definitions")),
+            },
+            Err(error) => return Err(error),
+        }
+        Ok(())
+    }
+
+    async fn sources_for_name(&self, name: &str) -> Result<Vec<DefinitionSource<T>>, ResourceError> {
+        Ok(self.sources().await?.into_iter().filter(|source| source.object.metadata.name == name).collect())
+    }
+
+    async fn sources(&self) -> Result<Vec<DefinitionSource<T>>, ResourceError> {
+        let local_root = self.backend.local_root()?;
+        let local = self.backend.using::<T>(&self.namespace).list().await?;
+        let mut sources = local
+            .items
+            .into_iter()
+            .map(|object| DefinitionSource { object, origin: local_root.clone(), synced_at: None })
+            .collect::<Vec<_>>();
+        let replicas = match &self.backend {
+            ResourceBackend::InMemory(backend) => backend.list_replicas_typed::<T>(&self.namespace).await?,
+            ResourceBackend::Sqlite(backend) => backend.list_replicas_typed::<T>(&self.namespace).await?,
+            ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP definition views are served by the origin store")),
+        };
+        sources.extend(replicas.into_iter().filter_map(|replica| match replica.provenance {
+            ResourceProvenance::Replica { origin_root, last_synced_at } => {
+                Some(DefinitionSource { object: replica.object, origin: origin_root, synced_at: Some(last_synced_at) })
+            }
+            ResourceProvenance::Local => None,
+        }));
+        Ok(sources)
+    }
+}
+
+fn ensure_definitions<T: Resource>() -> Result<(), ResourceError> {
+    if T::REPLICATION_CLASS == ReplicationClass::Definitions {
+        Ok(())
+    } else {
+        Err(ResourceError::invalid(format!("{} is not a definitions-class resource", T::API_PATHS.kind)))
+    }
+}
+
+fn spec_object<T: serde::Serialize>(spec: &T) -> Result<Map<String, Value>, ResourceError> {
+    serde_json::to_value(spec)
+        .map_err(|error| ResourceError::decode(format!("encode definition spec: {error}")))?
+        .as_object()
+        .cloned()
+        .ok_or_else(|| ResourceError::decode("definition spec is not a JSON object"))
+}
+
+fn causal_context<T: Resource>(sources: &[DefinitionSource<T>]) -> BTreeMap<NodeId, u64> {
+    let mut context = BTreeMap::new();
+    for source in sources {
+        if let Some(merge) = &source.object.metadata.merge {
+            merge_vector(&mut context, &merge.seen);
+            for field in merge.fields.values() {
+                merge_counter(&mut context, &field.dot.author_root, field.dot.author_counter);
+            }
+        } else {
+            merge_counter(&mut context, &source.origin, legacy_counter(&source.object));
+        }
+    }
+    context
+}
+
+fn merge_sources<T: Resource>(sources: &[DefinitionSource<T>]) -> Result<ResourceObject<T>, ResourceError> {
+    let context = causal_context(sources);
+    let mut sources = sources.iter().collect::<Vec<_>>();
+    sources.sort_by(|left, right| left.origin.cmp(&right.origin));
+    let mut field_candidates = BTreeMap::<String, Vec<FieldCandidate>>::new();
+    for source in &sources {
+        let spec = spec_object(&source.object.spec)?;
+        for (field, value) in spec {
+            let path = format!("spec.{field}");
+            let metadata = source
+                .object
+                .metadata
+                .merge
+                .as_ref()
+                .and_then(|merge| merge.fields.get(&path))
+                .cloned()
+                .unwrap_or_else(|| legacy_field(source));
+            field_candidates.entry(path).or_default().push(FieldCandidate { value, metadata });
+        }
+        let metadata = source
+            .object
+            .metadata
+            .merge
+            .as_ref()
+            .and_then(|merge| merge.fields.get(DELETION_FIELD))
+            .cloned()
+            .unwrap_or_else(|| legacy_field(source));
+        field_candidates
+            .entry(DELETION_FIELD.to_string())
+            .or_default()
+            .push(FieldCandidate { value: Value::Bool(source.object.metadata.deletion_timestamp.is_some()), metadata });
+    }
+
+    let mut merged_fields = BTreeMap::new();
+    let mut conflicts = BTreeMap::new();
+    let mut spec = Map::new();
+    let mut deleted_at = None;
+    for (path, candidates) in field_candidates {
+        let maximal = causally_maximal(candidates);
+        let mut distinct = BTreeMap::<String, FieldCandidate>::new();
+        for candidate in maximal {
+            let key = serde_json::to_string(&candidate.value)
+                .map_err(|error| ResourceError::decode(format!("encode merged definition field: {error}")))?;
+            distinct.entry(key).or_insert(candidate);
+        }
+        let mut values = distinct.into_values().collect::<Vec<_>>();
+        values.sort_by(|left, right| left.metadata.dot.cmp(&right.metadata.dot));
+        let chosen = values.first().cloned().ok_or_else(|| ResourceError::decode("definition field has no maximal value"))?;
+        if values.len() > 1 {
+            conflicts.insert(
+                path.clone(),
+                values
+                    .iter()
+                    .map(|candidate| MergeConflictSibling {
+                        value: candidate.value.clone(),
+                        dot: candidate.metadata.dot.clone(),
+                        written_at: candidate.metadata.written_at,
+                    })
+                    .collect(),
+            );
+        }
+        let chosen_written_at = chosen.metadata.written_at;
+        merged_fields.insert(path.clone(), chosen.metadata);
+        if path == DELETION_FIELD {
+            deleted_at = chosen.value.as_bool().unwrap_or(false).then_some(chosen_written_at);
+        } else if let Some(field) = path.strip_prefix("spec.") {
+            spec.insert(field.to_string(), chosen.value);
+        }
+    }
+
+    let source = sources.first().ok_or_else(|| ResourceError::decode("cannot merge an empty definition source set"))?;
+    let mut object = ResourceObject::<T> {
+        metadata: source.object.metadata.clone(),
+        spec: source.object.spec.clone(),
+        status: source.object.status.clone(),
+    };
+    object.spec = serde_json::from_value(Value::Object(spec))
+        .map_err(|error| ResourceError::decode(format!("decode merged definition spec: {error}")))?;
+    object.metadata.resource_version =
+        sources.iter().map(|source| format!("{}:{}", source.origin, source.object.metadata.resource_version)).collect::<Vec<_>>().join(",");
+    object.metadata.deletion_timestamp = deleted_at;
+    object.metadata.merge = Some(MergeMetadata { fields: merged_fields, seen: context, conflicts });
+    Ok(object)
+}
+
+fn causally_maximal(candidates: Vec<FieldCandidate>) -> Vec<FieldCandidate> {
+    candidates
+        .iter()
+        .enumerate()
+        .filter(|(index, candidate)| {
+            !candidates.iter().enumerate().any(|(other_index, other)| {
+                *index != other_index
+                    && other.metadata.dot != candidate.metadata.dot
+                    && covers(&other.metadata.seen, &candidate.metadata.dot)
+            })
+        })
+        .map(|(_, candidate)| candidate.clone())
+        .collect()
+}
+
+fn covers(seen: &BTreeMap<NodeId, u64>, dot: &CausalDot) -> bool {
+    seen.get(&dot.author_root).is_some_and(|counter| *counter >= dot.author_counter)
+}
+
+fn legacy_field<T: Resource>(source: &DefinitionSource<T>) -> FieldMergeMetadata {
+    FieldMergeMetadata {
+        dot: CausalDot { author_root: source.origin.clone(), author_counter: legacy_counter(&source.object) },
+        seen: BTreeMap::new(),
+        written_at: source.synced_at.unwrap_or(source.object.metadata.creation_timestamp),
+    }
+}
+
+fn legacy_counter<T: Resource>(object: &ResourceObject<T>) -> u64 {
+    object.metadata.resource_version.parse().unwrap_or(1)
+}
+
+fn merge_vector(target: &mut BTreeMap<NodeId, u64>, source: &BTreeMap<NodeId, u64>) {
+    for (root, counter) in source {
+        merge_counter(target, root, *counter);
+    }
+}
+
+fn merge_counter(target: &mut BTreeMap<NodeId, u64>, root: &NodeId, counter: u64) {
+    target.entry(root.clone()).and_modify(|current| *current = (*current).max(counter)).or_insert(counter);
+}

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -97,11 +97,19 @@ impl HttpBackend {
     }
 
     pub(crate) async fn list_including_replicas_typed<T: Resource>(&self, namespace: &str) -> Result<ReadResourceList<T>, ResourceError> {
+        self.list_read_view_typed::<T>(namespace, "includeReplicas").await
+    }
+
+    pub async fn list_replica_sources_typed<T: Resource>(&self, namespace: &str) -> Result<ReadResourceList<T>, ResourceError> {
+        self.list_read_view_typed::<T>(namespace, "replicaSources").await
+    }
+
+    async fn list_read_view_typed<T: Resource>(&self, namespace: &str, query_key: &str) -> Result<ReadResourceList<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
         let response = self
             .http
             .get(url)
-            .query(&[("includeReplicas", "true")])
+            .query(&[(query_key, "true")])
             .send()
             .await
             .map_err(|err| ResourceError::other(format!("LIST resources including replicas: {err}")))?;
@@ -119,11 +127,26 @@ impl HttpBackend {
         &self,
         namespace: &str,
     ) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
+        self.watch_read_view_typed::<T>(namespace, "includeReplicas").await
+    }
+
+    pub async fn watch_replica_sources_typed<T: Resource>(
+        &self,
+        namespace: &str,
+    ) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
+        self.watch_read_view_typed::<T>(namespace, "replicaSources").await
+    }
+
+    async fn watch_read_view_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        query_key: &str,
+    ) -> Result<futures::stream::BoxStream<'static, Result<ReadWatchEvent<T>, ResourceError>>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
         let response = self
             .http
             .get(url)
-            .query(&[("watch", "true"), ("includeReplicas", "true")])
+            .query(&[("watch", "true"), (query_key, "true")])
             .send()
             .await
             .map_err(|err| ResourceError::other(format!("WATCH resources including replicas: {err}")))?;

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, Mutex};
 use crate::{
     error::ResourceError,
     replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
-    resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
+    resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
     retention::{EventRetention, ResourceStoreDiagnostics},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
 };
@@ -26,6 +26,7 @@ pub struct InMemoryBackend {
     replicas: Arc<Mutex<ReplicaState>>,
     generation: Option<String>,
     event_retention: EventRetention,
+    local_root: Option<NodeId>,
 }
 
 type ReplicaKey = (NodeId, StoreKey);
@@ -103,15 +104,31 @@ impl InMemoryBackend {
             replicas: Arc::default(),
             generation: Some(uuid::Uuid::new_v4().to_string()),
             event_retention: EventRetention::default(),
+            local_root: None,
         }
     }
 
     pub fn with_event_retention(event_retention: EventRetention) -> Self {
-        Self { stores: Arc::default(), replicas: Arc::default(), generation: None, event_retention }
+        Self { stores: Arc::default(), replicas: Arc::default(), generation: None, event_retention, local_root: None }
     }
 
     pub fn observed_with_event_retention(event_retention: EventRetention) -> Self {
-        Self { stores: Arc::default(), replicas: Arc::default(), generation: Some(uuid::Uuid::new_v4().to_string()), event_retention }
+        Self {
+            stores: Arc::default(),
+            replicas: Arc::default(),
+            generation: Some(uuid::Uuid::new_v4().to_string()),
+            event_retention,
+            local_root: None,
+        }
+    }
+
+    pub(crate) fn with_local_root(mut self, local_root: NodeId) -> Self {
+        self.local_root = Some(local_root);
+        self
+    }
+
+    pub(crate) fn local_root(&self) -> NodeId {
+        self.local_root.clone().unwrap_or_else(|| NodeId::new("local"))
     }
 
     pub(crate) async fn diagnostics(&self) -> Result<ResourceStoreDiagnostics, ResourceError> {
@@ -279,6 +296,24 @@ impl InMemoryBackend {
         let encoded = Self::encode_object(object)?;
         let mut state = self.replicas.lock().await;
         let partition = state.partitions.entry(replica_key).or_default();
+        let unchanged = match kind {
+            StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
+                match (partition.objects.get(&object.metadata.name), partition.synced_at_by_name.get(&object.metadata.name)) {
+                    (Some(_), Some(existing_synced_at)) if existing_synced_at > &synced_at => true,
+                    (Some(existing), Some(existing_synced_at)) if existing_synced_at == &synced_at => {
+                        serde_json::to_string(existing)
+                            .map_err(|error| ResourceError::decode(format!("encode existing replica: {error}")))?
+                            >= serde_json::to_string(&encoded)
+                                .map_err(|error| ResourceError::decode(format!("encode incoming replica: {error}")))?
+                    }
+                    _ => false,
+                }
+            }
+            StoredReplicaEventKind::Deleted => !partition.objects.contains_key(&object.metadata.name),
+        };
+        if unchanged {
+            return Ok(());
+        }
         match kind {
             StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
                 partition.objects.insert(object.metadata.name.clone(), encoded.clone());
@@ -370,6 +405,26 @@ impl InMemoryBackend {
         meta: &InputMeta,
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
+        self.create_typed_with_merge(namespace, meta, spec, None).await
+    }
+
+    pub(crate) async fn create_definition_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        spec: &T::Spec,
+        merge: MergeMetadata,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        self.create_typed_with_merge(namespace, meta, spec, Some(merge)).await
+    }
+
+    async fn create_typed_with_merge<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        spec: &T::Spec,
+        merge: Option<MergeMetadata>,
+    ) -> Result<ResourceObject<T>, ResourceError> {
         self.with_store_mut::<T, _>(namespace, |store| {
             if store.objects.contains_key(&meta.name) {
                 return Err(ResourceError::conflict(&meta.name, "resource already exists"));
@@ -387,6 +442,7 @@ impl InMemoryBackend {
                     finalizers: meta.finalizers.clone(),
                     deletion_timestamp: meta.deletion_timestamp,
                     creation_timestamp: Utc::now(),
+                    merge,
                 },
                 spec: Self::clone_through_serde(spec)?,
                 status: None,
@@ -407,6 +463,28 @@ impl InMemoryBackend {
         resource_version: &str,
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
+        self.update_typed_with_merge(namespace, meta, resource_version, spec, None).await
+    }
+
+    pub(crate) async fn update_definition_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        resource_version: &str,
+        spec: &T::Spec,
+        merge: MergeMetadata,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        self.update_typed_with_merge(namespace, meta, resource_version, spec, Some(merge)).await
+    }
+
+    async fn update_typed_with_merge<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        resource_version: &str,
+        spec: &T::Spec,
+        admitted_merge: Option<MergeMetadata>,
+    ) -> Result<ResourceObject<T>, ResourceError> {
         self.with_store_mut::<T, _>(namespace, |store| {
             let existing = store.objects.get(&meta.name).cloned().ok_or_else(|| ResourceError::not_found(&meta.name))?;
             let mut object = Self::decode_object::<T>(existing)?;
@@ -414,7 +492,9 @@ impl InMemoryBackend {
                 return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
             }
             T::validate_spec_update(&object.spec, spec)?;
-            if object.matches_update(meta, spec)? {
+            if object.matches_update(meta, spec)?
+                && admitted_merge.as_ref().is_none_or(|merge| object.metadata.merge.as_ref() == Some(merge))
+            {
                 return Ok(object);
             }
 
@@ -425,10 +505,16 @@ impl InMemoryBackend {
             object.metadata.owner_references = meta.owner_references.clone();
             object.metadata.finalizers = meta.finalizers.clone();
             object.metadata.deletion_timestamp = meta.deletion_timestamp;
+            if let Some(merge) = admitted_merge {
+                object.metadata.merge = Some(merge);
+            }
             object.spec = Self::clone_through_serde(spec)?;
 
             let encoded = Self::encode_object(&object)?;
-            if object.metadata.deletion_timestamp.is_some() && object.metadata.finalizers.is_empty() {
+            if T::REPLICATION_CLASS != crate::ReplicationClass::Definitions
+                && object.metadata.deletion_timestamp.is_some()
+                && object.metadata.finalizers.is_empty()
+            {
                 store.objects.remove(&meta.name);
                 store.push_event(StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded }, self.event_retention);
             } else {

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -40,6 +40,8 @@ struct ReplicaState {
 #[derive(Debug, Default)]
 struct ReplicaPartition {
     objects: HashMap<String, Value>,
+    // Retained for deleted names as a tombstone so an older relayed write
+    // cannot resurrect an object after a newer delete.
     synced_at_by_name: HashMap<String, chrono::DateTime<Utc>>,
     cursor: Option<ReplicaCursor>,
 }
@@ -299,17 +301,22 @@ impl InMemoryBackend {
         let unchanged = match kind {
             StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
                 match (partition.objects.get(&object.metadata.name), partition.synced_at_by_name.get(&object.metadata.name)) {
-                    (Some(_), Some(existing_synced_at)) if existing_synced_at > &synced_at => true,
+                    (_, Some(existing_synced_at)) if existing_synced_at > &synced_at => true,
                     (Some(existing), Some(existing_synced_at)) if existing_synced_at == &synced_at => {
                         serde_json::to_string(existing)
                             .map_err(|error| ResourceError::decode(format!("encode existing replica: {error}")))?
                             >= serde_json::to_string(&encoded)
                                 .map_err(|error| ResourceError::decode(format!("encode incoming replica: {error}")))?
                     }
+                    (None, Some(existing_synced_at)) if existing_synced_at == &synced_at => true,
                     _ => false,
                 }
             }
-            StoredReplicaEventKind::Deleted => !partition.objects.contains_key(&object.metadata.name),
+            StoredReplicaEventKind::Deleted => match partition.synced_at_by_name.get(&object.metadata.name) {
+                Some(existing_synced_at) if existing_synced_at > &synced_at => true,
+                Some(existing_synced_at) if existing_synced_at == &synced_at => !partition.objects.contains_key(&object.metadata.name),
+                _ => false,
+            },
         };
         if unchanged {
             return Ok(());
@@ -321,7 +328,7 @@ impl InMemoryBackend {
             }
             StoredReplicaEventKind::Deleted => {
                 partition.objects.remove(&object.metadata.name);
-                partition.synced_at_by_name.remove(&object.metadata.name);
+                partition.synced_at_by_name.insert(object.metadata.name.clone(), synced_at);
             }
         }
         partition.cursor = Some(ReplicaCursor {

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -3,6 +3,7 @@ mod checkout;
 mod clone;
 pub mod controller;
 mod convoy;
+mod definition;
 mod environment;
 mod error;
 mod host;
@@ -38,6 +39,7 @@ pub use convoy::{
     ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot,
     PlacementStatus, ReconcileOutcome, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
 };
+pub use definition::DefinitionResolver;
 pub use environment::{
     DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus,
     EnvironmentStatusPatch, HostDirectEnvironmentSpec,
@@ -66,8 +68,9 @@ pub use project::{
 };
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
-    apply_resource_document, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas, resource_list_api_version,
-    watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas, DynamicResourceList, DynamicResourceObject,
+    apply_resource_document, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas,
+    list_resource_kind_replica_sources, resource_list_api_version, watch_resource_kind, watch_resource_kind_from,
+    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList, DynamicResourceObject,
     DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
@@ -77,8 +80,8 @@ pub use repository::{
     RepositoryRelation, RepositorySpec, RepositoryStatus, RepositoryStatusPatch, RepositoryUpstream,
 };
 pub use resource::{
-    api_version, ApiPaths, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject, K8sWatchEvent, ObjectMeta,
-    OwnerReference, Resource, ResourceObject,
+    api_version, ApiPaths, CausalDot, FieldMergeMetadata, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject,
+    K8sWatchEvent, MergeConflictSibling, MergeMetadata, ObjectMeta, OwnerReference, Resource, ResourceObject,
 };
 pub use retention::{EventRetention, ResourceStoreDiagnostics, ResourceStoreWarning};
 pub use sqlite::SqliteBackend;

--- a/crates/flotilla-resources/src/project.rs
+++ b/crates/flotilla-resources/src/project.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeSet;
 pub use flotilla_protocol::IssueSource;
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::NoStatusPatch, Repository, RepositoryKey, TypedResolver};
+use crate::{resource::define_resource, status_patch::NoStatusPatch, ReplicationClass, Repository, RepositoryKey, TypedResolver};
 
-define_resource!(Project, "projects", ProjectSpec, (), NoStatusPatch);
+define_resource!(Project, "projects", ProjectSpec, (), NoStatusPatch, replication = ReplicationClass::Definitions);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ProjectSpec {

--- a/crates/flotilla-resources/src/project.rs
+++ b/crates/flotilla-resources/src/project.rs
@@ -11,7 +11,9 @@ define_resource!(Project, "projects", ProjectSpec, (), NoStatusPatch, replicatio
 pub struct ProjectSpec {
     pub display_name: String,
     pub default_workflow_ref: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    // Definitions-class fields must serialize `None` as JSON null so clearing
+    // an optional value participates in the field-level causal merge.
+    #[serde(default)]
     pub issue_source: Option<IssueSource>,
     #[builder(default)]
     #[serde(default)]

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -9,8 +9,8 @@ use crate::{
     host::HostStatus,
     replica::{LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION},
     Checkout, Clone as CloneResource, Convoy, Demand, Environment, Host, InputMeta, ObjectMeta, OwnerReference, PlacementPolicy,
-    Presentation, Project, ReadWatchEvent, Regard, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject,
-    ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
+    Presentation, Project, ReadResourceList, ReadWatchEvent, Regard, Repository, Resource, ResourceBackend, ResourceError, ResourceList,
+    ResourceObject, ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,6 +194,22 @@ pub async fn watch_resource_kind_including_replicas(
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, watch_typed_including_replicas(backend, namespace).await)
 }
 
+pub async fn list_resource_kind_replica_sources(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+) -> Result<DynamicResourceList, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, list_typed_replica_sources(backend, namespace).await)
+}
+
+pub async fn watch_resource_kind_replica_sources(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+) -> Result<DynamicResourceWatch, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, watch_typed_replica_sources(backend, namespace).await)
+}
+
 pub async fn apply_resource_document(
     backend: &ResourceBackend,
     default_namespace: &str,
@@ -300,8 +316,32 @@ async fn list_typed_including_replicas<T: Resource>(
     })
 }
 
+async fn list_typed_replica_sources<T: Resource>(backend: &ResourceBackend, namespace: &str) -> Result<DynamicResourceList, ResourceError> {
+    let listed = backend.including_replicas::<T>(namespace).list_sources().await?;
+    dynamic_read_list::<T>(namespace, listed)
+}
+
+fn dynamic_read_list<T: Resource>(namespace: &str, listed: ReadResourceList<T>) -> Result<DynamicResourceList, ResourceError> {
+    let items = listed.items.iter().map(read_object_value).collect::<Result<Vec<_>, _>>()?;
+    Ok(DynamicResourceList {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value: json!({
+            "apiVersion": api_version(T::API_PATHS),
+            "kind": format!("{}List", T::API_PATHS.kind),
+            "metadata": {"resourceVersion": "overlay"},
+            "items": items,
+        }),
+    })
+}
+
 async fn get_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name: &str) -> Result<DynamicResourceObject, ResourceError> {
-    let object = backend.using::<T>(namespace).get(name).await?;
+    let object = if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+        backend.definitions::<T>(namespace).get(name).await?
+    } else {
+        backend.using::<T>(namespace).get(name).await?
+    };
     Ok(DynamicResourceObject {
         kind: T::API_PATHS.kind.to_string(),
         plural: T::API_PATHS.plural.to_string(),
@@ -373,6 +413,30 @@ async fn watch_typed_including_replicas<T: Resource>(
     })
 }
 
+async fn watch_typed_replica_sources<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+) -> Result<DynamicResourceWatch, ResourceError> {
+    let resolver = backend.including_replicas::<T>(namespace);
+    let stream = resolver.watch_sources().await?.map(|event| event.and_then(|event| read_watch_event_value(&event))).boxed();
+    let initial = resolver
+        .list_sources()
+        .await?
+        .items
+        .iter()
+        .map(|object| Ok(json!({"type": "ADDED", "object": read_object_value(object)?})))
+        .collect::<Result<Vec<_>, ResourceError>>()?;
+    Ok(DynamicResourceWatch {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        resource_version: "overlay".to_string(),
+        generation: None,
+        initial,
+        stream,
+    })
+}
+
 async fn apply_typed<T: Resource>(
     backend: &ResourceBackend,
     namespace: &str,
@@ -381,6 +445,20 @@ async fn apply_typed<T: Resource>(
 ) -> Result<DynamicResourceObject, ResourceError> {
     let spec = serde_json::from_value::<T::Spec>(spec)
         .map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", T::API_PATHS.kind)))?;
+    if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+        let meta = match backend.definitions::<T>(namespace).get(&metadata.name).await {
+            Ok(existing) => metadata.input_meta_for_update(&existing.metadata),
+            Err(ResourceError::NotFound { .. }) => metadata.input_meta_for_create(),
+            Err(error) => return Err(error),
+        };
+        let object = backend.definitions::<T>(namespace).apply(&meta, &spec).await?;
+        return Ok(DynamicResourceObject {
+            kind: T::API_PATHS.kind.to_string(),
+            plural: T::API_PATHS.plural.to_string(),
+            namespace: namespace.to_string(),
+            value: object_value(&object)?,
+        });
+    }
     let resolver = backend.using::<T>(namespace);
     let object = match resolver.get(&metadata.name).await {
         Ok(existing) => {

--- a/crates/flotilla-resources/src/replica.rs
+++ b/crates/flotilla-resources/src/replica.rs
@@ -14,6 +14,7 @@ pub(crate) const LAST_SYNCED_AT_ANNOTATION: &str = "flotilla.work/last-synced-at
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReplicationClass {
     None,
+    Definitions,
     HomeBoundRuntime,
 }
 

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
 use chrono::{DateTime, Utc};
+use flotilla_protocol::NodeId;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
@@ -114,6 +115,44 @@ pub struct OwnerReference {
     pub controller: bool,
 }
 
+/// One causally unique write in a definitions-class record.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct CausalDot {
+    pub author_root: NodeId,
+    pub author_counter: u64,
+}
+
+/// Causal state captured when a field was last authored.
+///
+/// The field-local context keeps a later disjoint-field edit from
+/// accidentally resolving an existing conflict in this field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldMergeMetadata {
+    pub dot: CausalDot,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub seen: BTreeMap<NodeId, u64>,
+    pub written_at: DateTime<Utc>,
+}
+
+/// One causally-maximal value shown when a definitions field conflicts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeConflictSibling {
+    pub value: serde_json::Value,
+    pub dot: CausalDot,
+    pub written_at: DateTime<Utc>,
+}
+
+/// Store-authored causal metadata for a definitions-class object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MergeMetadata {
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, FieldMergeMetadata>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub seen: BTreeMap<NodeId, u64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub conflicts: BTreeMap<String, Vec<MergeConflictSibling>>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, bon::Builder)]
 pub struct InputMeta {
     pub name: String,
@@ -178,6 +217,8 @@ pub struct ObjectMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deletion_timestamp: Option<DateTime<Utc>>,
     pub creation_timestamp: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge: Option<MergeMetadata>,
 }
 
 impl ObjectMeta {
@@ -282,6 +323,8 @@ pub struct K8sObjectMeta {
     pub deletion_timestamp: Option<DateTime<Utc>>,
     #[serde(rename = "creationTimestamp")]
     pub creation_timestamp: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub merge: Option<MergeMetadata>,
 }
 
 impl From<&ObjectMeta> for K8sObjectMeta {
@@ -296,6 +339,7 @@ impl From<&ObjectMeta> for K8sObjectMeta {
             finalizers: value.finalizers.clone(),
             deletion_timestamp: value.deletion_timestamp,
             creation_timestamp: value.creation_timestamp,
+            merge: value.merge.clone(),
         }
     }
 }
@@ -312,6 +356,7 @@ impl From<K8sObjectMeta> for ObjectMeta {
             finalizers: value.finalizers,
             deletion_timestamp: value.deletion_timestamp,
             creation_timestamp: value.creation_timestamp,
+            merge: value.merge,
         }
     }
 }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -16,7 +16,7 @@ use tokio_rusqlite::Connection;
 use crate::{
     error::ResourceError,
     replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
-    resource::{InputMeta, K8sResourceObject, ObjectMeta, Resource, ResourceObject},
+    resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
     retention::{EventRetention, ResourceStoreDiagnostics},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
 };
@@ -36,6 +36,7 @@ pub struct SqliteBackend {
     watchers: Arc<Mutex<WatchersByStore>>,
     replica_watchers: Arc<Mutex<ReplicaWatchersByStore>>,
     event_retention: EventRetention,
+    local_root: Option<NodeId>,
 }
 
 #[derive(Debug, Clone)]
@@ -103,6 +104,7 @@ impl SqliteBackend {
             watchers: Arc::new(Mutex::new(HashMap::new())),
             replica_watchers: Arc::new(Mutex::new(HashMap::new())),
             event_retention,
+            local_root: None,
         })
     }
 
@@ -116,7 +118,17 @@ impl SqliteBackend {
             watchers: Arc::new(Mutex::new(HashMap::new())),
             replica_watchers: Arc::new(Mutex::new(HashMap::new())),
             event_retention,
+            local_root: None,
         })
+    }
+
+    pub(crate) fn with_local_root(mut self, local_root: NodeId) -> Self {
+        self.local_root = Some(local_root);
+        self
+    }
+
+    pub(crate) fn local_root(&self) -> NodeId {
+        self.local_root.clone().unwrap_or_else(|| NodeId::new("local"))
     }
 
     fn initialize_connection(connection: &mut RusqliteConnection, event_retention: EventRetention) -> Result<(), ResourceError> {
@@ -630,46 +642,54 @@ impl SqliteBackend {
         let body =
             serde_json::to_string(&value).map_err(|err| ResourceError::decode(format!("encode sqlite replica event JSON: {err}")))?;
         let synced = synced_at.to_rfc3339();
-        self.call(move |connection| {
-            let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite replica event"))?;
-            match kind {
-                StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
-                    tx.execute(
-                        r#"
+        let changed = self
+            .call(move |connection| {
+                let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite replica event"))?;
+                let changed = match kind {
+                    StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => tx
+                        .execute(
+                            r#"
                         INSERT INTO replica_objects
                             (origin_root, group_name, version, kind, namespace, name, body_json, last_synced_at)
                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                         ON CONFLICT(origin_root, group_name, version, kind, namespace, name)
                         DO UPDATE SET body_json = excluded.body_json,
                                       last_synced_at = excluded.last_synced_at
+                        WHERE replica_objects.last_synced_at < excluded.last_synced_at
+                           OR (
+                               replica_objects.last_synced_at = excluded.last_synced_at
+                               AND replica_objects.body_json < excluded.body_json
+                           )
                         "#,
-                        params![origin, key.0, key.1, key.2, key.3, name, body, synced],
-                    )
-                    .map_err(|err| Self::map_sqlite(err, "upsert sqlite replica event object"))?;
-                }
-                StoredReplicaEventKind::Deleted => {
-                    tx.execute(
-                        r#"
+                            params![origin, key.0, key.1, key.2, key.3, name, body, synced],
+                        )
+                        .map_err(|err| Self::map_sqlite(err, "upsert sqlite replica event object"))?,
+                    StoredReplicaEventKind::Deleted => tx
+                        .execute(
+                            r#"
                         DELETE FROM replica_objects
                         WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5 AND name = ?6
                         "#,
-                        params![origin, key.0, key.1, key.2, key.3, name],
-                    )
-                    .map_err(|err| Self::map_sqlite(err, "delete sqlite replica event object"))?;
-                }
-            }
-            tx.execute(
-                r#"
+                            params![origin, key.0, key.1, key.2, key.3, name],
+                        )
+                        .map_err(|err| Self::map_sqlite(err, "delete sqlite replica event object"))?,
+                };
+                tx.execute(
+                    r#"
                 UPDATE replica_cursors
                 SET resource_version = ?6, last_synced_at = ?7
                 WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5
                 "#,
-                params![origin, key.0, key.1, key.2, key.3, resource_version, synced],
-            )
-            .map_err(|err| Self::map_sqlite(err, "advance sqlite replica cursor"))?;
-            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite replica event"))
-        })
-        .await?;
+                    params![origin, key.0, key.1, key.2, key.3, resource_version, synced],
+                )
+                .map_err(|err| Self::map_sqlite(err, "advance sqlite replica cursor"))?;
+                tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite replica event"))?;
+                Ok(changed > 0)
+            })
+            .await?;
+        if !changed {
+            return Ok(());
+        }
         Self::notify_replica_watchers(&self.replica_watchers, &operation_key, StoredReplicaEvent {
             origin_root: origin_root.clone(),
             synced_at,
@@ -775,6 +795,26 @@ impl SqliteBackend {
         meta: &InputMeta,
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
+        self.create_typed_with_merge(namespace, meta, spec, None).await
+    }
+
+    pub(crate) async fn create_definition_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        spec: &T::Spec,
+        merge: MergeMetadata,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        self.create_typed_with_merge(namespace, meta, spec, Some(merge)).await
+    }
+
+    async fn create_typed_with_merge<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        spec: &T::Spec,
+        merge: Option<MergeMetadata>,
+    ) -> Result<ResourceObject<T>, ResourceError> {
         let key = Self::store_key::<T>(namespace);
         let namespace = namespace.to_string();
         let meta = meta.clone();
@@ -811,6 +851,7 @@ impl SqliteBackend {
                     finalizers: meta.finalizers.clone(),
                     deletion_timestamp: meta.deletion_timestamp,
                     creation_timestamp: Utc::now(),
+                    merge,
                 },
                 spec: Self::clone_through_serde(&spec)?,
                 status: None,
@@ -840,6 +881,28 @@ impl SqliteBackend {
         resource_version: &str,
         spec: &T::Spec,
     ) -> Result<ResourceObject<T>, ResourceError> {
+        self.update_typed_with_merge(namespace, meta, resource_version, spec, None).await
+    }
+
+    pub(crate) async fn update_definition_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        resource_version: &str,
+        spec: &T::Spec,
+        merge: MergeMetadata,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        self.update_typed_with_merge(namespace, meta, resource_version, spec, Some(merge)).await
+    }
+
+    async fn update_typed_with_merge<T: Resource>(
+        &self,
+        namespace: &str,
+        meta: &InputMeta,
+        resource_version: &str,
+        spec: &T::Spec,
+        admitted_merge: Option<MergeMetadata>,
+    ) -> Result<ResourceObject<T>, ResourceError> {
         let key = Self::store_key::<T>(namespace);
         let meta = meta.clone();
         let resource_version = resource_version.to_string();
@@ -854,7 +917,9 @@ impl SqliteBackend {
                 return Err(ResourceError::conflict(&meta.name, "stale resourceVersion"));
             }
             T::validate_spec_update(&object.spec, &spec)?;
-            if object.matches_update(&meta, &spec)? {
+            if object.matches_update(&meta, &spec)?
+                && admitted_merge.as_ref().is_none_or(|merge| object.metadata.merge.as_ref() == Some(merge))
+            {
                 return Ok(object);
             }
 
@@ -865,11 +930,17 @@ impl SqliteBackend {
             object.metadata.owner_references = meta.owner_references.clone();
             object.metadata.finalizers = meta.finalizers.clone();
             object.metadata.deletion_timestamp = meta.deletion_timestamp;
+            if let Some(merge) = admitted_merge {
+                object.metadata.merge = Some(merge);
+            }
             object.spec = Self::clone_through_serde(&spec)?;
 
             let encoded = Self::encode_object(&object)?;
             let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
-            let event_kind = if object.metadata.deletion_timestamp.is_some() && object.metadata.finalizers.is_empty() {
+            let event_kind = if T::REPLICATION_CLASS != crate::ReplicationClass::Definitions
+                && object.metadata.deletion_timestamp.is_some()
+                && object.metadata.finalizers.is_empty()
+            {
                 tx.execute(
                     r#"
                     DELETE FROM resource_objects

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -204,6 +204,17 @@ impl SqliteBackend {
                     last_synced_at TEXT NOT NULL,
                     PRIMARY KEY (origin_root, group_name, version, kind, namespace)
                 );
+
+                CREATE TABLE IF NOT EXISTS replica_tombstones (
+                    origin_root TEXT NOT NULL,
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    last_synced_at TEXT NOT NULL,
+                    PRIMARY KEY (origin_root, group_name, version, kind, namespace, name)
+                );
                 "#,
             )
             .map_err(|err| ResourceError::other(format!("initialize sqlite resource store: {err}")))?;
@@ -565,6 +576,14 @@ impl SqliteBackend {
                     params![origin, key.0, key.1, key.2, key.3],
                 )
                 .map_err(|err| Self::map_sqlite(err, "clear sqlite replica partition"))?;
+                tx.execute(
+                    r#"
+                    DELETE FROM replica_tombstones
+                    WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5
+                    "#,
+                    params![origin, key.0, key.1, key.2, key.3],
+                )
+                .map_err(|err| Self::map_sqlite(err, "clear sqlite replica tombstones"))?;
                 for (name, body) in &encoded {
                     tx.execute(
                         r#"
@@ -645,9 +664,49 @@ impl SqliteBackend {
         let changed = self
             .call(move |connection| {
                 let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite replica event"))?;
-                let changed = match kind {
-                    StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => tx
-                        .execute(
+                let existing = tx
+                    .query_row(
+                        r#"
+                        SELECT body_json, last_synced_at
+                        FROM replica_objects
+                        WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5 AND name = ?6
+                        "#,
+                        params![origin, key.0, key.1, key.2, key.3, name],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                    )
+                    .optional()
+                    .map_err(|err| Self::map_sqlite(err, "read existing sqlite replica event object"))?;
+                let tombstone_synced_at = tx
+                    .query_row(
+                        r#"
+                        SELECT last_synced_at
+                        FROM replica_tombstones
+                        WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5 AND name = ?6
+                        "#,
+                        params![origin, key.0, key.1, key.2, key.3, name],
+                        |row| row.get::<_, String>(0),
+                    )
+                    .optional()
+                    .map_err(|err| Self::map_sqlite(err, "read sqlite replica tombstone"))?;
+                let unchanged = match kind {
+                    StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
+                        tombstone_synced_at.as_ref().is_some_and(|existing_synced| existing_synced >= &synced)
+                            || existing.as_ref().is_some_and(|(existing_body, existing_synced)| {
+                                existing_synced > &synced || (existing_synced == &synced && existing_body >= &body)
+                            })
+                    }
+                    StoredReplicaEventKind::Deleted => {
+                        tombstone_synced_at.as_ref().is_some_and(|existing_synced| existing_synced >= &synced)
+                            || existing.as_ref().is_some_and(|(_, existing_synced)| existing_synced > &synced)
+                    }
+                };
+                if unchanged {
+                    return Ok(false);
+                }
+
+                match kind {
+                    StoredReplicaEventKind::Added | StoredReplicaEventKind::Modified => {
+                        tx.execute(
                             r#"
                         INSERT INTO replica_objects
                             (origin_root, group_name, version, kind, namespace, name, body_json, last_synced_at)
@@ -655,25 +714,41 @@ impl SqliteBackend {
                         ON CONFLICT(origin_root, group_name, version, kind, namespace, name)
                         DO UPDATE SET body_json = excluded.body_json,
                                       last_synced_at = excluded.last_synced_at
-                        WHERE replica_objects.last_synced_at < excluded.last_synced_at
-                           OR (
-                               replica_objects.last_synced_at = excluded.last_synced_at
-                               AND replica_objects.body_json < excluded.body_json
-                           )
                         "#,
                             params![origin, key.0, key.1, key.2, key.3, name, body, synced],
                         )
-                        .map_err(|err| Self::map_sqlite(err, "upsert sqlite replica event object"))?,
-                    StoredReplicaEventKind::Deleted => tx
-                        .execute(
+                        .map_err(|err| Self::map_sqlite(err, "upsert sqlite replica event object"))?;
+                        tx.execute(
                             r#"
-                        DELETE FROM replica_objects
+                        DELETE FROM replica_tombstones
                         WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5 AND name = ?6
                         "#,
                             params![origin, key.0, key.1, key.2, key.3, name],
                         )
-                        .map_err(|err| Self::map_sqlite(err, "delete sqlite replica event object"))?,
-                };
+                        .map_err(|err| Self::map_sqlite(err, "clear sqlite replica tombstone"))?;
+                    }
+                    StoredReplicaEventKind::Deleted => {
+                        tx.execute(
+                            r#"
+                            DELETE FROM replica_objects
+                            WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5 AND name = ?6
+                            "#,
+                            params![origin, key.0, key.1, key.2, key.3, name],
+                        )
+                        .map_err(|err| Self::map_sqlite(err, "delete sqlite replica event object"))?;
+                        tx.execute(
+                            r#"
+                            INSERT INTO replica_tombstones
+                                (origin_root, group_name, version, kind, namespace, name, last_synced_at)
+                            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                            ON CONFLICT(origin_root, group_name, version, kind, namespace, name)
+                            DO UPDATE SET last_synced_at = excluded.last_synced_at
+                            "#,
+                            params![origin, key.0, key.1, key.2, key.3, name, synced],
+                        )
+                        .map_err(|err| Self::map_sqlite(err, "write sqlite replica tombstone"))?;
+                    }
+                }
                 tx.execute(
                     r#"
                 UPDATE replica_cursors
@@ -684,7 +759,7 @@ impl SqliteBackend {
                 )
                 .map_err(|err| Self::map_sqlite(err, "advance sqlite replica cursor"))?;
                 tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite replica event"))?;
-                Ok(changed > 0)
+                Ok(true)
             })
             .await?;
         if !changed {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -241,7 +241,11 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
     remote.delete("remote").await.expect("delete remote convoy");
     let deleted = remote.watch(WatchStart::resuming_from(&before_delete)).await.expect("watch remote delete").next().await;
     let deleted = deleted.expect("remote delete event").expect("valid remote delete");
-    backend.replica_writer::<Convoy>(origin, "flotilla").apply(deleted, Utc::now()).await.expect("apply remote delete");
+    backend
+        .replica_writer::<Convoy>(origin, "flotilla")
+        .apply(deleted, updated_sync + chrono::Duration::seconds(1))
+        .await
+        .expect("apply remote delete");
 
     let event = timeout(Duration::from_secs(1), watch.next()).await.expect("replica delete watch timeout");
     assert!(matches!(event, Some(Ok(flotilla_resources::ReadWatchEvent::Deleted(_)))));
@@ -263,6 +267,45 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
         .expect("read replaced cursor")
         .expect("replaced cursor");
     assert_eq!(cursor.generation.as_deref(), Some("generation-2"));
+}
+
+pub async fn assert_replica_events_ignore_stale_writes_and_deletes_with_backend(backend: ResourceBackend) {
+    let origin = flotilla_protocol::NodeId::new("feta-root");
+    let source_backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let source = source_backend.using::<Convoy>("flotilla");
+    let meta = convoy_meta("remote");
+    let first = source.create(&meta, &convoy_spec("first")).await.expect("create source convoy");
+    let first_synced_at = Utc::now();
+    let writer = backend.replica_writer::<Convoy>(origin, "flotilla");
+    writer.apply(WatchEvent::Added(first.clone()), first_synced_at).await.expect("apply initial replica event");
+
+    let second = source.update(&meta, &first.metadata.resource_version, &convoy_spec("second")).await.expect("update source convoy");
+    let stale_delete_synced_at = first_synced_at + chrono::Duration::seconds(1);
+    let second_synced_at = first_synced_at + chrono::Duration::seconds(2);
+    writer.apply(WatchEvent::Modified(second.clone()), second_synced_at).await.expect("apply newer replica update");
+    writer.apply(WatchEvent::Deleted(first), stale_delete_synced_at).await.expect("ignore stale replica delete");
+
+    let after_stale_delete = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list after stale delete");
+    assert_eq!(after_stale_delete.items.len(), 1);
+    assert_eq!(after_stale_delete.items[0].object.spec.workflow_ref, "second");
+
+    let delete_synced_at = first_synced_at + chrono::Duration::seconds(3);
+    writer.apply(WatchEvent::Deleted(second.clone()), delete_synced_at).await.expect("apply current replica delete");
+    writer.apply(WatchEvent::Modified(second.clone()), second_synced_at).await.expect("ignore stale replica update after delete");
+    assert!(
+        backend.including_replicas::<Convoy>("flotilla").list().await.expect("list after stale update").items.is_empty(),
+        "a retained delete tombstone must prevent resurrection by an older write"
+    );
+
+    writer
+        .apply(WatchEvent::Added(second), delete_synced_at + chrono::Duration::seconds(1))
+        .await
+        .expect("apply recreation newer than tombstone");
+    assert_eq!(
+        backend.including_replicas::<Convoy>("flotilla").list().await.expect("list recreated replica").items.len(),
+        1,
+        "a write newer than the delete tombstone should recreate the replica"
+    );
 }
 
 fn project_spec(display_name: &str, workflow: &str) -> ProjectSpec {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -1,11 +1,11 @@
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
 use chrono::Utc;
 use flotilla_protocol::ResourceRef;
 use flotilla_resources::{
     Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, OwnerReference, PrincipalRef,
-    Regard, RegardExpiryPolicy, RegardSource, RegardSpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
-    TypedResolver, WatchEvent, WatchStart, WorkflowTemplate,
+    Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RepositoryKey, Resource,
+    ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TypedResolver, WatchEvent, WatchStart, WorkflowTemplate,
 };
 use futures::StreamExt;
 use tokio::time::timeout;
@@ -263,6 +263,151 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
         .expect("read replaced cursor")
         .expect("replaced cursor");
     assert_eq!(cursor.generation.as_deref(), Some("generation-2"));
+}
+
+fn project_spec(display_name: &str, workflow: &str) -> ProjectSpec {
+    ProjectSpec::builder()
+        .display_name(display_name.to_string())
+        .default_workflow_ref(workflow.to_string())
+        .repositories(vec![ProjectRepositorySpec {
+            repo: RepositoryKey("github.com/acme/widgets".to_string()),
+            subpath: None,
+            default_branch: None,
+        }])
+        .build()
+}
+
+pub async fn assert_project_definition_edit_converges_with_backend(backend: ResourceBackend) {
+    let kiwi_root = flotilla_protocol::NodeId::new("kiwi-root");
+    let feta_root = flotilla_protocol::NodeId::new("feta-root");
+    let kiwi = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(kiwi_root.clone());
+    let feta = backend.with_local_root(feta_root.clone());
+    let meta = InputMeta::builder().name("widgets".to_string()).build();
+
+    kiwi.definitions::<Project>("flotilla").apply(&meta, &project_spec("Widgets", "default")).await.expect("create Project on kiwi");
+    let kiwi_log = kiwi.using::<Project>("flotilla").list().await.expect("list kiwi Project log");
+    feta.replica_writer::<Project>(kiwi_root.clone(), "flotilla")
+        .replace(&kiwi_log, Utc::now())
+        .await
+        .expect("replicate kiwi Project to feta");
+
+    let visible_on_feta = feta.definitions::<Project>("flotilla").get("widgets").await.expect("Project should be visible on feta");
+    assert_eq!(visible_on_feta.spec.display_name, "Widgets");
+    assert!(feta.using::<Project>("flotilla").list().await.expect("list feta local log").items.is_empty());
+
+    feta.definitions::<Project>("flotilla")
+        .apply(&InputMeta::from(&visible_on_feta.metadata), &project_spec("Feta Widgets", "default"))
+        .await
+        .expect("edit kiwi-authored Project on feta");
+    let feta_log = feta.using::<Project>("flotilla").list().await.expect("list feta Project log");
+    kiwi.replica_writer::<Project>(feta_root, "flotilla").replace(&feta_log, Utc::now()).await.expect("replicate feta Project to kiwi");
+
+    let converged_on_kiwi = kiwi.definitions::<Project>("flotilla").get("widgets").await.expect("merged Project on kiwi");
+    assert_eq!(converged_on_kiwi.spec.display_name, "Feta Widgets");
+    assert!(converged_on_kiwi.metadata.merge.as_ref().expect("definition merge metadata").conflicts.is_empty());
+}
+
+pub async fn assert_project_definition_causal_merge_with_backend(backend: ResourceBackend) {
+    let kiwi_root = flotilla_protocol::NodeId::new("kiwi-root");
+    let feta_root = flotilla_protocol::NodeId::new("feta-root");
+    let kiwi = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(kiwi_root.clone());
+    let feta = backend.with_local_root(feta_root.clone());
+    let meta = InputMeta::builder().name("widgets".to_string()).build();
+
+    kiwi.definitions::<Project>("flotilla").apply(&meta, &project_spec("Widgets", "default")).await.expect("create Project baseline");
+    let baseline = kiwi.using::<Project>("flotilla").list().await.expect("list Project baseline");
+    feta.replica_writer::<Project>(kiwi_root.clone(), "flotilla").replace(&baseline, Utc::now()).await.expect("replicate baseline to feta");
+
+    kiwi.definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Kiwi Widgets", "default"))
+        .await
+        .expect("concurrent kiwi display-name edit");
+    feta.definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Feta Widgets", "feta-flow"))
+        .await
+        .expect("concurrent feta display-name and workflow edit");
+
+    let kiwi_log = kiwi.using::<Project>("flotilla").list().await.expect("list updated kiwi log");
+    let feta_log = feta.using::<Project>("flotilla").list().await.expect("list updated feta log");
+    kiwi.replica_writer::<Project>(feta_root.clone(), "flotilla")
+        .replace(&feta_log, Utc::now())
+        .await
+        .expect("replicate concurrent feta edit to kiwi");
+    feta.replica_writer::<Project>(kiwi_root.clone(), "flotilla")
+        .replace(&kiwi_log, Utc::now())
+        .await
+        .expect("replicate concurrent kiwi edit to feta");
+
+    let merged_on_kiwi = kiwi.definitions::<Project>("flotilla").get("widgets").await.expect("merged Project on kiwi");
+    let merged_on_feta = feta.definitions::<Project>("flotilla").get("widgets").await.expect("merged Project on feta");
+    assert_eq!(
+        serde_json::to_value(&merged_on_kiwi).expect("serialize kiwi merge"),
+        serde_json::to_value(&merged_on_feta).expect("serialize feta merge"),
+        "the same source set must produce the same merged view on every root"
+    );
+
+    for merged in [merged_on_kiwi, merged_on_feta] {
+        assert_eq!(merged.spec.default_workflow_ref, "feta-flow", "disjoint-field edit should merge without conflict");
+        let conflicts = &merged.metadata.merge.as_ref().expect("definition merge metadata").conflicts;
+        let display_conflict = conflicts.get("spec.display_name").expect("concurrent same-field edits should conflict");
+        assert_eq!(display_conflict.len(), 2);
+        assert_eq!(
+            display_conflict.iter().map(|sibling| sibling.value.as_str().expect("string sibling")).collect::<BTreeSet<_>>(),
+            BTreeSet::from(["Feta Widgets", "Kiwi Widgets"])
+        );
+        assert!(!conflicts.contains_key("spec.default_workflow_ref"));
+    }
+
+    feta.definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Feta Widgets", "feta-flow"))
+        .await
+        .expect("resolve conflict by ordinarily writing an existing sibling");
+    let resolved_log = feta.using::<Project>("flotilla").list().await.expect("list resolution");
+    kiwi.replica_writer::<Project>(feta_root, "flotilla").replace(&resolved_log, Utc::now()).await.expect("replicate resolution to kiwi");
+
+    for merged in [
+        kiwi.definitions::<Project>("flotilla").get("widgets").await.expect("resolved Project on kiwi"),
+        feta.definitions::<Project>("flotilla").get("widgets").await.expect("resolved Project on feta"),
+    ] {
+        assert_eq!(merged.spec.display_name, "Feta Widgets");
+        assert!(merged.metadata.merge.as_ref().expect("definition merge metadata").conflicts.is_empty());
+    }
+}
+
+pub async fn assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend(backend: ResourceBackend) {
+    let kiwi_root = flotilla_protocol::NodeId::new("kiwi-root");
+    let feta_root = flotilla_protocol::NodeId::new("feta-root");
+    let kiwi = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(kiwi_root.clone());
+    let feta = backend.with_local_root(feta_root.clone());
+    let meta = InputMeta::builder().name("widgets".to_string()).build();
+
+    kiwi.definitions::<Project>("flotilla").apply(&meta, &project_spec("Widgets", "default")).await.expect("create Project baseline");
+    let baseline = kiwi.using::<Project>("flotilla").list().await.expect("list baseline");
+    feta.replica_writer::<Project>(kiwi_root.clone(), "flotilla").replace(&baseline, Utc::now()).await.expect("replicate baseline");
+
+    kiwi.definitions::<Project>("flotilla").delete("widgets").await.expect("delete on kiwi");
+    feta.definitions::<Project>("flotilla")
+        .apply(&meta, &project_spec("Edited on Feta", "default"))
+        .await
+        .expect("concurrent edit on feta");
+    let kiwi_log = kiwi.using::<Project>("flotilla").list().await.expect("list delete");
+    let feta_log = feta.using::<Project>("flotilla").list().await.expect("list edit");
+    kiwi.replica_writer::<Project>(feta_root, "flotilla").replace(&feta_log, Utc::now()).await.expect("sync edit");
+    feta.replica_writer::<Project>(kiwi_root, "flotilla").replace(&kiwi_log, Utc::now()).await.expect("sync delete");
+
+    let conflicted = feta.definitions::<Project>("flotilla").get("widgets").await.expect("delete/edit conflict remains visible");
+    let deletion = conflicted
+        .metadata
+        .merge
+        .as_ref()
+        .expect("definition merge metadata")
+        .conflicts
+        .get("$deleted")
+        .expect("concurrent delete and edit should conflict");
+    assert_eq!(
+        deletion.iter().map(|sibling| sibling.value.as_bool().expect("boolean deletion sibling")).collect::<BTreeSet<_>>(),
+        [false, true,].into_iter().collect()
+    );
 }
 
 pub fn resolver<F: ResourceContractFixture>(backend: ResourceBackend, namespace: &str) -> TypedResolver<F::Resource> {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -3,9 +3,9 @@ use std::{collections::BTreeSet, time::Duration};
 use chrono::Utc;
 use flotilla_protocol::ResourceRef;
 use flotilla_resources::{
-    Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, OwnerReference, PrincipalRef,
-    Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RepositoryKey, Resource,
-    ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TypedResolver, WatchEvent, WatchStart, WorkflowTemplate,
+    Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, IssueSource, OwnerReference,
+    PrincipalRef, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RepositoryKey,
+    Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TypedResolver, WatchEvent, WatchStart, WorkflowTemplate,
 };
 use futures::StreamExt;
 use tokio::time::timeout;
@@ -371,6 +371,81 @@ pub async fn assert_project_definition_causal_merge_with_backend(backend: Resour
     ] {
         assert_eq!(merged.spec.display_name, "Feta Widgets");
         assert!(merged.metadata.merge.as_ref().expect("definition merge metadata").conflicts.is_empty());
+    }
+}
+
+pub async fn assert_project_definition_optional_field_can_be_cleared_with_backend(backend: ResourceBackend) {
+    let kiwi_root = flotilla_protocol::NodeId::new("kiwi-root");
+    let feta_root = flotilla_protocol::NodeId::new("feta-root");
+    let kiwi = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(kiwi_root.clone());
+    let feta = backend.with_local_root(feta_root.clone());
+    let meta = InputMeta::builder().name("widgets".to_string()).build();
+    let mut original = project_spec("Widgets", "default");
+    original.issue_source = Some(IssueSource { service: "github".to_string(), scope: "acme/widgets".to_string() });
+
+    kiwi.definitions::<Project>("flotilla").apply(&meta, &original).await.expect("create Project with issue source");
+    let baseline = kiwi.using::<Project>("flotilla").list().await.expect("list Project baseline");
+    feta.replica_writer::<Project>(kiwi_root.clone(), "flotilla").replace(&baseline, Utc::now()).await.expect("replicate baseline");
+
+    let mut cleared = feta.definitions::<Project>("flotilla").get("widgets").await.expect("get replicated Project").spec;
+    cleared.issue_source = None;
+    feta.definitions::<Project>("flotilla").apply(&meta, &cleared).await.expect("clear replicated issue source");
+    assert_eq!(
+        feta.definitions::<Project>("flotilla").get("widgets").await.expect("get locally cleared Project").spec.issue_source,
+        None,
+        "an explicit null must causally supersede the replicated value"
+    );
+
+    let feta_log = feta.using::<Project>("flotilla").list().await.expect("list cleared Project log");
+    kiwi.replica_writer::<Project>(feta_root, "flotilla").replace(&feta_log, Utc::now()).await.expect("replicate cleared Project");
+    for merged in [
+        kiwi.definitions::<Project>("flotilla").get("widgets").await.expect("cleared Project on kiwi"),
+        feta.definitions::<Project>("flotilla").get("widgets").await.expect("cleared Project on feta"),
+    ] {
+        assert_eq!(merged.spec.issue_source, None);
+        assert!(merged.metadata.merge.as_ref().expect("definition merge metadata").conflicts.is_empty());
+    }
+}
+
+pub async fn assert_project_definition_edit_preserves_unrelated_conflict_with_backend(backend: ResourceBackend) {
+    let kiwi_root = flotilla_protocol::NodeId::new("kiwi-root");
+    let feta_root = flotilla_protocol::NodeId::new("feta-root");
+    let kiwi = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(kiwi_root.clone());
+    let feta = backend.with_local_root(feta_root.clone());
+    let meta = InputMeta::builder().name("widgets".to_string()).build();
+
+    kiwi.definitions::<Project>("flotilla").apply(&meta, &project_spec("Widgets", "default")).await.expect("create Project baseline");
+    let baseline = kiwi.using::<Project>("flotilla").list().await.expect("list Project baseline");
+    feta.replica_writer::<Project>(kiwi_root.clone(), "flotilla").replace(&baseline, Utc::now()).await.expect("replicate baseline");
+
+    kiwi.definitions::<Project>("flotilla").apply(&meta, &project_spec("Kiwi Widgets", "kiwi-flow")).await.expect("concurrent kiwi edit");
+    feta.definitions::<Project>("flotilla").apply(&meta, &project_spec("Feta Widgets", "feta-flow")).await.expect("concurrent feta edit");
+    let kiwi_log = kiwi.using::<Project>("flotilla").list().await.expect("list kiwi edit");
+    let feta_log = feta.using::<Project>("flotilla").list().await.expect("list feta edit");
+    kiwi.replica_writer::<Project>(feta_root.clone(), "flotilla").replace(&feta_log, Utc::now()).await.expect("sync feta edit");
+    feta.replica_writer::<Project>(kiwi_root, "flotilla").replace(&kiwi_log, Utc::now()).await.expect("sync kiwi edit");
+
+    let conflicted = feta.definitions::<Project>("flotilla").get("widgets").await.expect("get conflicted Project");
+    let conflicts = &conflicted.metadata.merge.as_ref().expect("definition merge metadata").conflicts;
+    assert!(conflicts.contains_key("spec.display_name"));
+    assert!(conflicts.contains_key("spec.default_workflow_ref"));
+
+    let mut resolved_display_name = conflicted.spec;
+    resolved_display_name.display_name = "Resolved Widgets".to_string();
+    feta.definitions::<Project>("flotilla").apply(&meta, &resolved_display_name).await.expect("resolve only the display-name conflict");
+    let resolution_log = feta.using::<Project>("flotilla").list().await.expect("list partial resolution");
+    kiwi.replica_writer::<Project>(feta_root, "flotilla").replace(&resolution_log, Utc::now()).await.expect("replicate partial resolution");
+
+    for merged in [
+        kiwi.definitions::<Project>("flotilla").get("widgets").await.expect("partially resolved Project on kiwi"),
+        feta.definitions::<Project>("flotilla").get("widgets").await.expect("partially resolved Project on feta"),
+    ] {
+        let conflicts = &merged.metadata.merge.as_ref().expect("definition merge metadata").conflicts;
+        assert!(!conflicts.contains_key("spec.display_name"), "the edited field should be resolved");
+        assert!(
+            conflicts.contains_key("spec.default_workflow_ref"),
+            "editing one field must not resolve an unrelated conflict echoed from the merged view"
+        );
     }
 }
 

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -190,6 +190,7 @@ pub fn object_meta(name: &str, namespace: &str, resource_version: &str) -> Objec
         finalizers: Vec::new(),
         deletion_timestamp: None,
         creation_timestamp: timestamp(1),
+        merge: None,
     }
 }
 

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -10,7 +10,8 @@ use common::{
         assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
         assert_project_definition_optional_field_can_be_cleared_with_backend,
-        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_replica_read_view_contract,
+        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
+        assert_replica_events_ignore_stale_writes_and_deletes_with_backend, assert_replica_read_view_contract,
         assert_stale_resource_version_conflicts, assert_store_diagnostics_report_retained_events_with_backend,
         assert_watch_from_version_replays, assert_watch_now_semantics,
         assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
@@ -122,6 +123,11 @@ resource_contract_tests!(demand_contract, DemandFixture);
 #[tokio::test]
 async fn replica_read_view_contract() {
     assert_replica_read_view_contract(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn replica_events_ignore_stale_writes_and_deletes() {
+    assert_replica_events_ignore_stale_writes_and_deletes_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -8,9 +8,11 @@ use common::{
         assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
         assert_metadata_roundtrip, assert_namespace_isolation, assert_project_definition_causal_merge_with_backend,
         assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
-        assert_project_definition_edit_converges_with_backend, assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
-        assert_replica_read_view_contract, assert_stale_resource_version_conflicts,
-        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays, assert_watch_now_semantics,
+        assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
+        assert_project_definition_optional_field_can_be_cleared_with_backend,
+        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_replica_read_view_contract,
+        assert_stale_resource_version_conflicts, assert_store_diagnostics_report_retained_events_with_backend,
+        assert_watch_from_version_replays, assert_watch_now_semantics,
         assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture, DemandFixture, RegardFixture,
     },
@@ -130,6 +132,16 @@ async fn project_definition_edit_converges() {
 #[tokio::test]
 async fn project_definition_causal_merge() {
     assert_project_definition_causal_merge_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn project_definition_optional_field_can_be_cleared() {
+    assert_project_definition_optional_field_can_be_cleared_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn project_definition_edit_preserves_unrelated_conflict() {
+    assert_project_definition_edit_preserves_unrelated_conflict_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -6,7 +6,9 @@ use common::{
     contract::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip,
         assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
-        assert_metadata_roundtrip, assert_namespace_isolation, assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
+        assert_metadata_roundtrip, assert_namespace_isolation, assert_project_definition_causal_merge_with_backend,
+        assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
+        assert_project_definition_edit_converges_with_backend, assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
         assert_replica_read_view_contract, assert_stale_resource_version_conflicts,
         assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays, assert_watch_now_semantics,
         assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
@@ -118,6 +120,22 @@ resource_contract_tests!(demand_contract, DemandFixture);
 #[tokio::test]
 async fn replica_read_view_contract() {
     assert_replica_read_view_contract(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn project_definition_edit_converges() {
+    assert_project_definition_edit_converges_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn project_definition_causal_merge() {
+    assert_project_definition_causal_merge_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn project_definition_delete_conflicts_with_concurrent_edit() {
+    assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend(ResourceBackend::InMemory(InMemoryBackend::default()))
+        .await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -8,10 +8,11 @@ use common::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip_with_backend,
         assert_delete_emits_event_with_backend, assert_identical_status_update_is_noop_with_backend,
         assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
-        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_replica_read_view_contract,
-        assert_stale_resource_version_conflicts_with_backend, assert_store_diagnostics_report_retained_events_with_backend,
-        assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend,
-        assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
+        assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
+        assert_project_definition_edit_converges_with_backend, assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
+        assert_replica_read_view_contract, assert_stale_resource_version_conflicts_with_backend,
+        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays_with_backend,
+        assert_watch_now_semantics_with_backend, assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture, DemandFixture, RegardFixture,
     },
     convoy_meta, convoy_spec, convoy_status, pending_task_state, resource_meta, TestLoopHarness,
@@ -19,9 +20,9 @@ use common::{
 use flotilla_controllers::reconcilers::VesselReconciler;
 use flotilla_resources::{
     controller::{Actuation, ControllerLoop, Reconciler},
-    ApiPaths, Convoy, ConvoyPhase, ConvoyReconciler, EventRetention, InMemoryBackend, NoStatusPatch, Resource, ResourceBackend,
-    ResourceError, SqliteBackend, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec, WatchEvent, WatchStart,
-    WorkPhase, WorkflowTemplate, CONVOY_LABEL, VESSEL_REF_LABEL,
+    ApiPaths, Convoy, ConvoyPhase, ConvoyReconciler, EventRetention, InMemoryBackend, InputMeta, NoStatusPatch, Project, ProjectSpec,
+    Resource, ResourceBackend, ResourceError, SqliteBackend, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel,
+    VesselSpec, WatchEvent, WatchStart, WorkPhase, WorkflowTemplate, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 use futures::StreamExt;
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
@@ -162,6 +163,21 @@ async fn replica_read_view_contract() {
 }
 
 #[tokio::test]
+async fn project_definition_edit_converges() {
+    assert_project_definition_edit_converges_with_backend(backend()).await;
+}
+
+#[tokio::test]
+async fn project_definition_causal_merge() {
+    assert_project_definition_causal_merge_with_backend(backend()).await;
+}
+
+#[tokio::test]
+async fn project_definition_delete_conflicts_with_concurrent_edit() {
+    assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend(backend()).await;
+}
+
+#[tokio::test]
 async fn replica_rows_and_cursor_survive_backend_restart() {
     let directory = tempfile::tempdir().expect("tempdir");
     let path = directory.path().join("resources.sqlite");
@@ -182,6 +198,47 @@ async fn replica_rows_and_cursor_survive_backend_restart() {
     let cursor =
         reopened.replica_writer::<Convoy>(origin, "flotilla").cursor().await.expect("read persisted cursor").expect("persisted cursor");
     assert_eq!(cursor.resource_version, listed.resource_version);
+}
+
+#[tokio::test]
+async fn replicated_project_definition_survives_backend_restart_without_peer() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("resources.sqlite");
+    let kiwi_root = flotilla_protocol::NodeId::new("kiwi-root");
+    let feta_root = flotilla_protocol::NodeId::new("feta-root");
+    let source = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(kiwi_root.clone());
+    source
+        .definitions::<Project>("flotilla")
+        .apply(
+            &InputMeta::builder().name("widgets".to_string()).build(),
+            &ProjectSpec::builder()
+                .display_name("Widgets".to_string())
+                .default_workflow_ref("default".to_string())
+                .repositories(Vec::new())
+                .build(),
+        )
+        .await
+        .expect("create source Project definition");
+    let source_log = source.using::<Project>("flotilla").list().await.expect("list source Project log");
+
+    {
+        let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("open sqlite backend")).with_local_root(feta_root.clone());
+        backend
+            .replica_writer::<Project>(kiwi_root, "flotilla")
+            .replace(&source_log, Utc::now())
+            .await
+            .expect("persist replicated Project");
+    }
+
+    let reopened = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("reopen sqlite backend")).with_local_root(feta_root);
+    let project = reopened
+        .definitions::<Project>("flotilla")
+        .get("widgets")
+        .await
+        .expect("Project definition should remain available without its peer");
+    assert_eq!(project.spec.display_name, "Widgets");
+    assert_eq!(project.spec.default_workflow_ref, "default");
+    assert!(project.metadata.merge.is_some(), "causal metadata must survive restart");
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -11,7 +11,8 @@ use common::{
         assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
         assert_project_definition_optional_field_can_be_cleared_with_backend,
-        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_replica_read_view_contract,
+        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
+        assert_replica_events_ignore_stale_writes_and_deletes_with_backend, assert_replica_read_view_contract,
         assert_stale_resource_version_conflicts_with_backend, assert_store_diagnostics_report_retained_events_with_backend,
         assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend,
         assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
@@ -165,6 +166,11 @@ async fn replica_read_view_contract() {
 }
 
 #[tokio::test]
+async fn replica_events_ignore_stale_writes_and_deletes() {
+    assert_replica_events_ignore_stale_writes_and_deletes_with_backend(backend()).await;
+}
+
+#[tokio::test]
 async fn project_definition_edit_converges() {
     assert_project_definition_edit_converges_with_backend(backend()).await;
 }
@@ -210,6 +216,36 @@ async fn replica_rows_and_cursor_survive_backend_restart() {
     let cursor =
         reopened.replica_writer::<Convoy>(origin, "flotilla").cursor().await.expect("read persisted cursor").expect("persisted cursor");
     assert_eq!(cursor.resource_version, listed.resource_version);
+}
+
+#[tokio::test]
+async fn replica_delete_tombstone_survives_backend_restart() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("resources.sqlite");
+    let origin = flotilla_protocol::NodeId::new("feta-root");
+    let source = ResourceBackend::InMemory(InMemoryBackend::default());
+    let object =
+        source.using::<Convoy>("flotilla").create(&convoy_meta("remote"), &convoy_spec("template")).await.expect("create source convoy");
+    let write_synced_at = Utc::now();
+    let delete_synced_at = write_synced_at + chrono::Duration::seconds(1);
+
+    {
+        let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("open sqlite backend"));
+        let writer = backend.replica_writer::<Convoy>(origin.clone(), "flotilla");
+        writer.apply(WatchEvent::Added(object.clone()), write_synced_at).await.expect("apply replica write");
+        writer.apply(WatchEvent::Deleted(object.clone()), delete_synced_at).await.expect("apply replica delete");
+    }
+
+    let reopened = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("reopen sqlite backend"));
+    reopened
+        .replica_writer::<Convoy>(origin, "flotilla")
+        .apply(WatchEvent::Modified(object), write_synced_at)
+        .await
+        .expect("ignore stale write after restart");
+    assert!(
+        reopened.including_replicas::<Convoy>("flotilla").list().await.expect("list replicas after restart").items.is_empty(),
+        "the persisted delete tombstone must prevent stale resurrection after restart"
+    );
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -9,10 +9,12 @@ use common::{
         assert_delete_emits_event_with_backend, assert_identical_status_update_is_noop_with_backend,
         assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
         assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
-        assert_project_definition_edit_converges_with_backend, assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
-        assert_replica_read_view_contract, assert_stale_resource_version_conflicts_with_backend,
-        assert_store_diagnostics_report_retained_events_with_backend, assert_watch_from_version_replays_with_backend,
-        assert_watch_now_semantics_with_backend, assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
+        assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
+        assert_project_definition_optional_field_can_be_cleared_with_backend,
+        assert_repeated_delete_with_pending_finalizers_is_noop_with_backend, assert_replica_read_view_contract,
+        assert_stale_resource_version_conflicts_with_backend, assert_store_diagnostics_report_retained_events_with_backend,
+        assert_watch_from_version_replays_with_backend, assert_watch_now_semantics_with_backend,
+        assert_watch_only_does_not_create_resource_stream_diagnostics_with_backend,
         assert_watch_retention_expires_only_versions_below_floor_with_backend, ConvoyFixture, DemandFixture, RegardFixture,
     },
     convoy_meta, convoy_spec, convoy_status, pending_task_state, resource_meta, TestLoopHarness,
@@ -170,6 +172,16 @@ async fn project_definition_edit_converges() {
 #[tokio::test]
 async fn project_definition_causal_merge() {
     assert_project_definition_causal_merge_with_backend(backend()).await;
+}
+
+#[tokio::test]
+async fn project_definition_optional_field_can_be_cleared() {
+    assert_project_definition_optional_field_can_be_cleared_with_backend(backend()).await;
+}
+
+#[tokio::test]
+async fn project_definition_edit_preserves_unrelated_conflict() {
+    assert_project_definition_edit_preserves_unrelated_conflict_with_backend(backend()).await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -162,7 +162,7 @@ fn format_project_list_human(response: &ProjectListResponse) -> String {
 
     let mut table = Table::new();
     table.load_preset(UTF8_FULL_CONDENSED);
-    table.set_header(vec!["Project", "Display Name", "Repositories", "Issue Source", "Workflow", "Address"]);
+    table.set_header(vec!["Project", "Display Name", "Repositories", "Issue Source", "Workflow", "Conflict", "Address"]);
     for project in &response.projects {
         let repository_count = project.repositories.len();
         let repositories = if repository_count <= 3 {
@@ -186,6 +186,7 @@ fn format_project_list_human(response: &ProjectListResponse) -> String {
             Cell::new(repositories),
             Cell::new(issue_source),
             Cell::new(&project.default_workflow_ref),
+            Cell::new(if project.conflicts.is_empty() { String::new() } else { format!("! {}", project.conflicts.join(", ")) }),
             Cell::new(project.address.human_label()),
         ]);
     }

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -244,6 +244,7 @@ mod project_list_human {
             .repositories(vec![repository("flotilla-org/cleat"), repository("flotilla-org/flotilla")])
             .maybe_issue_source(Some(IssueSource { service: "https://linear.app".into(), scope: "FLOT".into() }))
             .default_workflow_ref("review-and-fix".to_string())
+            .conflicts(vec!["spec.display_name".to_string()])
             .build();
         let many = ProjectListEntry::builder()
             .namespace("flotilla".to_string())
@@ -262,6 +263,7 @@ mod project_list_human {
         assert!(output.contains("flotilla-org/cleat, flotilla-org/flotilla"));
         assert!(output.contains("https://linear.app / FLOT"));
         assert!(output.contains("review-and-fix"));
+        assert!(output.contains("! spec.display_name"));
         assert!(output.contains("4 repositories"));
         assert!(!output.contains("one, two, three, four"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -962,6 +962,7 @@ async fn run_resource_watch(cli: &Cli, args: ResourceListArgs, format: OutputFor
                 namespace: args.namespace,
                 kind: args.kind,
                 include_replicas: args.include_replicas,
+                replica_sources: false,
                 cursor: None,
             },
         })


### PR DESCRIPTION
## Summary

- add `ReplicationClass::Definitions` and opt Project definitions into causal, field-level replication
- persist definition metadata and replica provenance across in-memory and SQLite backends
- relay definitions across direct and multi-hop connections without echo loops, and expose conflicts in Project CLI views
- cover cross-backend edits, conflict resolution, deletion semantics, restarts, reconnects, and multi-hop replication

Closes #1098

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
