### PR TITLE
fix: prune peer replicator supervisors after terminal disconnect

### DIFF
--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -55,6 +55,23 @@ pub(crate) struct PeerConnectedNotice {
     pub resource_socket_path: Option<PathBuf>,
 }
 
+/// Lifecycle event sent from connection sites to the outbound task.
+///
+/// `Connected` drives outbound state sync and starts resource replicators
+/// for the peer's generation. `Disconnected` is sent only from a
+/// connection-owning task that has no retry loop of its own (inbound
+/// `PeerConnection::run`, or the outbound per-target task's terminal
+/// shutdown branch) — never from a transient, still-retrying disconnect —
+/// so the outbound task can cancel and drop that peer's resource
+/// replicators. The generation is checked against the currently tracked
+/// generation before acting, so a stale/displaced connection's belated
+/// teardown can't cancel a newer, already-reconnected generation.
+#[cfg_attr(feature = "test-support", visibility::make(pub))]
+pub(crate) enum PeerConnectionEvent {
+    Connected(PeerConnectedNotice),
+    Disconnected { peer: NodeId, generation: u64 },
+}
+
 fn build_remote_command_router(daemon: &Arc<InProcessDaemon>, peer_manager: &Arc<Mutex<PeerManager>>) -> RemoteCommandRouter {
     let pending_remote_commands: PendingRemoteCommandMap = Arc::new(Mutex::new(HashMap::new()));
     let forwarded_commands: ForwardedCommandMap = Arc::new(Mutex::new(HashMap::new()));
@@ -142,12 +159,12 @@ pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &Con
 /// Test-only entry point: callers provide a PeerManager with pre-configured
 /// senders (e.g. CapturePeerSender). Passes `None` for `peer_data_rx` to skip
 /// the inbound connection task — tests drive the outbound task via the returned
-/// `PeerConnectedNotice` sender.
+/// `PeerConnectionEvent` sender.
 #[cfg(feature = "test-support")]
 pub fn spawn_test_peer_networking(
     daemon: Arc<InProcessDaemon>,
     peer_manager: Arc<Mutex<PeerManager>>,
-) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) {
+) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) {
     // Receiver dropped intentionally — None is passed for the inbound task,
     // so no messages are forwarded; the sender satisfies the runtime signature.
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(256);
@@ -155,7 +172,7 @@ pub fn spawn_test_peer_networking(
     spawn_peer_networking_runtime(
         daemon,
         peer_manager,
-        None, // No inbound task — test drives outbound via PeerConnectedNotice
+        None, // No inbound task — test drives outbound via PeerConnectionEvent
         peer_data_tx,
         remote_command_router,
         None,
@@ -408,7 +425,7 @@ fn spawn_peer_networking_runtime(
     peer_data_tx: mpsc::Sender<InboundPeerEnvelope>,
     remote_command_router: RemoteCommandRouter,
     resource_socket_dir: Option<PathBuf>,
-) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) {
+) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) {
     PeerRuntime::new(daemon, peer_manager, peer_data_rx, peer_data_tx, remote_command_router, resource_socket_dir).spawn()
 }
 
@@ -428,7 +445,7 @@ async fn handle_client(
     remote_command_router: RemoteCommandRouter,
     client_count: Arc<AtomicUsize>,
     client_notify: Arc<Notify>,
-    peer_connected_tx: mpsc::UnboundedSender<PeerConnectedNotice>,
+    peer_connected_tx: mpsc::UnboundedSender<PeerConnectionEvent>,
     agent_state_store: SharedAgentStateStore,
     environment_context: Option<EnvironmentId>,
 ) {
@@ -472,7 +489,7 @@ async fn handle_client_session(
     remote_command_router: RemoteCommandRouter,
     client_count: Arc<AtomicUsize>,
     client_notify: Arc<Notify>,
-    peer_connected_tx: mpsc::UnboundedSender<PeerConnectedNotice>,
+    peer_connected_tx: mpsc::UnboundedSender<PeerConnectionEvent>,
     agent_state_store: SharedAgentStateStore,
     environment_context: Option<EnvironmentId>,
 ) {

--- a/crates/flotilla-daemon/src/server/peer_connection.rs
+++ b/crates/flotilla-daemon/src/server/peer_connection.rs
@@ -11,7 +11,7 @@ use tracing::{error, info, warn};
 
 use super::{
     peer_runtime::disconnect_peer_and_rebuild, sync_peer_query_state, ConnectionDirection, ConnectionMeta, PeerConnectedNotice,
-    SocketPeerSender,
+    PeerConnectionEvent, SocketPeerSender,
 };
 use crate::peer::{ActivationResult, InboundPeerEnvelope, PeerManager};
 
@@ -20,7 +20,7 @@ pub(super) struct PeerConnection {
     shutdown_rx: watch::Receiver<bool>,
     peer_data_tx: mpsc::Sender<InboundPeerEnvelope>,
     peer_manager: Arc<Mutex<PeerManager>>,
-    peer_connected_tx: mpsc::UnboundedSender<PeerConnectedNotice>,
+    peer_connected_tx: mpsc::UnboundedSender<PeerConnectionEvent>,
     client_count: Arc<AtomicUsize>,
     client_notify: Arc<tokio::sync::Notify>,
 }
@@ -31,7 +31,7 @@ impl PeerConnection {
         shutdown_rx: watch::Receiver<bool>,
         peer_data_tx: mpsc::Sender<InboundPeerEnvelope>,
         peer_manager: Arc<Mutex<PeerManager>>,
-        peer_connected_tx: mpsc::UnboundedSender<PeerConnectedNotice>,
+        peer_connected_tx: mpsc::UnboundedSender<PeerConnectionEvent>,
         client_count: Arc<AtomicUsize>,
         client_notify: Arc<tokio::sync::Notify>,
     ) -> Self {
@@ -115,7 +115,11 @@ impl PeerConnection {
 
         sync_peer_query_state(&self.peer_manager, &self.daemon).await;
         self.daemon.publish_peer_connection_status(&peer_node, PeerConnectionState::Connected).await;
-        let _ = self.peer_connected_tx.send(PeerConnectedNotice { peer: node_id.clone(), generation, resource_socket_path: None });
+        let _ = self.peer_connected_tx.send(PeerConnectionEvent::Connected(PeerConnectedNotice {
+            peer: node_id.clone(),
+            generation,
+            resource_socket_path: None,
+        }));
 
         loop {
             tokio::select! {
@@ -158,6 +162,10 @@ impl PeerConnection {
         if plan.was_active {
             self.daemon.publish_peer_connection_status(&peer_node, PeerConnectionState::Disconnected).await;
         }
+        // Inbound connections never retry from this side — if the peer
+        // dials back in, it arrives as a fresh task with a fresh generation.
+        // So ending here is always a terminal teardown for this generation.
+        let _ = self.peer_connected_tx.send(PeerConnectionEvent::Disconnected { peer: node_id.clone(), generation });
         relay_task.abort();
         let count = self.client_count.fetch_sub(1, Ordering::SeqCst) - 1;
         info!(peer = %node_id, %count, "peer disconnected");

--- a/crates/flotilla-daemon/src/server/peer_runtime.rs
+++ b/crates/flotilla-daemon/src/server/peer_runtime.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info, warn};
 
 use super::{
     remote_commands::RemoteCommandRouter, replicator::PeerReplicatorSupervisors, shared::sync_peer_query_state, PeerConnectedNotice,
-    SshTransport,
+    PeerConnectionEvent, SshTransport,
 };
 use crate::peer::{dispatch_pending_sends, peer_resource_socket_path, HandleResult, InboundPeerEnvelope, PeerManager, PeerSender};
 
@@ -148,11 +148,11 @@ impl PeerRuntime {
         Self { daemon, peer_manager, peer_data_rx, peer_data_tx, remote_command_router, resource_socket_dir }
     }
 
-    pub(super) fn spawn(self) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) {
+    pub(super) fn spawn(self) -> (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) {
         let outbound_peer_manager = Arc::clone(&self.peer_manager);
         let peer_manager_task = Arc::clone(&self.peer_manager);
         let peer_data_tx_for_ssh = self.peer_data_tx.clone();
-        let (peer_connected_tx, peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+        let (peer_connected_tx, peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
         let peer_connected_tx_for_ssh = peer_connected_tx.clone();
         let peer_daemon = Arc::clone(&self.daemon);
         let remote_command_router_task = self.remote_command_router.clone();
@@ -197,11 +197,11 @@ impl PeerRuntime {
                             let mut inbound_rx = initial_connection.inbound_rx;
                             let generation = initial_connection.generation;
                             info!(peer = %peer_name, generation, "connected successfully");
-                            let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
+                            let _ = peer_connected_tx_clone.send(PeerConnectionEvent::Connected(PeerConnectedNotice {
                                 peer: peer_name.clone(),
                                 generation,
                                 resource_socket_path: resource_socket_path_for(resource_socket_dir.as_deref(), &target_label),
-                            });
+                            }));
                             last_known_session_id = {
                                 let pm_lock = pm.lock().await;
                                 pm_lock.peer_session_id(&peer_name)
@@ -216,7 +216,11 @@ impl PeerRuntime {
                                 ForwardResult::Disconnected
                             };
                             match forward_result {
-                                ForwardResult::Shutdown => return,
+                                ForwardResult::Shutdown => {
+                                    let _ = peer_connected_tx_clone
+                                        .send(PeerConnectionEvent::Disconnected { peer: peer_name.clone(), generation });
+                                    return;
+                                }
                                 ForwardResult::Disconnected => {
                                     info!(target = %target_label.0, peer = %peer_name, "SSH connection dropped, will reconnect");
                                 }
@@ -281,11 +285,11 @@ impl PeerRuntime {
                                             PeerConnectionState::Connected,
                                         )
                                         .await;
-                                    let _ = peer_connected_tx_clone.send(PeerConnectedNotice {
+                                    let _ = peer_connected_tx_clone.send(PeerConnectionEvent::Connected(PeerConnectedNotice {
                                         peer: peer_name.clone(),
                                         generation,
                                         resource_socket_path: resource_socket_path_for(resource_socket_dir.as_deref(), &target_label),
-                                    });
+                                    }));
                                     attempt = 1;
                                     let sender = {
                                         let pm_lock = pm.lock().await;
@@ -297,7 +301,11 @@ impl PeerRuntime {
                                         ForwardResult::Disconnected
                                     };
                                     match forward_result {
-                                        ForwardResult::Shutdown => return,
+                                        ForwardResult::Shutdown => {
+                                            let _ = peer_connected_tx_clone
+                                                .send(PeerConnectionEvent::Disconnected { peer: peer_name.clone(), generation });
+                                            return;
+                                        }
                                         ForwardResult::Disconnected => {
                                             info!(target = %target_label.0, peer = %peer_name, "SSH connection dropped, will reconnect");
                                         }
@@ -661,25 +669,32 @@ impl PeerRuntime {
 
             loop {
                 tokio::select! {
-                    notice = peer_connected_rx.recv() => {
-                        let Some(notice) = notice else { break };
-                        debug!(peer = %notice.peer, generation = notice.generation, "sending local state to newly connected peer");
-                        peer_replicators.peer_connected(
-                            outbound_remote_command_router.clone(),
-                            Arc::clone(&outbound_daemon),
-                            notice.peer.clone(),
-                            notice.generation,
-                            notice.resource_socket_path,
-                        ).await;
-                        send_local_to_peer(
-                            &outbound_daemon,
-                            &outbound_peer_manager,
-                            &node_id,
-                            &mut outbound_clock,
-                            &notice.peer,
-                            notice.generation,
-                        )
-                        .await;
+                    event = peer_connected_rx.recv() => {
+                        let Some(event) = event else { break };
+                        match event {
+                            PeerConnectionEvent::Connected(notice) => {
+                                debug!(peer = %notice.peer, generation = notice.generation, "sending local state to newly connected peer");
+                                peer_replicators.peer_connected(
+                                    outbound_remote_command_router.clone(),
+                                    Arc::clone(&outbound_daemon),
+                                    notice.peer.clone(),
+                                    notice.generation,
+                                    notice.resource_socket_path,
+                                ).await;
+                                send_local_to_peer(
+                                    &outbound_daemon,
+                                    &outbound_peer_manager,
+                                    &node_id,
+                                    &mut outbound_clock,
+                                    &notice.peer,
+                                    notice.generation,
+                                )
+                                .await;
+                            }
+                            PeerConnectionEvent::Disconnected { peer, generation } => {
+                                peer_replicators.peer_disconnected(&peer, generation);
+                            }
+                        }
                     }
                     event = event_rx.recv() => {
                         let repo_path = match event {

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -97,6 +97,27 @@ impl PeerReplicatorSupervisors {
         flotilla_resources::for_each_registered_resource!(spawn_kind, &daemon, &peer, generation, &transport, &cancellation)
     }
 
+    /// Cancel and drop a peer's resource replicators, but only if `generation`
+    /// still matches the generation currently tracked for that peer.
+    ///
+    /// Callers must only invoke this from a connection-owning task that has
+    /// no retry loop of its own (a terminal teardown), never from a
+    /// transient, still-retrying disconnect — otherwise replication could
+    /// not heal from a reconnect. The generation check guards against a
+    /// stale/displaced connection's belated teardown cancelling a newer,
+    /// already-reconnected generation's replicators.
+    pub(super) fn peer_disconnected(&mut self, peer: &NodeId, generation: u64) {
+        let is_current = self.generations.get(peer).is_some_and(|active| active.generation == generation);
+        if !is_current {
+            debug!(%peer, generation, "ignoring teardown for stale or already-superseded peer generation");
+            return;
+        }
+        if let Some(active) = self.generations.remove(peer) {
+            active.cancellation.cancel();
+            debug!(%peer, generation, "peer permanently disconnected; cancelled resource replicators");
+        }
+    }
+
     fn begin_generation(
         &mut self,
         peer: &NodeId,
@@ -861,5 +882,54 @@ mod tests {
             applications += 1;
         }
         assert_eq!(applications, 2, "a newer generation starts exactly one new application stream");
+    }
+
+    #[test]
+    fn permanent_disconnect_cancels_and_removes_the_current_generation() {
+        let peer = NodeId::new("peer");
+        let mut supervisors = PeerReplicatorSupervisors::default();
+        let (cancellation, _) = supervisors.begin_generation(&peer, 3, None).expect("start generation");
+        assert!(!cancellation.is_cancelled());
+
+        supervisors.peer_disconnected(&peer, 3);
+
+        assert!(cancellation.is_cancelled(), "terminal teardown of the current generation must cancel its replicators");
+        assert!(
+            supervisors.begin_generation(&peer, 3, None).is_some(),
+            "removing the entry lets a later reconnect at the same generation number start fresh, \
+             instead of being rejected as stale"
+        );
+    }
+
+    #[test]
+    fn stale_disconnect_notice_does_not_cancel_a_newer_generation() {
+        let peer = NodeId::new("peer");
+        let mut supervisors = PeerReplicatorSupervisors::default();
+        let (_old_cancellation, _) = supervisors.begin_generation(&peer, 1, None).expect("start old generation");
+        let (new_cancellation, _) = supervisors.begin_generation(&peer, 2, None).expect("start newer generation");
+
+        // A belated teardown notice for the superseded generation (e.g. the
+        // old connection's task finally winding down after being displaced)
+        // must not touch the newer, currently-active generation.
+        supervisors.peer_disconnected(&peer, 1);
+
+        assert!(!new_cancellation.is_cancelled(), "a stale-generation disconnect must not cancel the current generation's replicators");
+        assert!(
+            supervisors.begin_generation(&peer, 2, None).is_none(),
+            "the current generation's map entry must still be present after a stale disconnect notice"
+        );
+    }
+
+    #[test]
+    fn unknown_peer_disconnect_is_a_no_op() {
+        let peer = NodeId::new("peer");
+        let mut supervisors = PeerReplicatorSupervisors::default();
+
+        supervisors.peer_disconnected(&peer, 1);
+
+        assert!(
+            supervisors.begin_generation(&peer, 1, None).is_some(),
+            "disconnecting an untracked peer must not leave stray state behind"
+        );
     }
 }

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, watch, Mutex, Notify};
 use super::{build_remote_command_router, handle_client_session, spawn_peer_networking_runtime};
 use crate::{
     peer::{channel_transport::channel_transport_pair_with_nodes, PeerManager},
-    server::PeerConnectedNotice,
+    server::PeerConnectionEvent,
 };
 
 pub async fn apply_convoy_replica_feed(daemon: &InProcessDaemon, namespace: &str, name: &str, home: HostName) {
@@ -93,7 +93,7 @@ pub async fn spawn_in_memory_request_topology(
     let leader_remote_router = build_remote_command_router(&leader, &leader_peer_manager);
     let follower_remote_router = build_remote_command_router(&follower, &follower_peer_manager);
 
-    let (leader_runtime_handle, _leader_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) =
+    let (leader_runtime_handle, _leader_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) =
         spawn_peer_networking_runtime(
             Arc::clone(&leader),
             Arc::clone(&leader_peer_manager),
@@ -102,7 +102,7 @@ pub async fn spawn_in_memory_request_topology(
             leader_remote_router.clone(),
             None,
         );
-    let (follower_runtime_handle, _follower_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) =
+    let (follower_runtime_handle, _follower_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) =
         spawn_peer_networking_runtime(
             Arc::clone(&follower),
             Arc::clone(&follower_peer_manager),
@@ -183,7 +183,7 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
     let leader_remote_router = build_remote_command_router(&leader, &leader_peer_manager);
     let follower_remote_router = build_remote_command_router(&follower, &follower_peer_manager);
 
-    let (leader_runtime_handle, _leader_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) =
+    let (leader_runtime_handle, _leader_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) =
         spawn_peer_networking_runtime(
             Arc::clone(&leader),
             Arc::clone(&leader_peer_manager),
@@ -192,7 +192,7 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
             leader_remote_router.clone(),
             None,
         );
-    let (follower_runtime_handle, _follower_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectedNotice>) =
+    let (follower_runtime_handle, _follower_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) =
         spawn_peer_networking_runtime(
             Arc::clone(&follower),
             Arc::clone(&follower_peer_manager),
@@ -208,7 +208,7 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
     let leader_for_client = Arc::clone(&leader);
     let leader_peer_manager_for_client = Arc::clone(&leader_peer_manager);
     let leader_peer_data_tx_for_client = leader_peer_data_tx;
@@ -285,7 +285,7 @@ async fn spawn_topology_with_client(
     let client_notify = Arc::new(Notify::new());
     // The in-memory request topology only needs the sender side because readiness is polled from
     // each daemon's topology view below; peer-connected notices are intentionally ignored here.
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
     let leader_for_client = Arc::clone(&leader);
     let leader_peer_manager_for_client = Arc::clone(&leader_peer_manager);
     let leader_peer_data_tx_for_client = leader_peer_data_tx;

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -59,7 +59,7 @@ use super::{
     resource_http::serve_resource_http,
     shared::{sync_peer_query_state, write_message, SocketPeerSender},
     test_support::{apply_convoy_replica_feed, seed_trusted_remote_convoy_project},
-    DaemonServer, PeerConnectedNotice,
+    DaemonServer, PeerConnectionEvent,
 };
 
 #[tokio::test]
@@ -2910,7 +2910,7 @@ async fn handle_client_forwards_peer_data_and_registers_peer() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
 
     let (client_stream, server_stream) = tokio::net::UnixStream::pair().expect("pair");
 
@@ -3051,7 +3051,7 @@ async fn handle_client_streams_daemon_events_to_request_clients() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
 
     let (client_stream, server_stream) = tokio::net::UnixStream::pair().expect("pair");
     let daemon_for_task = Arc::clone(&daemon);
@@ -3133,7 +3133,7 @@ async fn handle_client_session_dispatches_request_messages() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
     let (client_session, server_session) = message_session_pair();
 
     let daemon_for_task = Arc::clone(&daemon);
@@ -3177,7 +3177,7 @@ async fn handle_client_session_streams_daemon_events_to_request_clients() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
     let (client_session, server_session) = message_session_pair();
 
     let daemon_for_task = Arc::clone(&daemon);
@@ -3246,7 +3246,7 @@ async fn handle_client_rejects_client_hello_with_version_mismatch() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
 
     let (client_stream, server_stream) = tokio::net::UnixStream::pair().expect("pair");
     let daemon_for_task = Arc::clone(&daemon);
@@ -3310,7 +3310,7 @@ async fn handle_client_session_filters_query_events_until_subscribed() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
     let (client_session, server_session) = message_session_pair();
 
     let daemon_for_task = Arc::clone(&daemon);
@@ -3749,7 +3749,7 @@ async fn handle_client_relays_outbound_peer_messages() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
 
     let (client_stream, server_stream) = tokio::net::UnixStream::pair().expect("pair");
 
@@ -3829,7 +3829,7 @@ async fn duplicate_inbound_peer_receives_goodbye_on_rejection() {
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectedNotice>();
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
 
     let (client_stream_a, server_stream_a) = tokio::net::UnixStream::pair().expect("pair a");
     let (client_stream_b, server_stream_b) = tokio::net::UnixStream::pair().expect("pair b");

--- a/crates/flotilla-daemon/tests/peer_connect_flow.rs
+++ b/crates/flotilla-daemon/tests/peer_connect_flow.rs
@@ -16,7 +16,7 @@ use flotilla_core::{
 };
 use flotilla_daemon::{
     peer::{test_support::ensure_test_connection_generation, PeerManager, PeerSender},
-    server::PeerConnectedNotice,
+    server::{PeerConnectedNotice, PeerConnectionEvent},
 };
 use flotilla_protocol::{GoodbyeReason, HostName, NodeId, PeerWireMessage, RepoSelector};
 use tokio::sync::{Mutex, Notify};
@@ -101,7 +101,9 @@ async fn peer_connect_triggers_local_state_send() {
 
     let (_handle, peer_connected_tx) = flotilla_daemon::server::spawn_test_peer_networking(Arc::clone(&daemon), Arc::clone(&peer_manager));
 
-    peer_connected_tx.send(PeerConnectedNotice { peer: node_b.clone(), generation, resource_socket_path: None }).expect("send notice");
+    peer_connected_tx
+        .send(PeerConnectionEvent::Connected(PeerConnectedNotice { peer: node_b.clone(), generation, resource_socket_path: None }))
+        .expect("send notice");
 
     wait_for_local_state(&sent, &notify, &node_a).await;
 
@@ -143,7 +145,7 @@ async fn peer_reconnect_resends_local_state() {
 
     // First connection
     peer_connected_tx
-        .send(PeerConnectedNotice { peer: node_b.clone(), generation: gen1, resource_socket_path: None })
+        .send(PeerConnectionEvent::Connected(PeerConnectedNotice { peer: node_b.clone(), generation: gen1, resource_socket_path: None }))
         .expect("send notice 1");
     wait_for_local_state(&sent, &notify, &node_a).await;
 
@@ -159,7 +161,7 @@ async fn peer_reconnect_resends_local_state() {
     };
 
     peer_connected_tx
-        .send(PeerConnectedNotice { peer: node_b.clone(), generation: gen2, resource_socket_path: None })
+        .send(PeerConnectionEvent::Connected(PeerConnectedNotice { peer: node_b.clone(), generation: gen2, resource_socket_path: None }))
         .expect("send notice 2");
     tokio::time::timeout(std::time::Duration::from_secs(5), async {
         loop {


### PR DESCRIPTION
## Summary

- add explicit peer connection lifecycle events so the outbound runtime can distinguish terminal teardown from reconnectable transport drops
- cancel and remove resource replicator supervisors only when the terminal event matches the currently tracked peer generation
- preserve same-generation reconnect healing and protect newer generations from stale teardown events
- cover terminal cancellation/removal, stale-generation teardown, unknown peers, and same-generation source refresh

## Root cause

`PeerReplicatorSupervisors` only retired a generation when a newer generation arrived. When a connection-owning task ended permanently, its cancellation token and supervisor map entry remained alive, leaving resource replication tasks retrying or parked indefinitely.

Transient SSH drops and keepalive failures are intentionally excluded from teardown because their owning task continues its reconnect loop.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Fixes #1014.