### PR TITLE
fix: isolate admission tests from host environment

### DIFF
--- a/crates/flotilla-core/src/admission.rs
+++ b/crates/flotilla-core/src/admission.rs
@@ -1,29 +1,46 @@
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use sysinfo::Disks;
 
 const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
 
-pub(crate) fn check_free_space_floor(host: &str, path: &Path, floor_gib: u64) -> Result<(), String> {
+pub(crate) trait AvailableSpaceProbe: Send + Sync {
+    fn measure(&self, path: &Path) -> Option<u64>;
+}
+
+struct SystemAvailableSpaceProbe;
+
+impl AvailableSpaceProbe for SystemAvailableSpaceProbe {
+    fn measure(&self, path: &Path) -> Option<u64> {
+        let disks = Disks::new_with_refreshed_list();
+        disks
+            .list()
+            .iter()
+            .filter(|disk| path.starts_with(disk.mount_point()))
+            .max_by_key(|disk| disk.mount_point().components().count())
+            .map(|disk| disk.available_space())
+    }
+}
+
+pub(crate) fn system_available_space_probe() -> Arc<dyn AvailableSpaceProbe> {
+    Arc::new(SystemAvailableSpaceProbe)
+}
+
+pub(crate) fn check_free_space_floor(probe: &dyn AvailableSpaceProbe, host: &str, path: &Path, floor_gib: u64) -> Result<(), String> {
     if floor_gib == 0 {
         return Ok(());
     }
 
     let floor_bytes =
         floor_gib.checked_mul(BYTES_PER_GIB).ok_or_else(|| format!("free-space floor for host `{host}` is too large: {floor_gib} GiB"))?;
-    let free_bytes = measure_available_space(path)
+    let free_bytes = probe
+        .measure(path)
         .ok_or_else(|| format!("placement refused on host `{host}`: free space could not be measured for {}", path.display()))?;
     check_measured_free_space(host, free_bytes, floor_bytes)
 }
 
 pub fn measure_available_space(path: &Path) -> Option<u64> {
-    let disks = Disks::new_with_refreshed_list();
-    disks
-        .list()
-        .iter()
-        .filter(|disk| path.starts_with(disk.mount_point()))
-        .max_by_key(|disk| disk.mount_point().components().count())
-        .map(|disk| disk.available_space())
+    SystemAvailableSpaceProbe.measure(path)
 }
 
 fn check_measured_free_space(host: &str, free_bytes: u64, floor_bytes: u64) -> Result<(), String> {
@@ -52,9 +69,19 @@ fn format_gib(bytes: u64) -> String {
 mod tests {
     use super::*;
 
+    struct FixedAvailableSpaceProbe(Option<u64>);
+
+    impl AvailableSpaceProbe for FixedAvailableSpaceProbe {
+        fn measure(&self, _path: &Path) -> Option<u64> {
+            self.0
+        }
+    }
+
     #[test]
-    fn below_floor_refusal_is_actionable() {
-        let result = check_measured_free_space("kiwi", 12 * BYTES_PER_GIB, 20 * BYTES_PER_GIB);
+    fn injected_space_below_floor_is_refused_with_actionable_error() {
+        let probe = FixedAvailableSpaceProbe(Some(12 * BYTES_PER_GIB));
+
+        let result = check_free_space_floor(&probe, "kiwi", Path::new("/workspace"), 20);
 
         assert_eq!(
             result,
@@ -65,8 +92,20 @@ mod tests {
     }
 
     #[test]
-    fn space_equal_to_floor_is_admitted() {
-        assert_eq!(check_measured_free_space("kiwi", 20 * BYTES_PER_GIB, 20 * BYTES_PER_GIB), Ok(()));
+    fn injected_space_equal_to_floor_is_admitted() {
+        let probe = FixedAvailableSpaceProbe(Some(20 * BYTES_PER_GIB));
+
+        assert_eq!(check_free_space_floor(&probe, "kiwi", Path::new("/workspace"), 20), Ok(()));
+    }
+
+    #[test]
+    fn injected_unmeasurable_space_is_refused() {
+        let probe = FixedAvailableSpaceProbe(None);
+
+        assert_eq!(
+            check_free_space_floor(&probe, "kiwi", Path::new("/workspace"), 20),
+            Err("placement refused on host `kiwi`: free space could not be measured for /workspace".to_string())
+        );
     }
 
     #[test]
@@ -80,6 +119,8 @@ mod tests {
 
     #[test]
     fn zero_floor_disables_the_probe() {
-        assert_eq!(check_free_space_floor("kiwi", Path::new("/path/that/does/not/exist"), 0), Ok(()));
+        let probe = FixedAvailableSpaceProbe(None);
+
+        assert_eq!(check_free_space_floor(&probe, "kiwi", Path::new("/path/that/does/not/exist"), 0), Ok(()));
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4017,10 +4017,16 @@ impl InProcessDaemon {
 
     async fn check_local_free_space_floor(&self) -> Result<(), String> {
         let config = Arc::clone(&self.config);
+        let available_space_probe = Arc::clone(&self.discovery.available_space_probe);
         let host_name = self.host_name.to_string();
         tokio::task::spawn_blocking(move || {
             let daemon_config = config.load_daemon_config()?;
-            crate::admission::check_free_space_floor(&host_name, config.state_dir().as_path(), daemon_config.admission.free_space_floor_gib)
+            crate::admission::check_free_space_floor(
+                &*available_space_probe,
+                &host_name,
+                config.state_dir().as_path(),
+                daemon_config.admission.free_space_floor_gib,
+            )
         })
         .await
         .map_err(|error| format!("free-space check failed on host `{}`: {error}", self.host_name))?

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -178,6 +178,7 @@ async fn adopted_checkout_with_explicit_transport_applies_fork_stance_config() {
     let config_base = temp.path().join("config");
     let repo = temp.path().join("repo");
     std::fs::create_dir_all(&repo).expect("create repo");
+    let repo = std::fs::canonicalize(repo).expect("canonicalize repo");
     std::fs::create_dir_all(&config_base).expect("create config dir");
     std::fs::write(config_base.join("daemon.toml"), "machine_id = \"adopted-fork-test\"\n").expect("write daemon config");
     overwrite_single_saved_repo_config(

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -25,6 +25,7 @@ use futures::stream;
 use tokio::sync::OnceCell as AsyncOnceCell;
 
 use crate::{
+    admission::{system_available_space_probe, AvailableSpaceProbe},
     agent_adapter::AgentAdapterRegistry,
     attachable::{shared_file_backed_attachable_store, SharedAttachableStore},
     config::ConfigStore,
@@ -500,6 +501,7 @@ impl FactoryRegistry {
 pub struct DiscoveryRuntime {
     pub runner: Arc<dyn CommandRunner>,
     pub env: Arc<dyn EnvVars>,
+    pub(crate) available_space_probe: Arc<dyn AvailableSpaceProbe>,
     pub host_detectors: Vec<Box<dyn HostDetector>>,
     pub repo_detectors: Vec<Box<dyn RepoDetector>>,
     pub factories: FactoryRegistry,
@@ -637,6 +639,7 @@ impl DiscoveryRuntime {
         Self {
             runner: Arc::new(crate::providers::ProcessCommandRunner),
             env: Arc::new(ProcessEnvVars),
+            available_space_probe: system_available_space_probe(),
             host_detectors: detectors::default_host_detectors(),
             repo_detectors: detectors::default_repo_detectors(),
             factories,

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -303,6 +303,7 @@ fn minimal_discovery_runtime(follower: bool, runner: std::sync::Arc<dyn CommandR
     super::DiscoveryRuntime {
         runner,
         env: std::sync::Arc::new(TestEnvVars::default()),
+        available_space_probe: fixed_available_space_probe(),
         host_detectors: vec![Box::new(super::detectors::generic::CommandDetector::new(
             "git",
             &["--version"],
@@ -1270,6 +1271,7 @@ pub fn fake_discovery_with_provider_set(providers: FakeDiscoveryProviders) -> Di
     DiscoveryRuntime {
         runner,
         env: Arc::new(TestEnvVars::default()),
+        available_space_probe: fixed_available_space_probe(),
         host_detectors: vec![],
         repo_detectors: vec![],
         factories: FactoryRegistry {
@@ -1287,6 +1289,18 @@ pub fn fake_discovery_with_provider_set(providers: FakeDiscoveryProviders) -> Di
         attachable_store,
         host_scoped_providers: Default::default(),
     }
+}
+
+fn fixed_available_space_probe() -> Arc<dyn crate::admission::AvailableSpaceProbe> {
+    struct FixedAvailableSpaceProbe;
+
+    impl crate::admission::AvailableSpaceProbe for FixedAvailableSpaceProbe {
+        fn measure(&self, _path: &Path) -> Option<u64> {
+            Some(100 * 1024 * 1024 * 1024)
+        }
+    }
+
+    Arc::new(FixedAvailableSpaceProbe)
 }
 
 /// Build a [`DiscoveryRuntime`] with [`FakeVcs`] and [`FakeCheckoutManager`]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2441,7 +2441,10 @@ mod tests {
     #[tokio::test]
     async fn provisioned_environment_discovers_and_registers_interior_agent_adapters() {
         let temp = TempDir::new().expect("tempdir");
-        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let config_base = temp.path().join("config");
+        fs::create_dir_all(&config_base).expect("config directory");
+        fs::write(config_base.join("daemon.toml"), "machine_id = \"interior-discovery-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_base));
         let mut discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
         discovery.host_detectors = flotilla_core::providers::discovery::detectors::default_host_detectors();
         let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
@@ -2499,7 +2502,10 @@ mod tests {
     #[tokio::test]
     async fn provisioned_environment_is_destroyed_when_declared_adapter_is_missing() {
         let temp = TempDir::new().expect("tempdir");
-        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let config_base = temp.path().join("config");
+        fs::create_dir_all(&config_base).expect("config directory");
+        fs::write(config_base.join("daemon.toml"), "machine_id = \"interior-rejection-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_base));
         let mut discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
         discovery.host_detectors = flotilla_core::providers::discovery::detectors::default_host_detectors();
         let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;


### PR DESCRIPTION
## Summary

- route convoy admission disk-floor measurement through an injected collaborator
- give test discovery runtimes a deterministic 100 GiB capacity while keeping process discovery real-backed
- cover below-floor, exactly-at-floor, and unmeasurable admission outcomes with injected values
- canonicalize the adopted-checkout fixture path so macOS `/var` aliases cannot hide fork configuration
- provide explicit machine identities to provisioned-environment tests

## Root cause

Admission used `sysinfo::Disks` directly, so otherwise deterministic daemon tests failed whenever the host had less than the configured 20 GiB floor. Two provisioned-environment tests also relied on ambient machine identity, and the adopted-checkout test wrote configuration under a path that canonicalizes differently on macOS.

The runtime heartbeat still calls the real `measure_available_space` function and continues reporting actual `disk_free_bytes`.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1175
Closes #1172