### PR TITLE
fix: preserve remote host self reports in fleet health

### DIFF
--- a/crates/flotilla-core/src/host_registry.rs
+++ b/crates/flotilla-core/src/host_registry.rs
@@ -125,7 +125,6 @@ impl HostRegistry {
         HostListResponse { hosts: host_entries }
     }
 
-    #[cfg(test)]
     pub(crate) async fn environment_id_for_node(&self, node_id: &NodeId) -> Option<EnvironmentId> {
         self.node_environments.read().await.get(node_id).cloned()
     }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5208,7 +5208,19 @@ impl InProcessDaemon {
                 }
                 ResourceProvenance::Local => None,
                 ResourceProvenance::Replica { origin_root, .. } => {
-                    self.host_registry.host_name_for_node(origin_root).await.or_else(|| configured_by_node.get(origin_root).cloned())
+                    // An origin replicates every Host it observes, including this daemon's Host.
+                    // Only the Host matching the origin's canonical environment is its self-report.
+                    let is_self_report = self
+                        .host_registry
+                        .environment_id_for_node(origin_root)
+                        .await
+                        .and_then(|environment_id| environment_id.host_id().map(ToString::to_string))
+                        .is_some_and(|host_id| host_id == resource_host.object.metadata.name);
+                    if !is_self_report {
+                        None
+                    } else {
+                        self.host_registry.host_name_for_node(origin_root).await.or_else(|| configured_by_node.get(origin_root).cloned())
+                    }
                 }
             };
             let (Some(host), Some(status)) = (host, resource_host.object.status) else {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1857,8 +1857,10 @@ async fn fleet_health_keeps_link_heartbeat_and_generation_disagreements_visible(
 
     let source = ResourceBackend::InMemory(InMemoryBackend::default());
     let source_hosts = source.using::<ResourceHost>("flotilla");
-    let remote =
-        source_hosts.create(&InputMeta::builder().name("feta-host".to_string()).build(), &HostSpec {}).await.expect("create source host");
+    let remote = source_hosts
+        .create(&InputMeta::builder().name("feta-feta-host".to_string()).build(), &HostSpec {})
+        .await
+        .expect("create source host");
     let frozen_heartbeat = Utc::now() - ChronoDuration::seconds(HEARTBEAT_READY_TTL_SECS + 1);
     source_hosts
         .update_status(&remote.metadata.name, &remote.metadata.resource_version, &HostStatus {

--- a/crates/flotilla-daemon/tests/overlay_replication.rs
+++ b/crates/flotilla-daemon/tests/overlay_replication.rs
@@ -2,10 +2,10 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use flotilla_core::{config::ConfigStore, in_process::InProcessDaemon, providers::discovery::test_support::fake_discovery};
 use flotilla_daemon::server::test_support::spawn_in_memory_request_topology;
-use flotilla_protocol::HostName;
+use flotilla_protocol::{HostName, PeerConnectionState};
 use flotilla_resources::{
-    watch_resource_kind_replica_sources, Convoy, ConvoySpec, InMemoryBackend, InputMeta, Project, ProjectSpec, ResourceBackend,
-    ResourceProvenance, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec,
+    watch_resource_kind_replica_sources, Convoy, ConvoySpec, Host, HostSpec, HostStatus, InMemoryBackend, InputMeta, Project, ProjectSpec,
+    ResourceBackend, ResourceProvenance, SqliteBackend, TerminalSession, TerminalSessionSource, TerminalSessionSpec, Vessel, VesselSpec,
 };
 use futures::StreamExt;
 
@@ -16,14 +16,76 @@ fn config(path: std::path::PathBuf, machine_id: &str) -> Arc<ConfigStore> {
 }
 
 async fn daemon(path: std::path::PathBuf, machine_id: &str, host: &str) -> Arc<InProcessDaemon> {
-    InProcessDaemon::new_with_resource_backend(
-        vec![],
-        config(path, machine_id),
-        fake_discovery(false),
-        HostName::new(host),
-        ResourceBackend::InMemory(InMemoryBackend::default()),
-    )
+    daemon_with_backend(path, machine_id, host, ResourceBackend::InMemory(InMemoryBackend::default())).await
+}
+
+async fn sqlite_daemon(path: std::path::PathBuf, machine_id: &str, host: &str) -> Arc<InProcessDaemon> {
+    std::fs::create_dir_all(&path).expect("create sqlite daemon directory");
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(path.join("resources.sqlite")).expect("open sqlite backend"));
+    daemon_with_backend(path, machine_id, host, backend).await
+}
+
+async fn daemon_with_backend(path: std::path::PathBuf, machine_id: &str, host: &str, backend: ResourceBackend) -> Arc<InProcessDaemon> {
+    InProcessDaemon::new_with_resource_backend(vec![], config(path, machine_id), fake_discovery(false), HostName::new(host), backend).await
+}
+
+#[tokio::test]
+async fn sqlite_daemons_expose_remote_host_self_report_in_fleet_health() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let kiwi = sqlite_daemon(temp.path().join("kiwi"), "kiwi-root", "kiwi").await;
+    let feta = sqlite_daemon(temp.path().join("feta"), "feta-root", "feta").await;
+    let feta_host_id = feta.local_host_summary().await.environment_id.host_id().expect("feta host id").to_string();
+    let started_at = chrono::Utc::now() - chrono::Duration::hours(2);
+    let heartbeat_at = chrono::Utc::now();
+    let feta_hosts = feta.resource_backend().using::<Host>("flotilla");
+    let feta_host = feta_hosts
+        .create(&InputMeta::builder().name(feta_host_id.clone()).build(), &HostSpec {})
+        .await
+        .expect("create feta host self-report");
+    feta_hosts
+        .update_status(&feta_host_id, &feta_host.metadata.resource_version, &HostStatus {
+            heartbeat_at: Some(heartbeat_at),
+            ready: true,
+            daemon_generation: Some("feta-generation".to_string()),
+            daemon_version: Some("0.1.0".to_string()),
+            daemon_started_at: Some(started_at),
+            disk_free_bytes: Some(459_371_896_832),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("publish feta host self-report");
+
+    let topology = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("connect sqlite daemons");
+
+    let replicated = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let hosts = kiwi.resource_backend().including_replicas::<Host>("flotilla").list().await.expect("list kiwi host sources");
+            if let Some(host) = hosts.items.into_iter().find(|host| {
+                matches!(host.provenance, ResourceProvenance::Replica { .. })
+                    && host.object.status.as_ref().and_then(|status| status.daemon_version.as_deref()) == Some("0.1.0")
+            }) {
+                break host;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
     .await
+    .expect("feta host self-report did not replicate to kiwi");
+    assert!(matches!(
+        replicated.provenance,
+        ResourceProvenance::Replica { ref origin_root, .. } if origin_root == feta.node_id()
+    ));
+
+    let health = kiwi.fleet_health_internal().await.expect("query kiwi fleet health");
+    let row = health.hosts.into_iter().find(|row| row.host == HostName::new("feta")).expect("feta fleet health row");
+
+    assert_eq!(row.daemon_version.as_deref(), Some("0.1.0"));
+    assert_eq!(row.daemon_generation.as_deref(), Some("feta-generation"));
+    assert_eq!(row.heartbeat_at, Some(heartbeat_at));
+    assert_eq!(row.link, PeerConnectionState::Connected);
+    assert_eq!(row.disk_free_bytes, Some(459_371_896_832));
+    assert!(row.daemon_uptime_seconds.is_some_and(|uptime| uptime >= 2 * 60 * 60));
+    drop(topology);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- identify each replicated Host self-report by the origin node's canonical host environment
- prevent a fresher peer-observation Host from replacing the origin daemon's version, generation, uptime, heartbeat, and disk status
- add an end-to-end regression using two SQLite-backed daemons and the real resource replication topology

## Root cause

Each daemon replicates every Host resource it observes. The fleet-health aggregator grouped all replicated Host resources by replica origin, so a remote daemon's fresher local observation of another host could replace that daemon's own Host status. In a two-host mesh, feta's observation of kiwi therefore won over feta's own self-report and left feta's health columns empty on kiwi.

The aggregator now accepts a replicated Host status only when the resource name matches the origin node's canonical host environment ID. Link state remains the local observation, while health fields come from the remote daemon's self-report.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-core --locked fleet_health_keeps_link_heartbeat_and_generation_disagreements_visible -- --nocapture`
- `cargo test -p flotilla-daemon --locked --features test-support --test overlay_replication sqlite_daemons_expose_remote_host_self_report_in_fleet_health -- --nocapture`
- `cargo test --workspace --locked`: all tests reached in the run passed except `in_process::tests::adopted_checkout_with_explicit_transport_applies_fork_stance_config`; the identical failure reproduces on untouched base commit `fa0bfbf8`

Closes #1177