### PR TITLE
fix: re-list replicas across peer generations

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -657,6 +657,24 @@ fn replica_staleness(entry: &FleetReplicaCacheEntry, now: DateTime<Utc>) -> Flee
     }
 }
 
+fn format_resource_replication_failures(failures: &[ResourceReplicationFailure]) -> Option<String> {
+    if failures.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "resource replication failed: {}",
+        failures.iter().map(|failure| format!("{}: {}", failure.kind, failure.message)).collect::<Vec<_>>().join("; ")
+    ))
+}
+
+fn join_replica_errors(first: Option<&str>, second: Option<&str>) -> Option<String> {
+    match (first, second) {
+        (Some(first), Some(second)) => Some(format!("{first}; {second}")),
+        (Some(message), None) | (None, Some(message)) => Some(message.to_string()),
+        (None, None) => None,
+    }
+}
+
 #[derive(Debug, Default)]
 struct ReplicaParseDiagnostics {
     skipped_records: usize,
@@ -1185,6 +1203,12 @@ struct FleetReplicaCacheEntry {
     last_error: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct ResourceReplicationFailure {
+    kind: String,
+    message: String,
+}
+
 const SUPERSEDED_BY_ANNOTATION: &str = "flotilla.work/superseded-by";
 
 #[derive(bon::Builder)]
@@ -1504,6 +1528,7 @@ pub struct InProcessDaemon {
     provisioning_namespace: std::sync::RwLock<String>,
     fleet_replica_cache: RwLock<HashMap<HostName, FleetReplicaCacheEntry>>,
     fleet_replica_tx: broadcast::Sender<Vec<FleetReplicaSnapshot>>,
+    resource_replication_failures: RwLock<HashMap<NodeId, BTreeMap<String, String>>>,
     repository_inspector: RwLock<Option<Arc<dyn RepositoryInspector>>>,
     local_placement_provider_statuses: RwLock<Vec<HostProviderStatus>>,
 }
@@ -1693,6 +1718,7 @@ impl InProcessDaemon {
             provisioning_namespace: std::sync::RwLock::new(DEFAULT_PROVISIONING_NAMESPACE.to_string()),
             fleet_replica_cache: RwLock::new(HashMap::new()),
             fleet_replica_tx,
+            resource_replication_failures: RwLock::new(HashMap::new()),
             repository_inspector: RwLock::new(None),
             local_placement_provider_statuses: RwLock::new(Vec::new()),
         });
@@ -2149,6 +2175,25 @@ impl InProcessDaemon {
                 let _ = self.event_tx.send(e);
             })
             .await;
+    }
+
+    pub async fn begin_peer_resource_replication(&self, peer: &NodeId) {
+        self.resource_replication_failures.write().await.remove(peer);
+    }
+
+    pub async fn report_resource_replication_failure(&self, peer: &NodeId, kind: &str, message: &str) {
+        self.resource_replication_failures.write().await.entry(peer.clone()).or_default().insert(kind.to_string(), message.to_string());
+    }
+
+    pub async fn report_resource_replication_healthy(&self, peer: &NodeId, kind: &str) {
+        let mut failures = self.resource_replication_failures.write().await;
+        let Some(peer_failures) = failures.get_mut(peer) else {
+            return;
+        };
+        peer_failures.remove(kind);
+        if peer_failures.is_empty() {
+            failures.remove(peer);
+        }
     }
 
     pub async fn publish_peer_summary(&self, summary: HostSummary) {
@@ -4845,10 +4890,21 @@ impl InProcessDaemon {
         let mut replicas = Vec::new();
         let now = Utc::now();
         let configured_hosts = self.config.load_hosts().map(|hosts| hosts.hosts).unwrap_or_default();
+        let failures = self.resource_replication_failures.read().await.clone();
+        let mut replication_failures_by_host = HashMap::<HostName, Vec<ResourceReplicationFailure>>::new();
+        for (peer, peer_failures) in failures {
+            let host = self.host_registry.host_name_for_node(&peer).await.unwrap_or_else(|| HostName::new(peer.as_str()));
+            replication_failures_by_host
+                .entry(host)
+                .or_default()
+                .extend(peer_failures.into_iter().map(|(kind, message)| ResourceReplicationFailure { kind, message }));
+        }
         let cache = self.fleet_replica_cache.read().await;
 
         for (label, remote) in configured_hosts {
             let host = HostName::new(remote.expected_host_name);
+            let replication_failures = replication_failures_by_host.remove(&host).unwrap_or_default();
+            let replication_error = format_resource_replication_failures(&replication_failures);
             match cache.get(&host) {
                 Some(entry) => {
                     let staleness = replica_staleness(entry, now);
@@ -4858,15 +4914,16 @@ impl InProcessDaemon {
                     }));
                     replicas.push(FleetReplicaStatus {
                         host,
-                        reachable: entry.last_error.is_none(),
+                        reachable: entry.last_error.is_none() && replication_error.is_none(),
                         last_sync: entry.last_sync,
                         generation: entry.generation.clone(),
                         skipped_records: entry.skipped_records,
                         first_parse_error: entry.first_parse_error.clone(),
-                        message: entry.last_error.clone(),
+                        message: join_replica_errors(entry.last_error.as_deref(), replication_error.as_deref()),
                     });
                 }
                 None => {
+                    let unsynced = format!("replica source '{label}' has not synced yet");
                     replicas.push(FleetReplicaStatus {
                         host,
                         reachable: false,
@@ -4874,10 +4931,21 @@ impl InProcessDaemon {
                         generation: None,
                         skipped_records: 0,
                         first_parse_error: None,
-                        message: Some(format!("replica source '{label}' has not synced yet")),
+                        message: join_replica_errors(Some(&unsynced), replication_error.as_deref()),
                     });
                 }
             }
+        }
+        for (host, failures) in replication_failures_by_host {
+            replicas.push(FleetReplicaStatus {
+                host,
+                reachable: false,
+                last_sync: None,
+                generation: None,
+                skipped_records: 0,
+                first_parse_error: None,
+                message: format_resource_replication_failures(&failures),
+            });
         }
 
         rows.sort_by(|left, right| {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1853,6 +1853,35 @@ async fn fleet_list_preserves_stale_rows_when_replica_is_unreachable() {
 }
 
 #[tokio::test]
+async fn fleet_list_reports_a_connected_peer_with_failed_resource_replication() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    write_attach_hosts_config(&config_base, &[("feta", "feta.local", Some("alice"))]);
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let peer = NodeId::new("feta-node");
+    daemon.set_configured_peers(vec![NodeInfo::new(peer.clone(), "feta")]).await;
+    publish_attach_host_summary(&daemon, "feta", "feta").await;
+    daemon.report_resource_replication_failure(&peer, "Convoy", "watch resourceVersion 7676 expired").await;
+
+    let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
+
+    assert_eq!(response.replicas.len(), 1);
+    assert_eq!(response.replicas[0].host, HostName::new("feta"));
+    assert!(!response.replicas[0].reachable);
+    assert!(
+        response.replicas[0]
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("Convoy") && message.contains("watch resourceVersion 7676 expired")),
+        "the failed peer must have an explicit resource-replication error: {:?}",
+        response.replicas[0]
+    );
+}
+
+#[tokio::test]
 async fn replica_refresh_replaces_rows_when_generation_changes() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -670,7 +670,7 @@ impl PeerRuntime {
                             notice.peer.clone(),
                             notice.generation,
                             notice.resource_socket_path,
-                        );
+                        ).await;
                         send_local_to_peer(
                             &outbound_daemon,
                             &outbound_peer_manager,

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -356,7 +356,7 @@ pub(super) async fn replicate_kind_over_http<T: Resource>(
 ) -> Result<(), String> {
     let remote = ResourceBackend::Http(http).using::<T>(REPLICATION_NAMESPACE);
     let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
-    let listed = remote.list().await.map_err(|error| error.to_string())?;
+    let mut listed = remote.list().await.map_err(|error| error.to_string())?;
     let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
     if let Some(cursor) = cursor.clone().filter(|cursor| cursor.generation == listed.generation) {
         let start = match cursor.generation {
@@ -370,6 +370,7 @@ pub(super) async fn replicate_kind_over_http<T: Resource>(
                     Ok(()) => return Ok(()),
                     Err(error) => {
                         debug!(%peer, kind = T::API_PATHS.kind, %error, "replica cursor watch failed; relisting origin");
+                        listed = remote.list().await.map_err(|error| error.to_string())?;
                     }
                 }
             }

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, NodeId, ResourceWatchCursor, ResourceWatchResponse};
 use flotilla_resources::{
-    HttpBackend, K8sWatchEvent, ReadWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject,
+    HttpBackend, K8sWatchEvent, ReadWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceList, ResourceObject,
     ResourceProvenance, WatchEvent, WatchStart,
 };
 use futures::StreamExt;
@@ -72,7 +72,7 @@ impl SocketPathSource {
 }
 
 impl PeerReplicatorSupervisors {
-    pub(super) fn peer_connected(
+    pub(super) async fn peer_connected(
         &mut self,
         router: RemoteCommandRouter,
         daemon: Arc<InProcessDaemon>,
@@ -83,6 +83,7 @@ impl PeerReplicatorSupervisors {
         let Some((cancellation, socket_path_source)) = self.begin_generation(&peer, generation, resource_socket_path.clone()) else {
             return;
         };
+        daemon.begin_peer_resource_replication(&peer).await;
         let transport = match resource_socket_path {
             Some(_) => ReplicationTransport::Http(socket_path_source),
             #[cfg(feature = "test-support")]
@@ -228,7 +229,11 @@ fn spawn_kind<T: Resource>(
                         let peer = run_peer.clone();
                         async move {
                             let http = HttpBackend::from_unix_socket(path).map_err(|error| error.to_string())?;
-                            replicate_kind_over_http::<T>(http, &daemon, &peer).await
+                            let result = replicate_kind_over_http::<T>(http, &daemon, &peer).await;
+                            if let Err(error) = &result {
+                                daemon.report_resource_replication_failure(&peer, T::API_PATHS.kind, error).await;
+                            }
+                            result
                         }
                     },
                 )
@@ -249,7 +254,13 @@ fn spawn_kind<T: Resource>(
                         let router = router.clone();
                         let daemon = Arc::clone(&run_daemon);
                         let peer = run_peer.clone();
-                        async move { replicate_kind_over_routed_watch::<T>(&router, &daemon, &peer).await }
+                        async move {
+                            let result = replicate_kind_over_routed_watch::<T>(&router, &daemon, &peer).await;
+                            if let Err(error) = &result {
+                                daemon.report_resource_replication_failure(&peer, T::API_PATHS.kind, error).await;
+                            }
+                            result
+                        }
                     },
                 )
                 .await;
@@ -345,25 +356,41 @@ pub(super) async fn replicate_kind_over_http<T: Resource>(
 ) -> Result<(), String> {
     let remote = ResourceBackend::Http(http).using::<T>(REPLICATION_NAMESPACE);
     let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
+    let listed = remote.list().await.map_err(|error| error.to_string())?;
     let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
-    if let Some(cursor) = cursor {
+    if let Some(cursor) = cursor.clone().filter(|cursor| cursor.generation == listed.generation) {
         let start = match cursor.generation {
             Some(generation) => WatchStart::FromVersionInGeneration { generation, resource_version: cursor.resource_version },
             None => WatchStart::FromVersion(cursor.resource_version),
         };
         match remote.watch(start).await {
-            Ok(watch) => return apply_http_watch(watch, &writer).await,
-            Err(error @ (ResourceError::WatchExpired { .. } | ResourceError::Invalid { .. })) => {
+            Ok(watch) => {
+                daemon.report_resource_replication_healthy(peer, T::API_PATHS.kind).await;
+                match apply_http_watch(watch, &writer).await {
+                    Ok(()) => return Ok(()),
+                    Err(error) => {
+                        debug!(%peer, kind = T::API_PATHS.kind, %error, "replica cursor watch failed; relisting origin");
+                    }
+                }
+            }
+            Err(error) => {
                 debug!(%peer, kind = T::API_PATHS.kind, %error, "replica cursor rejected; relisting origin");
             }
-            Err(error) => return Err(error.to_string()),
         }
+    } else if cursor.is_some() {
+        debug!(
+            %peer,
+            kind = T::API_PATHS.kind,
+            stored_generation = ?cursor.as_ref().and_then(|cursor| cursor.generation.as_deref()),
+            origin_generation = ?listed.generation,
+            "replica origin generation changed; replacing local view"
+        );
     }
 
-    let listed = remote.list().await.map_err(|error| error.to_string())?;
     let start = WatchStart::resuming_from(&listed);
     writer.replace(&listed, Utc::now()).await.map_err(|error| error.to_string())?;
     let watch = remote.watch(start).await.map_err(|error| error.to_string())?;
+    daemon.report_resource_replication_healthy(peer, T::API_PATHS.kind).await;
     apply_http_watch(watch, &writer).await
 }
 
@@ -425,6 +452,7 @@ async fn run_routed_watch<T: Resource>(
             None,
         )
         .await?;
+    daemon.report_resource_replication_healthy(peer, T::API_PATHS.kind).await;
     let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
     let mut initial = Vec::<ResourceObject<T>>::new();
     let mut initializing = !resuming;

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -29,10 +29,10 @@ use flotilla_protocol::{
     TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, HttpBackend, InMemoryBackend, InputMeta,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend, ResourceError, ResourceProvenance, Stance,
-    StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
-    TerminalSessionStatusPatch, WatchEvent, WatchStart, WorkflowTemplate,
+    list_resource_kind, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, HttpBackend,
+    InMemoryBackend, InputMeta, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend, ResourceError,
+    ResourceProvenance, Stance, StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, TerminalSessionStatusPatch, WatchEvent, WatchStart, WorkflowTemplate,
 };
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
@@ -180,16 +180,41 @@ async fn http_replicator_relists_after_an_origin_generation_change() {
     let new_generation =
         new_origin.using::<Convoy>("flotilla").list().await.expect("list new generation").generation.expect("new origin generation");
 
+    let listed = list_resource_kind(&new_origin, "flotilla", "convoys").await.expect("encode new generation list").value;
+    let listed_body = serde_json::to_vec(&listed).expect("encode new generation response");
     let socket_path = PathBuf::from(format!("/tmp/flotilla-replicator-http-{}.sock", uuid::Uuid::new_v4()));
     let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind replicator HTTP socket");
+    let requested_targets = Arc::new(StdMutex::new(Vec::new()));
+    let server_targets = Arc::clone(&requested_targets);
     let server = tokio::spawn(async move {
-        for _ in 0..3 {
+        loop {
             let (mut stream, _) = listener.accept().await.expect("accept replicator HTTP request");
-            let first_byte = tokio::io::AsyncReadExt::read_u8(&mut stream).await.expect("read HTTP preface");
-            let backend = new_origin.clone();
-            tokio::spawn(async move {
-                serve_resource_http(stream, first_byte, backend).await.expect("serve replicator HTTP request");
-            });
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                let mut buffer = [0_u8; 1024];
+                let read = tokio::io::AsyncReadExt::read(&mut stream, &mut buffer).await.expect("read replicator HTTP request");
+                assert_ne!(read, 0, "replicator HTTP request ended before its headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            let request = std::str::from_utf8(&request).expect("replicator HTTP request is UTF-8");
+            let target =
+                request.lines().next().and_then(|line| line.split_whitespace().nth(1)).expect("replicator HTTP request target").to_string();
+            server_targets.lock().expect("requested targets lock").push(target.clone());
+            if target.contains("watch=true") {
+                tokio::io::AsyncWriteExt::write_all(
+                    &mut stream,
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .expect("write hanging watch response");
+                std::future::pending::<()>().await;
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                listed_body.len()
+            );
+            tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes()).await.expect("write list response headers");
+            tokio::io::AsyncWriteExt::write_all(&mut stream, &listed_body).await.expect("write list response body");
         }
     });
 
@@ -222,6 +247,22 @@ async fn http_replicator_relists_after_an_origin_generation_change() {
     .await
     .expect("generation relist timeout");
 
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while requested_targets.lock().expect("requested targets lock").len() < 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replacement watch request timeout");
+    let requested_targets = requested_targets.lock().expect("requested targets lock").clone();
+    assert_eq!(requested_targets.len(), 2);
+    assert!(!requested_targets[0].contains("watch=true"), "the replicator must inspect the origin generation before resuming");
+    assert!(requested_targets[1].contains("watch=true"));
+    assert!(
+        requested_targets[1].contains(&format!("generation={new_generation}")),
+        "the replacement watch must be scoped to the new generation: {}",
+        requested_targets[1]
+    );
     replicator.abort();
     server.abort();
     let _ = replicator.await;

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -269,6 +269,129 @@ async fn http_replicator_relists_after_an_origin_generation_change() {
     let _ = server.await;
     std::fs::remove_file(&socket_path).expect("remove replicator HTTP socket");
 }
+
+#[tokio::test]
+async fn http_replicator_takes_a_fresh_list_after_a_resumed_watch_fails() {
+    let origin = ResourceBackend::InMemory(InMemoryBackend::observed());
+    origin
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("before-watch".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create initial convoy");
+    let initial = origin.using::<Convoy>("flotilla").list().await.expect("list initial origin");
+    let initial_body = serde_json::to_vec(&list_resource_kind(&origin, "flotilla", "convoys").await.expect("encode initial list").value)
+        .expect("encode initial response");
+
+    let holder_backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let origin_root = NodeId::new("remote-root");
+    holder_backend
+        .replica_writer::<Convoy>(origin_root.clone(), "flotilla")
+        .replace(&initial, chrono::Utc::now())
+        .await
+        .expect("seed resumable cursor");
+    origin
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("after-watch".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create convoy after initial list");
+    let fresh_body = serde_json::to_vec(&list_resource_kind(&origin, "flotilla", "convoys").await.expect("encode fresh list").value)
+        .expect("encode fresh response");
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let holder = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        test_config_store(temp.path().join("holder")),
+        fake_discovery(false),
+        HostName::new("holder"),
+        holder_backend.clone(),
+    )
+    .await;
+    let socket_path = PathBuf::from(format!("/tmp/flotilla-replicator-relist-{}.sock", uuid::Uuid::new_v4()));
+    let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind replicator HTTP socket");
+    let requested_targets = Arc::new(StdMutex::new(Vec::new()));
+    let server_targets = Arc::clone(&requested_targets);
+    let server = tokio::spawn(async move {
+        loop {
+            let (mut stream, _) = listener.accept().await.expect("accept replicator HTTP request");
+            let mut request = Vec::new();
+            while !request.ends_with(b"\r\n\r\n") {
+                let mut buffer = [0_u8; 1024];
+                let read = tokio::io::AsyncReadExt::read(&mut stream, &mut buffer).await.expect("read replicator HTTP request");
+                assert_ne!(read, 0, "replicator HTTP request ended before its headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
+            let request = std::str::from_utf8(&request).expect("replicator HTTP request is UTF-8");
+            let target =
+                request.lines().next().and_then(|line| line.split_whitespace().nth(1)).expect("replicator HTTP request target").to_string();
+            let request_number = {
+                let mut targets = server_targets.lock().expect("requested targets lock");
+                targets.push(target.clone());
+                targets.len()
+            };
+            if target.contains("watch=true") {
+                let body = if request_number == 2 { b"not-json\n".as_slice() } else { b"".as_slice() };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes()).await.expect("write watch response headers");
+                tokio::io::AsyncWriteExt::write_all(&mut stream, body).await.expect("write watch response body");
+                if request_number > 2 {
+                    std::future::pending::<()>().await;
+                }
+                continue;
+            }
+            let body = if request_number == 1 { &initial_body } else { &fresh_body };
+            let response =
+                format!("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", body.len());
+            tokio::io::AsyncWriteExt::write_all(&mut stream, response.as_bytes()).await.expect("write list response headers");
+            tokio::io::AsyncWriteExt::write_all(&mut stream, body).await.expect("write list response body");
+        }
+    });
+
+    let http = HttpBackend::from_unix_socket(&socket_path).expect("build replicator HTTP client");
+    let holder_for_replication = Arc::clone(&holder);
+    let origin_for_replication = origin_root.clone();
+    let replicator =
+        tokio::spawn(async move { replicate_kind_over_http::<Convoy>(http, &holder_for_replication, &origin_for_replication).await });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let listed = holder_backend.including_replicas::<Convoy>("flotilla").list().await.expect("list relisted replicas");
+            if listed.items.iter().any(|item| item.object.metadata.name == "after-watch") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("fresh relist timeout");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while requested_targets.lock().expect("requested targets lock").len() < 4 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replacement watch request timeout");
+    let requested_targets = requested_targets.lock().expect("requested targets lock").clone();
+    assert!(!requested_targets[0].contains("watch=true"));
+    assert!(requested_targets[1].contains("watch=true"));
+    assert!(!requested_targets[2].contains("watch=true"), "a failed resumed watch must trigger a fresh list");
+    assert!(requested_targets[3].contains("watch=true"));
+
+    replicator.abort();
+    server.abort();
+    let _ = replicator.await;
+    let _ = server.await;
+    std::fs::remove_file(&socket_path).expect("remove replicator HTTP socket");
+}
+
 use crate::peer::{
     test_support::{ensure_test_connection_generation, handle_test_peer_data, wait_for_command_result, BlockingPeerSender, MockPeerSender},
     InboundPeerEnvelope, PeerConnectionStatus, PeerManager, PeerSender, PeerTransport,


### PR DESCRIPTION
## Summary

- inspect the origin generation before resuming a stored replica cursor
- atomically replace replica rows and restart the watch when the generation changes or a resumed watch fails
- track per-peer, per-kind replication failures and surface them in `flotilla ls` replica status
- add regression coverage for proactive generation re-listing and explicit failed-peer status

## Root cause

The peer replicator resumed its stored `resourceVersion` before checking the restarted origin's generation. If the stale watch did not return one of the narrowly recognized cursor errors, the supervisor retried the same cursor indefinitely. Resource-replication health was also disconnected from fleet replica status, so the failed peer could be omitted from the status table.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- targeted InProcessDaemon, overlay replication, generation-change, and fleet-status regressions

Closes #1104