### PR TITLE
presentation: publish open entity kind strings

### DIFF
--- a/crates/flotilla-manifest/fixtures/generator/src/main.rs
+++ b/crates/flotilla-manifest/fixtures/generator/src/main.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, env, fs, path::Path};
 
 use andamento_shared::{
-    EntityKind, EntityRef, ExternalMessage, MetadataIdentity, MetadataPatch, MetadataTarget,
+    EntityRef, ExternalMessage, MetadataIdentity, MetadataPatch, MetadataTarget,
     MetadataValue, MetadataValueUpdate, ObservedMetadataIdentity, PaneTarget,
 };
 
@@ -31,9 +31,9 @@ fn patch(target: MetadataTarget, source_id: &str, set: Vec<(&str, MetadataValueU
     })
 }
 
-fn entity_target(kind: EntityKind, id: &str) -> MetadataTarget {
+fn entity_target(kind: &str, id: &str) -> MetadataTarget {
     MetadataTarget::Entity(EntityRef {
-        kind,
+        kind: kind.to_owned(),
         id: id.to_owned(),
     })
 }
@@ -45,7 +45,7 @@ fn main() {
 
     // 1. Catalog patch: a stable entity target with flat facts and one unset.
     let entity_patch = patch(
-        entity_target(EntityKind::Vessel, "dev/manifest-extraction/implement@feta"),
+        entity_target("vessel", "dev/manifest-extraction/implement@feta"),
         "flotilla-connector",
         vec![
             ("entity.kind", update(text("vessel"), Some(30_000))),
@@ -69,7 +69,7 @@ fn main() {
 
     // 2. Independent sessions remain first-class entities.
     let session_patch = patch(
-        entity_target(EntityKind::Session, "feta/dev/terminal-impl-coder"),
+        entity_target("session", "feta/dev/terminal-impl-coder"),
         "flotilla-connector",
         vec![
             ("entity.kind", update(text("session"), Some(30_000))),

--- a/crates/flotilla-manifest/src/entity.rs
+++ b/crates/flotilla-manifest/src/entity.rs
@@ -4,52 +4,18 @@
 //! sites. One entity kind has one id dialect, so two observations of the same
 //! thing fold onto the same wire target.
 
-use std::fmt;
-
 use flotilla_protocol::{IssueRef, ResourceRef};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum EntityKind {
-    Project,
-    Repo,
-    Convoy,
-    Vessel,
-    Issue,
-    Session,
-    Checkout,
-}
-
-impl EntityKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Project => "project",
-            Self::Repo => "repo",
-            Self::Convoy => "convoy",
-            Self::Vessel => "vessel",
-            Self::Issue => "issue",
-            Self::Session => "session",
-            Self::Checkout => "checkout",
-        }
-    }
-}
-
-impl fmt::Display for EntityKind {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct EntityRef {
-    pub kind: EntityKind,
+    pub kind: String,
     pub id: String,
 }
 
 impl EntityRef {
-    pub fn new(kind: EntityKind, id: impl Into<String>) -> Self {
-        Self { kind, id: id.into() }
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Self {
+        Self { kind: kind.into(), id: id.into() }
     }
 
     /// Stable value used by action facts and live-tab matching.
@@ -67,31 +33,31 @@ pub fn resource_origin(resource: &ResourceRef) -> String {
 }
 
 pub fn project(namespace: &str, name: &str, origin: &str) -> EntityRef {
-    EntityRef::new(EntityKind::Project, format!("{namespace}/{name}@{origin}"))
+    EntityRef::new("project", format!("{namespace}/{name}@{origin}"))
 }
 
 pub fn repo(forge_slug: &str) -> EntityRef {
-    EntityRef::new(EntityKind::Repo, forge_slug)
+    EntityRef::new("repo", forge_slug)
 }
 
 pub fn convoy(namespace: &str, name: &str, origin: &str) -> EntityRef {
-    EntityRef::new(EntityKind::Convoy, format!("{namespace}/{name}@{origin}"))
+    EntityRef::new("convoy", format!("{namespace}/{name}@{origin}"))
 }
 
 pub fn vessel(namespace: &str, convoy_name: &str, vessel_name: &str, origin: &str) -> EntityRef {
-    EntityRef::new(EntityKind::Vessel, format!("{namespace}/{convoy_name}/{vessel_name}@{origin}"))
+    EntityRef::new("vessel", format!("{namespace}/{convoy_name}/{vessel_name}@{origin}"))
 }
 
 pub fn issue(reference: &IssueRef) -> EntityRef {
-    EntityRef::new(EntityKind::Issue, format!("{}/{}#{}", reference.source.service, reference.source.scope, reference.id))
+    EntityRef::new("issue", format!("{}/{}#{}", reference.source.service, reference.source.scope, reference.id))
 }
 
 pub fn session(session_ref: &str) -> EntityRef {
-    EntityRef::new(EntityKind::Session, session_ref)
+    EntityRef::new("session", session_ref)
 }
 
 pub fn checkout(checkout_ref: &str) -> EntityRef {
-    EntityRef::new(EntityKind::Checkout, checkout_ref)
+    EntityRef::new("checkout", checkout_ref)
 }
 
 #[cfg(test)]
@@ -122,5 +88,15 @@ mod tests {
         let remote = local.clone().on_host(HostName::new("kiwi"));
         assert_eq!(resource_origin(&local), "fleet");
         assert_eq!(resource_origin(&remote), "kiwi");
+    }
+
+    #[test]
+    fn entity_kind_is_an_open_wire_string() {
+        let entity = EntityRef::new("deployment", "prod/api");
+        let json = serde_json::to_string(&entity).expect("serialize novel kind");
+        let decoded: EntityRef = serde_json::from_str(&json).expect("deserialize novel kind");
+
+        assert_eq!(json, r#"{"kind":"deployment","id":"prod/api"}"#);
+        assert_eq!(decoded, entity);
     }
 }

--- a/crates/flotilla-manifest/src/keys.rs
+++ b/crates/flotilla-manifest/src/keys.rs
@@ -62,8 +62,8 @@ pub const KEY_CREW_ROLES: &str = "flotilla.crew.roles";
 
 // Cross-producer vocabulary (proposed for the Leg-1 freeze, design §6/§9).
 
-/// Canonical presentation entity kind. Its value is one of the
-/// `EntityKind` wire spellings.
+/// Canonical presentation entity kind. Its value belongs to the
+/// publisher-owned open entity-kind vocabulary.
 pub const KEY_ENTITY_KIND: &str = "entity.kind";
 /// Canonical id within `entity.kind`'s one permitted id dialect.
 pub const KEY_ENTITY_ID: &str = "entity.id";

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -15,7 +15,7 @@ use flotilla_protocol::{
 };
 
 use crate::{
-    entity::{self, EntityKind, EntityRef},
+    entity::{self, EntityRef},
     keys::{
         ARCHIPELAGO_ORDINAL, CATALOG_TTL_MS, KEY_CHANGE_REQUEST_NUMBER, KEY_CHECKOUT_BRANCH, KEY_CHECKOUT_PATH, KEY_CONVOY,
         KEY_CONVOY_MESSAGE, KEY_CONVOY_NAME, KEY_CONVOY_PHASE, KEY_CONVOY_WORKFLOW, KEY_COUNT_CHECKOUTS, KEY_COUNT_CONVOYS,
@@ -141,7 +141,7 @@ impl Catalog {
         let target = MetadataTarget::Entity(entity.clone());
         let entry = self.facts.entry(target).or_default();
         let base = [
-            (KEY_ENTITY_KIND, MetadataValue::text(entity.kind.as_str())),
+            (KEY_ENTITY_KIND, MetadataValue::text(entity.kind.clone())),
             (KEY_ENTITY_ID, MetadataValue::text(entity.id)),
             (KEY_SOURCE, MetadataValue::text(SOURCE_FLOTILLA)),
         ];
@@ -324,7 +324,7 @@ fn awareness_entry_entity(entry: &AwarenessEntry, convoys: &[ConvoyRow]) -> Opti
             (entity, facts)
         }
         AwarenessKind::Issue => {
-            let entity = entry.issue_refs.first().map(entity::issue).unwrap_or_else(|| EntityRef::new(EntityKind::Issue, entry.id.clone()));
+            let entity = entry.issue_refs.first().map(entity::issue).unwrap_or_else(|| EntityRef::new("issue", entry.id.clone()));
             (entity.clone(), vec![(SEGMENT_ISSUE, MetadataValue::text(entity.id.clone()))])
         }
         AwarenessKind::Independent => {

--- a/crates/flotilla-manifest/src/projection/tests.rs
+++ b/crates/flotilla-manifest/src/projection/tests.rs
@@ -5,7 +5,7 @@ use flotilla_protocol::{
 
 use super::*;
 use crate::{
-    entity::{self, EntityKind},
+    entity,
     keys::{
         KEY_CHANGE_REQUEST_NUMBER, KEY_CHECKOUT_BRANCH, KEY_CHECKOUT_PATH, KEY_CONVOY, KEY_CONVOY_NAME, KEY_COUNT_CHECKOUTS,
         KEY_COUNT_ISSUES, KEY_COUNT_TOTAL, KEY_DISPLAY_LABEL, KEY_ENTITY_ID, KEY_ENTITY_KIND, KEY_PRIMARY_ACTION_RECIPE,
@@ -118,7 +118,7 @@ fn awareness_issues_are_recipe_less_entities_with_source_plus_id_identity() {
     let patches = project_catalog(&CatalogInput { awareness: Some(&[node]), convoys: &[], independents: &[] }, &mint()).reassert_patches();
     let issue_patch = find_entity(&patches, &entity::issue(&issue_ref));
     let project_patch = find_entity(&patches, &entity::project("dev", "platform", "fleet"));
-    assert_eq!(text(issue_patch, KEY_ENTITY_KIND), EntityKind::Issue.as_str());
+    assert_eq!(text(issue_patch, KEY_ENTITY_KIND), "issue");
     assert_eq!(
         project_patch.set[KEY_COUNT_ISSUES].value,
         MetadataValue::Integer(1),
@@ -258,7 +258,7 @@ fn awareness_repository_group_does_not_masquerade_as_project() {
     find_entity(&patches, &entity::repo("flotilla-org/flotilla"));
     find_entity(&patches, &entity::session("independent/dev/governor"));
     assert!(
-        patches.iter().all(|patch| !matches!(&patch.target, MetadataTarget::Entity(entity) if entity.kind == EntityKind::Project)),
+        patches.iter().all(|patch| !matches!(&patch.target, MetadataTarget::Entity(entity) if entity.kind == "project")),
         "repository-only awareness must not mint a project entity"
     );
 }

--- a/crates/flotilla-manifest/src/stamp.rs
+++ b/crates/flotilla-manifest/src/stamp.rs
@@ -51,7 +51,7 @@ pub fn pane_stamp(pane: PaneTarget, attach_ref: &str, binding: Option<&AttachBin
             (None, _, None) => None,
         };
         if let Some(entity) = entity {
-            fact(KEY_ENTITY_KIND, entity.kind.as_str().to_owned());
+            fact(KEY_ENTITY_KIND, entity.kind.clone());
             fact(KEY_ENTITY_ID, entity.id);
         }
         if let Some(session) = &binding.session {
@@ -86,7 +86,7 @@ pub struct WorkspaceStamp {
 pub fn tab_stamp(tab_id: u64, stamp: &WorkspaceStamp) -> MetadataPatch {
     let mut set = BTreeMap::new();
     set.insert(KEY_SOURCE.to_owned(), MetadataValueUpdate::new(MetadataValue::text(SOURCE_FLOTILLA), None));
-    set.insert(KEY_ENTITY_KIND.to_owned(), MetadataValueUpdate::new(MetadataValue::text(stamp.entity.kind.as_str()), None));
+    set.insert(KEY_ENTITY_KIND.to_owned(), MetadataValueUpdate::new(MetadataValue::text(stamp.entity.kind.clone()), None));
     set.insert(KEY_ENTITY_ID.to_owned(), MetadataValueUpdate::new(MetadataValue::text(stamp.entity.id.clone()), None));
     MetadataPatch { target: MetadataTarget::Tab(tab_id), source_id: SOURCE_ACTUATOR.to_owned(), set, unset: vec![] }
 }

--- a/crates/flotilla-manifest/src/wire.rs
+++ b/crates/flotilla-manifest/src/wire.rs
@@ -73,7 +73,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-pub use crate::entity::{EntityKind, EntityRef};
+pub use crate::entity::EntityRef;
 
 /// A metadata fact value.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/crates/flotilla-manifest/src/wire/tests.rs
+++ b/crates/flotilla-manifest/src/wire/tests.rs
@@ -27,7 +27,7 @@ fn entity_catalog_patch_round_trips() {
     let MetadataTarget::Entity(entity) = &patch.target else {
         panic!("expected entity target");
     };
-    assert_eq!(entity.kind, EntityKind::Vessel);
+    assert_eq!(entity.kind, "vessel");
     assert_eq!(entity.id, "dev/manifest-extraction/implement@feta");
     assert_eq!(patch.unset, vec!["status.attention"]);
     assert_eq!(patch.set["status.state"].ttl_ms, Some(30_000));
@@ -40,7 +40,7 @@ fn session_entity_patch_round_trips() {
     let MetadataTarget::Entity(entity) = &patch.target else {
         panic!("expected entity target");
     };
-    assert_eq!(entity.kind, EntityKind::Session);
+    assert_eq!(entity.kind, "session");
     assert_eq!(entity.id, "feta/dev/terminal-impl-coder");
     assert!(!patch.set.contains_key("tab.scope"));
 }

--- a/crates/flotilla-tui/src/pm_connect/tests.rs
+++ b/crates/flotilla-tui/src/pm_connect/tests.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use flotilla_manifest::{
     entity,
     keys::{KEY_SOURCE, KEY_STATUS_STATE, SOURCE_FLOTILLA},
-    wire::{EntityKind, EntityRef, MetadataTarget, MetadataValue},
+    wire::{EntityRef, MetadataTarget, MetadataValue},
 };
 use flotilla_protocol::{
     result_set::{AwarenessCounts, AwarenessEntry, AwarenessKind, AwarenessNode, AwarenessState, SessionPhase},
@@ -146,7 +146,7 @@ fn rebuild_prefers_awareness_transport_when_available() {
 
     assert!(patches
         .iter()
-        .any(|patch| { patch.target == MetadataTarget::Entity(EntityRef::new(EntityKind::Issue, "issue/flotilla-org/flotilla/862",)) }));
+        .any(|patch| { patch.target == MetadataTarget::Entity(EntityRef::new("issue", "issue/flotilla-org/flotilla/862",)) }));
     assert!(
         !patches.iter().any(|patch| patch.target == independent_entity("scratch")),
         "raw independent fallback is not projected once awareness is available"


### PR DESCRIPTION
Closes #1059.

Companion presentation implementation: flotilla-org/andamento#43

- replaces the closed manifest `EntityKind` enum with an open wire string
- preserves canonical producer spellings and entity id dialects
- updates projection, stamping, fixtures, and presentation-manager consumers
- proves a novel `deployment` kind round-trips unchanged through JSON

Validation:
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-manifest --locked` (37 passed)

Local full-workspace note: `cargo test --workspace --locked` built and ran, but the unchanged `flotilla-core::in_process::tests::adopted_checkout_with_explicit_transport_applies_fork_stance_config` baseline test failed both in the suite and alone. No files or call paths for that test are changed here; clean GitHub CI will provide the delivery verdict.