### PR TITLE
fix: harden aggregator projection liveness

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5285,6 +5285,12 @@ impl InProcessDaemon {
                 is_local,
             );
             let (crew_count, convoys) = counts.remove(&host).unwrap_or_default();
+            let degraded_conditions = status
+                .into_iter()
+                .flat_map(|status| status.conditions.iter())
+                .filter(|condition| condition.value == ConditionValue::False)
+                .map(|condition| format!("{}: {}", condition.condition_type, condition.message))
+                .collect();
 
             rows.push(
                 FleetHostRow::builder()
@@ -5305,6 +5311,7 @@ impl InProcessDaemon {
                     .maybe_disk_free_bytes(status.and_then(|status| status.disk_free_bytes))
                     .staleness(staleness)
                     .observation_agreement(observation_agreement)
+                    .degraded_conditions(degraded_conditions)
                     .build(),
             );
         }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -20,18 +20,18 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Convoy, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CredentialConsumer,
-    CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource,
-    CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec, CrewWorkPhase, CrewWorkState, Environment as ResourceEnvironment,
-    EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
-    ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus, Selector, Stance, TerminalBrief, TerminalCrewContext,
-    TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource,
-    TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus, Vessel, VesselPhase,
-    VesselRequirement, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
-    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL,
-    VESSEL_REF_LABEL,
+    CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
+    CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,
+    CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec, CrewWorkPhase,
+    CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost, HostCondition,
+    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
+    ProjectRepositorySpec, ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus, Selector, Stance,
+    TerminalBrief, TerminalCrewContext, TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus,
+    Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL,
+    VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 use super::*;
@@ -1871,6 +1871,13 @@ async fn fleet_health_keeps_link_heartbeat_and_generation_disagreements_visible(
             daemon_version: Some("0.9.0".to_string()),
             daemon_started_at: Some(Utc::now() - ChronoDuration::hours(2)),
             disk_free_bytes: Some(42 * 1024 * 1024 * 1024),
+            conditions: vec![HostCondition::builder()
+                .condition_type("Controller/checkout")
+                .value(ConditionValue::False)
+                .reason("RestartBudgetExhausted")
+                .message("checkout controller stopped after 10 consecutive failures")
+                .observed_at(Utc::now())
+                .build()],
             ..HostStatus::default()
         })
         .await
@@ -1918,6 +1925,7 @@ async fn fleet_health_keeps_link_heartbeat_and_generation_disagreements_visible(
     assert_eq!(feta.convoy_count, 1);
     assert_eq!(feta.staleness, FleetHostStaleness::Stale);
     assert_eq!(feta.observation_agreement, FleetObservationAgreement::Disagree);
+    assert_eq!(feta.degraded_conditions, vec!["Controller/checkout: checkout controller stopped after 10 consecutive failures"]);
 
     let udder = response.hosts.iter().find(|row| row.host == HostName::new("udder")).expect("unreachable configured host row");
     assert_eq!(udder.link, PeerConnectionState::Disconnected);

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -31,11 +31,11 @@ use flotilla_core::{
         ChannelLabel, CommandRunner,
     },
 };
-use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, TerminalStatus};
+use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, Rows, TerminalStatus};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance,
-    CheckoutIntegrationStatus, Clone, CloneSpec, Convoy, ConvoyReconciler, ConvoyTeardownRuntime, CrewSource, CrewSpec, Demand,
-    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
+    CheckoutIntegrationStatus, Clone, CloneSpec, ConditionValue, Convoy, ConvoyReconciler, ConvoyTeardownRuntime, CrewSource, CrewSpec,
+    Demand, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host, HostCondition,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
     InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError,
     ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
@@ -48,7 +48,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     credential::CredentialStore,
     sleep_inhibitor,
-    supervisor::{supervise, ControllerSupervision},
+    supervisor::{supervise, ControllerSupervision, RestartBudgetExhausted},
     Aggregator, AggregatorResolvers,
 };
 
@@ -166,6 +166,45 @@ struct DaemonHealthIdentity {
     started_at: chrono::DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct RuntimeHealth {
+    failures: Arc<StdMutex<BTreeMap<String, HostCondition>>>,
+}
+
+impl RuntimeHealth {
+    fn report_restart_budget_exhausted(&self, exhausted: RestartBudgetExhausted) {
+        let condition_type = format!("Controller/{}", exhausted.controller);
+        let condition = HostCondition::builder()
+            .condition_type(condition_type.clone())
+            .value(ConditionValue::False)
+            .reason("RestartBudgetExhausted")
+            .message(format!(
+                "{} controller stopped after {} consecutive failures: {}",
+                exhausted.controller, exhausted.attempts, exhausted.error
+            ))
+            .observed_at(Utc::now())
+            .build();
+        self.failures.lock().expect("runtime health lock poisoned").insert(condition_type, condition);
+    }
+
+    fn report_projection_parity(&self, condition: Option<HostCondition>) {
+        const CONDITION_TYPE: &str = "ProjectionParity";
+        let mut failures = self.failures.lock().expect("runtime health lock poisoned");
+        match condition {
+            Some(condition) => {
+                failures.insert(CONDITION_TYPE.to_string(), condition);
+            }
+            None => {
+                failures.remove(CONDITION_TYPE);
+            }
+        }
+    }
+
+    fn conditions(&self) -> Vec<HostCondition> {
+        self.failures.lock().expect("runtime health lock poisoned").values().cloned().collect()
+    }
+}
+
 #[cfg(test)]
 fn test_health_identity() -> DaemonHealthIdentity {
     DaemonHealthIdentity {
@@ -218,12 +257,14 @@ impl DaemonRuntime {
             started_at: Utc::now(),
         };
         daemon.set_local_placement_capabilities(&profile.available_agent_adapters, &profile.available_pools).await;
+        let runtime_health = RuntimeHealth::default();
         register_startup_resources(&daemon, &options.namespace, &profile).await?;
         flotilla_resources::PreparedSnapshotGarbageCollector::new(daemon.resource_backend(), &options.namespace)
             .recover_pending_claims()
             .await
             .map_err(|error| format!("recover prepared convoy admissions: {error}"))?;
-        apply_host_heartbeat_with_credentials(&daemon, &options.namespace, &profile, Some(&credential_store), &health).await?;
+        apply_host_heartbeat_with_credentials(&daemon, &options.namespace, &profile, Some(&credential_store), &health, &runtime_health)
+            .await?;
         if let Err(error) = daemon.reconcile_adopted_checkouts(&options.namespace).await {
             warn!(%error, "failed to restore adopted checkout observations during startup; periodic reconciliation will retry");
         }
@@ -235,16 +276,30 @@ impl DaemonRuntime {
                 profile.clone(),
                 Arc::new(Some(Arc::clone(&credential_store))),
                 health,
+                runtime_health.clone(),
                 options.heartbeat_interval,
             ),
             spawn_replica_refresh_task(Arc::clone(&daemon), options.heartbeat_interval),
             spawn_adopted_checkout_reconciliation_task(Arc::clone(&daemon), options.namespace.clone(), options.controller_resync_interval),
-            spawn_sleep_inhibitor_task(daemon.resource_backend(), options.namespace.clone(), options.controller_supervision.clone()),
+            spawn_projection_parity_task(
+                daemon.resource_backend(),
+                options.namespace.clone(),
+                aggregator_projection_state.clone(),
+                runtime_health.clone(),
+                options.heartbeat_interval,
+            ),
+            spawn_sleep_inhibitor_task(
+                daemon.resource_backend(),
+                options.namespace.clone(),
+                options.controller_supervision.clone(),
+                runtime_health.clone(),
+            ),
             spawn_aggregator_task(
                 Arc::clone(&daemon),
                 options.namespace.clone(),
                 aggregator_projection_state,
                 options.controller_supervision.clone(),
+                runtime_health.clone(),
             ),
         ];
 
@@ -267,6 +322,7 @@ impl DaemonRuntime {
                 &options.namespace,
                 options.controller_resync_interval,
                 options.controller_supervision.clone(),
+                runtime_health,
             ));
         }
 
@@ -680,9 +736,24 @@ async fn ensure_default_policies(backend: &ResourceBackend, namespace: &str, pro
     Ok(())
 }
 
-fn spawn_sleep_inhibitor_task(backend: ResourceBackend, namespace: String, supervision: ControllerSupervision) -> JoinHandle<()> {
+async fn supervise_controller<F, Fut>(name: &'static str, supervision: ControllerSupervision, runtime_health: RuntimeHealth, make_run: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<(), ResourceError>>,
+{
+    if let Err(exhausted) = supervise(name, supervision, make_run).await {
+        runtime_health.report_restart_budget_exhausted(exhausted);
+    }
+}
+
+fn spawn_sleep_inhibitor_task(
+    backend: ResourceBackend,
+    namespace: String,
+    supervision: ControllerSupervision,
+    runtime_health: RuntimeHealth,
+) -> JoinHandle<()> {
     tokio::spawn(async move {
-        supervise("sleep_inhibitor", supervision, move || {
+        supervise_controller("sleep_inhibitor", supervision, runtime_health, move || {
             let convoys = backend.clone().using::<Convoy>(&namespace);
             async move { sleep_inhibitor::run(convoys).await }
         })
@@ -698,7 +769,7 @@ fn spawn_heartbeat_task(
     health: DaemonHealthIdentity,
     interval: Duration,
 ) -> JoinHandle<()> {
-    spawn_heartbeat_task_with_credentials(daemon, namespace, profile, Arc::new(None), health, interval)
+    spawn_heartbeat_task_with_credentials(daemon, namespace, profile, Arc::new(None), health, RuntimeHealth::default(), interval)
 }
 
 fn spawn_heartbeat_task_with_credentials(
@@ -707,6 +778,7 @@ fn spawn_heartbeat_task_with_credentials(
     profile: LocalProvisioningProfile,
     credential_store: Arc<Option<Arc<CredentialStore>>>,
     health: DaemonHealthIdentity,
+    runtime_health: RuntimeHealth,
     interval: Duration,
 ) -> JoinHandle<()> {
     spawn_periodic_task(interval, PeriodicTaskStart::Immediate, move || {
@@ -715,9 +787,11 @@ fn spawn_heartbeat_task_with_credentials(
         let profile = profile.clone();
         let credential_store = Arc::clone(&credential_store);
         let health = health.clone();
+        let runtime_health = runtime_health.clone();
         async move {
             if let Err(err) =
-                apply_host_heartbeat_with_credentials(&daemon, &namespace, &profile, credential_store.as_deref(), &health).await
+                apply_host_heartbeat_with_credentials(&daemon, &namespace, &profile, credential_store.as_deref(), &health, &runtime_health)
+                    .await
             {
                 warn!(%err, "failed to publish host heartbeat");
             }
@@ -732,7 +806,7 @@ async fn apply_host_heartbeat(
     profile: &LocalProvisioningProfile,
     health: &DaemonHealthIdentity,
 ) -> Result<(), String> {
-    apply_host_heartbeat_with_credentials(daemon, namespace, profile, None, health).await
+    apply_host_heartbeat_with_credentials(daemon, namespace, profile, None, health, &RuntimeHealth::default()).await
 }
 
 fn spawn_replica_refresh_task(daemon: Arc<InProcessDaemon>, interval: Duration) -> JoinHandle<()> {
@@ -756,6 +830,70 @@ fn spawn_adopted_checkout_reconciliation_task(daemon: Arc<InProcessDaemon>, name
             }
         }
     })
+}
+
+fn spawn_projection_parity_task(
+    backend: ResourceBackend,
+    namespace: String,
+    projection: AggregatorProjectionState,
+    runtime_health: RuntimeHealth,
+    interval: Duration,
+) -> JoinHandle<()> {
+    spawn_periodic_task(interval, PeriodicTaskStart::AfterInterval, move || {
+        let backend = backend.clone();
+        let namespace = namespace.clone();
+        let projection = projection.clone();
+        let runtime_health = runtime_health.clone();
+        async move {
+            match projection_parity_condition(&backend, &namespace, &projection).await {
+                Ok(condition) => runtime_health.report_projection_parity(condition),
+                Err(error) => warn!(%error, "failed to evaluate aggregator projection parity"),
+            }
+        }
+    })
+}
+
+async fn projection_parity_condition(
+    backend: &ResourceBackend,
+    namespace: &str,
+    projection: &AggregatorProjectionState,
+) -> Result<Option<HostCondition>, String> {
+    let stored = backend.using::<Convoy>(namespace).list().await.map_err(|error| error.to_string())?;
+    let expected = stored
+        .items
+        .into_iter()
+        .filter(|convoy| !convoy.status.as_ref().is_some_and(|status| status.phase.is_terminal()))
+        .map(|convoy| convoy.metadata.name)
+        .collect::<BTreeSet<_>>();
+    let projected = match projection.local_result_set().await.rows {
+        Rows::Convoys { rows, .. } => rows.into_iter().map(|row| row.resource.name).collect::<BTreeSet<_>>(),
+        rows => return Err(format!("local convoy projection returned unexpected rows: {rows:?}")),
+    };
+    let missing = expected.difference(&projected).cloned().collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(None);
+    }
+    let message = format!(
+        "durable store has {} live convoys but the local aggregator projection has {}; missing: {}",
+        expected.len(),
+        projected.len(),
+        missing.join(", ")
+    );
+    error!(
+        stored = expected.len(),
+        projected = projected.len(),
+        missing = ?missing,
+        "aggregator projection parity check failed"
+    );
+    Ok(Some(
+        HostCondition::builder()
+            .condition_type("ProjectionParity")
+            .value(ConditionValue::False)
+            .reason("LocalRowsMissing")
+            .message(message)
+            .observed_at(Utc::now())
+            .build(),
+    ))
 }
 
 #[derive(Clone, Copy)]
@@ -800,6 +938,7 @@ async fn apply_host_heartbeat_with_credentials(
     profile: &LocalProvisioningProfile,
     credential_store: Option<&CredentialStore>,
     health: &DaemonHealthIdentity,
+    runtime_health: &RuntimeHealth,
 ) -> Result<(), String> {
     ensure_host_exists(&daemon.resource_backend(), namespace, &profile.host_id).await?;
     let backend = daemon.resource_backend();
@@ -825,15 +964,17 @@ async fn apply_host_heartbeat_with_credentials(
     let disk_free_bytes = tokio::task::spawn_blocking(move || measure_available_space(&repo_default_dir))
         .await
         .map_err(|error| format!("measure available disk space: {error}"))?;
+    let conditions = runtime_health.conditions();
     let status = HostStatus {
         capabilities: host_capabilities(&summary, profile, &held_credentials),
         heartbeat_at: Some(Utc::now()),
-        ready: true,
+        ready: conditions.is_empty(),
         resource_store,
         daemon_generation: health.generation.clone(),
         daemon_version: Some(health.version.clone()),
         daemon_started_at: Some(health.started_at),
         disk_free_bytes,
+        conditions,
     };
     hosts.update_status(&profile.host_id, &host.metadata.resource_version, &status).await.map_err(|err| err.to_string())?;
     daemon.refresh_connected_peer_host_heartbeats().await;
@@ -858,6 +999,7 @@ fn spawn_controller_loops(
     namespace: &str,
     controller_resync_interval: Duration,
     supervision: ControllerSupervision,
+    runtime_health: RuntimeHealth,
 ) -> Vec<JoinHandle<()>> {
     let backend = state.daemon.resource_backend();
     let observed_backend = state.daemon.observed_resource_backend();
@@ -873,8 +1015,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let forge_default_branch_resolver = forge_default_branch_resolver.clone();
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("repository", supervision, move || {
+                supervise_controller("repository", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let observed_backend = observed_backend.clone();
                     let namespace_string = namespace_string.clone();
@@ -903,8 +1046,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let state = Arc::clone(&state);
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("environment", supervision, move || {
+                supervise_controller("environment", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let state = Arc::clone(&state);
@@ -928,8 +1072,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let state = Arc::clone(&state);
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("clone", supervision, move || {
+                supervise_controller("clone", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let runner = state.daemon.local_command_runner().expect("local runner should exist");
@@ -956,8 +1101,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let state = Arc::clone(&state);
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("checkout", supervision, move || {
+                supervise_controller("checkout", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let state = Arc::clone(&state);
@@ -986,8 +1132,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let state = Arc::clone(&state);
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("terminal_session", supervision, move || {
+                supervise_controller("terminal_session", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let state = Arc::clone(&state);
@@ -1015,8 +1162,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let config_dir = state.config.base_path().as_path().to_path_buf();
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("vessel", supervision, move || {
+                supervise_controller("vessel", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let config_dir = config_dir.clone();
@@ -1040,8 +1188,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let state = Arc::clone(&state);
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("presentation", supervision, move || {
+                supervise_controller("presentation", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let state = Arc::clone(&state);
@@ -1088,8 +1237,9 @@ fn spawn_controller_loops(
             let namespace_string = namespace_string.clone();
             let daemon = Arc::clone(&state.daemon);
             let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
             async move {
-                supervise("convoy", supervision, move || {
+                supervise_controller("convoy", supervision, runtime_health, move || {
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let daemon = Arc::clone(&daemon);
@@ -1124,11 +1274,12 @@ fn spawn_aggregator_task(
     namespace: String,
     state: AggregatorProjectionState,
     supervision: ControllerSupervision,
+    runtime_health: RuntimeHealth,
 ) -> JoinHandle<()> {
     let durable = daemon.resource_backend();
     let observed = daemon.observed_resource_backend();
     tokio::spawn(async move {
-        supervise("aggregator", supervision, move || {
+        supervise_controller("aggregator", supervision, runtime_health, move || {
             let daemon = Arc::clone(&daemon);
             let durable = durable.clone();
             let observed = observed.clone();
@@ -2874,6 +3025,63 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn projection_parity_reports_and_clears_missing_local_convoys() {
+        let backend = ResourceBackend::InMemory(Default::default());
+        backend
+            .using::<Convoy>(NAMESPACE)
+            .create(&empty_meta("convoy-a"), &ConvoySpec::builder().workflow_ref("workflow".to_string()).build())
+            .await
+            .expect("create durable convoy");
+        let projection = AggregatorProjectionState::new();
+
+        let degraded = projection_parity_condition(&backend, NAMESPACE, &projection)
+            .await
+            .expect("evaluate parity")
+            .expect("missing projection should degrade the host");
+        assert_eq!(degraded.condition_type, "ProjectionParity");
+        assert_eq!(degraded.reason, "LocalRowsMissing");
+        assert!(degraded.message.contains("convoy-a"));
+
+        let resource = flotilla_protocol::ResourceRef::new("flotilla.work/v1", "Convoy", NAMESPACE, "convoy-a");
+        projection.write().await.local_rows.insert(
+            resource.clone(),
+            flotilla_protocol::ConvoyRow::builder()
+                .resource(resource)
+                .name("convoy-a")
+                .workflow_ref("workflow")
+                .phase(flotilla_protocol::ConvoyPhase::Pending)
+                .build(),
+        );
+        assert!(
+            projection_parity_condition(&backend, NAMESPACE, &projection).await.expect("evaluate restored parity").is_none(),
+            "restored parity should clear the degraded condition"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_budget_exhaustion_is_recorded_in_runtime_health() {
+        let runtime_health = RuntimeHealth::default();
+        supervise_controller(
+            "checkout",
+            ControllerSupervision {
+                max_consecutive_failures: 1,
+                initial_backoff: Duration::ZERO,
+                max_backoff: Duration::ZERO,
+                success_reset_after: Duration::from_secs(60),
+            },
+            runtime_health.clone(),
+            || async { Err(ResourceError::other("root-owned debris")) },
+        )
+        .await;
+
+        let conditions = runtime_health.conditions();
+        assert_eq!(conditions.len(), 1);
+        assert_eq!(conditions[0].condition_type, "Controller/checkout");
+        assert_eq!(conditions[0].reason, "RestartBudgetExhausted");
+        assert!(conditions[0].message.contains("root-owned debris"));
+    }
+
     async fn daemon_with_backend(tracked_repos: Vec<PathBuf>, config: Arc<ConfigStore>, backend: ResourceBackend) -> Arc<InProcessDaemon> {
         daemon_with_backend_and_runner(tracked_repos, config, backend, Arc::new(NoPrProcessRunner)).await
     }
@@ -2986,8 +3194,13 @@ mod tests {
             Some(ExecutionEnvironmentPath::new(&repo)),
             profile.host_direct_environment_name(),
         ));
-        let controller_handles =
-            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(25), ControllerSupervision::default());
+        let controller_handles = spawn_controller_loops(
+            Arc::clone(&state),
+            NAMESPACE,
+            Duration::from_millis(25),
+            ControllerSupervision::default(),
+            RuntimeHealth::default(),
+        );
 
         backend
             .clone()
@@ -3710,8 +3923,13 @@ mod tests {
             Some(ExecutionEnvironmentPath::new(&repo)),
             profile.host_direct_environment_name(),
         ));
-        let controller_handles =
-            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(20), ControllerSupervision::default());
+        let controller_handles = spawn_controller_loops(
+            Arc::clone(&state),
+            NAMESPACE,
+            Duration::from_millis(20),
+            ControllerSupervision::default(),
+            RuntimeHealth::default(),
+        );
 
         backend
             .clone()
@@ -3964,8 +4182,13 @@ mod tests {
             Some(ExecutionEnvironmentPath::new(&repo)),
             profile.host_direct_environment_name(),
         ));
-        let controller_handles =
-            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(20), ControllerSupervision::default());
+        let controller_handles = spawn_controller_loops(
+            Arc::clone(&state),
+            NAMESPACE,
+            Duration::from_millis(20),
+            ControllerSupervision::default(),
+            RuntimeHealth::default(),
+        );
         wait_until(|| {
             let terminals = terminals.clone();
             let name = coder.metadata.name.clone();
@@ -4178,8 +4401,13 @@ mod tests {
             Some(ExecutionEnvironmentPath::new(&repo)),
             profile.host_direct_environment_name(),
         ));
-        let controller_handles =
-            spawn_controller_loops(Arc::clone(&state), NAMESPACE, Duration::from_millis(25), ControllerSupervision::default());
+        let controller_handles = spawn_controller_loops(
+            Arc::clone(&state),
+            NAMESPACE,
+            Duration::from_millis(25),
+            ControllerSupervision::default(),
+            RuntimeHealth::default(),
+        );
 
         backend
             .clone()

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -378,6 +378,10 @@ pub(super) async fn replicate_kind_over_http<T: Resource>(
     let remote = ResourceBackend::Http(http).using::<T>(REPLICATION_NAMESPACE);
     let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
     let mut listed = remote.list().await.map_err(|error| error.to_string())?;
+    // Validate the persisted cache before trusting its cursor. The SQLite
+    // backend quarantines an undecodable replica partition and removes this
+    // cursor, turning a cache schema mismatch into the full relist below.
+    daemon.resource_backend().including_replicas::<T>(REPLICATION_NAMESPACE).list().await.map_err(|error| error.to_string())?;
     let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
     if let Some(cursor) = cursor.clone().filter(|cursor| cursor.generation == listed.generation) {
         let start = match cursor.generation {
@@ -433,6 +437,7 @@ async fn replicate_kind_over_routed_watch<T: Resource>(
     peer: &NodeId,
 ) -> Result<(), String> {
     let writer = daemon.resource_backend().replica_writer::<T>(peer.clone(), REPLICATION_NAMESPACE);
+    daemon.resource_backend().including_replicas::<T>(REPLICATION_NAMESPACE).list().await.map_err(|error| error.to_string())?;
     let cursor = writer.cursor().await.map_err(|error| error.to_string())?;
     match run_routed_watch::<T>(router, daemon, peer, cursor.clone()).await {
         Ok(()) => Ok(()),

--- a/crates/flotilla-daemon/src/supervisor.rs
+++ b/crates/flotilla-daemon/src/supervisor.rs
@@ -6,6 +6,13 @@ use std::{future::Future, time::Duration};
 use flotilla_resources::ResourceError;
 use tracing::{error, warn};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestartBudgetExhausted {
+    pub controller: &'static str,
+    pub error: ResourceError,
+    pub attempts: usize,
+}
+
 /// Bounded restart + exponential backoff config for [`supervise`].
 #[derive(Debug, Clone)]
 pub struct ControllerSupervision {
@@ -36,7 +43,7 @@ impl Default for ControllerSupervision {
 ///
 /// Returns when the controller returns `Ok(())` (clean shutdown — all watch
 /// streams closed) or when the consecutive-failure budget is exhausted.
-pub async fn supervise<F, Fut>(name: &'static str, config: ControllerSupervision, mut make_run: F)
+pub async fn supervise<F, Fut>(name: &'static str, config: ControllerSupervision, mut make_run: F) -> Result<(), RestartBudgetExhausted>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<(), ResourceError>>,
@@ -46,7 +53,7 @@ where
     loop {
         let started_at = tokio::time::Instant::now();
         match make_run().await {
-            Ok(()) => return,
+            Ok(()) => return Ok(()),
             Err(err) => {
                 if started_at.elapsed() >= config.success_reset_after {
                     consecutive_failures = 0;
@@ -60,7 +67,7 @@ where
                         attempts = consecutive_failures,
                         "controller exhausted restart budget; provisioning disabled until daemon restart",
                     );
-                    return;
+                    return Err(RestartBudgetExhausted { controller: name, error: err, attempts: consecutive_failures });
                 }
                 warn!(
                     controller = name,
@@ -107,7 +114,8 @@ mod tests {
                 }
             }
         })
-        .await;
+        .await
+        .expect("clean run should not exhaust its budget");
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
@@ -128,14 +136,15 @@ mod tests {
                 }
             }
         })
-        .await;
+        .await
+        .expect("eventually successful run should not exhaust its budget");
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 
     #[tokio::test]
     async fn supervise_gives_up_after_max_consecutive_failures() {
         let attempts = Arc::new(AtomicUsize::new(0));
-        supervise("test", fast_config(2), {
+        let exhausted = supervise("test", fast_config(2), {
             let attempts = Arc::clone(&attempts);
             move || {
                 let attempts = Arc::clone(&attempts);
@@ -145,9 +154,13 @@ mod tests {
                 }
             }
         })
-        .await;
+        .await
+        .expect_err("permanent failure should exhaust its budget");
         // Budget of 2 means: 1st failure (cf=1, 1>=2 false) retries; 2nd (cf=2, 2>=2) gives up.
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(exhausted.controller, "test");
+        assert_eq!(exhausted.attempts, 2);
+        assert_eq!(exhausted.error, ResourceError::other("permanent"));
     }
 
     #[tokio::test]
@@ -176,7 +189,8 @@ mod tests {
                 }
             }
         })
-        .await;
+        .await
+        .expect_err("third failure should exhaust the reset budget");
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 }

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -227,6 +227,9 @@ pub struct FleetHostRow {
     pub disk_free_bytes: Option<u64>,
     pub staleness: FleetHostStaleness,
     pub observation_agreement: FleetObservationAgreement,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub degraded_conditions: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -3,7 +3,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, retention::ResourceStoreDiagnostics, status_patch::StatusPatch, ReplicationClass};
+use crate::{
+    checkout::ConditionValue, resource::define_resource, retention::ResourceStoreDiagnostics, status_patch::StatusPatch, ReplicationClass,
+};
 
 define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
 
@@ -33,6 +35,9 @@ pub struct HostStatus {
     pub daemon_started_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disk_free_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub conditions: Vec<HostCondition>,
 }
 
 impl HostStatus {
@@ -46,10 +51,30 @@ impl HostStatus {
 
     pub fn apply_heartbeat_readiness(&mut self, now: DateTime<Utc>) {
         self.ready = self.ready
+            && !self.is_degraded()
             && self
                 .heartbeat_at
                 .is_some_and(|heartbeat_at| now.signed_duration_since(heartbeat_at) <= chrono::Duration::seconds(HEARTBEAT_READY_TTL_SECS));
     }
+
+    pub fn is_degraded(&self) -> bool {
+        self.conditions.iter().any(|condition| condition.value == ConditionValue::False)
+    }
+}
+
+/// A daemon-owned liveness invariant published on its [`Host`] resource.
+///
+/// `True` means the named subsystem is healthy; `False` makes the host
+/// degraded and unavailable for placement until a later observation clears it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[builder(on(String, into))]
+pub struct HostCondition {
+    #[serde(rename = "type")]
+    pub condition_type: String,
+    pub value: ConditionValue,
+    pub reason: String,
+    pub message: String,
+    pub observed_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -86,5 +111,33 @@ impl StatusPatch<HostStatus> for HostStatusPatch {
                 status.disk_free_bytes = *disk_free_bytes;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_host_condition_makes_fresh_heartbeat_not_ready() {
+        let now = Utc::now();
+        let mut status = HostStatus {
+            heartbeat_at: Some(now),
+            ready: true,
+            conditions: vec![HostCondition::builder()
+                .condition_type("Controller/checkout")
+                .value(ConditionValue::False)
+                .reason("RestartBudgetExhausted")
+                .message("checkout controller stopped")
+                .observed_at(now)
+                .build()],
+            ..HostStatus::default()
+        };
+
+        status.apply_heartbeat_readiness(now);
+
+        assert!(!status.ready);
+        let encoded = serde_json::to_value(&status).expect("serialize host status");
+        assert_eq!(encoded["conditions"][0]["type"], "Controller/checkout");
     }
 }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -56,8 +56,8 @@ pub use environment::{
 pub use error::ResourceError;
 pub use flotilla_protocol::PrincipalRef;
 pub use host::{
-    Host, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY, HEARTBEAT_READY_TTL_SECS, HELD_CREDENTIALS_CAPABILITY,
-    TERMINAL_POOLS_CAPABILITY,
+    Host, HostCondition, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY, HEARTBEAT_READY_TTL_SECS,
+    HELD_CREDENTIALS_CAPABILITY, TERMINAL_POOLS_CAPABILITY,
 };
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -465,7 +465,7 @@ impl SqliteBackend {
             let mut statement = connection
                 .prepare(
                     r#"
-                    SELECT o.origin_root, o.last_synced_at, o.body_json
+                    SELECT o.origin_root, o.name, o.last_synced_at, o.body_json
                     FROM replica_objects o
                     WHERE o.group_name = ?1 AND o.version = ?2 AND o.kind = ?3 AND o.namespace = ?4
                     ORDER BY o.origin_root, o.name
@@ -474,23 +474,62 @@ impl SqliteBackend {
                 .map_err(|err| Self::map_sqlite(err, "prepare sqlite replica list"))?;
             let rows = statement
                 .query_map(params![key.0, key.1, key.2, key.3], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?, row.get::<_, String>(3)?))
                 })
                 .map_err(|err| Self::map_sqlite(err, "query sqlite replica list"))?;
+            let rows = rows.collect::<Result<Vec<_>, _>>().map_err(|err| Self::map_sqlite(err, "read sqlite replica list row"))?;
+            drop(statement);
+
             let mut items = Vec::new();
-            for row in rows {
-                let (origin_root, last_synced_at, body) = row.map_err(|err| Self::map_sqlite(err, "read sqlite replica list row"))?;
-                let value =
-                    serde_json::from_str(&body).map_err(|err| ResourceError::decode(format!("decode replica object JSON: {err}")))?;
-                let last_synced_at = DateTime::parse_from_rfc3339(&last_synced_at)
-                    .map_err(|err| ResourceError::decode(format!("decode replica sync timestamp: {err}")))?
-                    .with_timezone(&Utc);
-                items.push(ReadResourceObject {
-                    object: Self::decode_object(value)?,
-                    provenance: ResourceProvenance::Replica { origin_root: NodeId::new(origin_root), last_synced_at },
-                });
+            let mut invalid_partitions = BTreeMap::<String, Vec<(String, String)>>::new();
+            for (origin_root, name, last_synced_at, body) in rows {
+                let identity = format!("kind={} namespace={} name={} origin={}", T::API_PATHS.kind, key.3, name, origin_root);
+                let decoded = serde_json::from_str(&body)
+                    .map_err(|err| format!("decode cached replica object {identity}: {err}"))
+                    .and_then(|value| Self::decode_object(value).map_err(|err| format!("decode cached replica object {identity}: {err}")))
+                    .and_then(|object| {
+                        DateTime::parse_from_rfc3339(&last_synced_at)
+                            .map(|last_synced_at| (object, last_synced_at.with_timezone(&Utc)))
+                            .map_err(|err| format!("decode cached replica sync timestamp {identity}: {err}"))
+                    });
+                match decoded {
+                    Ok((object, last_synced_at)) => items.push((origin_root.clone(), ReadResourceObject {
+                        object,
+                        provenance: ResourceProvenance::Replica { origin_root: NodeId::new(origin_root), last_synced_at },
+                    })),
+                    Err(error) => invalid_partitions.entry(origin_root).or_default().push((name, error)),
+                }
             }
-            Ok(items)
+            if !invalid_partitions.is_empty() {
+                let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin invalid replica cache cleanup"))?;
+                for (origin_root, failures) in &invalid_partitions {
+                    for table in ["replica_objects", "replica_tombstones", "replica_cursors"] {
+                        tx.execute(
+                            &format!(
+                                "DELETE FROM {table}
+                                 WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5"
+                            ),
+                            params![origin_root, key.0, key.1, key.2, key.3],
+                        )
+                        .map_err(|err| Self::map_sqlite(err, "drop undecodable sqlite replica partition"))?;
+                    }
+                    for (name, error) in failures {
+                        tracing::warn!(
+                            origin = %origin_root,
+                            kind = T::API_PATHS.kind,
+                            namespace = %key.3,
+                            %name,
+                            %error,
+                            "dropping undecodable cached replica partition; origin will be fully resynced"
+                        );
+                    }
+                }
+                tx.commit().map_err(|err| Self::map_sqlite(err, "commit invalid replica cache cleanup"))?;
+            }
+            Ok(items
+                .into_iter()
+                .filter_map(|(origin_root, item)| (!invalid_partitions.contains_key(&origin_root)).then_some(item))
+                .collect())
         })
         .await
     }

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -233,6 +233,45 @@ async fn replica_rows_and_cursor_survive_backend_restart() {
 }
 
 #[tokio::test]
+async fn undecodable_replica_partition_is_dropped_and_forces_full_resync() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("resources.sqlite");
+    let origin = flotilla_protocol::NodeId::new("feta-root");
+    let source = ResourceBackend::InMemory(InMemoryBackend::default());
+    source.using::<Convoy>("flotilla").create(&convoy_meta("remote"), &convoy_spec("template")).await.expect("create source convoy");
+    let listed = source.using::<Convoy>("flotilla").list().await.expect("list source convoy");
+
+    {
+        let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("open sqlite backend"));
+        backend.replica_writer::<Convoy>(origin.clone(), "flotilla").replace(&listed, Utc::now()).await.expect("persist replica");
+    }
+    {
+        let connection = rusqlite::Connection::open(&path).expect("open raw sqlite connection");
+        connection
+            .execute("UPDATE replica_objects SET body_json = '{}' WHERE origin_root = ?1 AND name = ?2", rusqlite::params![
+                origin.to_string(),
+                "remote"
+            ])
+            .expect("corrupt cached replica");
+    }
+
+    let reopened = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("reopen sqlite backend"));
+    let replicas = reopened.including_replicas::<Convoy>("flotilla").list().await.expect("quarantine invalid replica cache");
+    assert!(replicas.items.is_empty(), "an invalid cache partition must contribute no partial rows");
+    assert!(
+        reopened.replica_writer::<Convoy>(origin.clone(), "flotilla").cursor().await.expect("read cursor").is_none(),
+        "dropping the cursor makes the replicator relist the origin"
+    );
+
+    reopened
+        .replica_writer::<Convoy>(origin, "flotilla")
+        .replace(&listed, Utc::now())
+        .await
+        .expect("full resync should repopulate the partition");
+    assert_eq!(reopened.including_replicas::<Convoy>("flotilla").list().await.expect("list resynced replica").items.len(), 1);
+}
+
+#[tokio::test]
 async fn replica_delete_tombstone_survives_backend_restart() {
     let directory = tempfile::tempdir().expect("tempdir");
     let path = directory.path().join("resources.sqlite");

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -198,10 +198,14 @@ pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> Strin
             FleetHostStaleness::Stale => "STALE",
             FleetHostStaleness::Unknown => "unknown",
         };
-        let diagnosis = match host.observation_agreement {
-            FleetObservationAgreement::Agree => "agree",
-            FleetObservationAgreement::Disagree => "⚠ DISAGREE",
-            FleetObservationAgreement::Unknown => "unknown",
+        let diagnosis = if !host.degraded_conditions.is_empty() {
+            format!("⚠ DEGRADED: {}", host.degraded_conditions.join("; "))
+        } else {
+            match host.observation_agreement {
+                FleetObservationAgreement::Agree => "agree".to_string(),
+                FleetObservationAgreement::Disagree => "⚠ DISAGREE".to_string(),
+                FleetObservationAgreement::Unknown => "unknown".to_string(),
+            }
         };
         table.add_row(vec![
             Cell::new(name),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -692,6 +692,29 @@ mod command_result_human {
     }
 
     #[test]
+    fn fleet_health_shows_degraded_host_conditions() {
+        let result = CommandValue::FleetHealth(Box::new(FleetHealthResponse {
+            hosts: vec![FleetHostRow::builder()
+                .host(HostName::new("feta"))
+                .is_local(false)
+                .configured(true)
+                .link(PeerConnectionState::Connected)
+                .crew_count(0)
+                .convoy_count(4)
+                .staleness(FleetHostStaleness::Current)
+                .observation_agreement(FleetObservationAgreement::Agree)
+                .degraded_conditions(vec!["Controller/checkout: checkout controller stopped after 10 consecutive failures".to_string()])
+                .build()],
+        }));
+
+        let output = format_command_result(&result);
+
+        assert!(output.contains("⚠ DEGRADED"), "expected degraded diagnosis:\n{output}");
+        assert!(output.contains("Controller/checkout"), "expected named controller condition:\n{output}");
+        assert!(output.contains("10 consecutive failures"), "expected condition detail:\n{output}");
+    }
+
+    #[test]
     fn fleet_list_shows_crewless_failed_convoy() {
         let result = CommandValue::FleetList(Box::new(FleetListResponse {
             rows: vec![FleetListRow::builder()

--- a/crates/flotilla-tui/src/widgets/event_log.rs
+++ b/crates/flotilla-tui/src/widgets/event_log.rs
@@ -387,15 +387,16 @@ fn short_generation(generation: Option<&str>) -> String {
 fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame, area: Rect) {
     let now = Utc::now();
     let rows = hosts.iter().map(|host| {
+        let degraded = !host.degraded_conditions.is_empty();
         let disagreement = host.observation_agreement == FleetObservationAgreement::Disagree;
-        let icon = if disagreement {
+        let icon = if degraded || disagreement {
             "⚠"
         } else if host.staleness == FleetHostStaleness::Current {
             "●"
         } else {
             "○"
         };
-        let style = if disagreement {
+        let style = if degraded || disagreement {
             Style::default().fg(theme.warning)
         } else if host.staleness == FleetHostStaleness::Current {
             Style::default().fg(theme.status_ok)
@@ -419,10 +420,14 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
         let replica = format!("{} {}", fleet_age(host.replica_last_sync, now), short_generation(host.replica_generation.as_deref()));
         let disk =
             host.disk_free_bytes.map_or_else(|| "-".to_string(), |bytes| format!("{:.1}G", bytes as f64 / (1024.0 * 1024.0 * 1024.0)));
-        let stale = match host.staleness {
-            FleetHostStaleness::Current => "current",
-            FleetHostStaleness::Stale => "STALE",
-            FleetHostStaleness::Unknown => "unknown",
+        let stale = if degraded {
+            "DEGRADED"
+        } else {
+            match host.staleness {
+                FleetHostStaleness::Current => "current",
+                FleetHostStaleness::Stale => "STALE",
+                FleetHostStaleness::Unknown => "unknown",
+            }
         };
         Row::new(vec![
             Cell::from(Span::styled(icon, style)),


### PR DESCRIPTION
## Summary

- publish failed controller supervision and projection parity as degraded Host conditions
- surface degraded conditions in `fleet health` and the TUI fleet view
- quarantine undecodable persisted replica partitions, discard their cursors, and force a full origin relist
- name cached-object decode failures with kind, namespace, name, and origin

## Root cause

The aggregator's initial replica-inclusive list decoded an obsolete cached Convoy and returned an error for the whole source. Its bounded supervisor eventually exhausted the restart budget, but that terminal state existed only in logs. The healthy peer half of the projection remained visible, masking the dead local pump.

Replica data is rebuildable cache state. This change validates it before a replicator trusts its stored cursor; an undecodable partition is atomically removed with its cursor and tombstones so the origin is fully resynced.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1190
