### PR TITLE
feat: log daemon runtime liveness and supervisory-task abort

### DIFF
--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -31,7 +31,12 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
     let repo_root_paths = repo_roots.into_iter().map(|p| p.into_path_buf()).collect();
     let server = DaemonServer::new(repo_root_paths, Arc::clone(&config), discovery, socket_path.to_path_buf(), timeout).await?;
     let daemon = server.daemon();
-    let _runtime = DaemonRuntime::start(daemon, Arc::clone(&config), Some(socket_path.to_path_buf())).await?;
+    let runtime = DaemonRuntime::start(daemon, Arc::clone(&config), Some(socket_path.to_path_buf())).await?;
 
-    server.run().await
+    let result = server.run().await;
+    // Every path out of `run` here is an intended stop (SIGTERM, SIGINT, idle
+    // timeout, explicit shutdown); say so, so the runtime's Drop ERROR keeps
+    // meaning "this went away when it should not have".
+    runtime.shutdown();
+    result
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -41,7 +41,7 @@ use flotilla_resources::{
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
-use tracing::warn;
+use tracing::{error, info, warn};
 
 use crate::{
     sleep_inhibitor,
@@ -49,6 +49,10 @@ use crate::{
     Aggregator, AggregatorResolvers,
 };
 
+/// Cadence of the liveness marker (see `spawn_liveness_watchdog_task`). Long
+/// enough to be quiet in a healthy log, short enough to bound how much time a
+/// wedge can hide in.
+const LIVENESS_WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 
@@ -139,12 +143,20 @@ impl DaemonRuntime {
             ));
         }
 
+        tasks.push(spawn_liveness_watchdog_task(tasks.len(), LIVENESS_WATCHDOG_INTERVAL));
+
         Ok(Self { tasks })
     }
 }
 
 impl Drop for DaemonRuntime {
     fn drop(&mut self) {
+        // Dropping this value silently aborts every supervisory task —
+        // heartbeat, replica refresh, aggregator, controllers. A daemon whose
+        // runtime is dropped while its accept loop keeps running looks alive
+        // (process up, socket accepting) but serves nothing, and until this log
+        // existed it left no trace whatsoever (flotilla#1111).
+        error!(tasks = self.tasks.len(), "daemon runtime dropped; aborting supervisory tasks — the daemon can no longer do background work");
         for task in &self.tasks {
             task.abort();
         }
@@ -534,6 +546,17 @@ fn spawn_adopted_checkout_reconciliation_task(daemon: Arc<InProcessDaemon>, name
 enum PeriodicTaskStart {
     Immediate,
     AfterInterval,
+}
+
+/// Emits one liveness line per interval so a daemon that stops scheduling is
+/// visible in the log by the *absence* of a known-cadence marker, rather than by
+/// the absence of incidental chatter. Added after flotilla#1111, where the only
+/// evidence of a wedged daemon was that unrelated debug lines stopped.
+fn spawn_liveness_watchdog_task(tasks: usize, interval: Duration) -> JoinHandle<()> {
+    let started = tokio::time::Instant::now();
+    spawn_periodic_task(interval, PeriodicTaskStart::AfterInterval, move || async move {
+        info!(uptime_secs = started.elapsed().as_secs(), supervisory_tasks = tasks, "daemon alive");
+    })
 }
 
 fn spawn_periodic_task<Operation, OperationFuture>(interval: Duration, start: PeriodicTaskStart, mut operation: Operation) -> JoinHandle<()>

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -41,7 +41,7 @@ use flotilla_resources::{
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     sleep_inhibitor,
@@ -79,6 +79,9 @@ impl Default for RuntimeOptions {
 
 pub struct DaemonRuntime {
     tasks: Vec<JoinHandle<()>>,
+    /// Set by `shutdown` so `Drop` can tell an intended stop from a runtime
+    /// that vanished while the daemon was meant to keep working.
+    stop_expected: bool,
 }
 
 impl DaemonRuntime {
@@ -143,20 +146,43 @@ impl DaemonRuntime {
             ));
         }
 
-        tasks.push(spawn_liveness_watchdog_task(tasks.len(), LIVENESS_WATCHDOG_INTERVAL));
+        // +1 for the watchdog's own handle, pushed below, so this count matches
+        // `self.tasks.len()` at drop time.
+        let supervisory_tasks = tasks.len() + 1;
+        tasks.push(spawn_liveness_watchdog_task(supervisory_tasks, LIVENESS_WATCHDOG_INTERVAL));
 
-        Ok(Self { tasks })
+        Ok(Self { tasks, stop_expected: false })
+    }
+}
+
+impl DaemonRuntime {
+    /// Stop the supervisory tasks deliberately. Every routine daemon exit —
+    /// SIGTERM, SIGINT, idle timeout, explicit shutdown — should call this, so
+    /// that `Drop`'s ERROR path stays reserved for a runtime that disappeared
+    /// while the daemon was still meant to be working.
+    pub fn shutdown(mut self) {
+        self.stop_expected = true;
+        info!(tasks = self.tasks.len(), "daemon runtime stopping; aborting supervisory tasks");
     }
 }
 
 impl Drop for DaemonRuntime {
     fn drop(&mut self) {
-        // Dropping this value silently aborts every supervisory task —
-        // heartbeat, replica refresh, aggregator, controllers. A daemon whose
-        // runtime is dropped while its accept loop keeps running looks alive
-        // (process up, socket accepting) but serves nothing, and until this log
-        // existed it left no trace whatsoever (flotilla#1111).
-        error!(tasks = self.tasks.len(), "daemon runtime dropped; aborting supervisory tasks — the daemon can no longer do background work");
+        // Dropping this value aborts every supervisory task — heartbeat, replica
+        // refresh, aggregator, controllers. A daemon whose runtime is dropped
+        // while its accept loop keeps running looks alive (process up, socket
+        // accepting) but serves nothing, and until this log existed it left no
+        // trace whatsoever (flotilla#1111). An expected stop goes through
+        // `shutdown` and logs at INFO there; reaching here without that flag is
+        // the case worth shouting about.
+        if self.stop_expected {
+            debug!(tasks = self.tasks.len(), "daemon runtime dropped after expected shutdown");
+        } else {
+            error!(
+                tasks = self.tasks.len(),
+                "daemon runtime dropped unexpectedly; aborting supervisory tasks — the daemon can no longer do background work"
+            );
+        }
         for task in &self.tasks {
             task.abort();
         }


### PR DESCRIPTION
Diagnostics for #1111 — a daemon that stopped serving while staying alive, leaving no trace whatsoever.

- **`DaemonRuntime::drop` logs before aborting.** Dropping that value silently aborts heartbeat, replica refresh, aggregator, and controller tasks, leaving a process that satisfies every liveness check we have (pid alive, socket accepting) while doing no background work. It now says so at ERROR with the task count.
- **A liveness watchdog** emits one INFO line per minute carrying uptime and supervisory-task count. The point is that a wedge becomes visible through the *absence of a known-cadence marker*, rather than through the absence of incidental debug chatter — which was the only evidence available in #1111, and only noticeable in hindsight.

Neither is the fix for #1111. That trigger was most likely a full disk, and the real defect is that the daemon never recovers once space returns (a fresh daemon on the same disk works immediately). These changes make the next occurrence diagnosable rather than archaeological.

Gates: `cargo +nightly-2026-03-12 fmt --check` clean; `cargo build --bin flotillad` clean.

https://claude.ai/code/session_019iE3vGfKm6bZh7B6i1CUuY