### PR TITLE
fix: deduplicate prepared convoy snapshots

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2330,16 +2330,13 @@ impl InProcessDaemon {
             return Err(format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"));
         }
         let fallback_principal = PrincipalRef::implicit_for_namespace(&namespace);
-        let mut admission =
-            self.prepare_convoy_admission(&namespace, intent, dispatching_principal_ref.unwrap_or(&fallback_principal)).await?;
+        let admission = self.prepare_convoy_admission(&namespace, intent, dispatching_principal_ref.unwrap_or(&fallback_principal)).await?;
         let workflow_value = serde_json::to_value(&admission.workflow).map_err(|error| error.to_string())?;
-        let workflow_name = prepared_snapshot_name(&admission.name, "workflow", &workflow_value)?;
-        admission.spec.workflow_ref.clone_from(&workflow_name);
+        let workflow_name = prepared_snapshot_name("workflow", &workflow_value)?;
         let (placement_policy_name, placement_policy_spec) = match admission.placement_policy {
             Some(spec) => {
                 let value = serde_json::to_value(spec).map_err(|error| error.to_string())?;
-                let name = prepared_snapshot_name(&admission.name, "placement", &value)?;
-                admission.spec.placement_policy = Some(name.clone());
+                let name = prepared_snapshot_name("placement", &value)?;
                 (Some(name), Some(value))
             }
             None => (None, None),
@@ -3195,11 +3192,11 @@ async fn ensure_default_workflows(backend: &ResourceBackend, namespace: &str) ->
     Ok(())
 }
 
-fn prepared_snapshot_name(convoy_name: &str, kind: &str, spec: &serde_json::Value) -> Result<String, String> {
+fn prepared_snapshot_name(kind: &str, spec: &serde_json::Value) -> Result<String, String> {
     let encoded = serde_json::to_vec(spec).map_err(|error| error.to_string())?;
     let digest = Sha256::digest(encoded);
     let suffix = digest[..6].iter().map(|byte| format!("{byte:02x}")).collect::<String>();
-    Ok(format!("{convoy_name}-remote-{kind}-{suffix}"))
+    Ok(format!("{kind}-snapshot-{suffix}"))
 }
 
 async fn ensure_prepared_workflow_snapshot(
@@ -3213,7 +3210,16 @@ async fn ensure_prepared_workflow_snapshot(
         Ok(existing) if existing.spec == *spec => Ok(()),
         Ok(_) => Err(format!("prepared workflow snapshot {name} already exists with different contents")),
         Err(ResourceError::NotFound { .. }) => templates
-            .create(&InputMeta::builder().name(name.to_string()).build(), spec)
+            .create(
+                &InputMeta::builder()
+                    .name(name.to_string())
+                    .labels(BTreeMap::from([(
+                        flotilla_resources::PREPARED_SNAPSHOT_LABEL.to_string(),
+                        flotilla_resources::WORKFLOW_SNAPSHOT_KIND.to_string(),
+                    )]))
+                    .build(),
+                spec,
+            )
             .await
             .map(|_| ())
             .map_err(|error| error.to_string()),
@@ -3231,9 +3237,20 @@ async fn ensure_prepared_placement_snapshot(
     match policies.get(name).await {
         Ok(existing) if existing.spec == *spec => Ok(()),
         Ok(_) => Err(format!("prepared placement snapshot {name} already exists with different contents")),
-        Err(ResourceError::NotFound { .. }) => {
-            policies.create(&InputMeta::builder().name(name.to_string()).build(), spec).await.map(|_| ()).map_err(|error| error.to_string())
-        }
+        Err(ResourceError::NotFound { .. }) => policies
+            .create(
+                &InputMeta::builder()
+                    .name(name.to_string())
+                    .labels(BTreeMap::from([(
+                        flotilla_resources::PREPARED_SNAPSHOT_LABEL.to_string(),
+                        flotilla_resources::PLACEMENT_SNAPSHOT_KIND.to_string(),
+                    )]))
+                    .build(),
+                spec,
+            )
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string()),
         Err(error) => Err(error.to_string()),
     }
 }
@@ -3271,7 +3288,12 @@ async fn ensure_repository_and_default_project_workflow(
     flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(namespace), repository_key, repository_spec)
         .await
         .map_err(|error| error.to_string())?;
-    ensure_default_workflows(backend, namespace).await
+    ensure_default_workflows(backend, namespace).await?;
+    flotilla_resources::PreparedSnapshotGarbageCollector::new(backend.clone(), namespace)
+        .collect(None)
+        .await
+        .map(|_| ())
+        .map_err(|error| error.to_string())
 }
 
 fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: String) -> Result<ProjectSpec, String> {
@@ -3712,8 +3734,22 @@ impl InProcessDaemon {
         spec: &ConvoySpec,
         dispatch_regard: ConvoyDispatchRegard,
     ) -> Result<(), String> {
+        self.create_convoy_with_annotations(namespace, name, spec, dispatch_regard, BTreeMap::new()).await
+    }
+
+    async fn create_convoy_with_annotations(
+        &self,
+        namespace: &str,
+        name: &str,
+        spec: &ConvoySpec,
+        dispatch_regard: ConvoyDispatchRegard,
+        annotations: BTreeMap<String, String>,
+    ) -> Result<(), String> {
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
-        convoys.create(&InputMeta::builder().name(name.to_string()).build(), spec).await.map_err(|error| error.to_string())?;
+        convoys
+            .create(&InputMeta::builder().name(name.to_string()).annotations(annotations).build(), spec)
+            .await
+            .map_err(|error| error.to_string())?;
         if dispatch_regard == ConvoyDispatchRegard::Emit {
             if let Err(error) = self.emit_implicit_convoy_regard(namespace, name, &spec.dispatching_principal_ref).await {
                 warn!(%error, %namespace, %name, "failed to emit convoy dispatch regard");
@@ -3829,13 +3865,17 @@ impl InProcessDaemon {
             serde_json::from_value(start.convoy_spec.clone()).map_err(|error| format!("invalid prepared convoy spec: {error}"))?;
         let workflow_spec: WorkflowTemplateSpec =
             serde_json::from_value(start.workflow_spec.clone()).map_err(|error| format!("invalid prepared workflow snapshot: {error}"))?;
-        if convoy_spec.workflow_ref != start.workflow_name {
-            return Err("prepared convoy workflow reference does not match its snapshot name".to_string());
+        let expected_workflow_name = prepared_snapshot_name("workflow", &start.workflow_spec)
+            .map_err(|error| format!("invalid prepared workflow snapshot: {error}"))?;
+        if expected_workflow_name != start.workflow_name {
+            return Err("prepared workflow snapshot name does not match its contents".to_string());
         }
         let placement_spec = match (&start.placement_policy_name, &start.placement_policy_spec) {
             (Some(name), Some(value)) => {
-                if convoy_spec.placement_policy.as_deref() != Some(name) {
-                    return Err("prepared convoy placement reference does not match its snapshot name".to_string());
+                let expected_name =
+                    prepared_snapshot_name("placement", value).map_err(|error| format!("invalid prepared placement snapshot: {error}"))?;
+                if expected_name != *name {
+                    return Err("prepared placement snapshot name does not match its contents".to_string());
                 }
                 let spec: PlacementPolicySpec =
                     serde_json::from_value(value.clone()).map_err(|error| format!("invalid prepared placement snapshot: {error}"))?;
@@ -3866,7 +3906,11 @@ impl InProcessDaemon {
         if let Some((name, spec)) = placement_spec {
             ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, &spec).await?;
         }
-        self.create_convoy(&namespace, &start.name, &convoy_spec, start.dispatch_regard).await
+        let mut annotations = BTreeMap::from([(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), start.workflow_name.clone())]);
+        if let Some(name) = &start.placement_policy_name {
+            annotations.insert(flotilla_resources::PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), name.clone());
+        }
+        self.create_convoy_with_annotations(&namespace, &start.name, &convoy_spec, start.dispatch_regard, annotations).await
     }
 
     async fn supervise_convoy_start(&self, task: ConvoyStartTask) {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3926,19 +3926,19 @@ impl InProcessDaemon {
         .await;
         if let Err(error) = prepared {
             if let Err(cleanup_error) = convoys.delete(&start.name).await {
-                warn!(%cleanup_error, namespace, convoy = %start.name, "failed to remove incomplete prepared convoy claim");
+                warn!(%cleanup_error, %namespace, convoy = %start.name, "failed to remove incomplete prepared convoy claim");
             }
             if let Err(cleanup_error) = flotilla_resources::PreparedSnapshotGarbageCollector::new(self.resource_backend.clone(), &namespace)
                 .collect(Some(&start.name))
                 .await
             {
-                warn!(%cleanup_error, namespace, convoy = %start.name, "failed to collect snapshots after prepared convoy admission error");
+                warn!(%cleanup_error, %namespace, convoy = %start.name, "failed to collect snapshots after prepared convoy admission error");
             }
             return Err(error);
         }
         if start.dispatch_regard == flotilla_protocol::ConvoyDispatchRegard::Emit {
             if let Err(error) = self.emit_implicit_convoy_regard(&namespace, &start.name, &convoy_spec.dispatching_principal_ref).await {
-                warn!(%error, namespace, convoy = %start.name, "failed to emit convoy dispatch regard");
+                warn!(%error, %namespace, convoy = %start.name, "failed to emit convoy dispatch regard");
             }
         }
         Ok(())

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3902,15 +3902,60 @@ impl InProcessDaemon {
             Err(ResourceError::NotFound { .. }) => {}
             Err(error) => return Err(error.to_string()),
         }
-        ensure_prepared_workflow_snapshot(&self.resource_backend, &namespace, &start.workflow_name, &workflow_spec).await?;
-        if let Some((name, spec)) = placement_spec {
-            ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, &spec).await?;
-        }
         let mut annotations = BTreeMap::from([(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), start.workflow_name.clone())]);
         if let Some(name) = &start.placement_policy_name {
             annotations.insert(flotilla_resources::PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), name.clone());
         }
-        self.create_convoy_with_annotations(&namespace, &start.name, &convoy_spec, start.dispatch_regard, annotations).await
+        annotations.insert(flotilla_resources::PREPARED_SNAPSHOT_PENDING_ANNOTATION.to_string(), "true".to_string());
+        self.create_convoy_with_annotations(
+            &namespace,
+            &start.name,
+            &convoy_spec,
+            flotilla_protocol::ConvoyDispatchRegard::Suppress,
+            annotations,
+        )
+        .await?;
+
+        let prepared = async {
+            ensure_prepared_workflow_snapshot(&self.resource_backend, &namespace, &start.workflow_name, &workflow_spec).await?;
+            if let Some((name, spec)) = &placement_spec {
+                ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, spec).await?;
+            }
+            self.finish_prepared_convoy_claim(&namespace, &start.name).await
+        }
+        .await;
+        if let Err(error) = prepared {
+            if let Err(cleanup_error) = convoys.delete(&start.name).await {
+                warn!(%cleanup_error, namespace, convoy = %start.name, "failed to remove incomplete prepared convoy claim");
+            }
+            if let Err(cleanup_error) = flotilla_resources::PreparedSnapshotGarbageCollector::new(self.resource_backend.clone(), &namespace)
+                .collect(Some(&start.name))
+                .await
+            {
+                warn!(%cleanup_error, namespace, convoy = %start.name, "failed to collect snapshots after prepared convoy admission error");
+            }
+            return Err(error);
+        }
+        if start.dispatch_regard == flotilla_protocol::ConvoyDispatchRegard::Emit {
+            if let Err(error) = self.emit_implicit_convoy_regard(&namespace, &start.name, &convoy_spec.dispatching_principal_ref).await {
+                warn!(%error, namespace, convoy = %start.name, "failed to emit convoy dispatch regard");
+            }
+        }
+        Ok(())
+    }
+
+    async fn finish_prepared_convoy_claim(&self, namespace: &str, name: &str) -> Result<(), String> {
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
+        loop {
+            let convoy = convoys.get(name).await.map_err(|error| error.to_string())?;
+            let mut meta = InputMeta::from(&convoy.metadata);
+            meta.annotations.remove(flotilla_resources::PREPARED_SNAPSHOT_PENDING_ANNOTATION);
+            match convoys.update(&meta, &convoy.metadata.resource_version, &convoy.spec).await {
+                Ok(_) => return Ok(()),
+                Err(ResourceError::Conflict { .. }) => continue,
+                Err(error) => return Err(error.to_string()),
+            }
+        }
     }
 
     async fn supervise_convoy_start(&self, task: ConvoyStartTask) {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -244,13 +244,11 @@ async fn convoy_admission_uses_only_fresh_cached_issue_snapshots() {
 
 #[test]
 fn prepared_snapshot_names_are_content_addressed_for_safe_convoy_name_reuse() {
-    let first =
-        prepared_snapshot_name("remote-work", "workflow", &serde_json::json!({ "vessels": ["implement"] })).expect("first snapshot name");
-    let second =
-        prepared_snapshot_name("remote-work", "workflow", &serde_json::json!({ "vessels": ["review"] })).expect("second snapshot name");
+    let first = prepared_snapshot_name("workflow", &serde_json::json!({ "vessels": ["implement"] })).expect("first snapshot name");
+    let second = prepared_snapshot_name("workflow", &serde_json::json!({ "vessels": ["review"] })).expect("second snapshot name");
 
     assert_ne!(first, second);
-    assert!(first.starts_with("remote-work-remote-workflow-"));
+    assert!(first.starts_with("workflow-snapshot-"));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -832,7 +832,11 @@ fn spawn_controller_loops(
                             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(&namespace_string))
                                 .with_vessels(backend.clone().using::<Vessel>(&namespace_string))
                                 .with_presentations(backend.clone().using::<Presentation>(&namespace_string))
-                                .with_checkouts(backend.clone().using::<Checkout>(&namespace_string)),
+                                .with_checkouts(backend.clone().using::<Checkout>(&namespace_string))
+                                .with_prepared_snapshot_gc(flotilla_resources::PreparedSnapshotGarbageCollector::new(
+                                    backend.clone(),
+                                    &namespace_string,
+                                )),
                             resync_interval: controller_resync_interval,
                             backend,
                         }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -102,6 +102,10 @@ impl DaemonRuntime {
         let profile = build_local_profile(&daemon, &local_registry)?;
         daemon.set_local_placement_capabilities(&profile.available_agent_adapters, &profile.available_pools).await;
         register_startup_resources(&daemon, &options.namespace, &profile).await?;
+        flotilla_resources::PreparedSnapshotGarbageCollector::new(daemon.resource_backend(), &options.namespace)
+            .recover_pending_claims()
+            .await
+            .map_err(|error| format!("recover prepared convoy admissions: {error}"))?;
         apply_host_heartbeat(&daemon, &options.namespace, &profile).await?;
         if let Err(error) = daemon.reconcile_adopted_checkouts(&options.namespace).await {
             warn!(%error, "failed to restore adopted checkout observations during startup; periodic reconciliation will retry");

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1129,9 +1129,9 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
         let CommandAction::ConvoyStartPrepared { start } = &routed.action else {
             panic!("remote launch must carry an admitted convoy snapshot");
         };
-        assert!(start.workflow_name.starts_with("remote-work-remote-workflow-"));
+        assert!(start.workflow_name.starts_with("workflow-snapshot-"));
         let placement_snapshot_name = start.placement_policy_name.clone().expect("prepared placement snapshot name");
-        assert!(placement_snapshot_name.starts_with("remote-work-remote-placement-"));
+        assert!(placement_snapshot_name.starts_with("placement-snapshot-"));
         let mut delivered = routed.as_ref().clone();
         delivered.node_id = None;
         (delivered, start.workflow_name.clone(), placement_snapshot_name)
@@ -1143,13 +1143,13 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
     );
 
     let mut remote_events = remote_daemon.subscribe();
-    let remote_command_id = remote_daemon.execute(routed).await.expect("prepared command should be accepted by remote daemon");
+    let remote_command_id = remote_daemon.execute(routed.clone()).await.expect("prepared command should be accepted by remote daemon");
     let remote_result = wait_for_command_result(&mut remote_events, remote_command_id, StdDuration::from_secs(5)).await;
     assert_eq!(remote_result, CommandValue::ConvoyStarted { name: "remote-work".to_string(), attach_command: None, binding: None });
     let remote_backend = remote_daemon.resource_backend();
     let convoy = remote_backend.clone().using::<Convoy>("flotilla").get("remote-work").await.expect("remote daemon should persist convoy");
-    assert_eq!(convoy.spec.workflow_ref, workflow_snapshot_name);
-    assert_eq!(convoy.spec.placement_policy.as_deref(), Some(placement_snapshot_name.as_str()));
+    assert_eq!(convoy.spec.workflow_ref, "remote-workflow");
+    assert_eq!(convoy.spec.placement_policy.as_deref(), Some(remote_policy_name.as_str()));
     let remote_workflow = remote_backend
         .clone()
         .using::<WorkflowTemplate>("flotilla")
@@ -1158,11 +1158,52 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
         .expect("remote daemon should persist workflow snapshot");
     assert_eq!(remote_workflow.spec.vessels[0].stance, Stance::Trusted);
     let remote_policy = remote_backend
+        .clone()
         .using::<PlacementPolicy>("flotilla")
         .get(&placement_snapshot_name)
         .await
         .expect("remote daemon should persist placement snapshot");
     assert_eq!(remote_policy.spec.host_direct.expect("host-direct snapshot").host_ref, remote_host_id);
+
+    let mut repeated = match &routed.action {
+        CommandAction::ConvoyStartPrepared { start } => start.as_ref().clone(),
+        _ => panic!("routed command must remain a prepared convoy start"),
+    };
+    repeated.name = "remote-work-again".to_string();
+    let mut repeated_spec: serde_json::Value = repeated.convoy_spec.clone();
+    repeated_spec["ref"] = serde_json::Value::String("feat/remote-work-again".to_string());
+    repeated.convoy_spec = repeated_spec;
+    let mut repeated_events = remote_daemon.subscribe();
+    let repeated_id = remote_daemon
+        .execute(Command::builder().action(CommandAction::ConvoyStartPrepared { start: Box::new(repeated) }).build())
+        .await
+        .expect("repeated prepared command should be accepted");
+    assert_eq!(wait_for_command_result(&mut repeated_events, repeated_id, StdDuration::from_secs(5)).await, CommandValue::ConvoyStarted {
+        name: "remote-work-again".to_string(),
+        attach_command: None,
+        binding: None
+    });
+    let prepared_workflows = remote_backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .list()
+        .await
+        .expect("list workflow snapshots")
+        .items
+        .into_iter()
+        .filter(|workflow| workflow.metadata.name == workflow_snapshot_name)
+        .count();
+    let prepared_placements = remote_backend
+        .using::<PlacementPolicy>("flotilla")
+        .list()
+        .await
+        .expect("list placement snapshots")
+        .items
+        .into_iter()
+        .filter(|policy| policy.metadata.name == placement_snapshot_name)
+        .count();
+    assert_eq!(prepared_workflows, 1);
+    assert_eq!(prepared_placements, 1);
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -14,6 +14,7 @@ define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch,
 
 pub const WORKFLOW_SNAPSHOT_ANNOTATION: &str = "flotilla.work/workflow-snapshot";
 pub const PLACEMENT_SNAPSHOT_ANNOTATION: &str = "flotilla.work/placement-snapshot";
+pub const PREPARED_SNAPSHOT_PENDING_ANNOTATION: &str = "flotilla.work/prepared-snapshot-pending";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoySpec {
@@ -63,6 +64,10 @@ pub fn pinned_workflow_ref(convoy: &crate::ResourceObject<Convoy>) -> &str {
 
 pub fn pinned_placement_ref(convoy: &crate::ResourceObject<Convoy>) -> Option<&str> {
     convoy.metadata.annotations.get(PLACEMENT_SNAPSHOT_ANNOTATION).map(String::as_str).or(convoy.spec.placement_policy.as_deref())
+}
+
+pub fn prepared_snapshot_pending(convoy: &crate::ResourceObject<Convoy>) -> bool {
+    convoy.metadata.annotations.contains_key(PREPARED_SNAPSHOT_PENDING_ANNOTATION)
 }
 
 /// Durable source-qualified issue context captured when a convoy is admitted.

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -12,6 +12,9 @@ pub use reconcile::{reconcile, ConvoyEvent, ConvoyReconciler, ReconcileOutcome};
 
 define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
 
+pub const WORKFLOW_SNAPSHOT_ANNOTATION: &str = "flotilla.work/workflow-snapshot";
+pub const PLACEMENT_SNAPSHOT_ANNOTATION: &str = "flotilla.work/placement-snapshot";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoySpec {
     pub workflow_ref: String,
@@ -52,6 +55,14 @@ impl ConvoySpec {
         };
         Some(repository)
     }
+}
+
+pub fn pinned_workflow_ref(convoy: &crate::ResourceObject<Convoy>) -> &str {
+    convoy.metadata.annotations.get(WORKFLOW_SNAPSHOT_ANNOTATION).map(String::as_str).unwrap_or(&convoy.spec.workflow_ref)
+}
+
+pub fn pinned_placement_ref(convoy: &crate::ResourceObject<Convoy>) -> Option<&str> {
+    convoy.metadata.annotations.get(PLACEMENT_SNAPSHOT_ANNOTATION).map(String::as_str).or(convoy.spec.placement_policy.as_deref())
 }
 
 /// Durable source-qualified issue context captured when a convoy is admitted.

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -17,7 +17,7 @@ use crate::{
         SecondaryWatch,
     },
     labels::{CONVOY_LABEL, VESSEL_LABEL},
-    pinned_placement_ref, pinned_workflow_ref,
+    pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending,
     presentation::{Presentation, PresentationSpec},
     resource::ResourceObject,
     status_patch::StatusPatch,
@@ -189,6 +189,9 @@ fn reconcile_internal(
     presentations: &BTreeMap<String, ResourceObject<Presentation>>,
     now: DateTime<Utc>,
 ) -> InternalReconcileOutcome {
+    if prepared_snapshot_pending(convoy) {
+        return InternalReconcileOutcome { patch: None, actuations: Vec::new(), events: Vec::new() };
+    }
     let status = convoy.status.clone().unwrap_or_default();
 
     if matches!(status.phase, ConvoyPhase::Failed | ConvoyPhase::Cancelled | ConvoyPhase::Abandoned) {

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -17,12 +17,13 @@ use crate::{
         SecondaryWatch,
     },
     labels::{CONVOY_LABEL, VESSEL_LABEL},
+    pinned_placement_ref, pinned_workflow_ref,
     presentation::{Presentation, PresentationSpec},
     resource::ResourceObject,
     status_patch::StatusPatch,
     vessel::{Vessel, VesselPhase},
     workflow_template::{validate, visit_template_tokens, CrewSource, CrewSpec, ValidationError, WorkflowTemplate},
-    InputMeta, InputValue, OwnerReference, PlacementStatus, Resource, ResourceError, TypedResolver,
+    InputMeta, InputValue, OwnerReference, PlacementStatus, PreparedSnapshotGarbageCollector, Resource, ResourceError, TypedResolver,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,6 +55,7 @@ pub struct ConvoyReconciler {
     vessels: Option<TypedResolver<Vessel>>,
     presentations: Option<TypedResolver<Presentation>>,
     checkouts: Option<TypedResolver<Checkout>>,
+    prepared_snapshot_gc: Option<PreparedSnapshotGarbageCollector>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,7 +67,7 @@ pub struct ConvoyDependencies {
 
 impl ConvoyReconciler {
     pub fn new(templates: TypedResolver<WorkflowTemplate>) -> Self {
-        Self { templates, vessels: None, presentations: None, checkouts: None }
+        Self { templates, vessels: None, presentations: None, checkouts: None, prepared_snapshot_gc: None }
     }
 
     pub fn with_vessels(mut self, vessels: TypedResolver<Vessel>) -> Self {
@@ -80,6 +82,11 @@ impl ConvoyReconciler {
 
     pub fn with_checkouts(mut self, checkouts: TypedResolver<Checkout>) -> Self {
         self.checkouts = Some(checkouts);
+        self
+    }
+
+    pub fn with_prepared_snapshot_gc(mut self, collector: PreparedSnapshotGarbageCollector) -> Self {
+        self.prepared_snapshot_gc = Some(collector);
         self
     }
 
@@ -100,7 +107,7 @@ impl Reconciler for ConvoyReconciler {
         let template = if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() {
             None
         } else {
-            match self.templates.get(&obj.spec.workflow_ref).await {
+            match self.templates.get(pinned_workflow_ref(obj)).await {
                 Ok(template) => Some(template),
                 Err(ResourceError::NotFound { .. }) => None,
                 Err(err) => return Err(err),
@@ -154,6 +161,9 @@ impl Reconciler for ConvoyReconciler {
         }
         if let Some(checkouts) = &self.checkouts {
             delete_lifecycle_owned_matching(checkouts, &selector).await?;
+        }
+        if let Some(collector) = &self.prepared_snapshot_gc {
+            collector.collect(Some(&obj.metadata.name)).await?;
         }
         Ok(())
     }
@@ -694,7 +704,7 @@ fn cleanup_actuations(
 }
 
 fn create_vessel_outcome(convoy: &ResourceObject<Convoy>, vessel: &str, _now: DateTime<Utc>) -> Option<InternalReconcileOutcome> {
-    let placement_policy_ref = convoy.spec.placement_policy.clone()?;
+    let placement_policy_ref = pinned_placement_ref(convoy)?.to_string();
     let requirement = convoy.status.as_ref()?.workflow_snapshot.as_ref()?.vessels.iter().find(|requirement| requirement.name == vessel)?;
     let repository_refs = requirement
         .repository_refs

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -61,7 +61,8 @@ pub use placement_policy::{
     PlacementPolicy, PlacementPolicySpec,
 };
 pub use prepared_snapshot::{
-    PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PLACEMENT_SNAPSHOT_KIND, PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_KIND,
+    PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PreparedSnapshotRecoveryResult, PLACEMENT_SNAPSHOT_KIND,
+    PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_KIND,
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
 pub use principal_attention::{

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -11,6 +11,7 @@ mod http;
 mod in_memory;
 mod labels;
 mod placement_policy;
+mod prepared_snapshot;
 mod presentation;
 mod principal_attention;
 mod project;
@@ -35,9 +36,10 @@ pub use checkout::{
 };
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
-    controller_patches, external_patches, provisioning_patches, reconcile, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot,
-    PlacementStatus, ReconcileOutcome, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    controller_patches, external_patches, pinned_placement_ref, pinned_workflow_ref, provisioning_patches, reconcile, Convoy, ConvoyEvent,
+    ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase,
+    CrewWorkState, InputValue, IssueSnapshot, PlacementStatus, ReconcileOutcome, WorkCompletionAuthority, WorkPhase, WorkState,
+    WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use definition::DefinitionResolver;
 pub use environment::{
@@ -56,6 +58,9 @@ pub use labels::{
 pub use placement_policy::{
     DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,
     PlacementPolicy, PlacementPolicySpec,
+};
+pub use prepared_snapshot::{
+    PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PLACEMENT_SNAPSHOT_KIND, PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_KIND,
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
 pub use principal_attention::{

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -36,10 +36,11 @@ pub use checkout::{
 };
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
-    controller_patches, external_patches, pinned_placement_ref, pinned_workflow_ref, provisioning_patches, reconcile, Convoy, ConvoyEvent,
-    ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, CrewWorkPhase,
-    CrewWorkState, InputValue, IssueSnapshot, PlacementStatus, ReconcileOutcome, WorkCompletionAuthority, WorkPhase, WorkState,
-    WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
+    controller_patches, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches,
+    reconcile, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
+    ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot, PlacementStatus, ReconcileOutcome, WorkCompletionAuthority,
+    WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION,
+    WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use definition::DefinitionResolver;
 pub use environment::{

--- a/crates/flotilla-resources/src/prepared_snapshot.rs
+++ b/crates/flotilla-resources/src/prepared_snapshot.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    Convoy, PlacementPolicy, ResourceBackend, ResourceError, WorkflowTemplate, PLACEMENT_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
+    Convoy, InputMeta, PlacementPolicy, ResourceBackend, ResourceError, WorkflowTemplate, PLACEMENT_SNAPSHOT_ANNOTATION,
+    PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 
 pub const PREPARED_SNAPSHOT_LABEL: &str = "flotilla.work/prepared-snapshot";
@@ -20,9 +21,60 @@ pub struct PreparedSnapshotGcResult {
     pub placements_deleted: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PreparedSnapshotRecoveryResult {
+    pub completed: usize,
+    pub discarded: usize,
+}
+
 impl PreparedSnapshotGarbageCollector {
     pub fn new(backend: ResourceBackend, namespace: impl Into<String>) -> Self {
         Self { backend, namespace: namespace.into() }
+    }
+
+    /// Recover claims left pending by a daemon crash during prepared admission.
+    ///
+    /// Complete claims whose snapshots were fully materialized; discard claims
+    /// that cannot be completed because their shipped specs died with the
+    /// interrupted command.
+    pub async fn recover_pending_claims(&self) -> Result<PreparedSnapshotRecoveryResult, ResourceError> {
+        let convoys = self.backend.clone().using::<Convoy>(&self.namespace);
+        let workflows = self.backend.clone().using::<WorkflowTemplate>(&self.namespace);
+        let placements = self.backend.clone().using::<PlacementPolicy>(&self.namespace);
+        let mut result = PreparedSnapshotRecoveryResult::default();
+        for convoy in convoys.list().await?.items {
+            if !convoy.metadata.annotations.contains_key(PREPARED_SNAPSHOT_PENDING_ANNOTATION) {
+                continue;
+            }
+            let workflow_ready = match convoy.metadata.annotations.get(WORKFLOW_SNAPSHOT_ANNOTATION) {
+                Some(name) => resource_exists(&workflows, name).await?,
+                None => false,
+            };
+            let placement_ready = match convoy.metadata.annotations.get(PLACEMENT_SNAPSHOT_ANNOTATION) {
+                Some(name) => resource_exists(&placements, name).await?,
+                None => convoy.spec.placement_policy.is_none(),
+            };
+            if workflow_ready && placement_ready {
+                loop {
+                    let current = convoys.get(&convoy.metadata.name).await?;
+                    let mut meta = InputMeta::from(&current.metadata);
+                    meta.annotations.remove(PREPARED_SNAPSHOT_PENDING_ANNOTATION);
+                    match convoys.update(&meta, &current.metadata.resource_version, &current.spec).await {
+                        Ok(_) => {
+                            result.completed += 1;
+                            break;
+                        }
+                        Err(ResourceError::Conflict { .. }) => continue,
+                        Err(error) => return Err(error),
+                    }
+                }
+            } else {
+                convoys.delete(&convoy.metadata.name).await?;
+                result.discarded += 1;
+            }
+        }
+        self.collect(None).await?;
+        Ok(result)
     }
 
     /// Delete prepared snapshots not referenced by any remaining convoy.
@@ -76,6 +128,14 @@ impl PreparedSnapshotGarbageCollector {
             }
         }
         Ok(result)
+    }
+}
+
+async fn resource_exists<T: crate::Resource>(resolver: &crate::TypedResolver<T>, name: &str) -> Result<bool, ResourceError> {
+    match resolver.get(name).await {
+        Ok(_) => Ok(true),
+        Err(ResourceError::NotFound { .. }) => Ok(false),
+        Err(error) => Err(error),
     }
 }
 

--- a/crates/flotilla-resources/src/prepared_snapshot.rs
+++ b/crates/flotilla-resources/src/prepared_snapshot.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeSet;
+
+use crate::{
+    Convoy, PlacementPolicy, ResourceBackend, ResourceError, WorkflowTemplate, PLACEMENT_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
+};
+
+pub const PREPARED_SNAPSHOT_LABEL: &str = "flotilla.work/prepared-snapshot";
+pub const WORKFLOW_SNAPSHOT_KIND: &str = "workflow";
+pub const PLACEMENT_SNAPSHOT_KIND: &str = "placement";
+
+#[derive(Debug, Clone)]
+pub struct PreparedSnapshotGarbageCollector {
+    backend: ResourceBackend,
+    namespace: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PreparedSnapshotGcResult {
+    pub workflows_deleted: usize,
+    pub placements_deleted: usize,
+}
+
+impl PreparedSnapshotGarbageCollector {
+    pub fn new(backend: ResourceBackend, namespace: impl Into<String>) -> Self {
+        Self { backend, namespace: namespace.into() }
+    }
+
+    /// Delete prepared snapshots not referenced by any remaining convoy.
+    ///
+    /// `excluding_convoy` is used by the convoy finalizer: the deleting convoy
+    /// still exists until its finalizer returns, but no longer retains a claim.
+    pub async fn collect(&self, excluding_convoy: Option<&str>) -> Result<PreparedSnapshotGcResult, ResourceError> {
+        let convoys = self.backend.clone().using::<Convoy>(&self.namespace).list().await?;
+        let mut workflow_refs = BTreeSet::new();
+        let mut placement_refs = BTreeSet::new();
+        for convoy in convoys.items {
+            if excluding_convoy.is_some_and(|excluded| convoy.metadata.name == excluded) {
+                continue;
+            }
+            workflow_refs.insert(convoy.spec.workflow_ref);
+            if let Some(snapshot) = convoy.metadata.annotations.get(WORKFLOW_SNAPSHOT_ANNOTATION) {
+                workflow_refs.insert(snapshot.clone());
+            }
+            if let Some(policy) = convoy.spec.placement_policy {
+                placement_refs.insert(policy);
+            }
+            if let Some(snapshot) = convoy.metadata.annotations.get(PLACEMENT_SNAPSHOT_ANNOTATION) {
+                placement_refs.insert(snapshot.clone());
+            }
+        }
+
+        let workflows = self.backend.clone().using::<WorkflowTemplate>(&self.namespace);
+        let mut result = PreparedSnapshotGcResult::default();
+        for workflow in workflows.list().await?.items {
+            if is_prepared_snapshot(&workflow.metadata.name, &workflow.metadata.labels, WORKFLOW_SNAPSHOT_KIND)
+                && !workflow_refs.contains(&workflow.metadata.name)
+            {
+                match workflows.delete(&workflow.metadata.name).await {
+                    Ok(()) => result.workflows_deleted += 1,
+                    Err(ResourceError::NotFound { .. }) => {}
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+
+        let placements = self.backend.clone().using::<PlacementPolicy>(&self.namespace);
+        for placement in placements.list().await?.items {
+            if is_prepared_snapshot(&placement.metadata.name, &placement.metadata.labels, PLACEMENT_SNAPSHOT_KIND)
+                && !placement_refs.contains(&placement.metadata.name)
+            {
+                match placements.delete(&placement.metadata.name).await {
+                    Ok(()) => result.placements_deleted += 1,
+                    Err(ResourceError::NotFound { .. }) => {}
+                    Err(error) => return Err(error),
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+fn is_prepared_snapshot(name: &str, labels: &std::collections::BTreeMap<String, String>, kind: &str) -> bool {
+    labels.get(PREPARED_SNAPSHOT_LABEL).is_some_and(|value| value == kind)
+        || has_content_hash_suffix(name, &format!("{kind}-snapshot-"))
+        || has_content_hash_suffix(name, &format!("-remote-{kind}-"))
+}
+
+fn has_content_hash_suffix(name: &str, marker: &str) -> bool {
+    name.rsplit_once(marker).is_some_and(|(_, suffix)| suffix.len() == 12 && suffix.chars().all(|character| character.is_ascii_hexdigit()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_current_and_legacy_snapshot_names_without_matching_human_templates() {
+        let labels = Default::default();
+        assert!(is_prepared_snapshot("workflow-snapshot-012345abcdef", &labels, WORKFLOW_SNAPSHOT_KIND));
+        assert!(is_prepared_snapshot("old-convoy-remote-workflow-012345abcdef", &labels, WORKFLOW_SNAPSHOT_KIND));
+        assert!(!is_prepared_snapshot("workflow-snapshot-custom", &labels, WORKFLOW_SNAPSHOT_KIND));
+        assert!(!is_prepared_snapshot("my-workflow", &labels, WORKFLOW_SNAPSHOT_KIND));
+    }
+}

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -7,8 +7,10 @@ use common::{
 use flotilla_protocol::{IssueRef, IssueSource, IssueState};
 use flotilla_resources::{
     apply_status_patch, controller::ControllerLoop, external_patches, reconcile, Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
-    InMemoryBackend, InputMeta, IssueSnapshot, LifecycleAuthority, Presentation, PresentationSpec, RepositorySpec, ResourceBackend,
-    ResourceError, Vessel, VesselPhase, VesselStatus, WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
+    InMemoryBackend, InputMeta, IssueSnapshot, LifecycleAuthority, PlacementPolicy, PlacementPolicySpec, PreparedSnapshotGarbageCollector,
+    Presentation, PresentationSpec, RepositorySpec, ResourceBackend, ResourceError, Vessel, VesselPhase, VesselStatus, WorkflowTemplate,
+    WorkflowTemplateSpec, CONVOY_LABEL, PLACEMENT_SNAPSHOT_ANNOTATION, PLACEMENT_SNAPSHOT_KIND, PREPARED_SNAPSHOT_LABEL, VESSEL_LABEL,
+    WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
 };
 use tokio::time::{timeout, Duration};
 
@@ -287,9 +289,32 @@ async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
     let convoys = backend.clone().using::<Convoy>("flotilla");
     let workspaces = backend.clone().using::<Vessel>("flotilla");
     let presentations = backend.clone().using::<Presentation>("flotilla");
+    let workflow_snapshot_name = "workflow-snapshot-012345abcdef";
+    let placement_snapshot_name = "placement-snapshot-012345abcdef";
+    let snapshot_labels = |kind: &str| [(PREPARED_SNAPSHOT_LABEL.to_string(), kind.to_string())].into_iter().collect();
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(
+            &InputMeta::builder().name(workflow_snapshot_name.to_string()).labels(snapshot_labels(WORKFLOW_SNAPSHOT_KIND)).build(),
+            &WorkflowTemplateSpec::builder().vessels(Vec::new()).build(),
+        )
+        .await
+        .expect("workflow snapshot create should succeed");
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &InputMeta::builder().name(placement_snapshot_name.to_string()).labels(snapshot_labels(PLACEMENT_SNAPSHOT_KIND)).build(),
+            &PlacementPolicySpec::builder().pool("remote".to_string()).build(),
+        )
+        .await
+        .expect("placement snapshot create should succeed");
 
-    let created =
-        convoys.create(&convoy_meta("convoy-delete"), &task_provisioning_convoy_spec()).await.expect("convoy create should succeed");
+    let mut convoy_meta = convoy_meta("convoy-delete");
+    convoy_meta.annotations.insert(WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_snapshot_name.to_string());
+    convoy_meta.annotations.insert(PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), placement_snapshot_name.to_string());
+    let created = convoys.create(&convoy_meta, &task_provisioning_convoy_spec()).await.expect("convoy create should succeed");
     let mut status = bootstrapped_tool_only_convoy_status();
     status.phase = ConvoyPhase::Active;
     status.started_at = Some(timestamp(18));
@@ -437,7 +462,8 @@ async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
             secondaries: ConvoyReconciler::secondary_watches(),
             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla"))
                 .with_vessels(workspaces.clone())
-                .with_presentations(presentations.clone()),
+                .with_presentations(presentations.clone())
+                .with_prepared_snapshot_gc(PreparedSnapshotGarbageCollector::new(backend.clone(), "flotilla")),
             resync_interval: Duration::from_millis(50),
             backend: backend.clone(),
         }
@@ -463,6 +489,14 @@ async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
             if matches!(convoys.get("convoy-delete").await, Err(ResourceError::NotFound { .. }))
                 && matches!(workspaces.get("convoy-delete-implement").await, Err(ResourceError::NotFound { .. }))
                 && matches!(presentations.get("convoy-delete-implement").await, Err(ResourceError::NotFound { .. }))
+                && matches!(
+                    backend.clone().using::<WorkflowTemplate>("flotilla").get(workflow_snapshot_name).await,
+                    Err(ResourceError::NotFound { .. })
+                )
+                && matches!(
+                    backend.clone().using::<PlacementPolicy>("flotilla").get(placement_snapshot_name).await,
+                    Err(ResourceError::NotFound { .. })
+                )
             {
                 break;
             }

--- a/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
+++ b/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
@@ -1,0 +1,94 @@
+use std::collections::BTreeMap;
+
+use flotilla_resources::{
+    Convoy, ConvoySpec, InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, PreparedSnapshotGarbageCollector,
+    ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec, PLACEMENT_SNAPSHOT_ANNOTATION, PLACEMENT_SNAPSHOT_KIND,
+    PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
+};
+
+fn prepared_meta(name: &str, kind: &str) -> InputMeta {
+    InputMeta::builder().name(name.to_string()).labels(BTreeMap::from([(PREPARED_SNAPSHOT_LABEL.to_string(), kind.to_string())])).build()
+}
+
+async fn create_convoy(
+    backend: &ResourceBackend,
+    name: &str,
+    workflow_snapshot: &str,
+    placement_snapshot: &str,
+) -> Result<(), ResourceError> {
+    backend
+        .clone()
+        .using::<Convoy>("flotilla")
+        .create(
+            &InputMeta::builder()
+                .name(name.to_string())
+                .annotations(BTreeMap::from([
+                    (WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_snapshot.to_string()),
+                    (PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), placement_snapshot.to_string()),
+                ]))
+                .build(),
+            &ConvoySpec::builder().workflow_ref("logical-workflow".to_string()).placement_policy("logical-placement".to_string()).build(),
+        )
+        .await
+        .map(|_| ())
+}
+
+#[tokio::test]
+async fn shared_snapshots_are_collected_only_after_the_last_convoy_releases_them() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let workflow_name = "workflow-snapshot-012345abcdef";
+    let placement_name = "placement-snapshot-012345abcdef";
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&prepared_meta(workflow_name, WORKFLOW_SNAPSHOT_KIND), &WorkflowTemplateSpec::builder().vessels(Vec::new()).build())
+        .await
+        .expect("create prepared workflow");
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(&prepared_meta(placement_name, PLACEMENT_SNAPSHOT_KIND), &PlacementPolicySpec::builder().pool("remote".to_string()).build())
+        .await
+        .expect("create prepared placement");
+    create_convoy(&backend, "first", workflow_name, placement_name).await.expect("create first convoy");
+    create_convoy(&backend, "second", workflow_name, placement_name).await.expect("create second convoy");
+
+    let collector = PreparedSnapshotGarbageCollector::new(backend.clone(), "flotilla");
+    assert_eq!(collector.collect(Some("first")).await.expect("collect while shared").workflows_deleted, 0);
+
+    backend.clone().using::<Convoy>("flotilla").delete("first").await.expect("delete first convoy");
+    let result = collector.collect(Some("second")).await.expect("collect final references");
+    assert_eq!(result.workflows_deleted, 1);
+    assert_eq!(result.placements_deleted, 1);
+    assert!(matches!(backend.clone().using::<WorkflowTemplate>("flotilla").get(workflow_name).await, Err(ResourceError::NotFound { .. })));
+    assert!(matches!(backend.using::<PlacementPolicy>("flotilla").get(placement_name).await, Err(ResourceError::NotFound { .. })));
+}
+
+#[tokio::test]
+async fn sweep_removes_unreferenced_legacy_snapshots() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let legacy_workflow = "old-convoy-remote-workflow-012345abcdef";
+    let legacy_placement = "old-convoy-remote-placement-fedcba543210";
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(
+            &InputMeta::builder().name(legacy_workflow.to_string()).build(),
+            &WorkflowTemplateSpec::builder().vessels(Vec::new()).build(),
+        )
+        .await
+        .expect("create legacy workflow");
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &InputMeta::builder().name(legacy_placement.to_string()).build(),
+            &PlacementPolicySpec::builder().pool("remote".to_string()).build(),
+        )
+        .await
+        .expect("create legacy placement");
+
+    let result = PreparedSnapshotGarbageCollector::new(backend, "flotilla").collect(None).await.expect("sweep legacy snapshots");
+    assert_eq!(result.workflows_deleted, 1);
+    assert_eq!(result.placements_deleted, 1);
+}

--- a/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
+++ b/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
 use flotilla_resources::{
-    Convoy, ConvoySpec, InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, PreparedSnapshotGarbageCollector,
+    reconcile, Convoy, ConvoySpec, InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, PreparedSnapshotGarbageCollector,
     ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec, PLACEMENT_SNAPSHOT_ANNOTATION, PLACEMENT_SNAPSHOT_KIND,
-    PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
+    PREPARED_SNAPSHOT_LABEL, PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
 };
 
 fn prepared_meta(name: &str, kind: &str) -> InputMeta {
@@ -91,4 +91,37 @@ async fn sweep_removes_unreferenced_legacy_snapshots() {
     let result = PreparedSnapshotGarbageCollector::new(backend, "flotilla").collect(None).await.expect("sweep legacy snapshots");
     assert_eq!(result.workflows_deleted, 1);
     assert_eq!(result.placements_deleted, 1);
+}
+
+#[tokio::test]
+async fn pending_convoy_claim_protects_snapshots_without_bootstrapping_early() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let workflow_name = "workflow-snapshot-012345abcdef";
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    convoys
+        .create(
+            &InputMeta::builder()
+                .name("preparing".to_string())
+                .annotations(BTreeMap::from([
+                    (WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_name.to_string()),
+                    (PREPARED_SNAPSHOT_PENDING_ANNOTATION.to_string(), "true".to_string()),
+                ]))
+                .build(),
+            &ConvoySpec::builder().workflow_ref("logical-workflow".to_string()).build(),
+        )
+        .await
+        .expect("create pending convoy claim");
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&prepared_meta(workflow_name, WORKFLOW_SNAPSHOT_KIND), &WorkflowTemplateSpec::builder().vessels(Vec::new()).build())
+        .await
+        .expect("create prepared workflow");
+
+    let result = PreparedSnapshotGarbageCollector::new(backend, "flotilla").collect(None).await.expect("collect during preparation");
+    assert_eq!(result.workflows_deleted, 0);
+    let convoy = convoys.get("preparing").await.expect("get pending convoy claim");
+    let outcome = reconcile(&convoy, None, chrono::Utc::now());
+    assert!(outcome.patch.is_none());
+    assert!(outcome.events.is_empty());
 }

--- a/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
+++ b/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
@@ -118,10 +118,42 @@ async fn pending_convoy_claim_protects_snapshots_without_bootstrapping_early() {
         .await
         .expect("create prepared workflow");
 
-    let result = PreparedSnapshotGarbageCollector::new(backend, "flotilla").collect(None).await.expect("collect during preparation");
+    let collector = PreparedSnapshotGarbageCollector::new(backend, "flotilla");
+    let result = collector.collect(None).await.expect("collect during preparation");
     assert_eq!(result.workflows_deleted, 0);
     let convoy = convoys.get("preparing").await.expect("get pending convoy claim");
     let outcome = reconcile(&convoy, None, chrono::Utc::now());
     assert!(outcome.patch.is_none());
     assert!(outcome.events.is_empty());
+
+    let recovered = collector.recover_pending_claims().await.expect("recover completed pending claim");
+    assert_eq!(recovered.completed, 1);
+    assert_eq!(recovered.discarded, 0);
+    let convoy = convoys.get("preparing").await.expect("get recovered convoy");
+    assert!(!convoy.metadata.annotations.contains_key(PREPARED_SNAPSHOT_PENDING_ANNOTATION));
+}
+
+#[tokio::test]
+async fn recovery_discards_pending_claim_whose_snapshot_was_not_materialized() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    convoys
+        .create(
+            &InputMeta::builder()
+                .name("interrupted".to_string())
+                .annotations(BTreeMap::from([
+                    (WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), "workflow-snapshot-012345abcdef".to_string()),
+                    (PREPARED_SNAPSHOT_PENDING_ANNOTATION.to_string(), "true".to_string()),
+                ]))
+                .build(),
+            &ConvoySpec::builder().workflow_ref("logical-workflow".to_string()).build(),
+        )
+        .await
+        .expect("create interrupted claim");
+
+    let recovered =
+        PreparedSnapshotGarbageCollector::new(backend, "flotilla").recover_pending_claims().await.expect("recover interrupted claim");
+    assert_eq!(recovered.completed, 0);
+    assert_eq!(recovered.discarded, 1);
+    assert!(matches!(convoys.get("interrupted").await, Err(ResourceError::NotFound { .. })));
 }


### PR DESCRIPTION
Closes #1108.

## What changed

- preserve each convoy's logical workflow and placement names while storing pinned execution snapshots in internal annotations
- name prepared workflow and placement snapshots solely by content hash, so identical specs deduplicate across convoys
- garbage-collect unreferenced prepared snapshots during convoy finalization
- sweep unreferenced legacy `<convoy>-remote-{workflow,placement}-<hash>` snapshots when repository resources initialize
- validate prepared snapshot names against their shipped contents

## Why

Remote admission previously replaced the logical references in `ConvoySpec` with convoy-qualified snapshot names. That leaked an execution detail into the convoys table and created one resource per convoy even when the admitted specs were identical. Teardown also never removed those resources.

The convoy now retains logical intent for display and CLI round-tripping, while annotations carry the pinned references used by reconcilers. A reference-aware collector preserves shared snapshots until the final convoy releases them.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`