### PR TITLE
fix: normalize convoy project references

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3348,6 +3348,32 @@ fn required_admission_value<'a>(value: &'a str, field: &str) -> Result<&'a str, 
     }
 }
 
+fn resolve_project_ref(default_namespace: &str, value: &str) -> Result<(String, String), String> {
+    let value = required_admission_value(value, "project")?;
+    let address_value = value.strip_prefix(flotilla_protocol::view_address::SCHEME_PREFIX).unwrap_or(value);
+    if address_value.starts_with("project/") {
+        return match value.parse::<ViewAddress>() {
+            Ok(ViewAddress::Project { namespace, name }) => Ok((namespace, name)),
+            Ok(_) => unreachable!("project-prefixed addresses only parse as project views"),
+            Err(error) => Err(format!("invalid project reference {value}: {error}")),
+        };
+    }
+    match value.split('/').collect::<Vec<_>>().as_slice() {
+        [name] => Ok((default_namespace.to_string(), (*name).to_string())),
+        [namespace, name] if !namespace.is_empty() && !name.is_empty() => Ok(((*namespace).to_string(), (*name).to_string())),
+        _ => Err(format!("invalid project reference {value}: expected <name>, <namespace>/<name>, or project/<namespace>/<name>")),
+    }
+}
+
+fn project_not_ready_error(namespace: &str, project_ref: &str, error: ResourceError) -> String {
+    match error {
+        ResourceError::NotFound { name } => {
+            format!("project {namespace}/{project_ref} is not ready: resource not found: {name} (tried {namespace}/{project_ref})")
+        }
+        error => format!("project {project_ref} is not ready: {error}"),
+    }
+}
+
 fn workflow_has_in_crew_review(workflow: &WorkflowTemplateSpec) -> bool {
     workflow.vessels.iter().any(|vessel| {
         let agent_count = vessel.crew.iter().filter(|crew| matches!(crew.source, CrewSource::Agent { .. })).count();
@@ -3612,7 +3638,7 @@ impl InProcessDaemon {
             .definitions::<Project>(namespace)
             .get(project_ref)
             .await
-            .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
+            .map_err(|error| project_not_ready_error(namespace, project_ref, error))?;
         let repositories = self.snapshot_project_repositories(namespace, project_ref).await?;
         let mut seen_issue_selectors = HashSet::new();
         let mut issues = Vec::with_capacity(intent.issues.len());
@@ -3934,7 +3960,7 @@ impl InProcessDaemon {
             .definitions::<Project>(namespace)
             .get(project_ref)
             .await
-            .map_err(|error| format!("project {project_ref} is not ready: {error}"))?;
+            .map_err(|error| project_not_ready_error(namespace, project_ref, error))?;
         let repositories = self.resource_backend.clone().using::<Repository>(namespace);
         let mut unresolved = Vec::new();
         let mut snapshots = BTreeMap::<RepositoryKey, (String, RepositorySpec, Option<String>, BTreeSet<String>)>::new();
@@ -6273,10 +6299,20 @@ impl InProcessDaemon {
 
         if let flotilla_protocol::CommandAction::ConvoyStart { intent } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
-            let namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
+            let default_namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
+            let (namespace, project_ref) = match resolve_project_ref(&default_namespace, &intent.project_ref) {
+                Ok(resolved) => resolved,
+                Err(message) => {
+                    self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error { message });
+                    return Ok(id);
+                }
+            };
+            let mut intent = intent.as_ref().clone();
+            intent.namespace = Some(namespace.clone());
+            intent.project_ref = project_ref;
             let dispatching_principal_ref =
                 dispatching_principal_ref.clone().unwrap_or_else(|| PrincipalRef::implicit_for_namespace(&namespace));
-            let key = ConvoyStartKey::new(namespace, intent);
+            let key = ConvoyStartKey::new(namespace, &intent);
             if !self.pending_convoy_starts.lock().await.insert(key.clone()) {
                 self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error {
                     message: format!("convoy start for project {} is already in progress", intent.project_ref),
@@ -6285,7 +6321,7 @@ impl InProcessDaemon {
             }
             let task = ConvoyStartTask::builder()
                 .command_id(id)
-                .intent(intent.as_ref().clone())
+                .intent(intent)
                 .key(key.clone())
                 .dispatching_principal_ref(dispatching_principal_ref)
                 .build();

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2325,13 +2325,14 @@ impl InProcessDaemon {
         dispatching_principal_ref: Option<&PrincipalRef>,
     ) -> Result<flotilla_protocol::PreparedConvoyStart, String> {
         let namespace = self.provisioning_namespace().await;
-        let requested_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
+        let default_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
+        let (requested_namespace, intent) = normalize_convoy_start_intent(default_namespace, intent)?;
         if requested_namespace != namespace {
             return Err(format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"));
         }
         let fallback_principal = PrincipalRef::implicit_for_namespace(&namespace);
         let mut admission =
-            self.prepare_convoy_admission(&namespace, intent, dispatching_principal_ref.unwrap_or(&fallback_principal)).await?;
+            self.prepare_convoy_admission(&namespace, &intent, dispatching_principal_ref.unwrap_or(&fallback_principal)).await?;
         let workflow_value = serde_json::to_value(&admission.workflow).map_err(|error| error.to_string())?;
         let workflow_name = prepared_snapshot_name(&admission.name, "workflow", &workflow_value)?;
         admission.spec.workflow_ref.clone_from(&workflow_name);
@@ -3351,10 +3352,11 @@ fn required_admission_value<'a>(value: &'a str, field: &str) -> Result<&'a str, 
 fn resolve_project_ref(default_namespace: &str, value: &str) -> Result<(String, String), String> {
     let value = required_admission_value(value, "project")?;
     let address_value = value.strip_prefix(flotilla_protocol::view_address::SCHEME_PREFIX).unwrap_or(value);
-    if address_value.starts_with("project/") {
+    let has_scheme = address_value != value;
+    if has_scheme || (address_value.starts_with("project/") && address_value.split('/').count() != 2) {
         return match value.parse::<ViewAddress>() {
             Ok(ViewAddress::Project { namespace, name }) => Ok((namespace, name)),
-            Ok(_) => unreachable!("project-prefixed addresses only parse as project views"),
+            Ok(address) => Err(format!("invalid project reference {value}: expected a project address, got {}", address.kind_name())),
             Err(error) => Err(format!("invalid project reference {value}: {error}")),
         };
     }
@@ -3363,6 +3365,17 @@ fn resolve_project_ref(default_namespace: &str, value: &str) -> Result<(String, 
         [namespace, name] if !namespace.is_empty() && !name.is_empty() => Ok(((*namespace).to_string(), (*name).to_string())),
         _ => Err(format!("invalid project reference {value}: expected <name>, <namespace>/<name>, or project/<namespace>/<name>")),
     }
+}
+
+fn normalize_convoy_start_intent(
+    default_namespace: &str,
+    intent: &flotilla_protocol::ConvoyStartIntent,
+) -> Result<(String, flotilla_protocol::ConvoyStartIntent), String> {
+    let (namespace, project_ref) = resolve_project_ref(default_namespace, &intent.project_ref)?;
+    let mut intent = intent.clone();
+    intent.namespace = Some(namespace.clone());
+    intent.project_ref = project_ref;
+    Ok((namespace, intent))
 }
 
 fn project_not_ready_error(namespace: &str, project_ref: &str, error: ResourceError) -> String {
@@ -6300,16 +6313,13 @@ impl InProcessDaemon {
         if let flotilla_protocol::CommandAction::ConvoyStart { intent } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
             let default_namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
-            let (namespace, project_ref) = match resolve_project_ref(&default_namespace, &intent.project_ref) {
+            let (namespace, intent) = match normalize_convoy_start_intent(&default_namespace, intent) {
                 Ok(resolved) => resolved,
                 Err(message) => {
                     self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error { message });
                     return Ok(id);
                 }
             };
-            let mut intent = intent.as_ref().clone();
-            intent.namespace = Some(namespace.clone());
-            intent.project_ref = project_ref;
             let dispatching_principal_ref =
                 dispatching_principal_ref.clone().unwrap_or_else(|| PrincipalRef::implicit_for_namespace(&namespace));
             let key = ConvoyStartKey::new(namespace, &intent);

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -53,6 +53,12 @@ use crate::{
 
 const TEST_LOCAL_ATTACH_HOST: &str = "local";
 
+#[test]
+fn project_reference_distinguishes_project_namespace_from_full_address() {
+    assert_eq!(resolve_project_ref("flotilla", "project/widgets"), Ok(("project".into(), "widgets".into())));
+    assert_eq!(resolve_project_ref("flotilla", "project/project/widgets"), Ok(("project".into(), "widgets".into())));
+}
+
 fn overwrite_single_saved_repo_config(config_base: &Path, repo: &Path, body: String) {
     let store = ConfigStore::with_base(config_base);
     store.save_repo(&ExecutionEnvironmentPath::new(repo));

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1305,6 +1305,122 @@ async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
 }
 
 #[tokio::test]
+async fn convoy_start_accepts_project_list_identifier() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let daemon =
+        InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
+    let backend = daemon.resource_backend();
+    let repository = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    backend
+        .clone()
+        .using::<Repository>("flotilla")
+        .create(&InputMeta::builder().name(repository.key().to_string()).build(), &repository)
+        .await
+        .expect("repository create");
+    backend
+        .clone()
+        .using::<WorkflowTemplate>("flotilla")
+        .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &single_agent_contained_workflow_spec())
+        .await
+        .expect("workflow create");
+    create_test_contained_policy(&backend, "flotilla-test", BTreeSet::from(["codex".to_string()])).await;
+    backend
+        .clone()
+        .definitions::<Project>("flotilla")
+        .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
+            display_name: "Flotilla".into(),
+            default_workflow_ref: "single-agent-contained".into(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+        })
+        .await
+        .expect("project create");
+
+    let list_result = daemon
+        .execute_query(
+            Command { node_id: None, provisioning_target: None, context_repo: None, action: CommandAction::QueryProjectList {} },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("project list");
+    let CommandValue::ProjectList(projects) = list_result else {
+        panic!("expected project list, got {list_result:?}");
+    };
+    let listed = projects.projects.first().expect("listed project");
+    let project_identifiers = [format!("{}/{}", listed.namespace, listed.name), listed.address.human_label()];
+
+    let mut events = daemon.subscribe();
+    for (index, project_ref) in project_identifiers.into_iter().enumerate() {
+        let name = format!("listed-project-{index}");
+        let start_id = daemon
+            .execute(Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyStart {
+                    intent: Box::new(ConvoyStartIntent {
+                        namespace: None,
+                        project_ref,
+                        issues: Vec::new(),
+                        name: Some(name.clone()),
+                        branch: Some(format!("fix/{name}")),
+                        workflow_ref: None,
+                        inputs: Vec::new(),
+                        instruction: None,
+                        placement_policy: None,
+                        auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
+                    }),
+                },
+            })
+            .await
+            .expect("convoy start command accepted");
+
+        assert_eq!(recv_command_finished(&mut events, start_id).await, CommandValue::ConvoyStarted {
+            name: name.clone(),
+            attach_command: None,
+            binding: None
+        });
+        let convoy = backend.using::<ResourceConvoy>("flotilla").get(&name).await.expect("persisted convoy");
+        assert_eq!(convoy.spec.project_ref.as_deref(), Some("flotilla"));
+    }
+}
+
+#[tokio::test]
+async fn convoy_start_unknown_project_reports_resolved_reference_tried() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let daemon =
+        InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
+    let mut events = daemon.subscribe();
+
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "missing".into(),
+                    issues: Vec::new(),
+                    name: Some("unknown-project".into()),
+                    branch: Some("fix/unknown-project".into()),
+                    workflow_ref: None,
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
+                }),
+            },
+        })
+        .await
+        .expect("convoy start command accepted");
+
+    assert_eq!(recv_command_finished(&mut events, command_id).await, CommandValue::Error {
+        message: "project flotilla/missing is not ready: resource not found: missing (tried flotilla/missing)".into()
+    });
+}
+
+#[tokio::test]
 async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snapshot() {
     let reference =
         IssueRef { source: IssueSource { service: "https://github.com".into(), scope: "flotilla-org/planning".into() }, id: "732".into() };

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1092,7 +1092,7 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
         .action(CommandAction::ConvoyStart {
             intent: Box::new(
                 ConvoyStartIntent::builder()
-                    .project_ref("flotilla".to_string())
+                    .project_ref("flotilla/flotilla".to_string())
                     .name("remote-work".to_string())
                     .branch("feat/remote-work".to_string())
                     .placement_policy(remote_policy_name.clone())


### PR DESCRIPTION
## Summary

- normalize convoy start project references before admission
- accept both `namespace/name` and `project/namespace/name` identifiers printed by `flotilla project list`
- preserve the canonical bare project resource name in persisted convoy specs and deduplication keys
- report the resolved qualified lookup target when a project is unknown

## Root cause

Convoy admission passed the raw `--project` value directly to a namespace-scoped Project resolver. As a result, `flotilla/flotilla` was treated as a literal resource name inside the `flotilla` namespace instead of being split into namespace and name.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1129