### PR TITLE
fix: reconcile whole-repository projects

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -45,8 +45,8 @@ use flotilla_resources::{
     ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
     TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
-    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, ROLE_LABEL,
-    VESSEL_LABEL, VESSEL_REF_LABEL,
+    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL,
+    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -3451,6 +3451,48 @@ fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: St
     })
 }
 
+const WHOLE_REPOSITORY_PROJECT_MANAGED_BY_VALUE: &str = "whole-repository-project";
+
+fn whole_repository_project_meta(name: impl Into<String>) -> InputMeta {
+    InputMeta::builder()
+        .name(name.into())
+        .labels(BTreeMap::from([(MANAGED_BY_LABEL.to_string(), WHOLE_REPOSITORY_PROJECT_MANAGED_BY_VALUE.to_string())]))
+        .build()
+}
+
+/// Converges the fields owned by the whole-repository generator while leaving
+/// user-owned presentation and issue-routing fields intact.
+async fn reconcile_whole_repository_project_definition(
+    projects: &flotilla_resources::DefinitionResolver<Project>,
+    existing: ResourceObject<Project>,
+    generated: &ProjectSpec,
+) -> Result<ResourceObject<Project>, String> {
+    let generator_fields_diverged =
+        existing.spec.default_workflow_ref != generated.default_workflow_ref || existing.spec.repositories != generated.repositories;
+    let managed_by_generator =
+        existing.metadata.labels.get(MANAGED_BY_LABEL).is_some_and(|value| value == WHOLE_REPOSITORY_PROJECT_MANAGED_BY_VALUE);
+    if !generator_fields_diverged && managed_by_generator {
+        return Ok(existing);
+    }
+
+    let mut reconciled_spec = existing.spec.clone();
+    reconciled_spec.default_workflow_ref.clone_from(&generated.default_workflow_ref);
+    reconciled_spec.repositories.clone_from(&generated.repositories);
+    let mut meta = InputMeta::from(&existing.metadata);
+    meta.labels.insert(MANAGED_BY_LABEL.to_string(), WHOLE_REPOSITORY_PROJECT_MANAGED_BY_VALUE.to_string());
+    let reconciled = projects
+        .apply(&meta, &reconciled_spec)
+        .await
+        .map_err(|error| format!("reconcile generated whole-repository Project {}: {error}", existing.metadata.name))?;
+    if generator_fields_diverged {
+        warn!(
+            project = %existing.metadata.name,
+            "stored generator-owned whole-repository Project fields diverged; overwriting"
+        );
+    }
+    Ok(reconciled)
+}
+
 fn is_whole_repository_project(spec: &ProjectSpec, repository_key: &RepositoryKey) -> bool {
     matches!(
         spec.repositories.as_slice(),
@@ -4493,6 +4535,8 @@ impl InProcessDaemon {
                         existing.spec.display_name
                     ));
                 }
+                let generated = whole_repository_project_spec(key, existing.spec.display_name.clone())?;
+                reconcile_whole_repository_project_definition(&projects, existing, &generated).await?;
                 return Ok(project_name);
             }
             Err(ResourceError::NotFound { .. }) => {}
@@ -4500,7 +4544,7 @@ impl InProcessDaemon {
         }
 
         let spec = whole_repository_project_spec(key, explicit_display_name.map(str::to_string).unwrap_or(default_name))?;
-        projects.apply(&InputMeta::builder().name(project_name.clone()).build(), &spec).await.map_err(|error| error.to_string())?;
+        projects.apply(&whole_repository_project_meta(project_name.clone()), &spec).await.map_err(|error| error.to_string())?;
         Ok(project_name)
     }
 
@@ -4614,6 +4658,11 @@ impl InProcessDaemon {
             })
             .map(|project| project.metadata.name.clone());
         if let Some(primary_name) = &primary_name {
+            let primary = project_objects
+                .iter_mut()
+                .find(|project| project.metadata.name == *primary_name)
+                .expect("selected primary Project should remain in the listed objects");
+            *primary = reconcile_whole_repository_project_definition(&projects, primary.clone(), &spec).await?;
             for duplicate in project_objects.iter().filter(|project| {
                 project.metadata.name != *primary_name
                     && generated_names.contains(&project.metadata.name)
@@ -4666,11 +4715,12 @@ impl InProcessDaemon {
         }
 
         for project_name in whole_repository_project_names(repository_spec)? {
-            match projects.create(&InputMeta::builder().name(project_name.clone()).build(), &spec).await {
+            match projects.create(&whole_repository_project_meta(project_name.clone()), &spec).await {
                 Ok(_) => return Ok(identity_change),
                 Err(ResourceError::Conflict { .. }) => {
                     let existing = projects.get(&project_name).await.map_err(|error| error.to_string())?;
                     if is_whole_repository_project(&existing.spec, &repository_key) {
+                        reconcile_whole_repository_project_definition(&projects, existing, &spec).await?;
                         return Ok(identity_change);
                     }
                 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -7456,8 +7456,13 @@ impl InProcessDaemon {
             let result = match validate_project_name(name).and_then(|_| parse_project_yaml(spec_yaml)) {
                 Ok(spec) => match normalize_project_spec(spec) {
                     Ok(spec) => {
-                        let meta = InputMeta::builder().name(name.clone()).build();
-                        let outcome = projects.apply(&meta, &spec).await.map(|_| ());
+                        let outcome = match projects.get(name).await {
+                            Ok(existing) => projects.apply(&InputMeta::from(&existing.metadata), &spec).await.map(|_| ()),
+                            Err(ResourceError::NotFound { .. }) => {
+                                projects.apply(&InputMeta::builder().name(name.clone()).build(), &spec).await.map(|_| ())
+                            }
+                            Err(error) => Err(error),
+                        };
                         match outcome {
                             Ok(()) => flotilla_protocol::CommandValue::ProjectApplied { name: name.clone() },
                             Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -1116,6 +1116,61 @@ repositories:
 }
 
 #[tokio::test]
+async fn project_apply_preserves_existing_metadata() {
+    let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
+    let projects = backend.definitions::<Project>("flotilla");
+    projects
+        .create(
+            &InputMeta::builder()
+                .name("labelled".to_string())
+                .labels(BTreeMap::from([
+                    (MANAGED_BY_LABEL.to_string(), "whole-repository-project".to_string()),
+                    ("example.com/preserved".to_string(), "true".to_string()),
+                ]))
+                .annotations(BTreeMap::from([("example.com/note".to_string(), "keep".to_string())]))
+                .build(),
+            &ProjectSpec::builder()
+                .display_name("Before".to_string())
+                .default_workflow_ref("single-agent-trusted".to_string())
+                .repositories(vec![flotilla_resources::ProjectRepositorySpec {
+                    repo: RepositoryKey("repository".to_string()),
+                    subpath: None,
+                    default_branch: None,
+                }])
+                .build(),
+        )
+        .await
+        .expect("labelled Project should be created");
+    let mut rx = daemon.subscribe();
+    let yaml = r#"
+display_name: After
+default_workflow_ref: single-agent-trusted
+issue_source:
+  service: https://linear.app
+  scope: KEEP
+repositories:
+  - repo: repository
+"#;
+
+    let id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ProjectApply { name: "labelled".into(), spec_yaml: yaml.into() },
+        })
+        .await
+        .expect("execute");
+
+    assert_eq!(await_command_result(&mut rx, id).await, CommandValue::ProjectApplied { name: "labelled".into() });
+    let project = projects.get("labelled").await.expect("Project should remain");
+    assert_eq!(project.spec.display_name, "After");
+    assert_eq!(project.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("whole-repository-project"));
+    assert_eq!(project.metadata.labels.get("example.com/preserved").map(String::as_str), Some("true"));
+    assert_eq!(project.metadata.annotations.get("example.com/note").map(String::as_str), Some("keep"));
+}
+
+#[tokio::test]
 async fn convoy_create_carries_project_ref() {
     let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
     let mut rx = daemon.subscribe();

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -1,8 +1,10 @@
 //! Integration tests for ProjectAdd/ProjectApply and Project-backed convoy metadata.
 
 use std::{
+    collections::BTreeMap,
+    io,
     path::{Path, PathBuf},
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -18,8 +20,22 @@ use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{commands::RepositoryIdentityChange, Command, CommandAction, CommandValue, DaemonEvent, HostName, RepoSelector};
 use flotilla_resources::{
     Checkout, CheckoutSpec, Convoy, InMemoryBackend, InputMeta, IssueSource, ObservedCheckoutSpec, Project, ProjectSpec, Repository,
-    RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend,
+    RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend, MANAGED_BY_LABEL,
 };
+
+#[derive(Clone)]
+struct LogCaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for LogCaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("log capture lock should be healthy").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
 
 fn test_config(dir: PathBuf) -> Arc<ConfigStore> {
     std::fs::create_dir_all(&dir).expect("create config dir");
@@ -179,11 +195,129 @@ async fn tracking_repo_materializes_whole_repo_project() {
     let project = backend.using::<Project>("flotilla").get("tracked").await.expect("whole-repository project should exist");
     assert_eq!(project.spec.display_name, "tracked");
     assert_eq!(project.spec.default_workflow_ref, "single-agent-trusted");
+    assert_eq!(project.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("whole-repository-project"));
     assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
         repo: repository_key,
         subpath: None,
         default_branch: None,
     }]);
+}
+
+#[tokio::test]
+async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_custom_fields() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let checkout_path = tmp.path().join("tracked");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let repository_spec = RepositorySpec::remote("https://github.com/org/tracked.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![checkout_path],
+        config,
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec, host_ref: "host-01".to_string() })).await;
+
+    let projects = backend.definitions::<Project>("flotilla");
+    projects
+        .create(
+            &InputMeta::builder()
+                .name("tracked".to_string())
+                .labels(BTreeMap::from([("example.com/preserved".to_string(), "true".to_string())]))
+                .build(),
+            &ProjectSpec::builder()
+                .display_name("My Tracked Repository".to_string())
+                .default_workflow_ref("single-agent-contained".to_string())
+                .maybe_issue_source(Some(IssueSource { service: "https://linear.app".to_string(), scope: "TRACK".to_string() }))
+                .repositories(vec![flotilla_resources::ProjectRepositorySpec {
+                    repo: repository_key,
+                    subpath: None,
+                    default_branch: Some("release".to_string()),
+                }])
+                .build(),
+        )
+        .await
+        .expect("stale whole-repository Project should be created");
+
+    let log_output = Arc::new(Mutex::new(Vec::new()));
+    {
+        let writer = LogCaptureWriter(Arc::clone(&log_output));
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_target(false)
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(move || writer.clone())
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+        daemon.materialize_tracked_repo_projects().await.expect("tracked Project reconciliation should succeed");
+    }
+
+    let reconciled = projects.get("tracked").await.expect("tracked Project should remain");
+    assert_eq!(reconciled.spec.display_name, "My Tracked Repository");
+    assert_eq!(reconciled.spec.issue_source, Some(IssueSource { service: "https://linear.app".to_string(), scope: "TRACK".to_string() }));
+    assert_eq!(reconciled.spec.default_workflow_ref, "single-agent-trusted");
+    assert_eq!(reconciled.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
+        repo: RepositorySpec::remote("https://github.com/org/tracked.git").expect("repository spec").key(),
+        subpath: None,
+        default_branch: None,
+    }]);
+    assert_eq!(reconciled.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("whole-repository-project"));
+    assert_eq!(reconciled.metadata.labels.get("example.com/preserved").map(String::as_str), Some("true"));
+    let logs = String::from_utf8(log_output.lock().expect("log capture lock should be healthy").clone()).expect("logs should be utf-8");
+    assert!(logs.contains("stored generator-owned whole-repository Project fields diverged; overwriting"), "{logs}");
+    assert!(logs.contains("tracked"), "{logs}");
+
+    daemon.materialize_tracked_repo_projects().await.expect("steady-state reconciliation should succeed");
+    let unchanged = projects.get("tracked").await.expect("tracked Project should remain");
+    assert_eq!(unchanged.metadata.resource_version, reconciled.metadata.resource_version);
+}
+
+#[tokio::test]
+async fn tracked_repo_labels_matching_unlabelled_project_once() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = test_config(tmp.path().join("config"));
+    let checkout_path = tmp.path().join("tracked");
+    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    let repository_spec = RepositorySpec::remote("https://github.com/org/tracked.git").expect("repository spec");
+    let repository_key = repository_spec.key();
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![checkout_path],
+        config,
+        fake_discovery(false),
+        HostName::new("local"),
+        backend.clone(),
+    )
+    .await;
+    daemon.set_repository_inspector(Arc::new(FixedInspector { spec: repository_spec.clone(), host_ref: "host-01".to_string() })).await;
+
+    let projects = backend.definitions::<Project>("flotilla");
+    projects
+        .create(
+            &InputMeta::builder().name("tracked".to_string()).build(),
+            &ProjectSpec::builder()
+                .display_name("tracked".to_string())
+                .default_workflow_ref("single-agent-trusted".to_string())
+                .repositories(vec![flotilla_resources::ProjectRepositorySpec { repo: repository_key, subpath: None, default_branch: None }])
+                .build(),
+        )
+        .await
+        .expect("matching unlabelled Project should be created");
+    let unlabelled = projects.get("tracked").await.expect("Project should exist");
+
+    daemon.materialize_tracked_repo_projects().await.expect("ownership reconciliation should succeed");
+    let labelled = projects.get("tracked").await.expect("Project should remain");
+    assert_ne!(labelled.metadata.resource_version, unlabelled.metadata.resource_version);
+    assert_eq!(labelled.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("whole-repository-project"));
+
+    daemon.materialize_tracked_repo_projects().await.expect("steady-state reconciliation should succeed");
+    let unchanged = projects.get("tracked").await.expect("Project should remain");
+    assert_eq!(unchanged.metadata.resource_version, labelled.metadata.resource_version);
 }
 
 #[tokio::test]
@@ -913,7 +1047,7 @@ async fn concurrent_project_adds_of_one_identity_converge_on_one_verified_reposi
 }
 
 #[tokio::test]
-async fn repeated_project_add_preserves_evolved_definition() {
+async fn repeated_project_add_reconciles_owned_fields_and_preserves_custom_fields() {
     let (daemon, backend, _config, _runtime, _tmp) = start_daemon().await;
     let spec = RepositorySpec::remote("https://github.com/org/repo.git").expect("repository spec");
     let key = spec.key();
@@ -941,7 +1075,11 @@ async fn repeated_project_add_preserves_evolved_definition() {
     assert_eq!(execute_project_add(&daemon, &mut rx, "repo".to_string(), Some("core"), None).await, CommandValue::ProjectAdded {
         name: "core".into()
     });
-    assert_eq!(projects.get("core").await.expect("project").spec, evolved);
+    let reconciled = projects.get("core").await.expect("project");
+    assert_eq!(reconciled.spec.display_name, "Evolved");
+    assert_eq!(reconciled.spec.issue_source, evolved.issue_source);
+    assert_eq!(reconciled.spec.default_workflow_ref, "single-agent-trusted");
+    assert_eq!(reconciled.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("whole-repository-project"));
     assert!(matches!(
         execute_project_add(&daemon, &mut rx, "repo".to_string(), Some("core"), Some("Contradiction")).await,
         CommandValue::Error { message } if message.contains("project apply")

--- a/crates/flotilla-resources/src/definition.rs
+++ b/crates/flotilla-resources/src/definition.rs
@@ -80,9 +80,12 @@ impl<T: Resource> DefinitionResolver<T> {
         let local_root = self.backend.local_root()?;
         let sources = self.sources_for_name(&meta.name).await?;
         let current = (!sources.is_empty()).then(|| merge_sources(&sources)).transpose()?;
+        let mut admitted_meta = meta.clone();
+        admitted_meta.deletion_timestamp = None;
         let requested = spec_object(spec)?;
         let current_spec = current.as_ref().map(|object| spec_object(&object.spec)).transpose()?;
-        let mut changed = current_spec.is_none();
+        let metadata_changed = current.as_ref().is_some_and(|object| InputMeta::from(&object.metadata) != admitted_meta);
+        let mut changed = current_spec.is_none() || metadata_changed;
         let mut merge = current.as_ref().and_then(|object| object.metadata.merge.clone()).unwrap_or_else(|| MergeMetadata {
             fields: BTreeMap::new(),
             seen: BTreeMap::new(),
@@ -123,8 +126,6 @@ impl<T: Resource> DefinitionResolver<T> {
         merge.seen.insert(local_root, next_counter);
         merge.conflicts.clear();
 
-        let mut admitted_meta = meta.clone();
-        admitted_meta.deletion_timestamp = None;
         match self.backend.using::<T>(&self.namespace).get(&meta.name).await {
             Ok(local) => match &self.backend {
                 ResourceBackend::InMemory(backend) => {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -350,6 +350,22 @@ pub async fn assert_project_definition_edit_converges_with_backend(backend: Reso
     assert!(converged_on_kiwi.metadata.merge.as_ref().expect("definition merge metadata").conflicts.is_empty());
 }
 
+pub async fn assert_project_definition_metadata_edit_converges_with_backend(backend: ResourceBackend) {
+    let backend = backend.with_local_root(flotilla_protocol::NodeId::new("local-root"));
+    let projects = backend.definitions::<Project>("flotilla");
+    let spec = project_spec("Widgets", "default");
+    let created = projects.apply(&InputMeta::builder().name("widgets".to_string()).build(), &spec).await.expect("create Project baseline");
+    let mut labelled_meta = InputMeta::from(&created.metadata);
+    labelled_meta.labels.insert("flotilla.work/managed-by".to_string(), "generator".to_string());
+
+    let labelled = projects.apply(&labelled_meta, &spec).await.expect("apply Project metadata");
+    assert_ne!(labelled.metadata.resource_version, created.metadata.resource_version);
+    assert_eq!(labelled.metadata.labels.get("flotilla.work/managed-by").map(String::as_str), Some("generator"));
+
+    let unchanged = projects.apply(&labelled_meta, &spec).await.expect("reapply matching Project metadata");
+    assert_eq!(unchanged.metadata.resource_version, labelled.metadata.resource_version);
+}
+
 pub async fn assert_project_definition_causal_merge_with_backend(backend: ResourceBackend) {
     let kiwi_root = flotilla_protocol::NodeId::new("kiwi-root");
     let feta_root = flotilla_protocol::NodeId::new("feta-root");

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -9,6 +9,7 @@ use common::{
         assert_metadata_roundtrip, assert_namespace_isolation, assert_project_definition_causal_merge_with_backend,
         assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
+        assert_project_definition_metadata_edit_converges_with_backend,
         assert_project_definition_optional_field_can_be_cleared_with_backend,
         assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
         assert_replica_events_ignore_stale_writes_and_deletes_with_backend, assert_replica_read_view_contract,
@@ -133,6 +134,11 @@ async fn replica_events_ignore_stale_writes_and_deletes() {
 #[tokio::test]
 async fn project_definition_edit_converges() {
     assert_project_definition_edit_converges_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn project_definition_metadata_edit_converges() {
+    assert_project_definition_metadata_edit_converges_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -15,6 +15,7 @@ use common::{
         assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
         assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
+        assert_project_definition_metadata_edit_converges_with_backend,
         assert_project_definition_optional_field_can_be_cleared_with_backend,
         assert_repeated_delete_with_pending_finalizers_is_noop_with_backend,
         assert_replica_events_ignore_stale_writes_and_deletes_with_backend, assert_replica_read_view_contract,
@@ -187,6 +188,11 @@ async fn replica_events_ignore_stale_writes_and_deletes() {
 #[tokio::test]
 async fn project_definition_edit_converges() {
     assert_project_definition_edit_converges_with_backend(backend()).await;
+}
+
+#[tokio::test]
+async fn project_definition_metadata_edit_converges() {
+    assert_project_definition_metadata_edit_converges_with_backend(backend()).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- reconcile generator-owned whole-repository Project fields during materialization and repeated project adds
- preserve user-owned display names, issue sources, and unrelated metadata while stamping explicit generator ownership
- make metadata-only definition applies converge once, then remain no-ops

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1199