### PR TITLE
Recover crew sessions after daemon restart

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeMap, marker::PhantomData, path::PathBuf, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    marker::PhantomData,
+    path::PathBuf,
+    time::Duration,
+};
 
 use chrono::{DateTime, Utc};
 use flotilla_core::agent_adapter::{
@@ -10,18 +15,19 @@ use flotilla_resources::{
         delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
     },
     repository_workspace_slugs, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
-    CrewSource, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, Environment, EnvironmentMount, EnvironmentMountMode,
-    EnvironmentPhase, EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta,
-    LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey,
-    RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionIdentity,
-    TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, CONVOY_LABEL,
-    CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REFS_ENV, VESSEL_REF_LABEL,
+    CrewSource, CrewWorkPhase, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, Environment, EnvironmentMount,
+    EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, FreshCloneCheckoutSpec, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Repository,
+    RepositoryIdentity, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, WorkPhase,
+    CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REFS_ENV, VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
 const REPO_LABEL: &str = "flotilla.work/repo";
 const ENV_LABEL: &str = "flotilla.work/env";
 const VESSEL_PROVISIONING_REQUEUE_AFTER: Duration = Duration::from_secs(5);
+const VESSEL_INTERRUPTED_REQUEUE_AFTER: Duration = Duration::from_millis(250);
 const VESSEL_PROVISIONING_STUCK_SECONDS: i64 = 2 * 60;
 
 #[derive(bon::Builder)]
@@ -108,6 +114,10 @@ enum PlannedPatch {
         requested_stance: Stance,
         effective_stance: Stance,
     },
+    Interrupted {
+        roles: BTreeSet<String>,
+        message: String,
+    },
     Failed {
         message: String,
     },
@@ -155,6 +165,19 @@ impl VesselDeps {
 
     fn failed(message: impl Into<String>) -> Self {
         Self { patch: PlannedPatch::Failed { message: message.into() }, actuations: Vec::new() }
+    }
+
+    fn interrupted(role: String, terminal_name: &str, restart: bool, mut actuations: Vec<Actuation>) -> Self {
+        if restart {
+            actuations.push(Actuation::RestartTerminalSession { name: terminal_name.to_string() });
+        }
+        Self {
+            patch: PlannedPatch::Interrupted {
+                roles: BTreeSet::from([role]),
+                message: format!("crew terminal session {terminal_name} disappeared; relaunching from its durable brief"),
+            },
+            actuations,
+        }
     }
 }
 
@@ -666,9 +689,7 @@ impl Reconciler for VesselReconciler {
                 Ok(existing) => {
                     terminal_refs.push(terminal_name.clone());
                     let phase = existing.status.as_ref().map(|status| status.phase);
-                    if phase == Some(TerminalSessionPhase::Failed)
-                        || (phase == Some(TerminalSessionPhase::Stopped) && matches!(process.source, CrewSource::Tool { .. }))
-                    {
+                    if phase == Some(TerminalSessionPhase::Failed) {
                         let message = existing
                             .status
                             .as_ref()
@@ -677,9 +698,35 @@ impl Reconciler for VesselReconciler {
                         return Ok(VesselDeps::failed(message));
                     }
                     if phase == Some(TerminalSessionPhase::Stopped) {
-                        continue;
+                        if matches!(process.source, CrewSource::Agent { .. }) {
+                            let work_phase =
+                                convoy.status.as_ref().and_then(|status| status.work.get(&obj.spec.vessel_name)).map(|work| work.phase);
+                            let crew_phase = convoy
+                                .status
+                                .as_ref()
+                                .and_then(|status| status.crew_work.get(&obj.spec.vessel_name))
+                                .and_then(|crew| crew.get(&process.role))
+                                .map(|work| work.phase);
+                            let active = matches!(crew_phase, Some(CrewWorkPhase::Working | CrewWorkPhase::Interrupted))
+                                || (crew_phase.is_none() && should_start && work_phase == Some(WorkPhase::Running));
+                            if !active {
+                                continue;
+                            }
+                            return Ok(VesselDeps::interrupted(
+                                process.role.clone(),
+                                &terminal_name,
+                                work_phase != Some(WorkPhase::Running),
+                                actuations,
+                            ));
+                        }
+                        let message = existing
+                            .status
+                            .as_ref()
+                            .and_then(|status| status.message.clone())
+                            .unwrap_or_else(|| format!("terminal session {terminal_name} stopped"));
+                        return Ok(VesselDeps::failed(message));
                     }
-                    if should_start && phase != Some(TerminalSessionPhase::Running) {
+                    if phase == Some(TerminalSessionPhase::Starting) || (should_start && phase != Some(TerminalSessionPhase::Running)) {
                         return Ok(VesselDeps::provisioning(
                             &placement_policy,
                             format!("terminal session {terminal_name} to become running"),
@@ -802,12 +849,24 @@ impl Reconciler for VesselReconciler {
                     ready_at: now,
                 })
             }
+            PlannedPatch::Interrupted { roles, message }
+                if obj.status.as_ref().is_none_or(|status| {
+                    status.phase != VesselPhase::Interrupted
+                        || status.interrupted_roles != *roles
+                        || status.message.as_deref() != Some(message.as_str())
+                }) =>
+            {
+                Some(VesselStatusPatch::MarkInterrupted { roles: roles.clone(), message: message.clone() })
+            }
+            PlannedPatch::Interrupted { .. } => None,
             PlannedPatch::Failed { message } => Some(VesselStatusPatch::MarkFailed { message: message.clone() }),
         };
 
         let mut outcome = ReconcileOutcome::with_actuations(patch, deps.actuations.clone());
         if matches!(&deps.patch, PlannedPatch::Provisioning { .. }) {
             outcome.requeue_after = Some(VESSEL_PROVISIONING_REQUEUE_AFTER);
+        } else if matches!(&deps.patch, PlannedPatch::Interrupted { .. }) {
+            outcome.requeue_after = Some(VESSEL_INTERRUPTED_REQUEUE_AFTER);
         }
         outcome
     }

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -19,12 +19,13 @@ use flotilla_resources::{
     controller::{Actuation, Reconciler},
     ensure_repository, interactive_single_workflow_spec, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec,
     Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyTeardownRuntime, CrewSource,
-    CrewSpec, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, Environment,
-    EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus,
-    InputMeta, IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend,
-    ResourceError, Selector, Stance, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
-    TerminalSessionStatus, Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus, WorkPhase, WorkflowSnapshot, WorkflowTemplate,
-    CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    CrewSpec, CrewWorkPhase, CrewWorkState, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy,
+    DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec,
+    PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend, ResourceError, Selector, Stance, TerminalBrief, TerminalCrewContext,
+    TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselPhase,
+    VesselRequirement, VesselSpec, VesselStatus, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
+    CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
@@ -127,7 +128,7 @@ async fn contained_requirement_rejects_host_direct_placement() {
     let workspace =
         create_workspace(&backend, NAMESPACE, "workspace-contained", "convoy-contained", "implement", "policy-host", REPO_URL).await;
 
-    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
 
@@ -175,7 +176,7 @@ async fn ready_vessel_records_requested_and_effective_stance() {
     let workspace =
         create_workspace(&backend, NAMESPACE, "workspace-stance", "convoy-stance", "implement", "policy-stance", REPO_URL).await;
 
-    let reconciler = VesselReconciler::new(backend, NAMESPACE);
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
     let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
     let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
 
@@ -1352,6 +1353,122 @@ async fn child_failure_propagates_to_workspace_failure() {
     assert!(matches!(
         outcome.patch,
         Some(flotilla_resources::VesselStatusPatch::MarkFailed { ref message }) if message == "boom"
+    ));
+}
+
+#[tokio::test]
+async fn stopped_agent_session_interrupts_the_vessel_and_requests_a_restart() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-recover", "implement", REPO_URL, GIT_REF).await;
+    let mut status = convoy.status.expect("convoy status");
+    status.workflow_snapshot.as_mut().expect("workflow snapshot").vessels[0].crew[0].source = CrewSource::Agent {
+        selector: Selector { capability: "coding".to_string() },
+        prompt: Some("Finish the issue.".to_string()),
+        brief_template: None,
+    };
+    status.phase = ConvoyPhase::Active;
+    status.work.insert("implement".to_string(), WorkState::builder().phase(WorkPhase::Running).build());
+    status.crew_work.insert(
+        "implement".to_string(),
+        BTreeMap::from([("coder".to_string(), CrewWorkState::builder().phase(CrewWorkPhase::Working).build())]),
+    );
+    backend
+        .clone()
+        .using::<Convoy>(NAMESPACE)
+        .update_status("convoy-recover", &convoy.metadata.resource_version, &status)
+        .await
+        .expect("agent crew status");
+    create_host_direct_policy(&backend, NAMESPACE, "policy-recover", HOST_REF, "cleat").await;
+    create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
+    let clone_name =
+        format!("clone-{}", clone_key(&canonicalize_repo_url(REPO_URL).expect("repo canonicalization"), &host_direct_env_name()));
+    create_ready_clone(&backend, NAMESPACE, &clone_name, REPO_URL, &host_direct_env_name(), "/tmp/clone").await;
+    let checkout_path = "/Users/alice/dev/flotilla-repos/convoy-recover";
+    create_ready_checkout(
+        &backend,
+        NAMESPACE,
+        ReadyCheckoutFixture::builder()
+            .name("checkout-convoy-recover".to_string())
+            .env_ref(host_direct_env_name())
+            .git_ref(GIT_REF.to_string())
+            .path(checkout_path.to_string())
+            .maybe_worktree(Some(worktree_checkout_spec(&host_direct_env_name(), GIT_REF, checkout_path, &clone_name)))
+            .build(),
+    )
+    .await;
+    let workspace =
+        create_workspace(&backend, NAMESPACE, "workspace-recover", "convoy-recover", "implement", "policy-recover", REPO_URL).await;
+    let sessions = backend.clone().using::<TerminalSession>(NAMESPACE);
+    let terminal_name = "terminal-workspace-recover-coder";
+    let terminal = sessions
+        .create(&meta(terminal_name), &TerminalSessionSpec {
+            env_ref: host_direct_env_name(),
+            role: "coder".to_string(),
+            source: TerminalSessionSource::Agent {
+                selector: Selector { capability: "coding".to_string() },
+                brief: TerminalBrief {
+                    path: ".flotilla/briefs/coder.md".to_string(),
+                    content: "Finish the issue.".to_string(),
+                    copies: Vec::new(),
+                },
+                context: TerminalCrewContext {
+                    namespace: NAMESPACE.to_string(),
+                    convoy: "convoy-recover".to_string(),
+                    vessel_ref: "workspace-recover".to_string(),
+                },
+                message: None,
+            },
+            cwd: checkout_path.to_string(),
+            pool: "cleat".to_string(),
+        })
+        .await
+        .expect("terminal create");
+    sessions
+        .update_status(terminal_name, &terminal.metadata.resource_version, &TerminalSessionStatus {
+            phase: TerminalSessionPhase::Stopped,
+            session_id: Some(terminal_name.to_string()),
+            message: Some("session missing from cleat".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("terminal stopped");
+
+    let reconciler = VesselReconciler::new(backend.clone(), NAMESPACE);
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("deps should load");
+    let outcome = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::VesselStatusPatch::MarkInterrupted { ref roles, ref message })
+            if roles == &BTreeSet::from(["coder".to_string()])
+                && message.contains("disappeared")
+                && message.contains("relaunching")
+    ));
+    assert!(
+        outcome.actuations.is_empty(),
+        "the session must not restart before its interruption contradicts the durable Running work state"
+    );
+
+    flotilla_resources::apply_status_patch(
+        &backend.clone().using::<Vessel>(NAMESPACE),
+        &workspace.metadata.name,
+        outcome.patch.as_ref().expect("interrupted vessel patch"),
+    )
+    .await
+    .expect("persist vessel interruption");
+    let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+    let convoy = convoys.get("convoy-recover").await.expect("convoy after vessel interruption");
+    let mut status = convoy.status.expect("convoy status");
+    status.work.get_mut("implement").expect("work").phase = WorkPhase::Interrupted;
+    status.crew_work.get_mut("implement").expect("crew").get_mut("coder").expect("coder").phase = CrewWorkPhase::Interrupted;
+    convoys.update_status("convoy-recover", &convoy.metadata.resource_version, &status).await.expect("persist work interruption");
+    let workspace = backend.clone().using::<Vessel>(NAMESPACE).get("workspace-recover").await.expect("interrupted vessel");
+    let deps = reconciler.fetch_dependencies(&workspace).await.expect("recovery deps should load");
+    let recovery = reconciler.reconcile(&workspace, &deps, chrono::Utc::now());
+
+    assert!(matches!(
+        recovery.actuations.as_slice(),
+        [Actuation::RestartTerminalSession { name }] if name == terminal_name
     ));
 }
 

--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -430,7 +430,7 @@ fn sorted_project_scopes(projects: &HashMap<QueryScope, Vec<RepositoryKey>>) -> 
 }
 
 fn convoy_phase_represents_issues(phase: ConvoyPhase) -> bool {
-    matches!(phase, ConvoyPhase::Pending | ConvoyPhase::Active | ConvoyPhase::Anchored | ConvoyPhase::Landing)
+    matches!(phase, ConvoyPhase::Pending | ConvoyPhase::Active | ConvoyPhase::Interrupted | ConvoyPhase::Anchored | ConvoyPhase::Landing)
 }
 
 fn hide_terminal_convoys(mut set: ResultSet) -> ResultSet {

--- a/crates/flotilla-core/src/awareness_projection.rs
+++ b/crates/flotilla-core/src/awareness_projection.rs
@@ -405,6 +405,7 @@ fn convoy_state(phase: ConvoyPhase, initializing: bool) -> AwarenessState {
     match phase {
         ConvoyPhase::Pending => AwarenessState::Pending,
         ConvoyPhase::Active => AwarenessState::Active,
+        ConvoyPhase::Interrupted => AwarenessState::Waiting,
         ConvoyPhase::Landed => AwarenessState::Done,
         ConvoyPhase::Anchored | ConvoyPhase::Landing => AwarenessState::Active,
         ConvoyPhase::Failed => AwarenessState::Failed,
@@ -417,6 +418,7 @@ fn work_state(phase: WorkPhase) -> AwarenessState {
         WorkPhase::Pending => AwarenessState::Pending,
         WorkPhase::Ready => AwarenessState::Waiting,
         WorkPhase::Launching | WorkPhase::Running => AwarenessState::Active,
+        WorkPhase::Interrupted => AwarenessState::Waiting,
         WorkPhase::Complete => AwarenessState::Done,
         WorkPhase::Failed => AwarenessState::Failed,
         WorkPhase::Cancelled | WorkPhase::Abandoned => AwarenessState::Cancelled,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1470,6 +1470,7 @@ fn convoy_start_failure(convoy: &ResourceObject<ResourceConvoy>) -> Option<Strin
         flotilla_resources::ConvoyPhase::Cancelled => Some(format!("convoy {} was cancelled while starting", convoy.metadata.name)),
         flotilla_resources::ConvoyPhase::Pending
         | flotilla_resources::ConvoyPhase::Active
+        | flotilla_resources::ConvoyPhase::Interrupted
         | flotilla_resources::ConvoyPhase::Anchored
         | flotilla_resources::ConvoyPhase::Landing
         | flotilla_resources::ConvoyPhase::Landed

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1912,6 +1912,7 @@ fn convoy_phase(phase: ResourceConvoyPhase) -> ConvoyPhase {
     match phase {
         ResourceConvoyPhase::Pending => ConvoyPhase::Pending,
         ResourceConvoyPhase::Active => ConvoyPhase::Active,
+        ResourceConvoyPhase::Interrupted => ConvoyPhase::Interrupted,
         ResourceConvoyPhase::Anchored => ConvoyPhase::Anchored,
         ResourceConvoyPhase::Landing => ConvoyPhase::Landing,
         ResourceConvoyPhase::Landed => ConvoyPhase::Landed,
@@ -1938,6 +1939,7 @@ fn work_phase(phase: ResourceWorkPhase) -> WorkPhase {
         ResourceWorkPhase::Ready => WorkPhase::Ready,
         ResourceWorkPhase::Launching => WorkPhase::Launching,
         ResourceWorkPhase::Running => WorkPhase::Running,
+        ResourceWorkPhase::Interrupted => WorkPhase::Interrupted,
         ResourceWorkPhase::Complete => WorkPhase::Complete,
         ResourceWorkPhase::Failed => WorkPhase::Failed,
         ResourceWorkPhase::Cancelled => WorkPhase::Cancelled,

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1995,6 +1995,7 @@ mod tests {
         TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WorkPhase, WorkflowTemplate,
         WorkflowTemplateSpec,
     };
+    use futures::StreamExt;
     use tempfile::TempDir;
 
     use super::{test_git_repo::TestGitRepo, *};
@@ -2828,12 +2829,18 @@ mod tests {
     }
 
     async fn crew_daemon(config: Arc<ConfigStore>) -> (Arc<InProcessDaemon>, Arc<FakeTerminalPool>) {
+        crew_daemon_with_backend(config, ResourceBackend::InMemory(Default::default())).await
+    }
+
+    async fn crew_daemon_with_backend(config: Arc<ConfigStore>, backend: ResourceBackend) -> (Arc<InProcessDaemon>, Arc<FakeTerminalPool>) {
         let pool = Arc::new(FakeTerminalPool::new());
         let discovery = fake_discovery_with_provider_set(
             FakeDiscoveryProviders::new()
                 .with_terminal_pool(Arc::clone(&pool) as Arc<dyn flotilla_core::providers::terminal::TerminalPool>),
         );
-        let daemon = InProcessDaemon::new(Vec::new(), config, discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        let daemon =
+            InProcessDaemon::new_with_resource_backend(Vec::new(), config, discovery, flotilla_protocol::HostName::new("dinghy"), backend)
+                .await;
         daemon
             .replace_local_environment_bag_for_test(
                 EnvironmentBag::new()
@@ -3588,7 +3595,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn crew_provisioning_runs_coder_reviewer_handoffs_and_rejects_unknown_capabilities() {
+    async fn crew_provisioning_recovers_lost_session_after_in_process_daemon_restart_and_runs_handoffs() {
         let temp = TempDir::new().expect("tempdir");
         let repo = TestGitRepo::init(temp.path().join("repo"))
             .with_initial_commit()
@@ -3834,72 +3841,94 @@ mod tests {
         assert_eq!(reopened.crew_work["implement"]["coder"].phase, flotilla_resources::CrewWorkPhase::Working);
         assert_eq!(reopened.crew_work["implement"]["reviewer"].phase, flotilla_resources::CrewWorkPhase::HandedBack);
 
+        for handle in controller_handles {
+            handle.abort();
+            let _ = handle.await;
+        }
         pool.remove_session(&coder.metadata.name).await;
-        wait_until(|| {
-            let terminals = terminals.clone();
-            let name = coder.metadata.name.clone();
-            async move {
-                terminals
-                    .get(&name)
-                    .await
-                    .ok()
-                    .and_then(|session| session.status)
-                    .is_some_and(|status| status.phase == TerminalSessionPhase::Stopped)
-            }
-        })
-        .await;
-        assert!(matches!(
-            convoys.get("crew-convoy").await.expect("crew convoy").status.and_then(|status| status.work.get("implement").cloned()),
-            Some(task) if task.phase == WorkPhase::Running
-        ));
-        let stopped_list = daemon
-            .execute_query(
-                Command {
-                    node_id: None,
-                    provisioning_target: None,
-                    context_repo: None,
-                    action: CommandAction::QueryCrewList {
-                        context: CrewCommandContext { crew_id: Some(reviewer_id.clone()), ..Default::default() },
-                    },
-                },
-                uuid::Uuid::new_v4(),
-            )
+        let listed_before_restart = convoys.list().await.expect("convoys before daemon restart");
+        let mut convoy_watch =
+            convoys.watch(flotilla_resources::WatchStart::resuming_from(&listed_before_restart)).await.expect("watch convoy recovery");
+        let (daemon, pool) = crew_daemon_with_backend(Arc::clone(&config), backend.clone()).await;
+        let local_registry = probe_local_provider_registry(&daemon, &config).await.expect("crew provider registry after restart");
+        let profile = build_local_profile(&daemon, &local_registry).expect("local profile after restart");
+        let surviving_sessions = terminals
+            .list()
             .await
-            .expect("stopped crew list");
-        let CommandValue::CrewList(stopped_list) = stopped_list else { panic!("expected stopped crew list") };
-        assert_eq!(stopped_list.members.iter().find(|member| member.role == "coder").map(|member| member.state.as_str()), Some("stopped"));
-        let mut rx = daemon.subscribe();
-        let revive_id = daemon
-            .execute(Command {
-                node_id: None,
-                provisioning_target: None,
-                context_repo: None,
-                action: CommandAction::CrewHandoff {
-                    context: CrewCommandContext { crew_id: Some(reviewer_id.clone()), ..Default::default() },
-                    target: "coder".to_string(),
-                    message: "Resume after review".to_string(),
-                },
+            .expect("persisted terminal resources")
+            .items
+            .into_iter()
+            .filter(|session| session.metadata.name != coder.metadata.name)
+            .map(|session| {
+                flotilla_core::providers::terminal::TerminalSession::builder()
+                    .session_name(session.metadata.name)
+                    .status(TerminalStatus::Running)
+                    .command("persisted process".to_string())
+                    .working_directory(ExecutionEnvironmentPath::new(session.spec.cwd))
+                    .build()
             })
-            .await
-            .expect("revive coder");
-        assert_eq!(wait_for_command_result(&mut rx, revive_id).await, CommandValue::Ok);
+            .collect();
+        pool.add_sessions(surviving_sessions).await;
+        let state = Arc::new(ControllerRuntimeState::new(
+            Arc::clone(&daemon),
+            Arc::clone(&config),
+            local_registry,
+            None,
+            profile.host_id.clone(),
+            Some(ExecutionEnvironmentPath::new(&repo)),
+            profile.host_direct_environment_name(),
+        ));
+        let controller_handles =
+            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(20), ControllerSupervision::default());
         wait_until(|| {
             let terminals = terminals.clone();
             let name = coder.metadata.name.clone();
             let old_id = coder_id.clone();
             async move {
-                terminals
-                    .get(&name)
-                    .await
-                    .ok()
-                    .and_then(|session| session.status)
-                    .and_then(|status| status.crew)
-                    .is_some_and(|crew| crew.id != old_id)
+                terminals.get(&name).await.ok().and_then(|session| session.status).is_some_and(|status| {
+                    status.phase == TerminalSessionPhase::Running && status.crew.is_some_and(|crew| crew.id != old_id)
+                })
             }
         })
         .await;
+        wait_until(|| {
+            let convoys = convoys.clone();
+            async move {
+                convoys.get("crew-convoy").await.ok().and_then(|convoy| convoy.status).is_some_and(|status| {
+                    status.phase == ConvoyPhase::Active
+                        && status.work["implement"].phase == WorkPhase::Running
+                        && status.crew_work["implement"]["coder"].phase == flotilla_resources::CrewWorkPhase::Working
+                })
+            }
+        })
+        .await;
+        let mut saw_interrupted_work = false;
+        let mut saw_interrupted_convoy = false;
+        while !(saw_interrupted_work && saw_interrupted_convoy) {
+            let event = tokio::time::timeout(Duration::from_secs(1), convoy_watch.next())
+                .await
+                .expect("interruption should be durably observable")
+                .expect("convoy watch should remain open")
+                .expect("convoy watch event");
+            let convoy = match event {
+                flotilla_resources::WatchEvent::Added(convoy) | flotilla_resources::WatchEvent::Modified(convoy) => convoy,
+                flotilla_resources::WatchEvent::Deleted(_) => continue,
+            };
+            let Some(status) = convoy.status else { continue };
+            saw_interrupted_work |= status.work.get("implement").is_some_and(|work| work.phase == WorkPhase::Interrupted);
+            saw_interrupted_convoy |= status.phase == ConvoyPhase::Interrupted;
+        }
         let revived_coder = terminals.get(&coder.metadata.name).await.expect("revived coder");
         let revived_coder_id = revived_coder.status.as_ref().and_then(|status| status.crew.as_ref()).expect("revived identity").id.clone();
+        let reviewer = terminals
+            .list()
+            .await
+            .expect("terminal list after restart")
+            .items
+            .into_iter()
+            .find(|session| session.spec.role == "reviewer")
+            .expect("reviewer session after restart");
+        let reviewer_id = reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).expect("revived reviewer identity").id.clone();
 
         let attach = daemon.resolve_attach_command_internal("crew-convoy/implement/coder").await.expect("attach coder");
         let [flotilla_protocol::ResolvedAttachAction::Command(args)] = attach.plan.0.as_slice() else {

--- a/crates/flotilla-manifest/src/projection.rs
+++ b/crates/flotilla-manifest/src/projection.rs
@@ -70,6 +70,7 @@ pub fn convoy_badge(phase: ConvoyPhase, initializing: bool) -> Badge {
     match phase {
         ConvoyPhase::Pending => Badge { state: BadgeState::Waiting, attention: false },
         ConvoyPhase::Active => Badge { state: BadgeState::Active, attention: false },
+        ConvoyPhase::Interrupted => Badge { state: BadgeState::Waiting, attention: true },
         ConvoyPhase::Landed => Badge { state: BadgeState::Done, attention: false },
         ConvoyPhase::Anchored | ConvoyPhase::Landing => Badge { state: BadgeState::Active, attention: false },
         ConvoyPhase::Failed => Badge { state: BadgeState::Failed, attention: true },
@@ -82,6 +83,7 @@ pub fn work_badge(phase: WorkPhase) -> Badge {
         WorkPhase::Pending => Badge { state: BadgeState::Idle, attention: false },
         WorkPhase::Ready => Badge { state: BadgeState::Waiting, attention: true },
         WorkPhase::Launching | WorkPhase::Running => Badge { state: BadgeState::Active, attention: false },
+        WorkPhase::Interrupted => Badge { state: BadgeState::Waiting, attention: true },
         WorkPhase::Complete => Badge { state: BadgeState::Done, attention: false },
         WorkPhase::Failed => Badge { state: BadgeState::Failed, attention: true },
         WorkPhase::Cancelled | WorkPhase::Abandoned => Badge { state: BadgeState::Idle, attention: false },

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -705,6 +705,7 @@ pub enum ConvoyPhase {
     #[default]
     Pending,
     Active,
+    Interrupted,
     Anchored,
     Landing,
     Landed,
@@ -718,6 +719,7 @@ impl ConvoyPhase {
         match self {
             Self::Pending => "pending",
             Self::Active => "active",
+            Self::Interrupted => "interrupted",
             Self::Anchored => "anchored",
             Self::Landing => "landing",
             Self::Landed => "landed",
@@ -743,6 +745,7 @@ pub enum WorkPhase {
     Ready,
     Launching,
     Running,
+    Interrupted,
     Complete,
     Failed,
     Cancelled,
@@ -756,6 +759,7 @@ impl WorkPhase {
             Self::Ready => "ready",
             Self::Launching => "launching",
             Self::Running => "running",
+            Self::Interrupted => "interrupted",
             Self::Complete => "complete",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -78,6 +78,7 @@ pub enum Actuation {
     CreateClone { meta: InputMeta, spec: CloneSpec },
     CreateCheckout { meta: InputMeta, spec: CheckoutSpec },
     CreateTerminalSession { meta: InputMeta, spec: TerminalSessionSpec },
+    RestartTerminalSession { name: String },
     CreateVessel { meta: InputMeta, spec: VesselSpec },
     CreatePresentation { meta: InputMeta, spec: PresentationSpec },
     DeletePresentation { name: String },
@@ -303,6 +304,10 @@ impl<R: Reconciler> ControllerLoop<R> {
             Actuation::CreateTerminalSession { meta, spec } => {
                 let resolver = backend.using::<crate::TerminalSession>(namespace);
                 Self::create_if_missing(&resolver, meta, spec).await
+            }
+            Actuation::RestartTerminalSession { name } => {
+                let resolver = backend.using::<crate::TerminalSession>(namespace);
+                crate::apply_status_patch(&resolver, &name, &crate::TerminalSessionStatusPatch::MarkStarting).await.map(|_| ())
             }
             Actuation::CreateVessel { meta, spec } => {
                 let resolver = backend.using::<crate::Vessel>(namespace);

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -454,6 +454,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                 if let Some(state) = status.work.get_mut(work) {
                     state.phase = WorkPhase::Running;
                     state.completion_authority = WorkCompletionAuthority::CrewRollup;
+                    state.message = None;
                 }
                 if let Some(crew) = status.crew_work.get_mut(work) {
                     // Only the crew the vessel launched are working. A latent

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -160,6 +160,7 @@ pub enum ConvoyPhase {
     #[default]
     Pending,
     Active,
+    Interrupted,
     Anchored,
     Landing,
     Landed,
@@ -200,6 +201,7 @@ pub enum WorkPhase {
     Ready,
     Launching,
     Running,
+    Interrupted,
     Complete,
     Failed,
     Cancelled,
@@ -241,6 +243,7 @@ pub enum CrewWorkPhase {
     #[default]
     Pending,
     Working,
+    Interrupted,
     Done,
     HandedBack,
     Failed,
@@ -300,6 +303,11 @@ pub enum ConvoyStatusPatch {
         /// Crew whose sessions the vessel actually launched. Latent agents are
         /// absent and stay `Pending` until a handoff starts them.
         launched_roles: BTreeSet<String>,
+    },
+    WorkInterrupted {
+        work: String,
+        roles: BTreeSet<String>,
+        message: String,
     },
     ForceWorkCompleted {
         work: String,
@@ -457,6 +465,27 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                         state.phase = CrewWorkPhase::Working;
                         state.started_at.get_or_insert(*started_at);
                     }
+                    for state in crew.values_mut().filter(|state| state.phase == CrewWorkPhase::Interrupted) {
+                        state.phase = CrewWorkPhase::Working;
+                        state.message = None;
+                    }
+                }
+            }
+            Self::WorkInterrupted { work, roles, message } => {
+                if let Some(state) = status.work.get_mut(work) {
+                    state.phase = WorkPhase::Interrupted;
+                    state.completion_authority = WorkCompletionAuthority::CrewRollup;
+                    state.message = Some(message.clone());
+                    state.finished_at = None;
+                }
+                if let Some(crew) = status.crew_work.get_mut(work) {
+                    for (role, state) in crew.iter_mut().filter(|(role, state)| {
+                        roles.contains(*role) && matches!(state.phase, CrewWorkPhase::Working | CrewWorkPhase::Interrupted)
+                    }) {
+                        state.phase = CrewWorkPhase::Interrupted;
+                        state.message = Some(format!("crew session for `{role}` was interrupted"));
+                        state.finished_at = None;
+                    }
                 }
             }
             Self::ForceWorkCompleted { work, finished_at, message } => {
@@ -568,7 +597,7 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                             }
                             state.finished_at.get_or_insert(*transitioned_at);
                         }
-                        WorkPhase::Pending | WorkPhase::Ready | WorkPhase::Launching | WorkPhase::Running => {
+                        WorkPhase::Pending | WorkPhase::Ready | WorkPhase::Launching | WorkPhase::Running | WorkPhase::Interrupted => {
                             state.finished_at = None;
                         }
                     }
@@ -638,6 +667,10 @@ pub mod provisioning_patches {
 
     pub fn work_running(work: String, started_at: DateTime<Utc>, launched_roles: BTreeSet<String>) -> ConvoyStatusPatch {
         ConvoyStatusPatch::WorkRunning { work, started_at, launched_roles }
+    }
+
+    pub fn work_interrupted(work: String, roles: BTreeSet<String>, message: String) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::WorkInterrupted { work, roles, message }
     }
 }
 

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -683,6 +683,20 @@ fn roll_up_phase_outcome(
         });
     }
 
+    let any_interrupted = status.work.values().any(|state| state.phase == WorkPhase::Interrupted);
+    if any_interrupted && status.phase != ConvoyPhase::Interrupted {
+        return Some(ReconcileOutcome {
+            patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Interrupted, None, None)),
+            events: vec![ConvoyEvent::PhaseChanged { from: status.phase, to: ConvoyPhase::Interrupted }],
+        });
+    }
+    if !any_interrupted && status.phase == ConvoyPhase::Interrupted {
+        return Some(ReconcileOutcome {
+            patch: Some(controller_patches::roll_up_phase(ConvoyPhase::Active, None, None)),
+            events: vec![ConvoyEvent::PhaseChanged { from: ConvoyPhase::Interrupted, to: ConvoyPhase::Active }],
+        });
+    }
+
     let any_progressed = status.work.values().any(|state| state.phase != WorkPhase::Pending);
     if any_progressed && status.phase == ConvoyPhase::Pending {
         return Some(ReconcileOutcome {
@@ -762,9 +776,68 @@ fn vessel_outcome(
                 }
             }
             WorkPhase::Running => {
-                if let Some(vessel) = vessel.filter(|vessel| vessel.status.as_ref().map(|status| status.phase) == Some(VesselPhase::Failed))
-                {
-                    return work_failed_outcome(requirement.name.clone(), state.phase, vessel_failure_message(vessel), now, actuations);
+                if let Some(vessel) = vessel {
+                    match vessel.status.as_ref().map(|status| status.phase) {
+                        Some(VesselPhase::Failed) => {
+                            return work_failed_outcome(
+                                requirement.name.clone(),
+                                state.phase,
+                                vessel_failure_message(vessel),
+                                now,
+                                actuations,
+                            );
+                        }
+                        Some(VesselPhase::Interrupted) => {
+                            let vessel_status = vessel.status.as_ref().expect("interrupted vessel has status");
+                            let message =
+                                vessel_status.message.clone().unwrap_or_else(|| format!("vessel {} was interrupted", vessel.metadata.name));
+                            return InternalReconcileOutcome {
+                                patch: Some(provisioning_patches::work_interrupted(
+                                    requirement.name.clone(),
+                                    vessel_status.interrupted_roles.clone(),
+                                    message,
+                                )),
+                                actuations,
+                                events: vec![ConvoyEvent::WorkPhaseChanged {
+                                    work: requirement.name.clone(),
+                                    from: WorkPhase::Running,
+                                    to: WorkPhase::Interrupted,
+                                }],
+                            };
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            WorkPhase::Interrupted => {
+                if let Some(vessel) = vessel {
+                    match vessel.status.as_ref().map(|status| status.phase) {
+                        Some(VesselPhase::Failed) => {
+                            return work_failed_outcome(
+                                requirement.name.clone(),
+                                state.phase,
+                                vessel_failure_message(vessel),
+                                now,
+                                actuations,
+                            );
+                        }
+                        Some(VesselPhase::Ready) => {
+                            return InternalReconcileOutcome {
+                                patch: Some(provisioning_patches::work_running(
+                                    requirement.name.clone(),
+                                    now,
+                                    requirement.eagerly_started_roles(),
+                                )),
+                                actuations,
+                                events: vec![ConvoyEvent::WorkPhaseChanged {
+                                    work: requirement.name.clone(),
+                                    from: WorkPhase::Interrupted,
+                                    to: WorkPhase::Running,
+                                }],
+                            };
+                        }
+                        _ => {}
+                    }
                 }
             }
             WorkPhase::Pending | WorkPhase::Complete | WorkPhase::Failed | WorkPhase::Cancelled | WorkPhase::Abandoned => {}

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,7 @@ pub enum VesselPhase {
     Pending,
     Provisioning,
     Ready,
+    Interrupted,
     TearingDown,
     Failed,
 }
@@ -46,6 +47,8 @@ pub struct VesselStatus {
     pub checkout_refs: BTreeMap<RepositoryKey, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub terminal_session_refs: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub interrupted_roles: BTreeSet<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub started_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -73,6 +76,10 @@ pub enum VesselStatusPatch {
         requested_stance: Stance,
         effective_stance: Stance,
         ready_at: DateTime<Utc>,
+    },
+    MarkInterrupted {
+        roles: BTreeSet<String>,
+        message: String,
     },
     MarkTearingDown,
     MarkFailed {
@@ -106,10 +113,16 @@ impl StatusPatch<VesselStatus> for VesselStatusPatch {
                 status.image_digest = image_digest.clone();
                 status.checkout_refs = checkout_refs.clone();
                 status.terminal_session_refs = terminal_session_refs.clone();
+                status.interrupted_roles.clear();
                 status.requested_stance = Some(*requested_stance);
                 status.effective_stance = Some(*effective_stance);
                 status.ready_at.get_or_insert(*ready_at);
                 status.message = None;
+            }
+            Self::MarkInterrupted { roles, message } => {
+                status.phase = VesselPhase::Interrupted;
+                status.interrupted_roles = roles.clone();
+                status.message = Some(message.clone());
             }
             Self::MarkTearingDown => {
                 status.phase = VesselPhase::TearingDown;

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -258,6 +258,7 @@ async fn controller_loop_advances_task_via_vessel_secondary_watch() {
             image_digest: Some("sha256:test-image".to_string()),
             checkout_refs: Default::default(),
             terminal_session_refs: vec!["terminal-implement-coder".to_string()],
+            interrupted_roles: Default::default(),
             started_at: Some(timestamp(18)),
             ready_at: Some(timestamp(19)),
             requested_stance: None,

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -224,6 +224,7 @@ fn vessel_object_with_image_digest(
             image_digest: Some(image_digest.to_string()),
             checkout_refs: BTreeMap::from([(repository_key, format!("checkout-{task}"))]),
             terminal_session_refs: vec![format!("terminal-{task}-coder")],
+            interrupted_roles: (phase == VesselPhase::Interrupted).then(|| "coder".to_string()).into_iter().collect(),
             started_at: Some(timestamp(16)),
             ready_at: (phase == VesselPhase::Ready).then(|| timestamp(18)),
             requested_stance: None,
@@ -1081,6 +1082,56 @@ async fn running_task_with_failed_workspace_marks_task_failed() {
         outcome.patch,
         Some(ConvoyStatusPatch::MarkWorkFailed { ref work, finished_at, ref message })
             if work == "implement" && finished_at == timestamp(21) && message == "terminal session crashed"
+    ));
+}
+
+#[tokio::test]
+async fn running_agent_work_with_an_interrupted_vessel_becomes_recoverable() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Active;
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Running;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.crew_work.get_mut("implement").expect("implement crew").get_mut("coder").expect("coder").phase = CrewWorkPhase::Working;
+    let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+
+    let outcome = reconcile_once_with_resources(
+        &convoy,
+        None,
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Interrupted, Some("crew terminal session disappeared; relaunching"))],
+        Vec::new(),
+        timestamp(21),
+    )
+    .await;
+
+    let Some(ConvoyStatusPatch::WorkInterrupted { work, roles, message }) = outcome.patch else {
+        panic!("expected interrupted work patch");
+    };
+    assert_eq!(work, "implement");
+    assert_eq!(roles, ["coder".to_string()].into_iter().collect());
+    assert_eq!(message, "crew terminal session disappeared; relaunching");
+}
+
+#[tokio::test]
+async fn interrupted_agent_work_returns_to_running_only_after_its_vessel_is_ready() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Interrupted;
+    status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Interrupted;
+    status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.crew_work.get_mut("implement").expect("implement crew").get_mut("coder").expect("coder").phase = CrewWorkPhase::Interrupted;
+    let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+
+    let outcome = reconcile_once_with_resources(
+        &convoy,
+        None,
+        vec![vessel_object("convoy-a", "implement", VesselPhase::Ready, None)],
+        Vec::new(),
+        timestamp(22),
+    )
+    .await;
+
+    assert!(matches!(
+        outcome.patch,
+        Some(ConvoyStatusPatch::WorkRunning { ref work, .. }) if work == "implement"
     ));
 }
 

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -1117,7 +1117,10 @@ async fn interrupted_agent_work_returns_to_running_only_after_its_vessel_is_read
     status.phase = ConvoyPhase::Interrupted;
     status.work.get_mut("implement").expect("implement task").phase = WorkPhase::Interrupted;
     status.work.get_mut("implement").expect("implement task").started_at = Some(timestamp(18));
+    status.work.get_mut("implement").expect("implement task").message = Some("crew terminal session disappeared; relaunching".to_string());
     status.crew_work.get_mut("implement").expect("implement crew").get_mut("coder").expect("coder").phase = CrewWorkPhase::Interrupted;
+    status.crew_work.get_mut("implement").expect("implement crew").get_mut("coder").expect("coder").message =
+        Some("crew session for `coder` was interrupted".to_string());
     let convoy = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
 
     let outcome = reconcile_once_with_resources(
@@ -1129,10 +1132,14 @@ async fn interrupted_agent_work_returns_to_running_only_after_its_vessel_is_read
     )
     .await;
 
-    assert!(matches!(
-        outcome.patch,
-        Some(ConvoyStatusPatch::WorkRunning { ref work, .. }) if work == "implement"
-    ));
+    let patch = outcome.patch.expect("running work patch");
+    assert!(matches!(patch, ConvoyStatusPatch::WorkRunning { ref work, .. } if work == "implement"));
+    let mut recovered = convoy.status.expect("convoy status");
+    patch.apply(&mut recovered);
+    assert_eq!(recovered.work["implement"].phase, WorkPhase::Running);
+    assert_eq!(recovered.work["implement"].message, None);
+    assert_eq!(recovered.crew_work["implement"]["coder"].phase, CrewWorkPhase::Working);
+    assert_eq!(recovered.crew_work["implement"]["coder"].message, None);
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -57,6 +57,7 @@ define_patch_kinds! {
     ConvoySettle => DUPLICATE_RESETTLEMENT,
     ConvoyWorkLaunching => DUPLICATE,
     ConvoyWorkRunning => DUPLICATE,
+    ConvoyWorkInterrupted => CONTINUATION,
     ConvoyForceWorkCompleted => DUPLICATE,
     ConvoyMarkWorkFailed => DUPLICATE,
     ConvoyMarkWorkCancelled => DUPLICATE,
@@ -74,6 +75,7 @@ define_patch_kinds! {
     TerminalMarkFailed => DUPLICATE,
     VesselMarkProvisioning => DUPLICATE,
     VesselMarkReady => DUPLICATE,
+    VesselMarkInterrupted => NONE,
     VesselMarkTearingDown => NONE,
     VesselMarkFailed => NONE,
     PresentationMarkActive => DUPLICATE_NEW_ATTEMPT,
@@ -92,6 +94,7 @@ fn convoy_patch_kind(patch: &ConvoyStatusPatch) -> PatchKind {
         ConvoyStatusPatch::Settle { .. } => PatchKind::ConvoySettle,
         ConvoyStatusPatch::WorkLaunching { .. } => PatchKind::ConvoyWorkLaunching,
         ConvoyStatusPatch::WorkRunning { .. } => PatchKind::ConvoyWorkRunning,
+        ConvoyStatusPatch::WorkInterrupted { .. } => PatchKind::ConvoyWorkInterrupted,
         ConvoyStatusPatch::ForceWorkCompleted { .. } => PatchKind::ConvoyForceWorkCompleted,
         ConvoyStatusPatch::MarkWorkFailed { .. } => PatchKind::ConvoyMarkWorkFailed,
         ConvoyStatusPatch::MarkWorkCancelled { .. } => PatchKind::ConvoyMarkWorkCancelled,
@@ -119,6 +122,7 @@ fn vessel_patch_kind(patch: &VesselStatusPatch) -> PatchKind {
     match patch {
         VesselStatusPatch::MarkProvisioning { .. } => PatchKind::VesselMarkProvisioning,
         VesselStatusPatch::MarkReady { .. } => PatchKind::VesselMarkReady,
+        VesselStatusPatch::MarkInterrupted { .. } => PatchKind::VesselMarkInterrupted,
         VesselStatusPatch::MarkTearingDown => PatchKind::VesselMarkTearingDown,
         VesselStatusPatch::MarkFailed { .. } => PatchKind::VesselMarkFailed,
     }
@@ -682,6 +686,21 @@ fn continuation_transitions_keep_started_at_and_clear_finished_at() {
                     phase: WorkPhase::Running,
                     transitioned_at: ts(30),
                     message: None,
+                };
+                apply_and_replay(&mut status, &patch);
+                (before, work_timestamps(&status))
+            },
+        },
+        LifecycleCase {
+            name: "work interrupted",
+            kind: PatchKind::ConvoyWorkInterrupted,
+            exercise: || {
+                let mut status = settled_convoy_status();
+                let before = work_timestamps(&status);
+                let patch = ConvoyStatusPatch::WorkInterrupted {
+                    work: "implement".to_string(),
+                    roles: BTreeSet::from(["coder".to_string()]),
+                    message: "crew session disappeared".to_string(),
                 };
                 apply_and_replay(&mut status, &patch);
                 (before, work_timestamps(&status))

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -81,6 +81,7 @@ async fn vessel_metadata_and_status_roundtrip() {
             image_digest: Some("sha256:test-image".to_string()),
             checkout_refs: Default::default(),
             terminal_session_refs: vec!["term-a".to_string()],
+            interrupted_roles: Default::default(),
             started_at: Some(Utc::now()),
             ready_at: Some(Utc::now()),
             requested_stance: Some(flotilla_resources::Stance::WorkspaceWrite),

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1696,6 +1696,7 @@ fn wire_convoy_phase(phase: crate::convoy_model::ConvoyPhase) -> flotilla_protoc
     match phase {
         crate::convoy_model::ConvoyPhase::Pending => Wire::Pending,
         crate::convoy_model::ConvoyPhase::Active => Wire::Active,
+        crate::convoy_model::ConvoyPhase::Interrupted => Wire::Interrupted,
         crate::convoy_model::ConvoyPhase::Anchored => Wire::Anchored,
         crate::convoy_model::ConvoyPhase::Landing => Wire::Landing,
         crate::convoy_model::ConvoyPhase::Landed => Wire::Landed,
@@ -1712,6 +1713,7 @@ fn wire_work_phase(phase: crate::convoy_model::WorkPhase) -> flotilla_protocol::
         crate::convoy_model::WorkPhase::Ready => Wire::Ready,
         crate::convoy_model::WorkPhase::Launching => Wire::Launching,
         crate::convoy_model::WorkPhase::Running => Wire::Running,
+        crate::convoy_model::WorkPhase::Interrupted => Wire::Interrupted,
         crate::convoy_model::WorkPhase::Complete => Wire::Complete,
         crate::convoy_model::WorkPhase::Failed => Wire::Failed,
         crate::convoy_model::WorkPhase::Cancelled => Wire::Cancelled,

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -49,6 +49,7 @@ impl ConvoyId {
 pub enum ConvoyPhase {
     Pending,
     Active,
+    Interrupted,
     Anchored,
     Landing,
     Landed,
@@ -62,6 +63,7 @@ impl From<wire::ConvoyPhase> for ConvoyPhase {
         match phase {
             wire::ConvoyPhase::Pending => Self::Pending,
             wire::ConvoyPhase::Active => Self::Active,
+            wire::ConvoyPhase::Interrupted => Self::Interrupted,
             wire::ConvoyPhase::Anchored => Self::Anchored,
             wire::ConvoyPhase::Landing => Self::Landing,
             wire::ConvoyPhase::Landed => Self::Landed,
@@ -81,6 +83,7 @@ impl ConvoyPhase {
         match self {
             Self::Pending => "pending",
             Self::Active => "active",
+            Self::Interrupted => "interrupted",
             Self::Anchored => "anchored",
             Self::Landing => "landing",
             Self::Landed => "landed",
@@ -97,6 +100,7 @@ pub enum WorkPhase {
     Ready,
     Launching,
     Running,
+    Interrupted,
     Complete,
     Failed,
     Cancelled,
@@ -110,6 +114,7 @@ impl From<wire::WorkPhase> for WorkPhase {
             wire::WorkPhase::Ready => Self::Ready,
             wire::WorkPhase::Launching => Self::Launching,
             wire::WorkPhase::Running => Self::Running,
+            wire::WorkPhase::Interrupted => Self::Interrupted,
             wire::WorkPhase::Complete => Self::Complete,
             wire::WorkPhase::Failed => Self::Failed,
             wire::WorkPhase::Cancelled => Self::Cancelled,

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -1080,6 +1080,7 @@ fn convoy_phase(row: &ConvoySummary) -> CellValue {
     let tone = match row.phase {
         ConvoyPhase::Pending => CellTone::Muted,
         ConvoyPhase::Active => CellTone::Plain,
+        ConvoyPhase::Interrupted => CellTone::Warning,
         ConvoyPhase::Landed => CellTone::Success,
         ConvoyPhase::Anchored | ConvoyPhase::Landing => CellTone::Plain,
         ConvoyPhase::Failed => CellTone::Error,
@@ -1243,6 +1244,7 @@ fn vessel_phase(row: &VesselProjection) -> CellValue {
         WorkPhase::Ready => ("ready", CellTone::Warning),
         WorkPhase::Launching => ("launching", CellTone::Warning),
         WorkPhase::Running => ("running", CellTone::Plain),
+        WorkPhase::Interrupted => ("interrupted", CellTone::Warning),
         WorkPhase::Complete => ("complete", CellTone::Success),
         WorkPhase::Failed => ("failed", CellTone::Error),
         WorkPhase::Cancelled => ("cancelled", CellTone::Muted),


### PR DESCRIPTION
## Summary

- add explicit interrupted phases for convoys, work, crew work, and vessels so lost backing sessions are never presented as running
- propagate interrupted state through protocol, awareness, manifest, and TUI projections
- use the level-triggered reconciliation path to relaunch an interrupted agent session from its durable brief, then restore the work and convoy to active
- add an `InProcessDaemon` restart test that removes a crew session, observes the durable interruption, verifies relaunch with a new crew identity, and continues the handoff workflow

## Root cause

After a daemon restart, persisted terminal resources could outlive the backing terminal-pool sessions. Reconciliation marked the terminal stopped, but active agent work remained `Running` and no recovery actuation was issued.

## Impact

Active crew work now surfaces a recoverable interruption while its missing session is relaunched. Tool sessions and genuinely failed sessions retain their existing failure behavior.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1153