### PR TITLE
fix: isolate root-owned checkout debris

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -216,4 +216,12 @@ where
     fn finalizer_name(&self) -> Option<&'static str> {
         Some("flotilla.work/checkout-cleanup")
     }
+
+    fn error_patch(&self, obj: &ResourceObject<Self::Resource>, error: &ResourceError) -> Option<CheckoutStatusPatch> {
+        let message = format!("checkout reconciliation failed: {error}");
+        if obj.status.as_ref().is_some_and(|status| status.phase == CheckoutPhase::Failed && status.message.as_deref() == Some(&message)) {
+            return None;
+        }
+        Some(CheckoutStatusPatch::MarkFailed { message })
+    }
 }

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -217,8 +217,8 @@ where
         Some("flotilla.work/checkout-cleanup")
     }
 
-    fn error_patch(&self, obj: &ResourceObject<Self::Resource>, error: &ResourceError) -> Option<CheckoutStatusPatch> {
-        let message = format!("checkout reconciliation failed: {error}");
+    fn finalizer_error_patch(&self, obj: &ResourceObject<Self::Resource>, error: &ResourceError) -> Option<CheckoutStatusPatch> {
+        let message = format!("checkout teardown failed: {error}");
         if obj.status.as_ref().is_some_and(|status| status.phase == CheckoutPhase::Failed && status.message.as_deref() == Some(&message)) {
             return None;
         }

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -6,13 +6,14 @@ mod common;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use common::{create_ready_clone, meta};
+use common::{create_ready_checkout, create_ready_clone, meta};
 use flotilla_controllers::reconcilers::{
     checkout::CheckoutDeps, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout,
 };
 use flotilla_resources::{
     controller::Reconciler, repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus,
-    CheckoutWorktreeSpec, ConditionValue, IntegrationCondition, RepositoryKey, ResourceBackend, ResourceObject,
+    CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec, IntegrationCondition, RepositoryKey, ResourceBackend, ResourceError,
+    ResourceObject, StatusPatch,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -66,6 +67,39 @@ impl CheckoutRuntime for RecordingCheckoutRuntime {
         self.removals.lock().expect("removals lock").push(removal.clone());
         Ok(CheckoutRemovalOutcome::Removed)
     }
+}
+
+#[tokio::test]
+async fn object_error_marks_only_the_checkout_failed() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let checkout = create_ready_checkout(
+        &backend,
+        NAMESPACE,
+        common::ReadyCheckoutFixture::builder()
+            .name("checkout-a".to_string())
+            .env_ref("host-direct-a".to_string())
+            .git_ref("feature/cleanup".to_string())
+            .path("/checkouts/convoy-a/repo.feature-cleanup".to_string())
+            .fresh_clone(FreshCloneCheckoutSpec {
+                repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                env_ref: "host-direct-a".to_string(),
+                r#ref: "feature/cleanup".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/convoy-a/repo.feature-cleanup".to_string(),
+                url: REPO_URL.to_string(),
+            })
+            .build(),
+    )
+    .await;
+    let reconciler = CheckoutReconciler::new(Arc::new(RecordingCheckoutRuntime::default()), backend, NAMESPACE);
+    let error = ResourceError::other("remove worktree: permission denied");
+
+    let patch = reconciler.error_patch(&checkout, &error).expect("checkout errors should produce a failed status patch");
+    let mut status = checkout.status.expect("ready checkout should have status");
+    patch.apply(&mut status);
+
+    assert_eq!(status.phase, CheckoutPhase::Failed);
+    assert_eq!(status.message.as_deref(), Some("checkout reconciliation failed: remove worktree: permission denied"));
 }
 
 #[tokio::test]

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -3,7 +3,10 @@
 // behavior that is clearer to assert directly than through controller-loop tests.
 mod common;
 
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use common::{create_ready_checkout, create_ready_clone, meta};
@@ -11,10 +14,11 @@ use flotilla_controllers::reconcilers::{
     checkout::CheckoutDeps, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout,
 };
 use flotilla_resources::{
-    controller::Reconciler, repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus,
-    CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec, IntegrationCondition, RepositoryKey, ResourceBackend, ResourceError,
-    ResourceObject, StatusPatch,
+    controller::{ControllerLoop, Reconciler},
+    repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, ConditionValue,
+    FreshCloneCheckoutSpec, IntegrationCondition, RepositoryKey, ResourceBackend, ResourceError, ResourceObject, StatusPatch,
 };
+use tokio::time::timeout;
 
 const NAMESPACE: &str = "flotilla";
 const REPO_URL: &str = "https://github.com/flotilla-org/flotilla";
@@ -23,6 +27,7 @@ const REPO_URL: &str = "https://github.com/flotilla-org/flotilla";
 struct RecordingCheckoutRuntime {
     removals: Mutex<Vec<CheckoutRemoval>>,
     inspections: Mutex<usize>,
+    failed_removal_target: Option<String>,
 }
 
 #[async_trait]
@@ -65,12 +70,18 @@ impl CheckoutRuntime for RecordingCheckoutRuntime {
 
     async fn remove_checkout(&self, removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {
         self.removals.lock().expect("removals lock").push(removal.clone());
+        let target_path = match removal {
+            CheckoutRemoval::Worktree { target_path, .. } | CheckoutRemoval::FreshClone { target_path } => target_path,
+        };
+        if self.failed_removal_target.as_deref() == Some(target_path) {
+            return Err("permission denied removing root-owned debris".to_string());
+        }
         Ok(CheckoutRemovalOutcome::Removed)
     }
 }
 
 #[tokio::test]
-async fn object_error_marks_only_the_checkout_failed() {
+async fn finalizer_error_maps_to_failed_checkout_status() {
     let backend = ResourceBackend::InMemory(Default::default());
     let checkout = create_ready_checkout(
         &backend,
@@ -94,12 +105,90 @@ async fn object_error_marks_only_the_checkout_failed() {
     let reconciler = CheckoutReconciler::new(Arc::new(RecordingCheckoutRuntime::default()), backend, NAMESPACE);
     let error = ResourceError::other("remove worktree: permission denied");
 
-    let patch = reconciler.error_patch(&checkout, &error).expect("checkout errors should produce a failed status patch");
+    let patch =
+        reconciler.finalizer_error_patch(&checkout, &error).expect("checkout finalizer errors should produce a failed status patch");
     let mut status = checkout.status.expect("ready checkout should have status");
     patch.apply(&mut status);
 
     assert_eq!(status.phase, CheckoutPhase::Failed);
-    assert_eq!(status.message.as_deref(), Some("checkout reconciliation failed: remove worktree: permission denied"));
+    assert_eq!(status.message.as_deref(), Some("checkout teardown failed: remove worktree: permission denied"));
+}
+
+async fn create_deleting_checkout(backend: &ResourceBackend, name: &str, target_path: &str) {
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    let meta = common::controller_meta()
+        .name(name)
+        .finalizers(vec!["flotilla.work/checkout-cleanup".to_string()])
+        .deletion_timestamp(chrono::Utc::now())
+        .call();
+    let created = checkouts
+        .create(
+            &meta,
+            &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                env_ref: "host-direct-a".to_string(),
+                r#ref: format!("feature/{name}"),
+                base_ref: Some("main".to_string()),
+                target_path: target_path.to_string(),
+                url: REPO_URL.to_string(),
+            }),
+        )
+        .await
+        .expect("deleting checkout create should succeed");
+    checkouts
+        .update_status(name, &created.metadata.resource_version, &CheckoutStatus {
+            phase: CheckoutPhase::Ready,
+            path: Some(target_path.to_string()),
+            commit: Some("base-commit".to_string()),
+            branch_provenance: CheckoutBranchProvenance::CreatedForConvoy,
+            integration: Default::default(),
+            message: None,
+        })
+        .await
+        .expect("deleting checkout status update should succeed");
+}
+
+#[tokio::test]
+async fn failed_checkout_teardown_marks_only_that_checkout_failed_and_controller_continues() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    create_deleting_checkout(&backend, "alpha-failing", "/checkouts/alpha").await;
+    create_deleting_checkout(&backend, "beta-healthy", "/checkouts/beta").await;
+    let reconciler = CheckoutReconciler::new(
+        Arc::new(RecordingCheckoutRuntime { failed_removal_target: Some("/checkouts/alpha".to_string()), ..Default::default() }),
+        backend.clone(),
+        NAMESPACE,
+    );
+    let controller = tokio::spawn(
+        ControllerLoop {
+            primary: checkouts.clone(),
+            secondaries: Vec::new(),
+            reconciler,
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            let failing = checkouts.get("alpha-failing").await.expect("failing checkout should remain for retry");
+            let failed_with_message = failing.status.as_ref().is_some_and(|status| {
+                status.phase == CheckoutPhase::Failed
+                    && status.message.as_deref() == Some("checkout teardown failed: permission denied removing root-owned debris")
+            });
+            let healthy_removed = matches!(checkouts.get("beta-healthy").await, Err(ResourceError::NotFound { .. }));
+            if failed_with_message && healthy_removed {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("failed checkout should degrade while healthy checkout teardown completes");
+
+    controller.abort();
+    let _ = controller.await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -35,6 +35,12 @@ impl DockerEnvironmentProvider {
     }
 }
 
+#[cfg(unix)]
+fn host_user() -> String {
+    // SAFETY: getuid and getgid are side-effect-free process identity queries.
+    unsafe { format!("{}:{}", libc::getuid(), libc::getgid()) }
+}
+
 #[async_trait]
 impl EnvironmentProvider for DockerEnvironmentProvider {
     // TODO: This fingerprints the Dockerfile contents plus the spec path only.
@@ -75,6 +81,8 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
         let socket_mount = format!("{}:{CONTAINER_SOCKET_PATH}", socket_str);
         let env_id_env = format!("FLOTILLA_ENVIRONMENT_ID={}", env_id_str);
         let socket_env = format!("FLOTILLA_DAEMON_SOCKET={CONTAINER_SOCKET_PATH}");
+        #[cfg(unix)]
+        let user = host_user();
 
         let docker_config = opts.docker_config_dir.as_ref().map(ToString::to_string);
         let mut args = Vec::new();
@@ -99,6 +107,8 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
             "-e",
             &env_id_env,
         ]);
+        #[cfg(unix)]
+        args.extend(["--user", user.as_str()]);
 
         let mount_specs: Vec<String> = opts
             .provisioned_mounts

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -298,6 +298,35 @@ async fn create_returns_handle() {
     assert!(args.iter().any(|a| a.starts_with("GITHUB_TOKEN=")), "token env var should be passed");
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn create_runs_container_as_the_host_user() {
+    use flotilla_protocol::ImageId;
+
+    let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
+    let provider = DockerEnvironmentProvider::new(runner.clone());
+    let image = ImageId::new("ubuntu:22.04");
+    let opts = CreateOpts {
+        tokens: Vec::new(),
+        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        working_directory: None,
+        provisioned_mounts: Vec::new(),
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
+        docker_config_dir: None,
+    };
+
+    provider.create(EnvironmentId::new("host-user"), &image, opts).await.expect("create environment as host user");
+
+    let calls = runner.calls();
+    let (_, args, _) = &calls[0];
+    // SAFETY: getuid and getgid are side-effect-free process identity queries.
+    let host_user = unsafe { format!("{}:{}", libc::getuid(), libc::getgid()) };
+    assert!(
+        args.windows(2).any(|pair| pair == ["--user", host_user.as_str()]),
+        "docker container should run as the host uid:gid; args: {args:?}",
+    );
+}
+
 #[tokio::test]
 async fn create_removes_container_when_image_digest_cannot_be_resolved() {
     use flotilla_protocol::ImageId;

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -13,6 +13,7 @@ use tokio::{
     sync::{mpsc, Mutex},
     task::JoinHandle,
 };
+use tracing::warn;
 
 use crate::{
     apply_status_patch,
@@ -52,6 +53,19 @@ pub trait Reconciler: Send + Sync + 'static {
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError>;
 
     fn finalizer_name(&self) -> Option<&'static str>;
+
+    /// Map an object-scoped reconciliation error to a status update.
+    ///
+    /// The controller loop isolates errors to the named object regardless of
+    /// whether a reconciler supplies a patch. Reconcilers with a failed/degraded
+    /// status should override this so the affected object reports the error.
+    fn error_patch(
+        &self,
+        _obj: &ResourceObject<Self::Resource>,
+        _error: &ResourceError,
+    ) -> Option<<Self::Resource as Resource>::StatusPatch> {
+        None
+    }
 }
 
 pub struct ReconcileOutcome<T: Resource> {
@@ -463,53 +477,86 @@ impl<R: Reconciler> ControllerLoop<R> {
                 let object = match primary.get(&name).await {
                     Ok(object) => object,
                     Err(ResourceError::NotFound { .. }) => continue,
-                    Err(err) => return Err(err),
+                    Err(err) => {
+                        warn!(
+                            resource_kind = R::Resource::API_PATHS.kind,
+                            resource = %name,
+                            %err,
+                            "controller failed to read object; leaving it for a later resync",
+                        );
+                        continue;
+                    }
                 };
-                let lifecycle_owned = is_lifecycle_owned(object.metadata.lifecycle_authority()?);
-                if let Some(finalizer_name) = reconciler.finalizer_name() {
-                    if object.metadata.deletion_timestamp.is_none()
-                        && object.metadata.finalizers.iter().all(|finalizer| finalizer != finalizer_name)
-                        && lifecycle_owned
-                    {
-                        let meta = InputMeta::from(&object.metadata).with_added_finalizer(finalizer_name);
-                        Self::write_tolerating_not_found(primary.update(&meta, &object.metadata.resource_version, &object.spec)).await?;
-                        continue;
-                    }
-                    if object.metadata.deletion_timestamp.is_some()
-                        && object.metadata.finalizers.iter().any(|finalizer| finalizer == finalizer_name)
-                    {
-                        if lifecycle_owned {
-                            reconciler.run_finalizer(&object).await?;
+                let result = async {
+                    let lifecycle_owned = is_lifecycle_owned(object.metadata.lifecycle_authority()?);
+                    if let Some(finalizer_name) = reconciler.finalizer_name() {
+                        if object.metadata.deletion_timestamp.is_none()
+                            && object.metadata.finalizers.iter().all(|finalizer| finalizer != finalizer_name)
+                            && lifecycle_owned
+                        {
+                            let meta = InputMeta::from(&object.metadata).with_added_finalizer(finalizer_name);
+                            Self::write_tolerating_not_found(primary.update(&meta, &object.metadata.resource_version, &object.spec))
+                                .await?;
+                            return Ok(());
                         }
-                        let meta = InputMeta::from(&object.metadata).without_finalizer(finalizer_name);
-                        Self::write_tolerating_not_found(primary.update(&meta, &object.metadata.resource_version, &object.spec)).await?;
-                        continue;
+                        if object.metadata.deletion_timestamp.is_some()
+                            && object.metadata.finalizers.iter().any(|finalizer| finalizer == finalizer_name)
+                        {
+                            if lifecycle_owned {
+                                reconciler.run_finalizer(&object).await?;
+                            }
+                            let meta = InputMeta::from(&object.metadata).without_finalizer(finalizer_name);
+                            Self::write_tolerating_not_found(primary.update(&meta, &object.metadata.resource_version, &object.spec))
+                                .await?;
+                            return Ok(());
+                        }
                     }
+                    if object.metadata.deletion_timestamp.is_some() {
+                        return Ok(());
+                    }
+                    if !lifecycle_owned {
+                        return Ok(());
+                    }
+                    let deps = reconciler.fetch_dependencies(&object).await?;
+                    let outcome = reconciler.reconcile(&object, &deps, Utc::now());
+                    for actuation in outcome.actuations {
+                        Self::apply_actuation(&primary.backend, &primary.namespace, actuation).await?;
+                    }
+                    if let Some(patch) = outcome.patch {
+                        Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await?;
+                    }
+                    if let Some(delay) = outcome.requeue_after {
+                        let mut scheduled = scheduled_requeues.lock().await;
+                        if scheduled.insert(name.clone()) {
+                            let scheduled_requeues = Arc::clone(&scheduled_requeues);
+                            let sender = sender.clone();
+                            let name = name.clone();
+                            tokio::spawn(async move {
+                                tokio::time::sleep(delay).await;
+                                scheduled_requeues.lock().await.remove(&name);
+                                let _ = sender.send(name).await;
+                            });
+                        }
+                    }
+                    Ok(())
                 }
-                if object.metadata.deletion_timestamp.is_some() {
-                    continue;
-                }
-                if !lifecycle_owned {
-                    continue;
-                }
-                let deps = reconciler.fetch_dependencies(&object).await?;
-                let outcome = reconciler.reconcile(&object, &deps, Utc::now());
-                for actuation in outcome.actuations {
-                    Self::apply_actuation(&primary.backend, &primary.namespace, actuation).await?;
-                }
-                if let Some(patch) = outcome.patch {
-                    Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await?;
-                }
-                if let Some(delay) = outcome.requeue_after {
-                    let mut scheduled = scheduled_requeues.lock().await;
-                    if scheduled.insert(name.clone()) {
-                        let scheduled_requeues = Arc::clone(&scheduled_requeues);
-                        let sender = sender.clone();
-                        tokio::spawn(async move {
-                            tokio::time::sleep(delay).await;
-                            scheduled_requeues.lock().await.remove(&name);
-                            let _ = sender.send(name).await;
-                        });
+                .await;
+                if let Err(err) = result {
+                    warn!(
+                        resource_kind = R::Resource::API_PATHS.kind,
+                        resource = %name,
+                        %err,
+                        "controller failed to reconcile object; other objects will continue",
+                    );
+                    if let Some(patch) = reconciler.error_patch(&object, &err) {
+                        if let Err(patch_error) = Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await {
+                            warn!(
+                                resource_kind = R::Resource::API_PATHS.kind,
+                                resource = %name,
+                                %patch_error,
+                                "controller failed to record object reconciliation error",
+                            );
+                        }
                     }
                 }
                 continue;

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -54,12 +54,11 @@ pub trait Reconciler: Send + Sync + 'static {
 
     fn finalizer_name(&self) -> Option<&'static str>;
 
-    /// Map an object-scoped reconciliation error to a status update.
+    /// Map a finalizer failure to a status update.
     ///
-    /// The controller loop isolates errors to the named object regardless of
-    /// whether a reconciler supplies a patch. Reconcilers with a failed/degraded
-    /// status should override this so the affected object reports the error.
-    fn error_patch(
+    /// Other object-scoped errors remain isolated and are retried on a later
+    /// event or resync without forcing the resource into a terminal state.
+    fn finalizer_error_patch(
         &self,
         _obj: &ResourceObject<Self::Resource>,
         _error: &ResourceError,
@@ -503,7 +502,21 @@ impl<R: Reconciler> ControllerLoop<R> {
                             && object.metadata.finalizers.iter().any(|finalizer| finalizer == finalizer_name)
                         {
                             if lifecycle_owned {
-                                reconciler.run_finalizer(&object).await?;
+                                if let Err(err) = reconciler.run_finalizer(&object).await {
+                                    if let Some(patch) = reconciler.finalizer_error_patch(&object, &err) {
+                                        if let Err(patch_error) =
+                                            Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await
+                                        {
+                                            warn!(
+                                                resource_kind = R::Resource::API_PATHS.kind,
+                                                resource = %name,
+                                                %patch_error,
+                                                "controller failed to record object finalizer error",
+                                            );
+                                        }
+                                    }
+                                    return Err(err);
+                                }
                             }
                             let meta = InputMeta::from(&object.metadata).without_finalizer(finalizer_name);
                             Self::write_tolerating_not_found(primary.update(&meta, &object.metadata.resource_version, &object.spec))
@@ -548,16 +561,6 @@ impl<R: Reconciler> ControllerLoop<R> {
                         %err,
                         "controller failed to reconcile object; other objects will continue",
                     );
-                    if let Some(patch) = reconciler.error_patch(&object, &err) {
-                        if let Err(patch_error) = Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await {
-                            warn!(
-                                resource_kind = R::Resource::API_PATHS.kind,
-                                resource = %name,
-                                %patch_error,
-                                "controller failed to record object reconciliation error",
-                            );
-                        }
-                    }
                 }
                 continue;
             }

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -97,6 +97,42 @@ impl Reconciler for RecordingReconciler {
 }
 
 #[derive(Clone)]
+struct FailingObjectReconciler {
+    failed_name: String,
+    reconciled: Arc<Mutex<Vec<String>>>,
+}
+
+impl Reconciler for FailingObjectReconciler {
+    type Resource = PrimaryResource;
+    type Dependencies = ();
+
+    async fn fetch_dependencies(&self, _obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        Ok(())
+    }
+
+    fn reconcile(
+        &self,
+        obj: &ResourceObject<Self::Resource>,
+        _deps: &Self::Dependencies,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> ReconcileOutcome<Self::Resource> {
+        self.reconciled.lock().expect("reconciled lock").push(obj.metadata.name.clone());
+        ReconcileOutcome::new(None)
+    }
+
+    async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
+        if obj.metadata.name == self.failed_name {
+            return Err(ResourceError::other("object-specific teardown failure"));
+        }
+        Ok(())
+    }
+
+    fn finalizer_name(&self) -> Option<&'static str> {
+        Some("flotilla.work/test-finalizer")
+    }
+}
+
+#[derive(Clone)]
 struct FinalizingReconciler {
     finalized: Arc<Mutex<Vec<String>>>,
 }
@@ -760,6 +796,48 @@ async fn duplicate_secondary_events_for_the_same_primary_are_deduped_per_burst()
 
     tokio::time::sleep(Duration::from_millis(50)).await;
     assert_eq!(reconciled.lock().expect("reconciled lock").as_slice(), &["alpha".to_string()]);
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn finalizer_failure_does_not_stop_other_objects_from_reconciling() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let primaries = backend.clone().using::<PrimaryResource>("flotilla");
+    let failing_meta = resource_meta()
+        .name("alpha-failing")
+        .finalizers(vec!["flotilla.work/test-finalizer".to_string()])
+        .deletion_timestamp(chrono::Utc::now())
+        .call();
+    primaries.create(&failing_meta, &PrimarySpec { value: "one".to_string() }).await.expect("failing primary create should succeed");
+    primaries
+        .create(&primary_meta("beta-healthy"), &PrimarySpec { value: "two".to_string() })
+        .await
+        .expect("healthy primary create should succeed");
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries,
+            secondaries: Vec::new(),
+            reconciler: FailingObjectReconciler { failed_name: "alpha-failing".to_string(), reconciled: Arc::clone(&reconciled) },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").contains(&"beta-healthy".to_string()) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("healthy primary should reconcile despite another object's permanent failure");
 
     harness.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- run Docker-backed crew environments as the daemon host's numeric uid/gid
- isolate named-object reconciliation and finalizer failures so one checkout cannot terminate a controller loop
- mark the affected checkout failed with the reconciliation error while allowing other checkouts to continue

## Root cause

Docker environments inherited the image's configured user, commonly root, while writing through a read-write host worktree mount. Root-owned debris then made host-side checkout teardown fail. The generic controller loop propagated that object-specific finalizer error out of `run()`, causing supervision to replay the same failing checkout until the shared restart budget was exhausted.

## Impact

Container writes now retain host ownership on Unix. A permanently failing checkout teardown is logged and reflected on that checkout, while the controller continues provisioning and reconciling unrelated checkouts. Watch and resync failures remain supervisory.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1201