### PR TITLE
fix: preserve Docker workspace mount mode

### DIFF
--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -3,12 +3,14 @@ use std::{path::PathBuf, sync::Arc};
 use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        environment::{CreateOpts, EnvironmentProvider, ProvisionedMount},
+        environment::{CreateOpts, EnvironmentProvider, ProvisionedMount, ProvisionedMountMode},
         terminal::TerminalPool,
         vcs::{CloneInspection, CloneProvisioner},
     },
 };
-use flotilla_resources::{DockerEnvironmentSpec, FreshCloneCheckoutSpec, TerminalSessionSource, TerminalSessionSpec};
+use flotilla_resources::{
+    DockerEnvironmentSpec, EnvironmentMount, EnvironmentMountMode, FreshCloneCheckoutSpec, TerminalSessionSource, TerminalSessionSpec,
+};
 
 pub struct CloneActuator {
     provisioner: Arc<dyn CloneProvisioner>,
@@ -45,9 +47,17 @@ impl DockerEnvironmentActuator {
             tokens: self.tokens.clone(),
             daemon_socket_path: self.daemon_socket_path.clone(),
             working_directory: None,
-            provisioned_mounts: spec.mounts.iter().map(|mount| ProvisionedMount::new(&mount.source_path, &mount.target_path)).collect(),
+            provisioned_mounts: spec.mounts.iter().map(provisioned_mount).collect(),
         }
     }
+}
+
+pub fn provisioned_mount(mount: &EnvironmentMount) -> ProvisionedMount {
+    let mode = match mount.mode {
+        EnvironmentMountMode::Ro => ProvisionedMountMode::Ro,
+        EnvironmentMountMode::Rw => ProvisionedMountMode::Rw,
+    };
+    ProvisionedMount::new(&mount.source_path, &mount.target_path, mode)
 }
 
 pub struct TerminalActuator {

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        environment::{CreateOpts, EnvironmentProvider, ProvisionedEnvironment, ProvisionedMount},
+        environment::{CreateOpts, EnvironmentProvider, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode},
         terminal::{TerminalEnvVars, TerminalPool, TerminalSession as PoolSession},
         vcs::CloneProvisioner,
     },
@@ -114,7 +114,7 @@ async fn environment_actuator_translates_mounts_into_provider_create_opts() {
 
     let opts = actuator.build_create_opts(&spec);
 
-    assert_eq!(opts.provisioned_mounts, vec![ProvisionedMount::new("/Users/alice/dev/flotilla", "/workspace")]);
+    assert_eq!(opts.provisioned_mounts, vec![ProvisionedMount::new("/Users/alice/dev/flotilla", "/workspace", ProvisionedMountMode::Rw)]);
     assert_eq!(opts.tokens, vec![("GITHUB_TOKEN".to_string(), "secret".to_string())]);
 }
 

--- a/crates/flotilla-core/examples/environment_checkout.rs
+++ b/crates/flotilla-core/examples/environment_checkout.rs
@@ -66,6 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         provisioned_mounts: vec![flotilla_core::providers::environment::ProvisionedMount::new(
             reference_repo.as_path().to_path_buf(),
             "/ref/repo",
+            flotilla_core::providers::environment::ProvisionedMountMode::Ro,
         )],
     };
     let handle = provider.create(env_id, &image, opts).await?;

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -14,7 +14,7 @@ use crate::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
         discovery::{run_host_detectors, DiscoveryRuntime, EnvironmentAssertion, EnvironmentBag, FactoryRegistry},
-        environment::{CreateOpts, EnvironmentHandle, ProvisionedMount},
+        environment::{CreateOpts, EnvironmentHandle, ProvisionedMount, ProvisionedMountMode},
         registry::ProviderRegistry,
         CommandRunner,
     },
@@ -265,7 +265,7 @@ impl EnvironmentManager {
 
         let provisioned_mounts = reference_repo
             .as_ref()
-            .map(|repo| vec![ProvisionedMount::new(repo.as_path().to_path_buf(), PathBuf::from("/ref/repo"))])
+            .map(|repo| vec![ProvisionedMount::new(repo.as_path().to_path_buf(), PathBuf::from("/ref/repo"), ProvisionedMountMode::Ro)])
             .unwrap_or_default();
         let opts = CreateOpts { tokens, daemon_socket_path: daemon_socket_path.clone(), working_directory: None, provisioned_mounts };
         let handle = env_provider.create(env_id.clone(), &image, opts).await?;
@@ -588,7 +588,7 @@ mod tests {
     }
 
     fn reference_repo_mount() -> ProvisionedMount {
-        ProvisionedMount::new("/host/reference-repo", "/ref/repo")
+        ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -46,7 +46,7 @@ use crate::{
             },
             EnvironmentAssertion, EnvironmentBag, HostPlatform,
         },
-        environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount},
+        environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode},
         ChannelLabel, CommandOutput, CommandRunner,
     },
 };
@@ -4618,7 +4618,7 @@ async fn normalize_local_provider_hosts_uses_mount_metadata_for_provisioned_chec
         id: environment_id.clone(),
         image: ImageId::new("image:test"),
         runner: Arc::new(DiscoveryMockRunner::builder().build()),
-        mounts: vec![ProvisionedMount::new("/host/reference-repo", "/workspace/repo")],
+        mounts: vec![ProvisionedMount::new("/host/reference-repo", "/workspace/repo", ProvisionedMountMode::Ro)],
     });
     environment_manager
         .register_provisioned_environment(environment_id.clone(), handle, EnvironmentBag::new(), None)

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 
 use super::{
     runner::DockerEnvironmentRunner, CreateOpts, EnvironmentHandle, EnvironmentProvider, ProvisionedEnvironment, ProvisionedMount,
+    ProvisionedMountMode,
 };
 use crate::providers::{ChannelLabel, CommandRunner};
 
@@ -92,8 +93,17 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
             &env_id_env,
         ];
 
-        let mount_specs: Vec<String> =
-            opts.provisioned_mounts.iter().map(|mount| format!("{}:{}:ro", mount.host_path, mount.environment_path)).collect();
+        let mount_specs: Vec<String> = opts
+            .provisioned_mounts
+            .iter()
+            .map(|mount| {
+                let mode = match mount.mode {
+                    ProvisionedMountMode::Ro => "ro",
+                    ProvisionedMountMode::Rw => "rw",
+                };
+                format!("{}:{}:{mode}", mount.host_path, mount.environment_path)
+            })
+            .collect();
         for mount_spec in &mount_specs {
             args.push("-v");
             args.push(mount_spec);

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -32,11 +32,19 @@ pub struct CreateOpts {
 pub struct ProvisionedMount {
     pub host_path: DaemonHostPath,
     pub environment_path: ExecutionEnvironmentPath,
+    pub mode: ProvisionedMountMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProvisionedMountMode {
+    Ro,
+    Rw,
 }
 
 impl ProvisionedMount {
-    pub fn new(host_path: impl Into<PathBuf>, environment_path: impl Into<PathBuf>) -> Self {
-        Self { host_path: DaemonHostPath::new(host_path), environment_path: ExecutionEnvironmentPath::new(environment_path) }
+    pub fn new(host_path: impl Into<PathBuf>, environment_path: impl Into<PathBuf>, mode: ProvisionedMountMode) -> Self {
+        Self { host_path: DaemonHostPath::new(host_path), environment_path: ExecutionEnvironmentPath::new(environment_path), mode }
     }
 }
 

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -7,7 +7,10 @@ use std::{
 use async_trait::async_trait;
 use flotilla_protocol::{DaemonHostPath, EnvironmentId, EnvironmentSpec, EnvironmentStatus, HostName, ImageSource};
 
-use super::{docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, ProvisionedMount};
+use super::{
+    docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, ProvisionedMount,
+    ProvisionedMountMode,
+};
 use crate::providers::{ChannelLabel, CommandOutput, CommandRunner};
 
 /// A mock CommandRunner that records all (cmd, args, cwd) tuples passed to run/run_output.
@@ -296,7 +299,7 @@ async fn create_preserves_reference_repo_mount_metadata() {
         tokens: vec![],
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
-        provisioned_mounts: vec![ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo")],
+        provisioned_mounts: vec![ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo", ProvisionedMountMode::Ro)],
     };
 
     let id = EnvironmentId::new("test-env-metadata");
@@ -304,8 +307,39 @@ async fn create_preserves_reference_repo_mount_metadata() {
 
     assert_eq!(
         handle.provisioned_mounts(),
-        vec![ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo")],
+        vec![ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo", ProvisionedMountMode::Ro,)],
         "docker provisioned environments should retain flotilla-managed bind mount metadata",
+    );
+}
+
+#[tokio::test]
+async fn create_uses_requested_mount_modes_in_docker_arguments() {
+    use flotilla_protocol::ImageId;
+
+    let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
+    let provider = DockerEnvironmentProvider::new(runner.clone());
+    let image = ImageId::new("ubuntu:22.04");
+    let opts = CreateOpts {
+        tokens: vec![],
+        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        working_directory: None,
+        provisioned_mounts: vec![
+            ProvisionedMount::new("/host/workspace", "/workspace", ProvisionedMountMode::Rw),
+            ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro),
+        ],
+    };
+
+    provider.create(EnvironmentId::new("test-env-mount-modes"), &image, opts).await.expect("create");
+
+    let calls = runner.calls();
+    let (_, args, _) = &calls[0];
+    assert!(
+        args.windows(2).any(|pair| pair == ["-v", "/host/workspace:/workspace:rw"]),
+        "writable workspace mount should be passed to docker as :rw; args: {args:?}",
+    );
+    assert!(
+        args.windows(2).any(|pair| pair == ["-v", "/host/reference-repo:/ref/repo:ro"]),
+        "read-only reference mount should be passed to docker as :ro; args: {args:?}",
     );
 }
 
@@ -317,7 +351,8 @@ async fn list_preserves_reference_repo_mount_metadata() {
         Ok("container-id-123".into()),
         Ok(format!(
             "container-1\ttest-env-list\tubuntu:22.04\t{}\n",
-            serde_json::to_string(&vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo")]).expect("serialize mount metadata")
+            serde_json::to_string(&vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro,)])
+                .expect("serialize mount metadata")
         )),
     ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
@@ -326,7 +361,7 @@ async fn list_preserves_reference_repo_mount_metadata() {
         tokens: vec![],
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
-        provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo")],
+        provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
     };
 
     provider.create(EnvironmentId::new("test-env-list"), &image, opts).await.expect("create");
@@ -335,7 +370,7 @@ async fn list_preserves_reference_repo_mount_metadata() {
     assert_eq!(handles.len(), 1);
     assert_eq!(
         handles[0].provisioned_mounts(),
-        vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo")],
+        vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
         "docker list should preserve flotilla-managed bind mount metadata",
     );
 }
@@ -352,7 +387,7 @@ async fn list_fails_on_malformed_reference_repo_mount_metadata() {
         tokens: vec![],
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
-        provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo")],
+        provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
     };
 
     provider.create(EnvironmentId::new("test-env-list-malformed"), &image, opts).await.expect("create");
@@ -372,7 +407,7 @@ async fn list_rejects_missing_reference_repo_mount_metadata() {
         tokens: vec![],
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
-        provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo")],
+        provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
     };
 
     provider.create(EnvironmentId::new("test-env-list-missing"), &image, opts).await.expect("create");

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -23,7 +23,7 @@ use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
         discovery::{EnvironmentAssertion, EnvironmentBag},
-        environment::{CreateOpts, EnvironmentHandle, ProvisionedMount},
+        environment::{CreateOpts, EnvironmentHandle},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
         vcs::{CloneProvisioner, GitCloneProvisioner},
@@ -920,11 +920,7 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
                 tokens: Vec::new(),
                 daemon_socket_path,
                 working_directory: None,
-                provisioned_mounts: spec
-                    .mounts
-                    .iter()
-                    .map(|mount| ProvisionedMount::new(mount.source_path.clone(), mount.target_path.clone()))
-                    .collect(),
+                provisioned_mounts: spec.mounts.iter().map(flotilla_controllers::actuators::provisioned_mount).collect(),
             })
             .await?;
 


### PR DESCRIPTION
## What changed

- carry the requested mount mode through provisioned mount metadata
- translate resource mount modes in the shared controller actuator path used by the daemon runtime
- generate Docker bind-mount arguments with the requested `:rw` or `:ro` mode
- assert the final Docker invocation includes a writable `/workspace` mount while retaining read-only reference mounts

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1123