### PR TITLE
fix: require exact whole-repository project shape

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3397,6 +3397,13 @@ fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: St
     })
 }
 
+fn is_whole_repository_project(spec: &ProjectSpec, repository_key: &RepositoryKey) -> bool {
+    matches!(
+        spec.repositories.as_slice(),
+        [entry] if &entry.repo == repository_key && entry.subpath.is_none()
+    )
+}
+
 fn whole_repository_project_names(repository_spec: &RepositorySpec) -> Result<Vec<String>, String> {
     let repository_key = repository_spec.key();
     let display_name = normalize_project_name(&repository_spec.leaf_slug())?;
@@ -4296,11 +4303,7 @@ impl InProcessDaemon {
         let projects = self.resource_backend.clone().definitions::<Project>(&namespace);
         match projects.get(&project_name).await {
             Ok(existing) => {
-                let same_whole_repository = matches!(
-                    existing.spec.repositories.as_slice(),
-                    [entry] if entry.repo == key && entry.subpath.is_none()
-                );
-                if !same_whole_repository {
+                if !is_whole_repository_project(&existing.spec, &key) {
                     return Err(format!("project {project_name} already exists with a different repository definition"));
                 }
                 if explicit_display_name.is_some_and(|display_name| display_name != existing.spec.display_name) {
@@ -4419,12 +4422,7 @@ impl InProcessDaemon {
         let spec = whole_repository_project_spec(repository_key.clone(), display_name)?;
         let primary_name = project_objects
             .iter()
-            .filter(|project| {
-                matches!(
-                    project.spec.repositories.as_slice(),
-                    [entry] if entry.repo == repository_key && entry.subpath.is_none()
-                )
-            })
+            .filter(|project| is_whole_repository_project(&project.spec, &repository_key))
             .min_by_key(|project| {
                 (
                     !migrated_project_names.contains(&project.metadata.name),
@@ -4490,7 +4488,7 @@ impl InProcessDaemon {
                 Ok(_) => return Ok(identity_change),
                 Err(ResourceError::Conflict { .. }) => {
                     let existing = projects.get(&project_name).await.map_err(|error| error.to_string())?;
-                    if existing.spec.repositories.iter().any(|entry| entry.repo == repository_key && entry.subpath.is_none()) {
+                    if is_whole_repository_project(&existing.spec, &repository_key) {
                         return Ok(identity_change);
                     }
                 }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -3604,6 +3604,50 @@ async fn repository_identity_change_removes_old_repo_key_observed_checkouts() {
 }
 
 #[tokio::test]
+async fn whole_repository_materialization_skips_generated_name_occupied_by_multi_repository_project() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo dir");
+
+    let state = FakeVcsState::builder(repo.clone()).branch("main", true).checkout("main").is_main(true).path(&repo).build().build();
+    let mut discovery = fake_vcs_discovery(state);
+    discovery.repo_detectors.push(Box::new(FixedRemoteHostDetector { owner: "owner", repo: "repo" }));
+
+    let daemon = InProcessDaemon::new(Vec::new(), test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    install_test_repository_inspector(&daemon, Arc::new(std::sync::RwLock::new("repo".to_string()))).await;
+
+    let tracked = RepositorySpec::remote("https://github.com/owner/repo").expect("tracked repository spec");
+    let other = RepositorySpec::remote("https://github.com/owner/other").expect("other repository spec");
+    let projects = daemon.resource_backend().using::<Project>("flotilla");
+    projects
+        .create(&InputMeta::builder().name("repo".to_string()).build(), &ProjectSpec {
+            display_name: "repo suite".to_string(),
+            default_workflow_ref: "single-agent-contained".to_string(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec { repo: tracked.key(), subpath: None, default_branch: None }, ProjectRepositorySpec {
+                repo: other.key(),
+                subpath: None,
+                default_branch: None,
+            }],
+        })
+        .await
+        .expect("generated-name occupant should be creatable");
+
+    daemon.add_repo(&repo).await.expect("tracked repository should be added");
+
+    let materialized = projects.list().await.expect("project list should succeed");
+    assert_eq!(materialized.items.len(), 2);
+    assert!(materialized.items.iter().any(|project| {
+        matches!(
+            project.spec.repositories.as_slice(),
+            [entry] if entry.repo == tracked.key() && entry.subpath.is_none()
+        )
+    }));
+    let occupant = materialized.items.iter().find(|project| project.metadata.name == "repo").expect("collision occupant should remain");
+    assert_eq!(occupant.spec.repositories.len(), 2);
+}
+
+#[tokio::test]
 async fn repository_identity_change_tolerates_missing_superseded_repository_retained_by_durable_checkout() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let repo = temp.path().join("repo");

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -485,7 +485,7 @@ async fn tracking_repo_fails_when_its_project_cannot_be_materialized() {
 }
 
 #[tokio::test]
-async fn daemon_start_backfills_project_idempotently_and_preserves_edits() {
+async fn daemon_start_backfills_project_idempotently_and_preserves_edits_to_generated_name_occupant() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let config = test_config(tmp.path().join("config"));
     let checkout_path = tmp.path().join("backfilled");
@@ -534,7 +534,14 @@ async fn daemon_start_backfills_project_idempotently_and_preserves_edits() {
     let _restarted = DaemonRuntime::start_with_options(daemon, config, None, options).await.expect("runtime restart");
 
     assert_eq!(projects.get("backfilled").await.expect("evolved project").spec, evolved);
-    assert_eq!(projects.list().await.expect("project list").items.len(), 1);
+    let materialized = projects.list().await.expect("project list");
+    assert_eq!(materialized.items.len(), 2);
+    assert!(materialized.items.iter().any(|project| {
+        matches!(
+            project.spec.repositories.as_slice(),
+            [entry] if entry.repo == repository_key && entry.subpath.is_none()
+        )
+    }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- use one exact whole-repository shape predicate for primary selection and generated-name conflict handling
- continue deterministic name allocation when a multi-repository project occupies a candidate slug
- cover fresh materialization and restart backfill collision cases

## Testing
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1017