### PR TITLE
chore: split fleet target cache policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,10 @@ jobs:
         with:
           toolchain: nightly-2026-03-12
           components: rustfmt
-      - name: Test target pruning policy
-        run: scripts/test-prune-target.sh
+      - name: Test target cache policies
+        run: |
+          scripts/test-prune-target.sh
+          scripts/test-cargo-sweep-mtime.sh
       - name: Check Rust formatting
         run: cargo +nightly-2026-03-12 fmt --check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,14 @@ cargo test --workspace --locked                # CI test gate
 cargo +nightly-2026-03-12 fmt                  # apply pinned formatting
 cargo dylint --all -- --all-targets             # custom lints (requires cargo-dylint + dylint-link)
 cargo run                                      # run, auto-detect repo from cwd
-scripts/prune-target.sh --dry-run              # preview per-checkout target cache pruning
-scripts/prune-target.sh                        # prune aged/oversized target artifacts
+scripts/prune-target.sh --dry-run              # preview the per-checkout target size-cap backstop
+scripts/prune-target.sh                        # apply the per-checkout target size-cap backstop
+scripts/install-cargo-sweep-schedule.sh        # install/verify the daily per-host mtime sweep
 ```
 
 Before pushing, run the exact CI commands: `cargo +nightly-2026-03-12 fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked`.
 
-Developer incrementals stay enabled, with aged generations pruned under the target cache policy. See [docs/development.md](docs/development.md) for setup, thresholds, measurement, and the CI decision.
+Desk builds keep Cargo incrementals enabled. Crew vessel and CI builds set `CARGO_INCREMENTAL=0`. Each fleet host runs an mtime-based `cargo-sweep --time 3` daily, while `scripts/prune-target.sh` remains a size-cap backstop. See [docs/development.md](docs/development.md) for installation, scope, logs, and thresholds.
 
 **Nightly toolchain:** All nightly-dependent tools (rustfmt, llvm-cov, Dylint) are pinned to `nightly-2026-03-12`. Install with `rustup toolchain install nightly-2026-03-12 --component rustfmt llvm-tools-preview`.
 

--- a/config/launchd/org.flotilla.cargo-sweep-mtime.plist
+++ b/config/launchd/org.flotilla.cargo-sweep-mtime.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>org.flotilla.cargo-sweep-mtime</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>exec "$HOME/.local/libexec/flotilla/cargo-sweep-mtime.sh"</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>

--- a/config/systemd/user/flotilla-cargo-sweep-mtime.service
+++ b/config/systemd/user/flotilla-cargo-sweep-mtime.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Flotilla mtime-based Cargo artifact sweep
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/libexec/flotilla/cargo-sweep-mtime.sh

--- a/config/systemd/user/flotilla-cargo-sweep-mtime.timer
+++ b/config/systemd/user/flotilla-cargo-sweep-mtime.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Flotilla mtime-based Cargo artifact sweep daily
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=30m
+Unit=flotilla-cargo-sweep-mtime.service
+
+[Install]
+WantedBy=timers.target

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1290,7 +1290,7 @@ impl TerminalRuntime for TerminalControllerRuntime {
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", spec.pool, spec.env_ref))?;
 
         let cwd = ExecutionEnvironmentPath::new(&spec.cwd);
-        let (command, env, crew, initial_message) = match &spec.source {
+        let (command, mut env, crew, initial_message) = match &spec.source {
             TerminalSessionSource::Tool { command } => (command.clone(), Vec::new(), None, None),
             TerminalSessionSource::Agent { selector, brief, context, message } => {
                 let requirement = CapabilityTable::seeded().resolve(&selector.capability)?.clone();
@@ -1329,6 +1329,7 @@ impl TerminalRuntime for TerminalControllerRuntime {
                 (plan.command, env, Some(crew), message.clone())
             }
         };
+        env.push(("CARGO_INCREMENTAL".to_string(), "0".to_string()));
 
         if matches!(spec.source, TerminalSessionSource::Agent { .. })
             && pool.list_sessions().await?.iter().any(|session| session.session_name == name)
@@ -2979,6 +2980,9 @@ mod tests {
         assert!(coder_launch.command.contains("--dangerously-bypass-approvals-and-sandbox"));
         assert!(!coder_launch.command.contains("without leaking this full brief"));
         assert!(coder_launch.env_vars.iter().any(|(key, value)| key == "FLOTILLA_CREW_ID" && value == &coder_id));
+        assert!(coder_launch.env_vars.iter().any(|(key, value)| key == "CARGO_INCREMENTAL" && value == "0"));
+        let watcher_launch = ensured.iter().find(|launch| launch.session_name.ends_with("-watcher")).expect("watcher launch");
+        assert!(watcher_launch.env_vars.iter().any(|(key, value)| key == "CARGO_INCREMENTAL" && value == "0"));
         drop(ensured);
 
         let crew_context = CrewCommandContext { crew_id: Some(coder_id.clone()), ..Default::default() };

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,47 +2,81 @@
 
 ## Cargo target cache policy
 
-A checkout's `target/` is managed cache state. Developer builds keep Cargo's incremental compilation enabled because it materially shortens the edit-build loop, but old generations and dependency artifacts must not accumulate indefinitely.
+A checkout's `target/` is managed cache state. The fleet uses two complementary controls: a daily, per-host mtime-based sweep for old Cargo artifact families and a per-checkout size-cap backstop for unusually large targets.
 
-Install the pruning tool once:
+### Daily mtime-based sweep
+
+Install and immediately verify the schedule on each fleet host from a Flotilla checkout:
 
 ```bash
-cargo install cargo-sweep --version 0.8.0 --locked
+scripts/install-cargo-sweep-schedule.sh
 ```
 
-Preview the per-checkout policy, then apply it when no build or test is running:
+The installer pins `cargo-sweep` 0.8.0 when the command is absent, copies the runner to `~/.local/libexec/flotilla/`, installs a systemd user timer on Linux or the checked-in launchd agent on macOS, enables the daily schedule, and starts one observed run. The installed policy runs `cargo-sweep --time 3` once a day. This is an mtime-based three-day retention policy.
+
+Each run sweeps:
+
+- every immediate directory under `~/dev/` that has its own `target/`; and
+- every checkout with a `target/` beneath `~/dev/flotilla-repos`, covering that convoy root until lifecycle teardown owns checkout removal under #1113.
+
+The runner records reclaimed bytes for every root and the whole run in:
+
+```text
+~/.local/state/flotilla/cargo-sweep-mtime.log
+```
+
+Inspect the scheduler and the most recent result with:
+
+```bash
+# Linux
+systemctl --user status flotilla-cargo-sweep-mtime.timer
+systemctl --user status flotilla-cargo-sweep-mtime.service
+tail -n 50 ~/.local/state/flotilla/cargo-sweep-mtime.log
+
+# macOS
+launchctl print "gui/$UID/org.flotilla.cargo-sweep-mtime"
+tail -n 50 ~/.local/state/flotilla/cargo-sweep-mtime.log
+```
+
+An identity-based artifact policy remains a candidate for future evaluation; it is not part of the installed policy.
+
+### Incremental compilation split
+
+Interactive desk builds keep Cargo's incremental compilation enabled because it materially shortens the edit-build loop. Crew vessel provisioning exports `CARGO_INCREMENTAL=0`, so short-lived crew builds do not mint incremental generations. GitHub Actions also sets `CARGO_INCREMENTAL=0` for the same short-lived-build reason.
+
+To confirm the setting in a dispatched crew vessel, build once and check both the environment and target:
+
+```bash
+test "$CARGO_INCREMENTAL" = 0
+cargo check --locked
+test -z "$(find target -path '*/incremental/*' -print -quit)"
+```
+
+Current Cargo may create the empty `target/debug/incremental/` container even when incremental compilation is disabled; the verification checks that it contains no generated state.
+
+### Size-cap backstop
+
+The daily host sweep owns age-based removal. `scripts/prune-target.sh` only caps a single checkout when its target grows unusually large: it removes the oldest incremental generations until their total is at most 10 GiB, then asks `cargo-sweep` to reduce the complete target to at most 20 GiB.
+
+Preview the size decisions, then apply them when no build or test is running:
 
 ```bash
 scripts/prune-target.sh --dry-run
 scripts/prune-target.sh
 ```
 
-Preview mode runs the complete policy against a temporary hard-linked copy beside the target directory. This lets later size decisions observe the earlier simulated removals without changing the real target; the temporary copy is removed before the command exits.
+Preview mode runs the complete size-cap policy against a temporary hard-linked copy beside the target directory. This lets the complete-target decision observe the simulated incremental removals without changing the real target; the temporary copy is removed before the command exits.
 
-The command removes incremental generations and other Cargo artifact families unused for 30 days. It then removes the oldest remaining generations until incremental state is at most 10 GiB, and asks `cargo-sweep` to reduce the complete target to at most 20 GiB by discarding stale dependency/fingerprint companions. Recent compiler products are retained whenever they fit within the ceilings, so ordinary developer builds remain warm.
-
-Both thresholds can be overridden for an exceptional checkout:
+Both ceilings can be overridden for an exceptional checkout:
 
 ```bash
-FLOTILLA_TARGET_GC_DAYS=14 \
-  FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE=15GiB \
-  FLOTILLA_TARGET_GC_MAX_SIZE=30GiB \
+FLOTILLA_TARGET_INCREMENTAL_MAX_SIZE=15GiB \
+  FLOTILLA_TARGET_MAX_SIZE=30GiB \
   scripts/prune-target.sh
 ```
 
-Run the command in each long-lived checkout. With Cargo's default configuration it acts only on that checkout's `target/` and does not traverse sibling worktrees or shared development roots. When `CARGO_TARGET_DIR` is set, the command intentionally honors it; unset or redirect a shared target before pruning if other checkouts still use that cache. Relative values are anchored to this checkout's root, so use an absolute value if Cargo is normally invoked elsewhere.
+With Cargo's default configuration the script acts only on that checkout's `target/`. When `CARGO_TARGET_DIR` is set, the command intentionally honors it. Relative values are anchored to this checkout's root, so use an absolute value if Cargo is normally invoked elsewhere.
 
-### CI decision
+### CI cache decision
 
-GitHub Actions keeps target caches because compiled dependencies are expensive and reusable across runs with the same lockfile. Compiler incremental state is disabled in CI with `CARGO_INCREMENTAL=0`: clippy, tests, coverage, and Dylint run in short-lived checkouts, so uploading their incremental generations costs cache time and storage without a dependable later edit-build loop to amortize it. Cache keys were rotated when this policy was introduced, and every target-caching job removes restored incremental directories before the cache post-action saves a new entry; old generations are therefore neither restored through the new key prefixes nor re-uploaded.
-
-### Validation measurement
-
-The policy was validated on 2026-07-23 against a clone-on-write copy of a real, long-lived Flotilla target in a scratch checkout. The copy isolated the measurement from active developer work and exercised the same inode-heavy copy shape as a warm hull. Its source target occupied 50 GiB; splitting hard-linked artifact identities into cloned files made the scratch copy's initial `du` total 68 GiB.
-
-| State | Total target | `debug/incremental` | `debug/deps` | Files |
-|---|---:|---:|---:|---:|
-| Before | 68 GiB | 28 GiB | 38 GiB | 180,542 |
-| After `scripts/prune-target.sh` | 20 GiB | 9.9 GiB | 9.2 GiB | 52,150 |
-
-The run took 131.59 seconds and removed 362 of 539 incremental generation directories before pruning stale dependency families. It reclaimed 48 GiB and reduced file count by 71%, while retaining the newest 177 incremental generations.
+GitHub Actions keeps target caches because compiled dependencies are expensive and reusable across runs with the same lockfile. Compiler incremental state is disabled with `CARGO_INCREMENTAL=0`; every target-caching job removes restored incremental directories before the cache post-action saves a new entry, so incremental generations are neither restored nor re-uploaded.

--- a/scripts/cargo-sweep-mtime.sh
+++ b/scripts/cargo-sweep-mtime.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Daily per-host mtime-based Cargo artifact sweep. cargo-sweep decides which
+# artifact families are older than the configured three-day threshold.
+
+set -euo pipefail
+
+readonly retention_days=3
+state_dir=${XDG_STATE_HOME:-"$HOME/.local/state"}/flotilla
+log_file=${FLOTILLA_SWEEP_LOG:-"$state_dir/cargo-sweep-mtime.log"}
+lock_dir=$state_dir/cargo-sweep-mtime.lock
+
+mkdir -p "$state_dir"
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  printf '%s mtime-based cargo sweep skipped: another run holds %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$lock_dir" >> "$log_file"
+  exit 0
+fi
+trap 'rmdir "$lock_dir"' EXIT
+
+if [[ -x $HOME/.cargo/bin/cargo-sweep ]]; then
+  cargo_sweep=$HOME/.cargo/bin/cargo-sweep
+elif command -v cargo-sweep >/dev/null 2>&1; then
+  cargo_sweep=$(command -v cargo-sweep)
+else
+  printf '%s mtime-based cargo sweep failed: cargo-sweep is not installed\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" >> "$log_file"
+  exit 1
+fi
+
+size_kib() {
+  du -sk "$1" 2>/dev/null | awk '{ print $1 }'
+}
+
+contains_root() {
+  local candidate=$1
+  local root
+
+  for root in "${sweep_roots[@]}"; do
+    [[ $root == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+sweep_roots=()
+if [[ -d $HOME/dev ]]; then
+  for checkout in "$HOME"/dev/*; do
+    [[ -d $checkout/target ]] || continue
+    sweep_roots+=("$checkout")
+  done
+fi
+
+convoy_root=$HOME/dev/flotilla-repos
+if [[ -d $convoy_root ]]; then
+  while IFS= read -r -d '' target_dir; do
+    checkout=${target_dir%/target}
+    if [[ -f $checkout/Cargo.toml ]] && ! contains_root "$checkout"; then
+      sweep_roots+=("$checkout")
+    fi
+  done < <(find "$convoy_root" -type d -name target -prune -print0)
+fi
+
+{
+  started_at=$(date '+%Y-%m-%dT%H:%M:%S%z')
+  total_reclaimed_bytes=0
+  failed_roots=0
+  echo "$started_at mtime-based cargo sweep started: retention_days=$retention_days roots=${#sweep_roots[@]}"
+
+  for root in "${sweep_roots[@]}"; do
+    before_kib=$(size_kib "$root")
+    if ! "$cargo_sweep" sweep --time "$retention_days" "$root"; then
+      failed_roots=$((failed_roots + 1))
+      echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root failed"
+    fi
+    after_kib=$(size_kib "$root")
+    reclaimed_kib=$((before_kib > after_kib ? before_kib - after_kib : 0))
+    reclaimed_bytes=$((reclaimed_kib * 1024))
+    total_reclaimed_bytes=$((total_reclaimed_bytes + reclaimed_bytes))
+    echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root reclaimed_bytes=$reclaimed_bytes"
+  done
+
+  echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep completed: reclaimed_bytes=$total_reclaimed_bytes failed_roots=$failed_roots"
+  (( failed_roots == 0 ))
+} >> "$log_file" 2>&1

--- a/scripts/cargo-sweep-mtime.sh
+++ b/scripts/cargo-sweep-mtime.sh
@@ -34,6 +34,9 @@ contains_root() {
   local candidate=$1
   local root
 
+  if (( ${#sweep_roots[@]} == 0 )); then
+    return 1
+  fi
   for root in "${sweep_roots[@]}"; do
     [[ $root == "$candidate" ]] && return 0
   done
@@ -64,18 +67,30 @@ fi
   failed_roots=0
   echo "$started_at mtime-based cargo sweep started: retention_days=$retention_days roots=${#sweep_roots[@]}"
 
-  for root in "${sweep_roots[@]}"; do
-    before_kib=$(size_kib "$root")
-    if ! "$cargo_sweep" sweep --time "$retention_days" "$root"; then
-      failed_roots=$((failed_roots + 1))
-      echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root failed"
-    fi
-    after_kib=$(size_kib "$root")
-    reclaimed_kib=$((before_kib > after_kib ? before_kib - after_kib : 0))
-    reclaimed_bytes=$((reclaimed_kib * 1024))
-    total_reclaimed_bytes=$((total_reclaimed_bytes + reclaimed_bytes))
-    echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root reclaimed_bytes=$reclaimed_bytes"
-  done
+  if (( ${#sweep_roots[@]} > 0 )); then
+    for root in "${sweep_roots[@]}"; do
+      if ! before_kib=$(size_kib "$root"); then
+        failed_roots=$((failed_roots + 1))
+        echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root failed: could not measure before sweep"
+        continue
+      fi
+      root_failed=0
+      if ! "$cargo_sweep" sweep --time "$retention_days" "$root"; then
+        root_failed=1
+        echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root failed"
+      fi
+      if ! after_kib=$(size_kib "$root"); then
+        root_failed=1
+        echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root failed: could not measure after sweep"
+      else
+        reclaimed_kib=$((before_kib > after_kib ? before_kib - after_kib : 0))
+        reclaimed_bytes=$((reclaimed_kib * 1024))
+        total_reclaimed_bytes=$((total_reclaimed_bytes + reclaimed_bytes))
+        echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep root=$root reclaimed_bytes=$reclaimed_bytes"
+      fi
+      failed_roots=$((failed_roots + root_failed))
+    done
+  fi
 
   echo "$(date '+%Y-%m-%dT%H:%M:%S%z') mtime-based cargo sweep completed: reclaimed_bytes=$total_reclaimed_bytes failed_roots=$failed_roots"
   (( failed_roots == 0 ))

--- a/scripts/install-cargo-sweep-schedule.sh
+++ b/scripts/install-cargo-sweep-schedule.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+libexec_dir=$HOME/.local/libexec/flotilla
+
+if [[ ! -x $HOME/.cargo/bin/cargo-sweep ]] && ! command -v cargo-sweep >/dev/null 2>&1; then
+  cargo install cargo-sweep --version 0.8.0 --locked
+fi
+
+install -d "$libexec_dir"
+install -m 0755 "$repo_root/scripts/cargo-sweep-mtime.sh" "$libexec_dir/cargo-sweep-mtime.sh"
+
+case $(uname -s) in
+  Linux)
+    unit_dir=${XDG_CONFIG_HOME:-"$HOME/.config"}/systemd/user
+    install -d "$unit_dir"
+    install -m 0644 "$repo_root/config/systemd/user/flotilla-cargo-sweep-mtime.service" "$unit_dir/"
+    install -m 0644 "$repo_root/config/systemd/user/flotilla-cargo-sweep-mtime.timer" "$unit_dir/"
+    systemctl --user daemon-reload
+    systemctl --user enable --now flotilla-cargo-sweep-mtime.timer
+    systemctl --user start flotilla-cargo-sweep-mtime.service
+    systemctl --user status --no-pager flotilla-cargo-sweep-mtime.timer
+    ;;
+  Darwin)
+    agent_dir=$HOME/Library/LaunchAgents
+    plist=$agent_dir/org.flotilla.cargo-sweep-mtime.plist
+    install -d "$agent_dir"
+    install -m 0644 "$repo_root/config/launchd/org.flotilla.cargo-sweep-mtime.plist" "$plist"
+    launchctl bootout "gui/$UID/org.flotilla.cargo-sweep-mtime" 2>/dev/null || true
+    launchctl bootstrap "gui/$UID" "$plist"
+    launchctl kickstart -k "gui/$UID/org.flotilla.cargo-sweep-mtime"
+    launchctl print "gui/$UID/org.flotilla.cargo-sweep-mtime"
+    ;;
+  *)
+    echo "Unsupported operating system: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+echo "Installed daily mtime-based cargo sweep. Inspect reclaimed bytes in:"
+echo "  ${XDG_STATE_HOME:-"$HOME/.local/state"}/flotilla/cargo-sweep-mtime.log"

--- a/scripts/prune-target.sh
+++ b/scripts/prune-target.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
+# Size-cap backstop for one checkout's Cargo target. The daily, per-host
+# cargo-sweep mtime job owns age-based pruning; this script only enforces size
+# ceilings when a target grows unusually large.
+
 set -euo pipefail
 
-readonly default_age_days=30
 readonly default_incremental_max_size=10GiB
 readonly default_max_size=20GiB
 
-age_days=${FLOTILLA_TARGET_GC_DAYS:-$default_age_days}
-incremental_max_size=${FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE:-$default_incremental_max_size}
-max_size=${FLOTILLA_TARGET_GC_MAX_SIZE:-$default_max_size}
+incremental_max_size=${FLOTILLA_TARGET_INCREMENTAL_MAX_SIZE:-$default_incremental_max_size}
+max_size=${FLOTILLA_TARGET_MAX_SIZE:-$default_max_size}
 mode=apply
 preview_target_dir=
 candidate_file=
@@ -16,11 +18,10 @@ candidate_file=
 usage() {
   echo "Usage: scripts/prune-target.sh [--dry-run]"
   echo
-  echo "Prune this checkout's Cargo target by age, then cap its size."
+  echo "Apply the size-cap backstop to this checkout's Cargo target."
   echo "Environment overrides:"
-  echo "  FLOTILLA_TARGET_GC_DAYS                  retention in days (default: $default_age_days)"
-  echo "  FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE  incremental ceiling (default: $default_incremental_max_size)"
-  echo "  FLOTILLA_TARGET_GC_MAX_SIZE              target ceiling (default: $default_max_size)"
+  echo "  FLOTILLA_TARGET_INCREMENTAL_MAX_SIZE  incremental ceiling (default: $default_incremental_max_size)"
+  echo "  FLOTILLA_TARGET_MAX_SIZE              target ceiling (default: $default_max_size)"
 }
 
 case ${1:-} in
@@ -42,11 +43,6 @@ esac
 
 if (( $# != 0 )); then
   usage >&2
-  exit 2
-fi
-
-if [[ ! $age_days =~ ^[0-9]+$ ]]; then
-  echo "FLOTILLA_TARGET_GC_DAYS must be a non-negative integer; got '$age_days'." >&2
   exit 2
 fi
 
@@ -104,11 +100,11 @@ size_to_kib() {
 }
 
 incremental_max_kib=$(size_to_kib "$incremental_max_size") || {
-  echo "FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE must use whole MiB or GiB units; got '$incremental_max_size'." >&2
+  echo "FLOTILLA_TARGET_INCREMENTAL_MAX_SIZE must use whole MiB or GiB units; got '$incremental_max_size'." >&2
   exit 2
 }
 size_to_kib "$max_size" >/dev/null || {
-  echo "FLOTILLA_TARGET_GC_MAX_SIZE must use whole MiB or GiB units; got '$max_size'." >&2
+  echo "FLOTILLA_TARGET_MAX_SIZE must use whole MiB or GiB units; got '$max_size'." >&2
   exit 2
 }
 
@@ -159,36 +155,10 @@ prepare_preview_target() {
 
   target_parent=$(dirname -- "$target_dir")
   target_name=$(basename -- "$target_dir")
-  preview_target_dir=$(mktemp -d "$target_parent/.${target_name}.flotilla-target-gc-preview.XXXXXX")
+  preview_target_dir=$(mktemp -d "$target_parent/.${target_name}.flotilla-target-cap-preview.XXXXXX")
   cp -a -l "$target_dir/." "$preview_target_dir/"
   target_dir=$preview_target_dir
   export CARGO_TARGET_DIR=$target_dir
-}
-
-prune_aged_incrementals() {
-  local count=0
-  local reclaimed_kib=0
-  local generation
-  local generation_kib
-
-  if [[ ! -d $target_dir ]]; then
-    return 0
-  fi
-
-  while IFS= read -r generation; do
-    generation_kib=$(size_kib "$generation")
-    rm -rf -- "$generation"
-    count=$((count + 1))
-    reclaimed_kib=$((reclaimed_kib + generation_kib))
-  done < <(find "$target_dir" -type d -path '*/incremental/*/s-*' -mtime +"$age_days" -prune -print)
-
-  if (( count > 0 )); then
-    if [[ $mode == preview ]]; then
-      echo "Would remove $count incremental generations older than $age_days days ($(format_kib "$reclaimed_kib"))"
-    else
-      echo "Removed $count incremental generations older than $age_days days ($(format_kib "$reclaimed_kib"))"
-    fi
-  fi
 }
 
 cap_incrementals() {
@@ -199,16 +169,12 @@ cap_incrementals() {
   local removed_count=0
   local removed_kib=0
 
-  if [[ ! -d $target_dir ]]; then
-    return 0
-  fi
-
   current_kib=$(incremental_size_kib)
   if (( current_kib <= incremental_max_kib )); then
     return
   fi
 
-  candidate_file=$(mktemp "${TMPDIR:-/tmp}/flotilla-target-gc.XXXXXX")
+  candidate_file=$(mktemp "${TMPDIR:-/tmp}/flotilla-target-cap.XXXXXX")
   while IFS= read -r generation; do
     mtime=$(generation_mtime "$generation")
     generation_kib=$(size_kib "$generation")
@@ -234,47 +200,31 @@ cap_incrementals() {
   fi
 }
 
-run_sweep() {
-  local description=$1
+cap_target() {
   local after_kib
   local before_kib
   local sweep_output
 
-  shift
   if [[ $mode == apply ]]; then
-    cargo sweep "$@"
+    cargo sweep --maxsize "$max_size" "$repo_root"
     return
   fi
 
   before_kib=$(size_kib "$target_dir")
-  if ! sweep_output=$(cargo sweep "$@" 2>&1); then
+  if ! sweep_output=$(cargo sweep --maxsize "$max_size" "$repo_root" 2>&1); then
     printf '%s\n' "$sweep_output" >&2
     return 1
   fi
   after_kib=$(size_kib "$target_dir")
 
   if (( before_kib > after_kib )); then
-    echo "Would remove $description ($(format_kib "$((before_kib - after_kib))"))"
+    echo "Would remove Cargo artifact families to reach $max_size ($(format_kib "$((before_kib - after_kib))"))"
   else
-    echo "Would remove no $description"
+    echo "Would remove no Cargo artifact families to reach $max_size"
   fi
 }
 
-prune_aged_other_artifacts() {
-  run_sweep "Cargo artifact families older than $age_days days" --time "$age_days" "$repo_root"
-}
-
-cap_target() {
-  run_sweep "Cargo artifact families to reach $max_size" --maxsize "$max_size" "$repo_root"
-}
-
 prepare_preview_target
-
-echo "Pruning incremental generations older than $age_days days in $display_target_dir"
-prune_aged_incrementals
-
-echo "Pruning other Cargo artifacts older than $age_days days in $repo_root"
-prune_aged_other_artifacts
 
 echo "Capping incremental generations at $incremental_max_size in $display_target_dir"
 cap_incrementals

--- a/scripts/test-cargo-sweep-mtime.sh
+++ b/scripts/test-cargo-sweep-mtime.sh
@@ -8,6 +8,8 @@ test_root=$(mktemp -d "${TMPDIR:-/tmp}/flotilla-mtime-sweep-test.XXXXXX")
 test_home=$test_root/home
 stub_log=$test_root/invocations.log
 sweep_log=$test_root/sweep.log
+empty_home=$test_root/empty-home
+empty_log=$test_root/empty-sweep.log
 
 cleanup() {
   rm -rf -- "$test_root"
@@ -37,5 +39,16 @@ grep -Fxq "sweep --time 3 $test_home/dev/flotilla-repos/convoy" "$stub_log"
 [[ $(wc -l < "$stub_log") == 2 ]]
 ! grep -Fq "$test_home/dev/no-target" "$stub_log"
 grep -Fq "mtime-based cargo sweep completed: reclaimed_bytes=2097152 failed_roots=0" "$sweep_log"
+
+mkdir -p "$empty_home/.cargo/bin"
+cp "$test_home/.cargo/bin/cargo-sweep" "$empty_home/.cargo/bin/"
+HOME="$empty_home" \
+  FLOTILLA_SWEEP_LOG="$empty_log" \
+  FLOTILLA_SWEEP_TEST_INVOCATIONS="$stub_log" \
+  "$repo_root/scripts/cargo-sweep-mtime.sh"
+
+[[ $(wc -l < "$stub_log") == 2 ]]
+grep -Fq "mtime-based cargo sweep started: retention_days=3 roots=0" "$empty_log"
+grep -Fq "mtime-based cargo sweep completed: reclaimed_bytes=0 failed_roots=0" "$empty_log"
 
 echo "mtime-based cargo sweep behavior tests passed"

--- a/scripts/test-cargo-sweep-mtime.sh
+++ b/scripts/test-cargo-sweep-mtime.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd -- "$script_dir/.." && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/flotilla-mtime-sweep-test.XXXXXX")
+test_home=$test_root/home
+stub_log=$test_root/invocations.log
+sweep_log=$test_root/sweep.log
+
+cleanup() {
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT
+
+mkdir -p "$test_home/.cargo/bin" "$test_home/dev/desk/target" "$test_home/dev/no-target" "$test_home/dev/flotilla-repos/convoy/target"
+: > "$test_home/dev/flotilla-repos/convoy/Cargo.toml"
+dd if=/dev/zero of="$test_home/dev/desk/target/stale" bs=1048576 count=1 >/dev/null 2>&1
+dd if=/dev/zero of="$test_home/dev/flotilla-repos/convoy/target/stale" bs=1048576 count=1 >/dev/null 2>&1
+
+cat > "$test_home/.cargo/bin/cargo-sweep" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FLOTILLA_SWEEP_TEST_INVOCATIONS"
+find "${@: -1}" -type f -name stale -delete
+STUB
+chmod +x "$test_home/.cargo/bin/cargo-sweep"
+
+HOME="$test_home" \
+  FLOTILLA_SWEEP_LOG="$sweep_log" \
+  FLOTILLA_SWEEP_TEST_INVOCATIONS="$stub_log" \
+  "$repo_root/scripts/cargo-sweep-mtime.sh"
+
+grep -Fxq "sweep --time 3 $test_home/dev/desk" "$stub_log"
+grep -Fxq "sweep --time 3 $test_home/dev/flotilla-repos/convoy" "$stub_log"
+[[ $(wc -l < "$stub_log") == 2 ]]
+! grep -Fq "$test_home/dev/no-target" "$stub_log"
+grep -Fq "mtime-based cargo sweep completed: reclaimed_bytes=2097152 failed_roots=0" "$sweep_log"
+
+echo "mtime-based cargo sweep behavior tests passed"

--- a/scripts/test-prune-target.sh
+++ b/scripts/test-prune-target.sh
@@ -4,15 +4,13 @@ set -euo pipefail
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd -- "$script_dir/.." && pwd)
-test_root=$(mktemp -d "${TMPDIR:-/tmp}/flotilla-target-gc-test.XXXXXX")
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/flotilla-target-cap-test.XXXXXX")
 target_dir=$test_root/target
 stub_bin=$test_root/bin
 stub_log=$test_root/cargo-sweep.log
-relative_log=$test_root/cargo-sweep-relative.log
 relative_target_dir=$test_root/relative-target
-relative_target_link_name=.flotilla-target-gc-relative-test.$$
+relative_target_link_name=.flotilla-target-cap-relative-test.$$
 relative_target_link=$repo_root/$relative_target_link_name
-stale_dependency=$target_dir/debug/deps/stale.rlib
 final_cap_dependency=$target_dir/debug/deps/final-old.rlib
 
 cleanup() {
@@ -21,7 +19,7 @@ cleanup() {
 }
 
 fail() {
-  echo "target GC test failed: $*" >&2
+  echo "target size-cap test failed: $*" >&2
   exit 1
 }
 
@@ -33,7 +31,6 @@ for generation in old middle new; do
   mkdir -p "$generation_dir"
   dd if=/dev/zero of="$generation_dir/artifact.o" bs=1048576 count=2 >/dev/null 2>&1
 done
-dd if=/dev/zero of="$stale_dependency" bs=1048576 count=2 >/dev/null 2>&1
 dd if=/dev/zero of="$final_cap_dependency" bs=1048576 count=2 >/dev/null 2>&1
 
 touch -t 202001010000 "$target_dir/debug/incremental/probe/s-old"
@@ -52,25 +49,18 @@ if [[ ${FLOTILLA_SWEEP_TEST_FAIL:-0} == 1 ]]; then
   exit 42
 fi
 
-if [[ " $* " == *" --time "* ]]; then
-  rm -f -- "$CARGO_TARGET_DIR/debug/deps/stale.rlib"
-  echo "selected stale.rlib" >> "$FLOTILLA_SWEEP_TEST_LOG"
-  echo "[INFO] Cleaned 2.00 MiB from \"$CARGO_TARGET_DIR\""
-else
-  rm -f -- "$CARGO_TARGET_DIR/debug/deps/final-old.rlib"
-  echo "selected final-old.rlib" >> "$FLOTILLA_SWEEP_TEST_LOG"
-  echo "[INFO] Cleaned 2.00 MiB from \"$CARGO_TARGET_DIR\""
-fi
+rm -f -- "$CARGO_TARGET_DIR/debug/deps/final-old.rlib"
+echo "[INFO] Cleaned 2.00 MiB from \"$CARGO_TARGET_DIR\""
 STUB
 chmod +x "$stub_bin/cargo-sweep"
 
-run_gc() {
+run_cap() {
   PATH="$stub_bin:$PATH" \
     CARGO_TARGET_DIR="$target_dir" \
     FLOTILLA_SWEEP_TEST_FAIL="${FLOTILLA_SWEEP_TEST_FAIL:-0}" \
     FLOTILLA_SWEEP_TEST_LOG="$stub_log" \
-    FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE=3MiB \
-    FLOTILLA_TARGET_GC_MAX_SIZE=100MiB \
+    FLOTILLA_TARGET_INCREMENTAL_MAX_SIZE=3MiB \
+    FLOTILLA_TARGET_MAX_SIZE=100MiB \
     "$repo_root/scripts/prune-target.sh" "$@"
 }
 
@@ -96,49 +86,41 @@ ln -s "$relative_target_dir" "$relative_target_link"
   cd "$test_root"
   PATH="$stub_bin:$PATH" \
     CARGO_TARGET_DIR="$relative_target_link_name" \
-    FLOTILLA_SWEEP_TEST_LOG="$relative_log" \
-    FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE=100MiB \
-    FLOTILLA_TARGET_GC_MAX_SIZE=100MiB \
+    FLOTILLA_SWEEP_TEST_LOG="$stub_log" \
+    FLOTILLA_TARGET_INCREMENTAL_MAX_SIZE=100MiB \
+    FLOTILLA_TARGET_MAX_SIZE=100MiB \
     "$repo_root/scripts/prune-target.sh" >/dev/null
 )
-grep -Fq "target=$canonical_relative_target_dir" "$relative_log" || fail "cargo-sweep did not receive the canonical relative target"
+grep -Fq "target=$canonical_relative_target_dir" "$stub_log" || fail "cargo-sweep did not receive the canonical relative target"
 
 if PATH="$stub_bin:$PATH" CARGO_TARGET_DIR=// "$repo_root/scripts/prune-target.sh" --dry-run >/dev/null 2>&1; then
   fail "root alias was accepted as the target directory"
 fi
 
-assert_invalid_config FLOTILLA_TARGET_GC_DAYS nope
-assert_invalid_config FLOTILLA_TARGET_GC_INCREMENTAL_MAX_SIZE 3GB
-assert_invalid_config FLOTILLA_TARGET_GC_MAX_SIZE 20GB
+assert_invalid_config FLOTILLA_TARGET_INCREMENTAL_MAX_SIZE 3GB
+assert_invalid_config FLOTILLA_TARGET_MAX_SIZE 20GB
 
-if FLOTILLA_SWEEP_TEST_FAIL=1 run_gc --dry-run >/dev/null 2>&1; then
+if FLOTILLA_SWEEP_TEST_FAIL=1 run_cap --dry-run >/dev/null 2>&1; then
   fail "preview ignored a cargo-sweep failure"
 fi
-[[ -z $(find "$test_root" -maxdepth 1 -type d -name '.target.flotilla-target-gc-preview.*' -print -quit) ]] || fail "failed preview clone was not cleaned up"
+[[ -z $(find "$test_root" -maxdepth 1 -type d -name '.target.flotilla-target-cap-preview.*' -print -quit) ]] || fail "failed preview clone was not cleaned up"
 
-preview_output=$(run_gc --dry-run)
+preview_output=$(run_cap --dry-run)
 
-[[ -d $target_dir/debug/incremental/probe/s-old ]] || fail "preview removed the aged generation"
-[[ -d $target_dir/debug/incremental/probe/s-middle ]] || fail "preview removed the size-cap generation"
-[[ -f $stale_dependency ]] || fail "preview removed the stale dependency"
+[[ -d $target_dir/debug/incremental/probe/s-old ]] || fail "preview removed an incremental generation"
+[[ -d $target_dir/debug/incremental/probe/s-middle ]] || fail "preview removed an incremental generation"
 [[ -f $final_cap_dependency ]] || fail "preview removed the final-cap dependency"
-grep -Fq "Would remove 1 incremental generations older" <<< "$preview_output" || fail "preview missed the aged generation"
-grep -Fq "Would remove 1 oldest incremental generations" <<< "$preview_output" || fail "preview double-counted the aged generation"
-grep -Fq "Would remove Cargo artifact families older than 30 days (2.0 MiB)" <<< "$preview_output" || fail "preview missed the stale dependency"
-grep -Fq "Would remove Cargo artifact families to reach 100MiB (2.0 MiB)" <<< "$preview_output" || fail "preview missed the final-cap dependency"
-[[ $(grep -Fc "selected stale.rlib" "$stub_log") == 1 ]] || fail "preview did not select the aged Cargo family once"
-[[ $(grep -Fc "selected final-old.rlib" "$stub_log") == 1 ]] || fail "preview did not select the final Cargo family once"
-! grep -Fq -- "--dry-run" "$stub_log" || fail "preview did not simulate the preceding removals"
-[[ -z $(find "$test_root" -maxdepth 1 -type d -name '.target.flotilla-target-gc-preview.*' -print -quit) ]] || fail "preview clone was not cleaned up"
+grep -Fq "Would remove 2 oldest incremental generations" <<< "$preview_output" || fail "preview missed the incremental size cap"
+grep -Fq "Would remove Cargo artifact families to reach 100MiB (2.0 MiB)" <<< "$preview_output" || fail "preview missed the target size cap"
+! grep -Fq -- "--time" "$stub_log" || fail "size-cap backstop invoked age-based cargo-sweep"
+[[ -z $(find "$test_root" -maxdepth 1 -type d -name '.target.flotilla-target-cap-preview.*' -print -quit) ]] || fail "preview clone was not cleaned up"
 
-run_gc >/dev/null
+run_cap >/dev/null
 
-[[ ! -e $target_dir/debug/incremental/probe/s-old ]] || fail "apply retained the aged generation"
-[[ ! -e $target_dir/debug/incremental/probe/s-middle ]] || fail "apply retained the oldest excess generation"
+[[ ! -e $target_dir/debug/incremental/probe/s-old ]] || fail "apply retained the oldest excess generation"
+[[ ! -e $target_dir/debug/incremental/probe/s-middle ]] || fail "apply retained the next excess generation"
 [[ -d $target_dir/debug/incremental/probe/s-new ]] || fail "apply removed the newest generation"
-[[ ! -e $stale_dependency ]] || fail "apply retained the stale dependency"
 [[ ! -e $final_cap_dependency ]] || fail "apply retained the final-cap dependency"
-[[ $(grep -Fc "selected stale.rlib" "$stub_log") == 2 ]] || fail "preview and apply selected different aged Cargo families"
-[[ $(grep -Fc "selected final-old.rlib" "$stub_log") == 2 ]] || fail "preview and apply selected different final Cargo families"
+! grep -Fq -- "--time" "$stub_log" || fail "size-cap backstop invoked age-based cargo-sweep"
 
-echo "target GC behavior tests passed"
+echo "target size-cap behavior tests passed"


### PR DESCRIPTION
Closes #1114

## Summary

- install a daily per-host, three-day mtime-based cargo-sweep schedule with systemd and launchd definitions plus reclaimed-byte logging
- disable Cargo incremental generation in crew vessel provisioning while leaving desk builds unchanged
- reduce `prune-target.sh` to the 10 GiB incremental / 20 GiB total size-cap backstop
- document the installed policy, verification commands, and the non-built identity-based candidate

## Host verification

- **feta (complete):** installed cargo-sweep 0.8.0 and enabled `flotilla-cargo-sweep-mtime.timer`; an observed corrected service run exited successfully across 10 roots with `failed_roots=0`. The initial observed pass reclaimed 25,932,570,624 bytes from the three standing desk targets before exposing and motivating the convoy-root expansion fix; the successful rerun logged its complete reclaimed-byte total.
- **kiwi (operator handoff):** from this branch on kiwi, run `scripts/install-cargo-sweep-schedule.sh`, then verify `launchctl print "gui/$UID/org.flotilla.cargo-sweep-mtime"` and inspect `~/.local/state/flotilla/cargo-sweep-mtime.log`. I did not attempt to reach kiwi, per the issue instruction.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `scripts/test-prune-target.sh`
- `scripts/test-cargo-sweep-mtime.sh`
- targeted crew provisioning test confirms agent and tool sessions receive `CARGO_INCREMENTAL=0`
- isolated Cargo build produced no incremental generated state (current Cargo leaves an empty `debug/incremental/` container)
- installed systemd units verified and launchd plist XML validated