### PR TITLE
feat: stamp vessel image digests

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/environment.rs
+++ b/crates/flotilla-controllers/src/reconcilers/environment.rs
@@ -8,8 +8,15 @@ use flotilla_resources::{
 
 #[async_trait]
 pub trait DockerEnvironmentRuntime: Send + Sync {
-    async fn provision(&self, name: &str, spec: &DockerEnvironmentSpec) -> Result<String, String>;
+    async fn provision(&self, name: &str, spec: &DockerEnvironmentSpec) -> Result<DockerProvisioning, String>;
     async fn destroy(&self, container_id: &str) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DockerProvisioning {
+    pub container_id: String,
+    pub image_ref: String,
+    pub image_digest: String,
 }
 
 pub struct EnvironmentReconciler<R> {
@@ -24,7 +31,7 @@ impl<R> EnvironmentReconciler<R> {
 
 pub enum EnvironmentDeps {
     None,
-    Ready { docker_container_id: Option<String> },
+    Ready(DockerProvisioning),
     Failed(String),
 }
 
@@ -40,7 +47,7 @@ where
             EnvironmentPhase::Pending => {
                 if let Some(spec) = &obj.spec.docker {
                     match self.docker.provision(&obj.metadata.name, spec).await {
-                        Ok(container_id) => Ok(EnvironmentDeps::Ready { docker_container_id: Some(container_id) }),
+                        Ok(provisioning) => Ok(EnvironmentDeps::Ready(provisioning)),
                         Err(err) => Ok(EnvironmentDeps::Failed(err)),
                     }
                 } else {
@@ -59,12 +66,14 @@ where
     ) -> ReconcileOutcome<Self::Resource> {
         let patch = match obj.status.as_ref().map(|status| status.phase).unwrap_or(EnvironmentPhase::Pending) {
             EnvironmentPhase::Pending if obj.spec.host_direct.is_some() => {
-                Some(EnvironmentStatusPatch::MarkReady { docker_container_id: None })
+                Some(EnvironmentStatusPatch::MarkReady { docker_container_id: None, image_ref: None, image_digest: None })
             }
             EnvironmentPhase::Pending => match deps {
-                EnvironmentDeps::Ready { docker_container_id } => {
-                    Some(EnvironmentStatusPatch::MarkReady { docker_container_id: docker_container_id.clone() })
-                }
+                EnvironmentDeps::Ready(provisioning) => Some(EnvironmentStatusPatch::MarkReady {
+                    docker_container_id: Some(provisioning.container_id.clone()),
+                    image_ref: Some(provisioning.image_ref.clone()),
+                    image_digest: Some(provisioning.image_digest.clone()),
+                }),
                 EnvironmentDeps::Failed(message) => Some(EnvironmentStatusPatch::MarkFailed { message: message.clone() }),
                 EnvironmentDeps::None => None,
             },

--- a/crates/flotilla-controllers/src/reconcilers/mod.rs
+++ b/crates/flotilla-controllers/src/reconcilers/mod.rs
@@ -10,7 +10,7 @@ pub use checkout::{
     BranchPreservationReason, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout,
 };
 pub use clone::{CloneReconciler, CloneRuntime};
-pub use environment::{DockerEnvironmentRuntime, EnvironmentReconciler};
+pub use environment::{DockerEnvironmentRuntime, DockerProvisioning, EnvironmentReconciler};
 pub use presentation::{
     AppliedPresentation, ApplyPresentationError, DefaultPolicy, HopChainContext, PolicyContext, PresentationDeps, PresentationPlan,
     PresentationPolicy, PresentationPolicyRegistry, PresentationReconciler, PresentationRuntime, PreviousWorkspace,

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -99,6 +99,7 @@ enum PlannedPatch {
     },
     Ready {
         environment_ref: String,
+        image: Option<ImageStamp>,
         checkout_refs: BTreeMap<RepositoryKey, String>,
         terminal_session_refs: Vec<String>,
         requested_stance: Stance,
@@ -107,6 +108,12 @@ enum PlannedPatch {
     Failed {
         message: String,
     },
+}
+
+#[derive(Debug, Clone)]
+struct ImageStamp {
+    image_ref: String,
+    image_digest: String,
 }
 
 #[derive(Debug, Clone)]
@@ -126,6 +133,7 @@ impl VesselDeps {
 
     fn ready(
         environment_ref: String,
+        image: Option<ImageStamp>,
         checkout_refs: BTreeMap<RepositoryKey, String>,
         terminal_session_refs: Vec<String>,
         requested_stance: Stance,
@@ -133,7 +141,7 @@ impl VesselDeps {
         actuations: Vec<Actuation>,
     ) -> Self {
         Self {
-            patch: PlannedPatch::Ready { environment_ref, checkout_refs, terminal_session_refs, requested_stance, effective_stance },
+            patch: PlannedPatch::Ready { environment_ref, image, checkout_refs, terminal_session_refs, requested_stance, effective_stance },
             actuations,
         }
     }
@@ -707,7 +715,29 @@ impl Reconciler for VesselReconciler {
             }
         }
 
-        Ok(VesselDeps::ready(resolved_environment_ref, checkout_refs, terminal_refs, requirement.stance, effective_stance, actuations))
+        let image = match strategy {
+            PlacementStrategy::HostDirect { .. } => None,
+            PlacementStrategy::DockerWorktreeOnHostAndMount { .. } | PlacementStrategy::DockerFreshCloneInContainer { .. } => {
+                let environment = self.environments.get(&resolved_environment_ref).await?;
+                let status = environment.status.as_ref().expect("ready environment has status");
+                let Some(image_ref) = status.image_ref.clone() else {
+                    return Ok(VesselDeps::failed(format!("environment {resolved_environment_ref} is missing its image ref")));
+                };
+                let Some(image_digest) = status.image_digest.clone() else {
+                    return Ok(VesselDeps::failed(format!("environment {resolved_environment_ref} is missing its image digest")));
+                };
+                Some(ImageStamp { image_ref, image_digest })
+            }
+        };
+        Ok(VesselDeps::ready(
+            resolved_environment_ref,
+            image,
+            checkout_refs,
+            terminal_refs,
+            requirement.stance,
+            effective_stance,
+            actuations,
+        ))
     }
 
     fn reconcile(
@@ -723,9 +753,11 @@ impl Reconciler for VesselReconciler {
                 observed_policy_version: observed_policy_version.clone(),
                 started_at: now,
             }),
-            PlannedPatch::Ready { environment_ref, checkout_refs, terminal_session_refs, requested_stance, effective_stance } => {
+            PlannedPatch::Ready { environment_ref, image, checkout_refs, terminal_session_refs, requested_stance, effective_stance } => {
                 Some(VesselStatusPatch::MarkReady {
                     environment_ref: Some(environment_ref.clone()),
+                    image_ref: image.as_ref().map(|image| image.image_ref.clone()),
+                    image_digest: image.as_ref().map(|image| image.image_digest.clone()),
                     checkout_refs: checkout_refs.clone(),
                     terminal_session_refs: terminal_session_refs.clone(),
                     requested_stance: *requested_stance,

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -261,10 +261,10 @@ impl Reconciler for VesselReconciler {
             None
         };
 
-        let precreated_environment_ref = match &strategy {
+        let precreated_environment = match &strategy {
             PlacementStrategy::DockerFreshCloneInContainer { host_ref, image, pull_policy, env, .. } => {
                 let env_name = environment_name(&obj.metadata.name);
-                match self.environments.get(&env_name).await {
+                let image = match self.environments.get(&env_name).await {
                     Ok(existing) => {
                         if existing.status.as_ref().map(|status| status.phase) == Some(EnvironmentPhase::Failed) {
                             let message = existing
@@ -276,6 +276,10 @@ impl Reconciler for VesselReconciler {
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
                             return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                        }
+                        match image_stamp(&existing) {
+                            Ok(image) => image,
+                            Err(message) => return Ok(VesselDeps::failed(message)),
                         }
                     }
                     Err(ResourceError::NotFound { .. }) => {
@@ -296,8 +300,8 @@ impl Reconciler for VesselReconciler {
                         return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                     }
                     Err(err) => return Err(err),
-                }
-                Some(env_name)
+                };
+                Some((env_name, image))
             }
             _ => None,
         };
@@ -488,7 +492,10 @@ impl Reconciler for VesselReconciler {
                         }
                         PlacementStrategy::DockerFreshCloneInContainer { .. } => CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
                             repo_ref: repository_key,
-                            env_ref: precreated_environment_ref.clone().expect("fresh-clone strategy should precreate environment"),
+                            env_ref: precreated_environment
+                                .as_ref()
+                                .map(|(environment_ref, _)| environment_ref.clone())
+                                .expect("fresh-clone strategy should precreate environment"),
                             r#ref: git_ref.clone().expect("repository checkout requires a convoy ref"),
                             base_ref: Some(convoy_repository.source_ref.clone()),
                             target_path: checkout_target_path,
@@ -521,7 +528,7 @@ impl Reconciler for VesselReconciler {
             shared_clone_root.clone().unwrap_or_default()
         };
 
-        let resolved_environment_ref = match &strategy {
+        let (resolved_environment_ref, image) = match &strategy {
             PlacementStrategy::HostDirect { host_ref, .. } => {
                 let env_name = host_direct_environment_name(host_ref);
                 let environment = match self.environments.get(&env_name).await {
@@ -537,11 +544,11 @@ impl Reconciler for VesselReconciler {
                 if environment.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
                     return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                 }
-                env_name
+                (env_name, None)
             }
             PlacementStrategy::DockerWorktreeOnHostAndMount { host_ref, image, pull_policy, env, mount_path, .. } => {
                 let env_name = environment_name(&obj.metadata.name);
-                match self.environments.get(&env_name).await {
+                let image = match self.environments.get(&env_name).await {
                     Ok(existing) => {
                         if existing.status.as_ref().map(|status| status.phase) == Some(EnvironmentPhase::Failed) {
                             let message = existing
@@ -553,6 +560,10 @@ impl Reconciler for VesselReconciler {
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
                             return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                        }
+                        match image_stamp(&existing) {
+                            Ok(image) => image,
+                            Err(message) => return Ok(VesselDeps::failed(message)),
                         }
                     }
                     Err(ResourceError::NotFound { .. }) => {
@@ -580,11 +591,12 @@ impl Reconciler for VesselReconciler {
                         return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
                     }
                     Err(err) => return Err(err),
-                }
-                env_name
+                };
+                (env_name, Some(image))
             }
             PlacementStrategy::DockerFreshCloneInContainer { .. } => {
-                precreated_environment_ref.expect("fresh-clone strategy should resolve environment first")
+                let (environment_ref, image) = precreated_environment.expect("fresh-clone strategy should resolve environment first");
+                (environment_ref, Some(image))
             }
         };
         let terminal_cwd = strategy.terminal_cwd(&workspace_root, multi_repository, has_repositories);
@@ -715,20 +727,6 @@ impl Reconciler for VesselReconciler {
             }
         }
 
-        let image = match strategy {
-            PlacementStrategy::HostDirect { .. } => None,
-            PlacementStrategy::DockerWorktreeOnHostAndMount { .. } | PlacementStrategy::DockerFreshCloneInContainer { .. } => {
-                let environment = self.environments.get(&resolved_environment_ref).await?;
-                let status = environment.status.as_ref().expect("ready environment has status");
-                let Some(image_ref) = status.image_ref.clone() else {
-                    return Ok(VesselDeps::failed(format!("environment {resolved_environment_ref} is missing its image ref")));
-                };
-                let Some(image_digest) = status.image_digest.clone() else {
-                    return Ok(VesselDeps::failed(format!("environment {resolved_environment_ref} is missing its image digest")));
-                };
-                Some(ImageStamp { image_ref, image_digest })
-            }
-        };
         Ok(VesselDeps::ready(
             resolved_environment_ref,
             image,
@@ -784,6 +782,15 @@ impl Reconciler for VesselReconciler {
     fn finalizer_name(&self) -> Option<&'static str> {
         Some("flotilla.work/vessel-workspace-teardown")
     }
+}
+
+fn image_stamp(environment: &ResourceObject<Environment>) -> Result<ImageStamp, String> {
+    let status = environment.status.as_ref().expect("ready environment has status");
+    let image_ref =
+        status.image_ref.clone().ok_or_else(|| format!("environment {} is missing its image ref", environment.metadata.name))?;
+    let image_digest =
+        status.image_digest.clone().ok_or_else(|| format!("environment {} is missing its image digest", environment.metadata.name))?;
+    Ok(ImageStamp { image_ref, image_digest })
 }
 
 fn environment_with_credentials(

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -213,6 +213,8 @@ pub async fn create_ready_host_direct_environment(
             phase: EnvironmentPhase::Ready,
             ready: true,
             docker_container_id: None,
+            image_ref: None,
+            image_digest: None,
             message: None,
         })
         .await
@@ -227,6 +229,7 @@ pub async fn create_ready_docker_environment(
     docker: DockerEnvironmentSpec,
 ) -> flotilla_resources::ResourceObject<Environment> {
     let environments = backend.clone().using::<Environment>(namespace);
+    let image_ref = docker.image.clone();
     let created = environments
         .create(&meta(name), &EnvironmentSpec { host_direct: None, docker: Some(docker) })
         .await
@@ -236,6 +239,8 @@ pub async fn create_ready_docker_environment(
             phase: EnvironmentPhase::Ready,
             ready: true,
             docker_container_id: Some(format!("container-{name}")),
+            image_ref: Some(image_ref),
+            image_digest: Some("sha256:test-image".to_string()),
             message: None,
         })
         .await

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -700,7 +700,7 @@ async fn create_ready_host_direct_env(backend: &ResourceBackend, name: &str) {
         .await
         .expect("env create should succeed");
     let mut status = EnvironmentStatus::default();
-    EnvironmentStatusPatch::MarkReady { docker_container_id: None }.apply(&mut status);
+    EnvironmentStatusPatch::MarkReady { docker_container_id: None, image_ref: None, image_digest: None }.apply(&mut status);
     environments.update_status(name, &created.metadata.resource_version, &status).await.expect("env status update should succeed");
 }
 
@@ -721,7 +721,12 @@ async fn create_ready_docker_env(backend: &ResourceBackend, name: &str) {
         .await
         .expect("env create should succeed");
     let mut status = EnvironmentStatus::default();
-    EnvironmentStatusPatch::MarkReady { docker_container_id: Some("container-docker-env".to_string()) }.apply(&mut status);
+    EnvironmentStatusPatch::MarkReady {
+        docker_container_id: Some("container-docker-env".to_string()),
+        image_ref: Some("ubuntu:24.04".to_string()),
+        image_digest: Some("sha256:test-image".to_string()),
+    }
+    .apply(&mut status);
     environments.update_status(name, &created.metadata.resource_version, &status).await.expect("env status update should succeed");
 }
 

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -14,7 +14,7 @@ use common::{
 };
 use flotilla_controllers::reconcilers::{
     CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime,
-    EnvironmentReconciler, HopChainContext, PreparedCheckout, PresentationPolicyRegistry, PresentationReconciler,
+    DockerProvisioning, EnvironmentReconciler, HopChainContext, PreparedCheckout, PresentationPolicyRegistry, PresentationReconciler,
     ProviderPresentationRuntime, TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
 };
 use flotilla_core::{
@@ -46,8 +46,12 @@ struct FakeDockerRuntime {
 
 #[async_trait]
 impl DockerEnvironmentRuntime for FakeDockerRuntime {
-    async fn provision(&self, name: &str, _spec: &flotilla_resources::DockerEnvironmentSpec) -> Result<String, String> {
-        Ok(format!("container-{name}"))
+    async fn provision(&self, name: &str, spec: &flotilla_resources::DockerEnvironmentSpec) -> Result<DockerProvisioning, String> {
+        Ok(DockerProvisioning {
+            container_id: format!("container-{name}"),
+            image_ref: spec.image.clone(),
+            image_digest: "sha256:test-image".to_string(),
+        })
     }
 
     async fn destroy(&self, container_id: &str) -> Result<(), String> {
@@ -440,6 +444,8 @@ async fn environment_controller_marks_docker_environment_ready() {
                     Some(status)
                         if status.phase == EnvironmentPhase::Ready
                             && status.docker_container_id.as_deref() == Some("container-docker-env")
+                            && status.image_ref.as_deref() == Some("ghcr.io/flotilla/dev:latest")
+                            && status.image_digest.as_deref() == Some("sha256:test-image")
                 )
             }
         })

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -33,7 +33,7 @@ async fn terminal_session_failure_uses_injected_now_for_stopped_at() {
     environments
         .update_status("env-a", &env.metadata.resource_version, &{
             let mut status = EnvironmentStatus::default();
-            EnvironmentStatusPatch::MarkReady { docker_container_id: None }.apply(&mut status);
+            EnvironmentStatusPatch::MarkReady { docker_container_id: None, image_ref: None, image_digest: None }.apply(&mut status);
             status
         })
         .await
@@ -148,7 +148,7 @@ async fn session_provisioning_passes_convoy_and_vessel_tags_to_runtime() {
         .await
         .expect("environment");
     let mut env_status = EnvironmentStatus::default();
-    EnvironmentStatusPatch::MarkReady { docker_container_id: None }.apply(&mut env_status);
+    EnvironmentStatusPatch::MarkReady { docker_container_id: None, image_ref: None, image_digest: None }.apply(&mut env_status);
     environments.update_status("env-a", &env.metadata.resource_version, &env_status).await.expect("ready environment");
     let input = InputMeta::builder()
         .name("term-a".to_string())

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -1008,8 +1008,10 @@ async fn contained_requirement_runs_in_contained_docker_placement() {
         Some(flotilla_resources::VesselStatusPatch::MarkReady {
             requested_stance: Stance::Contained,
             effective_stance: Stance::Contained,
+            image_ref: Some(ref image_ref),
+            image_digest: Some(ref image_digest),
             ..
-        })
+        }) if image_ref == "ghcr.io/flotilla/dev:latest" && image_digest == "sha256:test-image"
     ));
 }
 

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -441,11 +441,10 @@ fn build_create_checkout_plan(
 ///
 /// Steps:
 /// 1. ReadEnvironmentSpec on Host(target_host) — reads `.flotilla/environment.yaml`
-/// 2. EnsureEnvironmentImage on Host(target_host) — resolves spec from prior step
-/// 3. CreateEnvironment on Host(target_host)
-/// 4. CreateCheckout on Environment(target_host, env_id)
-/// 5. PrepareWorkspace on Environment(target_host, env_id)
-/// 6. AttachWorkspace on Host(local_host)
+/// 2. CreateEnvironment on Host(target_host) — resolves and pulls/builds the image
+/// 3. CreateCheckout on Environment(target_host, env_id)
+/// 4. PrepareWorkspace on Environment(target_host, env_id)
+/// 5. AttachWorkspace on Host(local_host)
 fn build_environment_checkout_plan(
     provider: String,
     target: CheckoutTarget,
@@ -466,14 +465,9 @@ fn build_environment_checkout_plan(
     let mut steps = vec![
         Step { description: "Read environment spec".to_string(), host: host_context.clone(), action: StepAction::ReadEnvironmentSpec },
         Step {
-            description: "Ensure environment image".to_string(),
-            host: host_context.clone(),
-            action: StepAction::EnsureEnvironmentImage { provider: provider.clone() },
-        },
-        Step {
             description: format!("Create environment {env_id}"),
             host: host_context.clone(),
-            action: StepAction::CreateEnvironment { env_id: env_id.clone(), provider, image: None },
+            action: StepAction::CreateEnvironment { env_id: env_id.clone(), provider },
         },
         Step {
             description: format!("Create checkout for branch {branch}"),
@@ -1182,12 +1176,11 @@ impl StepResolver for ExecutorStepResolver {
                     serde_yml::from_str(&yaml).map_err(|e| format!("invalid .flotilla/environment.yaml: {e}"))?;
                 Ok(StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec }))
             }
-            StepAction::EnsureEnvironmentImage { provider } => {
-                // Extract spec from prior ReadEnvironmentSpec outcome
+            StepAction::CreateEnvironment { env_id, provider } => {
                 let spec = prior
                     .iter()
-                    .find_map(|o| match o {
-                        StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec }) => Some(spec.clone()),
+                    .find_map(|outcome| match outcome {
+                        StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec }) => Some(spec),
                         _ => None,
                     })
                     .ok_or_else(|| "spec not produced by prior ReadEnvironmentSpec step".to_string())?;
@@ -1196,36 +1189,18 @@ impl StepResolver for ExecutorStepResolver {
                     .environment_providers
                     .get(&provider)
                     .ok_or_else(|| format!("environment provider not available: {provider}"))?;
-                let image = env_provider.ensure_image(&spec, self.repo.root.as_path()).await?;
-                Ok(StepOutcome::Produced(CommandValue::ImageEnsured { image }))
-            }
-            StepAction::CreateEnvironment { env_id, provider, image: _ } => {
-                let image = prior
+                let image = env_provider.ensure_image(spec, self.repo.root.as_path()).await?;
+                let tokens = spec
+                    .token_env_vars
                     .iter()
-                    .find_map(|outcome| match outcome {
-                        StepOutcome::Produced(CommandValue::ImageEnsured { image }) => Some(image.clone()),
-                        _ => None,
+                    .filter_map(|name| match self.env.get(name) {
+                        Some(val) => Some((name.clone(), val)),
+                        None => {
+                            tracing::warn!(env_var = %name, "token env var not set on host, skipping");
+                            None
+                        }
                     })
-                    .ok_or_else(|| "image not produced by prior EnsureEnvironmentImage step".to_string())?;
-                let tokens = prior
-                    .iter()
-                    .find_map(|outcome| match outcome {
-                        StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec }) => Some(spec),
-                        _ => None,
-                    })
-                    .map(|spec| {
-                        spec.token_env_vars
-                            .iter()
-                            .filter_map(|name| match self.env.get(name) {
-                                Some(val) => Some((name.clone(), val)),
-                                None => {
-                                    tracing::warn!(env_var = %name, "token env var not set on host, skipping");
-                                    None
-                                }
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                    .collect();
                 let reference_repo = self.resolve_reference_repo().await;
                 let daemon_socket =
                     self.daemon_socket_path.clone().ok_or_else(|| "daemon socket path required for environment creation".to_string())?;
@@ -1241,7 +1216,7 @@ impl StepResolver for ExecutorStepResolver {
                         reference_repo,
                     })
                     .await?;
-                Ok(StepOutcome::Produced(CommandValue::EnvironmentCreated { env_id }))
+                Ok(StepOutcome::Completed)
             }
             StepAction::DestroyEnvironment { env_id } => {
                 self.environment_manager.destroy_provisioned_environment(&env_id).await?;

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -2898,38 +2898,35 @@ async fn build_plan_with_environment_prepends_lifecycle_steps() {
     .await
     .expect("build_plan should succeed");
 
-    // Verify 6 steps (create now initializes the environment for later env-scoped steps)
-    assert_eq!(plan.steps.len(), 6);
+    // Verify 5 steps (create resolves the image and initializes the environment).
+    assert_eq!(plan.steps.len(), 5);
 
     // Verify step actions in order
     assert!(matches!(plan.steps[0].action, StepAction::ReadEnvironmentSpec));
-    assert!(matches!(plan.steps[1].action, StepAction::EnsureEnvironmentImage { .. }));
-    assert!(matches!(plan.steps[2].action, StepAction::CreateEnvironment { .. }));
-    assert!(matches!(plan.steps[3].action, StepAction::CreateCheckout { .. }));
-    assert!(matches!(plan.steps[4].action, StepAction::PrepareWorkspace { .. }));
-    assert!(matches!(plan.steps[5].action, StepAction::AttachWorkspace));
+    assert!(matches!(plan.steps[1].action, StepAction::CreateEnvironment { .. }));
+    assert!(matches!(plan.steps[2].action, StepAction::CreateCheckout { .. }));
+    assert!(matches!(plan.steps[3].action, StepAction::PrepareWorkspace { .. }));
+    assert!(matches!(plan.steps[4].action, StepAction::AttachWorkspace));
 
-    // Verify host assignments — steps 0-2: Host(feta)
+    // Verify host assignments — steps 0-1: Host(feta)
     assert_eq!(plan.steps[0].host.node_id(), &node_id("feta-node"));
     assert_eq!(plan.steps[1].host.node_id(), &node_id("feta-node"));
-    assert_eq!(plan.steps[2].host.node_id(), &node_id("feta-node"));
     assert!(matches!(&plan.steps[0].host, StepExecutionContext::Host(_)));
     assert!(matches!(&plan.steps[1].host, StepExecutionContext::Host(_)));
-    assert!(matches!(&plan.steps[2].host, StepExecutionContext::Host(_)));
 
-    // Steps 3-4: Environment(feta, env_id)
+    // Steps 2-3: Environment(feta, env_id)
+    assert!(matches!(&plan.steps[2].host, StepExecutionContext::Environment(h, _) if *h == node_id("feta-node")));
     assert!(matches!(&plan.steps[3].host, StepExecutionContext::Environment(h, _) if *h == node_id("feta-node")));
-    assert!(matches!(&plan.steps[4].host, StepExecutionContext::Environment(h, _) if *h == node_id("feta-node")));
 
-    // Step 5: Host(laptop) — attach on local
-    assert_eq!(plan.steps[5].host.node_id(), &local_node_id());
-    assert!(matches!(&plan.steps[5].host, StepExecutionContext::Host(_)));
+    // Step 4: Host(laptop) — attach on local
+    assert_eq!(plan.steps[4].host.node_id(), &local_node_id());
+    assert!(matches!(&plan.steps[4].host, StepExecutionContext::Host(_)));
 
     // Verify workspace label includes remote host suffix
-    if let StepAction::PrepareWorkspace { ref label, .. } = plan.steps[4].action {
+    if let StepAction::PrepareWorkspace { ref label, .. } = plan.steps[3].action {
         assert_eq!(label, "feature-x@feta");
     } else {
-        panic!("step 4 should be PrepareWorkspace");
+        panic!("step 3 should be PrepareWorkspace");
     }
 }
 
@@ -2962,22 +2959,22 @@ async fn build_plan_with_environment_local_host_omits_suffix() {
     .await
     .expect("build_plan should succeed");
 
-    assert_eq!(plan.steps.len(), 6);
+    assert_eq!(plan.steps.len(), 5);
 
     // When target_host == local_host, workspace label should be just the branch
-    if let StepAction::PrepareWorkspace { ref label, .. } = plan.steps[4].action {
+    if let StepAction::PrepareWorkspace { ref label, .. } = plan.steps[3].action {
         assert_eq!(label, "main");
     } else {
-        panic!("step 4 should be PrepareWorkspace");
+        panic!("step 3 should be PrepareWorkspace");
     }
 
     // Checkout step should use ExistingBranch intent
-    if let StepAction::CreateCheckout { ref branch, create_branch, intent, .. } = plan.steps[3].action {
+    if let StepAction::CreateCheckout { ref branch, create_branch, intent, .. } = plan.steps[2].action {
         assert_eq!(branch, "main");
         assert!(!create_branch);
         assert_eq!(intent, CheckoutIntent::ExistingBranch);
     } else {
-        panic!("step 3 should be CreateCheckout");
+        panic!("step 2 should be CreateCheckout");
     }
 }
 
@@ -3563,70 +3560,6 @@ async fn manager_with_provisioned_environment(
 }
 
 #[tokio::test]
-async fn executor_step_resolver_ensure_environment_image() {
-    let config_base = config_base();
-    let provider = Arc::new(MockEnvironmentProvider {
-        ensure_image_results: tokio::sync::Mutex::new(vec![Ok(ImageId::new("flotilla:test-abc123"))]),
-        create_results: tokio::sync::Mutex::new(vec![]),
-        seen_create_opts: tokio::sync::Mutex::new(vec![]),
-    });
-    let registry = registry_with_env_provider(provider.clone());
-    let resolver = ExecutorStepResolver {
-        repo: RepoExecutionContext { identity: repo_identity(), root: repo_root() },
-        registry: Arc::new(registry),
-        providers_data: Arc::new(empty_data()),
-        runner: Arc::new(runner_ok()),
-        env: Arc::new(crate::providers::discovery::test_support::TestEnvVars::default()),
-        config_base: config_base.clone(),
-        attachable_store: test_attachable_store(&config_base),
-        daemon_socket_path: None,
-        local_node_id: local_node_id(),
-        local_host: local_host(),
-        environment_manager: empty_environment_manager().await,
-    };
-
-    // Spec is now read from the prior ReadEnvironmentSpec step outcome
-    let spec = EnvironmentSpec { image: flotilla_protocol::ImageSource::Registry("test:latest".into()), token_env_vars: vec![] };
-    let prior = vec![StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec })];
-    let action = StepAction::EnsureEnvironmentImage { provider: "docker".into() };
-    let context = StepExecutionContext::Host(local_node_id());
-    let outcome = resolver.resolve("ensure image", &context, action, &prior).await;
-    match outcome {
-        Ok(StepOutcome::Produced(CommandValue::ImageEnsured { image })) => {
-            assert_eq!(image, ImageId::new("flotilla:test-abc123"));
-        }
-        other => panic!("expected ImageEnsured outcome, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn executor_step_resolver_ensure_environment_image_error_when_no_provider() {
-    let config_base = config_base();
-    let resolver = ExecutorStepResolver {
-        repo: RepoExecutionContext { identity: repo_identity(), root: repo_root() },
-        registry: Arc::new(empty_registry()),
-        providers_data: Arc::new(empty_data()),
-        runner: Arc::new(runner_ok()),
-        env: Arc::new(crate::providers::discovery::test_support::TestEnvVars::default()),
-        config_base: config_base.clone(),
-        attachable_store: test_attachable_store(&config_base),
-        daemon_socket_path: None,
-        local_node_id: local_node_id(),
-        local_host: local_host(),
-        environment_manager: empty_environment_manager().await,
-    };
-
-    // Spec is now read from the prior ReadEnvironmentSpec step outcome
-    let spec = EnvironmentSpec { image: flotilla_protocol::ImageSource::Registry("test:latest".into()), token_env_vars: vec![] };
-    let prior = vec![StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec })];
-    let action = StepAction::EnsureEnvironmentImage { provider: "docker".into() };
-    let context = StepExecutionContext::Host(local_node_id());
-    let outcome = resolver.resolve("ensure image", &context, action, &prior).await;
-    assert!(outcome.is_err(), "should fail when no environment provider available");
-    assert!(outcome.unwrap_err().contains("environment provider not available"));
-}
-
-#[tokio::test]
 async fn executor_step_resolver_create_environment() {
     let config_base = config_base();
     let env_id = EnvironmentId::new("env-test-1");
@@ -3639,7 +3572,7 @@ async fn executor_step_resolver_create_environment() {
     });
 
     let provider = Arc::new(MockEnvironmentProvider {
-        ensure_image_results: tokio::sync::Mutex::new(vec![]),
+        ensure_image_results: tokio::sync::Mutex::new(vec![Ok(image_id.clone())]),
         create_results: tokio::sync::Mutex::new(vec![Ok(mock_env)]),
         seen_create_opts: tokio::sync::Mutex::new(vec![]),
     });
@@ -3664,19 +3597,11 @@ async fn executor_step_resolver_create_environment() {
         image: flotilla_protocol::ImageSource::Registry("test:latest".into()),
         token_env_vars: vec!["GITHUB_TOKEN".into()],
     };
-    let prior = vec![
-        StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec }),
-        StepOutcome::Produced(CommandValue::ImageEnsured { image: image_id.clone() }),
-    ];
-    let action = StepAction::CreateEnvironment { env_id: env_id.clone(), provider: "docker".into(), image: None };
+    let prior = vec![StepOutcome::Produced(CommandValue::EnvironmentSpecRead { spec })];
+    let action = StepAction::CreateEnvironment { env_id: env_id.clone(), provider: "docker".into() };
     let context = StepExecutionContext::Host(local_node_id());
     let outcome = resolver.resolve("create env", &context, action, &prior).await;
-    match outcome {
-        Ok(StepOutcome::Produced(CommandValue::EnvironmentCreated { env_id: created_id })) => {
-            assert_eq!(created_id, env_id);
-        }
-        other => panic!("expected EnvironmentCreated outcome, got {other:?}"),
-    }
+    assert!(matches!(outcome, Ok(StepOutcome::Completed)));
 
     assert!(
         resolver.environment_manager.environment_runner(&env_id).is_some(),
@@ -3688,7 +3613,7 @@ async fn executor_step_resolver_create_environment() {
 }
 
 #[tokio::test]
-async fn executor_step_resolver_create_environment_errors_without_image_outcome() {
+async fn executor_step_resolver_create_environment_errors_without_spec_outcome() {
     let config_base = config_base();
     let env_id = EnvironmentId::new("env-test-missing-image");
     let resolver = ExecutorStepResolver {
@@ -3705,12 +3630,12 @@ async fn executor_step_resolver_create_environment_errors_without_image_outcome(
         environment_manager: empty_environment_manager().await,
     };
 
-    let action = StepAction::CreateEnvironment { env_id, provider: "docker".into(), image: None };
+    let action = StepAction::CreateEnvironment { env_id, provider: "docker".into() };
     let context = StepExecutionContext::Host(local_node_id());
     let outcome = resolver.resolve("create env", &context, action, &[]).await;
 
-    assert!(outcome.is_err(), "create environment should fail without an ensured image");
-    assert!(outcome.unwrap_err().contains("image not produced by prior EnsureEnvironmentImage step"));
+    assert!(outcome.is_err(), "create environment should fail without an environment spec");
+    assert!(outcome.unwrap_err().contains("spec not produced by prior ReadEnvironmentSpec step"));
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4688,7 +4688,7 @@ async fn convoy_delete_refuses_diverged_checkout_without_a_change_request() {
         .on_run("git", &["rev-list", "--count", "origin/feature/diverged..HEAD"], Ok("0\n".into()))
         .on_run(
             "gh",
-            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt", "--limit", "1"],
+            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
             Ok("[]".into()),
         )
         .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
@@ -4729,12 +4729,34 @@ async fn convoy_delete_allows_multi_repo_convoy_with_work_on_only_one_side() {
         .on_run("git", &["rev-list", "--count", "origin/feature/one-sided-work..HEAD"], Ok("0\n".into()))
         .on_run(
             "gh",
-            &["pr", "list", "--head", "feature/one-sided-work", "--state", "all", "--json", "number,state,mergedAt", "--limit", "1"],
-            Ok(r#"[{"number":44,"state":"MERGED","mergedAt":"2026-07-27T12:00:00Z"}]"#.into()),
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/one-sided-work",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName",
+                "--limit",
+                "1",
+            ],
+            Ok(r#"[{"number":44,"state":"MERGED","mergedAt":"2026-07-27T12:00:00Z","baseRefName":"main"}]"#.into()),
         )
         .on_run(
             "gh",
-            &["pr", "list", "--head", "feature/one-sided-work", "--state", "all", "--json", "number,state,mergedAt", "--limit", "1"],
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/one-sided-work",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName",
+                "--limit",
+                "1",
+            ],
             Ok("[]".into()),
         )
         .on_run("git", &["rev-list", "--count", "main..HEAD"], Ok("0\n".into()))
@@ -4760,6 +4782,8 @@ async fn convoy_delete_allows_multi_repo_convoy_with_work_on_only_one_side() {
             phase: flotilla_resources::EnvironmentPhase::Ready,
             ready: true,
             docker_container_id: None,
+            image_ref: None,
+            image_digest: None,
             message: None,
         })
         .await

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -128,8 +128,18 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
         args.push("infinity");
 
         self.inner.runner.run("docker", &args, Path::new("/"), &ChannelLabel::Noop).await?;
+        let image_digest = match self.inner.image_digest(&container_name).await {
+            Ok(digest) => digest,
+            Err(error) => {
+                let cleanup = self.inner.destroy(&container_name).await;
+                return Err(match cleanup {
+                    Ok(()) => error,
+                    Err(cleanup_error) => format!("{error}; additionally failed to remove container {container_name}: {cleanup_error}"),
+                });
+            }
+        };
 
-        Ok(self.inner.provisioned_environment(id, image.clone(), container_name, opts.provisioned_mounts))
+        Ok(self.inner.provisioned_environment(id, image.clone(), image_digest, container_name, opts.provisioned_mounts))
     }
 
     async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
@@ -166,9 +176,11 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
                     return Err(format!("failed to parse provisioned mount metadata for container {container_name}: {err}"));
                 }
             };
+            let image_digest = self.inner.image_digest(&container_name).await?;
             handles.push(self.inner.provisioned_environment(
                 EnvironmentId::new(env_id),
                 ImageId::new(image),
+                image_digest,
                 container_name,
                 provisioned_mounts,
             ));
@@ -210,11 +222,30 @@ impl DockerEnvironmentProviderInner {
         self: &Arc<Self>,
         id: EnvironmentId,
         image: ImageId,
+        image_digest: String,
         container_name: String,
         provisioned_mounts: Vec<ProvisionedMount>,
     ) -> EnvironmentHandle {
         let runner = Arc::new(DockerEnvironmentRunner::new(container_name.clone(), Arc::clone(&self.runner))) as Arc<dyn CommandRunner>;
-        Arc::new(DockerProvisionedEnvironment { id, container_name, image, inner: Arc::clone(self), runner, provisioned_mounts })
+        Arc::new(DockerProvisionedEnvironment {
+            id,
+            container_name,
+            image,
+            image_digest,
+            inner: Arc::clone(self),
+            runner,
+            provisioned_mounts,
+        })
+    }
+
+    async fn image_digest(&self, container_name: &str) -> Result<String, String> {
+        let output =
+            self.runner.run("docker", &["inspect", "--format", "{{.Image}}", container_name], Path::new("/"), &ChannelLabel::Noop).await?;
+        let digest = output.trim();
+        if !digest.starts_with("sha256:") || digest.len() == "sha256:".len() {
+            return Err(format!("docker returned invalid image digest for container {container_name}: {digest:?}"));
+        }
+        Ok(digest.to_string())
     }
 
     async fn status(&self, container_name: &str) -> Result<EnvironmentStatus, String> {
@@ -261,6 +292,7 @@ pub struct DockerProvisionedEnvironment {
     id: EnvironmentId,
     container_name: String,
     image: ImageId,
+    image_digest: String,
     inner: Arc<DockerEnvironmentProviderInner>,
     runner: Arc<dyn CommandRunner>,
     provisioned_mounts: Vec<ProvisionedMount>,
@@ -274,6 +306,10 @@ impl ProvisionedEnvironment for DockerProvisionedEnvironment {
 
     fn image(&self) -> &ImageId {
         &self.image
+    }
+
+    fn image_digest(&self) -> Option<&str> {
+        Some(&self.image_digest)
     }
 
     fn container_name(&self) -> Option<&str> {

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -139,7 +139,7 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
             }
         };
 
-        Ok(self.inner.provisioned_environment(id, image.clone(), image_digest, container_name, opts.provisioned_mounts))
+        Ok(self.inner.provisioned_environment(id, image.clone(), Some(image_digest), container_name, opts.provisioned_mounts))
     }
 
     async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
@@ -176,11 +176,10 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
                     return Err(format!("failed to parse provisioned mount metadata for container {container_name}: {err}"));
                 }
             };
-            let image_digest = self.inner.image_digest(&container_name).await?;
             handles.push(self.inner.provisioned_environment(
                 EnvironmentId::new(env_id),
                 ImageId::new(image),
-                image_digest,
+                None,
                 container_name,
                 provisioned_mounts,
             ));
@@ -222,7 +221,7 @@ impl DockerEnvironmentProviderInner {
         self: &Arc<Self>,
         id: EnvironmentId,
         image: ImageId,
-        image_digest: String,
+        image_digest: Option<String>,
         container_name: String,
         provisioned_mounts: Vec<ProvisionedMount>,
     ) -> EnvironmentHandle {
@@ -292,7 +291,7 @@ pub struct DockerProvisionedEnvironment {
     id: EnvironmentId,
     container_name: String,
     image: ImageId,
-    image_digest: String,
+    image_digest: Option<String>,
     inner: Arc<DockerEnvironmentProviderInner>,
     runner: Arc<dyn CommandRunner>,
     provisioned_mounts: Vec<ProvisionedMount>,
@@ -309,7 +308,7 @@ impl ProvisionedEnvironment for DockerProvisionedEnvironment {
     }
 
     fn image_digest(&self) -> Option<&str> {
-        Some(&self.image_digest)
+        self.image_digest.as_deref()
     }
 
     fn container_name(&self) -> Option<&str> {

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -94,6 +94,10 @@ pub trait EnvironmentProvider: Send + Sync {
 pub trait ProvisionedEnvironment: Send + Sync {
     fn id(&self) -> &EnvironmentId;
     fn image(&self) -> &ImageId;
+    /// Immutable content digest of the image actually backing this environment.
+    fn image_digest(&self) -> Option<&str> {
+        None
+    }
     /// Provider-specific transport identifier (e.g. Docker container name).
     /// Used by hop chain to construct exec/enter commands.
     fn container_name(&self) -> Option<&str>;

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -37,6 +37,9 @@ impl RecordingRunner {
 impl CommandRunner for RecordingRunner {
     async fn run(&self, cmd: &str, args: &[&str], cwd: &Path, _label: &ChannelLabel) -> Result<String, String> {
         self.calls.lock().expect("calls mutex").push((cmd.to_string(), args.iter().map(|a| a.to_string()).collect(), cwd.to_path_buf()));
+        if cmd == "docker" && args.starts_with(&["inspect", "--format", "{{.Image}}"]) {
+            return Ok("sha256:test-image-digest\n".to_string());
+        }
         self.result.clone()
     }
 
@@ -247,7 +250,7 @@ async fn ensure_image_pulls_registry() {
 #[tokio::test]
 async fn create_returns_handle() {
     use flotilla_protocol::ImageId;
-    let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
+    let runner = Arc::new(QueuedRunner::new([Ok("container-id-123".into()), Ok("sha256:8c7f4e5d6a1b\n".into())]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
@@ -266,7 +269,7 @@ async fn create_returns_handle() {
     let handle = result.unwrap();
 
     let calls = runner.calls();
-    assert_eq!(calls.len(), 1);
+    assert_eq!(calls.len(), 2);
     let (cmd, args, _) = &calls[0];
     assert_eq!(cmd, "docker");
     assert_eq!(args[0], "run");
@@ -284,6 +287,12 @@ async fn create_returns_handle() {
     // Environment ID in handle should match label value
     let expected_id = label_val.strip_prefix("flotilla.environment=").unwrap();
     assert_eq!(handle.id().as_str(), expected_id);
+    assert_eq!(handle.image().as_str(), "ubuntu:22.04");
+    assert_eq!(handle.image_digest(), Some("sha256:8c7f4e5d6a1b"));
+
+    let (inspect_cmd, inspect_args, _) = &calls[1];
+    assert_eq!(inspect_cmd, "docker");
+    assert_eq!(inspect_args, &["inspect", "--format", "{{.Image}}", "flotilla-env-test-env-1"]);
 
     // Token env var should be present
     assert!(args.iter().any(|a| a.starts_with("GITHUB_TOKEN=")), "token env var should be passed");
@@ -311,7 +320,7 @@ async fn create_translates_image_pull_policy_to_docker_run() {
         provider.create(EnvironmentId::new(docker_value), &image, opts).await.expect("image policy should create an environment");
 
         let calls = runner.calls();
-        assert_eq!(calls.len(), 1);
+        assert_eq!(calls.len(), 2);
         let (_, args, _) = &calls[0];
         assert!(args.windows(2).any(|pair| pair == ["--pull", docker_value]));
         assert!(!calls.iter().any(|(_, args, _)| args.first().is_some_and(|arg| arg == "pull")));
@@ -409,11 +418,13 @@ async fn list_preserves_reference_repo_mount_metadata() {
 
     let runner = Arc::new(QueuedRunner::new([
         Ok("container-id-123".into()),
+        Ok("sha256:test-image".into()),
         Ok(format!(
             "container-1\ttest-env-list\tubuntu:22.04\t{}\n",
             serde_json::to_string(&vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro,)])
                 .expect("serialize mount metadata")
         )),
+        Ok("sha256:test-image".into()),
     ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
     let image = ImageId::new("ubuntu:22.04");
@@ -441,8 +452,11 @@ async fn list_preserves_reference_repo_mount_metadata() {
 async fn list_fails_on_malformed_reference_repo_mount_metadata() {
     use flotilla_protocol::ImageId;
 
-    let runner =
-        Arc::new(QueuedRunner::new([Ok("container-id-123".into()), Ok("container-1\ttest-env-list\tubuntu:22.04\tnot-json\n".into())]));
+    let runner = Arc::new(QueuedRunner::new([
+        Ok("container-id-123".into()),
+        Ok("sha256:test-image".into()),
+        Ok("container-1\ttest-env-list\tubuntu:22.04\tnot-json\n".into()),
+    ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
@@ -464,7 +478,11 @@ async fn list_fails_on_malformed_reference_repo_mount_metadata() {
 async fn list_rejects_missing_reference_repo_mount_metadata() {
     use flotilla_protocol::ImageId;
 
-    let runner = Arc::new(QueuedRunner::new([Ok("container-id-123".into()), Ok("container-1\ttest-env-list\tubuntu:22.04\t\n".into())]));
+    let runner = Arc::new(QueuedRunner::new([
+        Ok("container-id-123".into()),
+        Ok("sha256:test-image".into()),
+        Ok("container-1\ttest-env-list\tubuntu:22.04\t\n".into()),
+    ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
@@ -510,7 +528,8 @@ async fn status_returns_running() {
     use flotilla_protocol::ImageId;
     let runner = Arc::new(QueuedRunner::new([
         Ok("container-id".into()), // docker run
-        Ok("running".into()),      // docker inspect
+        Ok("sha256:test-image".into()),
+        Ok("running".into()), // docker inspect status
     ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
     let image = ImageId::new("ubuntu:22.04");
@@ -529,8 +548,8 @@ async fn status_returns_running() {
 
     assert_eq!(status, EnvironmentStatus::Running);
     let calls = runner.calls();
-    // Second call should be docker inspect
-    let (cmd, args, _) = &calls[1];
+    // Third call should inspect container status after image digest resolution.
+    let (cmd, args, _) = &calls[2];
     assert_eq!(cmd, "docker");
     assert_eq!(args[0], "inspect");
     assert!(args.contains(&"--format".to_string()));
@@ -540,7 +559,8 @@ async fn status_returns_running() {
 async fn env_vars_parses_output() {
     use flotilla_protocol::ImageId;
     let runner = Arc::new(QueuedRunner::new([
-        Ok("container-id".into()),       // docker run
+        Ok("container-id".into()), // docker run
+        Ok("sha256:test-image".into()),
         Ok("FOO=bar\nBAZ=qux\n".into()), // docker exec sh -lc env
     ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
@@ -562,7 +582,7 @@ async fn env_vars_parses_output() {
     assert_eq!(vars.get("BAZ"), Some(&"qux".to_string()));
 
     let calls = runner.calls();
-    let (cmd, args, _) = &calls[1];
+    let (cmd, args, _) = &calls[2];
     assert_eq!(cmd, "docker");
     assert_eq!(args[0], "exec");
     assert!(args.contains(&"sh".to_string()));
@@ -574,7 +594,8 @@ async fn destroy_calls_docker_rm() {
     use flotilla_protocol::ImageId;
     let runner = Arc::new(QueuedRunner::new([
         Ok("container-id".into()), // docker run
-        Ok("".into()),             // docker rm -f
+        Ok("sha256:test-image".into()),
+        Ok("".into()), // docker rm -f
     ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
     let image = ImageId::new("ubuntu:22.04");
@@ -593,7 +614,7 @@ async fn destroy_calls_docker_rm() {
     handle.destroy().await.expect("destroy");
 
     let calls = runner.calls();
-    let (cmd, args, _) = &calls[1];
+    let (cmd, args, _) = &calls[2];
     assert_eq!(cmd, "docker");
     assert_eq!(args[0], "rm");
     assert!(args.contains(&"-f".to_string()), "should pass -f flag");

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -299,6 +299,34 @@ async fn create_returns_handle() {
 }
 
 #[tokio::test]
+async fn create_removes_container_when_image_digest_cannot_be_resolved() {
+    use flotilla_protocol::ImageId;
+
+    let runner = Arc::new(QueuedRunner::new([Ok("container-id-123".into()), Ok("not-a-digest".into()), Err("docker rm failed".into())]));
+    let provider = DockerEnvironmentProvider::new(runner.clone());
+    let image = ImageId::new("registry.example/crew:latest");
+    let opts = CreateOpts {
+        tokens: Vec::new(),
+        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        working_directory: None,
+        provisioned_mounts: Vec::new(),
+        image_pull_policy: ImagePullPolicy::Always,
+        docker_config_dir: None,
+    };
+
+    let error = match provider.create(EnvironmentId::new("invalid-digest"), &image, opts).await {
+        Ok(_) => panic!("invalid digest should reject the environment"),
+        Err(error) => error,
+    };
+
+    assert!(error.contains("invalid image digest"), "{error}");
+    assert!(error.contains("additionally failed to remove container flotilla-env-invalid-digest: docker rm failed"), "{error}");
+    let calls = runner.calls();
+    assert_eq!(calls[2].0, "docker");
+    assert_eq!(calls[2].1, ["rm", "-f", "flotilla-env-invalid-digest"]);
+}
+
+#[tokio::test]
 async fn create_translates_image_pull_policy_to_docker_run() {
     use flotilla_protocol::ImageId;
 
@@ -424,7 +452,6 @@ async fn list_preserves_reference_repo_mount_metadata() {
             serde_json::to_string(&vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro,)])
                 .expect("serialize mount metadata")
         )),
-        Ok("sha256:test-image".into()),
     ]));
     let provider = DockerEnvironmentProvider::new(runner.clone());
     let image = ImageId::new("ubuntu:22.04");

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1760,6 +1760,10 @@ impl Aggregator {
             .and_then(|placement| placement.fields.get("effective_stance"))
             .and_then(serde_json::Value::as_str)
             .map(str::to_string);
+        let image_ref =
+            placement.and_then(|placement| placement.fields.get("image_ref")).and_then(serde_json::Value::as_str).map(str::to_string);
+        let image_digest =
+            placement.and_then(|placement| placement.fields.get("image_digest")).and_then(serde_json::Value::as_str).map(str::to_string);
         let crew = definition
             .crew
             .iter()
@@ -1803,6 +1807,8 @@ impl Aggregator {
             .maybe_message(state.and_then(|state| state.message.clone()))
             .requested_stance(requested_stance)
             .maybe_effective_stance(effective_stance)
+            .maybe_image_ref(image_ref)
+            .maybe_image_digest(image_digest)
             .depends_on(definition.depends_on.clone())
             .host(vessel_host.clone())
             .maybe_attach(self.vessel_attach(&convoy_ref.namespace, &convoy_ref.name, &definition.name))
@@ -3676,6 +3682,8 @@ mod tests {
             fields: BTreeMap::from([
                 ("requested_stance".to_string(), serde_json::json!("workspace-write")),
                 ("effective_stance".to_string(), serde_json::json!("contained")),
+                ("image_ref".to_string(), serde_json::json!("registry.example/crew:latest")),
+                ("image_digest".to_string(), serde_json::json!("sha256:test-image")),
             ]),
         });
 
@@ -3683,6 +3691,8 @@ mod tests {
 
         assert_eq!(vessel.requested_stance.as_deref(), Some("workspace-write"));
         assert_eq!(vessel.effective_stance.as_deref(), Some("contained"));
+        assert_eq!(vessel.image_ref.as_deref(), Some("registry.example/crew:latest"));
+        assert_eq!(vessel.image_digest.as_deref(), Some("sha256:test-image"));
         assert_eq!(vessel.crew[0].requested_stance.as_deref(), Some("workspace-write"));
         assert_eq!(vessel.crew[0].effective_stance.as_deref(), Some("contained"));
     }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{
     BranchPreservationReason, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, CloneReconciler, CloneRuntime,
-    DockerEnvironmentRuntime, EnvironmentReconciler, ForgeDefaultBranchResolver, HopChainContext, PreparedCheckout,
+    DockerEnvironmentRuntime, DockerProvisioning, EnvironmentReconciler, ForgeDefaultBranchResolver, HopChainContext, PreparedCheckout,
     PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime, RepositoryReconciler, TerminalRuntime,
     TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
 };
@@ -1040,7 +1040,7 @@ struct DockerControllerRuntime {
 
 #[async_trait]
 impl DockerEnvironmentRuntime for DockerControllerRuntime {
-    async fn provision(&self, name: &str, spec: &flotilla_resources::DockerEnvironmentSpec) -> Result<String, String> {
+    async fn provision(&self, name: &str, spec: &flotilla_resources::DockerEnvironmentSpec) -> Result<DockerProvisioning, String> {
         let credential_refs = credential_refs_from_environment(spec)?;
         let daemon_socket_path = self
             .state
@@ -1083,6 +1083,19 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
                 return Err(error);
             }
         };
+        let image_ref = handle.image().as_str().to_string();
+        let image_digest = match handle.image_digest() {
+            Some(digest) => digest.to_string(),
+            None => {
+                return Err(discard_failed_environment(
+                    &handle,
+                    self.state.credential_store.as_deref(),
+                    name,
+                    format!("docker environment provider did not report an image digest for {name}"),
+                )
+                .await)
+            }
+        };
 
         let container_id = handle.container_name().map(ToString::to_string).unwrap_or_else(|| format!("flotilla-env-{}", env_id));
         if let Some(store) = &self.state.credential_store {
@@ -1110,7 +1123,7 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             return Err(discard_failed_environment(&handle, self.state.credential_store.as_deref(), name, error).await);
         }
         self.state.provisioned_environments.lock().await.insert(container_id.clone(), ActiveProvisionedEnvironment { env_id, handle });
-        Ok(container_id)
+        Ok(DockerProvisioning { container_id, image_ref, image_digest })
     }
 
     async fn destroy(&self, container_id: &str) -> Result<(), String> {
@@ -1840,6 +1853,10 @@ mod tests {
 
         fn image(&self) -> &ImageId {
             &self.image
+        }
+
+        fn image_digest(&self) -> Option<&str> {
+            Some("sha256:test-interior")
         }
 
         fn container_name(&self) -> Option<&str> {

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -647,12 +647,6 @@ pub enum CommandValue {
     ResourceList(Box<ResourceJsonResponse>),
     ResourceObject(Box<ResourceJsonResponse>),
     ResourceWatchEvent(Box<ResourceWatchResponse>),
-    ImageEnsured {
-        image: crate::ImageId,
-    },
-    EnvironmentCreated {
-        env_id: crate::EnvironmentId,
-    },
     EnvironmentSpecRead {
         spec: crate::EnvironmentSpec,
     },
@@ -1302,8 +1296,6 @@ mod tests {
                     "object": { "apiVersion": "flotilla.work/v1", "kind": "Convoy", "metadata": { "name": "demo" }, "spec": {} }
                 }),
             })),
-            CommandValue::ImageEnsured { image: crate::ImageId::new("sha256:abc123") },
-            CommandValue::EnvironmentCreated { env_id: crate::EnvironmentId::new("env-1") },
             CommandValue::EnvironmentSpecRead {
                 spec: crate::EnvironmentSpec {
                     image: crate::ImageSource::Registry("ubuntu:24.04".into()),

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -857,6 +857,12 @@ pub struct VesselRow {
     pub requested_stance: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub effective_stance: Option<String>,
+    /// Placement image reference as named when this vessel was provisioned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
+    /// Immutable Docker image content digest actually run by this vessel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
     /// Names of sibling vessels this vessel depends on.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]

--- a/crates/flotilla-protocol/src/step.rs
+++ b/crates/flotilla-protocol/src/step.rs
@@ -135,17 +135,10 @@ pub enum StepAction {
     Noop,
 
     // Environment lifecycle
-    EnsureEnvironmentImage {
-        /// The environment provider to use (e.g. "docker").
-        provider: String,
-    },
     CreateEnvironment {
         env_id: crate::EnvironmentId,
         /// The environment provider to use (e.g. "docker").
         provider: String,
-        /// `None` means resolve from prior `EnsureEnvironmentImage` outcome.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        image: Option<crate::ImageId>,
     },
     DestroyEnvironment {
         env_id: crate::EnvironmentId,

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -967,6 +967,8 @@ fn placement_status(workspace: &ResourceObject<Vessel>) -> PlacementStatus {
     let mut fields = BTreeMap::from([("vessel_ref".to_string(), json!(workspace.metadata.name))]);
     if let Some(status) = workspace.status.as_ref() {
         insert_optional_field(&mut fields, "environment_ref", status.environment_ref.clone());
+        insert_optional_field(&mut fields, "image_ref", status.image_ref.clone());
+        insert_optional_field(&mut fields, "image_digest", status.image_digest.clone());
         if !status.checkout_refs.is_empty() {
             fields.insert("checkout_refs".to_string(), json!(status.checkout_refs));
         }

--- a/crates/flotilla-resources/src/environment.rs
+++ b/crates/flotilla-resources/src/environment.rs
@@ -66,12 +66,16 @@ pub struct EnvironmentStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docker_container_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnvironmentStatusPatch {
-    MarkReady { docker_container_id: Option<String> },
+    MarkReady { docker_container_id: Option<String>, image_ref: Option<String>, image_digest: Option<String> },
     MarkFailed { message: String },
     MarkTerminating,
 }
@@ -79,10 +83,12 @@ pub enum EnvironmentStatusPatch {
 impl StatusPatch<EnvironmentStatus> for EnvironmentStatusPatch {
     fn apply(&self, status: &mut EnvironmentStatus) {
         match self {
-            Self::MarkReady { docker_container_id } => {
+            Self::MarkReady { docker_container_id, image_ref, image_digest } => {
                 status.phase = EnvironmentPhase::Ready;
                 status.ready = true;
                 status.docker_container_id = docker_container_id.clone();
+                status.image_ref = image_ref.clone();
+                status.image_digest = image_digest.clone();
                 status.message = None;
             }
             Self::MarkFailed { message } => {

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -38,6 +38,10 @@ pub struct VesselStatus {
     pub observed_policy_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub environment_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub checkout_refs: BTreeMap<RepositoryKey, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -61,6 +65,8 @@ pub enum VesselStatusPatch {
     },
     MarkReady {
         environment_ref: Option<String>,
+        image_ref: Option<String>,
+        image_digest: Option<String>,
         checkout_refs: BTreeMap<RepositoryKey, String>,
         terminal_session_refs: Vec<String>,
         requested_stance: Stance,
@@ -83,9 +89,20 @@ impl StatusPatch<VesselStatus> for VesselStatusPatch {
                 status.started_at.get_or_insert(*started_at);
                 status.message = None;
             }
-            Self::MarkReady { environment_ref, checkout_refs, terminal_session_refs, requested_stance, effective_stance, ready_at } => {
+            Self::MarkReady {
+                environment_ref,
+                image_ref,
+                image_digest,
+                checkout_refs,
+                terminal_session_refs,
+                requested_stance,
+                effective_stance,
+                ready_at,
+            } => {
                 status.phase = VesselPhase::Ready;
                 status.environment_ref = environment_ref.clone();
+                status.image_ref = image_ref.clone();
+                status.image_digest = image_digest.clone();
                 status.checkout_refs = checkout_refs.clone();
                 status.terminal_session_refs = terminal_session_refs.clone();
                 status.requested_stance = Some(*requested_stance);

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -254,6 +254,8 @@ async fn controller_loop_advances_task_via_vessel_secondary_watch() {
             observed_policy_ref: Some("laptop-docker".to_string()),
             observed_policy_version: Some("17".to_string()),
             environment_ref: Some("env-implement".to_string()),
+            image_ref: Some("registry.example/crew:latest".to_string()),
+            image_digest: Some("sha256:test-image".to_string()),
             checkout_refs: Default::default(),
             terminal_session_refs: vec!["terminal-implement-coder".to_string()],
             started_at: Some(timestamp(18)),

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -194,6 +194,16 @@ fn vessel_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
 }
 
 fn vessel_object(convoy_name: &str, task: &str, phase: VesselPhase, message: Option<&str>) -> flotilla_resources::ResourceObject<Vessel> {
+    vessel_object_with_image_digest(convoy_name, task, phase, message, "sha256:first")
+}
+
+fn vessel_object_with_image_digest(
+    convoy_name: &str,
+    task: &str,
+    phase: VesselPhase,
+    message: Option<&str>,
+    image_digest: &str,
+) -> flotilla_resources::ResourceObject<Vessel> {
     let repository_key =
         flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository identity").key();
     flotilla_resources::ResourceObject {
@@ -210,6 +220,8 @@ fn vessel_object(convoy_name: &str, task: &str, phase: VesselPhase, message: Opt
             observed_policy_ref: Some("laptop-docker".to_string()),
             observed_policy_version: Some("19".to_string()),
             environment_ref: Some(format!("env-{task}")),
+            image_ref: Some("registry.example/crew:latest".to_string()),
+            image_digest: Some(image_digest.to_string()),
             checkout_refs: BTreeMap::from([(repository_key, format!("checkout-{task}"))]),
             terminal_session_refs: vec![format!("terminal-{task}-coder")],
             started_at: Some(timestamp(16)),
@@ -992,8 +1004,41 @@ async fn ready_task_with_ready_workspace_moves_to_launching() {
             if work == "implement"
                 && started_at == timestamp(20)
                 && placement.fields.get("environment_ref") == Some(&serde_json::Value::String("env-implement".to_string()))
+                && placement.fields.get("image_ref")
+                    == Some(&serde_json::Value::String("registry.example/crew:latest".to_string()))
+                && placement.fields.get("image_digest") == Some(&serde_json::Value::String("sha256:first".to_string()))
                 && placement.fields.get("checkout_refs") == Some(&expected_checkout_refs)
     ));
+}
+
+#[tokio::test]
+async fn same_image_tag_moving_between_convoys_produces_distinct_settlement_testimony() {
+    async fn testimony(convoy_name: &str, digest: &str) -> flotilla_resources::PlacementStatus {
+        let mut status = bootstrapped_tool_only_convoy_status();
+        status.work.get_mut("implement").expect("implement work").phase = WorkPhase::Ready;
+        status.work.get_mut("implement").expect("implement work").ready_at = Some(timestamp(12));
+        let convoy = convoy_object(convoy_name, task_provisioning_convoy_spec(), Some(status));
+        let outcome = reconcile_once_with_resources(
+            &convoy,
+            None,
+            vec![vessel_object_with_image_digest(convoy_name, "implement", VesselPhase::Ready, None, digest)],
+            Vec::new(),
+            timestamp(20),
+        )
+        .await;
+        match outcome.patch {
+            Some(ConvoyStatusPatch::WorkLaunching { placement, .. }) => placement,
+            other => panic!("expected placement testimony, got {other:?}"),
+        }
+    }
+
+    let first = testimony("convoy-first", "sha256:first").await;
+    let second = testimony("convoy-second", "sha256:second").await;
+
+    assert_eq!(first.fields.get("image_ref"), second.fields.get("image_ref"));
+    assert_eq!(first.fields.get("image_digest"), Some(&serde_json::json!("sha256:first")));
+    assert_eq!(second.fields.get("image_digest"), Some(&serde_json::json!("sha256:second")));
+    assert_ne!(first.fields.get("image_digest"), second.fields.get("image_digest"));
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -615,6 +615,8 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                 let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };
                 let patch = VesselStatusPatch::MarkReady {
                     environment_ref: Some("env-a".to_string()),
+                    image_ref: Some("registry.example/crew:latest".to_string()),
+                    image_digest: Some("sha256:test-image".to_string()),
                     checkout_refs: Default::default(),
                     terminal_session_refs: Vec::new(),
                     requested_stance: Stance::WorkspaceWrite,

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -77,6 +77,8 @@ async fn vessel_metadata_and_status_roundtrip() {
             observed_policy_ref: Some("docker-on-01HXYZ".to_string()),
             observed_policy_version: Some("12".to_string()),
             environment_ref: Some("env-a".to_string()),
+            image_ref: Some("registry.example/crew:latest".to_string()),
+            image_digest: Some("sha256:test-image".to_string()),
             checkout_refs: Default::default(),
             terminal_session_refs: vec!["term-a".to_string()],
             started_at: Some(Utc::now()),

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -24,10 +24,17 @@ fn host_status_patch_updates_heartbeat_snapshot() {
 #[test]
 fn environment_status_patch_marks_ready_and_failed() {
     let mut status = EnvironmentStatus::default();
-    EnvironmentStatusPatch::MarkReady { docker_container_id: Some("container-123".to_string()) }.apply(&mut status);
+    EnvironmentStatusPatch::MarkReady {
+        docker_container_id: Some("container-123".to_string()),
+        image_ref: Some("registry.example/crew:latest".to_string()),
+        image_digest: Some("sha256:first".to_string()),
+    }
+    .apply(&mut status);
     assert_eq!(status.phase, EnvironmentPhase::Ready);
     assert!(status.ready);
     assert_eq!(status.docker_container_id.as_deref(), Some("container-123"));
+    assert_eq!(status.image_ref.as_deref(), Some("registry.example/crew:latest"));
+    assert_eq!(status.image_digest.as_deref(), Some("sha256:first"));
 
     EnvironmentStatusPatch::MarkFailed { message: "docker run failed".to_string() }.apply(&mut status);
     assert_eq!(status.phase, EnvironmentPhase::Failed);
@@ -196,6 +203,8 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
 
     VesselStatusPatch::MarkReady {
         environment_ref: Some("env-a".to_string()),
+        image_ref: Some("registry.example/crew:latest".to_string()),
+        image_digest: Some("sha256:test-image".to_string()),
         checkout_refs: Default::default(),
         terminal_session_refs: vec!["term-a".to_string(), "term-b".to_string()],
         requested_stance: Stance::WorkspaceWrite,
@@ -205,9 +214,13 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
     .apply(&mut status);
     assert_eq!(status.phase, VesselPhase::Ready);
     assert_eq!(status.terminal_session_refs.len(), 2);
+    assert_eq!(status.image_ref.as_deref(), Some("registry.example/crew:latest"));
+    assert_eq!(status.image_digest.as_deref(), Some("sha256:test-image"));
 
     VesselStatusPatch::MarkReady {
         environment_ref: Some("env-a".to_string()),
+        image_ref: Some("registry.example/crew:latest".to_string()),
+        image_digest: Some("sha256:test-image".to_string()),
         checkout_refs: Default::default(),
         terminal_session_refs: vec!["term-a".to_string(), "term-b".to_string()],
         requested_stance: Stance::WorkspaceWrite,

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -272,7 +272,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         | CommandValue::ResourceWatchEvent(_) => {
             tracing::warn!("query result reached TUI handler — should be handled by CLI");
         }
-        CommandValue::ImageEnsured { .. } | CommandValue::EnvironmentCreated { .. } | CommandValue::EnvironmentSpecRead { .. } => {
+        CommandValue::EnvironmentSpecRead { .. } => {
             tracing::warn!("unexpected environment lifecycle result reached UI handler");
         }
         CommandValue::IssuePage(_) | CommandValue::IssuesByIds { .. } => {}

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2304,6 +2304,8 @@ fn convoy_with_vessels(name: &str, vessel_names: &[&str]) -> crate::convoy_model
             started_at: None,
             finished_at: None,
             message: None,
+            image_ref: None,
+            image_digest: None,
         })
         .collect();
     convoy

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -471,8 +471,6 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
             flotilla_protocol::output::json_pretty(&response.value)
         }
         CommandValue::ResourceWatchEvent(response) => flotilla_protocol::output::json_pretty(&response.event),
-        CommandValue::ImageEnsured { image } => format!("image ensured: {image}"),
-        CommandValue::EnvironmentCreated { env_id } => format!("environment created: {env_id}"),
         CommandValue::EnvironmentSpecRead { .. } => "environment spec read".to_string(),
         CommandValue::IssuePage(page) => format!("issue page: {} items, has_more={}", page.items.len(), page.has_more),
         CommandValue::IssuesByIds { items } => format!("issues by ids: {} items", items.len()),

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -148,6 +148,8 @@ pub struct VesselSummary {
     pub started_at: Option<Timestamp>,
     pub finished_at: Option<Timestamp>,
     pub message: Option<String>,
+    pub image_ref: Option<String>,
+    pub image_digest: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
@@ -226,6 +228,8 @@ fn vessel_summary(row: &wire::ConvoyRow, vessel: &wire::VesselRow) -> VesselSumm
         started_at: vessel.started_at,
         finished_at: vessel.finished_at,
         message: vessel.message.clone(),
+        image_ref: vessel.image_ref.clone(),
+        image_digest: vessel.image_digest.clone(),
     }
 }
 

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -834,6 +834,8 @@ mod tests {
                     started_at: None,
                     finished_at: None,
                     message: None,
+                    image_ref: None,
+                    image_digest: None,
                 })
                 .collect(),
             started_at: None,

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -1260,6 +1260,8 @@ fn vessel_description(row: &VesselProjection) -> Vec<DetailField> {
         DetailField { label: "Phase", value: vessel_phase(row).text },
         DetailField { label: "Crew", value: vessel_crew(row).text },
         DetailField { label: "Host", value: row.vessel.host.as_ref().map(ToString::to_string).unwrap_or_default() },
+        DetailField { label: "Image ref", value: row.vessel.image_ref.clone().unwrap_or_default() },
+        DetailField { label: "Image digest", value: row.vessel.image_digest.clone().unwrap_or_default() },
         DetailField { label: "Message", value: row.vessel.message.clone().unwrap_or_default() },
     ]
 }
@@ -1349,6 +1351,8 @@ mod tests {
             started_at: None,
             finished_at: None,
             message: None,
+            image_ref: None,
+            image_digest: None,
         }
     }
 
@@ -1498,7 +1502,10 @@ mod tests {
 
     #[test]
     fn vessel_address_scopes_rows_without_changing_the_widget_contract() {
-        let in_project = convoy(vec![vessel("implement", &[], WorkPhase::Running), vessel("review", &["implement"], WorkPhase::Pending)]);
+        let mut implement = vessel("implement", &[], WorkPhase::Running);
+        implement.image_ref = Some("registry.example/crew:latest".to_string());
+        implement.image_digest = Some("sha256:test-image".to_string());
+        let in_project = convoy(vec![implement, vessel("review", &["implement"], WorkPhase::Pending)]);
         let mut elsewhere = convoy(vec![]);
         elsewhere.id = ConvoyId::new("dev", "elsewhere");
         elsewhere.name = "elsewhere".into();
@@ -1507,6 +1514,12 @@ mod tests {
         let vessel = project_convoys("vessel/dev/tables/review", &[&in_project, &elsewhere]).expect("vessel table");
         assert_eq!(vessel.rows.len(), 1);
         assert_eq!(vessel.rows[0].cells[1].text, "review");
+
+        let implement = project_convoys("vessel/dev/tables/implement", &[&in_project]).expect("implement vessel table");
+        assert!(implement.rows[0]
+            .describe
+            .contains(&DetailField { label: "Image ref", value: "registry.example/crew:latest".to_string() }));
+        assert!(implement.rows[0].describe.contains(&DetailField { label: "Image digest", value: "sha256:test-image".to_string() }));
     }
 
     #[test]

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -9,6 +9,47 @@ forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1
 The explicit release tag is the deployment contract. Do not point placement
 policies at `latest`.
 
+This document is curation advice for the Flotilla project. It is not a schema
+or a contract that Flotilla validates. Flotilla's contract stays deliberately
+narrow: a placement names an image and declares the adapters it promises,
+admission checks those declarations, and provisioning records the named image
+reference together with the immutable digest actually run.
+
+## Why these layers pay here
+
+The boundary between image contents and startup installation is a caching
+decision, and it should follow the placement's host class.
+
+Fungible cloud runners commonly begin with a popular base image and install
+project tools at startup. A fresh runner can rely on the base being cached
+fleet-wide, but a project-specific layer is unlikely to survive for the next
+job, so the startup cost is a rational trade.
+
+Flotilla's hosts are persistent. Image layers are pulled once and remain in
+the host's Docker cache, while hull filesystem state such as dependency caches
+and build outputs also survives re-tasking. Persistent hosts therefore retain
+both halves of the cache. Putting stable toolchains and utilities in reusable
+layers pays on these hosts where it often does not on fungible runners.
+
+The placement already names the image, so it is also the right place for an
+operator to choose this boundary. A persistent Docker host can use a layered
+project image and do little at startup; a fungible cloud placement can use a
+generic image and install per job. This advice does not introduce a Flotilla
+image-content schema.
+
+## Keep image material project-side
+
+Image recipes, build automation, and registry entries belong to the project,
+never to an upstream repository merely because the project consumes its code.
+This keeps upstream policy from constraining what the project's convoys can
+run.
+
+- A fork-based project keeps image material in a project-owned repository.
+- A project that owns its code repository may use that same repository as its
+  operations home.
+- A multi-repository project records which member repositories an image serves
+  and uses distinct entries where their stacks require distinct images.
+
 ## Build and publish
 
 The Dockerfile is deliberately ordered from slowest-changing to


### PR DESCRIPTION
## What changed

- resolve the immutable Docker image ID after container creation and persist the named image ref plus actual digest through environment and vessel status
- carry image testimony into convoy settlement projections and show it in vessel `ls` detail
- cover moved-tag behavior with two convoys retaining the same ref and distinct digests
- remove the dormant `ImageEnsured` / `EnvironmentCreated` results and fold image resolution into environment creation
- document crew-image layering rationale, advice-only status, and project-side ownership principle

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`

Closes #1143
