### PR TITLE
fix: support docker placement pull policies

### DIFF
--- a/.flotilla/placement-policy.crew-image.yaml
+++ b/.flotilla/placement-policy.crew-image.yaml
@@ -10,6 +10,7 @@ spec:
   docker_per_vessel:
     host_ref: d49f4c59-811f-44aa-a4ca-d4cac66cf2a3
     image: forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1
+    pull_policy: always
     agent_adapters:
       - claude-code
       - codex

--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        environment::{CreateOpts, EnvironmentProvider, ProvisionedMount, ProvisionedMountMode},
+        environment::{CreateOpts, EnvironmentProvider, ImagePullPolicy, ProvisionedMount, ProvisionedMountMode},
         terminal::TerminalPool,
         vcs::{CloneInspection, CloneProvisioner},
     },
@@ -47,6 +47,11 @@ impl DockerEnvironmentActuator {
             tokens: self.tokens.clone(),
             daemon_socket_path: self.daemon_socket_path.clone(),
             working_directory: None,
+            image_pull_policy: match spec.pull_policy {
+                flotilla_resources::DockerImagePullPolicy::Always => ImagePullPolicy::Always,
+                flotilla_resources::DockerImagePullPolicy::IfNotPresent => ImagePullPolicy::IfNotPresent,
+                flotilla_resources::DockerImagePullPolicy::Never => ImagePullPolicy::Never,
+            },
             provisioned_mounts: spec.mounts.iter().map(provisioned_mount).collect(),
         }
     }

--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        environment::{CreateOpts, EnvironmentProvider, ImagePullPolicy, ProvisionedMount, ProvisionedMountMode},
+        environment::{CreateOpts, EnvironmentProvider, ProvisionedMount, ProvisionedMountMode},
         terminal::TerminalPool,
         vcs::{CloneInspection, CloneProvisioner},
     },
@@ -47,11 +47,7 @@ impl DockerEnvironmentActuator {
             tokens: self.tokens.clone(),
             daemon_socket_path: self.daemon_socket_path.clone(),
             working_directory: None,
-            image_pull_policy: match spec.pull_policy {
-                flotilla_resources::DockerImagePullPolicy::Always => ImagePullPolicy::Always,
-                flotilla_resources::DockerImagePullPolicy::IfNotPresent => ImagePullPolicy::IfNotPresent,
-                flotilla_resources::DockerImagePullPolicy::Never => ImagePullPolicy::Never,
-            },
+            image_pull_policy: spec.pull_policy.into(),
             provisioned_mounts: spec.mounts.iter().map(provisioned_mount).collect(),
         }
     }

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -10,8 +10,8 @@ use flotilla_resources::{
         delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
     },
     repository_workspace_slugs, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
-    CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase,
-    EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
+    CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, Environment, EnvironmentMount, EnvironmentMountMode,
+    EnvironmentPhase, EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
     LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey,
     RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionIdentity,
     TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, CONVOY_LABEL, VESSEL_REF_LABEL,
@@ -73,6 +73,7 @@ enum PlacementStrategy {
         host_ref: String,
         pool: String,
         image: String,
+        pull_policy: DockerImagePullPolicy,
         env: BTreeMap<String, String>,
         mount_path: String,
         default_cwd: Option<String>,
@@ -81,6 +82,7 @@ enum PlacementStrategy {
         host_ref: String,
         pool: String,
         image: String,
+        pull_policy: DockerImagePullPolicy,
         env: BTreeMap<String, String>,
         clone_path: String,
         default_cwd: Option<String>,
@@ -251,7 +253,7 @@ impl Reconciler for VesselReconciler {
         };
 
         let precreated_environment_ref = match &strategy {
-            PlacementStrategy::DockerFreshCloneInContainer { host_ref, image, env, .. } => {
+            PlacementStrategy::DockerFreshCloneInContainer { host_ref, image, pull_policy, env, .. } => {
                 let env_name = environment_name(&obj.metadata.name);
                 match self.environments.get(&env_name).await {
                     Ok(existing) => {
@@ -276,6 +278,7 @@ impl Reconciler for VesselReconciler {
                                     host_ref: host_ref.clone(),
                                     image: image.clone(),
                                     declared_agent_adapters: declared_agent_adapters.clone(),
+                                    pull_policy: *pull_policy,
                                     mounts: Vec::new(),
                                     env: env.clone(),
                                 }),
@@ -527,7 +530,7 @@ impl Reconciler for VesselReconciler {
                 }
                 env_name
             }
-            PlacementStrategy::DockerWorktreeOnHostAndMount { host_ref, image, env, mount_path, .. } => {
+            PlacementStrategy::DockerWorktreeOnHostAndMount { host_ref, image, pull_policy, env, mount_path, .. } => {
                 let env_name = environment_name(&obj.metadata.name);
                 match self.environments.get(&env_name).await {
                     Ok(existing) => {
@@ -552,6 +555,7 @@ impl Reconciler for VesselReconciler {
                                     host_ref: host_ref.clone(),
                                     image: image.clone(),
                                     declared_agent_adapters: declared_agent_adapters.clone(),
+                                    pull_policy: *pull_policy,
                                     mounts: has_repositories
                                         .then(|| EnvironmentMount {
                                             source_path: workspace_root.clone(),
@@ -753,6 +757,7 @@ fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, S
                 host_ref: docker.host_ref.clone(),
                 pool: spec.pool.clone(),
                 image: docker.image.clone(),
+                pull_policy: docker.pull_policy,
                 env: docker.env.clone(),
                 mount_path: mount_path.clone(),
                 default_cwd: docker.default_cwd.clone(),
@@ -761,6 +766,7 @@ fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, S
                 host_ref: docker.host_ref.clone(),
                 pool: spec.pool.clone(),
                 image: docker.image.clone(),
+                pull_policy: docker.pull_policy,
                 env: docker.env.clone(),
                 clone_path: clone_path.clone(),
                 default_cwd: docker.default_cwd.clone(),

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -105,6 +105,7 @@ async fn environment_actuator_translates_mounts_into_provider_create_opts() {
         host_ref: "01HXYZ".to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
         declared_agent_adapters: Default::default(),
+        pull_policy: Default::default(),
         mounts: vec![EnvironmentMount {
             source_path: "/Users/alice/dev/flotilla".to_string(),
             target_path: "/workspace".to_string(),

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -4,13 +4,15 @@ use async_trait::async_trait;
 use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        environment::{CreateOpts, EnvironmentProvider, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode},
+        environment::{CreateOpts, EnvironmentProvider, ImagePullPolicy, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode},
         terminal::{TerminalEnvVars, TerminalPool, TerminalSession as PoolSession},
         vcs::CloneProvisioner,
     },
 };
 use flotilla_protocol::{EnvironmentId, ImageId};
-use flotilla_resources::{DockerEnvironmentSpec, EnvironmentMount, EnvironmentMountMode, FreshCloneCheckoutSpec, TerminalSessionSpec};
+use flotilla_resources::{
+    DockerEnvironmentSpec, DockerImagePullPolicy, EnvironmentMount, EnvironmentMountMode, FreshCloneCheckoutSpec, TerminalSessionSpec,
+};
 
 #[derive(Default)]
 struct FakeCloneProvisioner;
@@ -105,7 +107,7 @@ async fn environment_actuator_translates_mounts_into_provider_create_opts() {
         host_ref: "01HXYZ".to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
         declared_agent_adapters: Default::default(),
-        pull_policy: Default::default(),
+        pull_policy: DockerImagePullPolicy::Never,
         mounts: vec![EnvironmentMount {
             source_path: "/Users/alice/dev/flotilla".to_string(),
             target_path: "/workspace".to_string(),
@@ -117,6 +119,7 @@ async fn environment_actuator_translates_mounts_into_provider_create_opts() {
     let opts = actuator.build_create_opts(&spec);
 
     assert_eq!(opts.provisioned_mounts, vec![ProvisionedMount::new("/Users/alice/dev/flotilla", "/workspace", ProvisionedMountMode::Rw)]);
+    assert_eq!(opts.image_pull_policy, ImagePullPolicy::Never);
     assert_eq!(opts.tokens, vec![("GITHUB_TOKEN".to_string(), "secret".to_string())]);
 }
 

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -180,6 +180,7 @@ pub async fn create_docker_worktree_policy(backend: &ResourceBackend, namespace:
             .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                 host_ref: fixture.host_ref,
                 image: fixture.image,
+                pull_policy: Default::default(),
                 agent_adapters: Default::default(),
                 default_cwd: fixture.default_cwd,
                 env: Default::default(),

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -712,6 +712,7 @@ async fn create_ready_docker_env(backend: &ResourceBackend, name: &str) {
                 host_ref: HOST_REF.to_string(),
                 image: "ubuntu:24.04".to_string(),
                 declared_agent_adapters: Default::default(),
+                pull_policy: Default::default(),
                 mounts: Vec::new(),
                 env: BTreeMap::new(),
             }),

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -415,6 +415,7 @@ async fn environment_controller_marks_docker_environment_ready() {
                 host_ref: "01HXYZ".to_string(),
                 image: "ghcr.io/flotilla/dev:latest".to_string(),
                 declared_agent_adapters: Default::default(),
+                pull_policy: Default::default(),
                 mounts: vec![EnvironmentMount {
                     source_path: "/tmp/src".to_string(),
                     target_path: "/workspace".to_string(),

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -1186,7 +1186,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: HOST_REF.to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
-                pull_policy: Default::default(),
+            pull_policy: Default::default(),
             agent_adapters: Default::default(),
             default_cwd: Some("/app".to_string()),
             env: Default::default(),

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -15,7 +15,7 @@ use flotilla_resources::{
     controller::{Actuation, Reconciler},
     ensure_repository, interactive_single_workflow_spec, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec,
     Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec,
-    DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec,
+    DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta,
     IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend,
     ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
@@ -706,6 +706,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
             .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                 host_ref: HOST_REF.to_string(),
                 image: "ghcr.io/flotilla/dev:latest".to_string(),
+                pull_policy: Default::default(),
                 agent_adapters: Default::default(),
                 default_cwd: None,
                 env: Default::default(),
@@ -718,6 +719,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
         declared_agent_adapters: Default::default(),
+        pull_policy: Default::default(),
         mounts: Vec::new(),
         env: Default::default(),
     })
@@ -917,6 +919,7 @@ async fn contained_requirement_runs_in_contained_docker_placement() {
             .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                 host_ref: HOST_REF.to_string(),
                 image: "ghcr.io/flotilla/dev:latest".to_string(),
+                pull_policy: Default::default(),
                 agent_adapters: Default::default(),
                 default_cwd: None,
                 env: Default::default(),
@@ -930,6 +933,7 @@ async fn contained_requirement_runs_in_contained_docker_placement() {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
         declared_agent_adapters: Default::default(),
+        pull_policy: Default::default(),
         mounts: Vec::new(),
         env: Default::default(),
     })
@@ -980,6 +984,50 @@ async fn contained_requirement_runs_in_contained_docker_placement() {
             ..
         })
     ));
+}
+
+#[tokio::test]
+async fn contained_docker_placement_propagates_never_pull_policy_to_environment() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-local-image", "implement", REPO_URL, GIT_REF).await;
+    create_policy(
+        &backend,
+        NAMESPACE,
+        "policy-local-image",
+        PlacementPolicySpec::builder()
+            .pool("cleat".to_string())
+            .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
+                host_ref: HOST_REF.to_string(),
+                image: "flotilla-dev-env:latest".to_string(),
+                pull_policy: DockerImagePullPolicy::Never,
+                agent_adapters: Default::default(),
+                default_cwd: None,
+                env: Default::default(),
+                checkout: DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },
+            })
+            .build(),
+    )
+    .await;
+    let vessel =
+        create_workspace(&backend, NAMESPACE, "workspace-local-image", "convoy-local-image", "implement", "policy-local-image", REPO_URL)
+            .await;
+
+    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&vessel).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&vessel, &deps, Utc::now());
+
+    assert!(outcome.actuations.iter().any(|actuation| {
+        matches!(
+            actuation,
+            Actuation::CreateEnvironment { spec, .. }
+                if matches!(
+                    spec.docker.as_ref(),
+                    Some(docker)
+                        if docker.image == "flotilla-dev-env:latest"
+                            && docker.pull_policy == DockerImagePullPolicy::Never
+                )
+        )
+    }));
 }
 
 #[tokio::test]
@@ -1109,6 +1157,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: HOST_REF.to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
+            pull_policy: Default::default(),
             agent_adapters: BTreeSet::from(["codex".to_string()]),
             default_cwd: None,
             env: Default::default(),
@@ -1121,6 +1170,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
         declared_agent_adapters: BTreeSet::from(["codex".to_string()]),
+        pull_policy: Default::default(),
         mounts: vec![flotilla_resources::EnvironmentMount {
             source_path: "/Users/alice/dev/flotilla-repos/github-com-flotilla-org-flotilla.workspace-docker-worktree".to_string(),
             target_path: "/workspace".to_string(),
@@ -1136,6 +1186,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: HOST_REF.to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
+                pull_policy: Default::default(),
             agent_adapters: Default::default(),
             default_cwd: Some("/app".to_string()),
             env: Default::default(),
@@ -1148,6 +1199,7 @@ async fn docker_worktree_waits_for_checkout_before_creating_environment() {
         host_ref: HOST_REF.to_string(),
         image: "ghcr.io/flotilla/dev:latest".to_string(),
         declared_agent_adapters: Default::default(),
+        pull_policy: Default::default(),
         mounts: Vec::new(),
         env: Default::default(),
     }),

--- a/crates/flotilla-core/examples/environment_checkout.rs
+++ b/crates/flotilla-core/examples/environment_checkout.rs
@@ -63,6 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokens: vec![],
         daemon_socket_path: socket_path,
         working_directory: None,
+        image_pull_policy: Default::default(),
         provisioned_mounts: vec![flotilla_core::providers::environment::ProvisionedMount::new(
             reference_repo.as_path().to_path_buf(),
             "/ref/repo",

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -270,7 +270,13 @@ impl EnvironmentManager {
             .as_ref()
             .map(|repo| vec![ProvisionedMount::new(repo.as_path().to_path_buf(), PathBuf::from("/ref/repo"), ProvisionedMountMode::Ro)])
             .unwrap_or_default();
-        let opts = CreateOpts { tokens, daemon_socket_path: daemon_socket_path.clone(), working_directory: None, provisioned_mounts };
+        let opts = CreateOpts {
+            tokens,
+            daemon_socket_path: daemon_socket_path.clone(),
+            working_directory: None,
+            provisioned_mounts,
+            image_pull_policy: Default::default(),
+        };
         let handle = env_provider.create(env_id.clone(), &image, opts).await?;
         let (env_bag, provider_registry) = self.probe_provisioned_environment(&env_id, &handle, config_base).await?;
         self.register_provisioned_environment(env_id, handle, env_bag, Some(Arc::new(provider_registry)))

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -79,6 +79,8 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
         let mut args = vec![
             "run",
             "-d",
+            "--pull",
+            opts.image_pull_policy.docker_value(),
             "--name",
             &container_name,
             "--label",

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -25,6 +25,25 @@ pub struct CreateOpts {
     pub daemon_socket_path: DaemonHostPath,
     pub working_directory: Option<ExecutionEnvironmentPath>,
     pub provisioned_mounts: Vec<ProvisionedMount>,
+    pub image_pull_policy: ImagePullPolicy,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ImagePullPolicy {
+    Always,
+    #[default]
+    IfNotPresent,
+    Never,
+}
+
+impl ImagePullPolicy {
+    fn docker_value(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::IfNotPresent => "missing",
+            Self::Never => "never",
+        }
+    }
 }
 
 /// Structured metadata for a flotilla-managed bind mount inside a provisioned environment.

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -46,6 +46,16 @@ impl ImagePullPolicy {
     }
 }
 
+impl From<flotilla_resources::DockerImagePullPolicy> for ImagePullPolicy {
+    fn from(value: flotilla_resources::DockerImagePullPolicy) -> Self {
+        match value {
+            flotilla_resources::DockerImagePullPolicy::Always => Self::Always,
+            flotilla_resources::DockerImagePullPolicy::IfNotPresent => Self::IfNotPresent,
+            flotilla_resources::DockerImagePullPolicy::Never => Self::Never,
+        }
+    }
+}
+
 /// Structured metadata for a flotilla-managed bind mount inside a provisioned environment.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProvisionedMount {

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -8,9 +8,8 @@ use async_trait::async_trait;
 use flotilla_protocol::{DaemonHostPath, EnvironmentId, EnvironmentSpec, EnvironmentStatus, HostName, ImageSource};
 
 use super::{
-    docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, ProvisionedMount,
+    docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, ImagePullPolicy, ProvisionedMount,
     ProvisionedMountMode,
-    ImagePullPolicy,
 };
 use crate::providers::{ChannelLabel, CommandOutput, CommandRunner};
 

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -10,6 +10,7 @@ use flotilla_protocol::{DaemonHostPath, EnvironmentId, EnvironmentSpec, Environm
 use super::{
     docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, ProvisionedMount,
     ProvisionedMountMode,
+    ImagePullPolicy,
 };
 use crate::providers::{ChannelLabel, CommandOutput, CommandRunner};
 
@@ -255,6 +256,7 @@ async fn create_returns_handle() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     let id = EnvironmentId::new("test-env-1");
@@ -288,6 +290,34 @@ async fn create_returns_handle() {
 }
 
 #[tokio::test]
+async fn create_translates_image_pull_policy_to_docker_run() {
+    use flotilla_protocol::ImageId;
+
+    for (policy, docker_value) in
+        [(ImagePullPolicy::Always, "always"), (ImagePullPolicy::IfNotPresent, "missing"), (ImagePullPolicy::Never, "never")]
+    {
+        let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
+        let provider = DockerEnvironmentProvider::new(runner.clone());
+        let image = ImageId::new("flotilla-dev-env:latest");
+        let opts = CreateOpts {
+            tokens: Vec::new(),
+            daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+            working_directory: None,
+            provisioned_mounts: Vec::new(),
+            image_pull_policy: policy,
+        };
+
+        provider.create(EnvironmentId::new(docker_value), &image, opts).await.expect("image policy should create an environment");
+
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 1);
+        let (_, args, _) = &calls[0];
+        assert!(args.windows(2).any(|pair| pair == ["--pull", docker_value]));
+        assert!(!calls.iter().any(|(_, args, _)| args.first().is_some_and(|arg| arg == "pull")));
+    }
+}
+
+#[tokio::test]
 async fn create_preserves_reference_repo_mount_metadata() {
     use flotilla_protocol::ImageId;
 
@@ -300,6 +330,7 @@ async fn create_preserves_reference_repo_mount_metadata() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo", ProvisionedMountMode::Ro)],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     let id = EnvironmentId::new("test-env-metadata");
@@ -327,6 +358,7 @@ async fn create_uses_requested_mount_modes_in_docker_arguments() {
             ProvisionedMount::new("/host/workspace", "/workspace", ProvisionedMountMode::Rw),
             ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro),
         ],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     provider.create(EnvironmentId::new("test-env-mount-modes"), &image, opts).await.expect("create");
@@ -362,6 +394,7 @@ async fn list_preserves_reference_repo_mount_metadata() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     provider.create(EnvironmentId::new("test-env-list"), &image, opts).await.expect("create");
@@ -388,6 +421,7 @@ async fn list_fails_on_malformed_reference_repo_mount_metadata() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     provider.create(EnvironmentId::new("test-env-list-malformed"), &image, opts).await.expect("create");
@@ -408,6 +442,7 @@ async fn list_rejects_missing_reference_repo_mount_metadata() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     provider.create(EnvironmentId::new("test-env-list-missing"), &image, opts).await.expect("create");
@@ -428,6 +463,7 @@ async fn provisioned_handle_returns_its_initialized_runner() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     let handle = provider.create(EnvironmentId::new("test-env-runner"), &image, opts).await.expect("create");
@@ -451,6 +487,7 @@ async fn status_returns_running() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     let id = EnvironmentId::new("test-env-status");
@@ -480,6 +517,7 @@ async fn env_vars_parses_output() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     let id = EnvironmentId::new("test-env-vars");
@@ -511,6 +549,7 @@ async fn destroy_calls_docker_rm() {
         daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
         working_directory: None,
         provisioned_mounts: vec![],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
     };
 
     let id = EnvironmentId::new("test-env-destroy");

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -889,6 +889,7 @@ async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBack
                 .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                     host_ref: "host-test".into(),
                     image: image.into(),
+                    pull_policy: Default::default(),
                     agent_adapters,
                     default_cwd: Some("/workspace".into()),
                     env: Default::default(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -23,7 +23,7 @@ use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
         discovery::{run_provisioned_host_detectors, EnvironmentBag},
-        environment::{CreateOpts, EnvironmentHandle, ImagePullPolicy},
+        environment::{CreateOpts, EnvironmentHandle},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
         vcs::{CloneProvisioner, GitCloneProvisioner},
@@ -33,11 +33,11 @@ use flotilla_core::{
 use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, TerminalStatus};
 use flotilla_resources::{
     clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, Clone,
-    CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec, Demand, DockerCheckoutStrategy, DockerImagePullPolicy,
-    DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host, HostDirectEnvironmentSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy,
-    PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError, ResourceObject, Stance,
-    TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
+    CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec, Demand, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec,
+    Environment, EnvironmentSpec, ForgeIdentity, Host, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation,
+    Project, Regard, Repository, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement,
+    WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -977,11 +977,7 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
                 tokens: Vec::new(),
                 daemon_socket_path,
                 working_directory: None,
-                image_pull_policy: match spec.pull_policy {
-                    DockerImagePullPolicy::Always => ImagePullPolicy::Always,
-                    DockerImagePullPolicy::IfNotPresent => ImagePullPolicy::IfNotPresent,
-                    DockerImagePullPolicy::Never => ImagePullPolicy::Never,
-                },
+                image_pull_policy: spec.pull_policy.into(),
                 provisioned_mounts: spec.mounts.iter().map(flotilla_controllers::actuators::provisioned_mount).collect(),
             })
             .await?;
@@ -1631,7 +1627,7 @@ mod tests {
             CommandRunner, ProcessCommandRunner,
         },
     };
-    use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent, ImageId};
+    use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent, ImageId, ImageSource};
     use flotilla_resources::{
         Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
         CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
@@ -2240,6 +2236,7 @@ mod tests {
             host_ref: "host-test".to_string(),
             image: "contained-image".to_string(),
             declared_agent_adapters: BTreeSet::from(["codex".to_string(), "missing-adapter".to_string()]),
+            pull_policy: Default::default(),
             mounts: Vec::new(),
             env: BTreeMap::new(),
         };
@@ -2284,6 +2281,7 @@ mod tests {
             host_ref: "host-test".to_string(),
             image: "contained-image".to_string(),
             declared_agent_adapters: BTreeSet::from(["codex".to_string()]),
+            pull_policy: Default::default(),
             mounts: Vec::new(),
             env: BTreeMap::new(),
         };

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -23,21 +23,21 @@ use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
         discovery::{run_provisioned_host_detectors, EnvironmentBag},
-        environment::{CreateOpts, EnvironmentHandle},
+        environment::{CreateOpts, EnvironmentHandle, ImagePullPolicy},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
         vcs::{CloneProvisioner, GitCloneProvisioner},
         ChannelLabel, CommandRunner,
     },
 };
-use flotilla_protocol::{EnvironmentId, EnvironmentSpec as RuntimeEnvironmentSpec, HostSummary, ImageId, ImageSource, TerminalStatus};
+use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, TerminalStatus};
 use flotilla_resources::{
     clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, Clone,
-    CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec, Demand, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec,
-    Environment, EnvironmentSpec, ForgeIdentity, Host, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation,
-    Project, Regard, Repository, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement,
-    WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
+    CloneSpec, Convoy, ConvoyReconciler, CrewSource, CrewSpec, Demand, DockerCheckoutStrategy, DockerImagePullPolicy,
+    DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host, HostDirectEnvironmentSpec,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy,
+    PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError, ResourceObject, Stance,
+    TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -506,6 +506,7 @@ async fn ensure_default_policies(backend: &ResourceBackend, namespace: &str, pro
                         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
                             host_ref: profile.host_id.clone(),
                             image: DEFAULT_DOCKER_IMAGE.to_string(),
+                            pull_policy: Default::default(),
                             agent_adapters: BTreeSet::new(),
                             default_cwd: Some("/workspace".to_string()),
                             env: BTreeMap::new(),
@@ -969,14 +970,18 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             .or_else(|| self.state.local_registry.environment_providers.preferred_with_desc())
             .ok_or_else(|| "docker environment provider unavailable".to_string())?;
 
-        let runtime_spec = RuntimeEnvironmentSpec { image: ImageSource::Registry(spec.image.clone()), token_env_vars: Vec::new() };
-        let image = provider.ensure_image(&runtime_spec, Path::new("/")).await?;
+        let image = ImageId::new(spec.image.clone());
         let env_id = EnvironmentId::new(name.to_string());
         let handle = provider
-            .create(env_id.clone(), &ImageId::new(image.as_str().to_string()), CreateOpts {
+            .create(env_id.clone(), &image, CreateOpts {
                 tokens: Vec::new(),
                 daemon_socket_path,
                 working_directory: None,
+                image_pull_policy: match spec.pull_policy {
+                    DockerImagePullPolicy::Always => ImagePullPolicy::Always,
+                    DockerImagePullPolicy::IfNotPresent => ImagePullPolicy::IfNotPresent,
+                    DockerImagePullPolicy::Never => ImagePullPolicy::Never,
+                },
                 provisioned_mounts: spec.mounts.iter().map(flotilla_controllers::actuators::provisioned_mount).collect(),
             })
             .await?;

--- a/crates/flotilla-resources/src/environment.rs
+++ b/crates/flotilla-resources/src/environment.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch};
+use crate::{placement_policy::DockerImagePullPolicy, resource::define_resource, status_patch::StatusPatch};
 
 define_resource!(Environment, "environments", EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch);
 
@@ -27,6 +27,8 @@ pub struct DockerEnvironmentSpec {
     /// Agent adapters the placement policy expects discovery to find in the image.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub declared_agent_adapters: BTreeSet<String>,
+    #[serde(default)]
+    pub pull_policy: DockerImagePullPolicy,
     #[serde(default)]
     pub mounts: Vec<EnvironmentMount>,
     #[serde(default)]

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -57,8 +57,8 @@ pub use labels::{
     VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 pub use placement_policy::{
-    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,
-    PlacementPolicy, PlacementPolicySpec,
+    DockerCheckoutStrategy, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, PlacementPolicy, PlacementPolicySpec,
 };
 pub use prepared_snapshot::{
     PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PreparedSnapshotRecoveryResult, PLACEMENT_SNAPSHOT_KIND,

--- a/crates/flotilla-resources/src/placement_policy.rs
+++ b/crates/flotilla-resources/src/placement_policy.rs
@@ -31,6 +31,10 @@ pub enum HostDirectPlacementPolicyCheckout {
 pub struct DockerPerVesselPlacementPolicySpec {
     pub host_ref: String,
     pub image: String,
+    /// Controls registry access for the literal image tag. Image build recipes
+    /// are intentionally outside placement policy and are tracked separately.
+    #[serde(default)]
+    pub pull_policy: DockerImagePullPolicy,
     /// Agent adapters the image recipe promises will be available after provisioning.
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub agent_adapters: BTreeSet<String>,
@@ -39,6 +43,15 @@ pub struct DockerPerVesselPlacementPolicySpec {
     #[serde(default)]
     pub env: BTreeMap<String, String>,
     pub checkout: DockerCheckoutStrategy,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DockerImagePullPolicy {
+    #[default]
+    Always,
+    IfNotPresent,
+    Never,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -3,8 +3,8 @@ mod common;
 use chrono::Utc;
 use common::{owner_reference, resource_meta};
 use flotilla_resources::{
-    Checkout, CheckoutSpec, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerPerVesselPlacementPolicySpec, Environment,
-    EnvironmentMount, EnvironmentMountMode, EnvironmentSpec, FreshCloneCheckoutSpec, Host, HostDirectEnvironmentSpec,
+    Checkout, CheckoutSpec, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec,
+    Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentSpec, FreshCloneCheckoutSpec, Host, HostDirectEnvironmentSpec,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InMemoryBackend, PlacementPolicy, PlacementPolicySpec,
     ResourceBackend, Selector, TerminalBrief, TerminalCrewContext, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel,
     VesselPhase, VesselSpec, VesselStatus,
@@ -105,6 +105,7 @@ async fn environment_and_checkout_specs_serialize_through_in_memory_backend() {
             host_ref: "01HXYZ".to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
             declared_agent_adapters: Default::default(),
+            pull_policy: Default::default(),
             mounts: vec![EnvironmentMount {
                 source_path: "/Users/alice/dev/flotilla.fix-bug-123".to_string(),
                 target_path: "/workspace".to_string(),
@@ -169,6 +170,7 @@ fn docker_per_vessel_policy_uses_vessel_spelling_in_serialized_resources() {
         .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
             host_ref: "01HXYZ".to_string(),
             image: "ghcr.io/flotilla/dev:latest".to_string(),
+            pull_policy: DockerImagePullPolicy::Never,
             agent_adapters: Default::default(),
             default_cwd: Some("/workspace".to_string()),
             env: [("FOO".to_string(), "bar".to_string())].into_iter().collect(),
@@ -183,6 +185,7 @@ fn docker_per_vessel_policy_uses_vessel_spelling_in_serialized_resources() {
             "docker_per_vessel": {
                 "host_ref": "01HXYZ",
                 "image": "ghcr.io/flotilla/dev:latest",
+                "pull_policy": "never",
                 "default_cwd": "/workspace",
                 "env": {"FOO": "bar"},
                 "checkout": {"fresh_clone_in_container": {"clone_path": "/workspace"}}

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -74,3 +74,11 @@ flotilla resource get \
 The host reference is an identity assigned by Flotilla. If kiwi is
 re-registered as a new host, update `host_ref`, reapply the manifest, and
 commit that change.
+
+`docker_per_vessel.image` remains a literal Docker image tag. Its
+`pull_policy` accepts `always` (the default), `if_not_present`, or `never`.
+Use `if_not_present` to prefer a locally-built image while retaining registry
+fallback, or `never` when the image must already exist on the placement host.
+This policy does not resolve or build the image recipe in
+`.flotilla/environment.yaml`; connecting placement tags to image recipes is a
+separate design concern.


### PR DESCRIPTION
## Summary
- add `always`, `if_not_present`, and `never` pull policies to Docker-per-vessel placements
- propagate the policy through generated Environment resources and use Docker `run --pull` semantics
- document that placement images remain literal tags while the recipe seam stays separate

## Verification
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1087