### PR TITLE
feat: add manifest apply reconciler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yml",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -366,6 +366,15 @@ pub struct DaemonConfig {
     pub logging: DaemonLoggingConfig,
     #[serde(default)]
     pub environments: BTreeMap<String, StaticEnvironmentConfig>,
+    #[serde(default)]
+    pub manifests: Option<ManifestsConfig>,
+}
+
+/// Host-local directory whose resource documents are continuously applied as
+/// additive desired state.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ManifestsConfig {
+    pub dir: PathBuf,
 }
 
 /// Host-local structured daemon logging settings.

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -367,13 +367,13 @@ pub struct DaemonConfig {
     #[serde(default)]
     pub environments: BTreeMap<String, StaticEnvironmentConfig>,
     #[serde(default)]
-    pub manifests: Option<ManifestsConfig>,
+    pub manifests: Option<ResourceManifestsConfig>,
 }
 
 /// Host-local directory whose resource documents are continuously applied as
 /// additive desired state.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-pub struct ManifestsConfig {
+pub struct ResourceManifestsConfig {
     pub dir: PathBuf,
 }
 

--- a/crates/flotilla-core/src/config/tests.rs
+++ b/crates/flotilla-core/src/config/tests.rs
@@ -626,6 +626,7 @@ fn load_daemon_config_missing_file_returns_default() {
     let config = store.load_daemon_config().unwrap();
     assert!(!config.follower);
     assert_eq!(config.host_name, None);
+    assert_eq!(config.manifests, None);
 }
 
 #[test]
@@ -638,6 +639,16 @@ fn load_daemon_config_from_file() {
     assert!(config.follower);
     assert_eq!(config.machine_id, Some("my-machine".into()));
     assert_eq!(config.host_name, Some("my-host".into()));
+}
+
+#[test]
+fn load_daemon_manifest_directory() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("daemon.toml"), "[manifests]\ndir = \"/srv/flotilla/manifests\"\n").unwrap();
+
+    let config = ConfigStore::with_base(dir.path()).load_daemon_config().expect("daemon config");
+
+    assert_eq!(config.manifests.expect("manifest config").dir, std::path::PathBuf::from("/srv/flotilla/manifests"));
 }
 
 #[test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3339,9 +3339,7 @@ async fn ensure_default_workflows(backend: &ResourceBackend, namespace: &str) ->
 }
 
 fn prepared_snapshot_name(kind: &str, spec: &serde_json::Value) -> Result<String, String> {
-    let encoded = serde_json::to_vec(spec).map_err(|error| error.to_string())?;
-    let digest = Sha256::digest(encoded);
-    let suffix = digest[..6].iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let suffix = flotilla_resources::content_hash(spec).map_err(|error| error.to_string())?;
     Ok(format!("{kind}-snapshot-{suffix}"))
 }
 

--- a/crates/flotilla-daemon/Cargo.toml
+++ b/crates/flotilla-daemon/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { workspace = true }
 tokio-util = "0.7"
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yml = "0.0.12"
 async-trait = { workspace = true }
 tracing = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -1,7 +1,7 @@
 mod aggregator;
 mod credential;
 mod issue_materializer;
-pub mod manifest;
+pub mod resource_manifest;
 mod sleep_inhibitor;
 pub use aggregator::{Aggregator, AggregatorResolvers};
 

--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -1,6 +1,7 @@
 mod aggregator;
 mod credential;
 mod issue_materializer;
+pub mod manifest;
 mod sleep_inhibitor;
 pub use aggregator::{Aggregator, AggregatorResolvers};
 

--- a/crates/flotilla-daemon/src/manifest.rs
+++ b/crates/flotilla-daemon/src/manifest.rs
@@ -76,8 +76,24 @@ impl ManifestReconciler {
     }
 
     pub async fn run(mut self, interval: Duration) -> Result<(), ResourceError> {
+        let mut last_root_error = None;
         loop {
-            let report = self.reconcile_once().await.map_err(ResourceError::other)?;
+            let report = match self.reconcile_once().await {
+                Ok(report) => {
+                    if let Some(previous) = last_root_error.take() {
+                        info!(root = %self.root.display(), %previous, "manifest directory recovered");
+                    }
+                    report
+                }
+                Err(error) => {
+                    if last_root_error.as_deref() != Some(error.as_str()) {
+                        warn!(root = %self.root.display(), %error, "manifest directory unavailable; reconciliation will retry");
+                        last_root_error = Some(error);
+                    }
+                    tokio::time::sleep(interval).await;
+                    continue;
+                }
+            };
             for error in &report.errors {
                 warn!(path = %error.path.display(), reason = %error.reason, "manifest document rejected");
             }
@@ -295,7 +311,9 @@ mod tests {
     #[tokio::test]
     async fn fresh_directory_applies_all_documents_with_ownership_and_source() {
         let dir = tempfile::tempdir().expect("tempdir");
-        write(&dir.path().join("alpha.yaml"), &manifest("alpha", "one"));
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).expect("nested manifest directory");
+        write(&nested.join("policies.yaml"), &format!("{}---\n{}", manifest("alpha", "one"), manifest("gamma", "three")));
         write(
             &dir.path().join("beta.json"),
             r#"{"apiVersion":"flotilla.work/v1","kind":"PlacementPolicy","metadata":{"name":"beta"},"spec":{"pool":"two"}}"#,
@@ -305,8 +323,8 @@ mod tests {
 
         let report = reconciler.reconcile_once().await.expect("manifest pass");
 
-        assert_eq!(report.created, 2);
-        for (name, source) in [("alpha", "alpha.yaml"), ("beta", "beta.json")] {
+        assert_eq!(report.created, 3);
+        for (name, source) in [("alpha", "nested/policies.yaml"), ("gamma", "nested/policies.yaml"), ("beta", "beta.json")] {
             let object = backend.using::<PlacementPolicy>(NAMESPACE).get(name).await.expect("manifest object");
             assert_eq!(object.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some(MANIFEST_MANAGED_BY_VALUE));
             assert_eq!(object.metadata.annotations.get(MANIFEST_SOURCE_ANNOTATION).map(String::as_str), Some(source));
@@ -337,6 +355,30 @@ mod tests {
         assert_eq!(report.unchanged, 1);
         assert_eq!(before.metadata.resource_version, after.metadata.resource_version);
         assert!(tokio::time::timeout(Duration::from_millis(20), events.next()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn loop_recovers_when_manifest_directory_appears_later() {
+        let parent = tempfile::tempdir().expect("tempdir");
+        let root = parent.path().join("not-created-yet");
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let task = tokio::spawn(ManifestReconciler::new(backend.clone(), NAMESPACE, root.clone()).run(Duration::from_millis(5)));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        std::fs::create_dir(&root).expect("create manifest directory");
+        write(&root.join("policy.yaml"), &manifest("late", "one"));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if backend.using::<PlacementPolicy>(NAMESPACE).get("late").await.is_ok() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("manifest loop should recover");
+
+        task.abort();
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/manifest.rs
+++ b/crates/flotilla-daemon/src/manifest.rs
@@ -10,7 +10,9 @@ use std::{
     time::Duration,
 };
 
-use flotilla_resources::{apply_resource_document, content_hash, get_resource_kind, ResourceBackend, ResourceError, MANAGED_BY_LABEL};
+use flotilla_resources::{
+    apply_resource_document, get_resource_kind, resource_document_spec_hash, ResourceBackend, ResourceError, MANAGED_BY_LABEL,
+};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use tracing::{info, warn};
@@ -119,8 +121,7 @@ impl ManifestReconciler {
 
     async fn reconcile_document(&mut self, source: &Path, mut document: Value, report: &mut ManifestPassReport) -> Result<(), String> {
         let identity = document_identity(&document, &self.default_namespace)?;
-        let desired_hash =
-            content_hash(document.get("spec").ok_or_else(|| format!("{identity}: missing spec"))?).map_err(|error| error.to_string())?;
+        let desired_hash = resource_document_spec_hash(&document).map_err(|error| format!("{identity}: {error}"))?;
         stamp_manifest_metadata(&mut document, source, &desired_hash)?;
 
         let existing = match get_resource_kind(&self.backend, &identity.namespace, &identity.kind, &identity.name).await {
@@ -146,8 +147,7 @@ impl ManifestReconciler {
         }
 
         let annotations = string_map(&existing, "annotations")?;
-        let live_hash = content_hash(existing.get("spec").ok_or_else(|| format!("{identity}: stored object has no spec"))?)
-            .map_err(|error| error.to_string())?;
+        let live_hash = resource_document_spec_hash(&existing).map_err(|error| format!("{identity}: {error}"))?;
         let last_applied = annotations.get(LAST_APPLIED_HASH_ANNOTATION).cloned().unwrap_or_else(|| "<missing>".to_string());
         if live_hash != last_applied {
             if self.warned_drift.insert((identity.clone(), live_hash.clone(), last_applied.clone())) {
@@ -169,6 +169,7 @@ impl ManifestReconciler {
             return Ok(());
         }
 
+        preserve_external_metadata(&mut document, &existing)?;
         apply_resource_document(&self.backend, &self.default_namespace, document).await.map_err(|error| format!("{identity}: {error}"))?;
         self.warned_drift.retain(|(warned, _, _)| warned != &identity);
         report.updated += 1;
@@ -246,6 +247,25 @@ fn insert_metadata_value(metadata: &mut Map<String, Value>, field: &str, key: &s
     Ok(())
 }
 
+fn preserve_external_metadata(document: &mut Value, existing: &Value) -> Result<(), String> {
+    let desired =
+        document.get_mut("metadata").and_then(Value::as_object_mut).ok_or_else(|| "missing or non-object metadata".to_string())?;
+    let stored = existing
+        .get("metadata")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "stored object has missing or non-object metadata".to_string())?;
+    for field in ["labels", "annotations"] {
+        let desired_values = desired.entry(field).or_insert_with(|| Value::Object(Map::new()));
+        let desired_values = desired_values.as_object_mut().ok_or_else(|| format!("metadata.{field} must be an object"))?;
+        if let Some(stored_values) = stored.get(field).and_then(Value::as_object) {
+            for (key, value) in stored_values {
+                desired_values.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        }
+    }
+    Ok(())
+}
+
 fn string_map(document: &Value, field: &str) -> Result<BTreeMap<String, String>, String> {
     let value = document.get("metadata").and_then(|metadata| metadata.get(field)).cloned().unwrap_or_else(|| Value::Object(Map::new()));
     serde_json::from_value(value).map_err(|error| format!("stored metadata.{field} is invalid: {error}"))
@@ -255,7 +275,9 @@ fn string_map(document: &Value, field: &str) -> Result<BTreeMap<String, String>,
 mod tests {
     use std::time::Duration;
 
-    use flotilla_resources::{InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend, WatchStart};
+    use flotilla_resources::{
+        InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend, WatchStart, WorkflowTemplate,
+    };
     use futures::StreamExt;
 
     use super::*;
@@ -290,7 +312,10 @@ mod tests {
             assert_eq!(object.metadata.annotations.get(MANIFEST_SOURCE_ANNOTATION).map(String::as_str), Some(source));
             assert_eq!(
                 object.metadata.annotations.get(LAST_APPLIED_HASH_ANNOTATION),
-                Some(&content_hash(&serde_json::to_value(&object.spec).expect("spec value")).expect("spec digest"))
+                Some(
+                    &resource_document_spec_hash(&serde_json::to_value(object.to_k8s_object()).expect("resource document"))
+                        .expect("spec digest")
+                )
             );
         }
     }
@@ -322,13 +347,44 @@ mod tests {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
         let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
         reconciler.reconcile_once().await.expect("initial pass");
+        let resolver = backend.using::<PlacementPolicy>(NAMESPACE);
+        let applied = resolver.get("moving").await.expect("policy");
+        let mut live_meta = InputMeta::from(&applied.metadata);
+        live_meta.labels.insert("another-controller/observation".to_string(), "kept".to_string());
+        resolver.update(&live_meta, &applied.metadata.resource_version, &applied.spec).await.expect("add external metadata");
 
         write(&path, &manifest("moving", "two"));
         let report = reconciler.reconcile_once().await.expect("fast-forward pass");
-        let object = backend.using::<PlacementPolicy>(NAMESPACE).get("moving").await.expect("policy");
+        let object = resolver.get("moving").await.expect("policy");
 
         assert_eq!(report.updated, 1);
         assert_eq!(object.spec.pool, "two");
+        assert_eq!(object.metadata.labels.get("another-controller/observation").map(String::as_str), Some("kept"));
+    }
+
+    #[tokio::test]
+    async fn omitted_serde_defaults_remain_steady_and_can_fast_forward() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("workflow.yaml");
+        let workflow = |command: &str| {
+            format!(
+                "apiVersion: flotilla.work/v1\nkind: WorkflowTemplate\nmetadata:\n  name: defaults\nspec:\n  vessels:\n    - name: work\n      crew:\n        - role: coder\n          command: {command}\n"
+            )
+        };
+        write(&path, &workflow("echo-one"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        reconciler.reconcile_once().await.expect("initial pass");
+
+        let steady = reconciler.reconcile_once().await.expect("steady pass");
+        write(&path, &workflow("echo-two"));
+        let updated = reconciler.reconcile_once().await.expect("fast-forward pass");
+        let object = backend.using::<WorkflowTemplate>(NAMESPACE).get("defaults").await.expect("workflow");
+
+        assert_eq!(steady.unchanged, 1);
+        assert_eq!(steady.drifted, 0);
+        assert_eq!(updated.updated, 1);
+        assert_eq!(serde_json::to_value(&object.spec).expect("workflow spec")["vessels"][0]["crew"][0]["command"], "echo-two");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/manifest.rs
+++ b/crates/flotilla-daemon/src/manifest.rs
@@ -1,0 +1,415 @@
+//! Additive, ownership-aware application of resource manifest directories.
+//!
+//! This reconciler intentionally does not prune objects whose source documents
+//! disappear. Deletion and adoption are separate, explicit lifecycle acts.
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use flotilla_resources::{apply_resource_document, content_hash, get_resource_kind, ResourceBackend, ResourceError, MANAGED_BY_LABEL};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use tracing::{info, warn};
+
+pub const MANIFEST_MANAGED_BY_VALUE: &str = "manifest";
+pub const MANIFEST_SOURCE_ANNOTATION: &str = "flotilla.work/manifest-source";
+pub const LAST_APPLIED_HASH_ANNOTATION: &str = "flotilla.work/last-applied-hash";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ObjectIdentity {
+    kind: String,
+    namespace: String,
+    name: String,
+}
+
+impl fmt::Display for ObjectIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}/{}/{}", self.kind, self.namespace, self.name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestDocumentError {
+    pub path: PathBuf,
+    pub reason: String,
+}
+
+impl fmt::Display for ManifestDocumentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.path.display(), self.reason)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ManifestPassReport {
+    pub created: usize,
+    pub updated: usize,
+    pub unchanged: usize,
+    pub drifted: usize,
+    pub unmanaged: usize,
+    pub errors: Vec<ManifestDocumentError>,
+}
+
+pub struct ManifestReconciler {
+    backend: ResourceBackend,
+    default_namespace: String,
+    root: PathBuf,
+    warned_unmanaged: HashSet<ObjectIdentity>,
+    warned_drift: HashSet<(ObjectIdentity, String, String)>,
+}
+
+impl ManifestReconciler {
+    pub fn new(backend: ResourceBackend, default_namespace: impl Into<String>, root: impl Into<PathBuf>) -> Self {
+        Self {
+            backend,
+            default_namespace: default_namespace.into(),
+            root: root.into(),
+            warned_unmanaged: HashSet::new(),
+            warned_drift: HashSet::new(),
+        }
+    }
+
+    pub async fn run(mut self, interval: Duration) -> Result<(), ResourceError> {
+        loop {
+            let report = self.reconcile_once().await.map_err(ResourceError::other)?;
+            for error in &report.errors {
+                warn!(path = %error.path.display(), reason = %error.reason, "manifest document rejected");
+            }
+            if report.created > 0 || report.updated > 0 {
+                info!(
+                    root = %self.root.display(),
+                    created = report.created,
+                    updated = report.updated,
+                    unchanged = report.unchanged,
+                    drifted = report.drifted,
+                    unmanaged = report.unmanaged,
+                    errors = report.errors.len(),
+                    "manifest reconciliation pass applied desired state"
+                );
+            }
+            tokio::time::sleep(interval).await;
+        }
+    }
+
+    pub async fn reconcile_once(&mut self) -> Result<ManifestPassReport, String> {
+        let files = manifest_files(&self.root)?;
+        let mut report = ManifestPassReport::default();
+        for path in files {
+            let relative = path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
+            let documents = match parse_documents(&path) {
+                Ok(documents) => documents,
+                Err(reason) => {
+                    report.errors.push(ManifestDocumentError { path: relative, reason });
+                    continue;
+                }
+            };
+            for (index, document) in documents.into_iter().enumerate() {
+                if let Err(reason) = self.reconcile_document(&relative, document, &mut report).await {
+                    let path = if index == 0 { relative.clone() } else { PathBuf::from(format!("{}#{}", relative.display(), index + 1)) };
+                    report.errors.push(ManifestDocumentError { path, reason });
+                }
+            }
+        }
+        Ok(report)
+    }
+
+    async fn reconcile_document(&mut self, source: &Path, mut document: Value, report: &mut ManifestPassReport) -> Result<(), String> {
+        let identity = document_identity(&document, &self.default_namespace)?;
+        let desired_hash =
+            content_hash(document.get("spec").ok_or_else(|| format!("{identity}: missing spec"))?).map_err(|error| error.to_string())?;
+        stamp_manifest_metadata(&mut document, source, &desired_hash)?;
+
+        let existing = match get_resource_kind(&self.backend, &identity.namespace, &identity.kind, &identity.name).await {
+            Ok(existing) => Some(existing.value),
+            Err(ResourceError::NotFound { .. }) => None,
+            Err(error) => return Err(format!("{identity}: {error}")),
+        };
+        let Some(existing) = existing else {
+            apply_resource_document(&self.backend, &self.default_namespace, document)
+                .await
+                .map_err(|error| format!("{identity}: {error}"))?;
+            report.created += 1;
+            return Ok(());
+        };
+
+        let labels = string_map(&existing, "labels")?;
+        if labels.get(MANAGED_BY_LABEL).map(String::as_str) != Some(MANIFEST_MANAGED_BY_VALUE) {
+            if self.warned_unmanaged.insert(identity.clone()) {
+                warn!(object = %identity, source = %source.display(), "manifest names an unmanaged object; refusing adoption");
+            }
+            report.unmanaged += 1;
+            return Ok(());
+        }
+
+        let annotations = string_map(&existing, "annotations")?;
+        let live_hash = content_hash(existing.get("spec").ok_or_else(|| format!("{identity}: stored object has no spec"))?)
+            .map_err(|error| error.to_string())?;
+        let last_applied = annotations.get(LAST_APPLIED_HASH_ANNOTATION).cloned().unwrap_or_else(|| "<missing>".to_string());
+        if live_hash != last_applied {
+            if self.warned_drift.insert((identity.clone(), live_hash.clone(), last_applied.clone())) {
+                warn!(
+                    object = %identity,
+                    live_digest = %live_hash,
+                    last_applied_digest = %last_applied,
+                    desired_digest = %desired_hash,
+                    "manifest-managed object has live drift; refusing overwrite"
+                );
+            }
+            report.drifted += 1;
+            return Ok(());
+        }
+
+        let source_value = source.to_string_lossy();
+        if desired_hash == last_applied && annotations.get(MANIFEST_SOURCE_ANNOTATION).map(String::as_str) == Some(source_value.as_ref()) {
+            report.unchanged += 1;
+            return Ok(());
+        }
+
+        apply_resource_document(&self.backend, &self.default_namespace, document).await.map_err(|error| format!("{identity}: {error}"))?;
+        self.warned_drift.retain(|(warned, _, _)| warned != &identity);
+        report.updated += 1;
+        Ok(())
+    }
+}
+
+fn manifest_files(root: &Path) -> Result<Vec<PathBuf>, String> {
+    fn collect(dir: &Path, files: &mut Vec<PathBuf>) -> Result<(), String> {
+        let entries = std::fs::read_dir(dir).map_err(|error| format!("read manifest directory {}: {error}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|error| format!("read manifest directory entry in {}: {error}", dir.display()))?;
+            let file_type = entry.file_type().map_err(|error| format!("inspect manifest path {}: {error}", entry.path().display()))?;
+            if file_type.is_dir() {
+                collect(&entry.path(), files)?;
+            } else if file_type.is_file()
+                && entry
+                    .path()
+                    .extension()
+                    .and_then(|extension| extension.to_str())
+                    .is_some_and(|extension| matches!(extension.to_ascii_lowercase().as_str(), "json" | "yaml" | "yml"))
+            {
+                files.push(entry.path());
+            }
+        }
+        Ok(())
+    }
+
+    let mut files = Vec::new();
+    collect(root, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn parse_documents(path: &Path) -> Result<Vec<Value>, String> {
+    let content = std::fs::read_to_string(path).map_err(|error| format!("read file: {error}"))?;
+    if path.extension().and_then(|extension| extension.to_str()).is_some_and(|extension| extension.eq_ignore_ascii_case("json")) {
+        return serde_json::from_str(&content).map(|document| vec![document]).map_err(|error| format!("parse JSON: {error}"));
+    }
+
+    let mut documents = Vec::new();
+    for document in serde_yml::Deserializer::from_str(&content) {
+        let value = Value::deserialize(document).map_err(|error| format!("parse YAML: {error}"))?;
+        if !value.is_null() {
+            documents.push(value);
+        }
+    }
+    if documents.is_empty() {
+        return Err("parse YAML: file contains no resource documents".to_string());
+    }
+    Ok(documents)
+}
+
+fn document_identity(document: &Value, default_namespace: &str) -> Result<ObjectIdentity, String> {
+    document.get("apiVersion").and_then(Value::as_str).ok_or_else(|| "missing or non-string apiVersion".to_string())?;
+    let kind = document.get("kind").and_then(Value::as_str).ok_or_else(|| "missing or non-string kind".to_string())?.to_string();
+    let metadata = document.get("metadata").and_then(Value::as_object).ok_or_else(|| "missing or non-object metadata".to_string())?;
+    let name = metadata.get("name").and_then(Value::as_str).ok_or_else(|| "missing or non-string metadata.name".to_string())?.to_string();
+    let namespace = metadata.get("namespace").and_then(Value::as_str).unwrap_or(default_namespace).to_string();
+    Ok(ObjectIdentity { kind, namespace, name })
+}
+
+fn stamp_manifest_metadata(document: &mut Value, source: &Path, hash: &str) -> Result<(), String> {
+    let metadata =
+        document.get_mut("metadata").and_then(Value::as_object_mut).ok_or_else(|| "missing or non-object metadata".to_string())?;
+    insert_metadata_value(metadata, "labels", MANAGED_BY_LABEL, MANIFEST_MANAGED_BY_VALUE)?;
+    insert_metadata_value(metadata, "annotations", MANIFEST_SOURCE_ANNOTATION, &source.to_string_lossy())?;
+    insert_metadata_value(metadata, "annotations", LAST_APPLIED_HASH_ANNOTATION, hash)
+}
+
+fn insert_metadata_value(metadata: &mut Map<String, Value>, field: &str, key: &str, value: &str) -> Result<(), String> {
+    let values = metadata.entry(field).or_insert_with(|| Value::Object(Map::new()));
+    let values = values.as_object_mut().ok_or_else(|| format!("metadata.{field} must be an object"))?;
+    values.insert(key.to_string(), Value::String(value.to_string()));
+    Ok(())
+}
+
+fn string_map(document: &Value, field: &str) -> Result<BTreeMap<String, String>, String> {
+    let value = document.get("metadata").and_then(|metadata| metadata.get(field)).cloned().unwrap_or_else(|| Value::Object(Map::new()));
+    serde_json::from_value(value).map_err(|error| format!("stored metadata.{field} is invalid: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use flotilla_resources::{InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend, WatchStart};
+    use futures::StreamExt;
+
+    use super::*;
+
+    const NAMESPACE: &str = "flotilla";
+
+    fn write(path: &Path, content: &str) {
+        std::fs::write(path, content).expect("write manifest");
+    }
+
+    fn manifest(name: &str, pool: &str) -> String {
+        format!("apiVersion: flotilla.work/v1\nkind: PlacementPolicy\nmetadata:\n  name: {name}\nspec:\n  pool: {pool}\n")
+    }
+
+    #[tokio::test]
+    async fn fresh_directory_applies_all_documents_with_ownership_and_source() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("alpha.yaml"), &manifest("alpha", "one"));
+        write(
+            &dir.path().join("beta.json"),
+            r#"{"apiVersion":"flotilla.work/v1","kind":"PlacementPolicy","metadata":{"name":"beta"},"spec":{"pool":"two"}}"#,
+        );
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+
+        let report = reconciler.reconcile_once().await.expect("manifest pass");
+
+        assert_eq!(report.created, 2);
+        for (name, source) in [("alpha", "alpha.yaml"), ("beta", "beta.json")] {
+            let object = backend.using::<PlacementPolicy>(NAMESPACE).get(name).await.expect("manifest object");
+            assert_eq!(object.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some(MANIFEST_MANAGED_BY_VALUE));
+            assert_eq!(object.metadata.annotations.get(MANIFEST_SOURCE_ANNOTATION).map(String::as_str), Some(source));
+            assert_eq!(
+                object.metadata.annotations.get(LAST_APPLIED_HASH_ANNOTATION),
+                Some(&content_hash(&serde_json::to_value(&object.spec).expect("spec value")).expect("spec digest"))
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn steady_state_and_restart_perform_no_writes_or_events() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("policy.yaml"), &manifest("steady", "one"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let mut first = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        first.reconcile_once().await.expect("initial pass");
+        let before = backend.using::<PlacementPolicy>(NAMESPACE).get("steady").await.expect("policy");
+
+        let mut events = backend.using::<PlacementPolicy>(NAMESPACE).watch(WatchStart::Now).await.expect("watch");
+        let mut restarted = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let report = restarted.reconcile_once().await.expect("restart pass");
+        let after = backend.using::<PlacementPolicy>(NAMESPACE).get("steady").await.expect("policy");
+
+        assert_eq!(report.unchanged, 1);
+        assert_eq!(before.metadata.resource_version, after.metadata.resource_version);
+        assert!(tokio::time::timeout(Duration::from_millis(20), events.next()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn fast_forwards_only_when_live_spec_matches_last_applied_hash() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("policy.yaml");
+        write(&path, &manifest("moving", "one"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        reconciler.reconcile_once().await.expect("initial pass");
+
+        write(&path, &manifest("moving", "two"));
+        let report = reconciler.reconcile_once().await.expect("fast-forward pass");
+        let object = backend.using::<PlacementPolicy>(NAMESPACE).get("moving").await.expect("policy");
+
+        assert_eq!(report.updated, 1);
+        assert_eq!(object.spec.pool, "two");
+    }
+
+    #[tokio::test]
+    async fn live_drift_is_left_untouched() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("policy.yaml");
+        write(&path, &manifest("drifted", "one"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        reconciler.reconcile_once().await.expect("initial pass");
+        let resolver = backend.using::<PlacementPolicy>(NAMESPACE);
+        let applied = resolver.get("drifted").await.expect("policy");
+        resolver
+            .update(
+                &InputMeta::from(&applied.metadata),
+                &applied.metadata.resource_version,
+                &PlacementPolicySpec::builder().pool("live-edit".to_string()).build(),
+            )
+            .await
+            .expect("edit live spec");
+
+        write(&path, &manifest("drifted", "manifest-edit"));
+        let report = reconciler.reconcile_once().await.expect("drift pass");
+        let object = resolver.get("drifted").await.expect("policy");
+
+        assert_eq!(report.drifted, 1);
+        assert_eq!(object.spec.pool, "live-edit");
+    }
+
+    #[tokio::test]
+    async fn unmanaged_object_is_never_adopted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("policy.yaml"), &manifest("unmanaged", "manifest"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        backend
+            .using::<PlacementPolicy>(NAMESPACE)
+            .create(
+                &InputMeta::builder().name("unmanaged".to_string()).build(),
+                &PlacementPolicySpec::builder().pool("live".to_string()).build(),
+            )
+            .await
+            .expect("unmanaged policy");
+        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+
+        let report = reconciler.reconcile_once().await.expect("manifest pass");
+        let object = backend.using::<PlacementPolicy>(NAMESPACE).get("unmanaged").await.expect("policy");
+
+        assert_eq!(report.unmanaged, 1);
+        assert_eq!(object.spec.pool, "live");
+        assert!(!object.metadata.labels.contains_key(MANAGED_BY_LABEL));
+    }
+
+    #[tokio::test]
+    async fn malformed_document_reports_its_path_and_does_not_block_remaining_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("broken.yaml"), "kind: [");
+        write(&dir.path().join("valid.yaml"), &manifest("valid", "one"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+
+        let report = reconciler.reconcile_once().await.expect("manifest pass");
+
+        assert_eq!(report.created, 1);
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(report.errors[0].path, PathBuf::from("broken.yaml"));
+        assert!(report.errors[0].reason.contains("parse YAML"));
+        backend.using::<PlacementPolicy>(NAMESPACE).get("valid").await.expect("valid policy");
+    }
+
+    #[tokio::test]
+    async fn removing_a_manifest_does_not_prune_its_object() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("policy.yaml");
+        write(&path, &manifest("retained", "one"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        reconciler.reconcile_once().await.expect("initial pass");
+        std::fs::remove_file(path).expect("remove manifest");
+
+        reconciler.reconcile_once().await.expect("additive pass");
+
+        backend.using::<PlacementPolicy>(NAMESPACE).get("retained").await.expect("object must not be pruned");
+    }
+}

--- a/crates/flotilla-daemon/src/resource_manifest.rs
+++ b/crates/flotilla-daemon/src/resource_manifest.rs
@@ -166,6 +166,7 @@ impl ResourceManifestReconciler {
             report.unmanaged += 1;
             return Ok(());
         }
+        self.warned_unmanaged.remove(&identity);
 
         let annotations = string_map(&existing, "annotations")?;
         let live_hash = resource_document_spec_hash(&existing).map_err(|error| format!("{identity}: {error}"))?;
@@ -492,6 +493,43 @@ mod tests {
         assert_eq!(report.unmanaged, 1);
         assert_eq!(object.spec.pool, "live");
         assert!(!object.metadata.labels.contains_key(MANAGED_BY_LABEL));
+    }
+
+    #[tokio::test]
+    async fn unmanaged_warning_is_rearmed_after_ownership_is_restored() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(&dir.path().join("policy.yaml"), &manifest("unmanaged", "manifest"));
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let resolver = backend.using::<PlacementPolicy>(NAMESPACE);
+        resolver
+            .create(
+                &InputMeta::builder().name("unmanaged".to_string()).build(),
+                &PlacementPolicySpec::builder().pool("live".to_string()).build(),
+            )
+            .await
+            .expect("unmanaged policy");
+        let mut reconciler = ResourceManifestReconciler::new(backend, NAMESPACE, dir.path());
+        let identity =
+            ObjectIdentity { kind: "PlacementPolicy".to_string(), namespace: NAMESPACE.to_string(), name: "unmanaged".to_string() };
+
+        reconciler.reconcile_once().await.expect("initial unmanaged pass");
+        assert!(reconciler.warned_unmanaged.contains(&identity));
+
+        let object = resolver.get("unmanaged").await.expect("policy");
+        let mut meta = InputMeta::from(&object.metadata);
+        meta.labels.insert(MANAGED_BY_LABEL.to_string(), MANIFEST_MANAGED_BY_VALUE.to_string());
+        resolver.update(&meta, &object.metadata.resource_version, &object.spec).await.expect("restore ownership");
+        reconciler.reconcile_once().await.expect("managed pass");
+        assert!(!reconciler.warned_unmanaged.contains(&identity));
+
+        let object = resolver.get("unmanaged").await.expect("policy");
+        let mut meta = InputMeta::from(&object.metadata);
+        meta.labels.remove(MANAGED_BY_LABEL);
+        resolver.update(&meta, &object.metadata.resource_version, &object.spec).await.expect("remove ownership");
+        let report = reconciler.reconcile_once().await.expect("unmanaged again");
+
+        assert_eq!(report.unmanaged, 1);
+        assert!(reconciler.warned_unmanaged.contains(&identity));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/resource_manifest.rs
+++ b/crates/flotilla-daemon/src/resource_manifest.rs
@@ -21,6 +21,8 @@ pub const MANIFEST_MANAGED_BY_VALUE: &str = "manifest";
 pub const MANIFEST_SOURCE_ANNOTATION: &str = "flotilla.work/manifest-source";
 pub const LAST_APPLIED_HASH_ANNOTATION: &str = "flotilla.work/last-applied-hash";
 
+type LoadedManifestFile = (PathBuf, Result<Vec<Value>, String>);
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ObjectIdentity {
     kind: String,
@@ -56,7 +58,7 @@ pub struct ManifestPassReport {
     pub errors: Vec<ManifestDocumentError>,
 }
 
-pub struct ManifestReconciler {
+pub struct ResourceManifestReconciler {
     backend: ResourceBackend,
     default_namespace: String,
     root: PathBuf,
@@ -64,7 +66,7 @@ pub struct ManifestReconciler {
     warned_drift: HashSet<(ObjectIdentity, String, String)>,
 }
 
-impl ManifestReconciler {
+impl ResourceManifestReconciler {
     pub fn new(backend: ResourceBackend, default_namespace: impl Into<String>, root: impl Into<PathBuf>) -> Self {
         Self {
             backend,
@@ -114,11 +116,14 @@ impl ManifestReconciler {
     }
 
     pub async fn reconcile_once(&mut self) -> Result<ManifestPassReport, String> {
-        let files = manifest_files(&self.root)?;
+        let root = self.root.clone();
+        let files = tokio::task::spawn_blocking(move || load_manifest_files(&root))
+            .await
+            .map_err(|error| format!("manifest file loading task failed: {error}"))??;
         let mut report = ManifestPassReport::default();
-        for path in files {
+        for (path, documents) in files {
             let relative = path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
-            let documents = match parse_documents(&path) {
+            let documents = match documents {
                 Ok(documents) => documents,
                 Err(reason) => {
                     report.errors.push(ManifestDocumentError { path: relative, reason });
@@ -220,6 +225,16 @@ fn manifest_files(root: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(files)
 }
 
+fn load_manifest_files(root: &Path) -> Result<Vec<LoadedManifestFile>, String> {
+    Ok(manifest_files(root)?
+        .into_iter()
+        .map(|path| {
+            let documents = parse_documents(&path);
+            (path, documents)
+        })
+        .collect())
+}
+
 fn parse_documents(path: &Path) -> Result<Vec<Value>, String> {
     let content = std::fs::read_to_string(path).map_err(|error| format!("read file: {error}"))?;
     if path.extension().and_then(|extension| extension.to_str()).is_some_and(|extension| extension.eq_ignore_ascii_case("json")) {
@@ -319,7 +334,7 @@ mod tests {
             r#"{"apiVersion":"flotilla.work/v1","kind":"PlacementPolicy","metadata":{"name":"beta"},"spec":{"pool":"two"}}"#,
         );
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
 
         let report = reconciler.reconcile_once().await.expect("manifest pass");
 
@@ -343,12 +358,12 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         write(&dir.path().join("policy.yaml"), &manifest("steady", "one"));
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let mut first = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut first = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
         first.reconcile_once().await.expect("initial pass");
         let before = backend.using::<PlacementPolicy>(NAMESPACE).get("steady").await.expect("policy");
 
         let mut events = backend.using::<PlacementPolicy>(NAMESPACE).watch(WatchStart::Now).await.expect("watch");
-        let mut restarted = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut restarted = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
         let report = restarted.reconcile_once().await.expect("restart pass");
         let after = backend.using::<PlacementPolicy>(NAMESPACE).get("steady").await.expect("policy");
 
@@ -362,7 +377,7 @@ mod tests {
         let parent = tempfile::tempdir().expect("tempdir");
         let root = parent.path().join("not-created-yet");
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let task = tokio::spawn(ManifestReconciler::new(backend.clone(), NAMESPACE, root.clone()).run(Duration::from_millis(5)));
+        let task = tokio::spawn(ResourceManifestReconciler::new(backend.clone(), NAMESPACE, root.clone()).run(Duration::from_millis(5)));
         tokio::time::sleep(Duration::from_millis(10)).await;
 
         std::fs::create_dir(&root).expect("create manifest directory");
@@ -387,7 +402,7 @@ mod tests {
         let path = dir.path().join("policy.yaml");
         write(&path, &manifest("moving", "one"));
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
         reconciler.reconcile_once().await.expect("initial pass");
         let resolver = backend.using::<PlacementPolicy>(NAMESPACE);
         let applied = resolver.get("moving").await.expect("policy");
@@ -415,7 +430,7 @@ mod tests {
         };
         write(&path, &workflow("echo-one"));
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
         reconciler.reconcile_once().await.expect("initial pass");
 
         let steady = reconciler.reconcile_once().await.expect("steady pass");
@@ -435,7 +450,7 @@ mod tests {
         let path = dir.path().join("policy.yaml");
         write(&path, &manifest("drifted", "one"));
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
         reconciler.reconcile_once().await.expect("initial pass");
         let resolver = backend.using::<PlacementPolicy>(NAMESPACE);
         let applied = resolver.get("drifted").await.expect("policy");
@@ -469,7 +484,7 @@ mod tests {
             )
             .await
             .expect("unmanaged policy");
-        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
 
         let report = reconciler.reconcile_once().await.expect("manifest pass");
         let object = backend.using::<PlacementPolicy>(NAMESPACE).get("unmanaged").await.expect("policy");
@@ -485,7 +500,7 @@ mod tests {
         write(&dir.path().join("broken.yaml"), "kind: [");
         write(&dir.path().join("valid.yaml"), &manifest("valid", "one"));
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
 
         let report = reconciler.reconcile_once().await.expect("manifest pass");
 
@@ -502,7 +517,7 @@ mod tests {
         let path = dir.path().join("policy.yaml");
         write(&path, &manifest("retained", "one"));
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-        let mut reconciler = ManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
+        let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
         reconciler.reconcile_once().await.expect("initial pass");
         std::fs::remove_file(path).expect("remove manifest");
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -312,6 +312,7 @@ impl DaemonRuntime {
                 manifests.dir,
                 MANIFEST_RECONCILE_INTERVAL,
                 options.controller_supervision.clone(),
+                runtime_health.clone(),
             ));
         }
 
@@ -353,9 +354,10 @@ fn spawn_manifest_reconciler_task(
     root: PathBuf,
     interval: Duration,
     supervision: ControllerSupervision,
+    runtime_health: RuntimeHealth,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        supervise("manifest", supervision, move || {
+        supervise_controller("manifest", supervision, runtime_health, move || {
             let reconciler = ResourceManifestReconciler::new(backend.clone(), namespace.clone(), root.clone());
             async move { reconciler.run(interval).await }
         })

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -47,6 +47,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     credential::CredentialStore,
+    manifest::ManifestReconciler,
     sleep_inhibitor,
     supervisor::{supervise, ControllerSupervision},
     Aggregator, AggregatorResolvers,
@@ -56,6 +57,7 @@ use crate::{
 /// enough to be quiet in a healthy log, short enough to bound how much time a
 /// wedge can hide in.
 const LIVENESS_WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
+const MANIFEST_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 const BUILTIN_MANAGED_BY_VALUE: &str = "builtin";
@@ -195,6 +197,7 @@ impl DaemonRuntime {
         }
         daemon.set_provisioning_namespace(options.namespace.clone()).await;
         let aggregator_projection_state = daemon.aggregator_projection_state().await;
+        let manifests = config.load_daemon_config()?.manifests;
 
         let local_registry = probe_local_provider_registry(&daemon, &config).await?;
         let profile = build_local_profile(&daemon, &local_registry)?;
@@ -247,6 +250,15 @@ impl DaemonRuntime {
                 options.controller_supervision.clone(),
             ),
         ];
+        if let Some(manifests) = manifests {
+            tasks.push(spawn_manifest_reconciler_task(
+                daemon.resource_backend(),
+                options.namespace.clone(),
+                manifests.dir,
+                MANIFEST_RECONCILE_INTERVAL,
+                options.controller_supervision.clone(),
+            ));
+        }
 
         if options.start_controllers {
             let local_repo_root = daemon.tracked_repo_paths().await.into_iter().next().map(ExecutionEnvironmentPath::new);
@@ -277,6 +289,22 @@ impl DaemonRuntime {
 
         Ok(Self { tasks, stop_expected: false })
     }
+}
+
+fn spawn_manifest_reconciler_task(
+    backend: ResourceBackend,
+    namespace: String,
+    root: PathBuf,
+    interval: Duration,
+    supervision: ControllerSupervision,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        supervise("manifest", supervision, move || {
+            let reconciler = ManifestReconciler::new(backend.clone(), namespace.clone(), root.clone());
+            async move { reconciler.run(interval).await }
+        })
+        .await;
+    })
 }
 
 impl DaemonRuntime {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -47,7 +47,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     credential::CredentialStore,
-    manifest::ManifestReconciler,
+    resource_manifest::ResourceManifestReconciler,
     sleep_inhibitor,
     supervisor::{supervise, ControllerSupervision},
     Aggregator, AggregatorResolvers,
@@ -300,7 +300,7 @@ fn spawn_manifest_reconciler_task(
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         supervise("manifest", supervision, move || {
-            let reconciler = ManifestReconciler::new(backend.clone(), namespace.clone(), root.clone());
+            let reconciler = ResourceManifestReconciler::new(backend.clone(), namespace.clone(), root.clone());
             async move { reconciler.run(interval).await }
         })
         .await;

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -85,9 +85,9 @@ pub use project::{
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
     apply_resource_document, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas,
-    list_resource_kind_replica_sources, resource_list_api_version, watch_resource_kind, watch_resource_kind_from,
-    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList, DynamicResourceObject,
-    DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
+    list_resource_kind_replica_sources, resource_document_spec_hash, resource_list_api_version, watch_resource_kind,
+    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList,
+    DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -70,7 +70,7 @@ pub use placement_policy::{
     HostDirectPlacementPolicySpec, PlacementPolicy, PlacementPolicySpec,
 };
 pub use prepared_snapshot::{
-    PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PreparedSnapshotRecoveryResult, PLACEMENT_SNAPSHOT_KIND,
+    content_hash, PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PreparedSnapshotRecoveryResult, PLACEMENT_SNAPSHOT_KIND,
     PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_KIND,
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};

--- a/crates/flotilla-resources/src/prepared_snapshot.rs
+++ b/crates/flotilla-resources/src/prepared_snapshot.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeSet;
 
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
 use crate::{
     Convoy, InputMeta, PlacementPolicy, ResourceBackend, ResourceError, WorkflowTemplate, PLACEMENT_SNAPSHOT_ANNOTATION,
     PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
@@ -8,6 +11,14 @@ use crate::{
 pub const PREPARED_SNAPSHOT_LABEL: &str = "flotilla.work/prepared-snapshot";
 pub const WORKFLOW_SNAPSHOT_KIND: &str = "workflow";
 pub const PLACEMENT_SNAPSHOT_KIND: &str = "placement";
+
+/// The short, stable JSON content digest used by prepared snapshots and
+/// last-applied manifest annotations.
+pub fn content_hash(value: &Value) -> Result<String, ResourceError> {
+    let encoded = serde_json::to_vec(value).map_err(|error| ResourceError::decode(format!("encode content for digest: {error}")))?;
+    let digest = Sha256::digest(encoded);
+    Ok(digest[..6].iter().map(|byte| format!("{byte:02x}")).collect())
+}
 
 #[derive(Debug, Clone)]
 pub struct PreparedSnapshotGarbageCollector {

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -163,6 +163,26 @@ macro_rules! dispatch_resource_kind {
             RegisteredResource::WorkflowTemplate => $body::<WorkflowTemplate>(),
         }
     };
+    ($resource:expr, $body:ident($($arg:expr),*)) => {
+        match $resource {
+            RegisteredResource::Checkout => $body::<Checkout>($($arg),*),
+            RegisteredResource::Clone => $body::<CloneResource>($($arg),*),
+            RegisteredResource::Convoy => $body::<Convoy>($($arg),*),
+            RegisteredResource::CredentialGrant => $body::<CredentialGrant>($($arg),*),
+            RegisteredResource::CredentialSpec => $body::<CredentialSpec>($($arg),*),
+            RegisteredResource::Demand => $body::<Demand>($($arg),*),
+            RegisteredResource::Environment => $body::<Environment>($($arg),*),
+            RegisteredResource::Host => $body::<Host>($($arg),*),
+            RegisteredResource::PlacementPolicy => $body::<PlacementPolicy>($($arg),*),
+            RegisteredResource::Presentation => $body::<Presentation>($($arg),*),
+            RegisteredResource::Project => $body::<Project>($($arg),*),
+            RegisteredResource::Regard => $body::<Regard>($($arg),*),
+            RegisteredResource::Repository => $body::<Repository>($($arg),*),
+            RegisteredResource::TerminalSession => $body::<TerminalSession>($($arg),*),
+            RegisteredResource::Vessel => $body::<Vessel>($($arg),*),
+            RegisteredResource::WorkflowTemplate => $body::<WorkflowTemplate>($($arg),*),
+        }
+    };
 }
 
 pub async fn list_resource_kind(
@@ -243,6 +263,25 @@ pub async fn apply_resource_document(
         lookup_resource_kind(&document.kind)?.resource,
         apply_typed(backend, &namespace, document.metadata, document.spec).await
     )
+}
+
+/// Hash a resource document's spec after its registered typed representation
+/// has applied Serde defaults.
+pub fn resource_document_spec_hash(document: &Value) -> Result<String, ResourceError> {
+    let kind = document
+        .get("kind")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ResourceError::decode("decode resource document: missing or non-string kind"))?;
+    let spec = document.get("spec").ok_or_else(|| ResourceError::decode("decode resource document: missing spec"))?;
+    dispatch_resource_kind!(lookup_resource_kind(kind)?.resource, typed_spec_hash(spec))
+}
+
+fn typed_spec_hash<T: Resource>(spec: &Value) -> Result<String, ResourceError> {
+    let typed = serde_json::from_value::<T::Spec>(spec.clone())
+        .map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", T::API_PATHS.kind)))?;
+    let normalized = serde_json::to_value(typed)
+        .map_err(|error| ResourceError::decode(format!("encode normalized {} spec: {error}", T::API_PATHS.kind)))?;
+    crate::content_hash(&normalized)
 }
 
 fn lookup_resource_kind(kind: &str) -> Result<&'static RegisteredResourceKind, ResourceError> {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,27 @@ flotilla logs --host feta --since 2h --level warn --target flotilla_daemon::peer
 
 Output remains JSONL so it can be piped directly to `jq`.
 
+## Resource manifests
+
+A daemon can continuously apply a directory of JSON and YAML resource
+documents as additive desired state:
+
+```toml
+[manifests]
+dir = "/home/alice/dev/project-map/flotilla"
+```
+
+Each file contains one or more full resource envelopes (`apiVersion`, `kind`,
+`metadata`, and `spec`). The daemon labels created objects as managed by the
+manifest reconciler and records the relative source path and last-applied spec
+digest. It fast-forwards a changed manifest only while the live spec still
+matches that digest; live drift and collisions with unmanaged objects are
+reported and left untouched.
+
+This first manifest-reconciliation slice is deliberately additive: removing a
+file does not delete its object, and existing unmanaged objects are never
+adopted. Omit `[manifests]` to disable the loop.
+
 ## Dependencies
 
 Flotilla auto-detects available tools. Nothing is strictly required beyond git, but more tools unlock more features.


### PR DESCRIPTION
Closes #1196.

## What changed

- add optional `[manifests] dir = "..."` daemon configuration
- run a supervised, level-triggered manifest reconciliation loop every five seconds
- load recursive JSON and YAML full-envelope resource documents through the existing dynamic apply path
- stamp manifest ownership, relative source path, and the shared prepared-snapshot content digest
- create absent objects, fast-forward unchanged live state, and refuse live drift or unmanaged collisions
- isolate malformed files so later documents still apply
- keep this first slice explicitly additive with no pruning

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`