### PR TITLE
fix: allow untouched checkouts through teardown gate

### DIFF
--- a/crates/flotilla-core/src/checkout_integration.rs
+++ b/crates/flotilla-core/src/checkout_integration.rs
@@ -30,11 +30,20 @@ impl fmt::Display for EmbeddedRepository {
     }
 }
 
-pub fn checkout_branch_from_spec(spec: &CheckoutSpec) -> &str {
+fn checkout_branch_from_spec(spec: &CheckoutSpec) -> &str {
     match spec {
         CheckoutSpec::Worktree(spec) => &spec.r#ref,
         CheckoutSpec::FreshClone(spec) => &spec.r#ref,
         CheckoutSpec::Observed(spec) => &spec.r#ref,
+    }
+}
+
+fn checkout_base_ref_from_spec(spec: &CheckoutSpec) -> Option<&str> {
+    match spec {
+        CheckoutSpec::Worktree(spec) => spec.base_ref.as_deref(),
+        CheckoutSpec::FreshClone(spec) => spec.base_ref.as_deref(),
+        CheckoutSpec::Observed(spec) if spec.is_main => Some(&spec.r#ref),
+        CheckoutSpec::Observed(_) => None,
     }
 }
 
@@ -45,11 +54,16 @@ pub fn checkout_path_from_status_and_spec<'a>(status: Option<&'a CheckoutStatus>
     })
 }
 
-pub async fn inspect_checkout_integration(runner: &dyn CommandRunner, checkout_path: &Path, branch: &str) -> CheckoutIntegrationStatus {
+pub async fn inspect_checkout_integration(
+    runner: &dyn CommandRunner,
+    checkout_path: &Path,
+    spec: &CheckoutSpec,
+) -> CheckoutIntegrationStatus {
     let observed_at = Utc::now().to_rfc3339();
     let clean = inspect_clean(runner, checkout_path, &observed_at).await;
     let pushed = inspect_pushed(runner, checkout_path, &observed_at).await;
-    let (landed, landed_evidence) = inspect_landed(runner, checkout_path, branch, &observed_at).await;
+    let (landed, landed_evidence) =
+        inspect_landed(runner, checkout_path, checkout_branch_from_spec(spec), checkout_base_ref_from_spec(spec), &observed_at).await;
     CheckoutIntegrationStatus { clean, pushed, landed, landed_evidence }
 }
 
@@ -217,6 +231,7 @@ async fn inspect_landed(
     runner: &dyn CommandRunner,
     checkout_path: &Path,
     branch: &str,
+    base_ref: Option<&str>,
     observed_at: &str,
 ) -> (IntegrationCondition, Option<LandedEvidence>) {
     match runner
@@ -258,14 +273,7 @@ async fn inspect_landed(
                         )
                     }
                 }
-                None => (
-                    IntegrationCondition::builder()
-                        .value(ConditionValue::True)
-                        .details(vec!["no change request exists for branch".to_string()])
-                        .observed_at(observed_at.to_string())
-                        .build(),
-                    None,
-                ),
+                None => (inspect_no_change_request(runner, checkout_path, base_ref, observed_at).await, None),
             },
             Ok(_) | Err(_) => (
                 IntegrationCondition::builder()
@@ -292,6 +300,64 @@ async fn inspect_landed(
                 .build(),
             None,
         ),
+    }
+}
+
+async fn inspect_no_change_request(
+    runner: &dyn CommandRunner,
+    checkout_path: &Path,
+    base_ref: Option<&str>,
+    observed_at: &str,
+) -> IntegrationCondition {
+    let base_ref = match base_ref {
+        Some(base_ref) => base_ref.to_string(),
+        None => match runner.run_output("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], checkout_path, &ChannelLabel::Noop).await {
+            Ok(output) if output.success && !output.stdout.trim().is_empty() => output.stdout.trim().to_string(),
+            Ok(output) => {
+                return IntegrationCondition::builder()
+                    .value(ConditionValue::Unknown)
+                    .details(vec![non_empty_output_or("no change request exists and the base ref could not be determined", &output.stderr)])
+                    .observed_at(observed_at.to_string())
+                    .build();
+            }
+            Err(error) => {
+                return IntegrationCondition::builder()
+                    .value(ConditionValue::Unknown)
+                    .details(vec![format!("no change request exists and the base ref could not be determined: {error}")])
+                    .observed_at(observed_at.to_string())
+                    .build();
+            }
+        },
+    };
+    let range = format!("{base_ref}..HEAD");
+    match runner.run_output("git", &["rev-list", "--count", &range], checkout_path, &ChannelLabel::Noop).await {
+        Ok(output) if output.success => match output.stdout.trim().parse::<usize>() {
+            Ok(0) => IntegrationCondition::builder()
+                .value(ConditionValue::True)
+                .details(vec![format!("no change request exists; branch has no commits beyond {base_ref}")])
+                .observed_at(observed_at.to_string())
+                .build(),
+            Ok(count) => IntegrationCondition::builder()
+                .value(ConditionValue::False)
+                .details(vec![format!("no change request exists; {count} commit{} beyond {base_ref}", if count == 1 { "" } else { "s" })])
+                .observed_at(observed_at.to_string())
+                .build(),
+            Err(_) => IntegrationCondition::builder()
+                .value(ConditionValue::Unknown)
+                .details(vec![format!("could not parse commit count beyond {base_ref}: {}", output.stdout.trim())])
+                .observed_at(observed_at.to_string())
+                .build(),
+        },
+        Ok(output) => IntegrationCondition::builder()
+            .value(ConditionValue::Unknown)
+            .details(vec![non_empty_output_or(&format!("could not compare branch with base ref {base_ref}"), &output.stderr)])
+            .observed_at(observed_at.to_string())
+            .build(),
+        Err(error) => IntegrationCondition::builder()
+            .value(ConditionValue::Unknown)
+            .details(vec![format!("could not compare branch with base ref {base_ref}: {error}")])
+            .observed_at(observed_at.to_string())
+            .build(),
     }
 }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -57,7 +57,7 @@ use tracing::{debug, info, warn};
 use crate::{
     agent_adapter::CapabilityTable,
     aggregator_projection::AggregatorProjectionState,
-    checkout_integration::{checkout_branch_from_spec, checkout_path_from_status_and_spec, inspect_checkout_integration},
+    checkout_integration::{checkout_path_from_status_and_spec, inspect_checkout_integration},
     config::{ConfigStore, RemoteHostConfig, StaticEnvironmentConfig},
     convert::snapshot_to_proto,
     daemon::{DaemonHandle, QuerySubscription},
@@ -1432,10 +1432,6 @@ fn convoy_start_failure(convoy: &ResourceObject<ResourceConvoy>) -> Option<Strin
     }
 }
 
-fn checkout_branch(checkout: &ResourceObject<ResourceCheckout>) -> &str {
-    checkout_branch_from_spec(&checkout.spec)
-}
-
 fn checkout_path(checkout: &ResourceObject<ResourceCheckout>) -> Option<&str> {
     checkout_path_from_status_and_spec(checkout.status.as_ref(), &checkout.spec)
 }
@@ -2104,7 +2100,7 @@ impl InProcessDaemon {
                 continue;
             };
             let runner = self.runner_for_resource_checkout(&checkout).await?;
-            let mut integration = inspect_checkout_integration(&*runner, Path::new(path), checkout_branch(&checkout)).await;
+            let mut integration = inspect_checkout_integration(&*runner, Path::new(path), &checkout.spec).await;
             if let Some(existing) = checkout.status.as_ref().filter(|status| status.integration.landed.value == ConditionValue::True) {
                 integration.landed.value = ConditionValue::True;
                 if integration.landed_evidence.is_none() {
@@ -5464,7 +5460,7 @@ impl InProcessDaemon {
                     continue;
                 }
             };
-            let mut integration = inspect_checkout_integration(&*runner, &path, checkout_branch(&checkout)).await;
+            let mut integration = inspect_checkout_integration(&*runner, &path, &checkout.spec).await;
             if let Some(existing) = checkout.status.as_ref().filter(|status| status.integration.landed.value == ConditionValue::True) {
                 integration.landed.value = ConditionValue::True;
                 if integration.landed_evidence.is_none() {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use bon::builder;
 use flotilla_protocol::{
     qualified_path::{HostId, QualifiedPath},
     result_set::{
@@ -876,6 +877,46 @@ async fn create_ready_observed_checkout_for_convoy(
                 repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
                 host_ref: "host-01".to_string(),
                 is_main: false,
+            }),
+        )
+        .await
+        .expect("checkout should be created");
+    checkouts
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            path: Some(path.to_string()),
+            commit: None,
+            branch_provenance: Default::default(),
+            integration: Default::default(),
+            message: None,
+        })
+        .await
+        .expect("checkout should be ready");
+}
+
+#[builder]
+async fn create_ready_worktree_checkout_for_repository(
+    daemon: &InProcessDaemon,
+    namespace: &str,
+    convoy: &str,
+    checkout_name: &str,
+    path: &str,
+    branch: &str,
+    base_ref: &str,
+    repository: &str,
+    environment: &str,
+) {
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>(namespace);
+    let created = checkouts
+        .create(
+            &input_meta_with_labels(checkout_name, BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.to_string())])),
+            &ResourceCheckoutSpec::Worktree(flotilla_resources::CheckoutWorktreeSpec {
+                repo_ref: flotilla_resources::RepositoryKey(repository.to_string()),
+                env_ref: environment.to_string(),
+                r#ref: branch.to_string(),
+                base_ref: Some(base_ref.to_string()),
+                target_path: path.to_string(),
+                clone_ref: format!("clone-{repository}"),
             }),
         )
         .await
@@ -4611,6 +4652,126 @@ async fn convoy_delete_refuses_completed_convoy_with_unpushed_checkout_until_for
 
     assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
     assert!(matches!(convoys.get("completed-convoy").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
+}
+
+#[tokio::test]
+async fn convoy_delete_refuses_diverged_checkout_without_a_change_request() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/diverged\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/diverged..HEAD"], Ok("0\n".into()))
+        .on_run(
+            "gh",
+            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt", "--limit", "1"],
+            Ok("[]".into()),
+        )
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("1\n".into()))
+        .build();
+    let mut discovery = fake_discovery(false);
+    discovery.runner = Arc::new(runner);
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), discovery, HostName::local()).await;
+    let convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    convoys
+        .create(&empty_input_meta("diverged-convoy"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+        .await
+        .expect("convoy create should succeed");
+    create_ready_observed_checkout_for_convoy(&daemon, "flotilla", "diverged-convoy", "checkout-diverged", "/repo", "feature/diverged")
+        .await;
+
+    let result = daemon.verify_convoy_teardown_gate("flotilla", "diverged-convoy", false).await;
+
+    let error = result.expect_err("diverged checkout without a change request must block teardown");
+    assert!(error.contains("Landed=False"), "refusal should identify the landed condition: {error}");
+}
+
+#[tokio::test]
+async fn convoy_delete_allows_multi_repo_convoy_with_work_on_only_one_side() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/one-sided-work\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/one-sided-work\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/one-sided-work..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/one-sided-work..HEAD"], Ok("0\n".into()))
+        .on_run(
+            "gh",
+            &["pr", "list", "--head", "feature/one-sided-work", "--state", "all", "--json", "number,state,mergedAt", "--limit", "1"],
+            Ok(r#"[{"number":44,"state":"MERGED","mergedAt":"2026-07-27T12:00:00Z"}]"#.into()),
+        )
+        .on_run(
+            "gh",
+            &["pr", "list", "--head", "feature/one-sided-work", "--state", "all", "--json", "number,state,mergedAt", "--limit", "1"],
+            Ok("[]".into()),
+        )
+        .on_run("git", &["rev-list", "--count", "main..HEAD"], Ok("0\n".into()))
+        .build();
+    let mut discovery = fake_discovery(false);
+    discovery.runner = Arc::new(runner);
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), discovery, HostName::local()).await;
+    let convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    convoys
+        .create(&empty_input_meta("one-sided-convoy"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+        .await
+        .expect("convoy create should succeed");
+    let environments = daemon.resource_backend().using::<ResourceEnvironment>("flotilla");
+    let environment = environments
+        .create(&empty_input_meta("host-env"), &ResourceEnvironmentSpec {
+            host_direct: Some(HostDirectEnvironmentSpec { host_ref: "host-01".to_string(), repo_default_dir: "/work".to_string() }),
+            docker: None,
+        })
+        .await
+        .expect("environment create should succeed");
+    environments
+        .update_status(&environment.metadata.name, &environment.metadata.resource_version, &flotilla_resources::EnvironmentStatus {
+            phase: flotilla_resources::EnvironmentPhase::Ready,
+            ready: true,
+            docker_container_id: None,
+            message: None,
+        })
+        .await
+        .expect("environment status should update");
+    create_ready_worktree_checkout_for_repository()
+        .daemon(&daemon)
+        .namespace("flotilla")
+        .convoy("one-sided-convoy")
+        .checkout_name("checkout-a-andamento")
+        .path("/work/andamento")
+        .branch("feature/one-sided-work")
+        .base_ref("main")
+        .repository("andamento")
+        .environment("host-env")
+        .call()
+        .await;
+    create_ready_worktree_checkout_for_repository()
+        .daemon(&daemon)
+        .namespace("flotilla")
+        .convoy("one-sided-convoy")
+        .checkout_name("checkout-b-flotilla")
+        .path("/work/flotilla")
+        .branch("feature/one-sided-work")
+        .base_ref("main")
+        .repository("flotilla")
+        .environment("host-env")
+        .call()
+        .await;
+
+    let result = daemon.verify_convoy_teardown_gate("flotilla", "one-sided-convoy", false).await;
+
+    result.expect("untouched checkout alongside landed work must not block teardown");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -17,7 +17,7 @@ use flotilla_controllers::reconcilers::{
 use flotilla_core::{
     agent_adapter::{AgentLaunchRequest, CapabilityTable},
     aggregator_projection::AggregatorProjectionState,
-    checkout_integration::{checkout_branch_from_spec, checkout_path_from_status_and_spec, inspect_checkout_integration},
+    checkout_integration::{checkout_path_from_status_and_spec, inspect_checkout_integration},
     config::ConfigStore,
     in_process::InProcessDaemon,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
@@ -1221,10 +1221,6 @@ impl CheckoutControllerRuntime {
         checkout_path_from_status_and_spec(checkout.status.as_ref(), &checkout.spec)
             .ok_or_else(|| format!("checkout {} has no resolved path", checkout.metadata.name))
     }
-
-    fn checkout_branch<'a>(&self, checkout: &'a ResourceObject<Checkout>) -> &'a str {
-        checkout_branch_from_spec(&checkout.spec)
-    }
 }
 
 #[async_trait]
@@ -1372,8 +1368,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
     }
 
     async fn inspect_integration(&self, checkout: &ResourceObject<Checkout>) -> Result<CheckoutIntegrationStatus, String> {
-        Ok(inspect_checkout_integration(&*self.local_runner()?, Path::new(self.checkout_path(checkout)?), self.checkout_branch(checkout))
-            .await)
+        Ok(inspect_checkout_integration(&*self.local_runner()?, Path::new(self.checkout_path(checkout)?), &checkout.spec).await)
     }
 
     async fn remove_checkout(&self, removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {

--- a/docs/adr/0021-convoy-lifecycle-landing-landed-anchored.md
+++ b/docs/adr/0021-convoy-lifecycle-landing-landed-anchored.md
@@ -63,9 +63,10 @@ preserving ADR 0017's claims/conditions split:
 - **`Landing → Landed` is condition-written.** The sole writer is the
   lifecycle reconciler, continuously evaluating the standing integration
   condition: *no change request remains outstanding* — which uniformly
-  covers merged, closed, and never-existed (a no-CR convoy satisfies the
-  condition on first evaluation and lands immediately). Testimony can
-  never write `Landed`.
+  covers merged and closed change requests. A checkout for which no change
+  request ever existed satisfies `Landed` only when its branch has no commits
+  beyond its base ref; a divergent no-CR branch remains unsettled. Testimony
+  can never write `Landed`.
 
 ### Refinement of ADR 0017's "No `Integrated` phase, ever"
 


### PR DESCRIPTION
Closes #1154.

## What changed

- Treat a checkout with no change request as landed only when `git rev-list <base>..HEAD` reports zero commits.
- Use the checkout's declared base ref for managed worktrees and fresh clones, with `origin/HEAD` fallback for observed non-main checkouts.
- Keep divergent no-PR branches blocked, reporting their commit count in the `Landed` condition.
- Cover a two-repository convoy where one checkout has a merged PR and the other is untouched, plus a divergent no-PR refusal.

## Why

A branch name alone is not evidence of unlanded work. Multi-repository convoys can legitimately do work in only one checkout; the untouched checkout should not force deletion to use `--force`. At the same time, a fully pushed divergent branch without a PR must remain protected by the teardown gate.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`