### PR TITLE
fix: expose follower provider suppression

### DIFF
--- a/crates/flotilla-core/src/convert.rs
+++ b/crates/flotilla-core/src/convert.rs
@@ -265,6 +265,7 @@ pub fn provider_health_to_host_statuses(health: &HashMap<(&'static str, String),
             // keys, but will break if a display name diverges from its key.
             implementation: name.to_lowercase(),
             healthy: *healthy,
+            disabled_reason: None,
         })
         .collect();
     statuses.sort_by(|a, b| a.category.cmp(&b.category).then_with(|| a.name.cmp(&b.name)));
@@ -392,13 +393,15 @@ mod tests {
             category: "vcs".into(),
             name: "Git".into(),
             implementation: "git".into(),
-            healthy: true
+            healthy: true,
+            disabled_reason: None,
         }));
         assert!(statuses.contains(&HostProviderStatus {
             category: "cloud_agent".into(),
             name: "Claude".into(),
             implementation: "claude".into(),
-            healthy: false
+            healthy: false,
+            disabled_reason: None,
         }));
     }
 

--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -914,6 +914,7 @@ mod tests {
                 name: "cmux".into(),
                 implementation: "cmux".into(),
                 healthy: true,
+                disabled_reason: None,
             }],
             environments: vec![],
         };
@@ -946,6 +947,7 @@ mod tests {
                 name: "cmux".into(),
                 implementation: "cmux".into(),
                 healthy: true,
+                disabled_reason: None,
             }],
             environments: vec![],
         };
@@ -1354,6 +1356,7 @@ mod tests {
                 name: "cmux".into(),
                 implementation: "cmux".into(),
                 healthy: true,
+                disabled_reason: None,
             }],
             environments: vec![],
         };
@@ -1464,6 +1467,7 @@ mod tests {
                 name: "cmux".into(),
                 implementation: "cmux".into(),
                 healthy: true,
+                disabled_reason: None,
             }],
             environments: vec![],
         };

--- a/crates/flotilla-core/src/host_summary.rs
+++ b/crates/flotilla-core/src/host_summary.rs
@@ -45,6 +45,7 @@ pub fn provider_statuses_from_registries<'a>(registries: impl IntoIterator<Item 
                         name: entry.display_name,
                         implementation: entry.implementation,
                         healthy: true,
+                        disabled_reason: None,
                     });
                 }
             }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1906,9 +1906,9 @@ impl InProcessDaemon {
             .host_scoped_providers
             .discover_for_environment(&self.local_environment_id, &host_bag, &self.discovery.factories, &self.config, &probe_root, runner)
             .await;
-        let provider = host_scoped
-            .issue_provider_for(source)
-            .ok_or_else(|| format!("no issue provider available for {} {}", source.service, source.scope))?;
+        let provider = host_scoped.issue_provider_for(source).ok_or_else(|| {
+            self.missing_external_provider_error(&format!("no issue provider available for {} {}", source.service, source.scope))
+        })?;
         Ok(provider)
     }
 
@@ -4950,8 +4950,14 @@ impl InProcessDaemon {
             .into_iter()
             .map(|(category, name)| {
                 let healthy = snapshot.provider_health.get(&category).and_then(|providers| providers.get(&name)).copied().unwrap_or(true);
-                ProviderInfo { category, name, healthy }
+                ProviderInfo { category, name, healthy, disabled_reason: None }
             })
+            .chain(self.discovery.follower_suppressions().map(|category| ProviderInfo {
+                category: category.slug().to_string(),
+                name: category.display_name().to_string(),
+                healthy: true,
+                disabled_reason: Some("follower mode".to_string()),
+            }))
             .collect();
 
         let unmet_requirements =
@@ -6251,6 +6257,11 @@ impl InProcessDaemon {
                 providers.push(advertised.clone());
             }
         }
+        providers.extend(
+            self.discovery
+                .follower_suppressions()
+                .map(|category| HostProviderStatus::disabled(category.slug(), category.display_name(), "follower mode")),
+        );
         providers.sort_by(|left, right| (&left.category, &left.name).cmp(&(&right.category, &right.name)));
         let summary = crate::host_summary::build_local_host_summary(
             &self.node_id,
@@ -6270,11 +6281,18 @@ impl InProcessDaemon {
         let repos = self.repos.read().await;
         let state = repos.get(&identity).ok_or_else(|| "repo not found".to_string())?;
         let source = forge_issue_source(state.identity());
-        let provider = state
-            .registry()
-            .issue_provider_for(&source)
-            .ok_or_else(|| format!("no issue provider available for {} {}", source.service, source.scope))?;
+        let provider = state.registry().issue_provider_for(&source).ok_or_else(|| {
+            self.missing_external_provider_error(&format!("no issue provider available for {} {}", source.service, source.scope))
+        })?;
         Ok((provider, source))
+    }
+
+    fn missing_external_provider_error(&self, error: &str) -> String {
+        if self.follower {
+            format!("{error}: this host runs in follower mode; dispatch from a leader host")
+        } else {
+            error.to_string()
+        }
     }
 
     pub async fn execute_with_remote_executor(

--- a/crates/flotilla-core/src/providers/discovery/factories/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/factories/mod.rs
@@ -117,4 +117,11 @@ mod tests {
         assert!(!reg.terminal_pools.is_empty());
         assert_eq!(reg.suppressions, super::super::ProviderCategory::FOLLOWER_SUPPRESSED);
     }
+
+    #[test]
+    fn follower_detection_is_independent_of_suppression_order() {
+        let mut runtime = super::super::DiscoveryRuntime::for_process(true);
+        runtime.factories.suppressions.reverse();
+        assert!(runtime.is_follower());
+    }
 }

--- a/crates/flotilla-core/src/providers/discovery/factories/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/factories/mod.rs
@@ -66,6 +66,7 @@ impl FactoryRegistry {
             presentation_managers: presentation_factories(),
             terminal_pools: terminal_pool_factories(),
             environment_providers: vec![Box::new(docker::DockerEnvironmentFactory)],
+            suppressions: vec![],
         }
     }
 
@@ -80,6 +81,7 @@ impl FactoryRegistry {
             presentation_managers: presentation_factories(),
             terminal_pools: terminal_pool_factories(),
             environment_providers: vec![Box::new(docker::DockerEnvironmentFactory)],
+            suppressions: super::ProviderCategory::FOLLOWER_SUPPRESSED.to_vec(),
         }
     }
 }
@@ -99,6 +101,7 @@ mod tests {
         assert!(!reg.ai_utilities.is_empty());
         assert!(!reg.presentation_managers.is_empty());
         assert!(!reg.terminal_pools.is_empty());
+        assert!(reg.suppressions.is_empty());
     }
 
     #[test]
@@ -112,5 +115,6 @@ mod tests {
         assert!(reg.ai_utilities.is_empty());
         assert!(!reg.presentation_managers.is_empty());
         assert!(!reg.terminal_pools.is_empty());
+        assert_eq!(reg.suppressions, super::super::ProviderCategory::FOLLOWER_SUPPRESSED);
     }
 }

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -268,6 +268,8 @@ pub enum ProviderCategory {
 }
 
 impl ProviderCategory {
+    pub const FOLLOWER_SUPPRESSED: [Self; 4] = [Self::ChangeRequest, Self::IssueProvider, Self::CloudAgent, Self::AiUtility];
+
     pub fn slug(&self) -> &'static str {
         match self {
             Self::Vcs => "vcs",
@@ -429,6 +431,8 @@ pub struct FactoryRegistry {
     pub presentation_managers: Vec<Box<PresentationManagerFactory>>,
     pub terminal_pools: Vec<Box<TerminalPoolFactory>>,
     pub environment_providers: Vec<Box<EnvironmentProviderFactory>>,
+    /// Categories intentionally omitted by the selected daemon mode.
+    pub suppressions: Vec<ProviderCategory>,
 }
 
 impl FactoryRegistry {
@@ -645,14 +649,12 @@ impl DiscoveryRuntime {
         Arc::clone(self.attachable_store.get_or_init(|| shared_file_backed_attachable_store(config.base_path())))
     }
 
-    /// A runtime is considered follower-mode when no external-provider factory
-    /// categories are registered. Update this check if new external-provider
-    /// factory categories are added to `FactoryRegistry`.
     pub fn is_follower(&self) -> bool {
-        self.factories.change_requests.is_empty()
-            && self.factories.issue_trackers.is_empty()
-            && self.factories.cloud_agents.is_empty()
-            && self.factories.ai_utilities.is_empty()
+        self.factories.suppressions == ProviderCategory::FOLLOWER_SUPPRESSED
+    }
+
+    pub fn follower_suppressions(&self) -> impl Iterator<Item = ProviderCategory> + '_ {
+        self.factories.suppressions.iter().copied()
     }
 }
 
@@ -1031,6 +1033,7 @@ mod orchestrator_tests {
             presentation_managers: vec![],
             terminal_pools: vec![],
             environment_providers: vec![],
+            suppressions: vec![],
         };
 
         let result = discover_providers(&host_bag, &repo_root, &repo_dets, &fact_reg, &config, runner, &TestEnvVars::default()).await;
@@ -1060,6 +1063,7 @@ mod orchestrator_tests {
             presentation_managers: vec![],
             terminal_pools: vec![],
             environment_providers: vec![],
+            suppressions: vec![],
         };
 
         let result = discover_providers(&host_bag, &repo_root, &repo_dets, &fact_reg, &config, runner, &TestEnvVars::default()).await;

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -650,7 +650,8 @@ impl DiscoveryRuntime {
     }
 
     pub fn is_follower(&self) -> bool {
-        self.factories.suppressions == ProviderCategory::FOLLOWER_SUPPRESSED
+        self.factories.suppressions.len() == ProviderCategory::FOLLOWER_SUPPRESSED.len()
+            && ProviderCategory::FOLLOWER_SUPPRESSED.iter().all(|category| self.factories.suppressions.contains(category))
     }
 
     pub fn follower_suppressions(&self) -> impl Iterator<Item = ProviderCategory> + '_ {

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -1276,6 +1276,7 @@ pub fn fake_discovery_with_provider_set(providers: FakeDiscoveryProviders) -> Di
             presentation_managers: presentation_manager_factories,
             terminal_pools: terminal_pool_factories,
             environment_providers: vec![],
+            suppressions: vec![],
         },
         attachable_store,
         host_scoped_providers: Default::default(),

--- a/crates/flotilla-core/src/providers/discovery/tests.rs
+++ b/crates/flotilla-core/src/providers/discovery/tests.rs
@@ -303,6 +303,7 @@ fn factories_with_presentation(factory: CountingPresentationFactory) -> FactoryR
         presentation_managers: vec![Box::new(factory)],
         terminal_pools: vec![],
         environment_providers: vec![],
+        suppressions: vec![],
     }
 }
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -510,7 +510,13 @@ fn sample_remote_host_summary(name: &str) -> HostSummary {
             environment: HostEnvironment::Container,
         },
         inventory: ToolInventory::default(),
-        providers: vec![HostProviderStatus { category: "vcs".into(), name: "Git".into(), implementation: "git".into(), healthy: true }],
+        providers: vec![HostProviderStatus {
+            category: "vcs".into(),
+            name: "Git".into(),
+            implementation: "git".into(),
+            healthy: true,
+            disabled_reason: None,
+        }],
         environments: vec![],
     }
 }
@@ -5683,6 +5689,10 @@ async fn follower_mode_flag_is_stored() {
     let config = test_config_store(config_tmp.path().to_path_buf());
     let leader = InProcessDaemon::new(vec![], config.clone(), fake_discovery(false), HostName::local()).await;
     assert!(!leader.is_follower(), "default daemon should not be follower");
+    assert!(
+        leader.local_host_summary().await.providers.iter().all(|provider| provider.disabled_reason.is_none()),
+        "leader provider listing should not contain follower suppressions"
+    );
 
     let follower = InProcessDaemon::new(vec![], config, fake_discovery(true), HostName::local()).await;
     assert!(follower.is_follower(), "follower daemon should report follower=true");
@@ -5718,6 +5728,45 @@ async fn follower_mode_skips_external_providers() {
     // In follower mode they should always be absent.
     assert!(!provider_names.contains_key("cloud_agent"), "follower should not have cloud_agent provider");
     assert!(!provider_names.contains_key("ai_utility"), "follower should not have ai_utility provider");
+
+    let expected_suppressions = ["ai_utility", "change_request", "cloud_agent", "issue_tracker"];
+    let host_summary = daemon.local_host_summary().await;
+    let mut host_suppressions = host_summary
+        .providers
+        .iter()
+        .filter(|provider| provider.disabled_reason.as_deref() == Some("follower mode"))
+        .map(|provider| provider.category.as_str())
+        .collect::<Vec<_>>();
+    host_suppressions.sort_unstable();
+    assert_eq!(host_suppressions, expected_suppressions);
+
+    let repo_providers = daemon.get_repo_providers_internal(&RepoSelector::Path(repo)).await.expect("repo providers");
+    let mut repo_suppressions = repo_providers
+        .providers
+        .iter()
+        .filter(|provider| provider.disabled_reason.as_deref() == Some("follower mode"))
+        .map(|provider| provider.category.as_str())
+        .collect::<Vec<_>>();
+    repo_suppressions.sort_unstable();
+    assert_eq!(repo_suppressions, expected_suppressions);
+}
+
+#[tokio::test]
+async fn missing_issue_provider_explains_follower_mode_only_on_followers() {
+    let config_tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(config_tmp.path().to_path_buf());
+    let source = IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() };
+
+    let leader = InProcessDaemon::new(vec![], config.clone(), fake_discovery(false), HostName::local()).await;
+    let leader_error = leader.issue_provider_for_source(&source).await.err().expect("leader should have no provider in test environment");
+    assert_eq!(leader_error, "no issue provider available for https://github.com flotilla-org/flotilla");
+
+    let follower = InProcessDaemon::new(vec![], config, fake_discovery(true), HostName::local()).await;
+    let follower_error = follower.issue_provider_for_source(&source).await.err().expect("follower should have no issue provider");
+    assert_eq!(
+        follower_error,
+        "no issue provider available for https://github.com flotilla-org/flotilla: this host runs in follower mode; dispatch from a leader host"
+    );
 }
 
 #[tokio::test]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -1198,6 +1198,7 @@ mod tests {
                         name: "Git".into(),
                         implementation: "git".into(),
                         healthy: true,
+                        disabled_reason: None,
                     }],
                     environments: vec![],
                 }),

--- a/crates/flotilla-protocol/src/host_summary.rs
+++ b/crates/flotilla-protocol/src/host_summary.rs
@@ -95,12 +95,25 @@ pub struct HostProviderStatus {
     #[serde(default)]
     pub implementation: String,
     pub healthy: bool,
+    /// Why this provider category is intentionally unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_reason: Option<String>,
 }
 
 impl HostProviderStatus {
     pub fn available(category: impl Into<String>, implementation: impl Into<String>) -> Self {
         let implementation = implementation.into();
         Self::builder().category(category.into()).name(implementation.clone()).implementation(implementation).healthy(true).build()
+    }
+
+    pub fn disabled(category: impl Into<String>, name: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::builder()
+            .category(category.into())
+            .name(name.into())
+            .implementation(String::new())
+            .healthy(true)
+            .disabled_reason(reason.into())
+            .build()
     }
 }
 
@@ -135,7 +148,13 @@ mod tests {
                 environment: HostEnvironment::Container,
             },
             inventory: ToolInventory::default(),
-            providers: vec![HostProviderStatus { category: "vcs".into(), name: "Git".into(), implementation: "git".into(), healthy: true }],
+            providers: vec![HostProviderStatus {
+                category: "vcs".into(),
+                name: "Git".into(),
+                implementation: "git".into(),
+                healthy: true,
+                disabled_reason: None,
+            }],
             environments: vec![
                 EnvironmentInfo::Direct {
                     id: EnvironmentId::new("env-direct"),

--- a/crates/flotilla-protocol/src/peer.rs
+++ b/crates/flotilla-protocol/src/peer.rs
@@ -263,7 +263,13 @@ mod tests {
                 environment: HostEnvironment::Container,
             },
             inventory: ToolInventory::default(),
-            providers: vec![HostProviderStatus { category: "vcs".into(), name: "Git".into(), implementation: "git".into(), healthy: true }],
+            providers: vec![HostProviderStatus {
+                category: "vcs".into(),
+                name: "Git".into(),
+                implementation: "git".into(),
+                healthy: true,
+                disabled_reason: None,
+            }],
             environments: vec![],
         }
     }

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -101,6 +101,8 @@ pub struct ProviderInfo {
     pub category: String,
     pub name: String,
     pub healthy: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -408,7 +410,13 @@ mod tests {
                 environment: HostEnvironment::Container,
             },
             inventory: ToolInventory::default(),
-            providers: vec![HostProviderStatus { category: "vcs".into(), name: "Git".into(), implementation: "git".into(), healthy: true }],
+            providers: vec![HostProviderStatus {
+                category: "vcs".into(),
+                name: "Git".into(),
+                implementation: "git".into(),
+                healthy: true,
+                disabled_reason: None,
+            }],
             environments: vec![],
         }
     }

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -256,7 +256,10 @@ fn format_host_providers_human(response: &HostProvidersResponse) -> String {
         table.add_row(vec![
             Cell::new(&provider.category),
             Cell::new(&provider.name),
-            Cell::new(if provider.healthy { "ok" } else { "error" }),
+            Cell::new(provider.disabled_reason.as_ref().map_or_else(
+                || if provider.healthy { "ok".to_string() } else { "error".to_string() },
+                |reason| format!("disabled: {reason}"),
+            )),
         ]);
     }
     out.push_str(&table.to_string());
@@ -669,7 +672,14 @@ fn format_repo_providers_human(resp: &RepoProvidersResponse) -> String {
         table.load_preset(UTF8_FULL_CONDENSED);
         table.set_header(vec!["Category", "Name", "Health"]);
         for p in &resp.providers {
-            table.add_row(vec![Cell::new(&p.category), Cell::new(&p.name), Cell::new(if p.healthy { "ok" } else { "error" })]);
+            table.add_row(vec![
+                Cell::new(&p.category),
+                Cell::new(&p.name),
+                Cell::new(p.disabled_reason.as_ref().map_or_else(
+                    || if p.healthy { "ok".to_string() } else { "error".to_string() },
+                    |reason| format!("disabled: {reason}"),
+                )),
+            ]);
         }
         out.push_str(&table.to_string());
         out.push('\n');

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -92,7 +92,13 @@ mod status_human {
                 environment: HostEnvironment::Container,
             },
             inventory: ToolInventory::default(),
-            providers: vec![HostProviderStatus { category: "vcs".into(), name: "Git".into(), implementation: "git".into(), healthy: true }],
+            providers: vec![HostProviderStatus {
+                category: "vcs".into(),
+                name: "Git".into(),
+                implementation: "git".into(),
+                healthy: true,
+                disabled_reason: None,
+            }],
             environments: vec![],
         }
     }
@@ -177,7 +183,7 @@ mod status_human {
 
     #[test]
     fn host_providers_shows_inventory_and_provider_rows() {
-        let response = HostProvidersResponse {
+        let mut response = HostProvidersResponse {
             environment_id: EnvironmentId::host(HostId::new("local-env")),
             host_name: HostName::new("local"),
             node: NodeInfo::new(NodeId::new("local"), "local"),
@@ -187,10 +193,12 @@ mod status_human {
             summary: sample_host_summary("local"),
             visible_environments: sample_visible_environments(),
         };
+        response.summary.providers.push(HostProviderStatus::disabled("issue_tracker", "Issue Provider", "follower mode"));
 
         let output = format_host_providers_human(&response);
         assert!(output.contains("Providers:"));
         assert!(output.contains("Git"));
+        assert!(output.contains("disabled: follower mode"));
         assert!(output.contains("Visible Environments:"));
         assert!(output.contains("direct-env"));
         assert!(output.contains("provisioned-env"));
@@ -934,17 +942,32 @@ mod repo_providers_human {
     #[test]
     fn with_providers_table() {
         let mut resp = empty_response();
-        resp.providers = vec![ProviderInfo { category: "vcs".into(), name: "Git".into(), healthy: true }, ProviderInfo {
-            category: "change_request".into(),
-            name: "GitHub".into(),
-            healthy: false,
-        }];
+        resp.providers =
+            vec![ProviderInfo { category: "vcs".into(), name: "Git".into(), healthy: true, disabled_reason: None }, ProviderInfo {
+                category: "change_request".into(),
+                name: "GitHub".into(),
+                healthy: false,
+                disabled_reason: None,
+            }];
         let output = format_repo_providers_human(&resp);
         assert!(output.contains("Providers:"), "should show providers header");
         assert!(output.contains("vcs"), "should show category");
         assert!(output.contains("Git"), "should show name");
         assert!(output.contains("ok"), "should show healthy as ok");
         assert!(output.contains("error"), "should show unhealthy as error");
+    }
+
+    #[test]
+    fn with_follower_suppression() {
+        let mut resp = empty_response();
+        resp.providers = vec![ProviderInfo {
+            category: "issue_tracker".into(),
+            name: "Issue Provider".into(),
+            healthy: true,
+            disabled_reason: Some("follower mode".into()),
+        }];
+        let output = format_repo_providers_human(&resp);
+        assert!(output.contains("disabled: follower mode"));
     }
 
     #[test]

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -1059,6 +1059,7 @@ mod tests {
             name: "Docker".to_string(),
             implementation: "docker".to_string(),
             healthy: true,
+            disabled_reason: None,
         });
         feta_summary.environments.push(EnvironmentInfo::Provisioned {
             id: EnvironmentId::new("env-abc123"),

--- a/crates/flotilla-tui/src/widgets/event_log.rs
+++ b/crates/flotilla-tui/src/widgets/event_log.rs
@@ -330,16 +330,7 @@ fn render_hosts_status(model: &TuiModel, theme: &Theme, frame: &mut Frame, area:
                     }
                 });
 
-                let providers: String = h
-                    .summary
-                    .providers
-                    .iter()
-                    .map(|p| {
-                        let check = if p.healthy { "\u{2713}" } else { "\u{2717}" };
-                        format!("{} {check}", p.name)
-                    })
-                    .collect::<Vec<_>>()
-                    .join("  ");
+                let providers: String = h.summary.providers.iter().map(format_host_provider_status).collect::<Vec<_>>().join("  ");
 
                 Row::new(vec![
                     Cell::from(Span::styled(format!("{icon} "), icon_style)),
@@ -365,6 +356,16 @@ fn render_hosts_status(model: &TuiModel, theme: &Theme, frame: &mut Frame, area:
     frame.render_widget(table, area);
 }
 
+fn format_host_provider_status(provider: &flotilla_protocol::HostProviderStatus) -> String {
+    match provider.disabled_reason.as_deref() {
+        Some(reason) => format!("{} (disabled: {reason})", provider.name),
+        None => {
+            let check = if provider.healthy { "\u{2713}" } else { "\u{2717}" };
+            format!("{} {check}", provider.name)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ratatui::layout::Rect;
@@ -378,6 +379,12 @@ mod tests {
         assert_eq!(w.count, 0);
         assert_eq!(w.filter, tracing::Level::INFO);
         assert_eq!(w.filter_area, Rect::default());
+    }
+
+    #[test]
+    fn disabled_host_provider_is_not_rendered_as_healthy() {
+        let provider = flotilla_protocol::HostProviderStatus::disabled("issue_tracker", "Issue Provider", "follower mode");
+        assert_eq!(format_host_provider_status(&provider), "Issue Provider (disabled: follower mode)");
     }
 
     // ── select_next ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- represent follower-mode factory suppression explicitly for change requests, issue trackers, cloud agents, and AI utilities
- show suppressed categories as `disabled: follower mode` in host and repository provider listings
- explain follower mode and leader dispatch when convoy issue admission cannot resolve an issue provider
- preserve the existing missing-provider error and provider listings on leader daemons

## Root cause

Follower daemons intentionally use `FactoryRegistry::for_follower()`, which omits external-provider factories. Provider queries previously represented only active factories and unmet requirements, leaving intentional suppression as a silent third state.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #903
