### PR TITLE
fix: deduplicate scoped convoy snapshots

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -6,7 +6,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use flotilla_protocol::{
@@ -133,6 +133,11 @@ pub struct AggregatorProjectionState {
     salience: Arc<RwLock<SalienceProjection>>,
     #[builder(skip)]
     project_catalog: Arc<RwLock<ProjectCatalogProjection>>,
+    /// Last projected snapshot observed by subscription replay or live
+    /// delivery. Scoped Convoys use full snapshots, so retaining their last
+    /// rows lets rebuilds suppress notifications for unrelated projects.
+    #[builder(skip)]
+    scoped_convoy_snapshots: Arc<Mutex<HashMap<QueryId, ResultSet>>>,
     /// Subscriber ownership and demand-backed materializations belong to the
     /// Aggregator state, shared with the daemon's subscription transport.
     demand_backed: QueryRegistry,
@@ -229,11 +234,19 @@ impl AggregatorProjectionState {
     /// Replace one subscriber's complete demand and return queries whose
     /// materialization lifetime was newly created.
     pub fn replace_subscriber(&self, subscriber: Uuid, cursors: &[QueryCursor]) -> HashSet<QueryId> {
-        self.demand_backed.replace(subscriber, cursors)
+        let newly_materialized = self.demand_backed.replace(subscriber, cursors);
+        self.retain_subscribed_scoped_convoy_snapshots();
+        newly_materialized
     }
 
     pub fn remove_subscriber(&self, subscriber: Uuid) {
         self.demand_backed.remove(subscriber);
+        self.retain_subscribed_scoped_convoy_snapshots();
+    }
+
+    fn retain_subscribed_scoped_convoy_snapshots(&self) {
+        let subscribed = self.demand_backed.subscribed_queries();
+        self.scoped_convoy_snapshots.lock().expect("scoped convoy snapshot lock poisoned").retain(|query, _| subscribed.contains(query));
     }
 
     pub fn subscribed_queries(&self) -> HashSet<QueryId> {
@@ -288,12 +301,55 @@ impl AggregatorProjectionState {
 
     /// The current fleet-merged result set for one named query.
     pub async fn result_set_for(&self, query: &QueryId) -> Option<ResultSet> {
-        match query {
+        let result_set = match query {
             QueryId::Convoys { scope } => Some(self.convoy_result_set(scope).await),
             QueryId::Independents { scope } => Some(self.independents_result_set(scope).await),
             QueryId::Issues { .. } => self.demand_backed.result_set(query),
             QueryId::Checkouts { scope } => Some(self.checkouts.write().await.result_set(scope)),
             QueryId::Awareness { scope, grouping, limit } => Some(self.awareness_result_set(scope, *grouping, *limit).await),
+        };
+        if let Some(result_set) = result_set.as_ref().filter(|result_set| matches!(result_set.query(), QueryId::Convoys { scope: Some(_) }))
+        {
+            self.remember_scoped_convoy_snapshot(result_set);
+        }
+        result_set
+    }
+
+    /// Return only live scoped Convoys snapshots whose projected rows changed
+    /// since subscription replay or the previous live delivery.
+    pub async fn changed_scoped_convoy_result_sets(&self) -> Vec<ResultSet> {
+        let queries =
+            self.subscribed_queries().into_iter().filter(|query| matches!(query, QueryId::Convoys { scope: Some(_) })).collect::<Vec<_>>();
+        let mut changed = Vec::new();
+        for query in queries {
+            let QueryId::Convoys { scope } = &query else { unreachable!("queries were filtered to scoped Convoys") };
+            let result_set = self.convoy_result_set(scope).await;
+            let mut snapshots = self.scoped_convoy_snapshots.lock().expect("scoped convoy snapshot lock poisoned");
+            let projected_changed =
+                snapshots.get(&query).is_none_or(|previous| previous.rows != result_set.rows || previous.state != result_set.state);
+            let is_stale = snapshots.get(&query).is_some_and(|previous| previous.seq > result_set.seq);
+            tracing::debug!(
+                query = %query,
+                rows = result_set.rows.len(),
+                projected_changed,
+                "evaluated scoped convoy snapshot"
+            );
+            if !is_stale {
+                snapshots.insert(query, result_set.clone());
+            }
+            drop(snapshots);
+            if projected_changed && !is_stale {
+                changed.push(result_set);
+            }
+        }
+        changed
+    }
+
+    fn remember_scoped_convoy_snapshot(&self, result_set: &ResultSet) {
+        let query = result_set.query();
+        let mut snapshots = self.scoped_convoy_snapshots.lock().expect("scoped convoy snapshot lock poisoned");
+        if snapshots.get(&query).is_none_or(|previous| previous.seq <= result_set.seq) {
+            snapshots.insert(query, result_set.clone());
         }
     }
 
@@ -584,6 +640,50 @@ mod tests {
 
         let global = state.result_set_for(&QueryId::Convoys { scope: None }).await.expect("global convoy result set");
         assert_eq!(global.rows.as_convoys().expect("global convoy rows").len(), 3);
+    }
+
+    #[tokio::test]
+    async fn scoped_convoy_snapshots_advance_only_when_projected_rows_change() {
+        let state = AggregatorProjectionState::new();
+        let query = QueryId::Convoys { scope: Some(scope("roadmap")) };
+        let roadmap = convoy_row("flotilla", "roadmap-work", "roadmap");
+        let mut unrelated = convoy_row("flotilla", "other-work", "other");
+        {
+            let mut convoys = state.write().await;
+            convoys.local_rows = [roadmap.clone(), unrelated.clone()].into_iter().map(|row| (row.resource.clone(), row)).collect();
+            convoys.seq = 1;
+        }
+        state.replace_subscriber(Uuid::new_v4(), &[QueryCursor { query: query.clone(), since: None }]);
+        let initial = state.result_set_for(&query).await.expect("initial scoped result set");
+        assert_eq!(initial.rows.as_convoys().expect("initial scoped rows"), std::slice::from_ref(&roadmap));
+
+        unrelated.workflow_ref = "review".into();
+        {
+            let mut convoys = state.write().await;
+            convoys.local_rows.insert(unrelated.resource.clone(), unrelated);
+            convoys.seq = 2;
+        }
+        assert!(state.changed_scoped_convoy_result_sets().await.is_empty());
+
+        let mut changed_roadmap = roadmap.clone();
+        changed_roadmap.workflow_ref = "review".into();
+        {
+            let mut convoys = state.write().await;
+            convoys.local_rows.insert(changed_roadmap.resource.clone(), changed_roadmap.clone());
+            convoys.seq = 3;
+        }
+        let changed = state.changed_scoped_convoy_result_sets().await;
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].rows.as_convoys().expect("changed scoped rows"), std::slice::from_ref(&changed_roadmap));
+
+        {
+            let mut convoys = state.write().await;
+            convoys.local_rows.remove(&changed_roadmap.resource);
+            convoys.seq = 4;
+        }
+        let removed = state.changed_scoped_convoy_result_sets().await;
+        assert_eq!(removed.len(), 1);
+        assert!(removed[0].rows.is_empty());
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -28,6 +28,7 @@ use flotilla_resources::{
 };
 use futures::{stream::BoxStream, FutureExt, StreamExt};
 use tokio::sync::{broadcast, mpsc};
+use tracing::debug;
 
 use crate::issue_materializer::{IssueMaterializationResolver, IssueMaterializer};
 
@@ -1437,13 +1438,20 @@ impl Aggregator {
     }
 
     async fn emit_scoped_convoy_result_sets(&self) {
-        for query in self.state.subscribed_queries() {
-            if !matches!(query, QueryId::Convoys { scope: Some(_) }) {
-                continue;
-            }
-            if let Some(result_set) = self.state.result_set_for(&query).await {
-                let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
-            }
+        let fleet_rows = self.state.result_set().await.rows.len();
+        let subscribed_scopes =
+            self.state.subscribed_queries().into_iter().filter(|query| matches!(query, QueryId::Convoys { scope: Some(_) })).count();
+        let result_sets = self.state.changed_scoped_convoy_result_sets().await;
+        let scoped_row_counts = result_sets.iter().map(|result_set| (result_set.query(), result_set.rows.len())).collect::<Vec<_>>();
+        debug!(
+            fleet_rows,
+            subscribed_scopes,
+            changed_scopes = result_sets.len(),
+            scoped_row_counts = ?scoped_row_counts,
+            "projected scoped convoy snapshots"
+        );
+        for result_set in result_sets {
+            let _ = self.event_tx.send(DaemonEvent::ResultSet(Box::new(result_set)));
         }
     }
 
@@ -2892,10 +2900,13 @@ mod tests {
         let (event_tx, mut event_rx) = broadcast::channel(8);
         let mut convoy = convoy_with_branch("convoy-a").await;
         convoy.spec.project_ref = Some("roadmap".into());
+        let mut unrelated_convoy = convoy_with_branch("convoy-b").await;
+        unrelated_convoy.spec.project_ref = Some("other".into());
         let mut deleting_convoy = convoy.clone();
         deleting_convoy.metadata.deletion_timestamp = Some(Utc::now());
         let durable_convoys = ScriptedSource::new(vec![empty_list()], vec![Ok(watch_events(vec![
             WatchEvent::Added(convoy),
+            WatchEvent::Added(unrelated_convoy),
             WatchEvent::Modified(deleting_convoy),
         ]))]);
         let durable_presentations = ScriptedSource::new(vec![empty_list()], vec![Ok(pending_watch())]);
@@ -2928,6 +2939,13 @@ mod tests {
                 let scoped = recv_query_event(&mut event_rx, scoped_query.clone(), "scoped convoy insert result set").await;
                 let DaemonEvent::ResultSet(scoped) = scoped else { panic!("expected scoped result set") };
                 assert_eq!(scoped.rows.as_convoys().expect("scoped convoy rows")[0].name, "convoy-a");
+
+                let unrelated =
+                    recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "unrelated convoy insert delta").await;
+                let DaemonEvent::ResultDelta(unrelated) = unrelated else { panic!("expected unrelated insert delta") };
+                let QueryChanges::Convoys { changed, removed, .. } = &unrelated.changes else { panic!("expected convoy changes") };
+                assert_eq!(changed.iter().map(|row| row.name.as_str()).collect::<Vec<_>>(), vec!["convoy-b"]);
+                assert!(removed.is_empty());
 
                 let removed = recv_query_event(&mut event_rx, QueryId::Convoys { scope: None }, "convoy removal delta").await;
                 let DaemonEvent::ResultDelta(removed) = removed else { panic!("expected removal delta") };


### PR DESCRIPTION
## Summary

- retain the last delivered project-scoped convoy projection across subscription replay and live updates
- suppress full scoped snapshots when only unrelated projects changed while preserving global incremental deltas
- log fleet and scoped projection cardinalities and cover unrelated-project updates plus scoped insert/removal behavior

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1077