### PR TITLE
fix: clean up zombie crew sessions

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
-    controller::{ReconcileOutcome, Reconciler},
-    Environment, EnvironmentPhase, ResourceBackend, ResourceError, ResourceObject, TerminalAttention, TerminalAttentionSource,
-    TerminalAttentionState, TerminalSession, TerminalSessionPhase, TerminalSessionStatusPatch, TerminalSessionTag, TypedResolver,
-    CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REF_SESSION_TAG, VESSEL_REF_LABEL,
+    controller::{Actuation, ReconcileOutcome, Reconciler},
+    Convoy, Environment, EnvironmentPhase, ResourceBackend, ResourceError, ResourceObject, TerminalAttention, TerminalAttentionSource,
+    TerminalAttentionState, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, TerminalSessionTag,
+    TypedResolver, CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REF_SESSION_TAG, VESSEL_REF_LABEL,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
@@ -53,12 +53,13 @@ pub trait TerminalRuntime: Send + Sync {
 
 pub struct TerminalSessionReconciler<R> {
     runtime: Arc<R>,
+    convoys: TypedResolver<Convoy>,
     environments: TypedResolver<Environment>,
 }
 
 impl<R> TerminalSessionReconciler<R> {
     pub fn new(runtime: Arc<R>, backend: ResourceBackend, namespace: &str) -> Self {
-        Self { runtime, environments: backend.using::<Environment>(namespace) }
+        Self { runtime, convoys: backend.clone().using::<Convoy>(namespace), environments: backend.using::<Environment>(namespace) }
     }
 }
 
@@ -70,6 +71,7 @@ pub enum TerminalDeps {
     Stopped,
     Attention(TerminalAttention),
     AttentionStale,
+    OwnerMissing,
     Failed(String),
 }
 
@@ -81,6 +83,18 @@ where
     type Dependencies = TerminalDeps;
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        let convoy_ref = match &obj.spec.source {
+            TerminalSessionSource::Agent { context, .. } => Some(context.convoy.as_str()),
+            TerminalSessionSource::Tool { .. } => obj.metadata.labels.get(CONVOY_LABEL).map(String::as_str),
+        };
+        if let Some(convoy_ref) = convoy_ref {
+            match self.convoys.get(convoy_ref).await {
+                Ok(convoy) if convoy.metadata.deletion_timestamp.is_none() => {}
+                Ok(_) | Err(ResourceError::NotFound { .. }) => return Ok(TerminalDeps::OwnerMissing),
+                Err(err) => return Err(err),
+            }
+        }
+
         let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(TerminalSessionPhase::Starting);
         if phase == TerminalSessionPhase::Running {
             let session_id = obj
@@ -147,6 +161,10 @@ where
         deps: &Self::Dependencies,
         now: chrono::DateTime<chrono::Utc>,
     ) -> ReconcileOutcome<Self::Resource> {
+        if matches!(deps, TerminalDeps::OwnerMissing) {
+            return ReconcileOutcome::with_actuations(None, vec![Actuation::DeleteTerminalSession { name: obj.metadata.name.clone() }]);
+        }
+
         let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(TerminalSessionPhase::Starting);
         let patch = match phase {
             TerminalSessionPhase::Starting => match deps {
@@ -166,7 +184,8 @@ where
                 | TerminalDeps::Stopped
                 | TerminalDeps::MessageDelivered(_)
                 | TerminalDeps::Attention(_)
-                | TerminalDeps::AttentionStale => None,
+                | TerminalDeps::AttentionStale
+                | TerminalDeps::OwnerMissing => None,
             },
             TerminalSessionPhase::Running if matches!(deps, TerminalDeps::Stopped) => Some(TerminalSessionStatusPatch::MarkStopped {
                 stopped_at: now,

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -708,14 +708,16 @@ impl Reconciler for VesselReconciler {
                                 .and_then(|crew| crew.get(&process.role))
                                 .map(|work| work.phase);
                             let active = matches!(crew_phase, Some(CrewWorkPhase::Working | CrewWorkPhase::Interrupted))
-                                || (crew_phase.is_none() && should_start && work_phase == Some(WorkPhase::Running));
+                                || (matches!(crew_phase, None | Some(CrewWorkPhase::Pending))
+                                    && should_start
+                                    && matches!(work_phase, Some(WorkPhase::Launching | WorkPhase::Running)));
                             if !active {
                                 continue;
                             }
                             return Ok(VesselDeps::interrupted(
                                 process.role.clone(),
                                 &terminal_name,
-                                work_phase != Some(WorkPhase::Running),
+                                work_phase == Some(WorkPhase::Interrupted),
                                 actuations,
                             ));
                         }

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -7,13 +7,14 @@ use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
 use flotilla_resources::{
-    controller::Reconciler, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta,
-    ResourceBackend, StatusPatch, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSessionPhase,
-    TerminalSessionSpec, CONVOY_LABEL, VESSEL_REF_LABEL,
+    controller::{Actuation, Reconciler},
+    EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta, ResourceBackend, StatusPatch,
+    TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSessionPhase, TerminalSessionSpec, CONVOY_LABEL,
+    VESSEL_REF_LABEL,
 };
 
 mod common;
-use common::meta;
+use common::{create_convoy_with_single_task, meta};
 
 #[tokio::test]
 async fn terminal_session_failure_uses_injected_now_for_stopped_at() {
@@ -80,6 +81,50 @@ impl TerminalRuntime for FailingTerminalRuntime {
 }
 
 #[tokio::test]
+async fn orphaned_convoy_session_is_deleted_without_relaunching() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
+    let session = sessions
+        .create(
+            &InputMeta::builder()
+                .name("terminal-deleted-convoy-work-coder".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "deleted-convoy".to_string())]))
+                .build(),
+            &TerminalSessionSpec {
+                env_ref: "host-direct-feta".to_string(),
+                role: "coder".to_string(),
+                source: flotilla_resources::TerminalSessionSource::Agent {
+                    selector: flotilla_resources::Selector { capability: "coding".to_string() },
+                    brief: flotilla_resources::TerminalBrief {
+                        path: ".flotilla/briefs/coder.md".to_string(),
+                        content: "brief".to_string(),
+                        copies: Vec::new(),
+                    },
+                    context: flotilla_resources::TerminalCrewContext {
+                        namespace: "flotilla".to_string(),
+                        convoy: "deleted-convoy".to_string(),
+                        vessel_ref: "deleted-convoy-work".to_string(),
+                    },
+                    message: None,
+                },
+                cwd: "/workspace".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("session create should succeed");
+    let reconciler = TerminalSessionReconciler::new(Arc::new(MissingTerminalRuntime), backend, "flotilla");
+
+    let deps = reconciler.fetch_dependencies(&session).await.expect("orphan dependencies should load");
+    let outcome = reconciler.reconcile(&session, &deps, Utc::now());
+
+    assert!(matches!(
+        outcome.actuations.as_slice(),
+        [Actuation::DeleteTerminalSession { name }] if name == "terminal-deleted-convoy-work-coder"
+    ));
+}
+
+#[tokio::test]
 async fn terminal_finalizer_kills_the_persisted_session_using_its_spec() {
     let backend = ResourceBackend::InMemory(Default::default());
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
@@ -138,6 +183,7 @@ impl TerminalRuntime for RecordingTerminalRuntime {
 #[tokio::test]
 async fn session_provisioning_passes_convoy_and_vessel_tags_to_runtime() {
     let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, "flotilla", "demo", "work", "https://github.com/flotilla-org/flotilla", "main").await;
     let environments = backend.clone().using::<flotilla_resources::Environment>("flotilla");
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
     let env = environments
@@ -207,6 +253,7 @@ impl TerminalRuntime for TagRecordingRuntime {
 #[tokio::test]
 async fn a_disappeared_running_session_is_observed_as_stopped() {
     let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, "flotilla", "demo", "implement", "https://github.com/flotilla-org/flotilla", "main").await;
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
     let created = sessions
         .create(&meta("term-a"), &TerminalSessionSpec {
@@ -279,6 +326,7 @@ impl TerminalRuntime for MissingTerminalRuntime {
 #[tokio::test]
 async fn a_message_queued_during_startup_is_delivered_before_attention_observation() {
     let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, "flotilla", "demo", "review", "https://github.com/flotilla-org/flotilla", "main").await;
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
     let created = sessions
         .create(&meta("term-a"), &TerminalSessionSpec {

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -1356,8 +1356,14 @@ async fn child_failure_propagates_to_workspace_failure() {
     ));
 }
 
+#[rstest]
+#[case(WorkPhase::Running, CrewWorkPhase::Working)]
+#[case(WorkPhase::Launching, CrewWorkPhase::Pending)]
 #[tokio::test]
-async fn stopped_agent_session_interrupts_the_vessel_and_requests_a_restart() {
+async fn disappeared_live_agent_session_interrupts_the_vessel_and_requests_a_restart(
+    #[case] work_phase: WorkPhase,
+    #[case] crew_phase: CrewWorkPhase,
+) {
     let backend = ResourceBackend::InMemory(Default::default());
     let convoy = create_convoy_with_single_task(&backend, NAMESPACE, "convoy-recover", "implement", REPO_URL, GIT_REF).await;
     let mut status = convoy.status.expect("convoy status");
@@ -1367,11 +1373,10 @@ async fn stopped_agent_session_interrupts_the_vessel_and_requests_a_restart() {
         brief_template: None,
     };
     status.phase = ConvoyPhase::Active;
-    status.work.insert("implement".to_string(), WorkState::builder().phase(WorkPhase::Running).build());
-    status.crew_work.insert(
-        "implement".to_string(),
-        BTreeMap::from([("coder".to_string(), CrewWorkState::builder().phase(CrewWorkPhase::Working).build())]),
-    );
+    status.work.insert("implement".to_string(), WorkState::builder().phase(work_phase).build());
+    status
+        .crew_work
+        .insert("implement".to_string(), BTreeMap::from([("coder".to_string(), CrewWorkState::builder().phase(crew_phase).build())]));
     backend
         .clone()
         .using::<Convoy>(NAMESPACE)

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -38,7 +38,7 @@ use flotilla_resources::{
     DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, ForgeIdentity, Host,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition,
     InputMeta, PlacementPolicy, PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError,
-    ResourceObject, Stance, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    ResourceObject, Stance, TerminalSession, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
     AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY, MANAGED_BY_LABEL,
 };
 use serde_json::json;
@@ -1099,6 +1099,7 @@ fn spawn_controller_loops(
                             secondaries: ConvoyReconciler::secondary_watches(),
                             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(&namespace_string))
                                 .with_vessels(backend.clone().using::<Vessel>(&namespace_string))
+                                .with_terminal_sessions(backend.clone().using::<TerminalSession>(&namespace_string))
                                 .with_presentations(backend.clone().using::<Presentation>(&namespace_string))
                                 .with_checkouts(backend.clone().using::<Checkout>(&namespace_string))
                                 .with_teardown_runtime(Arc::new(DaemonConvoyTeardownRuntime::new(daemon)))

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -79,6 +79,7 @@ pub enum Actuation {
     CreateCheckout { meta: InputMeta, spec: CheckoutSpec },
     CreateTerminalSession { meta: InputMeta, spec: TerminalSessionSpec },
     RestartTerminalSession { name: String },
+    DeleteTerminalSession { name: String },
     CreateVessel { meta: InputMeta, spec: VesselSpec },
     CreatePresentation { meta: InputMeta, spec: PresentationSpec },
     DeletePresentation { name: String },
@@ -308,6 +309,10 @@ impl<R: Reconciler> ControllerLoop<R> {
             Actuation::RestartTerminalSession { name } => {
                 let resolver = backend.using::<crate::TerminalSession>(namespace);
                 crate::apply_status_patch(&resolver, &name, &crate::TerminalSessionStatusPatch::MarkStarting).await.map(|_| ())
+            }
+            Actuation::DeleteTerminalSession { name } => {
+                let resolver = backend.using::<crate::TerminalSession>(namespace);
+                Self::delete_if_lifecycle_owned(&resolver, &name).await
             }
             Actuation::CreateVessel { meta, spec } => {
                 let resolver = backend.using::<crate::Vessel>(namespace);

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -23,6 +23,7 @@ use crate::{
     presentation::{Presentation, PresentationSpec},
     resource::ResourceObject,
     status_patch::StatusPatch,
+    terminal_session::TerminalSession,
     vessel::{Vessel, VesselPhase},
     workflow_template::{validate, visit_template_tokens, CrewSource, CrewSpec, ValidationError, WorkflowTemplate},
     InputMeta, InputValue, OwnerReference, PlacementStatus, PreparedSnapshotGarbageCollector, Resource, ResourceError, TypedResolver,
@@ -80,6 +81,7 @@ pub enum ConvoyEvent {
 pub struct ConvoyReconciler {
     templates: TypedResolver<WorkflowTemplate>,
     vessels: Option<TypedResolver<Vessel>>,
+    terminal_sessions: Option<TypedResolver<TerminalSession>>,
     presentations: Option<TypedResolver<Presentation>>,
     checkouts: Option<TypedResolver<Checkout>>,
     prepared_snapshot_gc: Option<PreparedSnapshotGarbageCollector>,
@@ -98,11 +100,24 @@ pub struct ConvoyDependencies {
 
 impl ConvoyReconciler {
     pub fn new(templates: TypedResolver<WorkflowTemplate>) -> Self {
-        Self { templates, vessels: None, presentations: None, checkouts: None, prepared_snapshot_gc: None, teardown_runtime: None }
+        Self {
+            templates,
+            vessels: None,
+            terminal_sessions: None,
+            presentations: None,
+            checkouts: None,
+            prepared_snapshot_gc: None,
+            teardown_runtime: None,
+        }
     }
 
     pub fn with_vessels(mut self, vessels: TypedResolver<Vessel>) -> Self {
         self.vessels = Some(vessels);
+        self
+    }
+
+    pub fn with_terminal_sessions(mut self, terminal_sessions: TypedResolver<TerminalSession>) -> Self {
+        self.terminal_sessions = Some(terminal_sessions);
         self
     }
 
@@ -233,6 +248,9 @@ impl Reconciler for ConvoyReconciler {
         let selector = BTreeMap::from([(CONVOY_LABEL.to_string(), obj.metadata.name.clone())]);
         if let Some(presentations) = &self.presentations {
             delete_lifecycle_owned_matching(presentations, &selector).await?;
+        }
+        if let Some(terminal_sessions) = &self.terminal_sessions {
+            delete_lifecycle_owned_matching(terminal_sessions, &selector).await?;
         }
         if let Some(vessels) = &self.vessels {
             delete_lifecycle_owned_matching(vessels, &selector).await?;

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -249,11 +249,11 @@ impl Reconciler for ConvoyReconciler {
         if let Some(presentations) = &self.presentations {
             delete_lifecycle_owned_matching(presentations, &selector).await?;
         }
-        if let Some(terminal_sessions) = &self.terminal_sessions {
-            delete_lifecycle_owned_matching(terminal_sessions, &selector).await?;
-        }
         if let Some(vessels) = &self.vessels {
             delete_lifecycle_owned_matching(vessels, &selector).await?;
+        }
+        if let Some(terminal_sessions) = &self.terminal_sessions {
+            delete_lifecycle_owned_matching(terminal_sessions, &selector).await?;
         }
         if let Some(checkouts) = &self.checkouts {
             delete_lifecycle_owned_matching(checkouts, &selector).await?;

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -14,8 +14,8 @@ use flotilla_resources::{
     CheckoutStatus, ConditionValue, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatus, ConvoyStatusPatch,
     ConvoyTeardownRuntime, CrewSource, CrewWorkPhase, InMemoryBackend, InputMeta, InputValue, IntegrationCondition, LandedEvidence,
     ObservedCheckoutSpec, OwnerReference, Presentation, PresentationSpec, RepositoryKey, ResourceBackend, StatusPatch, TargetMismatch,
-    ValidationError, Vessel, VesselPhase, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkflowSnapshot, WorkflowTemplate,
-    CONVOY_LABEL, VESSEL_LABEL,
+    TerminalSession, TerminalSessionSource, TerminalSessionSpec, ValidationError, Vessel, VesselPhase, VesselSpec, VesselStatus,
+    WorkCompletionAuthority, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
 };
 
 struct AlwaysEligible;
@@ -167,6 +167,38 @@ async fn reconcile_landing_with_observed_change_request(
     let reconciler = ConvoyReconciler::new(templates).with_checkouts(checkouts);
     let deps = reconciler.fetch_dependencies(&current).await.expect("dependencies");
     reconciler.reconcile(&current, &deps, timestamp(40))
+}
+
+#[tokio::test]
+async fn convoy_finalizer_deletes_orphaned_terminal_sessions() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    let sessions = backend.clone().using::<TerminalSession>("flotilla");
+    let convoy = convoys.create(&convoy_meta("convoy-a"), &valid_convoy_spec()).await.expect("convoy create should succeed");
+    sessions
+        .create(
+            &InputMeta::builder()
+                .name("terminal-convoy-a-work-coder".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), convoy.metadata.name.clone())]))
+                .build(),
+            &TerminalSessionSpec {
+                env_ref: "host-direct-feta".to_string(),
+                role: "coder".to_string(),
+                source: TerminalSessionSource::Tool { command: "cargo test".to_string() },
+                cwd: "/workspace".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("terminal create should succeed");
+
+    ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla"))
+        .with_terminal_sessions(sessions.clone())
+        .run_finalizer(&convoy)
+        .await
+        .expect("convoy finalizer should succeed");
+
+    assert!(matches!(sessions.get("terminal-convoy-a-work-coder").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
 }
 
 fn vessel_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {


### PR DESCRIPTION
## Summary

- delete convoy-owned terminal-session records directly during convoy finalization, including records orphaned from their vessel
- reject and garbage-collect terminal-session recovery when the owning convoy is absent or deleting
- recover disappeared eager crew sessions while work is either Launching or Running

## Root cause

The resurrector is the durable control-plane state in `resources.sqlite`, not cleat: a surviving `TerminalSession` is reconciled directly, while a surviving `Convoy`/`Vessel` work graph recreates a missing terminal record. Convoy teardown previously relied only on the vessel cascade, which let partial/orphaned session records survive. Recovery also treated Running work as live but excluded eager work still Launching, and terminal reconciliation did not validate the owning convoy before ensuring a session.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1202