### PR TITLE
fix: fall back to watch for held controller seats

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -376,6 +376,8 @@ pub async fn build_plan(
         | CommandAction::QueryHostStatus { .. }
         | CommandAction::QueryHostProviders { .. }
         | CommandAction::Attach { .. }
+        | CommandAction::AttachTake { .. }
+        | CommandAction::AttachWatch { .. }
         | CommandAction::AttachTransient { .. }
         | CommandAction::QueryIssues { .. }
         | CommandAction::QueryIssueFetchByIds { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6141,7 +6141,11 @@ impl InProcessDaemon {
                     let holder = if holder.is_empty() { fallback_holder.to_string() } else { holder };
                     (pool.watch_args(attach_target.session_id)?, Some(holder))
                 }
-                Ok(None) | Err(_) => (pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?, None),
+                Ok(None) => (pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?, None),
+                Err(error) => {
+                    warn!(session = attach_target.session_id, %error, "could not inspect terminal controller; attempting control attach");
+                    (pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?, None)
+                }
             },
             AttachSeatRequest::WatchIfControlled => {
                 let holder = pool

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -366,6 +366,18 @@ pub struct ResolvedAttach {
     pub binding: Option<AttachBinding>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttachSeatRequest {
+    Control,
+    WatchIfControlled,
+    Take,
+}
+
+fn watch_banner_command(command: &str, holder: &str) -> String {
+    let banner = format!("watching — controller held by {holder}; --take to take control");
+    format!("printf '%s\\n' {} >&2; {command}", flotilla_protocol::arg::shell_quote(&banner))
+}
+
 fn attach_reference_keys(session_name: &str, labels: &BTreeMap<String, String>) -> Vec<String> {
     let mut refs = vec![session_name.to_string()];
 
@@ -438,10 +450,16 @@ enum AttachTarget {
 }
 
 impl AttachTarget {
-    async fn resolve(&self, daemon: &InProcessDaemon, reference: &str, transient: bool) -> Result<ResolvedAttach, String> {
+    async fn resolve(
+        &self,
+        daemon: &InProcessDaemon,
+        reference: &str,
+        transient: bool,
+        seat: AttachSeatRequest,
+    ) -> Result<ResolvedAttach, String> {
         match self {
             Self::Local(session) => {
-                let (command, host) = daemon.attach_command_for_session(reference, session, transient).await?;
+                let (command, host) = daemon.attach_command_for_session(reference, session, transient, seat).await?;
                 let labels = &session.metadata.labels;
                 let binding = AttachBinding::builder()
                     .host(host)
@@ -454,7 +472,7 @@ impl AttachTarget {
                 Ok(ResolvedAttach { command, binding: Some(binding) })
             }
             Self::Replica { row } => {
-                let command = daemon.recursive_attach_command_for_remote(&row.host, reference, transient).await?;
+                let command = daemon.recursive_attach_command_for_remote(&row.host, reference, transient, seat).await?;
                 // Replica rows carry crew as "vessel/role" (or a bare role)
                 // and the owning host's namespace + session name, so
                 // cross-host panes stamp the full join key.
@@ -505,6 +523,7 @@ impl AttachCandidateIndex {
         reference: &str,
         host: Option<&HostName>,
         transient: bool,
+        seat: AttachSeatRequest,
     ) -> Result<ResolvedAttach, String> {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
@@ -526,7 +545,7 @@ impl AttachCandidateIndex {
                 Some(host) => Err(format!("no attach target matching '{reference}' on host '{host}'")),
                 None => Err(format!("no attach target matching '{reference}'")),
             },
-            [index] => self.candidates[*index].target.resolve(daemon, reference, transient).await,
+            [index] => self.candidates[*index].target.resolve(daemon, reference, transient, seat).await,
             _ => {
                 let mut labels: Vec<_> = matches.iter().map(|index| self.candidates[*index].label.clone()).collect();
                 labels.sort();
@@ -5596,7 +5615,32 @@ impl InProcessDaemon {
             return Err("attach reference is required".to_string());
         }
         let index = self.attach_candidate_index().await?;
-        index.resolve(self, reference, host, false).await
+        index.resolve(self, reference, host, false, AttachSeatRequest::Control).await
+    }
+
+    pub async fn resolve_take_attach_command_on_host_internal(
+        &self,
+        reference: &str,
+        host: Option<&HostName>,
+    ) -> Result<ResolvedAttach, String> {
+        if reference.trim().is_empty() {
+            return Err("attach reference is required".to_string());
+        }
+        let index = self.attach_candidate_index().await?;
+        index.resolve(self, reference, host, false, AttachSeatRequest::Take).await
+    }
+
+    pub async fn resolve_watch_attach_command_on_host_internal(
+        &self,
+        reference: &str,
+        host: Option<&HostName>,
+        transient: bool,
+    ) -> Result<ResolvedAttach, String> {
+        if reference.trim().is_empty() {
+            return Err("attach reference is required".to_string());
+        }
+        let index = self.attach_candidate_index().await?;
+        index.resolve(self, reference, host, transient, AttachSeatRequest::WatchIfControlled).await
     }
 
     pub async fn resolve_transient_attach_command_internal(
@@ -5608,7 +5652,7 @@ impl InProcessDaemon {
             return Err("attach reference is required".to_string());
         }
         let index = self.attach_candidate_index().await?;
-        index.resolve(self, reference, host, true).await
+        index.resolve(self, reference, host, true, AttachSeatRequest::Control).await
     }
 
     pub async fn resolvable_attach_references_internal(&self, references: &[String]) -> Result<HashSet<String>, String> {
@@ -5618,7 +5662,7 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = HashSet::new();
         for reference in references {
-            if index.resolve(self, reference, None, false).await.is_ok() {
+            if index.resolve(self, reference, None, false, AttachSeatRequest::Control).await.is_ok() {
                 resolved.insert(reference.clone());
             }
         }
@@ -5629,7 +5673,7 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = Vec::with_capacity(targets.len());
         for (reference, host) in targets {
-            resolved.push(index.resolve(self, reference, Some(host), false).await.is_ok());
+            resolved.push(index.resolve(self, reference, Some(host), false, AttachSeatRequest::Control).await.is_ok());
         }
         Ok(resolved)
     }
@@ -5794,6 +5838,7 @@ impl InProcessDaemon {
         reference: &str,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
         transient: bool,
+        seat: AttachSeatRequest,
     ) -> Result<(String, HostName), String> {
         let namespace = self.provisioning_namespace().await;
         let environments = self.resource_backend.clone().using::<ResourceEnvironment>(&namespace);
@@ -5810,11 +5855,11 @@ impl InProcessDaemon {
             .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
         let target_host = self.target_host_for_resource_ref(host_ref);
         if target_host != self.host_name {
-            let command = self.recursive_attach_command_for_remote(&target_host, reference, transient).await?;
+            let command = self.recursive_attach_command_for_remote(&target_host, reference, transient, seat).await?;
             return Ok((command, target_host));
         }
 
-        let command = self.local_attach_command_for_session(session, &environment).await?;
+        let command = self.local_attach_command_for_session(session, &environment, seat).await?;
         Ok((command, self.host_name.clone()))
     }
 
@@ -5823,6 +5868,7 @@ impl InProcessDaemon {
         target_host: &HostName,
         reference: &str,
         transient: bool,
+        seat: AttachSeatRequest,
     ) -> Result<String, String> {
         let next_hop = self.host_registry.next_hop_host_for_target_host(target_host).await?.unwrap_or_else(|| target_host.clone());
         if next_hop == self.host_name {
@@ -5837,6 +5883,15 @@ impl InProcessDaemon {
         if transient {
             command.push(flotilla_protocol::arg::Arg::Literal("--transient".to_string()));
         }
+        match seat {
+            AttachSeatRequest::Control => {}
+            AttachSeatRequest::WatchIfControlled => {
+                command.push(flotilla_protocol::arg::Arg::Literal("--watch-if-controlled".to_string()));
+            }
+            AttachSeatRequest::Take => {
+                command.push(flotilla_protocol::arg::Arg::Literal("--take".to_string()));
+            }
+        }
         command.push(flotilla_protocol::arg::Arg::Quoted(reference.to_string()));
         let args = resolver
             .one_hop_command_args(&next_hop, command)
@@ -5850,13 +5905,14 @@ impl InProcessDaemon {
             .as_deref()
             .or(binding.convoy.as_deref())
             .ok_or_else(|| "remote attach binding has neither a session nor convoy reference".to_string())?;
-        self.recursive_attach_command_for_remote(&binding.host, reference, false).await
+        self.recursive_attach_command_for_remote(&binding.host, reference, false, AttachSeatRequest::Control).await
     }
 
     async fn local_attach_command_for_session(
         &self,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
         environment: &flotilla_resources::ResourceObject<ResourceEnvironment>,
+        seat: AttachSeatRequest,
     ) -> Result<String, String> {
         let cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
         let registry = self.registry_for_resource_environment(environment, cwd.as_path()).await?;
@@ -5866,7 +5922,31 @@ impl InProcessDaemon {
             .map(|(_, pool)| Arc::clone(pool))
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
         let attach_target = terminal_session_attach_target(session)?;
-        let attach_args = pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?;
+        let fallback_holder = if matches!(session.spec.source, flotilla_resources::TerminalSessionSource::Agent { .. }) {
+            "crew runner"
+        } else {
+            "another principal"
+        };
+        let (attach_args, watch_holder) = match seat {
+            AttachSeatRequest::Control => match pool.controller_holder(attach_target.session_id).await {
+                Ok(Some(holder)) => {
+                    let holder = if holder.is_empty() { fallback_holder.to_string() } else { holder };
+                    (pool.watch_args(attach_target.session_id)?, Some(holder))
+                }
+                Ok(None) | Err(_) => (pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?, None),
+            },
+            AttachSeatRequest::WatchIfControlled => {
+                let holder = pool
+                    .controller_holder(attach_target.session_id)
+                    .await?
+                    .ok_or_else(|| "controller seat is no longer held".to_string())?;
+                let holder = if holder.is_empty() { fallback_holder.to_string() } else { holder };
+                (pool.watch_args(attach_target.session_id)?, Some(holder))
+            }
+            AttachSeatRequest::Take => {
+                (pool.take_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new()).await?, None)
+            }
+        };
         if environment.spec.docker.is_some() {
             let command = ResolvedPaneCommand { role: session.spec.role.clone(), args: attach_args };
             let environment_id = EnvironmentId::new(session.spec.env_ref.clone());
@@ -5880,13 +5960,21 @@ impl InProcessDaemon {
                 Some(&environment_id),
                 container_name,
             )?;
-            return resolved
+            let command = resolved
                 .into_iter()
                 .next()
                 .map(|(_, command)| command)
-                .ok_or_else(|| "attach command resolution produced no command".to_string());
+                .ok_or_else(|| "attach command resolution produced no command".to_string())?;
+            return Ok(match watch_holder {
+                Some(holder) => watch_banner_command(&command, &holder),
+                None => command,
+            });
         }
-        Ok(flotilla_protocol::arg::flatten(&attach_args, 0))
+        let command = flotilla_protocol::arg::flatten(&attach_args, 0);
+        Ok(match watch_holder {
+            Some(holder) => watch_banner_command(&command, &holder),
+            None => command,
+        })
     }
 
     fn target_host_for_resource_ref(&self, host_ref: &str) -> HostName {
@@ -7098,6 +7186,27 @@ impl DaemonHandle for InProcessDaemon {
                 }
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
             },
+            CommandAction::AttachTake { reference, host } => {
+                match self.resolve_take_attach_command_on_host_internal(reference, host.as_ref()).await {
+                    Ok(resolved) => {
+                        if let Some(binding) = &resolved.binding {
+                            if let Err(error) = self.emit_attach_regard(binding, session_id).await {
+                                warn!(%error, "failed to emit attach regard");
+                            }
+                        }
+                        Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command: resolved.command, binding: resolved.binding })
+                    }
+                    Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
+                }
+            }
+            CommandAction::AttachWatch { reference, host, transient } => {
+                match self.resolve_watch_attach_command_on_host_internal(reference, host.as_ref(), *transient).await {
+                    Ok(resolved) => {
+                        Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command: resolved.command, binding: resolved.binding })
+                    }
+                    Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
+                }
+            }
             CommandAction::AttachTransient { reference, host } => {
                 match self.resolve_transient_attach_command_internal(reference, host.as_ref()).await {
                     Ok(resolved) => {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -498,7 +498,7 @@ impl AttachTarget {
                 let command = if row.host == daemon.host_name {
                     daemon.local_checkout_terminal_command(row).await?
                 } else {
-                    daemon.recursive_attach_command_for_remote(&row.host, reference, true).await?
+                    daemon.recursive_attach_command_for_remote(&row.host, reference, true, AttachSeatRequest::Control).await?
                 };
                 Ok(ResolvedAttach { command, binding: None })
             }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2300,6 +2300,46 @@ async fn watch_fallback_refuses_when_the_controller_seat_is_available() {
 }
 
 #[tokio::test]
+async fn attach_query_fails_open_when_controller_inspection_errors() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "cleat-session-1",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+    terminal_pool.set_controller_holder_error("cleat inspect schema changed").await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command, .. } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert_eq!(command, "attach cleat-session-1");
+}
+
+#[tokio::test]
 async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2195,6 +2195,84 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
 }
 
 #[tokio::test]
+async fn attach_query_falls_back_to_watch_with_controller_banner() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "cleat-session-1",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+    terminal_pool.set_controller_holder("cleat-session-1", "crew runner").await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should execute");
+
+    let CommandValue::AttachCommandResolved { command, .. } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert!(command.contains("watching — controller held by crew runner; --take to take control"));
+    assert!(command.ends_with("watch cleat-session-1"));
+    assert!(!command.contains("attach cleat-session-1"));
+}
+
+#[tokio::test]
+async fn watch_fallback_refuses_when_the_controller_seat_is_available() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "cleat-session-1",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::AttachWatch { reference: "convoy-a/implement/coder".to_string(), host: None, transient: false },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("watch fallback query should execute");
+
+    assert_eq!(result, CommandValue::Error { message: "controller seat is no longer held".to_string() });
+}
+
+#[tokio::test]
 async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
@@ -2306,6 +2384,24 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
     assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
     assert!(!command.contains("remote-provider-session"), "remote hop must not include terminal-provider attach args: {command}");
     assert_eq!(command.matches("flotilla attach").count(), 1, "command should contain exactly one recursive attach invocation: {command}");
+
+    let take_result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::AttachTake { reference: "convoy-a/implement/coder".to_string(), host: None },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("take attach query should execute");
+    let CommandValue::AttachCommandResolved { command, .. } = take_result else {
+        panic!("expected take attach command, got {take_result:?}");
+    };
+    assert!(command.contains("flotilla attach --host"));
+    assert!(command.contains("--take"));
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -797,6 +797,7 @@ pub struct FakeTerminalPool {
     pub delivered: Arc<TokioMutex<Vec<(String, String, bool)>>>,
     pub ensured: Arc<TokioMutex<Vec<EnsuredTerminalSession>>>,
     pub captured_screens: Arc<TokioMutex<HashMap<String, String>>>,
+    pub controller_holders: Arc<TokioMutex<HashMap<String, String>>>,
 }
 
 pub struct EnsuredTerminalSession {
@@ -820,6 +821,7 @@ impl FakeTerminalPool {
             delivered: Arc::new(TokioMutex::new(Vec::new())),
             ensured: Arc::new(TokioMutex::new(Vec::new())),
             captured_screens: Arc::new(TokioMutex::new(HashMap::new())),
+            controller_holders: Arc::new(TokioMutex::new(HashMap::new())),
         }
     }
 
@@ -833,6 +835,10 @@ impl FakeTerminalPool {
 
     pub async fn set_captured_screen(&self, session_name: &str, screen: &str) {
         self.captured_screens.lock().await.insert(session_name.to_string(), screen.to_string());
+    }
+
+    pub async fn set_controller_holder(&self, session_name: &str, holder: &str) {
+        self.controller_holders.lock().await.insert(session_name.to_string(), holder.to_string());
     }
 }
 
@@ -882,6 +888,14 @@ impl TerminalPool for FakeTerminalPool {
         _env_vars: &super::super::terminal::TerminalEnvVars,
     ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
         Ok(vec![flotilla_protocol::arg::Arg::Literal(format!("attach {session_name}"))])
+    }
+
+    async fn controller_holder(&self, session_name: &str) -> Result<Option<String>, String> {
+        Ok(self.controller_holders.lock().await.get(session_name).cloned())
+    }
+
+    fn watch_args(&self, session_name: &str) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
+        Ok(vec![flotilla_protocol::arg::Arg::Literal(format!("watch {session_name}"))])
     }
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -798,6 +798,7 @@ pub struct FakeTerminalPool {
     pub ensured: Arc<TokioMutex<Vec<EnsuredTerminalSession>>>,
     pub captured_screens: Arc<TokioMutex<HashMap<String, String>>>,
     pub controller_holders: Arc<TokioMutex<HashMap<String, String>>>,
+    pub controller_holder_error: Arc<TokioMutex<Option<String>>>,
 }
 
 pub struct EnsuredTerminalSession {
@@ -822,6 +823,7 @@ impl FakeTerminalPool {
             ensured: Arc::new(TokioMutex::new(Vec::new())),
             captured_screens: Arc::new(TokioMutex::new(HashMap::new())),
             controller_holders: Arc::new(TokioMutex::new(HashMap::new())),
+            controller_holder_error: Arc::new(TokioMutex::new(None)),
         }
     }
 
@@ -839,6 +841,10 @@ impl FakeTerminalPool {
 
     pub async fn set_controller_holder(&self, session_name: &str, holder: &str) {
         self.controller_holders.lock().await.insert(session_name.to_string(), holder.to_string());
+    }
+
+    pub async fn set_controller_holder_error(&self, error: &str) {
+        *self.controller_holder_error.lock().await = Some(error.to_string());
     }
 }
 
@@ -891,6 +897,9 @@ impl TerminalPool for FakeTerminalPool {
     }
 
     async fn controller_holder(&self, session_name: &str) -> Result<Option<String>, String> {
+        if let Some(error) = self.controller_holder_error.lock().await.clone() {
+            return Err(error);
+        }
         Ok(self.controller_holders.lock().await.get(session_name).cloned())
     }
 

--- a/crates/flotilla-core/src/providers/scan_cache.rs
+++ b/crates/flotilla-core/src/providers/scan_cache.rs
@@ -174,6 +174,24 @@ impl TerminalPool for SharedTerminalPool {
         self.inner.attach_args(session_name, command, cwd, env_vars)
     }
 
+    async fn controller_holder(&self, session_name: &str) -> Result<Option<String>, String> {
+        self.inner.controller_holder(session_name).await
+    }
+
+    fn watch_args(&self, session_name: &str) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
+        self.inner.watch_args(session_name)
+    }
+
+    async fn take_args(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+    ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
+        self.inner.take_args(session_name, command, cwd, env_vars).await
+    }
+
     async fn attach_command(
         &self,
         session_name: &str,

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -20,6 +20,11 @@ struct SessionInfo {
 }
 
 #[derive(Debug, Deserialize)]
+struct InspectResult {
+    attachments: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 enum SessionStatus {
     Attached,
@@ -51,6 +56,18 @@ impl CleatTerminalPool {
 
     fn parse_list_output(json: &str) -> Result<Vec<SessionInfo>, String> {
         serde_json::from_str(json).map_err(|err| format!("parse session list: {err}"))
+    }
+
+    fn attachment_identity(attachment: &serde_json::Value) -> Option<String> {
+        ["holder", "identity", "principal", "name"].into_iter().find_map(|field| {
+            let value = attachment.get(field)?;
+            value.as_str().map(str::to_string).or_else(|| {
+                value
+                    .as_object()
+                    .and_then(|identity| ["display_name", "name", "id"].into_iter().find_map(|key| identity.get(key)?.as_str()))
+                    .map(str::to_string)
+            })
+        })
     }
 }
 
@@ -134,6 +151,38 @@ impl TerminalPool for CleatTerminalPool {
             Arg::Literal("--cwd".into()),
             Arg::Quoted(cwd.as_path().display().to_string()),
         ])
+    }
+
+    async fn controller_holder(&self, session_name: &str) -> Result<Option<String>, String> {
+        let output = run!(self.runner, &self.binary, &["inspect", "--json", session_name], Path::new("/"))?;
+        let inspect: InspectResult = serde_json::from_str(&output).map_err(|err| format!("parse cleat inspect output: {err}"))?;
+        Ok(inspect.attachments.iter().find_map(|attachment| {
+            (attachment.get("role").and_then(serde_json::Value::as_str) == Some("controller"))
+                .then(|| Self::attachment_identity(attachment).unwrap_or_default())
+        }))
+    }
+
+    fn watch_args(&self, session_name: &str) -> Result<Vec<Arg>, String> {
+        Ok(vec![Arg::Literal(self.binary.clone()), Arg::Literal("watch".into()), Arg::Literal(session_name.into())])
+    }
+
+    async fn take_args(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+    ) -> Result<Vec<Arg>, String> {
+        let help = run!(self.runner, &self.binary, &["attach", "--help"], Path::new("/"))?;
+        if !help.lines().any(|line| line.split_whitespace().any(|word| word == "--take")) {
+            return Err(
+                "`flotilla attach --take` requires cleat force-take support; this cleat does not provide `attach --take` (see flotilla-org/cleat#177)"
+                    .to_string(),
+            );
+        }
+        let mut args = self.attach_args(session_name, command, cwd, env_vars)?;
+        args.insert(2, Arg::Literal("--take".into()));
+        Ok(args)
     }
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {
@@ -417,5 +466,45 @@ mod tests {
         let term_pos = cmd_val.find("TERM=").expect("should contain TERM");
         let foo_pos = cmd_val.find("FOO=").expect("should contain FOO");
         assert!(term_pos < foo_pos, "terminal defaults should appear before caller env vars: {cmd_val}");
+    }
+
+    #[tokio::test]
+    async fn controller_holder_reads_identity_when_cleat_reports_it() {
+        let inspect = r#"{"attachments":[{"role":"controller","identity":{"display_name":"alice"}},{"role":"watcher"}]}"#;
+        let pool = CleatTerminalPool::new(Arc::new(MockRunner::new(vec![Ok(inspect.into())])), "cleat");
+
+        assert_eq!(pool.controller_holder("sess").await.expect("inspect controller").as_deref(), Some("alice"));
+    }
+
+    #[tokio::test]
+    async fn controller_holder_marks_an_unidentified_controller() {
+        let inspect = r#"{"attachments":[{"role":"controller"}]}"#;
+        let pool = CleatTerminalPool::new(Arc::new(MockRunner::new(vec![Ok(inspect.into())])), "cleat");
+
+        assert_eq!(pool.controller_holder("sess").await.expect("inspect controller").as_deref(), Some(""));
+    }
+
+    #[tokio::test]
+    async fn take_reports_when_installed_cleat_lacks_the_capability() {
+        let pool = CleatTerminalPool::new(Arc::new(MockRunner::new(vec![Ok("Usage: cleat attach [OPTIONS]".into())])), "cleat");
+
+        let error = pool
+            .take_args("sess", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![])
+            .await
+            .expect_err("old cleat should reject take");
+
+        assert!(error.contains("does not provide `attach --take`"));
+        assert!(error.contains("cleat#177"));
+    }
+
+    #[tokio::test]
+    async fn take_uses_the_capability_when_cleat_advertises_it() {
+        let pool =
+            CleatTerminalPool::new(Arc::new(MockRunner::new(vec![Ok("Options:\n      --take  Force take control".into())])), "cleat");
+
+        let args =
+            pool.take_args("sess", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![]).await.expect("new cleat should support take");
+
+        assert_eq!(flotilla_protocol::arg::flatten(&args, 0), "cleat attach --take sess --cwd '/repo'");
     }
 }

--- a/crates/flotilla-core/src/providers/terminal/mod.rs
+++ b/crates/flotilla-core/src/providers/terminal/mod.rs
@@ -110,6 +110,30 @@ pub trait TerminalPool: Send + Sync {
         env_vars: &TerminalEnvVars,
     ) -> Result<Vec<Arg>, String>;
 
+    /// Reports the current controller, when the pool exposes seat state.
+    ///
+    /// `None` means the seat is available. Pools without controller seats use
+    /// the default implementation.
+    async fn controller_holder(&self, _session_name: &str) -> Result<Option<String>, String> {
+        Ok(None)
+    }
+
+    /// Returns a read-only attachment command for a session.
+    fn watch_args(&self, _session_name: &str) -> Result<Vec<Arg>, String> {
+        Err("terminal pool does not support read-only watch".to_string())
+    }
+
+    /// Returns an attachment command that force-takes the controller seat.
+    async fn take_args(
+        &self,
+        _session_name: &str,
+        _command: &str,
+        _cwd: &ExecutionEnvironmentPath,
+        _env_vars: &TerminalEnvVars,
+    ) -> Result<Vec<Arg>, String> {
+        Err("terminal pool does not support taking the controller seat".to_string())
+    }
+
     /// Returns the attach command as a flat shell string.
     /// Default implementation calls `attach_args()` + `flatten()`.
     async fn attach_command(

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -241,6 +241,20 @@ pub enum CommandAction {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         host: Option<crate::HostName>,
     },
+    /// Resolve an attach that force-takes the controller seat.
+    AttachTake {
+        reference: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        host: Option<crate::HostName>,
+    },
+    /// Resolve a read-only fallback only when the controller seat is held.
+    AttachWatch {
+        reference: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        host: Option<crate::HostName>,
+        #[serde(default, skip_serializing_if = "is_false")]
+        transient: bool,
+    },
     /// Resolve an attach for a temporary foreground excursion. Unlike the
     /// human-facing CLI attach, recursive hops must not stamp PM metadata.
     AttachTransient {
@@ -474,6 +488,8 @@ impl CommandAction {
                 | CommandAction::QueryResourceList { .. }
                 | CommandAction::QueryResourceGet { .. }
                 | CommandAction::Attach { .. }
+                | CommandAction::AttachTake { .. }
+                | CommandAction::AttachWatch { .. }
                 | CommandAction::AttachTransient { .. }
                 | CommandAction::QueryIssues { .. }
                 | CommandAction::QueryIssueFetchByIds { .. }
@@ -489,6 +505,8 @@ impl Command {
             CommandAction::CreateWorkspaceFromPreparedTerminal { .. } => "Creating workspace...",
             CommandAction::SelectWorkspace { .. } => "Switching workspace...",
             CommandAction::Attach { .. } => "Resolving attach target...",
+            CommandAction::AttachTake { .. } => "Resolving controller takeover...",
+            CommandAction::AttachWatch { .. } => "Resolving read-only fallback...",
             CommandAction::AttachTransient { .. } => "Resolving temporary attach target...",
             CommandAction::PrepareTerminalForCheckout { .. } => "Preparing terminal...",
             CommandAction::Checkout { target, .. } => match target {

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,12 +87,18 @@ enum SubCommand {
     Attach {
         /// Convoy, vessel, role, terminal session, or unique prefix
         reference: String,
+        /// Force-take the controller seat, demoting its current holder to watcher.
+        #[arg(long)]
+        take: bool,
         /// Internal attach mode used by temporary TUI excursions.
         #[arg(long, hide = true)]
         transient: bool,
         /// Restrict internal attach resolution to the daemon owning this row.
         #[arg(long, hide = true)]
         host: Option<String>,
+        /// Internal retry mode: resolve watch only if the controller is held.
+        #[arg(long, hide = true)]
+        watch_if_controlled: bool,
     },
     /// Emit this host's store-backed fleet replica snapshot
     #[command(hide = true)]
@@ -314,7 +320,9 @@ async fn main() -> Result<()> {
         Some(SubCommand::Watch) => run_watch(&cli, format).await,
         Some(SubCommand::Topology) => run_topology_command(&cli, format).await,
         Some(SubCommand::Ls) => run_fleet_list(&cli, format).await,
-        Some(SubCommand::Attach { reference, transient, host }) => run_attach(&cli, &reference, transient, host.as_deref(), format).await,
+        Some(SubCommand::Attach { reference, take, transient, host, watch_if_controlled }) => {
+            run_attach(&cli, &reference, take, transient, host.as_deref(), watch_if_controlled, format).await
+        }
         Some(SubCommand::ReplicaSnapshot) => run_replica_snapshot(&cli).await,
         Some(SubCommand::Hook { harness, event_type }) => run_hook(&cli, &harness, &event_type).await,
         Some(SubCommand::Hooks { command }) => run_hooks_command(&command).await,
@@ -759,7 +767,15 @@ fn exit_command_error(message: String, format: OutputFormat) -> ! {
     std::process::exit(1);
 }
 
-async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&str>, format: OutputFormat) -> Result<()> {
+async fn run_attach(
+    cli: &Cli,
+    reference: &str,
+    take: bool,
+    transient: bool,
+    host: Option<&str>,
+    watch_if_controlled: bool,
+    format: OutputFormat,
+) -> Result<()> {
     reset_sigpipe();
     let daemon = connect_daemon(cli).await?;
     let result = daemon
@@ -768,7 +784,15 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: if transient {
+                action: if watch_if_controlled {
+                    CommandAction::AttachWatch {
+                        reference: reference.to_string(),
+                        host: host.map(flotilla_protocol::HostName::new),
+                        transient,
+                    }
+                } else if take {
+                    CommandAction::AttachTake { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
+                } else if transient {
                     CommandAction::AttachTransient { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
                 } else {
                     CommandAction::Attach { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
@@ -789,7 +813,31 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
                 if !transient {
                     stamp_pane_identity(reference, binding.as_ref()).await;
                 }
-                run_attach_command(&command)
+                let status = run_attach_command_status(&command)?;
+                if status.success() || take || watch_if_controlled {
+                    terminate_with_attach_status(status);
+                }
+
+                let fallback = daemon
+                    .execute_query(
+                        Command {
+                            node_id: None,
+                            provisioning_target: None,
+                            context_repo: None,
+                            action: CommandAction::AttachWatch {
+                                reference: reference.to_string(),
+                                host: host.map(flotilla_protocol::HostName::new),
+                                transient,
+                            },
+                        },
+                        uuid::Uuid::new_v4(),
+                    )
+                    .await
+                    .map_err(|e| color_eyre::eyre::eyre!(e))?;
+                if let CommandValue::AttachCommandResolved { command, .. } = fallback {
+                    return run_attach_command(&command);
+                }
+                terminate_with_attach_status(status);
             }
         },
         CommandValue::Error { message } => match format {
@@ -1010,10 +1058,13 @@ fn print_resource_watch_event(response: &flotilla_protocol::ResourceWatchRespons
 }
 
 fn run_attach_command(command: &str) -> Result<()> {
-    let status = std::process::Command::new("sh").arg("-lc").arg(command).status()?;
+    let status = run_attach_command_status(command)?;
     terminate_with_attach_status(status)
 }
 
+fn run_attach_command_status(command: &str) -> std::io::Result<ExitStatus> {
+    std::process::Command::new("sh").arg("-lc").arg(command).status()
+}
 #[derive(Debug, PartialEq, Eq)]
 enum AttachExitDisposition {
     Code(i32),
@@ -1824,7 +1875,23 @@ mod tests {
         let cli = Cli::try_parse_from(["flotilla", "attach", "convoy-a/implement/coder"]).expect("attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, transient: false, host: None }) if reference == "convoy-a/implement/coder"
+            Some(SubCommand::Attach {
+                reference,
+                take: false,
+                transient: false,
+                host: None,
+                watch_if_controlled: false,
+            }) if reference == "convoy-a/implement/coder"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_attach_take() {
+        let cli = Cli::try_parse_from(["flotilla", "attach", "--take", "convoy-a/implement/coder"]).expect("take attach should parse");
+        assert!(matches!(
+            cli.command,
+            Some(SubCommand::Attach { reference, take: true, transient: false, host: None, watch_if_controlled: false })
+                if reference == "convoy-a/implement/coder"
         ));
     }
 
@@ -1834,7 +1901,13 @@ mod tests {
             .expect("transient attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, transient: true, host: Some(host) })
+            Some(SubCommand::Attach {
+                reference,
+                take: false,
+                transient: true,
+                host: Some(host),
+                watch_if_controlled: false,
+            })
                 if reference == "terminal-scratch" && host == "feta"
         ));
     }
@@ -1845,7 +1918,13 @@ mod tests {
             .expect("host-qualified attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, transient: false, host: Some(host) })
+            Some(SubCommand::Attach {
+                reference,
+                take: false,
+                transient: false,
+                host: Some(host),
+                watch_if_controlled: false,
+            })
                 if reference == "terminal-scratch" && host == "feta"
         ));
     }


### PR DESCRIPTION
Closes #1010.

## What changed

- Inspect cleat controller-seat state while resolving terminal attaches.
- Automatically resolve held seats to `cleat watch` with a visible holder banner, including crew-runner inference until cleat exposes attachment identity.
- Retry a failed attach as watch to cover the inspect/attach race.
- Add `flotilla attach --take` and preserve takeover intent across remote attach hops.
- Detect whether the installed cleat supports `attach --take` and return a clear compatibility message linked to cleat#177 when it does not.

## Impact

Convoy tabs and direct `flotilla attach` calls no longer fail when the crew runner or another principal holds the single controller seat. Users land in a legible read-only watch instead and can request takeover explicitly when the cleat capability is available.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`