### PR TITLE
Attach through transport hops with send keys

### DIFF
--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -16,7 +16,8 @@ use std::{
 use flotilla_protocol::{
     arg::Arg,
     qualified_path::{PathQualifier, QualifiedPath},
-    CheckoutTarget, Command, CommandAction, CommandValue, HostName, NodeId, PreparedWorkspace, ResolvedPaneCommand,
+    CheckoutTarget, Command, CommandAction, CommandValue, HostName, NodeId, PreparedWorkspace, ResolvedAttachAction, ResolvedAttachPlan,
+    ResolvedPaneCommand,
 };
 use tracing::{debug, error, info};
 
@@ -759,7 +760,8 @@ impl StepResolver for ExecutorStepResolver {
                 let cmd = resolve_attach_command(&session_id, self.registry.as_ref(), self.providers_data.as_ref()).await?;
                 // Step-planned attach paths resolve provider sessions directly
                 // and have no resource-level binding to stamp.
-                Ok(StepOutcome::Produced(CommandValue::AttachCommandResolved { command: cmd, binding: None }))
+                let plan = ResolvedAttachPlan(vec![ResolvedAttachAction::Command(vec![Arg::Literal(cmd)])]);
+                Ok(StepOutcome::Produced(CommandValue::AttachCommandResolved { plan, binding: None }))
             }
             StepAction::EnsureCheckoutForTeleport { branch, checkout_key, initial_path } => {
                 if let Some(path) = initial_path {
@@ -783,13 +785,17 @@ impl StepResolver for ExecutorStepResolver {
                 }
             }
             StepAction::CreateTeleportWorkspace { session_id: _, branch } => {
-                let cmd = prior
+                let plan = prior
                     .iter()
                     .find_map(|o| match o {
-                        StepOutcome::Produced(CommandValue::AttachCommandResolved { command, .. }) => Some(command.clone()),
+                        StepOutcome::Produced(CommandValue::AttachCommandResolved { plan, .. }) => Some(plan),
                         _ => None,
                     })
                     .ok_or_else(|| "attach command not resolved by prior step".to_string())?;
+                let [ResolvedAttachAction::Command(args)] = plan.0.as_slice() else {
+                    return Err("teleport workspace requires a single resolved attach command".to_string());
+                };
+                let cmd = flotilla_protocol::arg::flatten(args, 0);
 
                 let path = prior
                     .iter()

--- a/crates/flotilla-core/src/executor/workspace.rs
+++ b/crates/flotilla-core/src/executor/workspace.rs
@@ -12,7 +12,7 @@ use crate::{
         builder::HopPlanBuilder,
         environment::{DockerEnvironmentHopResolver, NoopEnvironmentHopResolver},
         remote::ssh_resolver_from_config,
-        resolver::{AlwaysWrap, HopResolver},
+        resolver::{HopResolver, ResolutionPurpose},
         terminal::NoopTerminalHopResolver,
         Hop, ResolutionContext, ResolvedAction,
     },
@@ -328,7 +328,7 @@ fn workspace_attach_request_from_config(config: crate::providers::types::Workspa
 /// suitable for workspace manager consumption.
 ///
 /// For each `ResolvedPaneCommand`, builds a `HopPlan` via `HopPlanBuilder::build_for_prepared_command`,
-/// resolves it with `SshRemoteHopResolver` + `AlwaysWrap`, and flattens the resulting `Command` to a string.
+/// resolves it for non-interactive command execution and flattens the resulting wrapped `Command` to a string.
 pub(crate) fn resolve_prepared_commands_via_hop_chain(
     target_host: &HostName,
     checkout_path: &Path,
@@ -347,12 +347,8 @@ pub(crate) fn resolve_prepared_commands_via_hop_chain(
         }
         _ => Arc::new(NoopEnvironmentHopResolver),
     };
-    let hop_resolver = HopResolver {
-        remote: Arc::new(ssh_resolver),
-        environment: env_resolver,
-        terminal: Arc::new(NoopTerminalHopResolver),
-        strategy: Arc::new(AlwaysWrap),
-    };
+    let hop_resolver =
+        HopResolver::new(Arc::new(ssh_resolver), env_resolver, Arc::new(NoopTerminalHopResolver), ResolutionPurpose::CommandExecution);
     let plan_builder = HopPlanBuilder::new(local_host);
 
     let mut result = Vec::with_capacity(commands.len());
@@ -371,11 +367,11 @@ pub(crate) fn resolve_prepared_commands_via_hop_chain(
         };
         let resolved = hop_resolver.resolve(&plan, &mut context)?;
 
-        // AlwaysWrap should produce exactly one Command action. Assert this invariant
+        // CommandExecution purpose should produce exactly one wrapped Command action. Assert this invariant
         // so multi-action plans don't silently lose actions.
         if resolved.0.len() != 1 {
             return Err(format!(
-                "hop chain resolution produced {} actions for role '{}', expected exactly 1 (AlwaysWrap)",
+                "hop chain resolution produced {} actions for role '{}', expected exactly 1 (command execution)",
                 resolved.0.len(),
                 cmd.role
             ));

--- a/crates/flotilla-core/src/hop_chain/environment.rs
+++ b/crates/flotilla-core/src/hop_chain/environment.rs
@@ -48,7 +48,7 @@ impl EnvironmentHopResolver for DockerEnvironmentHopResolver {
             docker_args.push(Arg::Literal("-w".into()));
             docker_args.push(Arg::Quoted(dir.to_string()));
         }
-        docker_args.push(Arg::Literal(container.to_string()));
+        docker_args.push(Arg::Quoted(container.to_string()));
         docker_args.extend(inner_args);
 
         context.actions.push(ResolvedAction::Command(docker_args));
@@ -68,8 +68,11 @@ impl EnvironmentHopResolver for DockerEnvironmentHopResolver {
 
         // Convert inner command to SendKeys (if non-empty)
         if !inner_args.is_empty() {
-            let text = flotilla_protocol::arg::flatten(&inner_args, 0);
-            context.actions.push(ResolvedAction::SendKeys { steps: vec![SendKeyStep::Type(text), SendKeyStep::WaitForPrompt] });
+            let text = format!("exec {}", flotilla_protocol::arg::flatten(&inner_args, 0));
+            context.actions.push(ResolvedAction::SendKeys {
+                hop: format!("docker environment '{env_id}'"),
+                steps: vec![SendKeyStep::Type { text }, SendKeyStep::WaitForReady],
+            });
         }
 
         // Push docker exec enter command
@@ -78,7 +81,7 @@ impl EnvironmentHopResolver for DockerEnvironmentHopResolver {
             docker_args.push(Arg::Literal("-w".into()));
             docker_args.push(Arg::Quoted(dir.to_string()));
         }
-        docker_args.push(Arg::Literal(container.to_string()));
+        docker_args.push(Arg::Quoted(container.to_string()));
         docker_args.push(Arg::Literal("/bin/sh".into()));
         context.actions.push(ResolvedAction::Command(docker_args));
         Ok(())

--- a/crates/flotilla-core/src/hop_chain/mod.rs
+++ b/crates/flotilla-core/src/hop_chain/mod.rs
@@ -1,3 +1,13 @@
+//! Structured resolution of transport hops.
+//!
+//! Resolution is keyed by purpose rather than transport type. Interactive
+//! attaches use send-keys at every SSH or environment boundary: enter a real
+//! shell, wait for it to become ready, then type the next transient
+//! `flotilla attach`. Non-interactive command execution (workspace
+//! provisioning, probes, and command runners) wraps the inner command into
+//! the outer transport invocation. Both purposes use the same per-hop
+//! resolvers and quoting model.
+
 pub mod builder;
 pub mod environment;
 pub mod flatten;
@@ -7,7 +17,7 @@ pub mod terminal;
 #[cfg(test)]
 mod tests;
 
-pub use flotilla_protocol::arg::Arg;
+pub use flotilla_protocol::{arg::Arg, ResolvedAttachAction as ResolvedAction, SendKeyStep};
 use flotilla_protocol::{EnvironmentId, HostName};
 
 use crate::{attachable::AttachableId, path_context::ExecutionEnvironmentPath};
@@ -25,19 +35,6 @@ pub enum Hop {
 /// layer, the last hop is the innermost action. Resolution walks inside-out.
 #[derive(Debug, Clone)]
 pub struct HopPlan(pub Vec<Hop>);
-
-/// What the consumer actually executes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ResolvedAction {
-    Command(Vec<Arg>),
-    SendKeys { steps: Vec<SendKeyStep> },
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SendKeyStep {
-    Type(String),
-    WaitForPrompt,
-}
 
 /// The resolved output — M actions from N hops where M <= N.
 #[derive(Debug, Clone)]

--- a/crates/flotilla-core/src/hop_chain/remote.rs
+++ b/crates/flotilla-core/src/hop_chain/remote.rs
@@ -163,7 +163,7 @@ impl RemoteHopResolver for SshRemoteHopResolver {
     ///
     /// Produces two actions on the stack:
     ///   1. Command: `ssh -t [multiplex] user@host` (bottom — runs first)
-    ///   2. SendKeys: Type(flattened inner command) + WaitForPrompt (top)
+    ///   2. SendKeys: Type(flattened inner command) + WaitForReady (top)
     fn resolve_enter(&self, host: &HostName, context: &mut ResolutionContext) -> Result<(), String> {
         let info = self.ssh_info(host)?;
 
@@ -180,17 +180,20 @@ impl RemoteHopResolver for SshRemoteHopResolver {
             type_parts.push(format!("cd {}", flotilla_protocol::arg::shell_quote(&dir.to_string())));
             if !inner_args.is_empty() {
                 type_parts.push("&&".into());
-                type_parts.push(flotilla_protocol::arg::flatten(&inner_args, 0));
+                type_parts.push(format!("exec {}", flotilla_protocol::arg::flatten(&inner_args, 0)));
             }
         } else if !inner_args.is_empty() {
-            type_parts.push(flotilla_protocol::arg::flatten(&inner_args, 0));
+            type_parts.push(format!("exec {}", flotilla_protocol::arg::flatten(&inner_args, 0)));
         }
 
         let type_text = type_parts.join(" ");
 
         // Push SendKeys for the inner command (if non-empty)
         if !type_text.is_empty() {
-            context.actions.push(ResolvedAction::SendKeys { steps: vec![SendKeyStep::Type(type_text), SendKeyStep::WaitForPrompt] });
+            context.actions.push(ResolvedAction::SendKeys {
+                hop: format!("remote host '{host}'"),
+                steps: vec![SendKeyStep::Type { text: type_text }, SendKeyStep::WaitForReady],
+            });
         }
 
         // Push SSH enter command (no remote command — just open the session)

--- a/crates/flotilla-core/src/hop_chain/resolver.rs
+++ b/crates/flotilla-core/src/hop_chain/resolver.rs
@@ -11,7 +11,17 @@ pub trait CombineStrategy: Send + Sync {
     fn should_wrap(&self, hop: &Hop, context: &ResolutionContext) -> bool;
 }
 
-/// Always nests commands as arguments. Matches current SSH wrapping behavior. Default.
+/// Why a hop chain is being resolved.
+///
+/// Interactive attaches enter one boundary at a time and type the next
+/// command. Non-interactive execution keeps a single wrapped command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolutionPurpose {
+    Attach,
+    CommandExecution,
+}
+
+/// Always nests commands as arguments for non-interactive execution.
 pub struct AlwaysWrap;
 
 impl CombineStrategy for AlwaysWrap {
@@ -20,7 +30,7 @@ impl CombineStrategy for AlwaysWrap {
     }
 }
 
-/// Always creates execution boundaries. For resolution-level testing only in Phase A.
+/// Always creates execution boundaries for interactive attaches.
 pub struct AlwaysSendKeys;
 
 impl CombineStrategy for AlwaysSendKeys {
@@ -45,6 +55,19 @@ pub struct HopResolver {
 }
 
 impl HopResolver {
+    pub fn new(
+        remote: Arc<dyn RemoteHopResolver>,
+        environment: Arc<dyn EnvironmentHopResolver>,
+        terminal: Arc<dyn TerminalHopResolver>,
+        purpose: ResolutionPurpose,
+    ) -> Self {
+        let strategy: Arc<dyn CombineStrategy> = match purpose {
+            ResolutionPurpose::Attach => Arc::new(AlwaysSendKeys),
+            ResolutionPurpose::CommandExecution => Arc::new(AlwaysWrap),
+        };
+        Self { remote, environment, terminal, strategy }
+    }
+
     pub fn resolve(&self, plan: &HopPlan, context: &mut ResolutionContext) -> Result<ResolvedPlan, String> {
         // Walk inside-out (reverse order)
         for hop in plan.0.iter().rev() {
@@ -62,6 +85,9 @@ impl HopResolver {
                     if context.current_environment.as_ref() == Some(env_id) {
                         continue; // collapse — already inside this environment
                     }
+                    // Future depth/total-command-length policy belongs at this
+                    // strategy decision seam; it must not leak into individual
+                    // SSH or environment adapters.
                     if self.strategy.should_wrap(hop, context) {
                         self.environment.resolve_wrap(env_id, context)?;
                     } else {

--- a/crates/flotilla-core/src/hop_chain/snapshots/flotilla_core__hop_chain__tests__e2e_remote_send_keys_flattened.snap
+++ b/crates/flotilla-core/src/hop_chain/snapshots/flotilla_core__hop_chain__tests__e2e_remote_send_keys_flattened.snap
@@ -3,6 +3,6 @@ source: crates/flotilla-core/src/hop_chain/tests.rs
 expression: "&flattened"
 ---
 [
-    "SendKeys: [Type(\"cd '/home/alice/dev/my-repo/wt-feat' && cleat attach feat__shell__0 --cwd '/home/alice/dev/my-repo/wt-feat'\"), WaitForPrompt]",
+    "SendKeys(remote host 'feta'): [Type { text: \"cd '/home/alice/dev/my-repo/wt-feat' && exec cleat attach feat__shell__0 --cwd '/home/alice/dev/my-repo/wt-feat'\" }, WaitForReady]",
     "Command: ssh -t 'alice@feta.local'",
 ]

--- a/crates/flotilla-core/src/hop_chain/snapshots/flotilla_core__hop_chain__tests__e2e_remote_send_keys_resolved_plan.snap
+++ b/crates/flotilla-core/src/hop_chain/snapshots/flotilla_core__hop_chain__tests__e2e_remote_send_keys_resolved_plan.snap
@@ -5,11 +5,12 @@ expression: "&resolved"
 ResolvedPlan(
     [
         SendKeys {
+            hop: "remote host 'feta'",
             steps: [
-                Type(
-                    "cd '/home/alice/dev/my-repo/wt-feat' && cleat attach feat__shell__0 --cwd '/home/alice/dev/my-repo/wt-feat'",
-                ),
-                WaitForPrompt,
+                Type {
+                    text: "cd '/home/alice/dev/my-repo/wt-feat' && exec cleat attach feat__shell__0 --cwd '/home/alice/dev/my-repo/wt-feat'",
+                },
+                WaitForReady,
             ],
         },
         Command(

--- a/crates/flotilla-core/src/hop_chain/tests.rs
+++ b/crates/flotilla-core/src/hop_chain/tests.rs
@@ -9,7 +9,7 @@ use flotilla_protocol::{arg::flatten, EnvironmentId, HostName, TerminalStatus};
 use super::{
     environment::{DockerEnvironmentHopResolver, EnvironmentHopResolver, NoopEnvironmentHopResolver},
     remote::{RemoteHopResolver, SshRemoteHopResolver},
-    resolver::{AlwaysSendKeys, AlwaysWrap, CombineStrategy, HopResolver},
+    resolver::{AlwaysSendKeys, AlwaysWrap, CombineStrategy, HopResolver, ResolutionPurpose},
     terminal::TerminalHopResolver,
     Arg, Hop, HopPlan, ResolutionContext, ResolvedAction, ResolvedPlan, SendKeyStep,
 };
@@ -46,7 +46,7 @@ fn expect_command(action: &ResolvedAction) -> &[Arg] {
 #[track_caller]
 fn expect_send_keys(action: &ResolvedAction) -> &[SendKeyStep] {
     match action {
-        ResolvedAction::SendKeys { steps } => steps,
+        ResolvedAction::SendKeys { steps, .. } => steps,
         other => panic!("expected SendKeys, got {other:?}"),
     }
 }
@@ -54,7 +54,7 @@ fn expect_send_keys(action: &ResolvedAction) -> &[SendKeyStep] {
 #[track_caller]
 fn expect_type_step(step: &SendKeyStep) -> &str {
     match step {
-        SendKeyStep::Type(text) => text,
+        SendKeyStep::Type { text } => text,
         other => panic!("expected Type step, got {other:?}"),
     }
 }
@@ -72,7 +72,7 @@ fn flatten_actions(actions: &[ResolvedAction]) -> Vec<String> {
         .iter()
         .map(|action| match action {
             ResolvedAction::Command(args) => format!("Command: {}", flatten(args, 0)),
-            ResolvedAction::SendKeys { steps } => format!("SendKeys: {steps:?}"),
+            ResolvedAction::SendKeys { hop, steps } => format!("SendKeys({hop}): {steps:?}"),
         })
         .collect()
 }
@@ -359,7 +359,7 @@ fn wrap_empty_stack_returns_error() {
 fn wrap_non_command_on_stack_returns_error() {
     let resolver = test_resolver_no_multiplex();
     let mut context = minimal_context();
-    context.actions.push(ResolvedAction::SendKeys { steps: vec![SendKeyStep::Type("hello".into())] });
+    context.actions.push(ResolvedAction::SendKeys { hop: "test hop".into(), steps: vec![SendKeyStep::Type { text: "hello".into() }] });
 
     let err = resolver.resolve_wrap(&HostName::new("feta"), &mut context).expect_err("should fail with non-Command");
     assert!(err.contains("expected Command"), "error should mention expected Command: {err}");
@@ -407,7 +407,7 @@ fn enter_produces_ssh_command_and_sendkeys() {
     assert!(text.contains("cd"), "should include cd: {text}");
     assert!(text.contains("/home/alice/dev/my-repo"), "should include dir: {text}");
     assert!(text.contains("cleat attach sess-1"), "should include inner cmd: {text}");
-    assert_eq!(steps[1], SendKeyStep::WaitForPrompt);
+    assert_eq!(steps[1], SendKeyStep::WaitForReady);
 
     // Top: SSH enter command (no inner command arg)
     let args = expect_command(&context.actions[1]);
@@ -430,7 +430,7 @@ fn enter_without_working_directory() {
     // SendKeys should just have the inner command, no cd
     let text = expect_type_step(&expect_send_keys(&context.actions[0])[0]);
     assert!(!text.contains("cd"), "should not include cd: {text}");
-    assert_eq!(text, "echo 'hello'");
+    assert_eq!(text, "exec echo 'hello'");
 }
 
 #[test]
@@ -709,7 +709,10 @@ impl RemoteHopResolver for MockRemoteHopResolver {
         // Convert inner to SendKeys
         if !inner_args.is_empty() {
             let text = flotilla_protocol::arg::flatten(&inner_args, 0);
-            context.actions.push(ResolvedAction::SendKeys { steps: vec![SendKeyStep::Type(text), SendKeyStep::WaitForPrompt] });
+            context.actions.push(ResolvedAction::SendKeys {
+                hop: format!("remote host '{host}'"),
+                steps: vec![SendKeyStep::Type { text }, SendKeyStep::WaitForReady],
+            });
         }
 
         // Push SSH enter command
@@ -765,6 +768,15 @@ fn resolve_with_mocks(strategy: Arc<dyn CombineStrategy>, hops: Vec<Hop>) -> Moc
     MockResolution { resolved, remote_calls: remote.recorded_calls(), terminal_calls: terminal.recorded_calls(), context }
 }
 
+fn resolve_with_mocks_for_purpose(purpose: ResolutionPurpose, hops: Vec<Hop>) -> MockResolution {
+    let remote = Arc::new(MockRemoteHopResolver::new());
+    let terminal = Arc::new(MockTerminalHopResolver::new());
+    let resolver = HopResolver::new(remote.clone(), Arc::new(NoopEnvironmentHopResolver), terminal.clone(), purpose);
+    let mut context = minimal_context();
+    let resolved = resolver.resolve(&HopPlan(hops), &mut context).expect("resolution should succeed");
+    MockResolution { resolved, remote_calls: remote.recorded_calls(), terminal_calls: terminal.recorded_calls(), context }
+}
+
 // ── HopResolver tests ────────────────────────────────────────────────
 
 #[test]
@@ -799,7 +811,7 @@ fn hop_resolver_remote_run_command_with_always_send_keys() {
     let text = expect_type_step(&steps[0]);
     assert!(text.contains("echo"), "SendKeys should contain inner command: {text}");
     assert!(text.contains("hello"), "SendKeys should contain inner command args: {text}");
-    assert_eq!(steps[1], SendKeyStep::WaitForPrompt);
+    assert_eq!(steps[1], SendKeyStep::WaitForReady);
 
     let args = expect_command(&r.resolved.0[1]);
     assert_eq!(args[0], Arg::Literal("ssh".into()));
@@ -809,6 +821,19 @@ fn hop_resolver_remote_run_command_with_always_send_keys() {
     assert_eq!(r.remote_calls.len(), 1);
     assert!(matches!(&r.remote_calls[0], MockRemoteCall::Enter(h) if h.as_str() == "feta"));
     assert!(r.terminal_calls.is_empty());
+}
+
+#[test]
+fn resolution_purpose_selects_attach_send_keys_and_command_wrapping() {
+    let hops = vec![Hop::RemoteToHost { host: HostName::new("feta") }, Hop::RunCommand {
+        command: vec![Arg::Literal("echo".into()), Arg::Quoted("hello world".into())],
+    }];
+
+    let attach = resolve_with_mocks_for_purpose(ResolutionPurpose::Attach, hops.clone());
+    assert!(matches!(attach.resolved.0.as_slice(), [ResolvedAction::SendKeys { .. }, ResolvedAction::Command(_)]));
+
+    let command = resolve_with_mocks_for_purpose(ResolutionPurpose::CommandExecution, hops);
+    assert!(matches!(command.resolved.0.as_slice(), [ResolvedAction::Command(_)]));
 }
 
 #[test]
@@ -1210,7 +1235,7 @@ fn enter_environment_wrap_produces_docker_exec() {
     assert_eq!(args[0], Arg::Literal("docker".into()));
     assert_eq!(args[1], Arg::Literal("exec".into()));
     assert_eq!(args[2], Arg::Literal("-it".into()));
-    assert_eq!(args[3], Arg::Literal("my-container".into()));
+    assert_eq!(args[3], Arg::Quoted("my-container".into()));
     assert_eq!(args[4], Arg::Literal("mock-attach".into()));
     assert_eq!(args[5], Arg::Quoted("sess-1".into()));
 
@@ -1267,7 +1292,7 @@ fn remote_then_environment_then_terminal() {
     assert_eq!(nested[0], Arg::Literal("docker".into()));
     assert_eq!(nested[1], Arg::Literal("exec".into()));
     assert_eq!(nested[2], Arg::Literal("-it".into()));
-    assert_eq!(nested[3], Arg::Literal("container-abc".into()));
+    assert_eq!(nested[3], Arg::Quoted("container-abc".into()));
     assert_eq!(nested[4], Arg::Literal("mock-attach".into()));
     assert_eq!(nested[5], Arg::Quoted("sess-1".into()));
 
@@ -1305,15 +1330,39 @@ fn enter_environment_enter_produces_docker_exec_shell_and_sendkeys() {
     assert_eq!(steps.len(), 2);
     let text = expect_type_step(&steps[0]);
     assert!(text.contains("mock-attach"), "SendKeys should contain terminal command: {text}");
-    assert_eq!(steps[1], SendKeyStep::WaitForPrompt);
+    assert_eq!(steps[1], SendKeyStep::WaitForReady);
 
     // Second action: docker exec enter command
     let args = expect_command(&resolved.0[1]);
     assert_eq!(args[0], Arg::Literal("docker".into()));
     assert_eq!(args[1], Arg::Literal("exec".into()));
     assert_eq!(args[2], Arg::Literal("-it".into()));
-    assert_eq!(args[3], Arg::Literal("my-container".into()));
+    assert_eq!(args[3], Arg::Quoted("my-container".into()));
     assert_eq!(args[4], Arg::Literal("/bin/sh".into()));
+}
+
+#[test]
+fn send_keys_quotes_hostile_attach_names_exactly_once() {
+    let env_id = EnvironmentId::new("my env '雪'");
+    let container = "container with 'quote' 雪";
+    let resolver = DockerEnvironmentHopResolver::new(HashMap::from([(env_id.clone(), container.to_string())]));
+    let mut context = minimal_context();
+    context.actions.push(ResolvedAction::Command(vec![
+        Arg::Literal("flotilla".into()),
+        Arg::Literal("attach".into()),
+        Arg::Quoted("crew with 'quote' 雪".into()),
+    ]));
+
+    resolver.resolve_enter(&env_id, &mut context).expect("hostile names should resolve");
+
+    let steps = expect_send_keys(&context.actions[0]);
+    assert_eq!(expect_type_step(&steps[0]), "exec flotilla attach 'crew with '\\''quote'\\'' 雪'");
+    let command = expect_command(&context.actions[1]);
+    assert_eq!(
+        flatten(command, 0),
+        "docker exec -it 'container with '\\''quote'\\'' 雪' /bin/sh",
+        "the container name and typed payload should each be quoted only at their own shell boundary"
+    );
 }
 
 #[test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -26,9 +26,9 @@ use flotilla_protocol::{
     FleetStaleness, HostListResponse, HostName, HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId,
     NodeInfo, PeerConnectionState, PrincipalRef, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo,
     QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse,
-    ResolvedPaneCommand, ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey,
-    SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY,
-    TERMINAL_POOL_PROVIDER_CATEGORY,
+    ResolvedAttachAction, ResolvedAttachPlan, ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus,
+    StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
+    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
@@ -64,7 +64,13 @@ use crate::{
     environment_manager::EnvironmentManager,
     executor,
     executor::checkout::{checkout_matches_scope, CheckoutResolutionScope},
-    hop_chain::remote::ssh_resolver_from_config,
+    hop_chain::{
+        environment::{DockerEnvironmentHopResolver, NoopEnvironmentHopResolver},
+        remote::ssh_resolver_from_config,
+        resolver::{HopResolver, ResolutionPurpose},
+        terminal::NoopTerminalHopResolver,
+        Hop, HopPlan, ResolutionContext,
+    },
     host_identity::{
         resolve_local_environment_state_dir, resolve_local_host_id, resolve_local_node_id, resolve_or_create_environment_id,
         resolve_or_create_remote_environment_id, resolve_or_create_remote_host_id,
@@ -358,11 +364,11 @@ fn empty_repo_identity() -> flotilla_protocol::RepoIdentity {
     flotilla_protocol::RepoIdentity { authority: String::new(), path: String::new() }
 }
 
-/// An attach resolution: the command the CLI should exec, plus the
+/// An attach resolution: the plan the CLI should execute, plus the
 /// structured binding it stamps onto its enclosing PM pane (#708).
 #[derive(Debug, Clone)]
 pub struct ResolvedAttach {
-    pub command: String,
+    pub plan: ResolvedAttachPlan,
     pub binding: Option<AttachBinding>,
 }
 
@@ -442,7 +448,7 @@ impl AttachTarget {
     async fn resolve(&self, daemon: &InProcessDaemon, reference: &str, transient: bool) -> Result<ResolvedAttach, String> {
         match self {
             Self::Local(session) => {
-                let (command, host) = daemon.attach_command_for_session(reference, session, transient).await?;
+                let (plan, host) = daemon.attach_plan_for_session(reference, session).await?;
                 let labels = &session.metadata.labels;
                 let binding = AttachBinding::builder()
                     .host(host)
@@ -452,10 +458,10 @@ impl AttachTarget {
                     .maybe_vessel(labels.get(VESSEL_LABEL).cloned())
                     .role(labels.get(ROLE_LABEL).cloned().unwrap_or_else(|| session.spec.role.clone()))
                     .build();
-                Ok(ResolvedAttach { command, binding: Some(binding) })
+                Ok(ResolvedAttach { plan, binding: Some(binding) })
             }
             Self::Replica { row } => {
-                let command = daemon.recursive_attach_command_for_remote(&row.host, reference, transient).await?;
+                let plan = daemon.recursive_attach_plan_for_remote(&row.host, reference).await?;
                 // Replica rows carry crew as "vessel/role" (or a bare role)
                 // and the owning host's namespace + session name, so
                 // cross-host panes stamp the full join key.
@@ -471,18 +477,18 @@ impl AttachTarget {
                     .maybe_vessel(vessel)
                     .maybe_role(role)
                     .build();
-                Ok(ResolvedAttach { command, binding: Some(binding) })
+                Ok(ResolvedAttach { plan, binding: Some(binding) })
             }
             Self::Checkout(row) => {
                 if !transient {
                     return Err(format!("checkout '{}' is only available as a transient attach target", row.path));
                 }
-                let command = if row.host == daemon.host_name {
-                    daemon.local_checkout_terminal_command(row).await?
+                let plan = if row.host == daemon.host_name {
+                    daemon.local_checkout_terminal_plan(row).await?
                 } else {
-                    daemon.recursive_attach_command_for_remote(&row.host, reference, true).await?
+                    daemon.recursive_attach_plan_for_remote(&row.host, reference).await?
                 };
-                Ok(ResolvedAttach { command, binding: None })
+                Ok(ResolvedAttach { plan, binding: None })
             }
         }
     }
@@ -3926,14 +3932,12 @@ impl InProcessDaemon {
         let auto_attach = self.should_auto_attach(intent.auto_attach);
         match self.admit_convoy_start(&namespace, &intent, &dispatching_principal_ref).await {
             Ok(name) if auto_attach => match self.wait_for_convoy_attach(&namespace, &name).await {
-                Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
-                    name,
-                    attach_command: Some(resolved.command),
-                    binding: resolved.binding,
-                },
+                Ok(resolved) => {
+                    flotilla_protocol::CommandValue::ConvoyStarted { name, attach_plan: Some(resolved.plan), binding: resolved.binding }
+                }
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             },
-            Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_command: None, binding: None },
+            Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_plan: None, binding: None },
             Err(message) => flotilla_protocol::CommandValue::Error { message },
         }
     }
@@ -3943,12 +3947,12 @@ impl InProcessDaemon {
             Ok(()) if start.auto_attach => match self.wait_for_convoy_attach(&start.namespace, &start.name).await {
                 Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
                     name: start.name,
-                    attach_command: Some(resolved.command),
+                    attach_plan: Some(resolved.plan),
                     binding: resolved.binding,
                 },
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             },
-            Ok(()) => flotilla_protocol::CommandValue::ConvoyStarted { name: start.name, attach_command: None, binding: None },
+            Ok(()) => flotilla_protocol::CommandValue::ConvoyStarted { name: start.name, attach_plan: None, binding: None },
             Err(message) => flotilla_protocol::CommandValue::Error { message },
         }
     }
@@ -6011,7 +6015,7 @@ impl InProcessDaemon {
         Ok(AttachCandidateIndex::new(candidates))
     }
 
-    async fn local_checkout_terminal_command(&self, checkout: &CheckoutRow) -> Result<String, String> {
+    async fn local_checkout_terminal_plan(&self, checkout: &CheckoutRow) -> Result<ResolvedAttachPlan, String> {
         let cwd = ExecutionEnvironmentPath::new(&checkout.path);
         let discovery = discover_repo_for_environment(
             &self.environment_manager,
@@ -6032,17 +6036,17 @@ impl InProcessDaemon {
         let session_name = transient_checkout_session_name(checkout);
         let command = "${SHELL:-/bin/sh}";
         pool.ensure_session(&session_name, command, &cwd, &Vec::new(), &[]).await?;
-        pool.attach_command(&session_name, command, &cwd, &Vec::new()).await
+        let args = pool.attach_args(&session_name, command, &cwd, &Vec::new())?;
+        Ok(ResolvedAttachPlan(vec![ResolvedAttachAction::Command(args)]))
     }
 
-    /// Resolve the attach command for a locally-known session, returning it
+    /// Resolve the attach plan for a locally-known session, returning it
     /// with the host that actually owns the session (the binding host).
-    async fn attach_command_for_session(
+    async fn attach_plan_for_session(
         &self,
         reference: &str,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
-        transient: bool,
-    ) -> Result<(String, HostName), String> {
+    ) -> Result<(ResolvedAttachPlan, HostName), String> {
         let namespace = self.provisioning_namespace().await;
         let environments = self.resource_backend.clone().using::<ResourceEnvironment>(&namespace);
         let environment = environments
@@ -6058,20 +6062,15 @@ impl InProcessDaemon {
             .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
         let target_host = self.target_host_for_resource_ref(host_ref);
         if target_host != self.host_name {
-            let command = self.recursive_attach_command_for_remote(&target_host, reference, transient).await?;
-            return Ok((command, target_host));
+            let plan = self.recursive_attach_plan_for_remote(&target_host, reference).await?;
+            return Ok((plan, target_host));
         }
 
-        let command = self.local_attach_command_for_session(session, &environment).await?;
-        Ok((command, self.host_name.clone()))
+        let plan = self.local_attach_plan_for_session(session, &environment).await?;
+        Ok((plan, self.host_name.clone()))
     }
 
-    async fn recursive_attach_command_for_remote(
-        &self,
-        target_host: &HostName,
-        reference: &str,
-        transient: bool,
-    ) -> Result<String, String> {
+    async fn recursive_attach_plan_for_remote(&self, target_host: &HostName, reference: &str) -> Result<ResolvedAttachPlan, String> {
         let next_hop = self.host_registry.next_hop_host_for_target_host(target_host).await?.unwrap_or_else(|| target_host.clone());
         if next_hop == self.host_name {
             return Err(format!("unreachable next hop for host '{target_host}': route points back to local host"));
@@ -6082,30 +6081,44 @@ impl InProcessDaemon {
             vec![flotilla_protocol::arg::Arg::Literal("flotilla".to_string()), flotilla_protocol::arg::Arg::Literal("attach".to_string())];
         command.push(flotilla_protocol::arg::Arg::Literal("--host".to_string()));
         command.push(flotilla_protocol::arg::Arg::Quoted(target_host.to_string()));
-        if transient {
-            command.push(flotilla_protocol::arg::Arg::Literal("--transient".to_string()));
-        }
+        // Recursive attaches only traverse transport boundaries; Presentation
+        // Manager identity belongs to the original foreground attach.
+        command.push(flotilla_protocol::arg::Arg::Literal("--transient".to_string()));
         command.push(flotilla_protocol::arg::Arg::Quoted(reference.to_string()));
-        let args = resolver
-            .one_hop_command_args(&next_hop, command)
-            .map_err(|err| format!("unreachable next hop '{next_hop}' for host '{target_host}': {err}"))?;
-        Ok(flotilla_protocol::arg::flatten(&args, 0))
+        let hop_resolver = HopResolver::new(
+            Arc::new(resolver),
+            Arc::new(NoopEnvironmentHopResolver),
+            Arc::new(NoopTerminalHopResolver),
+            ResolutionPurpose::Attach,
+        );
+        let plan = HopPlan(vec![Hop::RemoteToHost { host: next_hop.clone() }, Hop::RunCommand { command }]);
+        let mut context = ResolutionContext {
+            current_host: self.host_name.clone(),
+            current_environment: None,
+            working_directory: None,
+            actions: Vec::new(),
+            nesting_depth: 0,
+        };
+        hop_resolver
+            .resolve(&plan, &mut context)
+            .map(|resolved| ResolvedAttachPlan(resolved.0))
+            .map_err(|err| format!("unreachable next hop '{next_hop}' for host '{target_host}': {err}"))
     }
 
-    pub async fn route_remote_attach_binding(&self, binding: &AttachBinding) -> Result<String, String> {
+    pub async fn route_remote_attach_binding(&self, binding: &AttachBinding) -> Result<ResolvedAttachPlan, String> {
         let reference = binding
             .session
             .as_deref()
             .or(binding.convoy.as_deref())
             .ok_or_else(|| "remote attach binding has neither a session nor convoy reference".to_string())?;
-        self.recursive_attach_command_for_remote(&binding.host, reference, false).await
+        self.recursive_attach_plan_for_remote(&binding.host, reference).await
     }
 
-    async fn local_attach_command_for_session(
+    async fn local_attach_plan_for_session(
         &self,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
         environment: &flotilla_resources::ResourceObject<ResourceEnvironment>,
-    ) -> Result<String, String> {
+    ) -> Result<ResolvedAttachPlan, String> {
         let cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
         let registry = self.registry_for_resource_environment(environment, cwd.as_path()).await?;
         let pool = registry
@@ -6116,25 +6129,31 @@ impl InProcessDaemon {
         let attach_target = terminal_session_attach_target(session)?;
         let attach_args = pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?;
         if environment.spec.docker.is_some() {
-            let command = ResolvedPaneCommand { role: session.spec.role.clone(), args: attach_args };
             let environment_id = EnvironmentId::new(session.spec.env_ref.clone());
             let container_name = environment.status.as_ref().and_then(|status| status.docker_container_id.as_deref());
-            let resolved = executor::workspace::resolve_prepared_commands_via_hop_chain(
-                &self.host_name,
-                cwd.as_path(),
-                &[command],
-                self.config.base_path().as_path(),
-                &self.host_name,
-                Some(&environment_id),
-                container_name,
-            )?;
-            return resolved
-                .into_iter()
-                .next()
-                .map(|(_, command)| command)
-                .ok_or_else(|| "attach command resolution produced no command".to_string());
+            let container_name =
+                container_name.ok_or_else(|| format!("environment {} has no docker container id", session.spec.env_ref))?;
+            let environment_resolver =
+                DockerEnvironmentHopResolver::new(HashMap::from([(environment_id.clone(), container_name.to_string())]));
+            let hop_resolver = HopResolver::new(
+                Arc::new(crate::hop_chain::remote::NoopRemoteHopResolver),
+                Arc::new(environment_resolver),
+                Arc::new(NoopTerminalHopResolver),
+                ResolutionPurpose::Attach,
+            );
+            let plan = HopPlan(vec![Hop::EnterEnvironment { env_id: environment_id, provider: "docker".to_string() }, Hop::RunCommand {
+                command: attach_args,
+            }]);
+            let mut context = ResolutionContext {
+                current_host: self.host_name.clone(),
+                current_environment: None,
+                working_directory: Some(cwd),
+                actions: Vec::new(),
+                nesting_depth: 0,
+            };
+            return hop_resolver.resolve(&plan, &mut context).map(|resolved| ResolvedAttachPlan(resolved.0));
         }
-        Ok(flotilla_protocol::arg::flatten(&attach_args, 0))
+        Ok(ResolvedAttachPlan(vec![ResolvedAttachAction::Command(attach_args)]))
     }
 
     fn target_host_for_resource_ref(&self, host_ref: &str) -> HostName {
@@ -7358,14 +7377,14 @@ impl DaemonHandle for InProcessDaemon {
                             warn!(%error, "failed to emit attach regard");
                         }
                     }
-                    Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command: resolved.command, binding: resolved.binding })
+                    Ok(flotilla_protocol::CommandValue::AttachCommandResolved { plan: resolved.plan, binding: resolved.binding })
                 }
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
             },
             CommandAction::AttachTransient { reference, host } => {
                 match self.resolve_transient_attach_command_internal(reference, host.as_ref()).await {
                     Ok(resolved) => {
-                        Ok(flotilla_protocol::CommandValue::AttachCommandResolved { command: resolved.command, binding: resolved.binding })
+                        Ok(flotilla_protocol::CommandValue::AttachCommandResolved { plan: resolved.plan, binding: resolved.binding })
                     }
                     Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
                 }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -53,6 +53,31 @@ use crate::{
 
 const TEST_LOCAL_ATTACH_HOST: &str = "local";
 
+fn attach_plan_text(plan: &flotilla_protocol::ResolvedAttachPlan) -> String {
+    plan.0
+        .iter()
+        .map(|action| match action {
+            flotilla_protocol::ResolvedAttachAction::Command(args) => flotilla_protocol::arg::flatten(args, 0),
+            flotilla_protocol::ResolvedAttachAction::SendKeys { steps, .. } => steps
+                .iter()
+                .filter_map(|step| match step {
+                    flotilla_protocol::SendKeyStep::Type { text } => Some(text.clone()),
+                    flotilla_protocol::SendKeyStep::WaitForReady => None,
+                })
+                .collect::<Vec<_>>()
+                .join(" "),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn single_attach_command(plan: &flotilla_protocol::ResolvedAttachPlan) -> String {
+    let [flotilla_protocol::ResolvedAttachAction::Command(args)] = plan.0.as_slice() else {
+        panic!("expected one attach command, got {plan:?}");
+    };
+    flotilla_protocol::arg::flatten(args, 0)
+}
+
 #[test]
 fn project_reference_distinguishes_project_namespace_from_full_address() {
     assert_eq!(resolve_project_ref("flotilla", "project/widgets"), Ok(("project".into(), "widgets".into())));
@@ -2209,9 +2234,10 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
         .await
         .expect("attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, binding } = result else {
+    let CommandValue::AttachCommandResolved { plan, binding } = result else {
         panic!("expected attach command, got {result:?}");
     };
+    let command = single_attach_command(&plan);
     assert_eq!(command, "attach cleat-session-1");
     let binding = binding.expect("local resolution carries the structured binding");
     assert_eq!(binding.session.as_deref(), Some("terminal-convoy-a-implement-coder"));
@@ -2330,12 +2356,14 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
         .await
         .expect("attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, .. } = result else {
+    let CommandValue::AttachCommandResolved { plan, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert!(command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")), "command should target the next host over SSH: {command}");
-    assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
+    let command = attach_plan_text(&plan);
+    assert!(command.contains(&format!("ssh -t 'alice@{remote_hostname}'")), "command should target the next host over SSH: {command}");
+    assert!(!command.contains("${SHELL:-/bin/sh} -l -c"), "interactive attach should enter SSH without wrapping: {command}");
     assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach: {command}");
+    assert!(command.contains("--transient"), "every recursive attach hop must avoid Presentation Manager stamping: {command}");
     assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
     assert!(!command.contains("remote-provider-session"), "remote hop must not include terminal-provider attach args: {command}");
     assert_eq!(command.matches("flotilla attach").count(), 1, "command should contain exactly one recursive attach invocation: {command}");
@@ -2420,8 +2448,9 @@ async fn replicated_session_recipe_tracks_live_route_and_resolves_through_the_ho
         daemon.resolvable_attach_references_internal(&references).await.expect("connected capability query").contains(session_name),
         "the recipe should appear when the origin route becomes live"
     );
-    assert!(resolved.command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")), "attach should use the live hop");
-    assert!(resolved.command.contains("flotilla attach"), "attach should re-resolve on the remote daemon");
+    let plan_text = attach_plan_text(&resolved.plan);
+    assert!(plan_text.contains(&format!("ssh -t 'alice@{remote_hostname}'")), "attach should use the live hop");
+    assert!(plan_text.contains("flotilla attach"), "attach should re-resolve on the remote daemon");
     assert_eq!(resolved.binding.expect("remote binding").host, HostName::new(remote_host));
 
     daemon.set_topology_routes(Vec::new()).await;
@@ -2516,13 +2545,14 @@ async fn host_qualified_attach_disambiguates_same_named_local_and_replica_sessio
 
     let local =
         daemon.resolve_attach_command_on_host_internal(session_name, Some(&local_host)).await.expect("resolve local same-name session");
-    assert_eq!(local.command, "attach local-provider-session");
+    assert_eq!(single_attach_command(&local.plan), "attach local-provider-session");
     assert_eq!(local.binding.expect("local binding").host, local_host);
 
     let remote =
         daemon.resolve_attach_command_on_host_internal(session_name, Some(&remote_host)).await.expect("resolve remote same-name session");
-    assert!(remote.command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")));
-    assert!(remote.command.contains("--host"));
+    let remote_plan = attach_plan_text(&remote.plan);
+    assert!(remote_plan.contains(&format!("ssh -t 'alice@{remote_hostname}'")));
+    assert!(remote_plan.contains("--host"));
     assert_eq!(remote.binding.expect("remote binding").host, remote_host);
 }
 
@@ -2569,9 +2599,10 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
         .await
         .expect("attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, binding } = result else {
+    let CommandValue::AttachCommandResolved { plan, binding } = result else {
         panic!("expected attach command, got {result:?}");
     };
+    let command = attach_plan_text(&plan);
     let binding = binding.expect("replica resolution carries the structured binding");
     assert_eq!(binding.host.as_str(), remote_host);
     assert_eq!(binding.namespace, "dev");
@@ -2579,11 +2610,8 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
     assert_eq!(binding.convoy.as_deref(), Some("convoy-a"));
     assert_eq!(binding.vessel.as_deref(), Some("implement"));
     assert_eq!(binding.role.as_deref(), Some("coder"));
-    assert!(
-        command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")),
-        "command should target the replica host over SSH: {command}"
-    );
-    assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
+    assert!(command.contains(&format!("ssh -t 'alice@{remote_hostname}'")), "command should target the replica host over SSH: {command}");
+    assert!(!command.contains("${SHELL:-/bin/sh} -l -c"), "interactive attach should enter SSH without wrapping: {command}");
     assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach: {command}");
     assert!(command.contains("convoy-a/implement/coder"), "command should preserve the original reference: {command}");
 
@@ -2600,13 +2628,11 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
         .await
         .expect("attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, .. } = result else {
+    let CommandValue::AttachCommandResolved { plan, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert!(
-        command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")),
-        "bare role should resolve through the replica host: {command}"
-    );
+    let command = attach_plan_text(&plan);
+    assert!(command.contains(&format!("ssh -t 'alice@{remote_hostname}'")), "bare role should resolve through the replica host: {command}");
     assert!(command.contains("flotilla attach"), "bare role should recursively invoke flotilla attach: {command}");
     assert!(command.contains("coder"), "command should preserve the original bare role reference: {command}");
 
@@ -2623,11 +2649,12 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
         .await
         .expect("attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, .. } = result else {
+    let CommandValue::AttachCommandResolved { plan, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
+    let command = attach_plan_text(&plan);
     assert!(
-        command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")),
+        command.contains(&format!("ssh -t 'alice@{remote_hostname}'")),
         "session name should resolve through the replica host: {command}"
     );
     assert!(command.contains("terminal-remote-coder"), "command should preserve the independent row's attach reference: {command}");
@@ -2696,16 +2723,17 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
         .await
         .expect("transient attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, binding } = result else {
+    let CommandValue::AttachCommandResolved { plan, binding } = result else {
         panic!("expected attach command, got {result:?}");
     };
+    let command = attach_plan_text(&plan);
     let binding = binding.expect("replica resolution carries a structured binding");
     assert_eq!(binding.host, HostName::new(selected_host));
     assert_eq!(binding.session.as_deref(), Some("terminal-scratch"));
     assert_eq!(binding.convoy, None);
     assert_eq!(binding.role, None);
     assert!(
-        command.starts_with(&format!("ssh -t 'alice@{selected_hostname}' ")),
+        command.contains(&format!("ssh -t 'alice@{selected_hostname}'")),
         "selected row should route through {selected_host}: {command}"
     );
     assert!(command.contains("--transient"), "recursive attach must preserve the no-stamp mode: {command}");
@@ -2750,11 +2778,11 @@ async fn transient_attach_resolves_standing_checkout_paths_locally_and_determini
             )
             .await
             .expect("transient attach query should execute");
-        let CommandValue::AttachCommandResolved { command, binding } = result else {
+        let CommandValue::AttachCommandResolved { plan, binding } = result else {
             panic!("expected attach command, got {result:?}");
         };
         assert!(binding.is_none(), "standing checkout terminals are deliberately not stamped as convoy sessions");
-        resolved.push(command);
+        resolved.push(single_attach_command(&plan));
     }
     assert_eq!(resolved[0], resolved[1], "the same checkout must resolve to the same terminal target");
     let ensured = terminal_pool.ensured.lock().await;
@@ -2800,11 +2828,12 @@ async fn transient_attach_routes_standing_checkout_paths_to_the_displayed_remote
         )
         .await
         .expect("transient attach query should execute");
-    let CommandValue::AttachCommandResolved { command, binding } = result else {
+    let CommandValue::AttachCommandResolved { plan, binding } = result else {
         panic!("expected attach command, got {result:?}");
     };
+    let command = attach_plan_text(&plan);
     assert!(binding.is_none());
-    assert!(command.starts_with(&format!("ssh -t 'alice@{remote_hostname}' ")));
+    assert!(command.contains(&format!("ssh -t 'alice@{remote_hostname}'")));
     assert!(command.contains("--transient"));
     assert!(command.contains("/work/standing"));
 }
@@ -2906,11 +2935,12 @@ async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
         .await
         .expect("attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, .. } = result else {
+    let CommandValue::AttachCommandResolved { plan, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert!(command.starts_with(&format!("ssh -t 'alice@{next_hop_hostname}' ")), "command should target the routed next hop: {command}");
-    assert!(command.contains("${SHELL:-/bin/sh} -l -c"), "command should run through a remote login shell: {command}");
+    let command = attach_plan_text(&plan);
+    assert!(command.contains(&format!("ssh -t 'alice@{next_hop_hostname}'")), "command should target the routed next hop: {command}");
+    assert!(!command.contains("${SHELL:-/bin/sh} -l -c"), "interactive attach should enter SSH without wrapping: {command}");
     assert!(command.contains("flotilla attach"), "command should recursively invoke flotilla attach on the next hop: {command}");
     assert!(!command.contains(&target_hostname), "command should not try to jump directly to the final host: {command}");
     assert!(!command.contains("gouda-provider-session"), "command should not embed final terminal-provider attach args: {command}");
@@ -2959,9 +2989,10 @@ async fn attach_query_prefers_exact_reference_over_prefix_matches() {
         .await
         .expect("attach query should execute");
 
-    let CommandValue::AttachCommandResolved { command, binding } = result else {
+    let CommandValue::AttachCommandResolved { plan, binding } = result else {
         panic!("expected attach command, got {result:?}");
     };
+    let command = single_attach_command(&plan);
     assert_eq!(command, "attach session-exact");
     assert_eq!(binding.expect("binding present").session.as_deref(), Some("terminal-convoy-a-implement-coder"));
 }

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -699,7 +699,7 @@ fn hop_chain_resolves_remote_plus_environment_plus_terminal() {
     assert_eq!(docker_nested[0], Arg::Literal("docker".into()), "middle command should be docker");
     assert_eq!(docker_nested[1], Arg::Literal("exec".into()), "docker subcommand should be exec");
     assert_eq!(docker_nested[2], Arg::Literal("-it".into()), "docker exec should have -it flag");
-    assert_eq!(docker_nested[3], Arg::Literal("container-abc".into()), "docker exec target should be container-abc");
+    assert_eq!(docker_nested[3], Arg::Quoted("container-abc".into()), "docker exec target should be container-abc");
 
     // Innermost args are flattened directly into the docker exec invocation
     assert_eq!(docker_nested[4], Arg::Literal("cleat".into()), "innermost command should be cleat");
@@ -710,7 +710,8 @@ fn hop_chain_resolves_remote_plus_environment_plus_terminal() {
     // Verify flatten produces the expected structure
     let flat = flatten(outer_args, 0);
     assert!(flat.starts_with("ssh "), "flattened output should start with ssh: {flat}");
-    assert!(flat.contains("docker exec -it container-abc"), "should contain docker exec: {flat}");
+    assert!(flat.contains("docker exec -it"), "should contain docker exec: {flat}");
+    assert!(flat.contains("container-abc"), "should contain the quoted container target: {flat}");
     assert!(flat.contains("cleat attach"), "should contain cleat attach: {flat}");
     assert!(flat.contains(att_id.as_str()), "should contain session id: {flat}");
 

--- a/crates/flotilla-core/src/step/tests.rs
+++ b/crates/flotilla-core/src/step/tests.rs
@@ -324,7 +324,10 @@ async fn symbolic_step_action_succeeds() {
 async fn produced_does_not_override_final_result() {
     let (cancel, tx) = setup();
     let resolver = TestResolver::new(vec![
-        Ok(StepOutcome::Produced(CommandValue::AttachCommandResolved { command: "attach cmd".into(), binding: None })),
+        Ok(StepOutcome::Produced(CommandValue::AttachCommandResolved {
+            plan: flotilla_protocol::ResolvedAttachPlan::shell_command("attach cmd"),
+            binding: None,
+        })),
         Ok(StepOutcome::Completed),
     ]);
     let plan = StepPlan::new(vec![make_step("step-a"), make_step("step-b")]);
@@ -386,7 +389,7 @@ async fn local_step_consumes_produced_outcome_from_remote_step() {
             prior: &[StepOutcome],
         ) -> Result<StepOutcome, String> {
             assert_eq!(prior, &[StepOutcome::Produced(CommandValue::AttachCommandResolved {
-                command: "attach remote".into(),
+                plan: flotilla_protocol::ResolvedAttachPlan::shell_command("attach remote"),
                 binding: None
             })]);
             Ok(StepOutcome::Completed)
@@ -403,7 +406,10 @@ async fn local_step_consumes_produced_outcome_from_remote_step() {
         assert_host: remote_host.clone(),
         progress: vec![],
         wait_for_cancel: None,
-        result: Ok(vec![StepOutcome::Produced(CommandValue::AttachCommandResolved { command: "attach remote".into(), binding: None })]),
+        result: Ok(vec![StepOutcome::Produced(CommandValue::AttachCommandResolved {
+            plan: flotilla_protocol::ResolvedAttachPlan::shell_command("attach remote"),
+            binding: None,
+        })]),
     }]);
 
     let result = run_step_plan_with_remote_executor(

--- a/crates/flotilla-core/src/terminal_manager.rs
+++ b/crates/flotilla-core/src/terminal_manager.rs
@@ -11,7 +11,7 @@ use crate::{
         builder::HopPlanBuilder,
         environment::NoopEnvironmentHopResolver,
         remote::NoopRemoteHopResolver,
-        resolver::{AlwaysWrap, HopResolver},
+        resolver::{HopResolver, ResolutionPurpose},
         terminal::PoolTerminalHopResolver,
         ResolutionContext, ResolvedAction,
     },
@@ -165,7 +165,7 @@ impl TerminalManager {
     /// Returns the command string needed to attach to a terminal session.
     ///
     /// Uses the hop chain internally: builds a `HopPlan` via `HopPlanBuilder::build_for_attachable()`,
-    /// resolves it with `PoolTerminalHopResolver` + `AlwaysWrap`, and flattens to a string.
+    /// resolves it for interactive attach and flattens the sole local command to a string.
     /// For local attach (same-host), the plan is just `[AttachTerminal(id)]` with no remote hop.
     pub async fn attach_command(&self, attachable_id: &AttachableId, daemon_socket_path: Option<&str>) -> Result<String, String> {
         let plan = {
@@ -185,12 +185,12 @@ impl TerminalManager {
 
         let terminal_resolver =
             PoolTerminalHopResolver::new(Arc::clone(&self.pool), self.store.clone(), daemon_socket_path.map(|s| s.to_string()));
-        let hop_resolver = HopResolver {
-            remote: Arc::new(NoopRemoteHopResolver),
-            environment: Arc::new(NoopEnvironmentHopResolver),
-            terminal: Arc::new(terminal_resolver),
-            strategy: Arc::new(AlwaysWrap),
-        };
+        let hop_resolver = HopResolver::new(
+            Arc::new(NoopRemoteHopResolver),
+            Arc::new(NoopEnvironmentHopResolver),
+            Arc::new(terminal_resolver),
+            ResolutionPurpose::Attach,
+        );
 
         let mut context = ResolutionContext {
             current_host: self.local_host.clone(),

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1005,14 +1005,14 @@ async fn fork_stance_refuses_reviewless_dispatch_and_admits_implement_review() {
     let overridden_id = daemon.execute(start("overridden", "single-agent-contained")).await.expect("override dispatch command");
     assert_eq!(recv_command_finished(&mut events, overridden_id).await, CommandValue::ConvoyStarted {
         name: "overridden".into(),
-        attach_command: None,
+        attach_plan: None,
         binding: None
     });
 
     let admitted_id = daemon.execute(start("reviewed", "implement-review")).await.expect("dispatch command");
     assert_eq!(recv_command_finished(&mut events, admitted_id).await, CommandValue::ConvoyStarted {
         name: "reviewed".into(),
-        attach_command: None,
+        attach_plan: None,
         binding: None
     });
     let convoy = backend.using::<ResourceConvoy>("flotilla").get("reviewed").await.expect("reviewed convoy");
@@ -1183,7 +1183,7 @@ async fn bare_convoy_start_uses_the_viable_local_host_direct_policy() {
     })
     .await
     .expect("start command should finish");
-    assert_eq!(result, CommandValue::ConvoyStarted { name: "local-default".into(), attach_command: None, binding: None });
+    assert_eq!(result, CommandValue::ConvoyStarted { name: "local-default".into(), attach_plan: None, binding: None });
     let convoy = backend.using::<ResourceConvoy>("flotilla").get("local-default").await.expect("persisted convoy");
     assert_eq!(convoy.spec.placement_policy.as_deref(), Some("host-direct-z-local"));
 }
@@ -1377,7 +1377,7 @@ async fn convoy_start_accepts_project_list_identifier() {
 
         assert_eq!(recv_command_finished(&mut events, start_id).await, CommandValue::ConvoyStarted {
             name: name.clone(),
-            attach_command: None,
+            attach_plan: None,
             binding: None
         });
         let convoy = backend.using::<ResourceConvoy>("flotilla").get(&name).await.expect("persisted convoy");
@@ -1503,7 +1503,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     .await
     .expect("start command should finish");
 
-    assert_eq!(result, CommandValue::ConvoyStarted { name: "issue-732".into(), attach_command: None, binding: None });
+    assert_eq!(result, CommandValue::ConvoyStarted { name: "issue-732".into(), attach_plan: None, binding: None });
     let persisted = backend.using::<ResourceConvoy>("flotilla").get("issue-732").await.expect("persisted convoy");
     assert_eq!(persisted.spec.project_ref.as_deref(), Some("flotilla"));
     assert_eq!(persisted.spec.workflow_ref, "single-agent-contained");
@@ -1548,7 +1548,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
         .expect("default start command accepted");
     assert_eq!(recv_command_finished(&mut events, default_id).await, CommandValue::ConvoyStarted {
         name: "default-regard".into(),
-        attach_command: None,
+        attach_plan: None,
         binding: None
     });
     let default_convoy = backend.using::<ResourceConvoy>("flotilla").get("default-regard").await.expect("default convoy");
@@ -1596,7 +1596,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     })
     .await
     .expect("batch start should finish");
-    assert_eq!(batch_result, CommandValue::ConvoyStarted { name: "batch-732-733".into(), attach_command: None, binding: None });
+    assert_eq!(batch_result, CommandValue::ConvoyStarted { name: "batch-732-733".into(), attach_plan: None, binding: None });
     let batch = backend.using::<ResourceConvoy>("flotilla").get("batch-732-733").await.expect("batch convoy");
     assert_eq!(batch.spec.issues.iter().map(|issue| &issue.reference).collect::<Vec<_>>(), vec![&reference, &reference_two]);
     assert_eq!(batch.spec.instruction.as_deref(), Some("Fix both issues in one convoy."));
@@ -1642,7 +1642,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     .expect("offline fallback should finish");
     assert_eq!(fallback_result, CommandValue::ConvoyStarted {
         name: "start-convoy-from-an-issue-732".into(),
-        attach_command: None,
+        attach_plan: None,
         binding: None,
     });
     let fallback = backend.using::<ResourceConvoy>("flotilla").get("start-convoy-from-an-issue-732").await.expect("fallback convoy");
@@ -1693,7 +1693,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     })
     .await
     .expect("explicit workflow should not consult the missing default");
-    assert_eq!(explicit_result, CommandValue::ConvoyStarted { name: "explicit-workflow".into(), attach_command: None, binding: None });
+    assert_eq!(explicit_result, CommandValue::ConvoyStarted { name: "explicit-workflow".into(), attach_plan: None, binding: None });
 
     let wrong_namespace_id = daemon
         .execute(Command {
@@ -1844,7 +1844,7 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
     .await
     .expect("start command should finish");
 
-    assert_eq!(result, CommandValue::ConvoyStarted { name: "generated-convoy".into(), attach_command: None, binding: None });
+    assert_eq!(result, CommandValue::ConvoyStarted { name: "generated-convoy".into(), attach_plan: None, binding: None });
     let persisted = backend.using::<ResourceConvoy>("flotilla").get("generated-convoy").await.expect("persisted convoy");
     assert_eq!(persisted.spec.r#ref.as_deref(), Some("fix/generated-convoy"));
     assert_eq!(utility.calls.load(Ordering::SeqCst), 1);
@@ -2009,7 +2009,7 @@ async fn convoy_start_worker_panic_finishes_the_command_and_allows_retry() {
 
     let retry_id = daemon.execute(command).await.expect("matching convoy start retry should be accepted");
     let retry_result = recv_command_finished(&mut events, retry_id).await;
-    assert_eq!(retry_result, CommandValue::ConvoyStarted { name: "retried-convoy".into(), attach_command: None, binding: None });
+    assert_eq!(retry_result, CommandValue::ConvoyStarted { name: "retried-convoy".into(), attach_plan: None, binding: None });
 
     drop(temp);
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -3464,7 +3464,10 @@ mod tests {
         let revived_coder_id = revived_coder.status.as_ref().and_then(|status| status.crew.as_ref()).expect("revived identity").id.clone();
 
         let attach = daemon.resolve_attach_command_internal("crew-convoy/implement/coder").await.expect("attach coder");
-        assert!(attach.command.contains("attach terminal-crew-convoy-implement-coder"));
+        let [flotilla_protocol::ResolvedAttachAction::Command(args)] = attach.plan.0.as_slice() else {
+            panic!("expected one local attach command, got {:?}", attach.plan);
+        };
+        assert!(flotilla_protocol::arg::flatten(args, 0).contains("attach terminal-crew-convoy-implement-coder"));
 
         let mut rx = daemon.subscribe();
         let coder_recomplete_id = daemon

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -490,17 +490,17 @@ impl RemoteCommandRouter {
     }
 
     async fn route_remote_result(&self, result: CommandValue) -> CommandValue {
-        let CommandValue::ConvoyStarted { name, attach_command, binding } = result else {
+        let CommandValue::ConvoyStarted { name, attach_plan, binding } = result else {
             return result;
         };
         let Some(binding) = binding else {
-            return CommandValue::ConvoyStarted { name, attach_command, binding: None };
+            return CommandValue::ConvoyStarted { name, attach_plan, binding: None };
         };
-        if attach_command.is_none() || binding.host == *self.daemon.host_name() {
-            return CommandValue::ConvoyStarted { name, attach_command, binding: Some(binding) };
+        if attach_plan.is_none() || binding.host == *self.daemon.host_name() {
+            return CommandValue::ConvoyStarted { name, attach_plan, binding: Some(binding) };
         }
         match self.daemon.route_remote_attach_binding(&binding).await {
-            Ok(command) => CommandValue::ConvoyStarted { name, attach_command: Some(command), binding: Some(binding) },
+            Ok(plan) => CommandValue::ConvoyStarted { name, attach_plan: Some(plan), binding: Some(binding) },
             Err(message) => CommandValue::Error { message: format!("convoy {name} started, but remote attach routing failed: {message}") },
         }
     }

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1309,7 +1309,7 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
     let mut remote_events = remote_daemon.subscribe();
     let remote_command_id = remote_daemon.execute(routed.clone()).await.expect("prepared command should be accepted by remote daemon");
     let remote_result = wait_for_command_result(&mut remote_events, remote_command_id, StdDuration::from_secs(5)).await;
-    assert_eq!(remote_result, CommandValue::ConvoyStarted { name: "remote-work".to_string(), attach_command: None, binding: None });
+    assert_eq!(remote_result, CommandValue::ConvoyStarted { name: "remote-work".to_string(), attach_plan: None, binding: None });
     let remote_backend = remote_daemon.resource_backend();
     let convoy = remote_backend.clone().using::<Convoy>("flotilla").get("remote-work").await.expect("remote daemon should persist convoy");
     assert_eq!(convoy.spec.workflow_ref, "remote-workflow");
@@ -1344,7 +1344,7 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
         .expect("repeated prepared command should be accepted");
     assert_eq!(wait_for_command_result(&mut repeated_events, repeated_id, StdDuration::from_secs(5)).await, CommandValue::ConvoyStarted {
         name: "remote-work-again".to_string(),
-        attach_command: None,
+        attach_plan: None,
         binding: None
     });
     let prepared_workflows = remote_backend
@@ -1403,7 +1403,7 @@ daemon_socket = "/run/user/1000/flotilla.sock"
             repo: None,
             result: CommandValue::ConvoyStarted {
                 name: "remote-work".to_string(),
-                attach_command: Some("cleat attach remote-session".to_string()),
+                attach_plan: Some(flotilla_protocol::ResolvedAttachPlan::shell_command("cleat attach remote-session")),
                 binding: Some(
                     AttachBinding::builder()
                         .host(HostName::new("feta"))
@@ -1419,12 +1419,13 @@ daemon_socket = "/run/user/1000/flotilla.sock"
         DaemonEvent::CommandFinished { command_id: 42, result, .. } => result,
         event => panic!("expected command finished, got {event:?}"),
     };
-    let CommandValue::ConvoyStarted { attach_command: Some(command), .. } = result else {
+    let CommandValue::ConvoyStarted { attach_plan: Some(plan), .. } = result else {
         panic!("expected routed convoy attach result, got {result:?}");
     };
-    assert!(command.contains("feta.example"), "attach should route through configured peer: {command}");
-    assert!(command.contains("remote-session"), "attach should preserve the remote session reference: {command}");
-    assert!(!command.starts_with("cleat attach"), "origin must not execute the remote host's local attach command");
+    let rendered = format!("{plan:?}");
+    assert!(rendered.contains("feta.example"), "attach should route through configured peer: {rendered}");
+    assert!(rendered.contains("remote-session"), "attach should preserve the remote session reference: {rendered}");
+    assert!(!rendered.starts_with("cleat attach"), "origin must not execute the remote host's local attach command");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -515,7 +515,7 @@ async fn convoy_start_uses_live_peer_route_when_presentation_membership_is_stale
 
     assert_eq!(await_command_result(&mut events, command_id).await, CommandValue::ConvoyStarted {
         name: "remote-work".to_string(),
-        attach_command: None,
+        attach_plan: None,
         binding: None
     });
     topology

--- a/crates/flotilla-protocol/src/attach_plan.rs
+++ b/crates/flotilla-protocol/src/attach_plan.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+use crate::arg::Arg;
+
+/// An interactive attach plan in execution-stack order.
+///
+/// Consumers pop actions from the end: run the outer command first, then wait
+/// for and type each successively inner command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedAttachPlan(pub Vec<ResolvedAttachAction>);
+
+impl ResolvedAttachPlan {
+    pub fn command(args: Vec<Arg>) -> Self {
+        Self(vec![ResolvedAttachAction::Command(args)])
+    }
+
+    pub fn shell_command(command: impl Into<String>) -> Self {
+        Self::command(vec![Arg::Literal(command.into())])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum ResolvedAttachAction {
+    Command(Vec<Arg>),
+    /// Steps are also in stack order and are popped from the end.
+    SendKeys {
+        hop: String,
+        steps: Vec<SendKeyStep>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SendKeyStep {
+    WaitForReady,
+    Type { text: String },
+}

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -625,7 +625,7 @@ pub enum CommandValue {
     },
     Cancelled,
     AttachCommandResolved {
-        command: String,
+        plan: crate::ResolvedAttachPlan,
         /// Structured binding for pane→identity stamping; `None` when the
         /// resolving path cannot describe the target session.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -666,7 +666,7 @@ pub enum CommandValue {
     ConvoyStarted {
         name: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        attach_command: Option<String>,
+        attach_plan: Option<crate::ResolvedAttachPlan>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         binding: Option<AttachBinding>,
     },
@@ -1135,7 +1135,7 @@ mod tests {
             }),
             CommandValue::Error { message: "something failed".into() },
             CommandValue::Cancelled,
-            CommandValue::AttachCommandResolved { command: "bash --login".into(), binding: None },
+            CommandValue::AttachCommandResolved { plan: crate::ResolvedAttachPlan::shell_command("bash --login"), binding: None },
             CommandValue::CheckoutPathResolved { path: PathBuf::from("/repos/project/wt-1") },
             CommandValue::RepoDetail(Box::new(RepoDetailResponse {
                 path: PathBuf::from("/repo"),

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod arg;
+pub mod attach_plan;
 pub mod commands;
 pub mod delta;
 pub mod environment;
@@ -26,6 +27,7 @@ pub mod test_support;
 
 use std::fmt;
 
+pub use attach_plan::{ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
 pub use environment::{EnvironmentId, EnvironmentInfo, EnvironmentKind, EnvironmentSpec, EnvironmentStatus, ImageId, ImageSource};
 pub use host::{HostName, HostPath, RepoIdentity};
 pub use host_summary::{

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -155,8 +155,8 @@ pub fn handle_dispatch_completion(result: Result<u64, String>, pending_ctx: Opti
 
 pub fn handle_attach_dispatch_completion(result: Result<CommandValue, String>, app: &mut App) {
     match result {
-        Ok(CommandValue::AttachCommandResolved { command, .. }) => {
-            app.pending_attach_command = Some(command);
+        Ok(CommandValue::AttachCommandResolved { plan, .. }) => {
+            app.pending_attach_plan = Some(plan);
         }
         Ok(CommandValue::Error { message }) | Err(message) => {
             app.set_status_message(Some(message));
@@ -280,11 +280,11 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
             info!(%name, "convoy created");
             app.set_status_message(Some(format!("Convoy created: {name}")));
         }
-        CommandValue::ConvoyStarted { name, attach_command, .. } => {
+        CommandValue::ConvoyStarted { name, attach_plan, .. } => {
             info!(%name, "convoy started");
             app.set_status_message(Some(format!("Convoy started: {name}")));
-            if let Some(command) = attach_command {
-                app.pending_attach_command = Some(command);
+            if let Some(plan) = attach_plan {
+                app.pending_attach_plan = Some(plan);
             }
         }
         CommandValue::WorkflowTemplateApplied { name } => {
@@ -599,7 +599,7 @@ mod tests {
     #[tokio::test]
     async fn pane_attach_query_hands_the_resolved_command_to_the_event_loop() {
         let mut app = stub_app_with_query_result(Ok(CommandValue::AttachCommandResolved {
-            command: "cleat attach terminal-scratch".to_string(),
+            plan: flotilla_protocol::ResolvedAttachPlan::shell_command("cleat attach terminal-scratch"),
             binding: None,
         }));
         let command = app.command(CommandAction::AttachTransient {
@@ -615,7 +615,7 @@ mod tests {
             other => panic!("unexpected event: {other:?}"),
         }
 
-        assert_eq!(app.pending_attach_command.as_deref(), Some("cleat attach terminal-scratch"));
+        assert_eq!(app.pending_attach_plan, Some(flotilla_protocol::ResolvedAttachPlan::shell_command("cleat attach terminal-scratch")));
         assert!(app.model.status_message.is_none());
     }
 
@@ -1094,7 +1094,13 @@ mod tests {
     #[test]
     fn attach_command_resolved_is_noop() {
         let mut app = stub_app();
-        handle_result(CommandValue::AttachCommandResolved { command: "bash --login".into(), binding: None }, &mut app);
+        handle_result(
+            CommandValue::AttachCommandResolved {
+                plan: flotilla_protocol::ResolvedAttachPlan::shell_command("bash --login"),
+                binding: None,
+            },
+            &mut app,
+        );
         assert!(app.model.status_message.is_none());
         assert!(app.proto_commands.take_next().is_none());
     }

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -530,7 +530,7 @@ pub struct App {
     pub subscriptions_dirty: bool,
     /// A resolved pane attach waiting for the event loop to leave raw mode,
     /// run it as a child process, and then restore the TUI.
-    pub pending_attach_command: Option<String>,
+    pub pending_attach_plan: Option<flotilla_protocol::ResolvedAttachPlan>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -710,7 +710,7 @@ impl App {
             pending_repo_opens: Vec::new(),
             query_seqs: HashMap::new(),
             subscriptions_dirty: true,
-            pending_attach_command: None,
+            pending_attach_plan: None,
         }
     }
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -477,8 +477,8 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::IssuePage(page) => format!("issue page: {} items, has_more={}", page.items.len(), page.has_more),
         CommandValue::IssuesByIds { items } => format!("issues by ids: {} items", items.len()),
         CommandValue::ConvoyCreated { name } => format!("convoy created: {name}"),
-        CommandValue::ConvoyStarted { name, attach_command, .. } => {
-            format!("convoy started: {name}{}", if attach_command.is_some() { " (crew ready)" } else { "" })
+        CommandValue::ConvoyStarted { name, attach_plan, .. } => {
+            format!("convoy started: {name}{}", if attach_plan.is_some() { " (crew ready)" } else { "" })
         }
         CommandValue::WorkflowTemplateApplied { name } => format!("workflow template applied: {name}"),
         CommandValue::ProjectAdded { name } => format!("project added: {name}"),

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -154,9 +154,9 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
         while let Some((cmd, pending_ctx)) = app.proto_commands.take_next() {
             app::executor::dispatch(cmd, &mut app, pending_ctx, events.sender());
         }
-        if let Some(command) = app.pending_attach_command.take() {
+        if let Some(plan) = app.pending_attach_plan.take() {
             events.pause_terminal_input().await;
-            let (next_terminal, result) = crate::terminal::run_temporary_attach(&command);
+            let (next_terminal, result) = crate::terminal::run_temporary_attach(&plan);
             terminal = next_terminal;
             terminal_title = None;
             events.resume_terminal_input();

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,4 +1,8 @@
-use std::io::stdout;
+use std::{
+    collections::HashSet,
+    io::stdout,
+    sync::{LazyLock, Mutex},
+};
 
 use crossterm::{event::DisableMouseCapture, execute};
 use flotilla_protocol::{arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
@@ -28,9 +32,29 @@ trait AttachCommandRunner {
 
 struct SystemAttachCommandRunner;
 
+static ACTIVE_ATTACH_BRIDGES: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+
 impl AttachCommandRunner for SystemAttachCommandRunner {
     fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String> {
         std::process::Command::new(program).args(args).status().map_err(|error| format!("could not start {program}: {error}"))
+    }
+}
+
+fn register_attach_bridge(bridge: &str) {
+    ACTIVE_ATTACH_BRIDGES.lock().expect("active attach bridge lock poisoned").insert(bridge.to_string());
+}
+
+fn kill_attach_bridge(bridge: &str, runner: &mut dyn AttachCommandRunner) {
+    if ACTIVE_ATTACH_BRIDGES.lock().expect("active attach bridge lock poisoned").remove(bridge) {
+        let _ = runner.status("cleat", &["kill".to_string(), bridge.to_string()]);
+    }
+}
+
+fn kill_all_attach_bridges() {
+    let bridges: Vec<_> = ACTIVE_ATTACH_BRIDGES.lock().expect("active attach bridge lock poisoned").drain().collect();
+    let mut runner = SystemAttachCommandRunner;
+    for bridge in bridges {
+        let _ = runner.status("cleat", &["kill".to_string(), bridge]);
     }
 }
 
@@ -52,9 +76,17 @@ fn run_send_keys_attach(
         return Err("attach plan must end with an outer command".to_string());
     };
     let command = arg::flatten(&args, 0);
+    register_attach_bridge(bridge);
     let launch =
-        runner.status("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command])?;
+        match runner.status("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command]) {
+            Ok(status) => status,
+            Err(error) => {
+                kill_attach_bridge(bridge, runner);
+                return Err(error);
+            }
+        };
     if !launch.success() {
+        kill_attach_bridge(bridge, runner);
         return Err(format!("could not launch attach bridge for outer command (status {launch})"));
     }
 
@@ -90,7 +122,7 @@ fn run_send_keys_attach(
         runner.status("cleat", &["attach".to_string(), bridge.to_string()])
     })();
 
-    let _ = runner.status("cleat", &["kill".to_string(), bridge.to_string()]);
+    kill_attach_bridge(bridge, runner);
     result
 }
 
@@ -134,23 +166,30 @@ pub fn install_panic_hook() {
     let hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         restore_terminal();
+        kill_all_attach_bridges();
         hook(info);
     }));
 }
 
-/// Spawn a background task that listens for SIGTERM and cleanly exits.
+/// Spawn a background task that listens for SIGINT or SIGTERM and cleanly exits.
 ///
 /// Must be called after `ratatui::init()` within a tokio runtime.
 /// Covers the entire process lifetime — including the startup window
 /// before the event loop begins.
 #[cfg(unix)]
 pub fn install_sigterm_handler() {
-    let mut sigterm =
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).expect("failed to register SIGTERM handler");
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut sigint = signal(SignalKind::interrupt()).expect("failed to register SIGINT handler");
+    let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
     tokio::spawn(async move {
-        sigterm.recv().await;
+        let exit_code = tokio::select! {
+            _ = sigint.recv() => 130,
+            _ = sigterm.recv() => 0,
+        };
         restore_terminal();
-        std::process::exit(0);
+        kill_all_attach_bridges();
+        std::process::exit(exit_code);
     });
 }
 
@@ -229,7 +268,7 @@ mod tests {
     fn shell_death_while_waiting_names_the_hop() {
         let mut runner = FakeRunner::with_statuses([0, 2, 0]);
 
-        let error = run_send_keys_attach(&two_hop_plan(), "bridge", &mut runner).expect_err("dead shell should fail");
+        let error = run_send_keys_attach(&two_hop_plan(), "dead-bridge", &mut runner).expect_err("dead shell should fail");
 
         assert!(error.contains("docker environment 'crew-box'"), "{error}");
         assert!(error.contains("did not become ready"), "{error}");
@@ -240,7 +279,7 @@ mod tests {
     fn readiness_uses_screen_stability_before_sending_echoed_text() {
         let mut runner = FakeRunner::default();
 
-        run_send_keys_attach(&two_hop_plan(), "bridge", &mut runner).expect("attach plan should run");
+        run_send_keys_attach(&two_hop_plan(), "ready-bridge", &mut runner).expect("attach plan should run");
 
         let commands: Vec<_> = runner.calls.iter().map(|(_, args)| args[0].as_str()).collect();
         assert_eq!(commands, ["launch", "wait", "send", "attach", "kill"]);

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::sync::Once;
 use std::{
     collections::HashSet,
     io::stdout,
@@ -33,6 +35,8 @@ trait AttachCommandRunner {
 struct SystemAttachCommandRunner;
 
 static ACTIVE_ATTACH_BRIDGES: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+#[cfg(unix)]
+static ATTACH_SIGNAL_HANDLER: Once = Once::new();
 
 impl AttachCommandRunner for SystemAttachCommandRunner {
     fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String> {
@@ -128,6 +132,11 @@ fn run_send_keys_attach(
 
 /// Execute an interactive attach plan and return the attached process status.
 pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<std::process::ExitStatus, String> {
+    // Standalone CLI and convoy auto-attach paths do not pass through TUI
+    // startup, so install the idempotent bridge cleanup handler here too.
+    #[cfg(unix)]
+    install_sigterm_handler();
+
     let mut runner = SystemAttachCommandRunner;
     match plan.0.as_slice() {
         [ResolvedAttachAction::Command(args)] => run_direct_attach(args, &mut runner),
@@ -178,18 +187,20 @@ pub fn install_panic_hook() {
 /// before the event loop begins.
 #[cfg(unix)]
 pub fn install_sigterm_handler() {
-    use tokio::signal::unix::{signal, SignalKind};
+    ATTACH_SIGNAL_HANDLER.call_once(|| {
+        use tokio::signal::unix::{signal, SignalKind};
 
-    let mut sigint = signal(SignalKind::interrupt()).expect("failed to register SIGINT handler");
-    let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
-    tokio::spawn(async move {
-        let exit_code = tokio::select! {
-            _ = sigint.recv() => 130,
-            _ = sigterm.recv() => 0,
-        };
-        restore_terminal();
-        kill_all_attach_bridges();
-        std::process::exit(exit_code);
+        let mut sigint = signal(SignalKind::interrupt()).expect("failed to register SIGINT handler");
+        let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+        tokio::spawn(async move {
+            let exit_code = tokio::select! {
+                _ = sigint.recv() => 130,
+                _ = sigterm.recv() => 0,
+            };
+            restore_terminal();
+            kill_all_attach_bridges();
+            std::process::exit(exit_code);
+        });
     });
 }
 

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,9 +1,7 @@
-#[cfg(unix)]
-use std::sync::Once;
 use std::{
     collections::HashSet,
     io::stdout,
-    sync::{LazyLock, Mutex},
+    sync::{LazyLock, Mutex, MutexGuard, Once},
 };
 
 use crossterm::{event::DisableMouseCapture, execute};
@@ -35,6 +33,7 @@ trait AttachCommandRunner {
 struct SystemAttachCommandRunner;
 
 static ACTIVE_ATTACH_BRIDGES: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
+static ATTACH_PANIC_HOOK: Once = Once::new();
 #[cfg(unix)]
 static ATTACH_SIGNAL_HANDLER: Once = Once::new();
 
@@ -44,18 +43,25 @@ impl AttachCommandRunner for SystemAttachCommandRunner {
     }
 }
 
+fn active_attach_bridges() -> MutexGuard<'static, HashSet<String>> {
+    match ACTIVE_ATTACH_BRIDGES.lock() {
+        Ok(bridges) => bridges,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 fn register_attach_bridge(bridge: &str) {
-    ACTIVE_ATTACH_BRIDGES.lock().expect("active attach bridge lock poisoned").insert(bridge.to_string());
+    active_attach_bridges().insert(bridge.to_string());
 }
 
 fn kill_attach_bridge(bridge: &str, runner: &mut dyn AttachCommandRunner) {
-    if ACTIVE_ATTACH_BRIDGES.lock().expect("active attach bridge lock poisoned").remove(bridge) {
+    if active_attach_bridges().remove(bridge) {
         let _ = runner.status("cleat", &["kill".to_string(), bridge.to_string()]);
     }
 }
 
 fn kill_all_attach_bridges() {
-    let bridges: Vec<_> = ACTIVE_ATTACH_BRIDGES.lock().expect("active attach bridge lock poisoned").drain().collect();
+    let bridges: Vec<_> = active_attach_bridges().drain().collect();
     let mut runner = SystemAttachCommandRunner;
     for bridge in bridges {
         let _ = runner.status("cleat", &["kill".to_string(), bridge]);
@@ -133,7 +139,8 @@ fn run_send_keys_attach(
 /// Execute an interactive attach plan and return the attached process status.
 pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<std::process::ExitStatus, String> {
     // Standalone CLI and convoy auto-attach paths do not pass through TUI
-    // startup, so install the idempotent bridge cleanup handler here too.
+    // startup, so install the idempotent bridge cleanup hooks here too.
+    install_panic_hook();
     #[cfg(unix)]
     install_sigterm_handler();
 
@@ -169,22 +176,25 @@ pub fn run_temporary_attach(plan: &ResolvedAttachPlan) -> (ratatui::DefaultTermi
 
 /// Install a panic hook that restores the terminal before printing the panic.
 ///
-/// Must be called after `ratatui::init()`. Wraps whatever hook is currently
-/// installed (including color_eyre's) so error reporting still works.
+/// Safe to call before terminal initialization and more than once. Wraps
+/// whatever hook is currently installed (including color_eyre's) so error
+/// reporting still works.
 pub fn install_panic_hook() {
-    let hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        restore_terminal();
-        kill_all_attach_bridges();
-        hook(info);
-    }));
+    ATTACH_PANIC_HOOK.call_once(|| {
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            restore_terminal();
+            kill_all_attach_bridges();
+            hook(info);
+        }));
+    });
 }
 
 /// Spawn a background task that listens for SIGINT or SIGTERM and cleanly exits.
 ///
-/// Must be called after `ratatui::init()` within a tokio runtime.
-/// Covers the entire process lifetime — including the startup window
-/// before the event loop begins.
+/// Must be called within a tokio runtime. Safe before terminal initialization
+/// and safe to call more than once. Covers the entire process lifetime,
+/// including the startup window before the event loop begins.
 #[cfg(unix)]
 pub fn install_sigterm_handler() {
     ATTACH_SIGNAL_HANDLER.call_once(|| {

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,6 +1,7 @@
 use std::io::stdout;
 
 use crossterm::{event::DisableMouseCapture, execute};
+use flotilla_protocol::{arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
 
 /// Restore the terminal to its original state.
 ///
@@ -21,28 +22,107 @@ fn reinitialize_terminal() -> ratatui::DefaultTerminal {
     terminal
 }
 
+trait AttachCommandRunner {
+    fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String>;
+}
+
+struct SystemAttachCommandRunner;
+
+impl AttachCommandRunner for SystemAttachCommandRunner {
+    fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String> {
+        std::process::Command::new(program).args(args).status().map_err(|error| format!("could not start {program}: {error}"))
+    }
+}
+
+fn run_direct_attach(
+    args: &[flotilla_protocol::arg::Arg],
+    runner: &mut dyn AttachCommandRunner,
+) -> Result<std::process::ExitStatus, String> {
+    let command = arg::flatten(args, 0);
+    runner.status("sh", &["-lc".to_string(), command])
+}
+
+fn run_send_keys_attach(
+    plan: &ResolvedAttachPlan,
+    bridge: &str,
+    runner: &mut dyn AttachCommandRunner,
+) -> Result<std::process::ExitStatus, String> {
+    let mut actions = plan.0.clone();
+    let Some(ResolvedAttachAction::Command(args)) = actions.pop() else {
+        return Err("attach plan must end with an outer command".to_string());
+    };
+    let command = arg::flatten(&args, 0);
+    let launch =
+        runner.status("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command])?;
+    if !launch.success() {
+        return Err(format!("could not launch attach bridge for outer command (status {launch})"));
+    }
+
+    let result = (|| {
+        while let Some(action) = actions.pop() {
+            let ResolvedAttachAction::SendKeys { hop, mut steps } = action else {
+                return Err("attach plan contains more than one executable command".to_string());
+            };
+            while let Some(step) = steps.pop() {
+                match step {
+                    SendKeyStep::WaitForReady => {
+                        let status = runner.status("cleat", &[
+                            "wait".to_string(),
+                            bridge.to_string(),
+                            "--screen-stable".to_string(),
+                            "100ms".to_string(),
+                            "--timeout".to_string(),
+                            "30".to_string(),
+                        ])?;
+                        if !status.success() {
+                            return Err(format!("attach hop {hop} did not become ready (cleat wait status {status})"));
+                        }
+                    }
+                    SendKeyStep::Type { text } => {
+                        let status = runner.status("cleat", &["send".to_string(), bridge.to_string(), text])?;
+                        if !status.success() {
+                            return Err(format!("could not send keys for attach hop {hop} (cleat send status {status})"));
+                        }
+                    }
+                }
+            }
+        }
+        runner.status("cleat", &["attach".to_string(), bridge.to_string()])
+    })();
+
+    let _ = runner.status("cleat", &["kill".to_string(), bridge.to_string()]);
+    result
+}
+
+/// Execute an interactive attach plan and return the attached process status.
+pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<std::process::ExitStatus, String> {
+    let mut runner = SystemAttachCommandRunner;
+    match plan.0.as_slice() {
+        [ResolvedAttachAction::Command(args)] => run_direct_attach(args, &mut runner),
+        _ => {
+            let bridge = format!("flotilla-attach-{}", uuid::Uuid::new_v4());
+            run_send_keys_attach(plan, &bridge, &mut runner)
+        }
+    }
+}
+
 /// Temporarily leave the TUI to inspect a terminal session, then restore it.
 ///
 /// This deliberately does not stamp Presentation Manager metadata: the pane
 /// remains owned by its existing project/archipelago context while the attach
 /// is only a transient foreground excursion.
-pub fn run_temporary_attach(command: &str) -> (ratatui::DefaultTerminal, Result<(), String>) {
+pub fn run_temporary_attach(plan: &ResolvedAttachPlan) -> (ratatui::DefaultTerminal, Result<(), String>) {
     restore_terminal();
-    let result = std::process::Command::new("sh")
-        .arg("-lc")
-        .arg(command)
-        .status()
-        .map_err(|error| format!("could not start attach command: {error}"))
-        .and_then(|status| {
-            if status.success() {
-                Ok(())
-            } else {
-                Err(format!(
-                    "attach command exited with status {}",
-                    status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
-                ))
-            }
-        });
+    let result = run_attach_plan(plan).and_then(|status| {
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!(
+                "attach command exited with status {}",
+                status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
+            ))
+        }
+    });
     (reinitialize_terminal(), result)
 }
 
@@ -72,6 +152,146 @@ pub fn install_sigterm_handler() {
         restore_terminal();
         std::process::exit(0);
     });
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::{collections::VecDeque, os::unix::process::ExitStatusExt, process::ExitStatus};
+
+    use flotilla_protocol::{arg::Arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
+
+    use super::{run_send_keys_attach, AttachCommandRunner};
+
+    #[derive(Default)]
+    struct FakeRunner {
+        statuses: VecDeque<i32>,
+        calls: Vec<(String, Vec<String>)>,
+    }
+
+    impl FakeRunner {
+        fn with_statuses(statuses: impl IntoIterator<Item = i32>) -> Self {
+            Self { statuses: statuses.into_iter().collect(), calls: Vec::new() }
+        }
+    }
+
+    impl AttachCommandRunner for FakeRunner {
+        fn status(&mut self, program: &str, args: &[String]) -> Result<ExitStatus, String> {
+            self.calls.push((program.to_string(), args.to_vec()));
+            let code = self.statuses.pop_front().unwrap_or(0);
+            Ok(ExitStatus::from_raw(code << 8))
+        }
+    }
+
+    struct DockerProbeRunner {
+        marker: String,
+        inner: super::SystemAttachCommandRunner,
+    }
+
+    impl AttachCommandRunner for DockerProbeRunner {
+        fn status(&mut self, program: &str, args: &[String]) -> Result<ExitStatus, String> {
+            if program == "cleat" && args.first().is_some_and(|command| command == "attach") {
+                return self.inner.status("cleat", &[
+                    "expect".to_string(),
+                    args[1].clone(),
+                    "--since-marker".to_string(),
+                    "before-inner-attach".to_string(),
+                    "--text".to_string(),
+                    self.marker.clone(),
+                    "--timeout".to_string(),
+                    "10".to_string(),
+                ]);
+            }
+            let status = self.inner.status(program, args)?;
+            if status.success() && program == "cleat" && args.first().is_some_and(|command| command == "wait") {
+                return self.inner.status("cleat", &["mark".to_string(), args[1].clone(), "before-inner-attach".to_string()]);
+            }
+            Ok(status)
+        }
+    }
+
+    fn two_hop_plan() -> ResolvedAttachPlan {
+        ResolvedAttachPlan(vec![
+            ResolvedAttachAction::SendKeys {
+                hop: "docker environment 'crew-box'".into(),
+                steps: vec![SendKeyStep::Type { text: "exec flotilla attach 'crew session'".into() }, SendKeyStep::WaitForReady],
+            },
+            ResolvedAttachAction::Command(vec![
+                Arg::Literal("docker".into()),
+                Arg::Literal("exec".into()),
+                Arg::Literal("-it".into()),
+                Arg::Quoted("crew-box".into()),
+                Arg::Literal("/bin/sh".into()),
+            ]),
+        ])
+    }
+
+    #[test]
+    fn shell_death_while_waiting_names_the_hop() {
+        let mut runner = FakeRunner::with_statuses([0, 2, 0]);
+
+        let error = run_send_keys_attach(&two_hop_plan(), "bridge", &mut runner).expect_err("dead shell should fail");
+
+        assert!(error.contains("docker environment 'crew-box'"), "{error}");
+        assert!(error.contains("did not become ready"), "{error}");
+        assert_eq!(runner.calls.last().expect("cleanup call").1[0], "kill");
+    }
+
+    #[test]
+    fn readiness_uses_screen_stability_before_sending_echoed_text() {
+        let mut runner = FakeRunner::default();
+
+        run_send_keys_attach(&two_hop_plan(), "bridge", &mut runner).expect("attach plan should run");
+
+        let commands: Vec<_> = runner.calls.iter().map(|(_, args)| args[0].as_str()).collect();
+        assert_eq!(commands, ["launch", "wait", "send", "attach", "kill"]);
+        let wait = &runner.calls[1].1;
+        assert!(wait.windows(2).any(|pair| pair == ["--screen-stable", "100ms"]));
+        assert!(!runner.calls.iter().any(|(_, args)| args.iter().any(|arg| arg == "expect")));
+    }
+
+    #[test]
+    #[ignore = "requires Docker, cleat, and the debian:trixie-slim image"]
+    fn real_docker_hop_types_the_inner_attach_into_the_container_shell() {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let container = format!("flotilla-attach-test-{suffix}");
+        let bridge = format!("flotilla-attach-test-{suffix}");
+        let marker = format!("CREW_READY_{suffix}");
+        let split = marker.len() / 2;
+        let typed = format!("exec sh -c \"printf '{}''{}'; exit\"", &marker[..split], &marker[split..]);
+        let plan = ResolvedAttachPlan(vec![
+            ResolvedAttachAction::SendKeys {
+                hop: format!("docker container '{container}'"),
+                steps: vec![SendKeyStep::Type { text: typed }, SendKeyStep::WaitForReady],
+            },
+            ResolvedAttachAction::Command(vec![
+                Arg::Literal("docker".into()),
+                Arg::Literal("exec".into()),
+                Arg::Literal("-it".into()),
+                Arg::Quoted(container.clone()),
+                Arg::Literal("/bin/sh".into()),
+            ]),
+        ]);
+
+        let started = std::process::Command::new("docker")
+            .args(["run", "-d", "--name", &container, "debian:trixie-slim", "sleep", "infinity"])
+            .status()
+            .expect("start docker container");
+        assert!(started.success(), "docker container should start");
+
+        let result = (|| {
+            let mut runner = DockerProbeRunner { marker, inner: super::SystemAttachCommandRunner };
+            let status = run_send_keys_attach(&plan, &bridge, &mut runner)?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(format!("container crew marker was not observed (status {status})"))
+            }
+        })();
+
+        let _ = std::process::Command::new("cleat").args(["kill", &bridge]).status();
+        let _ = std::process::Command::new("docker").args(["rm", "-f", &container]).status();
+        result.expect("send-keys should land in the container shell");
+    }
 }
 
 /// Suspend the process (Ctrl-Z / SIGTSTP).

--- a/docs/superpowers/research/2026-07-27-contained-vessel-plumbing.md
+++ b/docs/superpowers/research/2026-07-27-contained-vessel-plumbing.md
@@ -36,7 +36,7 @@ attach path, so the final classification is **probably works**, not **works**.
 
 | Link | Verdict | Short reason |
 |---|---|---|
-| Docker hop in the hop-chain abstraction | **works** | `EnterEnvironment` wraps an inner structured command with `docker exec -it`, including `-w` for the interior cwd. |
+| Docker hop in the hop-chain abstraction | **works** | `EnterEnvironment` supports both architecture-level forms: interactive attach enters `docker exec -it ... /bin/sh` and sends the inner attach one boundary at a time; non-interactive execution wraps the structured command with `docker exec -it`, including `-w` for the interior cwd. |
 | Current crew attach with `pool: passthrough` | **probably works** | The control-plane attach path supplies the container id and resolves the passthrough launch command through the Docker hop; only synthetic/unit coverage proves it. |
 | Hop-chain quoting | **probably works** | Quoting is centralized in the structured `Arg` tree and handles nested commands and apostrophes; the already-built agent command remains trusted raw shell. |
 | `worktree_on_host_and_mount` writable workspace | **broken** | The reconciler asks for `Rw`, the runtime erases the mode, and Docker emits `:ro`. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -742,10 +742,10 @@ async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) 
     if let CommandValue::Error { .. } = result {
         std::process::exit(1);
     }
-    if let CommandValue::ConvoyStarted { name, attach_command: Some(command), binding } = result {
+    if let CommandValue::ConvoyStarted { name, attach_plan: Some(plan), binding } = result {
         if matches!(format, OutputFormat::Human) {
             stamp_pane_identity(&name, binding.as_ref()).await;
-            return run_attach_command(&command);
+            return run_attach_plan(&plan);
         }
     }
     Ok(())
@@ -780,16 +780,16 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
         .map_err(|e| color_eyre::eyre::eyre!(e))?;
 
     match result {
-        CommandValue::AttachCommandResolved { command, binding } => match format {
+        CommandValue::AttachCommandResolved { plan, binding } => match format {
             OutputFormat::Json => {
-                println!("{}", flotilla_protocol::output::json_pretty(&CommandValue::AttachCommandResolved { command, binding }));
+                println!("{}", flotilla_protocol::output::json_pretty(&CommandValue::AttachCommandResolved { plan, binding }));
                 Ok(())
             }
             OutputFormat::Human => {
                 if !transient {
                     stamp_pane_identity(reference, binding.as_ref()).await;
                 }
-                run_attach_command(&command)
+                run_attach_plan(&plan)
             }
         },
         CommandValue::Error { message } => match format {
@@ -1009,8 +1009,8 @@ fn print_resource_watch_event(response: &flotilla_protocol::ResourceWatchRespons
     }
 }
 
-fn run_attach_command(command: &str) -> Result<()> {
-    let status = std::process::Command::new("sh").arg("-lc").arg(command).status()?;
+fn run_attach_plan(plan: &flotilla_protocol::ResolvedAttachPlan) -> Result<()> {
+    let status = flotilla_tui::terminal::run_attach_plan(plan).map_err(|error| color_eyre::eyre::eyre!(error))?;
     terminate_with_attach_status(status)
 }
 


### PR DESCRIPTION
## What changed

- resolve interactive attach hop chains by entering each SSH or Docker boundary and sending the next transient attach command one hop at a time
- keep non-interactive execution paths fully wrapped through the same purpose-keyed resolver seam
- carry structured attach plans over the protocol and execute multi-action plans through a recorded cleat bridge
- wait for shell screen stability, surface hop-specific failures, and clean up the bridge after attach
- test hostile names with spaces, quotes, and Unicode, recursive `AttachTransient`, readiness/echo behavior, shell death, and the real Docker path (ignored unless its external prerequisites are present)

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1125
