### PR TITLE
fix: discover adapters inside contained environments

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -165,6 +165,8 @@ impl Reconciler for VesselReconciler {
             Ok(strategy) => strategy,
             Err(message) => return Ok(VesselDeps::failed(message)),
         };
+        let declared_agent_adapters =
+            placement_policy.spec.docker_per_vessel.as_ref().map(|docker| docker.agent_adapters.clone()).unwrap_or_default();
 
         let (vessel_index, requirement) = match convoy
             .status
@@ -273,6 +275,7 @@ impl Reconciler for VesselReconciler {
                                 docker: Some(DockerEnvironmentSpec {
                                     host_ref: host_ref.clone(),
                                     image: image.clone(),
+                                    declared_agent_adapters: declared_agent_adapters.clone(),
                                     mounts: Vec::new(),
                                     env: env.clone(),
                                 }),
@@ -548,6 +551,7 @@ impl Reconciler for VesselReconciler {
                                 docker: Some(DockerEnvironmentSpec {
                                     host_ref: host_ref.clone(),
                                     image: image.clone(),
+                                    declared_agent_adapters: declared_agent_adapters.clone(),
                                     mounts: has_repositories
                                         .then(|| EnvironmentMount {
                                             source_path: workspace_root.clone(),

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -104,6 +104,7 @@ async fn environment_actuator_translates_mounts_into_provider_create_opts() {
     let spec = DockerEnvironmentSpec {
         host_ref: "01HXYZ".to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
+        declared_agent_adapters: Default::default(),
         mounts: vec![EnvironmentMount {
             source_path: "/Users/alice/dev/flotilla".to_string(),
             target_path: "/workspace".to_string(),

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -711,6 +711,7 @@ async fn create_ready_docker_env(backend: &ResourceBackend, name: &str) {
             docker: Some(flotilla_resources::DockerEnvironmentSpec {
                 host_ref: HOST_REF.to_string(),
                 image: "ubuntu:24.04".to_string(),
+                declared_agent_adapters: Default::default(),
                 mounts: Vec::new(),
                 env: BTreeMap::new(),
             }),

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -414,6 +414,7 @@ async fn environment_controller_marks_docker_environment_ready() {
             docker: Some(DockerEnvironmentSpec {
                 host_ref: "01HXYZ".to_string(),
                 image: "ghcr.io/flotilla/dev:latest".to_string(),
+                declared_agent_adapters: Default::default(),
                 mounts: vec![EnvironmentMount {
                     source_path: "/tmp/src".to_string(),
                     target_path: "/workspace".to_string(),

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::Utc;
 use common::{
@@ -717,6 +717,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
     create_ready_docker_environment(&backend, NAMESPACE, "env-workspace-multi-fresh", DockerEnvironmentSpec {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
+        declared_agent_adapters: Default::default(),
         mounts: Vec::new(),
         env: Default::default(),
     })
@@ -928,6 +929,7 @@ async fn contained_requirement_runs_in_contained_docker_placement() {
     create_ready_docker_environment(&backend, NAMESPACE, environment_ref, DockerEnvironmentSpec {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
+        declared_agent_adapters: Default::default(),
         mounts: Vec::new(),
         env: Default::default(),
     })
@@ -1107,7 +1109,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: HOST_REF.to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
-            agent_adapters: Default::default(),
+            agent_adapters: BTreeSet::from(["codex".to_string()]),
             default_cwd: None,
             env: Default::default(),
             checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".to_string() },
@@ -1118,6 +1120,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
     Some(DockerEnvironmentSpec {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
+        declared_agent_adapters: BTreeSet::from(["codex".to_string()]),
         mounts: vec![flotilla_resources::EnvironmentMount {
             source_path: "/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-docker-worktree".to_string(),
             target_path: "/workspace".to_string(),
@@ -1144,6 +1147,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
     Some(DockerEnvironmentSpec {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
+        declared_agent_adapters: Default::default(),
         mounts: Vec::new(),
         env: Default::default(),
     }),

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -13,7 +13,10 @@ use crate::{
     config::ConfigStore,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        discovery::{run_host_detectors, DiscoveryRuntime, EnvironmentAssertion, EnvironmentBag, FactoryRegistry},
+        discovery::{
+            detectors::default_host_detectors, run_host_detectors, run_provisioned_host_detectors, DiscoveryRuntime, EnvironmentBag,
+            FactoryRegistry,
+        },
         environment::{CreateOpts, EnvironmentHandle, ProvisionedMount, ProvisionedMountMode},
         registry::ProviderRegistry,
         CommandRunner,
@@ -408,10 +411,7 @@ impl EnvironmentManager {
         let env_runner = handle.runner();
 
         let raw_env_vars = handle.env_vars().await?;
-        let mut bag = EnvironmentBag::new();
-        for (key, value) in &raw_env_vars {
-            bag = bag.with(EnvironmentAssertion::env_var(key, value));
-        }
+        let bag = run_provisioned_host_detectors(&default_host_detectors(), &*env_runner, &raw_env_vars).await;
 
         let config = ConfigStore::with_base(config_base.as_path().join(format!("env-discovery/{env_id}")));
         let env_repo_root = ExecutionEnvironmentPath::new("/workspace");
@@ -958,7 +958,18 @@ mod tests {
         let env_id = EnvironmentId::new("env-discover-1");
         let discovery = fake_discovery(false);
         let manager = EnvironmentManager::new_local(&discovery, test_local_environment_id(), test_local_host_id()).await;
-        let (handle, _) = mock_handle(&env_id, HashMap::from([(String::from("ANTHROPIC_API_KEY"), String::from("test-key"))]), None);
+        let handle: EnvironmentHandle = Arc::new(MockProvisionedEnvironment {
+            id: env_id.clone(),
+            image: ImageId::new("mock:image"),
+            runner: Arc::new(DiscoveryMockRunner::builder().on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string())).build()),
+            env_vars: HashMap::from([
+                (String::from("ANTHROPIC_API_KEY"), String::from("test-key")),
+                (String::from("FLOTILLA_ENVIRONMENT_ID"), String::from("env-discover-1")),
+            ]),
+            provisioned_mounts: Vec::new(),
+            destroyed: Arc::new(AtomicBool::new(false)),
+            destroy_error: None,
+        });
         manager
             .register_provisioned_environment(env_id.clone(), handle, EnvironmentBag::new(), None)
             .expect("register provisioned environment");
@@ -969,7 +980,11 @@ mod tests {
             .expect("ensure providers");
 
         assert_eq!(manager.environment_bag(&env_id).expect("environment bag").find_env_var("ANTHROPIC_API_KEY"), Some("test-key"));
-        assert!(manager.environment_registry(&env_id).is_some());
+        assert_eq!(
+            manager.environment_bag(&env_id).expect("environment bag").find_env_var("FLOTILLA_ENVIRONMENT_ID"),
+            Some("env-discover-1")
+        );
+        assert!(manager.environment_registry(&env_id).expect("environment registry").agent_adapters.get("codex").is_some());
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -672,6 +672,30 @@ pub async fn run_host_detectors(detectors: &[Box<dyn HostDetector>], runner: &dy
     stream::iter(detectors).fold(EnvironmentBag::new(), |bag, det| async move { bag.extend(det.detect(runner, env).await) }).await
 }
 
+/// Build a provisioned environment's host bag from its complete environment,
+/// then add assertions detected through its interior command runner.
+pub async fn run_provisioned_host_detectors(
+    detectors: &[Box<dyn HostDetector>],
+    runner: &dyn CommandRunner,
+    env_vars: &HashMap<String, String>,
+) -> EnvironmentBag {
+    struct ProvisionedEnvVars<'a> {
+        values: &'a HashMap<String, String>,
+    }
+
+    impl EnvVars for ProvisionedEnvVars<'_> {
+        fn get(&self, key: &str) -> Option<String> {
+            self.values.get(key).cloned()
+        }
+    }
+
+    let bag = env_vars
+        .iter()
+        .fold(EnvironmentBag::new(), |bag, (key, value)| bag.with(EnvironmentAssertion::env_var(key.clone(), value.clone())));
+    let detected = run_host_detectors(detectors, runner, &ProvisionedEnvVars { values: env_vars }).await;
+    bag.extend(detected.assertions().iter().cloned())
+}
+
 pub async fn discover_providers(
     host_bag: &EnvironmentBag,
     repo_root: &ExecutionEnvironmentPath,
@@ -1061,5 +1085,20 @@ mod orchestrator_tests {
 
         // At minimum, git binary should be detected
         assert!(bag.find_binary("git").is_some(), "host detectors should find git binary");
+    }
+
+    #[tokio::test]
+    async fn provisioned_host_detection_preserves_all_env_vars_and_adds_binary_assertions() {
+        let runner = DiscoveryMockRunner::builder().on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string())).build();
+        let env_vars = HashMap::from([
+            ("HOME".to_string(), "/home/crew".to_string()),
+            ("FLOTILLA_ENVIRONMENT_ID".to_string(), "contained-work".to_string()),
+        ]);
+
+        let bag = run_provisioned_host_detectors(&detectors::default_host_detectors(), &runner, &env_vars).await;
+
+        assert_eq!(bag.find_env_var("FLOTILLA_ENVIRONMENT_ID"), Some("contained-work"));
+        assert_eq!(bag.find_env_var("HOME"), Some("/home/crew"));
+        assert!(bag.find_binary("codex").is_some());
     }
 }

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -693,7 +693,7 @@ pub async fn run_provisioned_host_detectors(
         .iter()
         .fold(EnvironmentBag::new(), |bag, (key, value)| bag.with(EnvironmentAssertion::env_var(key.clone(), value.clone())));
     let detected = run_host_detectors(detectors, runner, &ProvisionedEnvVars { values: env_vars }).await;
-    bag.extend(detected.assertions().iter().cloned())
+    bag.extend(detected.assertions().iter().filter(|assertion| !matches!(assertion, EnvironmentAssertion::EnvVarSet { .. })).cloned())
 }
 
 pub async fn discover_providers(
@@ -1100,5 +1100,13 @@ mod orchestrator_tests {
         assert_eq!(bag.find_env_var("FLOTILLA_ENVIRONMENT_ID"), Some("contained-work"));
         assert_eq!(bag.find_env_var("HOME"), Some("/home/crew"));
         assert!(bag.find_binary("codex").is_some());
+        assert_eq!(
+            bag.assertions()
+                .iter()
+                .filter(|assertion| matches!(assertion, EnvironmentAssertion::EnvVarSet { key, .. } if key == "HOME"))
+                .count(),
+            1,
+            "raw env vars should not be duplicated by env-var detectors"
+        );
     }
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -22,7 +22,7 @@ use flotilla_core::{
     in_process::InProcessDaemon,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        discovery::{EnvironmentAssertion, EnvironmentBag},
+        discovery::{run_host_detectors, EnvVars, EnvironmentBag},
         environment::{CreateOpts, EnvironmentHandle, ProvisionedMount},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
@@ -929,11 +929,21 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             .await?;
 
         let container_id = handle.container_name().map(ToString::to_string).unwrap_or_else(|| format!("flotilla-env-{}", env_id));
-        let (bag, registry) = probe_provisioned_environment(&self.state, &env_id, &handle).await?;
-        self.state
+        let (bag, registry) = match probe_provisioned_environment(&self.state, &env_id, &handle).await {
+            Ok(probed) => probed,
+            Err(error) => return Err(discard_failed_environment(&handle, error).await),
+        };
+        if let Err(error) = verify_declared_agent_adapters(spec, &registry) {
+            return Err(discard_failed_environment(&handle, error).await);
+        }
+        if let Err(error) = self
+            .state
             .daemon
             .register_provisioned_environment(env_id.clone(), Arc::clone(&handle), bag, Some(registry))
-            .map_err(|err| format!("failed to register provisioned environment {env_id}: {err}"))?;
+            .map_err(|err| format!("failed to register provisioned environment {env_id}: {err}"))
+        {
+            return Err(discard_failed_environment(&handle, error).await);
+        }
         self.state.provisioned_environments.lock().await.insert(container_id.clone(), ActiveProvisionedEnvironment { env_id, handle });
         Ok(container_id)
     }
@@ -949,19 +959,51 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
     }
 }
 
+fn verify_declared_agent_adapters(spec: &flotilla_resources::DockerEnvironmentSpec, registry: &ProviderRegistry) -> Result<(), String> {
+    let discovered = registry.agent_adapters.ids().collect::<BTreeSet<_>>();
+    let missing =
+        spec.declared_agent_adapters.iter().map(String::as_str).filter(|adapter| !discovered.contains(adapter)).collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(format!(
+        "image `{}` declares agent adapter{} {}, but interior discovery did not find {}",
+        spec.image,
+        if missing.len() == 1 { "" } else { "s" },
+        missing.iter().map(|adapter| format!("`{adapter}`")).collect::<Vec<_>>().join(", "),
+        if missing.len() == 1 { "it" } else { "them" },
+    ))
+}
+
+async fn discard_failed_environment(handle: &EnvironmentHandle, error: String) -> String {
+    match handle.destroy().await {
+        Ok(()) => error,
+        Err(cleanup_error) => format!("{error}; additionally failed to destroy rejected environment: {cleanup_error}"),
+    }
+}
+
 async fn probe_provisioned_environment(
     state: &ControllerRuntimeState,
     env_id: &EnvironmentId,
     handle: &EnvironmentHandle,
 ) -> Result<(EnvironmentBag, Arc<ProviderRegistry>), String> {
-    let mut bag = EnvironmentBag::new();
-    for (key, value) in handle.env_vars().await? {
-        bag = bag.with(EnvironmentAssertion::env_var(key, value));
-    }
+    let env_vars = InteriorEnvVars { values: handle.env_vars().await? };
+    let discovery = state.daemon.discovery_runtime();
+    let bag = run_host_detectors(&discovery.host_detectors, &*handle.runner(), &env_vars).await;
     let probe_root = ExecutionEnvironmentPath::new("/workspace");
     let config = ConfigStore::with_base(state.config.base_path().as_path().join(format!("env-discovery/{env_id}")));
-    let registry = state.daemon.discovery_runtime().factories.probe_all(&bag, &config, &probe_root, handle.runner()).await;
+    let registry = discovery.factories.probe_all(&bag, &config, &probe_root, handle.runner()).await;
     Ok((bag, Arc::new(registry)))
+}
+
+struct InteriorEnvVars {
+    values: HashMap<String, String>,
+}
+
+impl EnvVars for InteriorEnvVars {
+    fn get(&self, key: &str) -> Option<String> {
+        self.values.get(key).cloned()
+    }
 }
 
 struct CloneControllerRuntime {
@@ -1514,7 +1556,7 @@ mod test_git_repo;
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, process::Command as ProcessCommand, sync::Arc};
+    use std::{collections::HashMap, fs, process::Command as ProcessCommand, sync::Arc};
 
     use flotilla_core::{
         config::ConfigStore,
@@ -1523,15 +1565,16 @@ mod tests {
         providers::{
             discovery::{
                 test_support::{
-                    fake_discovery_with_provider_set, git_process_discovery, FakeDiscoveryProviders, FakeTerminalPool,
+                    fake_discovery_with_provider_set, git_process_discovery, DiscoveryMockRunner, FakeDiscoveryProviders, FakeTerminalPool,
                     MergedPrProcessRunner,
                 },
                 EnvironmentAssertion, EnvironmentBag,
             },
+            environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount},
             CommandRunner, ProcessCommandRunner,
         },
     };
-    use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent};
+    use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent, ImageId};
     use flotilla_resources::{
         Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
         CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
@@ -1547,6 +1590,48 @@ mod tests {
     enum CompletionAction {
         Retain,
         Delete,
+    }
+
+    struct TestInteriorEnvironment {
+        id: EnvironmentId,
+        image: ImageId,
+        runner: Arc<dyn CommandRunner>,
+        env_vars: HashMap<String, String>,
+    }
+
+    #[async_trait]
+    impl ProvisionedEnvironment for TestInteriorEnvironment {
+        fn id(&self) -> &EnvironmentId {
+            &self.id
+        }
+
+        fn image(&self) -> &ImageId {
+            &self.image
+        }
+
+        fn container_name(&self) -> Option<&str> {
+            Some("test-interior")
+        }
+
+        fn provisioned_mounts(&self) -> Vec<ProvisionedMount> {
+            Vec::new()
+        }
+
+        async fn status(&self) -> Result<flotilla_protocol::EnvironmentStatus, String> {
+            Ok(flotilla_protocol::EnvironmentStatus::Running)
+        }
+
+        async fn env_vars(&self) -> Result<HashMap<String, String>, String> {
+            Ok(self.env_vars.clone())
+        }
+
+        fn runner(&self) -> Arc<dyn CommandRunner> {
+            Arc::clone(&self.runner)
+        }
+
+        async fn destroy(&self) -> Result<(), String> {
+            Ok(())
+        }
     }
 
     #[tokio::test]
@@ -2022,6 +2107,62 @@ mod tests {
             Arc::new(PassthroughTerminalPool),
         );
         Arc::new(registry)
+    }
+
+    #[tokio::test]
+    async fn provisioned_environment_discovers_and_registers_interior_agent_adapters() {
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let mut discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
+        discovery.host_detectors = flotilla_core::providers::discovery::detectors::default_host_detectors();
+        let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        let state = ControllerRuntimeState::new(
+            Arc::clone(&daemon),
+            config,
+            passthrough_registry(),
+            None,
+            "host-test".to_string(),
+            None,
+            "host-direct-host-test".to_string(),
+        );
+        let env_id = EnvironmentId::new("contained-work");
+        let runner: Arc<dyn CommandRunner> = Arc::new(
+            DiscoveryMockRunner::builder()
+                .on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string()))
+                .on_run("claude", &["--version"], Ok("1.0.0 (Claude Code)".to_string()))
+                .build(),
+        );
+        let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {
+            id: env_id.clone(),
+            image: ImageId::new("contained-image"),
+            runner,
+            env_vars: HashMap::from([("HOME".to_string(), "/home/crew".to_string())]),
+        });
+
+        let (bag, registry) = probe_provisioned_environment(&state, &env_id, &handle).await.expect("interior discovery should succeed");
+
+        assert!(bag.find_binary("codex").is_some());
+        assert!(bag.find_binary("claude").is_some());
+        assert_eq!(bag.find_env_var("HOME"), Some("/home/crew"));
+        assert!(registry.agent_adapters.get("codex").is_some());
+        assert!(registry.agent_adapters.get("claude-code").is_some());
+
+        daemon
+            .register_provisioned_environment(env_id.clone(), Arc::clone(&handle), bag, Some(Arc::clone(&registry)))
+            .expect("provisioned environment should register");
+        let registered = daemon.environment_registry_for_environment(&env_id).expect("interior registry should be available");
+        assert!(registered.agent_adapters.get("codex").is_some());
+        assert!(registered.agent_adapters.get("claude-code").is_some());
+
+        let spec = flotilla_resources::DockerEnvironmentSpec {
+            host_ref: "host-test".to_string(),
+            image: "contained-image".to_string(),
+            declared_agent_adapters: BTreeSet::from(["codex".to_string(), "missing-adapter".to_string()]),
+            mounts: Vec::new(),
+            env: BTreeMap::new(),
+        };
+        let error = verify_declared_agent_adapters(&spec, &registry).expect_err("missing declared adapter should fail");
+        assert_eq!(error, "image `contained-image` declares agent adapter `missing-adapter`, but interior discovery did not find it");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -22,7 +22,7 @@ use flotilla_core::{
     in_process::InProcessDaemon,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        discovery::{run_host_detectors, EnvVars, EnvironmentBag},
+        discovery::{run_provisioned_host_detectors, EnvironmentBag},
         environment::{CreateOpts, EnvironmentHandle},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
@@ -1040,23 +1040,13 @@ async fn probe_provisioned_environment(
     env_id: &EnvironmentId,
     handle: &EnvironmentHandle,
 ) -> Result<(EnvironmentBag, Arc<ProviderRegistry>), String> {
-    let env_vars = InteriorEnvVars { values: handle.env_vars().await? };
+    let env_vars = handle.env_vars().await?;
     let discovery = state.daemon.discovery_runtime();
-    let bag = run_host_detectors(&discovery.host_detectors, &*handle.runner(), &env_vars).await;
+    let bag = run_provisioned_host_detectors(&discovery.host_detectors, &*handle.runner(), &env_vars).await;
     let probe_root = ExecutionEnvironmentPath::new("/workspace");
     let config = ConfigStore::with_base(state.config.base_path().as_path().join(format!("env-discovery/{env_id}")));
     let registry = discovery.factories.probe_all(&bag, &config, &probe_root, handle.runner()).await;
     Ok((bag, Arc::new(registry)))
-}
-
-struct InteriorEnvVars {
-    values: HashMap<String, String>,
-}
-
-impl EnvVars for InteriorEnvVars {
-    fn get(&self, key: &str) -> Option<String> {
-        self.values.get(key).cloned()
-    }
 }
 
 struct CloneControllerRuntime {
@@ -1609,7 +1599,15 @@ mod test_git_repo;
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs, process::Command as ProcessCommand, sync::Arc};
+    use std::{
+        collections::HashMap,
+        fs,
+        process::Command as ProcessCommand,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
 
     use flotilla_core::{
         config::ConfigStore,
@@ -1623,7 +1621,7 @@ mod tests {
                 },
                 EnvironmentAssertion, EnvironmentBag,
             },
-            environment::{EnvironmentHandle, ProvisionedEnvironment, ProvisionedMount},
+            environment::{EnvironmentHandle, EnvironmentProvider, ProvisionedEnvironment, ProvisionedMount},
             CommandRunner, ProcessCommandRunner,
         },
     };
@@ -1650,6 +1648,7 @@ mod tests {
         image: ImageId,
         runner: Arc<dyn CommandRunner>,
         env_vars: HashMap<String, String>,
+        destroyed: Arc<AtomicBool>,
     }
 
     #[async_trait]
@@ -1683,7 +1682,30 @@ mod tests {
         }
 
         async fn destroy(&self) -> Result<(), String> {
+            self.destroyed.store(true, Ordering::SeqCst);
             Ok(())
+        }
+    }
+
+    struct TestInteriorEnvironmentProvider {
+        handle: Mutex<Option<EnvironmentHandle>>,
+    }
+
+    #[async_trait]
+    impl EnvironmentProvider for TestInteriorEnvironmentProvider {
+        async fn ensure_image(&self, spec: &flotilla_protocol::EnvironmentSpec, _repo_root: &Path) -> Result<ImageId, String> {
+            match &spec.image {
+                ImageSource::Registry(image) => Ok(ImageId::new(image.clone())),
+                ImageSource::Dockerfile { .. } => Err("test provider expects a registry image".to_string()),
+            }
+        }
+
+        async fn create(&self, _id: EnvironmentId, _image: &ImageId, _opts: CreateOpts) -> Result<EnvironmentHandle, String> {
+            self.handle.lock().await.take().ok_or_else(|| "test environment already created".to_string())
+        }
+
+        async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
+            Ok(Vec::new())
         }
     }
 
@@ -2190,6 +2212,7 @@ mod tests {
             image: ImageId::new("contained-image"),
             runner,
             env_vars: HashMap::from([("HOME".to_string(), "/home/crew".to_string())]),
+            destroyed: Arc::new(AtomicBool::new(false)),
         });
 
         let (bag, registry) = probe_provisioned_environment(&state, &env_id, &handle).await.expect("interior discovery should succeed");
@@ -2216,6 +2239,56 @@ mod tests {
         };
         let error = verify_declared_agent_adapters(&spec, &registry).expect_err("missing declared adapter should fail");
         assert_eq!(error, "image `contained-image` declares agent adapter `missing-adapter`, but interior discovery did not find it");
+    }
+
+    #[tokio::test]
+    async fn provisioned_environment_is_destroyed_when_declared_adapter_is_missing() {
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let mut discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
+        discovery.host_detectors = flotilla_core::providers::discovery::detectors::default_host_detectors();
+        let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        let destroyed = Arc::new(AtomicBool::new(false));
+        let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {
+            id: EnvironmentId::new("contained-rejected"),
+            image: ImageId::new("contained-image"),
+            runner: Arc::new(DiscoveryMockRunner::builder().build()),
+            env_vars: HashMap::from([("HOME".to_string(), "/home/crew".to_string())]),
+            destroyed: Arc::clone(&destroyed),
+        });
+        let mut local_registry = ProviderRegistry::new();
+        local_registry.environment_providers.insert(
+            "docker",
+            flotilla_core::providers::discovery::ProviderDescriptor::named(
+                flotilla_core::providers::discovery::ProviderCategory::EnvironmentProvider,
+                "docker",
+            ),
+            Arc::new(TestInteriorEnvironmentProvider { handle: Mutex::new(Some(handle)) }),
+        );
+        let state = Arc::new(ControllerRuntimeState::new(
+            daemon,
+            config,
+            Arc::new(local_registry),
+            Some(DaemonHostPath::new("/tmp/flotilla.sock")),
+            "host-test".to_string(),
+            None,
+            "host-direct-host-test".to_string(),
+        ));
+        let spec = flotilla_resources::DockerEnvironmentSpec {
+            host_ref: "host-test".to_string(),
+            image: "contained-image".to_string(),
+            declared_agent_adapters: BTreeSet::from(["codex".to_string()]),
+            mounts: Vec::new(),
+            env: BTreeMap::new(),
+        };
+
+        let error = DockerControllerRuntime { state }
+            .provision("contained-rejected", &spec)
+            .await
+            .expect_err("missing declared adapter should reject the environment");
+
+        assert_eq!(error, "image `contained-image` declares agent adapter `codex`, but interior discovery did not find it");
+        assert!(destroyed.load(Ordering::SeqCst), "rejected environment should be destroyed");
     }
 
     #[tokio::test]

--- a/crates/flotilla-resources/src/environment.rs
+++ b/crates/flotilla-resources/src/environment.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +24,9 @@ pub struct HostDirectEnvironmentSpec {
 pub struct DockerEnvironmentSpec {
     pub host_ref: String,
     pub image: String,
+    /// Agent adapters the placement policy expects discovery to find in the image.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub declared_agent_adapters: BTreeSet<String>,
     #[serde(default)]
     pub mounts: Vec<EnvironmentMount>,
     #[serde(default)]

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -104,6 +104,7 @@ async fn environment_and_checkout_specs_serialize_through_in_memory_backend() {
         docker: Some(DockerEnvironmentSpec {
             host_ref: "01HXYZ".to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
+            declared_agent_adapters: Default::default(),
             mounts: vec![EnvironmentMount {
                 source_path: "/Users/alice/dev/flotilla.fix-bug-123".to_string(),
                 target_path: "/workspace".to_string(),


### PR DESCRIPTION
Closes #1124

## Summary

- run the existing host detectors against each provisioned environment’s interior command runner and environment variables
- register agent adapters discovered inside the container for contained terminal sessions
- carry placement-policy adapter declarations into the environment and reject images whose discovered adapters do not match
- destroy containers rejected during discovery, verification, or registration

## Root cause

Provisioning previously copied interior environment variables into an `EnvironmentBag` but never ran host detectors against the interior runner. The resulting bag had no binary assertions, so adapter discovery could never register Codex or Claude Code. The policy’s declared adapters were also discarded before provisioning and could not be verified.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`