### PR TITLE
fix: publish project checkouts independently

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4475,7 +4475,7 @@ impl InProcessDaemon {
 
         ensure_repository_and_default_project_workflow(&self.resource_backend, &namespace, &key, &repository_spec).await?;
         if let Some(checkout) = checkout {
-            self.ensure_project_checkout(&namespace, &key, &repository_spec, checkout).await?;
+            self.reconcile_project_checkouts(&namespace, &key, &repository_spec, checkout).await?;
         }
 
         let default_name = normalize_project_name(&repository_spec.leaf_slug())?;
@@ -4512,6 +4512,7 @@ impl InProcessDaemon {
         let repository_spec = &inspection.spec;
         let repository_key = repository_spec.key();
         ensure_repository_and_default_project_workflow(&self.resource_backend, &namespace, &repository_key, repository_spec).await?;
+        self.reconcile_project_checkouts(&namespace, &repository_key, repository_spec, inspection.checkout.clone()).await?;
         let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
         let stored = repositories.get(&repository_key.to_string()).await.map_err(|error| error.to_string())?;
         if stored.spec != *repository_spec {
@@ -4769,6 +4770,21 @@ impl InProcessDaemon {
             .await
             .map(|_| ())
             .map_err(|error| error.to_string())
+    }
+
+    async fn reconcile_project_checkouts(
+        &self,
+        namespace: &str,
+        repository_key: &RepositoryKey,
+        repository_spec: &RepositorySpec,
+        checkout: crate::repository_inspection::LocalCheckoutInspection,
+    ) -> Result<(), String> {
+        let inspection = RepositoryInspection { spec: repository_spec.clone(), checkout, transport_url: None };
+        let inspector = self.repository_inspector().await?;
+        for checkout in inspector.inspect_checkouts(&inspection).await? {
+            self.ensure_project_checkout(namespace, repository_key, repository_spec, checkout).await?;
+        }
+        Ok(())
     }
 
     pub async fn refresh(&self, repo: &flotilla_protocol::RepoSelector) -> Result<Option<RepositoryIdentityChange>, String> {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -45,8 +45,8 @@ use flotilla_resources::{
     ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
     TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
-    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, REPO_KEY_LABEL,
-    REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, ROLE_LABEL,
+    VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -4717,61 +4717,6 @@ impl InProcessDaemon {
         Ok(())
     }
 
-    async fn ensure_project_checkout(
-        &self,
-        namespace: &str,
-        repository_key: &RepositoryKey,
-        repository_spec: &RepositorySpec,
-        checkout: crate::repository_inspection::LocalCheckoutInspection,
-    ) -> Result<(), String> {
-        let checkouts = self.observed_resource_backend.clone().using::<ResourceCheckout>(namespace);
-        let checkout_name = format!(
-            "checkout-{}",
-            flotilla_resources::repo_key(&format!("{}\0{}\0{}", repository_key, checkout.host_ref, checkout.path.display()))
-        );
-        let spec = ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
-            r#ref: checkout.git_ref,
-            path: checkout.path.to_string_lossy().into_owned(),
-            repo_ref: repository_key.clone(),
-            host_ref: checkout.host_ref,
-            is_main: checkout.is_main,
-        });
-        let meta = InputMeta::builder()
-            .name(checkout_name.clone())
-            .labels(BTreeMap::from([
-                (REPO_KEY_LABEL.to_string(), repository_key.to_string()),
-                (REPO_LABEL.to_string(), repository_spec.catalog_slug()),
-            ]))
-            .build()
-            .with_lifecycle_authority(LifecycleAuthority::Observed);
-        let stored = match checkouts.create(&meta, &spec).await {
-            Ok(created) => created,
-            Err(ResourceError::Conflict { .. }) => {
-                let existing = checkouts.get(&checkout_name).await.map_err(|error| error.to_string())?;
-                if existing.spec != spec {
-                    return Err(format!("checkout {checkout_name} already exists with a different observation"));
-                }
-                existing
-            }
-            Err(error) => return Err(error.to_string()),
-        };
-        checkouts
-            .update_status(&checkout_name, &stored.metadata.resource_version, &ResourceCheckoutStatus {
-                phase: ResourceCheckoutPhase::Ready,
-                path: spec.target_path().map(str::to_string).or_else(|| match &spec {
-                    ResourceCheckoutSpec::Observed(observed) => Some(observed.path.clone()),
-                    _ => None,
-                }),
-                commit: None,
-                branch_provenance: Default::default(),
-                integration: Default::default(),
-                message: None,
-            })
-            .await
-            .map(|_| ())
-            .map_err(|error| error.to_string())
-    }
-
     async fn reconcile_project_checkouts(
         &self,
         namespace: &str,
@@ -4781,10 +4726,31 @@ impl InProcessDaemon {
     ) -> Result<(), String> {
         let inspection = RepositoryInspection { spec: repository_spec.clone(), checkout, transport_url: None };
         let inspector = self.repository_inspector().await?;
+        let mut providers = ProviderData::default();
         for checkout in inspector.inspect_checkouts(&inspection).await? {
-            self.ensure_project_checkout(namespace, repository_key, repository_spec, checkout).await?;
+            providers.checkouts.insert(QualifiedPath::host(HostId::new(checkout.host_ref), checkout.path), flotilla_protocol::Checkout {
+                branch: checkout.git_ref,
+                is_main: checkout.is_main,
+                trunk_ahead_behind: None,
+                remote_ahead_behind: None,
+                working_tree: None,
+                last_commit: None,
+                correlation_keys: Vec::new(),
+                association_keys: Vec::new(),
+                host_name: None,
+                environment_id: None,
+            });
         }
-        Ok(())
+        crate::observed_resources::reconcile_checkouts(
+            &self.observed_resource_backend,
+            namespace,
+            repository_key,
+            &repository_spec.catalog_slug(),
+            &providers,
+            &inspection.checkout.host_ref,
+        )
+        .await
+        .map_err(|error| error.to_string())
     }
 
     pub async fn refresh(&self, repo: &flotilla_protocol::RepoSelector) -> Result<Option<RepositoryIdentityChange>, String> {

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -6,7 +6,13 @@ use std::{
 use async_trait::async_trait;
 use flotilla_resources::{RepositoryKey, RepositorySpec};
 
-use crate::providers::{ChannelLabel, CommandRunner};
+use crate::{
+    path_context::ExecutionEnvironmentPath,
+    providers::{
+        vcs::{git_worktree::GitCheckoutManager, CheckoutManager},
+        ChannelLabel, CommandRunner,
+    },
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 pub struct LocalCheckoutInspection {
@@ -32,6 +38,15 @@ impl RepositoryInspection {
 #[async_trait]
 pub trait RepositoryInspector: Send + Sync {
     async fn inspect_path(&self, path: &Path, remote: Option<&str>) -> Result<RepositoryInspection, String>;
+
+    /// Enumerate every local checkout that belongs to an inspected repository.
+    ///
+    /// Test and non-git inspectors may only know about the checkout used to
+    /// establish repository identity. Git-backed inspection overrides this to
+    /// include every worktree.
+    async fn inspect_checkouts(&self, inspection: &RepositoryInspection) -> Result<Vec<LocalCheckoutInspection>, String> {
+        Ok(vec![inspection.checkout.clone()])
+    }
 
     async fn resolve_remote(&self, remote: &str) -> Result<RepositorySpec, String> {
         RepositorySpec::remote(remote)
@@ -173,6 +188,21 @@ impl RepositoryInspector for GitRepositoryInspector {
 
     async fn resolve_remote(&self, remote: &str) -> Result<RepositorySpec, String> {
         RepositorySpec::remote(self.canonical_remote(Path::new("/"), remote).await?)
+    }
+
+    async fn inspect_checkouts(&self, inspection: &RepositoryInspection) -> Result<Vec<LocalCheckoutInspection>, String> {
+        let manager = GitCheckoutManager::new(crate::config::default_checkout_path(), Arc::clone(&self.runner));
+        manager.list_checkouts(&ExecutionEnvironmentPath::new(&inspection.checkout.path)).await.map(|checkouts| {
+            checkouts
+                .into_iter()
+                .map(|(path, checkout)| LocalCheckoutInspection {
+                    path: path.into_path_buf(),
+                    host_ref: self.host_ref.clone(),
+                    git_ref: checkout.branch,
+                    is_main: checkout.is_main,
+                })
+                .collect()
+        })
     }
 }
 

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -191,6 +191,8 @@ impl RepositoryInspector for GitRepositoryInspector {
     }
 
     async fn inspect_checkouts(&self, inspection: &RepositoryInspection) -> Result<Vec<LocalCheckoutInspection>, String> {
+        // The path template is used only when creating a worktree;
+        // enumeration reads Git's existing worktree registry.
         let manager = GitCheckoutManager::new(crate::config::default_checkout_path(), Arc::clone(&self.runner));
         manager.list_checkouts(&ExecutionEnvironmentPath::new(&inspection.checkout.path)).await.map(|checkouts| {
             checkouts
@@ -225,9 +227,9 @@ fn ssh_remote_host(remote: &str) -> Option<&str> {
 mod tests {
     use std::sync::Arc;
 
-    use flotilla_resources::RepositoryIdentity;
+    use flotilla_resources::{RepositoryIdentity, RepositorySpec};
 
-    use super::{GitRepositoryInspector, RepositoryInspector};
+    use super::{GitRepositoryInspector, LocalCheckoutInspection, RepositoryInspection, RepositoryInspector};
     use crate::providers::discovery::test_support::DiscoveryMockRunner;
 
     fn git_repo() -> (tempfile::TempDir, std::path::PathBuf) {
@@ -236,6 +238,40 @@ mod tests {
         std::fs::create_dir(&root).expect("repo dir");
         std::fs::create_dir(root.join(".git")).expect("git dir");
         (temp, root)
+    }
+
+    #[tokio::test]
+    async fn git_inspection_enumerates_main_and_linked_worktree_checkouts() {
+        let (_temp, root) = git_repo();
+        let feature = root.parent().expect("repo parent").join("repo.feature");
+        let porcelain = format!(
+            "worktree {}\nHEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nbranch refs/heads/main\n\n\
+             worktree {}\nHEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\nbranch refs/heads/feature\n",
+            root.display(),
+            feature.display()
+        );
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("git", &["worktree", "list", "--porcelain"], Ok(porcelain))
+            .on_run("git", &["symbolic-ref", "refs/remotes/origin/HEAD", "--short"], Ok("origin/main\n".to_string()))
+            .build();
+        let inspector = GitRepositoryInspector::new(Arc::new(runner), "host-01");
+        let inspection = RepositoryInspection {
+            spec: RepositorySpec::remote("https://github.com/org/repo").expect("repository spec"),
+            checkout: LocalCheckoutInspection {
+                path: root.clone(),
+                host_ref: "host-01".to_string(),
+                git_ref: "main".to_string(),
+                is_main: true,
+            },
+            transport_url: None,
+        };
+
+        let checkouts = inspector.inspect_checkouts(&inspection).await.expect("checkout inspection");
+
+        assert_eq!(checkouts, vec![
+            LocalCheckoutInspection { path: root, host_ref: "host-01".to_string(), git_ref: "main".to_string(), is_main: true },
+            LocalCheckoutInspection { path: feature, host_ref: "host-01".to_string(), git_ref: "feature".to_string(), is_main: false },
+        ]);
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -106,17 +106,21 @@ impl RepositoryInspector for FailingInspector {
 #[derive(Clone)]
 struct WorktreeInspector {
     spec: RepositorySpec,
-    checkouts: Vec<LocalCheckoutInspection>,
+    checkouts: Arc<RwLock<Vec<LocalCheckoutInspection>>>,
 }
 
 #[async_trait]
 impl RepositoryInspector for WorktreeInspector {
     async fn inspect_path(&self, _path: &Path, _remote: Option<&str>) -> Result<RepositoryInspection, String> {
-        Ok(RepositoryInspection { spec: self.spec.clone(), checkout: self.checkouts[0].clone(), transport_url: None })
+        Ok(RepositoryInspection {
+            spec: self.spec.clone(),
+            checkout: self.checkouts.read().expect("checkout inspection lock should not be poisoned")[0].clone(),
+            transport_url: None,
+        })
     }
 
     async fn inspect_checkouts(&self, _inspection: &RepositoryInspection) -> Result<Vec<LocalCheckoutInspection>, String> {
-        Ok(self.checkouts.clone())
+        Ok(self.checkouts.read().expect("checkout inspection lock should not be poisoned").clone())
     }
 }
 
@@ -754,10 +758,10 @@ async fn project_checkout_set_with_store_history(tmp: &tempfile::TempDir, with_h
     let worktree_path = tmp.path().join("view-only.feature");
     std::fs::create_dir_all(&main_path).expect("main checkout");
     std::fs::create_dir_all(&worktree_path).expect("worktree checkout");
-    let checkouts = vec![
+    let checkouts = Arc::new(RwLock::new(vec![
         LocalCheckoutInspection { path: main_path.clone(), host_ref: "host-01".to_string(), git_ref: "main".to_string(), is_main: true },
         LocalCheckoutInspection { path: worktree_path, host_ref: "host-01".to_string(), git_ref: "feature".to_string(), is_main: false },
-    ];
+    ]));
     daemon.set_repository_inspector(Arc::new(WorktreeInspector { spec: spec.clone(), checkouts })).await;
 
     if with_history {
@@ -811,6 +815,45 @@ async fn view_only_project_rebuilds_the_same_checkout_set_on_an_empty_store() {
 
     assert_eq!(cold, historical);
     assert_eq!(cold.len(), 2);
+}
+
+#[tokio::test]
+async fn repeated_project_materialization_updates_and_retracts_worktree_observations() {
+    let (daemon, _backend, _config, _runtime, tmp) = start_daemon().await;
+    let spec = RepositorySpec::remote("https://github.com/org/reconciled.git").expect("repository spec");
+    let main_path = tmp.path().join("reconciled");
+    let worktree_path = tmp.path().join("reconciled.feature");
+    std::fs::create_dir_all(&main_path).expect("main checkout");
+    std::fs::create_dir_all(&worktree_path).expect("worktree checkout");
+    let checkouts = Arc::new(RwLock::new(vec![
+        LocalCheckoutInspection { path: main_path.clone(), host_ref: "host-01".to_string(), git_ref: "main".to_string(), is_main: true },
+        LocalCheckoutInspection {
+            path: worktree_path.clone(),
+            host_ref: "host-01".to_string(),
+            git_ref: "feature".to_string(),
+            is_main: false,
+        },
+    ]));
+    daemon.set_repository_inspector(Arc::new(WorktreeInspector { spec, checkouts: Arc::clone(&checkouts) })).await;
+    let mut rx = daemon.subscribe();
+
+    execute_project_add(&daemon, &mut rx, main_path.to_string_lossy().into_owned(), None, None).await;
+    checkouts.write().expect("checkout inspection lock should not be poisoned")[1].git_ref = "renamed-feature".to_string();
+    execute_project_add(&daemon, &mut rx, main_path.to_string_lossy().into_owned(), None, None).await;
+
+    let observed = daemon.observed_resource_backend().using::<Checkout>("flotilla");
+    let after_update = observed.list().await.expect("updated checkout list").items;
+    assert_eq!(after_update.len(), 2);
+    assert!(after_update.iter().any(|checkout| {
+        matches!(&checkout.spec, CheckoutSpec::Observed(spec) if spec.path == worktree_path.to_string_lossy() && spec.r#ref == "renamed-feature")
+    }));
+
+    checkouts.write().expect("checkout inspection lock should not be poisoned").pop();
+    execute_project_add(&daemon, &mut rx, main_path.to_string_lossy().into_owned(), None, None).await;
+
+    let after_removal = observed.list().await.expect("checkout list after removal").items;
+    assert_eq!(after_removal.len(), 1);
+    assert!(matches!(&after_removal[0].spec, CheckoutSpec::Observed(spec) if spec.path == main_path.to_string_lossy()));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -103,6 +103,23 @@ impl RepositoryInspector for FailingInspector {
     }
 }
 
+#[derive(Clone)]
+struct WorktreeInspector {
+    spec: RepositorySpec,
+    checkouts: Vec<LocalCheckoutInspection>,
+}
+
+#[async_trait]
+impl RepositoryInspector for WorktreeInspector {
+    async fn inspect_path(&self, _path: &Path, _remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        Ok(RepositoryInspection { spec: self.spec.clone(), checkout: self.checkouts[0].clone(), transport_url: None })
+    }
+
+    async fn inspect_checkouts(&self, _inspection: &RepositoryInspection) -> Result<Vec<LocalCheckoutInspection>, String> {
+        Ok(self.checkouts.clone())
+    }
+}
+
 async fn track_repository(daemon: &Arc<InProcessDaemon>, tmp: &tempfile::TempDir, directory_name: &str, remote: &str) -> RepositoryKey {
     let repository_spec = RepositorySpec::remote(remote).expect("repository spec");
     let repository_key = repository_spec.key();
@@ -710,6 +727,90 @@ async fn project_add_untracked_path_ensures_repository_checkout_and_whole_repo_p
         subpath: None,
         default_branch: None,
     }]);
+}
+
+async fn project_checkout_set_with_store_history(tmp: &tempfile::TempDir, with_history: bool) -> Vec<CheckoutSpec> {
+    let config = test_config(tmp.path().join(if with_history { "history-config" } else { "cold-config" }));
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    let options = RuntimeOptions {
+        namespace: "flotilla".to_string(),
+        heartbeat_interval: Duration::from_secs(300),
+        controller_resync_interval: Duration::from_secs(300),
+        start_controllers: false,
+        ..RuntimeOptions::default()
+    };
+    let _runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), config, None, options).await.expect("runtime start");
+    let spec = RepositorySpec::remote("https://github.com/org/view-only.git").expect("repository spec");
+    let key = spec.key();
+    let main_path = tmp.path().join("view-only");
+    let worktree_path = tmp.path().join("view-only.feature");
+    std::fs::create_dir_all(&main_path).expect("main checkout");
+    std::fs::create_dir_all(&worktree_path).expect("worktree checkout");
+    let checkouts = vec![
+        LocalCheckoutInspection { path: main_path.clone(), host_ref: "host-01".to_string(), git_ref: "main".to_string(), is_main: true },
+        LocalCheckoutInspection { path: worktree_path, host_ref: "host-01".to_string(), git_ref: "feature".to_string(), is_main: false },
+    ];
+    daemon.set_repository_inspector(Arc::new(WorktreeInspector { spec: spec.clone(), checkouts })).await;
+
+    if with_history {
+        backend
+            .clone()
+            .using::<Repository>("flotilla")
+            .create(&InputMeta::builder().name(key.to_string()).build(), &spec)
+            .await
+            .expect("historical repository");
+        backend
+            .clone()
+            .using::<Project>("flotilla")
+            .create(
+                &InputMeta::builder().name("view-only".to_string()).build(),
+                &ProjectSpec::builder()
+                    .display_name("view-only".to_string())
+                    .default_workflow_ref("single-agent-trusted".to_string())
+                    .repositories(vec![flotilla_resources::ProjectRepositorySpec::builder().repo(key).build()])
+                    .build(),
+            )
+            .await
+            .expect("historical project");
+    }
+
+    let mut rx = daemon.subscribe();
+    assert_eq!(
+        execute_project_add(&daemon, &mut rx, main_path.to_string_lossy().into_owned(), None, None).await,
+        CommandValue::ProjectAdded { name: "view-only".into() }
+    );
+    assert!(daemon.tracked_repo_paths().await.is_empty(), "project materialization must not depend on Plane-A tracking");
+    let mut specs = daemon
+        .observed_resource_backend()
+        .using::<Checkout>("flotilla")
+        .list()
+        .await
+        .expect("checkout list")
+        .items
+        .into_iter()
+        .map(|checkout| checkout.spec)
+        .collect::<Vec<_>>();
+    specs.sort_by_key(|spec| spec.target_path().map(str::to_string));
+    specs
+}
+
+#[tokio::test]
+async fn view_only_project_rebuilds_the_same_checkout_set_on_an_empty_store() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+
+    let cold = project_checkout_set_with_store_history(&tmp, false).await;
+    let historical = project_checkout_set_with_store_history(&tmp, true).await;
+
+    assert_eq!(cold, historical);
+    assert_eq!(cold.len(), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

- make project reconciliation publish observed checkouts directly instead of relying on Plane-A repository refresh
- extend repository inspection with local checkout enumeration so Git-backed projects publish every worktree, not only the main checkout
- add coverage proving an untracked, view-only project reconstructs the same checkout set on an empty store as it does with historical Repository and Project resources

## Why

Observed checkout publication was still coupled to Plane-A tracking. Projects materialized from local paths could therefore exist without any checkout observations after the observed store was rebuilt, leaving project views empty even though the working copies remained on disk.

Project materialization now owns checkout observation. Plane-A refresh can continue publishing the same facts during the transition, but it is no longer required for the project path to work.

## Impact

Repositories referenced only through Project/view materialization are visible with their main checkout and worktrees after a fresh store boot. Replaying materialization is idempotent whether or not durable Repository and Project history already exists.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`

Closes #1191