### PR TITLE
feat: default whole-repo projects to trusted workflow interim

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3326,6 +3326,7 @@ async fn ensure_default_workflows(backend: &ResourceBackend, namespace: &str) ->
     let templates = backend.clone().using::<WorkflowTemplate>(namespace);
     for (name, spec) in [
         ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
+        ("single-agent-trusted", flotilla_resources::single_agent_trusted_workflow_spec()),
         ("implement-review", flotilla_resources::implement_review_workflow_spec()),
     ] {
         let meta = InputMeta::builder().name(name.to_string()).build();
@@ -3444,7 +3445,7 @@ async fn ensure_repository_and_default_project_workflow(
 fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: String) -> Result<ProjectSpec, String> {
     normalize_project_spec(ProjectSpec {
         display_name,
-        default_workflow_ref: "single-agent-contained".to_string(),
+        default_workflow_ref: "single-agent-trusted".to_string(),
         issue_source: None,
         repositories: vec![ProjectRepositorySpec { repo: repository_key, subpath: None, default_branch: None }],
     })

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -478,6 +478,7 @@ fn builtin_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
         ("implement-review", flotilla_resources::implement_review_workflow_spec()),
         ("interactive-single", flotilla_resources::interactive_single_workflow_spec()),
         ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
+        ("single-agent-trusted", flotilla_resources::single_agent_trusted_workflow_spec()),
     ]
 }
 

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -157,7 +157,7 @@ async fn tracking_repo_materializes_whole_repo_project() {
 
     let project = backend.using::<Project>("flotilla").get("tracked").await.expect("whole-repository project should exist");
     assert_eq!(project.spec.display_name, "tracked");
-    assert_eq!(project.spec.default_workflow_ref, "single-agent-contained");
+    assert_eq!(project.spec.default_workflow_ref, "single-agent-trusted");
     assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
         repo: repository_key,
         subpath: None,
@@ -704,7 +704,7 @@ async fn project_add_untracked_path_ensures_repository_checkout_and_whole_repo_p
     assert_eq!(checkouts.items.len(), 1);
     let project = backend.using::<Project>("flotilla").get("my-project").await.expect("project should exist");
     assert_eq!(project.spec.display_name, "My Project");
-    assert_eq!(project.spec.default_workflow_ref, "single-agent-contained");
+    assert_eq!(project.spec.default_workflow_ref, "single-agent-trusted");
     assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
         repo: repository_key,
         subpath: None,

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -202,7 +202,7 @@ async fn retracking_path_after_remote_appears_migrates_repository_identity() {
             &InputMeta::builder().name("github-com-flotilla-org-andamento".to_string()).build(),
             &ProjectSpec::builder()
                 .display_name("andamento".to_string())
-                .default_workflow_ref("single-agent-contained".to_string())
+                .default_workflow_ref("single-agent-trusted".to_string())
                 .repositories(vec![flotilla_resources::ProjectRepositorySpec::builder().repo(remote_key.clone()).build()])
                 .build(),
         )
@@ -345,7 +345,7 @@ async fn identity_change_preserves_migrated_project_when_local_and_remote_names_
             &InputMeta::builder().name("a-remote-name".to_string()).build(),
             &ProjectSpec::builder()
                 .display_name("a-remote-name".to_string())
-                .default_workflow_ref("single-agent-contained".to_string())
+                .default_workflow_ref("single-agent-trusted".to_string())
                 .repositories(vec![flotilla_resources::ProjectRepositorySpec::builder().repo(remote_key.clone()).build()])
                 .build(),
         )

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -134,7 +134,7 @@ macro_rules! for_each_registered_resource {
     }};
 }
 pub use workflow_template::{
-    implement_review_workflow_spec, interactive_single_workflow_spec, single_agent_contained_workflow_spec, validate, CrewSource, CrewSpec,
-    InputDefinition, InterpolationField, InterpolationLocation, Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate,
-    WorkflowTemplateSpec,
+    implement_review_workflow_spec, interactive_single_workflow_spec, single_agent_contained_workflow_spec,
+    single_agent_trusted_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation,
+    Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -126,6 +126,23 @@ pub fn single_agent_contained_workflow_spec() -> WorkflowTemplateSpec {
         .build()
 }
 
+/// Interim default while contained crews lack credential seeding
+/// (flotilla-org/flotilla#1140): the single-agent coding workflow with a
+/// trusted stance. Retire in favour of `single-agent-contained` once the
+/// contained smoke passes with credentials.
+pub fn single_agent_trusted_workflow_spec() -> WorkflowTemplateSpec {
+    WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Trusted)
+            .crew(vec![CrewSpec::builder()
+                .role("coder".to_string())
+                .source(CrewSource::Agent { selector: Selector { capability: "code".to_string() }, prompt: None, brief_template: None })
+                .build()])
+            .build()])
+        .build()
+}
+
 pub fn interactive_single_workflow_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
         .vessels(vec![VesselRequirement::builder()


### PR DESCRIPTION
## Summary

- promote `single-agent-trusted` to a code builtin (doc-commented as interim, retirement condition stated)
- register it in both builtin lists (daemon runtime + InProcessDaemon), where #1193's reconciler will converge it onto live stores
- flip the whole-repo project `default_workflow_ref` to it: plain `convoy start` works again everywhere while contained crews await credential seeding (#1140)

Ruled by Robert 2026-07-28 (option a: explicit interim default over per-dispatch discipline or silent dynamic fallback). Flip-back is an acceptance criterion of the #1140 seeding work.

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` (one pre-existing flake, filed #1197)

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp