### PR TITLE
fix: enforce convoy free-space admission floor

### DIFF
--- a/crates/flotilla-core/src/admission.rs
+++ b/crates/flotilla-core/src/admission.rs
@@ -1,0 +1,71 @@
+use std::path::Path;
+
+use sysinfo::Disks;
+
+const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
+
+pub(crate) fn check_free_space_floor(host: &str, path: &Path, floor_gib: u64) -> Result<(), String> {
+    if floor_gib == 0 {
+        return Ok(());
+    }
+
+    let floor_bytes =
+        floor_gib.checked_mul(BYTES_PER_GIB).ok_or_else(|| format!("free-space floor for host `{host}` is too large: {floor_gib} GiB"))?;
+    let free_bytes = available_space(path)
+        .ok_or_else(|| format!("placement refused on host `{host}`: free space could not be measured for {}", path.display()))?;
+    check_measured_free_space(host, free_bytes, floor_bytes)
+}
+
+fn available_space(path: &Path) -> Option<u64> {
+    let disks = Disks::new_with_refreshed_list();
+    disks
+        .list()
+        .iter()
+        .filter(|disk| path.starts_with(disk.mount_point()))
+        .max_by_key(|disk| disk.mount_point().components().count())
+        .map(|disk| disk.available_space())
+}
+
+fn check_measured_free_space(host: &str, free_bytes: u64, floor_bytes: u64) -> Result<(), String> {
+    if free_bytes >= floor_bytes {
+        return Ok(());
+    }
+
+    Err(format!(
+        "placement refused on host `{host}`: {} free is below the {} floor; reap settled convoys, run scripts/prune-target.sh, or pick another host",
+        format_gib(free_bytes),
+        format_gib(floor_bytes),
+    ))
+}
+
+fn format_gib(bytes: u64) -> String {
+    let gib = bytes as f64 / BYTES_PER_GIB as f64;
+    format!("{gib:.1} GiB")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn below_floor_refusal_is_actionable() {
+        let result = check_measured_free_space("kiwi", 12 * BYTES_PER_GIB, 20 * BYTES_PER_GIB);
+
+        assert_eq!(
+            result,
+            Err("placement refused on host `kiwi`: 12.0 GiB free is below the 20.0 GiB floor; \
+                 reap settled convoys, run scripts/prune-target.sh, or pick another host"
+                .to_string())
+        );
+    }
+
+    #[test]
+    fn space_equal_to_floor_is_admitted() {
+        assert_eq!(check_measured_free_space("kiwi", 20 * BYTES_PER_GIB, 20 * BYTES_PER_GIB), Ok(()));
+    }
+
+    #[test]
+    fn zero_floor_disables_the_probe() {
+        assert_eq!(check_free_space_floor("kiwi", Path::new("/path/that/does/not/exist"), 0), Ok(()));
+    }
+}

--- a/crates/flotilla-core/src/admission.rs
+++ b/crates/flotilla-core/src/admission.rs
@@ -33,9 +33,14 @@ fn check_measured_free_space(host: &str, free_bytes: u64, floor_bytes: u64) -> R
 
     Err(format!(
         "placement refused on host `{host}`: {} free is below the {} floor; reap settled convoys, run scripts/prune-target.sh, or pick another host",
-        format_gib(free_bytes),
+        format_free_gib(free_bytes),
         format_gib(floor_bytes),
     ))
+}
+
+fn format_free_gib(bytes: u64) -> String {
+    let tenths = u128::from(bytes) * 10 / u128::from(BYTES_PER_GIB);
+    format!("{}.{:01} GiB", tenths / 10, tenths % 10)
 }
 
 fn format_gib(bytes: u64) -> String {
@@ -62,6 +67,15 @@ mod tests {
     #[test]
     fn space_equal_to_floor_is_admitted() {
         assert_eq!(check_measured_free_space("kiwi", 20 * BYTES_PER_GIB, 20 * BYTES_PER_GIB), Ok(()));
+    }
+
+    #[test]
+    fn refusal_does_not_round_free_space_up_to_the_floor() {
+        let just_below_floor = 20 * BYTES_PER_GIB - 1;
+
+        let result = check_measured_free_space("kiwi", just_below_floor, 20 * BYTES_PER_GIB);
+
+        assert!(result.expect_err("space below the floor should be refused").contains("19.9 GiB free is below the 20.0 GiB floor"));
     }
 
     #[test]

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -361,7 +361,28 @@ pub struct DaemonConfig {
     pub machine_id: Option<String>,
     pub host_name: Option<String>,
     #[serde(default)]
+    pub admission: AdmissionConfig,
+    #[serde(default)]
     pub environments: BTreeMap<String, StaticEnvironmentConfig>,
+}
+
+/// Deterministic admission limits enforced by this host.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AdmissionConfig {
+    /// Refuse new convoy placement when the volume containing Flotilla's
+    /// state directory has less than this many GiB available.
+    #[serde(default = "default_free_space_floor_gib")]
+    pub free_space_floor_gib: u64,
+}
+
+impl Default for AdmissionConfig {
+    fn default() -> Self {
+        Self { free_space_floor_gib: default_free_space_floor_gib() }
+    }
+}
+
+const fn default_free_space_floor_gib() -> u64 {
+    20
 }
 
 /// Static SSH-backed direct execution environment configured in `daemon.toml`.

--- a/crates/flotilla-core/src/config/tests.rs
+++ b/crates/flotilla-core/src/config/tests.rs
@@ -526,11 +526,15 @@ fn parse_daemon_config_follower() {
 follower = true
 machine_id = "my-machine"
 host_name = "my-desktop"
+
+[admission]
+free_space_floor_gib = 50
 "#;
     let config: DaemonConfig = toml::from_str(toml).unwrap();
     assert!(config.follower);
     assert_eq!(config.machine_id, Some("my-machine".into()));
     assert_eq!(config.host_name, Some("my-desktop".into()));
+    assert_eq!(config.admission.free_space_floor_gib, 50);
     assert!(config.environments.is_empty());
 }
 
@@ -540,6 +544,7 @@ fn parse_daemon_config_defaults() {
     assert!(!config.follower);
     assert_eq!(config.machine_id, None);
     assert_eq!(config.host_name, None);
+    assert_eq!(config.admission.free_space_floor_gib, 20);
     assert!(config.environments.is_empty());
 }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3819,19 +3819,21 @@ impl InProcessDaemon {
         intent: &flotilla_protocol::ConvoyStartIntent,
         dispatching_principal_ref: &PrincipalRef,
     ) -> Result<String, String> {
+        self.check_local_free_space_floor().await?;
         let admission = self.prepare_convoy_admission(namespace, intent, dispatching_principal_ref).await?;
-        self.check_local_free_space_floor()?;
         self.create_convoy(namespace, &admission.name, &admission.spec, intent.auto_attach.into()).await?;
         Ok(admission.name)
     }
 
-    fn check_local_free_space_floor(&self) -> Result<(), String> {
-        let config = self.config.load_daemon_config()?;
-        crate::admission::check_free_space_floor(
-            self.host_name.as_str(),
-            self.config.state_dir().as_path(),
-            config.admission.free_space_floor_gib,
-        )
+    async fn check_local_free_space_floor(&self) -> Result<(), String> {
+        let config = Arc::clone(&self.config);
+        let host_name = self.host_name.to_string();
+        tokio::task::spawn_blocking(move || {
+            let daemon_config = config.load_daemon_config()?;
+            crate::admission::check_free_space_floor(&host_name, config.state_dir().as_path(), daemon_config.admission.free_space_floor_gib)
+        })
+        .await
+        .map_err(|error| format!("free-space check failed on host `{}`: {error}", self.host_name))?
     }
 
     async fn create_convoy(
@@ -4012,7 +4014,7 @@ impl InProcessDaemon {
         // The target daemon is authoritative for its own capacity. Keep this
         // ahead of the prepared Convoy claim and snapshot persistence so a
         // refusal cannot leave any partial resource state behind.
-        self.check_local_free_space_floor()?;
+        self.check_local_free_space_floor().await?;
         let mut annotations = BTreeMap::from([(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), start.workflow_name.clone())]);
         if let Some(name) = &start.placement_policy_name {
             annotations.insert(flotilla_resources::PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), name.clone());
@@ -6635,6 +6637,17 @@ impl InProcessDaemon {
                     });
                     return Ok(id);
                 }
+            }
+            if let Err(message) = self.check_local_free_space_floor().await {
+                let result = flotilla_protocol::CommandValue::Error { message };
+                let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                    command_id: id,
+                    node_id: self.node_id.clone(),
+                    repo_identity: empty_identity,
+                    repo: None,
+                    result,
+                });
+                return Ok(id);
             }
             let workflow = match self
                 .resource_backend

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3701,8 +3701,18 @@ impl InProcessDaemon {
         dispatching_principal_ref: &PrincipalRef,
     ) -> Result<String, String> {
         let admission = self.prepare_convoy_admission(namespace, intent, dispatching_principal_ref).await?;
+        self.check_local_free_space_floor()?;
         self.create_convoy(namespace, &admission.name, &admission.spec, intent.auto_attach.into()).await?;
         Ok(admission.name)
+    }
+
+    fn check_local_free_space_floor(&self) -> Result<(), String> {
+        let config = self.config.load_daemon_config()?;
+        crate::admission::check_free_space_floor(
+            self.host_name.as_str(),
+            self.config.state_dir().as_path(),
+            config.admission.free_space_floor_gib,
+        )
     }
 
     async fn create_convoy(
@@ -3862,6 +3872,10 @@ impl InProcessDaemon {
             Err(ResourceError::NotFound { .. }) => {}
             Err(error) => return Err(error.to_string()),
         }
+        // The target daemon is authoritative for its own capacity. Keep this
+        // ahead of snapshot persistence so a refusal cannot leave prepared
+        // workflow or placement resources behind.
+        self.check_local_free_space_floor()?;
         ensure_prepared_workflow_snapshot(&self.resource_backend, &namespace, &start.workflow_name, &workflow_spec).await?;
         if let Some((name, spec)) = placement_spec {
             ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, &spec).await?;

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4010,6 +4010,50 @@ async fn convoy_start_refuses_local_placement_below_configured_free_space_floor_
 }
 
 #[tokio::test]
+async fn convoy_create_refuses_local_placement_below_configured_free_space_floor_without_creating_state() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n\n[admission]\nfree_space_floor_gib = 1000000\n")
+        .expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::new("kiwi")).await;
+    let backend = daemon.resource_backend();
+    create_empty_workflow(&backend, "scratch").await;
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "create-disk-hungry".to_string(),
+                workflow_ref: "scratch".to_string(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: None,
+                adopted_checkout: None,
+            },
+        })
+        .await
+        .expect("execute should return a command id");
+
+    let result = wait_for_command_result(&mut events, command_id).await;
+    let CommandValue::Error { message } = result else {
+        panic!("expected free-space refusal, got {result:?}");
+    };
+    assert!(message.contains("host `kiwi`"), "{message}");
+    assert!(message.contains("free is below the 1000000.0 GiB floor"), "{message}");
+    assert!(
+        matches!(backend.using::<Convoy>("flotilla").get("create-disk-hungry").await, Err(ResourceError::NotFound { .. })),
+        "refused ConvoyCreate dispatch must not create a Convoy"
+    );
+}
+
+#[tokio::test]
 async fn direct_repository_admission_snapshots_its_resolved_default_branch() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -3825,6 +3825,62 @@ async fn create_empty_workflow(backend: &ResourceBackend, name: &str) {
 }
 
 #[tokio::test]
+async fn convoy_start_refuses_local_placement_below_configured_free_space_floor_without_creating_state() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n\n[admission]\nfree_space_floor_gib = 1000000\n")
+        .expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::new("kiwi")).await;
+    let backend = daemon.resource_backend();
+    create_empty_workflow(&backend, "scratch").await;
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(
+            &empty_input_meta("flotilla"),
+            &ProjectSpec::builder().display_name("Flotilla".to_string()).default_workflow_ref("scratch".to_string()).build(),
+        )
+        .await
+        .expect("project create should succeed");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(
+                    ConvoyStartIntent::builder()
+                        .project_ref("flotilla".to_string())
+                        .name("disk-hungry".to_string())
+                        .branch("feat/disk-hungry".to_string())
+                        .auto_attach(flotilla_protocol::ConvoyAutoAttach::Never)
+                        .build(),
+                ),
+            },
+        })
+        .await
+        .expect("execute should return a command id");
+
+    let result = wait_for_command_result(&mut events, command_id).await;
+    let CommandValue::Error { message } = result else {
+        panic!("expected free-space refusal, got {result:?}");
+    };
+    assert!(message.contains("host `kiwi`"), "{message}");
+    assert!(message.contains("free is below the 1000000.0 GiB floor"), "{message}");
+    assert!(message.contains("reap settled convoys"), "{message}");
+    assert!(message.contains("scripts/prune-target.sh"), "{message}");
+    assert!(message.contains("pick another host"), "{message}");
+    assert!(
+        matches!(backend.using::<Convoy>("flotilla").get("disk-hungry").await, Err(ResourceError::NotFound { .. })),
+        "refused local dispatch must not create a Convoy"
+    );
+}
+
+#[tokio::test]
 async fn direct_repository_admission_snapshots_its_resolved_default_branch() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -1,3 +1,4 @@
+mod admission;
 pub mod agent_adapter;
 pub mod agents;
 pub mod aggregator_projection;

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -30,14 +30,23 @@ use flotilla_resources::{
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
+    test_config_store_with_floor(config_dir, None)
+}
+
+fn test_config_store_with_floor(config_dir: std::path::PathBuf, free_space_floor_gib: Option<u64>) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&config_dir).expect("create config dir");
-    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let floor = free_space_floor_gib.map(|floor| format!("\n[admission]\nfree_space_floor_gib = {floor}\n")).unwrap_or_default();
+    std::fs::write(config_dir.join("daemon.toml"), format!("machine_id = \"test-machine\"\n{floor}")).expect("write daemon config");
     Arc::new(ConfigStore::with_base(config_dir))
 }
 
 async fn empty_daemon_named(host_name: &str) -> Arc<InProcessDaemon> {
+    empty_daemon_named_with_floor(host_name, None).await
+}
+
+async fn empty_daemon_named_with_floor(host_name: &str, free_space_floor_gib: Option<u64>) -> Arc<InProcessDaemon> {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let config = test_config_store(tmp.keep());
+    let config = test_config_store_with_floor(tmp.keep(), free_space_floor_gib);
     InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::new(host_name)).await
 }
 
@@ -525,6 +534,115 @@ async fn convoy_start_uses_live_peer_route_when_presentation_membership_is_stale
         .get("remote-work")
         .await
         .expect("convoy should be created on live placement host");
+}
+
+#[tokio::test]
+async fn remote_convoy_start_enforces_target_free_space_floor_without_leaving_prepared_state() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named_with_floor("follower", Some(1_000_000)).await;
+    follower.set_local_placement_capabilities(&BTreeSet::from(["codex".to_string()]), &["cleat".to_string()]).await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let remote_host_id = topology.follower.local_host_id().expect("follower host identity").to_string();
+    let placement_policy = format!("host-direct-{remote_host_id}");
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if topology.leader.resource_backend().using::<PlacementPolicy>(namespace).get(&placement_policy).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("peer host summary should materialize placement policy");
+    seed_trusted_remote_convoy_project(&topology.leader, namespace).await;
+
+    let follower_backend = topology.follower.resource_backend();
+    let workflows_before = follower_backend
+        .clone()
+        .using::<WorkflowTemplate>(namespace)
+        .list()
+        .await
+        .expect("list target workflows before dispatch")
+        .items
+        .into_iter()
+        .map(|resource| resource.metadata.name)
+        .collect::<BTreeSet<_>>();
+    let policies_before = follower_backend
+        .clone()
+        .using::<PlacementPolicy>(namespace)
+        .list()
+        .await
+        .expect("list target policies before dispatch")
+        .items
+        .into_iter()
+        .map(|resource| resource.metadata.name)
+        .collect::<BTreeSet<_>>();
+
+    let mut events = topology.leader.subscribe();
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(
+                    ConvoyStartIntent::builder()
+                        .project_ref("flotilla".to_string())
+                        .name("remote-disk-hungry".to_string())
+                        .branch("fix/remote-disk-hungry".to_string())
+                        .placement_policy(placement_policy)
+                        .auto_attach(flotilla_protocol::ConvoyAutoAttach::Never)
+                        .build(),
+                ),
+            },
+        })
+        .await
+        .expect("remote convoy dispatch should be routed");
+
+    let result = await_command_result(&mut events, command_id).await;
+    let CommandValue::Error { message } = result else {
+        panic!("expected target free-space refusal, got {result:?}");
+    };
+    assert!(message.contains("host `follower`"), "{message}");
+    assert!(message.contains("free is below the 1000000.0 GiB floor"), "{message}");
+    assert!(message.contains("reap settled convoys"), "{message}");
+    assert!(message.contains("scripts/prune-target.sh"), "{message}");
+    assert!(message.contains("pick another host"), "{message}");
+
+    assert!(
+        matches!(follower_backend.using::<Convoy>(namespace).get("remote-disk-hungry").await, Err(ResourceError::NotFound { .. })),
+        "refused remote dispatch must not create a Convoy"
+    );
+    assert_eq!(
+        follower_backend
+            .clone()
+            .using::<WorkflowTemplate>(namespace)
+            .list()
+            .await
+            .expect("list target workflows after dispatch")
+            .items
+            .into_iter()
+            .map(|resource| resource.metadata.name)
+            .collect::<BTreeSet<_>>(),
+        workflows_before,
+        "refused remote dispatch must not persist a prepared workflow snapshot"
+    );
+    assert_eq!(
+        follower_backend
+            .using::<PlacementPolicy>(namespace)
+            .list()
+            .await
+            .expect("list target policies after dispatch")
+            .items
+            .into_iter()
+            .map(|resource| resource.metadata.name)
+            .collect::<BTreeSet<_>>(),
+        policies_before,
+        "refused remote dispatch must not persist a prepared placement snapshot"
+    );
 }
 
 /// A stateless remote issue query should return results end-to-end.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,15 @@ per host in that host's `~/.config/flotilla/daemon.toml`:
 free_space_floor_gib = 50
 ```
 
+The state-directory volume is the admission proxy for host capacity; checkout
+paths can be configured on other volumes and are not measured by this check.
+Hosts that separate those volumes should provide an equivalent capacity guard
+for each checkout volume.
+
+If Flotilla cannot identify the state-directory volume or measure its available
+space, placement is refused. This fail-closed behavior prevents an unavailable
+measurement from silently disabling admission.
+
 Set the floor to `0` only when an external system provides an equivalent
 capacity guard.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,20 @@ To override the default for every convoy start that omits those flags, set
 auto_attach = false
 ```
 
+## Convoy placement admission
+
+Each host refuses new convoy placement when the volume containing its Flotilla
+state directory is below a free-space floor. The default is 20 GiB. Override it
+per host in that host's `~/.config/flotilla/daemon.toml`:
+
+```toml
+[admission]
+free_space_floor_gib = 50
+```
+
+Set the floor to `0` only when an external system provides an equivalent
+capacity guard.
+
 ## Dependencies
 
 Flotilla auto-detects available tools. Nothing is strictly required beyond git, but more tools unlock more features.


### PR DESCRIPTION
## Summary

- enforce a 20 GiB default free-space floor on the candidate host before convoy persistence
- configure the floor per host through `[admission].free_space_floor_gib` in `daemon.toml`
- enforce the check on the remote execution daemon before prepared workflow or placement snapshots are written
- return an actionable refusal naming the host, measured free space, configured floor, and remediation options

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1135