### PR TITLE
fix: reconcile builtin workflow templates

### DIFF
--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -451,12 +451,12 @@ async fn register_startup_resources(
     ensure_host_direct_environment_exists(&backend, namespace, profile).await?;
     discover_local_clones(daemon, &backend, namespace, profile).await?;
     ensure_default_policies(&backend, namespace, profile).await?;
-    ensure_default_workflow_templates(&backend, namespace).await?;
+    reconcile_builtin_workflow_templates(&backend, namespace).await?;
     daemon.materialize_tracked_repo_projects().await?;
     Ok(())
 }
 
-fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
+fn builtin_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
     vec![
         (
             "scratch",
@@ -480,15 +480,21 @@ fn default_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
     ]
 }
 
-async fn ensure_default_workflow_templates(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
+async fn reconcile_builtin_workflow_templates(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
     let templates = backend.clone().using::<WorkflowTemplate>(namespace);
-    for (name, spec) in default_workflow_templates() {
+    for (name, spec) in builtin_workflow_templates() {
         match templates.get(name).await {
-            Ok(_) => continue,
-            Err(ResourceError::NotFound { .. }) => {}
+            Ok(existing) => {
+                templates
+                    .update(&InputMeta::from(&existing.metadata), &existing.metadata.resource_version, &spec)
+                    .await
+                    .map_err(|err| format!("reconcile builtin workflow template {name}: {err}"))?;
+            }
+            Err(ResourceError::NotFound { .. }) => {
+                templates.create(&empty_meta(name), &spec).await.map_err(|err| format!("seed builtin workflow template {name}: {err}"))?;
+            }
             Err(err) => return Err(format!("check workflow template {name}: {err}")),
         }
-        templates.create(&empty_meta(name), &spec).await.map(|_| ()).map_err(|err| format!("seed workflow template {name}: {err}"))?;
     }
     Ok(())
 }
@@ -2750,30 +2756,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn startup_seeding_preserves_existing_contained_template_definition() {
+    async fn startup_seeding_reconciles_existing_builtin_template_definition() {
         let backend = ResourceBackend::InMemory(Default::default());
         let templates = backend.clone().using::<WorkflowTemplate>(NAMESPACE);
-        let custom = WorkflowTemplateSpec::builder()
-            .vessels(vec![VesselRequirement::builder()
-                .name("custom".to_string())
-                .stance(Stance::Contained)
-                .crew(vec![CrewSpec::builder()
-                    .role("maintainer".to_string())
-                    .source(CrewSource::Agent {
-                        selector: Selector { capability: "custom-code".to_string() },
-                        prompt: Some("Keep this definition".to_string()),
-                        brief_template: None,
-                    })
-                    .build()])
-                .build()])
-            .build();
-        templates.create(&empty_meta("single-agent-contained"), &custom).await.expect("custom template create should succeed");
+        let mut stale = flotilla_resources::single_agent_contained_workflow_spec();
+        stale.vessels[0].stance = Stance::Trusted;
+        templates.create(&empty_meta("single-agent-contained"), &stale).await.expect("stale template create should succeed");
 
-        ensure_default_workflow_templates(&backend, NAMESPACE).await.expect("startup seeding should succeed");
-        ensure_default_workflow_templates(&backend, NAMESPACE).await.expect("restart seeding should succeed");
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("startup reconciliation should succeed");
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("restart reconciliation should succeed");
 
-        let preserved = templates.get("single-agent-contained").await.expect("template should remain");
-        assert_eq!(preserved.spec, custom);
+        let reconciled = templates.get("single-agent-contained").await.expect("template should remain");
+        assert_eq!(reconciled.spec, flotilla_resources::single_agent_contained_workflow_spec());
     }
 
     fn manual_profile(host_id: &str, docker_available: bool) -> LocalProvisioningProfile {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -39,7 +39,7 @@ use flotilla_resources::{
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
     InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError,
     ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
-    AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY,
+    AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY, MANAGED_BY_LABEL,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -58,6 +58,7 @@ use crate::{
 const LIVENESS_WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
+const BUILTIN_MANAGED_BY_VALUE: &str = "builtin";
 
 struct DaemonConvoyTeardownRuntime {
     daemon: Arc<InProcessDaemon>,
@@ -480,18 +481,35 @@ fn builtin_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
     ]
 }
 
+fn mark_builtin_managed(mut meta: InputMeta) -> InputMeta {
+    meta.labels.insert(MANAGED_BY_LABEL.to_string(), BUILTIN_MANAGED_BY_VALUE.to_string());
+    meta
+}
+
+/// Reconciles code-owned manifests as the builtin special case of the ruled
+/// manifest loop in https://github.com/flotilla-org/flotilla/issues/1192.
 async fn reconcile_builtin_workflow_templates(backend: &ResourceBackend, namespace: &str) -> Result<(), String> {
     let templates = backend.clone().using::<WorkflowTemplate>(namespace);
     for (name, spec) in builtin_workflow_templates() {
         match templates.get(name).await {
             Ok(existing) => {
+                let spec_diverged = existing.spec != spec;
+                if !spec_diverged {
+                    continue;
+                }
                 templates
-                    .update(&InputMeta::from(&existing.metadata), &existing.metadata.resource_version, &spec)
+                    .update(&mark_builtin_managed(InputMeta::from(&existing.metadata)), &existing.metadata.resource_version, &spec)
                     .await
                     .map_err(|err| format!("reconcile builtin workflow template {name}: {err}"))?;
+                if spec_diverged {
+                    warn!(template = %name, "stored spec diverged from code builtin; overwriting");
+                }
             }
             Err(ResourceError::NotFound { .. }) => {
-                templates.create(&empty_meta(name), &spec).await.map_err(|err| format!("seed builtin workflow template {name}: {err}"))?;
+                templates
+                    .create(&mark_builtin_managed(empty_meta(name)), &spec)
+                    .await
+                    .map_err(|err| format!("seed builtin workflow template {name}: {err}"))?;
             }
             Err(err) => return Err(format!("check workflow template {name}: {err}")),
         }
@@ -2012,6 +2030,20 @@ mod tests {
         Delete,
     }
 
+    #[derive(Clone)]
+    struct LogCaptureWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for LogCaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log output lock should be healthy").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     struct NoPrProcessRunner;
 
     #[async_trait]
@@ -2761,13 +2793,60 @@ mod tests {
         let templates = backend.clone().using::<WorkflowTemplate>(NAMESPACE);
         let mut stale = flotilla_resources::single_agent_contained_workflow_spec();
         stale.vessels[0].stance = Stance::Trusted;
-        templates.create(&empty_meta("single-agent-contained"), &stale).await.expect("stale template create should succeed");
+        templates
+            .create(
+                &empty_meta_with_labels(
+                    "single-agent-contained",
+                    BTreeMap::from([("example.com/preserved".to_string(), "true".to_string())]),
+                ),
+                &stale,
+            )
+            .await
+            .expect("stale template create should succeed");
 
-        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("startup reconciliation should succeed");
-        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("restart reconciliation should succeed");
+        let log_output = Arc::new(std::sync::Mutex::new(Vec::new()));
+        {
+            let writer = LogCaptureWriter(Arc::clone(&log_output));
+            let subscriber = tracing_subscriber::fmt()
+                .without_time()
+                .with_ansi(false)
+                .with_target(false)
+                .with_max_level(tracing::Level::WARN)
+                .with_writer(move || writer.clone())
+                .finish();
+            let _guard = tracing::subscriber::set_default(subscriber);
+            reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("startup reconciliation should succeed");
+        }
 
         let reconciled = templates.get("single-agent-contained").await.expect("template should remain");
         assert_eq!(reconciled.spec, flotilla_resources::single_agent_contained_workflow_spec());
+        assert_eq!(reconciled.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some(BUILTIN_MANAGED_BY_VALUE));
+        assert_eq!(reconciled.metadata.labels.get("example.com/preserved").map(String::as_str), Some("true"));
+        let logs = String::from_utf8(log_output.lock().expect("log output lock should be healthy").clone()).expect("logs should be utf-8");
+        assert!(logs.contains("stored spec diverged from code builtin; overwriting"), "missing overwrite warning: {logs}");
+        assert!(logs.contains("single-agent-contained"), "warning should name the template: {logs}");
+
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("restart reconciliation should succeed");
+        let unchanged = templates.get("single-agent-contained").await.expect("template should remain");
+        assert_eq!(unchanged.metadata.resource_version, reconciled.metadata.resource_version);
+    }
+
+    #[tokio::test]
+    async fn startup_seeding_does_not_update_matching_unlabelled_builtin_template() {
+        const NAMESPACE: &str = "test";
+        let backend = ResourceBackend::InMemory(Default::default());
+        let templates = backend.clone().using::<WorkflowTemplate>(NAMESPACE);
+        templates
+            .create(&empty_meta("single-agent-contained"), &flotilla_resources::single_agent_contained_workflow_spec())
+            .await
+            .expect("matching template create should succeed");
+        let existing = templates.get("single-agent-contained").await.expect("template should exist");
+
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("startup reconciliation should succeed");
+
+        let unchanged = templates.get("single-agent-contained").await.expect("template should remain");
+        assert_eq!(unchanged.metadata.resource_version, existing.metadata.resource_version);
+        assert!(!unchanged.metadata.labels.contains_key(MANAGED_BY_LABEL));
     }
 
     fn manual_profile(host_id: &str, docker_available: bool) -> LocalProvisioningProfile {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -494,16 +494,23 @@ async fn reconcile_builtin_workflow_templates(backend: &ResourceBackend, namespa
         match templates.get(name).await {
             Ok(existing) => {
                 let spec_diverged = existing.spec != spec;
+                let managed_by_builtin =
+                    existing.metadata.labels.get(MANAGED_BY_LABEL).is_some_and(|value| value == BUILTIN_MANAGED_BY_VALUE);
+                if !spec_diverged && managed_by_builtin {
+                    continue;
+                }
                 if !spec_diverged {
+                    templates
+                        .update(&mark_builtin_managed(InputMeta::from(&existing.metadata)), &existing.metadata.resource_version, &spec)
+                        .await
+                        .map_err(|err| format!("reconcile builtin workflow template {name}: {err}"))?;
                     continue;
                 }
                 templates
                     .update(&mark_builtin_managed(InputMeta::from(&existing.metadata)), &existing.metadata.resource_version, &spec)
                     .await
                     .map_err(|err| format!("reconcile builtin workflow template {name}: {err}"))?;
-                if spec_diverged {
-                    warn!(template = %name, "stored spec diverged from code builtin; overwriting");
-                }
+                warn!(template = %name, "stored spec diverged from code builtin; overwriting");
             }
             Err(ResourceError::NotFound { .. }) => {
                 templates
@@ -2832,7 +2839,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn startup_seeding_does_not_update_matching_unlabelled_builtin_template() {
+    async fn startup_seeding_labels_matching_unlabelled_builtin_template_once() {
         const NAMESPACE: &str = "test";
         let backend = ResourceBackend::InMemory(Default::default());
         let templates = backend.clone().using::<WorkflowTemplate>(NAMESPACE);
@@ -2844,9 +2851,14 @@ mod tests {
 
         reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("startup reconciliation should succeed");
 
+        let labelled = templates.get("single-agent-contained").await.expect("template should remain");
+        assert_ne!(labelled.metadata.resource_version, existing.metadata.resource_version);
+        assert_eq!(labelled.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some(BUILTIN_MANAGED_BY_VALUE));
+
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("restart reconciliation should succeed");
+
         let unchanged = templates.get("single-agent-contained").await.expect("template should remain");
-        assert_eq!(unchanged.metadata.resource_version, existing.metadata.resource_version);
-        assert!(!unchanged.metadata.labels.contains_key(MANAGED_BY_LABEL));
+        assert_eq!(unchanged.metadata.resource_version, labelled.metadata.resource_version);
     }
 
     fn manual_profile(host_id: &str, docker_available: bool) -> LocalProvisioningProfile {

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -10,7 +10,7 @@ use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName, PrincipalRef};
 use flotilla_resources::{
     single_agent_contained_workflow_spec, Convoy, ConvoyPhase, CrewSource, InMemoryBackend, InputMeta, PlacementPolicy, ResourceBackend,
-    SqliteBackend, Stance, WorkflowTemplate,
+    SqliteBackend, Stance, WorkflowTemplate, MANAGED_BY_LABEL,
 };
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -91,6 +91,7 @@ async fn scratch_workflow_template_is_seeded_at_startup() {
     let templates = backend.using::<WorkflowTemplate>("flotilla");
     let scratch = templates.get("scratch").await.expect("scratch template should be seeded");
     assert_eq!(scratch.metadata.name, "scratch");
+    assert_eq!(scratch.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("builtin"));
     assert_eq!(scratch.spec.vessels.len(), 1);
     assert_eq!(scratch.spec.vessels[0].name, "work");
 

--- a/crates/flotilla-daemon/tests/convoy_create_cli.rs
+++ b/crates/flotilla-daemon/tests/convoy_create_cli.rs
@@ -8,7 +8,10 @@ use flotilla_core::{
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, HostName, PrincipalRef};
-use flotilla_resources::{Convoy, ConvoyPhase, CrewSource, InMemoryBackend, ResourceBackend, SqliteBackend, Stance, WorkflowTemplate};
+use flotilla_resources::{
+    single_agent_contained_workflow_spec, Convoy, ConvoyPhase, CrewSource, InMemoryBackend, InputMeta, PlacementPolicy, ResourceBackend,
+    SqliteBackend, Stance, WorkflowTemplate,
+};
 
 fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&dir).expect("create config dir");
@@ -17,9 +20,14 @@ fn test_config(dir: std::path::PathBuf) -> Arc<ConfigStore> {
 }
 
 async fn start_daemon() -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigStore>, DaemonRuntime, tempfile::TempDir) {
+    start_daemon_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await
+}
+
+async fn start_daemon_with_backend(
+    backend: ResourceBackend,
+) -> (Arc<InProcessDaemon>, ResourceBackend, Arc<ConfigStore>, DaemonRuntime, tempfile::TempDir) {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let config = test_config(tmp.path().join("config"));
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let daemon = InProcessDaemon::new_with_resource_backend(
         vec![],
         Arc::clone(&config),
@@ -113,6 +121,57 @@ async fn scratch_workflow_template_is_seeded_at_startup() {
                     } if selector.capability == "code" && brief_template == "interactive-session"
                 )
     ));
+}
+
+#[tokio::test]
+async fn stale_builtin_is_reconciled_before_contained_dispatch() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
+    let mut stale = single_agent_contained_workflow_spec();
+    stale.vessels[0].stance = Stance::Trusted;
+    templates
+        .create(&InputMeta::builder().name("single-agent-contained".to_string()).build(), &stale)
+        .await
+        .expect("stale template should be created");
+
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon_with_backend(backend).await;
+    let reconciled = templates.get("single-agent-contained").await.expect("builtin should remain");
+    assert_eq!(reconciled.spec, single_agent_contained_workflow_spec());
+
+    let host_direct_policy = backend
+        .using::<PlacementPolicy>("flotilla")
+        .list()
+        .await
+        .expect("placement policies should list")
+        .items
+        .into_iter()
+        .find(|policy| policy.spec.host_direct.is_some())
+        .expect("host-direct policy should be seeded")
+        .metadata
+        .name;
+    let mut rx = daemon.subscribe();
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "must-remain-contained".into(),
+                workflow_ref: "single-agent-contained".into(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: Some(host_direct_policy.clone()),
+                adopted_checkout: None,
+            },
+        })
+        .await
+        .expect("execute");
+
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::Error {
+        message: format!("contained workflow requires a docker placement policy, but {host_direct_policy} is not contained"),
+    });
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/src/labels.rs
+++ b/crates/flotilla-resources/src/labels.rs
@@ -8,5 +8,6 @@ pub const ROLE_LABEL: &str = "flotilla.work/role";
 pub const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
 pub const VESSEL_ORDINAL_LABEL: &str = "flotilla.work/vessel_ordinal";
 pub const CREW_ORDINAL_LABEL: &str = "flotilla.work/crew_ordinal";
+pub const MANAGED_BY_LABEL: &str = "flotilla.work/managed-by";
 pub const REPO_LABEL: &str = "flotilla.work/repo";
 pub const RESERVED_PREFIX: &str = "flotilla.work/";

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -62,8 +62,8 @@ pub use host::{
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use labels::{
-    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, CREW_ORDINAL_LABEL, REPO_KEY_LABEL, REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL,
-    VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, CREW_ORDINAL_LABEL, MANAGED_BY_LABEL, REPO_KEY_LABEL, REPO_LABEL, RESERVED_PREFIX,
+    ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 pub use placement_policy::{
     DockerCheckoutStrategy, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, HostDirectPlacementPolicyCheckout,


### PR DESCRIPTION
## Summary

- reconcile every code-owned builtin workflow template spec during daemon startup
- overwrite stale stored builtin definitions while preserving their metadata
- cover stale trusted `single-agent-contained` startup state through host-direct dispatch refusal

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1187