### PR TITLE
fix: recover dropped reconcile actuations

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -10,6 +10,7 @@ use flotilla_resources::{
 use tracing::warn;
 
 const CHECKOUT_INTEGRATION_REFRESH_AFTER: Duration = Duration::from_secs(6 * 60 * 60);
+const CHECKOUT_PROVISIONING_REQUEUE_AFTER: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckoutRemoval {
@@ -187,7 +188,13 @@ where
             None
         };
 
-        ReconcileOutcome::new(patch)
+        let mut outcome = ReconcileOutcome::new(patch);
+        if obj.status.as_ref().map(|status| status.phase).unwrap_or(CheckoutPhase::Pending) == CheckoutPhase::Pending
+            && !matches!(deps, CheckoutDeps::Failed(_))
+        {
+            outcome.requeue_after = Some(CHECKOUT_PROVISIONING_REQUEUE_AFTER);
+        }
+        outcome
     }
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -131,12 +131,11 @@ impl VesselDeps {
     }
 
     fn provisioning(
-        obj: &ResourceObject<Vessel>,
         placement_policy: &ResourceObject<PlacementPolicy>,
         waiting_for: impl Into<String>,
         actuations: Vec<Actuation>,
     ) -> Self {
-        Self { patch: provisioning_patch(obj, placement_policy, waiting_for.into()), actuations }
+        Self { patch: provisioning_patch(placement_policy, waiting_for.into()), actuations }
     }
 
     fn ready(
@@ -262,12 +261,7 @@ impl Reconciler for VesselReconciler {
                 None => return Ok(VesselDeps::failed(format!("environment {clone_env_ref} is not a host_direct environment"))),
             };
             if clone_env.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                return Ok(VesselDeps::provisioning(
-                    obj,
-                    &placement_policy,
-                    format!("environment {clone_env_ref} to become ready"),
-                    actuations,
-                ));
+                return Ok(VesselDeps::provisioning(&placement_policy, format!("environment {clone_env_ref} to become ready"), actuations));
             }
             Some(clone_env_spec.repo_default_dir.clone())
         } else {
@@ -289,7 +283,6 @@ impl Reconciler for VesselReconciler {
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
                             return Ok(VesselDeps::provisioning(
-                                obj,
                                 &placement_policy,
                                 format!("environment {env_name} to become ready"),
                                 actuations,
@@ -316,7 +309,6 @@ impl Reconciler for VesselReconciler {
                             },
                         });
                         return Ok(VesselDeps::provisioning(
-                            obj,
                             &placement_policy,
                             format!("environment {env_name} to become ready"),
                             actuations,
@@ -540,10 +532,10 @@ impl Reconciler for VesselReconciler {
             }
         }
         if !waiting_for_checkouts.is_empty() {
+            let checkout_label = if waiting_for_checkouts.len() == 1 { "checkout" } else { "checkouts" };
             return Ok(VesselDeps::provisioning(
-                obj,
                 &placement_policy,
-                format!("checkout {} to become ready", waiting_for_checkouts.join(", ")),
+                format!("{checkout_label} {} to become ready", waiting_for_checkouts.join(", ")),
                 actuations,
             ));
         }
@@ -570,12 +562,7 @@ impl Reconciler for VesselReconciler {
                     return Ok(VesselDeps::failed(format!("environment {env_name} failed")));
                 }
                 if environment.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                    return Ok(VesselDeps::provisioning(
-                        obj,
-                        &placement_policy,
-                        format!("environment {env_name} to become ready"),
-                        actuations,
-                    ));
+                    return Ok(VesselDeps::provisioning(&placement_policy, format!("environment {env_name} to become ready"), actuations));
                 }
                 (env_name, None)
             }
@@ -593,7 +580,6 @@ impl Reconciler for VesselReconciler {
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
                             return Ok(VesselDeps::provisioning(
-                                obj,
                                 &placement_policy,
                                 format!("environment {env_name} to become ready"),
                                 actuations,
@@ -627,7 +613,6 @@ impl Reconciler for VesselReconciler {
                             },
                         });
                         return Ok(VesselDeps::provisioning(
-                            obj,
                             &placement_policy,
                             format!("environment {env_name} to become ready"),
                             actuations,
@@ -696,7 +681,6 @@ impl Reconciler for VesselReconciler {
                     }
                     if should_start && phase != Some(TerminalSessionPhase::Running) {
                         return Ok(VesselDeps::provisioning(
-                            obj,
                             &placement_policy,
                             format!("terminal session {terminal_name} to become running"),
                             actuations,
@@ -770,7 +754,6 @@ impl Reconciler for VesselReconciler {
                         },
                     });
                     return Ok(VesselDeps::provisioning(
-                        obj,
                         &placement_policy,
                         format!("terminal session {terminal_name} to become running"),
                         actuations,
@@ -894,11 +877,7 @@ fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, S
     Err("placement policy must define exactly one supported strategy".to_string())
 }
 
-fn provisioning_patch(
-    _obj: &ResourceObject<Vessel>,
-    placement_policy: &ResourceObject<PlacementPolicy>,
-    waiting_for: String,
-) -> PlannedPatch {
+fn provisioning_patch(placement_policy: &ResourceObject<PlacementPolicy>, waiting_for: String) -> PlannedPatch {
     PlannedPatch::Provisioning {
         observed_policy_ref: placement_policy.metadata.name.clone(),
         observed_policy_version: placement_policy.metadata.resource_version.clone(),

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, marker::PhantomData, path::PathBuf};
+use std::{collections::BTreeMap, marker::PhantomData, path::PathBuf, time::Duration};
 
 use chrono::{DateTime, Utc};
 use flotilla_core::agent_adapter::{
@@ -21,6 +21,8 @@ use flotilla_resources::{
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
 const REPO_LABEL: &str = "flotilla.work/repo";
 const ENV_LABEL: &str = "flotilla.work/env";
+const VESSEL_PROVISIONING_REQUEUE_AFTER: Duration = Duration::from_secs(5);
+const VESSEL_PROVISIONING_STUCK_SECONDS: i64 = 2 * 60;
 
 #[derive(bon::Builder)]
 pub struct VesselReconciler {
@@ -96,6 +98,7 @@ enum PlannedPatch {
     Provisioning {
         observed_policy_ref: String,
         observed_policy_version: String,
+        waiting_for: String,
     },
     Ready {
         environment_ref: String,
@@ -127,8 +130,13 @@ impl VesselDeps {
         Self { patch: PlannedPatch::None, actuations: Vec::new() }
     }
 
-    fn provisioning(obj: &ResourceObject<Vessel>, placement_policy: &ResourceObject<PlacementPolicy>, actuations: Vec<Actuation>) -> Self {
-        Self { patch: provisioning_patch(obj, placement_policy), actuations }
+    fn provisioning(
+        obj: &ResourceObject<Vessel>,
+        placement_policy: &ResourceObject<PlacementPolicy>,
+        waiting_for: impl Into<String>,
+        actuations: Vec<Actuation>,
+    ) -> Self {
+        Self { patch: provisioning_patch(obj, placement_policy, waiting_for.into()), actuations }
     }
 
     fn ready(
@@ -254,7 +262,12 @@ impl Reconciler for VesselReconciler {
                 None => return Ok(VesselDeps::failed(format!("environment {clone_env_ref} is not a host_direct environment"))),
             };
             if clone_env.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                return Ok(VesselDeps::provisioning(
+                    obj,
+                    &placement_policy,
+                    format!("environment {clone_env_ref} to become ready"),
+                    actuations,
+                ));
             }
             Some(clone_env_spec.repo_default_dir.clone())
         } else {
@@ -275,7 +288,12 @@ impl Reconciler for VesselReconciler {
                             return Ok(VesselDeps::failed(message));
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                            return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                            return Ok(VesselDeps::provisioning(
+                                obj,
+                                &placement_policy,
+                                format!("environment {env_name} to become ready"),
+                                actuations,
+                            ));
                         }
                         match image_stamp(&existing) {
                             Ok(image) => image,
@@ -297,7 +315,12 @@ impl Reconciler for VesselReconciler {
                                 }),
                             },
                         });
-                        return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                        return Ok(VesselDeps::provisioning(
+                            obj,
+                            &placement_policy,
+                            format!("environment {env_name} to become ready"),
+                            actuations,
+                        ));
                     }
                     Err(err) => return Err(err),
                 };
@@ -323,7 +346,7 @@ impl Reconciler for VesselReconciler {
         };
         let mut checkout_refs = BTreeMap::new();
         let mut checkout_paths = BTreeMap::new();
-        let mut waiting_for_checkouts = false;
+        let mut waiting_for_checkouts = Vec::new();
         let mut fork_stance = false;
         for convoy_repository in convoy_repositories {
             let repository_spec = match self.repositories.get(&convoy_repository.repo_ref.to_string()).await {
@@ -472,7 +495,7 @@ impl Reconciler for VesselReconciler {
                         checkout_refs.insert(repository_key.clone(), checkout_name);
                         checkout_paths.insert(repository_key, path);
                     } else {
-                        waiting_for_checkouts = true;
+                        waiting_for_checkouts.push(checkout_name);
                     }
                 }
                 Err(ResourceError::NotFound { .. }) => {
@@ -511,13 +534,18 @@ impl Reconciler for VesselReconciler {
                         PlacementStrategy::DockerFreshCloneInContainer { .. } => owned_child_meta(&checkout_name, obj, labels),
                     };
                     actuations.push(Actuation::CreateCheckout { meta, spec });
-                    waiting_for_checkouts = true;
+                    waiting_for_checkouts.push(checkout_name);
                 }
                 Err(err) => return Err(err),
             }
         }
-        if waiting_for_checkouts {
-            return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+        if !waiting_for_checkouts.is_empty() {
+            return Ok(VesselDeps::provisioning(
+                obj,
+                &placement_policy,
+                format!("checkout {} to become ready", waiting_for_checkouts.join(", ")),
+                actuations,
+            ));
         }
         let has_repositories = !repository_refs.is_empty();
         let workspace_root = if multi_repository {
@@ -542,7 +570,12 @@ impl Reconciler for VesselReconciler {
                     return Ok(VesselDeps::failed(format!("environment {env_name} failed")));
                 }
                 if environment.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                    return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                    return Ok(VesselDeps::provisioning(
+                        obj,
+                        &placement_policy,
+                        format!("environment {env_name} to become ready"),
+                        actuations,
+                    ));
                 }
                 (env_name, None)
             }
@@ -559,7 +592,12 @@ impl Reconciler for VesselReconciler {
                             return Ok(VesselDeps::failed(message));
                         }
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                            return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                            return Ok(VesselDeps::provisioning(
+                                obj,
+                                &placement_policy,
+                                format!("environment {env_name} to become ready"),
+                                actuations,
+                            ));
                         }
                         match image_stamp(&existing) {
                             Ok(image) => image,
@@ -588,7 +626,12 @@ impl Reconciler for VesselReconciler {
                                 }),
                             },
                         });
-                        return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                        return Ok(VesselDeps::provisioning(
+                            obj,
+                            &placement_policy,
+                            format!("environment {env_name} to become ready"),
+                            actuations,
+                        ));
                     }
                     Err(err) => return Err(err),
                 };
@@ -652,7 +695,12 @@ impl Reconciler for VesselReconciler {
                         continue;
                     }
                     if should_start && phase != Some(TerminalSessionPhase::Running) {
-                        return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                        return Ok(VesselDeps::provisioning(
+                            obj,
+                            &placement_policy,
+                            format!("terminal session {terminal_name} to become running"),
+                            actuations,
+                        ));
                     }
                 }
                 Err(ResourceError::NotFound { .. }) => {
@@ -721,7 +769,12 @@ impl Reconciler for VesselReconciler {
                             pool: strategy.pool().to_string(),
                         },
                     });
-                    return Ok(VesselDeps::provisioning(obj, &placement_policy, actuations));
+                    return Ok(VesselDeps::provisioning(
+                        obj,
+                        &placement_policy,
+                        format!("terminal session {terminal_name} to become running"),
+                        actuations,
+                    ));
                 }
                 Err(err) => return Err(err),
             }
@@ -740,17 +793,20 @@ impl Reconciler for VesselReconciler {
 
     fn reconcile(
         &self,
-        _obj: &ResourceObject<Self::Resource>,
+        obj: &ResourceObject<Self::Resource>,
         deps: &Self::Dependencies,
         now: DateTime<Utc>,
     ) -> ReconcileOutcome<Self::Resource> {
         let patch = match &deps.patch {
             PlannedPatch::None => None,
-            PlannedPatch::Provisioning { observed_policy_ref, observed_policy_version } => Some(VesselStatusPatch::MarkProvisioning {
-                observed_policy_ref: observed_policy_ref.clone(),
-                observed_policy_version: observed_policy_version.clone(),
-                started_at: now,
-            }),
+            PlannedPatch::Provisioning { observed_policy_ref, observed_policy_version, waiting_for } => {
+                Some(VesselStatusPatch::MarkProvisioning {
+                    observed_policy_ref: observed_policy_ref.clone(),
+                    observed_policy_version: observed_policy_version.clone(),
+                    started_at: now,
+                    message: provisioning_stuck_message(obj, waiting_for, now),
+                })
+            }
             PlannedPatch::Ready { environment_ref, image, checkout_refs, terminal_session_refs, requested_stance, effective_stance } => {
                 Some(VesselStatusPatch::MarkReady {
                     environment_ref: Some(environment_ref.clone()),
@@ -766,7 +822,11 @@ impl Reconciler for VesselReconciler {
             PlannedPatch::Failed { message } => Some(VesselStatusPatch::MarkFailed { message: message.clone() }),
         };
 
-        ReconcileOutcome::with_actuations(patch, deps.actuations.clone())
+        let mut outcome = ReconcileOutcome::with_actuations(patch, deps.actuations.clone());
+        if matches!(&deps.patch, PlannedPatch::Provisioning { .. }) {
+            outcome.requeue_after = Some(VESSEL_PROVISIONING_REQUEUE_AFTER);
+        }
+        outcome
     }
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
@@ -834,15 +894,22 @@ fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, S
     Err("placement policy must define exactly one supported strategy".to_string())
 }
 
-fn provisioning_patch(obj: &ResourceObject<Vessel>, placement_policy: &ResourceObject<PlacementPolicy>) -> PlannedPatch {
-    if obj.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Provisioning) {
-        PlannedPatch::None
-    } else {
-        PlannedPatch::Provisioning {
-            observed_policy_ref: placement_policy.metadata.name.clone(),
-            observed_policy_version: placement_policy.metadata.resource_version.clone(),
-        }
+fn provisioning_patch(
+    _obj: &ResourceObject<Vessel>,
+    placement_policy: &ResourceObject<PlacementPolicy>,
+    waiting_for: String,
+) -> PlannedPatch {
+    PlannedPatch::Provisioning {
+        observed_policy_ref: placement_policy.metadata.name.clone(),
+        observed_policy_version: placement_policy.metadata.resource_version.clone(),
+        waiting_for,
     }
+}
+
+fn provisioning_stuck_message(obj: &ResourceObject<Vessel>, waiting_for: &str, now: DateTime<Utc>) -> Option<String> {
+    let started_at = obj.status.as_ref().filter(|status| status.phase == VesselPhase::Provisioning).and_then(|status| status.started_at)?;
+    (now.signed_duration_since(started_at) >= chrono::Duration::seconds(VESSEL_PROVISIONING_STUCK_SECONDS))
+        .then(|| format!("provisioning is stalled while waiting for {waiting_for}; reconciliation will continue retrying"))
 }
 
 fn host_direct_environment_name(host_ref: &str) -> String {

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -2,7 +2,10 @@ mod common;
 
 use std::{
     collections::BTreeMap,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
     time::Duration,
 };
 
@@ -13,9 +16,10 @@ use common::{
     create_workspace, ControllerLoopHarness,
 };
 use flotilla_controllers::reconcilers::{
-    CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, CloneReconciler, CloneRuntime, DockerEnvironmentRuntime,
-    DockerProvisioning, EnvironmentReconciler, HopChainContext, PreparedCheckout, PresentationPolicyRegistry, PresentationReconciler,
-    ProviderPresentationRuntime, TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
+    checkout::CheckoutDeps, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, CloneReconciler, CloneRuntime,
+    DockerEnvironmentRuntime, DockerProvisioning, EnvironmentReconciler, HopChainContext, PreparedCheckout, PresentationPolicyRegistry,
+    PresentationReconciler, ProviderPresentationRuntime, TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler,
+    VesselReconciler,
 };
 use flotilla_core::{
     path_context::DaemonHostPath,
@@ -29,12 +33,14 @@ use flotilla_core::{
     HostName,
 };
 use flotilla_resources::{
-    canonicalize_repo_url, clone_key, controller::ControllerLoop, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec,
-    CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec,
-    DockerEnvironmentSpec, Environment, EnvironmentMount, EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host,
-    HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation, PresentationPhase, PresentationSpec, Repository, RepositorySpec,
-    ResourceBackend, ResourceError, Stance, StatusPatch, TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, VesselRequirement,
-    CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    canonicalize_repo_url, clone_key,
+    controller::{ControllerLoop, ReconcileOutcome, Reconciler},
+    Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerEnvironmentSpec, Environment, EnvironmentMount,
+    EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host, HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation,
+    PresentationPhase, PresentationSpec, Repository, RepositorySpec, ResourceBackend, ResourceError, ResourceObject, Stance, StatusPatch,
+    TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, VesselRequirement, CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL,
+    VESSEL_REF_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -108,6 +114,82 @@ impl CheckoutRuntime for FakeCheckoutRuntime {
 
     async fn remove_checkout(&self, _removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {
         Ok(CheckoutRemovalOutcome::Removed)
+    }
+}
+
+#[derive(Default)]
+struct CountingCheckoutRuntime {
+    attempts: AtomicUsize,
+}
+
+#[async_trait]
+impl CheckoutRuntime for CountingCheckoutRuntime {
+    async fn create_worktree(
+        &self,
+        _clone_path: &str,
+        _branch: &str,
+        _base_ref: Option<&str>,
+        _target_path: &str,
+    ) -> Result<PreparedCheckout, String> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        Ok(PreparedCheckout { commit: Some("44982740".to_string()), branch_provenance: CheckoutBranchProvenance::CreatedForConvoy })
+    }
+
+    async fn create_fresh_clone(
+        &self,
+        _repo_url: &str,
+        _branch: &str,
+        _base_ref: Option<&str>,
+        _target_path: &str,
+    ) -> Result<PreparedCheckout, String> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        Ok(PreparedCheckout { commit: Some("44982740".to_string()), branch_provenance: CheckoutBranchProvenance::PreExisting })
+    }
+
+    async fn inspect_integration(
+        &self,
+        _checkout: &ResourceObject<Checkout>,
+    ) -> Result<flotilla_resources::CheckoutIntegrationStatus, String> {
+        Ok(flotilla_resources::CheckoutIntegrationStatus::default())
+    }
+
+    async fn remove_checkout(&self, _removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {
+        Ok(CheckoutRemovalOutcome::Removed)
+    }
+}
+
+struct DropFirstCheckoutCompletion {
+    inner: CheckoutReconciler<CountingCheckoutRuntime>,
+    dropped: AtomicBool,
+}
+
+impl Reconciler for DropFirstCheckoutCompletion {
+    type Resource = Checkout;
+    type Dependencies = CheckoutDeps;
+
+    async fn fetch_dependencies(&self, obj: &ResourceObject<Checkout>) -> Result<Self::Dependencies, ResourceError> {
+        self.inner.fetch_dependencies(obj).await
+    }
+
+    fn reconcile(
+        &self,
+        obj: &ResourceObject<Checkout>,
+        deps: &Self::Dependencies,
+        now: chrono::DateTime<Utc>,
+    ) -> ReconcileOutcome<Checkout> {
+        let mut outcome = self.inner.reconcile(obj, deps, now);
+        if !self.dropped.swap(true, Ordering::SeqCst) {
+            outcome.patch = None;
+        }
+        outcome
+    }
+
+    async fn run_finalizer(&self, obj: &ResourceObject<Checkout>) -> Result<(), ResourceError> {
+        self.inner.run_finalizer(obj).await
+    }
+
+    fn finalizer_name(&self) -> Option<&'static str> {
+        self.inner.finalizer_name()
     }
 }
 
@@ -497,6 +579,69 @@ async fn checkout_controller_marks_worktree_checkout_ready() {
             }
         })
         .await;
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn checkout_controller_requeues_when_first_completion_is_dropped() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_clone(
+        &backend,
+        NAMESPACE,
+        "clone-a",
+        "git@github.com:flotilla-org/flotilla.git",
+        "host-direct-01HXYZ",
+        "/Users/alice/dev/flotilla",
+    )
+    .await;
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    checkouts
+        .create(
+            &controller_meta().name("checkout-redrive").call(),
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: flotilla_resources::RepositoryKey(flotilla_resources::repo_key("https://github.com/flotilla-org/flotilla")),
+                env_ref: "host-direct-01HXYZ".to_string(),
+                r#ref: "feat/actuation-recovery".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/Users/alice/dev/flotilla.feat-actuation-recovery".to_string(),
+                clone_ref: "clone-a".to_string(),
+            }),
+        )
+        .await
+        .expect("checkout create should succeed");
+
+    let runtime = Arc::new(CountingCheckoutRuntime::default());
+    let reconciler = DropFirstCheckoutCompletion {
+        inner: CheckoutReconciler::new(Arc::clone(&runtime), backend.clone(), NAMESPACE),
+        dropped: AtomicBool::new(false),
+    };
+    let mut harness = ControllerLoopHarness::new(backend.clone());
+    harness.spawn(
+        ControllerLoop {
+            primary: checkouts.clone(),
+            secondaries: vec![],
+            reconciler,
+            // The point retry must recover without waiting for the ordinary
+            // production resync or restarting the controller.
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    harness
+        .wait_until(Duration::from_secs(3), || {
+            let checkouts = checkouts.clone();
+            async move {
+                matches!(
+                    checkouts.get("checkout-redrive").await.ok().and_then(|checkout| checkout.status),
+                    Some(status) if status.phase == CheckoutPhase::Ready
+                )
+            }
+        })
+        .await;
+    assert!(runtime.attempts.load(Ordering::SeqCst) >= 2, "dropped checkout completion should be re-driven");
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -23,8 +23,8 @@ use flotilla_resources::{
     EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus,
     InputMeta, IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend,
     ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
-    TerminalSessionStatus, Vessel, VesselRequirement, VesselSpec, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
-    CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    TerminalSessionStatus, Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus, WorkPhase, WorkflowSnapshot, WorkflowTemplate,
+    CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
@@ -258,6 +258,60 @@ async fn sequential_vessels_share_a_convoy_owned_worktree_checkout() {
         .await
         .expect("convoy finalization");
     assert!(matches!(checkouts.get(&checkout_meta.name).await, Err(ResourceError::NotFound { .. })));
+}
+
+#[tokio::test]
+async fn stuck_provisioning_vessel_surfaces_the_statusless_checkout_it_is_retrying() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, NAMESPACE, "convoy-stuck", "implement", REPO_URL, GIT_REF).await;
+    create_host_direct_policy(&backend, NAMESPACE, "policy-stuck", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    let clone_name =
+        format!("clone-{}", clone_key(&canonicalize_repo_url(REPO_URL).expect("repo canonicalization"), &host_direct_env_name()));
+    create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/tmp/clone").await;
+    let vessels = backend.clone().using::<Vessel>(NAMESPACE);
+    let vessel = create_workspace(&backend, NAMESPACE, "workspace-stuck", "convoy-stuck", "implement", "policy-stuck", REPO_URL).await;
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&vessel).await.expect("initial dependencies");
+    let initial = reconciler.reconcile(&vessel, &deps, Utc::now());
+    let (checkout_meta, checkout_spec) = initial
+        .actuations
+        .into_iter()
+        .find_map(|actuation| match actuation {
+            Actuation::CreateCheckout { meta, spec } => Some((meta, spec)),
+            _ => None,
+        })
+        .expect("initial pass should request the checkout");
+    backend
+        .clone()
+        .using::<Checkout>(NAMESPACE)
+        .create(&checkout_meta, &checkout_spec)
+        .await
+        .expect("checkout resource should be created without a completion status");
+    let now = Utc::now();
+    vessels
+        .update_status(&vessel.metadata.name, &vessel.metadata.resource_version, &VesselStatus {
+            phase: VesselPhase::Provisioning,
+            started_at: Some(now - chrono::Duration::minutes(3)),
+            ..VesselStatus::default()
+        })
+        .await
+        .expect("vessel should be marked provisioning");
+    let vessel = vessels.get("workspace-stuck").await.expect("vessel should exist");
+
+    let deps = reconciler.fetch_dependencies(&vessel).await.expect("stuck dependencies");
+    let outcome = reconciler.reconcile(&vessel, &deps, now);
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::VesselStatusPatch::MarkProvisioning {
+            message: Some(ref message),
+            ..
+        }) if message.contains("provisioning is stalled")
+            && message.contains("checkout checkout-convoy-stuck")
+            && message.contains("continue retrying")
+    ));
+    assert!(outcome.requeue_after.is_some(), "stuck provisioning must schedule another convergence pass");
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1517,6 +1517,13 @@ fn checkout_integration_summary(checkout: &ResourceObject<ResourceCheckout>, int
     }
 }
 
+fn integration_observation_matches(left: &CheckoutIntegrationStatus, right: &CheckoutIntegrationStatus) -> bool {
+    [(&left.clean, &right.clean), (&left.pushed, &right.pushed), (&left.landed, &right.landed)]
+        .into_iter()
+        .all(|(left, right)| left.value == right.value && left.details == right.details)
+        && left.landed_evidence == right.landed_evidence
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExistingConvoyTarget {
     pub home: HostName,
@@ -5695,6 +5702,25 @@ impl InProcessDaemon {
                     continue;
                 }
             };
+            match runner.path_exists(&path).await {
+                Ok(false) => {
+                    warn!(
+                        checkout = %checkout.metadata.name,
+                        path = %path.display(),
+                        "checkout path is already gone; allowing reclaim to finish"
+                    );
+                    continue;
+                }
+                Ok(true) => {}
+                Err(error) => {
+                    refusals.push(format!(
+                        "{} [{}]: Clean=Unknown (checkout path could not be probed: {error})",
+                        checkout.metadata.name,
+                        path.display()
+                    ));
+                    continue;
+                }
+            }
             let mut integration = inspect_checkout_integration(&*runner, &path, &checkout.spec).await;
             if let Some(existing) = checkout
                 .status
@@ -5706,14 +5732,20 @@ impl InProcessDaemon {
                     integration.landed_evidence = existing.integration.landed_evidence.clone();
                 }
             }
-            if let Err(error) = apply_resource_status_patch(
-                &checkouts,
-                &checkout.metadata.name,
-                &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: integration.clone() },
-            )
-            .await
-            {
-                warn!(checkout = %checkout.metadata.name, %error, "failed to persist checkout integration conditions during teardown gate");
+            if !checkout.status.as_ref().is_some_and(|status| integration_observation_matches(&status.integration, &integration)) {
+                if let Err(error) = apply_resource_status_patch(
+                    &checkouts,
+                    &checkout.metadata.name,
+                    &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: integration.clone() },
+                )
+                .await
+                {
+                    warn!(
+                        checkout = %checkout.metadata.name,
+                        %error,
+                        "failed to persist checkout integration conditions during teardown gate"
+                    );
+                }
             }
             if is_adopted {
                 if let Some(summary) = checkout_integration_summary(&checkout, &integration) {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5763,6 +5763,7 @@ impl InProcessDaemon {
         if refusals.is_empty() {
             Ok(())
         } else {
+            refusals.sort();
             Err(format!("convoy {namespace}/{name} is not safe to delete:\n{}", refusals.join("\n")))
         }
     }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4795,6 +4795,95 @@ async fn convoy_delete_refuses_diverged_checkout_without_a_change_request() {
 }
 
 #[tokio::test]
+async fn repeated_identical_reclaim_refusal_does_not_rewrite_checkout_status() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/diverged\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/diverged\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/diverged..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/diverged..HEAD"], Ok("0\n".into()))
+        .on_run(
+            "gh",
+            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+            Ok("[]".into()),
+        )
+        .on_run(
+            "gh",
+            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+            Ok("[]".into()),
+        )
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("1\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("1\n".into()))
+        .build();
+    let daemon = InProcessDaemon::new(
+        vec![],
+        Arc::new(ConfigStore::with_base(&config_base)),
+        fake_discovery_with_runner(false, Arc::new(runner)),
+        HostName::local(),
+    )
+    .await;
+    daemon
+        .resource_backend()
+        .using::<Convoy>("flotilla")
+        .create(&empty_input_meta("refused-convoy"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+        .await
+        .expect("convoy create should succeed");
+    create_ready_observed_checkout_for_convoy(&daemon, "flotilla", "refused-convoy", "checkout-refused", "/repo", "feature/diverged").await;
+
+    daemon.verify_convoy_teardown_gate("flotilla", "refused-convoy", false).await.expect_err("first reclaim should refuse");
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let first = checkouts.get("checkout-refused").await.expect("checkout after first refusal");
+    daemon.verify_convoy_teardown_gate("flotilla", "refused-convoy", false).await.expect_err("second reclaim should refuse");
+    let second = checkouts.get("checkout-refused").await.expect("checkout after second refusal");
+
+    assert_eq!(
+        second.metadata.resource_version, first.metadata.resource_version,
+        "an identical refusal must not emit a status write that immediately requeues the convoy"
+    );
+}
+
+#[tokio::test]
+async fn convoy_reclaim_allows_managed_checkout_whose_path_is_already_gone() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), git_process_discovery(false), HostName::local()).await;
+    daemon
+        .resource_backend()
+        .using::<Convoy>("flotilla")
+        .create(&empty_input_meta("half-reclaimed"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+        .await
+        .expect("convoy create should succeed");
+    let missing_path = temp.path().join("already-removed");
+    create_ready_observed_checkout_for_convoy(
+        &daemon,
+        "flotilla",
+        "half-reclaimed",
+        "checkout-already-removed",
+        missing_path.to_str().expect("utf-8 path"),
+        "feature/already-removed",
+    )
+    .await;
+
+    daemon
+        .verify_convoy_teardown_gate("flotilla", "half-reclaimed", false)
+        .await
+        .expect("a missing checkout path has no integration work left to protect");
+}
+
+#[tokio::test]
 async fn convoy_delete_allows_multi_repo_convoy_with_work_on_only_one_side() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -267,6 +267,10 @@ impl CommandRunner for DiscoveryMockRunner {
         self.tool_exists.get(cmd).copied().unwrap_or(false)
     }
 
+    async fn path_exists(&self, _path: &Path) -> Result<bool, String> {
+        Ok(true)
+    }
+
     async fn ensure_file(&self, path: &Path, content: &str) -> Result<String, String> {
         let mut files = self.files.lock().expect("lock poisoned");
         Ok(files.entry(path.to_path_buf()).or_insert_with(|| content.to_owned()).clone())

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -231,6 +231,15 @@ pub trait CommandRunner: Send + Sync {
     /// Check if a command is available by running it.
     async fn exists(&self, cmd: &str, args: &[&str]) -> bool;
 
+    /// Check whether a path exists in the runner's execution environment.
+    ///
+    /// Unlike checking from the daemon process, this preserves container and
+    /// remote-host path semantics.
+    async fn path_exists(&self, path: &Path) -> Result<bool, String> {
+        let path = path.to_string_lossy();
+        self.run_output("test", &["-e", &path], Path::new("/"), &ChannelLabel::Noop).await.map(|output| output.success)
+    }
+
     /// Ensure `path` exists with `content` if absent, returning the resulting
     /// file contents. Existing files are preserved.
     async fn ensure_file(&self, _path: &Path, content: &str) -> Result<String, String> {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -33,13 +33,13 @@ use flotilla_core::{
 };
 use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, TerminalStatus};
 use flotilla_resources::{
-    clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, Clone,
-    CloneSpec, Convoy, ConvoyReconciler, ConvoyTeardownRuntime, CrewSource, CrewSpec, Demand, DockerCheckoutStrategy,
-    DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host, HostDirectEnvironmentSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta, PlacementPolicy,
-    PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError, ResourceObject, Stance,
-    TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
-    CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY,
+    canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance,
+    CheckoutIntegrationStatus, Clone, CloneSpec, Convoy, ConvoyReconciler, ConvoyTeardownRuntime, CrewSource, CrewSpec, Demand,
+    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
+    InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError,
+    ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -1347,6 +1347,9 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
         let runner = self.local_runner()?;
         let clone_path = utf8_path(clone_path)?;
         let target_path = utf8_path(target_path)?;
+        if let Some(prepared) = recover_existing_worktree(&*runner, clone_path, branch, target_path).await? {
+            return Ok(prepared);
+        }
 
         let local_ref = format!("refs/heads/{branch}");
         let remote_ref = format!("refs/remotes/origin/{branch}");
@@ -1448,6 +1451,9 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
     ) -> Result<PreparedCheckout, String> {
         let runner = self.local_runner()?;
         let target_path = utf8_path(target_path)?;
+        if let Some(prepared) = recover_existing_fresh_clone(&*runner, repo_url, branch, target_path).await? {
+            return Ok(prepared);
+        }
         let clone_ref = base_ref.unwrap_or(branch);
         if clone_ref == "HEAD" {
             runner.run("git", &["clone", repo_url, target_path], Path::new("/"), &ChannelLabel::Noop).await?;
@@ -1550,6 +1556,94 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
             }
         }
     }
+}
+
+async fn recover_existing_worktree(
+    runner: &dyn CommandRunner,
+    clone_path: &str,
+    branch: &str,
+    target_path: &str,
+) -> Result<Option<PreparedCheckout>, String> {
+    if !runner.path_exists(Path::new(target_path)).await? {
+        return Ok(None);
+    }
+
+    let target_common_dir = runner
+        .run("git", &["-C", target_path, "rev-parse", "--path-format=absolute", "--git-common-dir"], Path::new("/"), &ChannelLabel::Noop)
+        .await
+        .map_err(|error| format!("checkout target {target_path} already exists but is not a reusable git worktree: {error}"))?;
+    let clone_common_dir = runner
+        .run("git", &["-C", clone_path, "rev-parse", "--path-format=absolute", "--git-common-dir"], Path::new("/"), &ChannelLabel::Noop)
+        .await?;
+    if target_common_dir.trim() != clone_common_dir.trim() {
+        return Err(format!("checkout target {target_path} already exists but belongs to a different git repository"));
+    }
+
+    let current_branch =
+        runner.run("git", &["-C", target_path, "symbolic-ref", "--quiet", "--short", "HEAD"], Path::new("/"), &ChannelLabel::Noop).await;
+    if current_branch.as_deref().map(str::trim) != Ok(branch) {
+        let target_commit = resolve_head_commit(runner, target_path).await?;
+        let expected_commit = runner.run("git", &["-C", clone_path, "rev-parse", branch], Path::new("/"), &ChannelLabel::Noop).await?;
+        if target_commit.as_deref() != Some(expected_commit.trim()) {
+            return Err(format!("checkout target {target_path} already exists at a different ref than {branch}"));
+        }
+    }
+
+    let branch_provenance = if runner
+        .run(
+            "git",
+            &["-C", clone_path, "show-ref", "--verify", "--quiet", &bootstrap_branch_ref(branch)],
+            Path::new("/"),
+            &ChannelLabel::Noop,
+        )
+        .await
+        .is_ok()
+    {
+        CheckoutBranchProvenance::CreatedForConvoy
+    } else {
+        CheckoutBranchProvenance::PreExisting
+    };
+    Ok(Some(PreparedCheckout { commit: resolve_head_commit(runner, target_path).await?, branch_provenance }))
+}
+
+async fn recover_existing_fresh_clone(
+    runner: &dyn CommandRunner,
+    repo_url: &str,
+    branch: &str,
+    target_path: &str,
+) -> Result<Option<PreparedCheckout>, String> {
+    if !runner.path_exists(Path::new(target_path)).await? {
+        return Ok(None);
+    }
+
+    let origin = runner
+        .run("git", &["-C", target_path, "remote", "get-url", "origin"], Path::new("/"), &ChannelLabel::Noop)
+        .await
+        .map_err(|error| format!("checkout target {target_path} already exists but is not a reusable clone: {error}"))?;
+    let origin = origin.trim();
+    let same_origin = origin == repo_url
+        || canonicalize_repo_url(origin)
+            .ok()
+            .zip(canonicalize_repo_url(repo_url).ok())
+            .is_some_and(|(origin, expected)| origin == expected);
+    if !same_origin {
+        return Err(format!("checkout target {target_path} already exists with origin {origin}, expected {repo_url}"));
+    }
+
+    if branch != "HEAD" {
+        let current_branch = runner
+            .run("git", &["-C", target_path, "symbolic-ref", "--quiet", "--short", "HEAD"], Path::new("/"), &ChannelLabel::Noop)
+            .await
+            .map_err(|error| format!("checkout target {target_path} already exists but its branch cannot be resolved: {error}"))?;
+        if current_branch.trim() != branch {
+            return Err(format!("checkout target {target_path} already exists on branch {}, expected {branch}", current_branch.trim()));
+        }
+    }
+
+    Ok(Some(PreparedCheckout {
+        commit: resolve_head_commit(runner, target_path).await?,
+        branch_provenance: CheckoutBranchProvenance::PreExisting,
+    }))
 }
 
 fn bootstrap_branch_ref(branch: &str) -> String {
@@ -2032,6 +2126,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn checkout_runtime_recovers_a_worktree_after_its_completion_is_lost() {
+        let temp = TempDir::new().expect("tempdir");
+        let clone = TestGitRepo::init(temp.path().join("clone")).with_initial_commit();
+        let target = temp.path().join("workspace/flotilla");
+        let runtime = CheckoutControllerRuntime { runner: Arc::new(ProcessCommandRunner) };
+
+        let first = runtime
+            .create_worktree(
+                clone.path().to_str().expect("utf-8 clone path"),
+                "feature/redrive",
+                Some("main"),
+                target.to_str().expect("utf-8 target path"),
+            )
+            .await
+            .expect("first worktree actuation should succeed");
+        let recovered = runtime
+            .create_worktree(
+                clone.path().to_str().expect("utf-8 clone path"),
+                "feature/redrive",
+                Some("main"),
+                target.to_str().expect("utf-8 target path"),
+            )
+            .await
+            .expect("redrive should recover the worktree already created on disk");
+
+        assert_eq!(recovered, first);
+    }
+
+    #[tokio::test]
     async fn checkout_runtime_removes_zero_commit_worktree_without_git_or_directory_debris() {
         let temp = TempDir::new().expect("tempdir");
         let clone = TestGitRepo::init(temp.path().join("clone")).with_initial_commit();
@@ -2411,6 +2534,35 @@ mod tests {
             .expect("git should run");
         assert!(branch.status.success());
         assert_eq!(String::from_utf8(branch.stdout).expect("utf-8 branch").trim(), "feature/multi-repo");
+    }
+
+    #[tokio::test]
+    async fn checkout_runtime_recovers_a_fresh_clone_after_its_completion_is_lost() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = TestGitRepo::init(temp.path().join("source")).with_initial_commit();
+        let target = temp.path().join("fresh-clone");
+        let runtime = CheckoutControllerRuntime { runner: Arc::new(ProcessCommandRunner) };
+
+        let first = runtime
+            .create_fresh_clone(
+                source.path().to_str().expect("utf-8 source path"),
+                "feature/redrive",
+                Some("main"),
+                target.to_str().expect("utf-8 target path"),
+            )
+            .await
+            .expect("first clone actuation should succeed");
+        let recovered = runtime
+            .create_fresh_clone(
+                source.path().to_str().expect("utf-8 source path"),
+                "feature/redrive",
+                Some("main"),
+                target.to_str().expect("utf-8 target path"),
+            )
+            .await
+            .expect("redrive should recover the clone already created on disk");
+
+        assert_eq!(recovered, first);
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     future::Future,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex as StdMutex},
     time::Duration,
 };
 
@@ -61,6 +61,18 @@ const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 
 struct DaemonConvoyTeardownRuntime {
     daemon: Arc<InProcessDaemon>,
+    reclaim_refusals: StdMutex<HashMap<String, ReclaimRefusal>>,
+}
+
+struct ReclaimRefusal {
+    error: String,
+    attempts: u64,
+}
+
+impl DaemonConvoyTeardownRuntime {
+    fn new(daemon: Arc<InProcessDaemon>) -> Self {
+        Self { daemon, reclaim_refusals: StdMutex::new(HashMap::new()) }
+    }
 }
 
 #[async_trait]
@@ -75,13 +87,44 @@ impl ConvoyTeardownRuntime for DaemonConvoyTeardownRuntime {
 
     async fn verify_reclaim(&self, convoy: &ResourceObject<Convoy>) -> Result<(), String> {
         let result = self.daemon.verify_convoy_teardown_gate(&convoy.metadata.namespace, &convoy.metadata.name, false).await;
-        if let Err(error) = &result {
-            warn!(
-                namespace = %convoy.metadata.namespace,
-                convoy = %convoy.metadata.name,
-                %error,
-                "automatic convoy reclaim refused"
-            );
+        let key = format!("{}/{}", convoy.metadata.namespace, convoy.metadata.name);
+        match &result {
+            Err(error) => {
+                let attempts = {
+                    let mut refusals = self.reclaim_refusals.lock().expect("reclaim refusal lock poisoned");
+                    match refusals.get_mut(&key) {
+                        Some(refusal) if refusal.error == *error => {
+                            refusal.attempts += 1;
+                            refusal.attempts
+                        }
+                        _ => {
+                            refusals.insert(key, ReclaimRefusal { error: error.clone(), attempts: 1 });
+                            1
+                        }
+                    }
+                };
+                if attempts == 1 {
+                    warn!(
+                        namespace = %convoy.metadata.namespace,
+                        convoy = %convoy.metadata.name,
+                        attempts,
+                        %error,
+                        "automatic convoy reclaim refused"
+                    );
+                }
+            }
+            Ok(()) => {
+                if let Some(refusal) = self.reclaim_refusals.lock().expect("reclaim refusal lock poisoned").remove(&key) {
+                    if refusal.attempts > 1 {
+                        info!(
+                            namespace = %convoy.metadata.namespace,
+                            convoy = %convoy.metadata.name,
+                            refused_attempts = refusal.attempts,
+                            "automatic convoy reclaim recovered after repeated refusal"
+                        );
+                    }
+                }
+            }
         }
         result
     }
@@ -1026,7 +1069,7 @@ fn spawn_controller_loops(
                                 .with_vessels(backend.clone().using::<Vessel>(&namespace_string))
                                 .with_presentations(backend.clone().using::<Presentation>(&namespace_string))
                                 .with_checkouts(backend.clone().using::<Checkout>(&namespace_string))
-                                .with_teardown_runtime(Arc::new(DaemonConvoyTeardownRuntime { daemon }))
+                                .with_teardown_runtime(Arc::new(DaemonConvoyTeardownRuntime::new(daemon)))
                                 .with_prepared_snapshot_gc(flotilla_resources::PreparedSnapshotGarbageCollector::new(
                                     backend.clone(),
                                     &namespace_string,

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -1,14 +1,18 @@
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, HashSet, VecDeque},
     future::Future,
     marker::PhantomData,
     pin::Pin,
+    sync::Arc,
     time::Duration,
 };
 
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, Mutex},
+    task::JoinHandle,
+};
 
 use crate::{
     apply_status_patch,
@@ -447,6 +451,7 @@ impl<R: Reconciler> ControllerLoop<R> {
         let mut resync = tokio::time::interval(resync_interval);
         resync.tick().await;
         let mut pending: VecDeque<String> = VecDeque::new();
+        let scheduled_requeues = Arc::new(Mutex::new(HashSet::new()));
 
         loop {
             if let Some(name) = pending.pop_front() {
@@ -489,6 +494,18 @@ impl<R: Reconciler> ControllerLoop<R> {
                 }
                 if let Some(patch) = outcome.patch {
                     Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await?;
+                }
+                if let Some(delay) = outcome.requeue_after {
+                    let mut scheduled = scheduled_requeues.lock().await;
+                    if scheduled.insert(name.clone()) {
+                        let scheduled_requeues = Arc::clone(&scheduled_requeues);
+                        let sender = sender.clone();
+                        tokio::spawn(async move {
+                            tokio::time::sleep(delay).await;
+                            scheduled_requeues.lock().await.remove(&name);
+                            let _ = sender.send(name).await;
+                        });
+                    }
                 }
                 continue;
             }

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -62,6 +62,7 @@ pub enum VesselStatusPatch {
         observed_policy_ref: String,
         observed_policy_version: String,
         started_at: DateTime<Utc>,
+        message: Option<String>,
     },
     MarkReady {
         environment_ref: Option<String>,
@@ -82,12 +83,12 @@ pub enum VesselStatusPatch {
 impl StatusPatch<VesselStatus> for VesselStatusPatch {
     fn apply(&self, status: &mut VesselStatus) {
         match self {
-            Self::MarkProvisioning { observed_policy_ref, observed_policy_version, started_at } => {
+            Self::MarkProvisioning { observed_policy_ref, observed_policy_version, started_at, message } => {
                 status.phase = VesselPhase::Provisioning;
                 status.observed_policy_ref = Some(observed_policy_ref.clone());
                 status.observed_policy_version = Some(observed_policy_version.clone());
                 status.started_at.get_or_insert(*started_at);
-                status.message = None;
+                status.message = message.clone();
             }
             Self::MarkReady {
                 environment_ref,

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -245,6 +245,7 @@ fn patch_variants_exhaustively_declare_their_lifecycle_classes() {
             observed_policy_ref: "docker".to_string(),
             observed_policy_version: "2".to_string(),
             started_at: ts(30),
+            message: None,
         }),
         PatchKind::VesselMarkProvisioning
     );
@@ -600,6 +601,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                     observed_policy_ref: "docker".to_string(),
                     observed_policy_version: "2".to_string(),
                     started_at: ts(30),
+                    message: None,
                 };
                 apply_and_replay(&mut status, &patch);
                 let after = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -192,6 +192,7 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
         observed_policy_version: "12".to_string(),
         started_at,
+        message: None,
     }
     .apply(&mut status);
     assert_eq!(status.phase, VesselPhase::Provisioning);
@@ -201,9 +202,11 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
         observed_policy_version: "13".to_string(),
         started_at: Utc.timestamp_opt(11, 0).single().expect("timestamp"),
+        message: Some("still waiting".to_string()),
     }
     .apply(&mut status);
     assert_eq!(status.started_at, Some(started_at), "reconcile must not restamp an in-progress transition");
+    assert_eq!(status.message.as_deref(), Some("still waiting"));
 
     VesselStatusPatch::MarkReady {
         environment_ref: Some("env-a".to_string()),


### PR DESCRIPTION
## Summary

- honor reconciler `requeue_after` outcomes so statusless checkout provisioning is retried after a dropped completion
- keep provisioning vessels convergent by retrying missing child resources and surfacing a stalled-status message after the deadline
- make reclaim verification idempotent for missing checkout paths and unchanged integration observations, while suppressing repeated identical refusal warnings

## Root cause

The controller loop ignored `ReconcileOutcome::requeue_after`, making provisioning effectively edge-triggered when an initial completion was lost. Reclaim verification also rewrote timestamp-only status on every refusal, feeding its own watch loop and repeatedly logging the same error.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- focused controller, resource, core, and daemon regression tests
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked` (all changed-area tests pass; two pre-existing macOS-only daemon fixtures fail because their fake runner cannot resolve `IOPlatformUUID`, while Linux CI reads `/etc/machine-id`)

Closes #1165
Closes #1166