### PR TITLE
fix: detect and surface sleep inhibitor failures

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5291,6 +5291,7 @@ impl InProcessDaemon {
                     .crew_count(crew_count)
                     .convoy_count(convoys.len())
                     .maybe_disk_free_bytes(status.and_then(|status| status.disk_free_bytes))
+                    .sleep_inhibition(status.map(|status| status.sleep_inhibition.clone()).unwrap_or_default())
                     .staleness(staleness)
                     .observation_agreement(observation_agreement)
                     .degraded_conditions(degraded_conditions)

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -291,6 +291,7 @@ impl DaemonRuntime {
             spawn_sleep_inhibitor_task(
                 daemon.resource_backend(),
                 options.namespace.clone(),
+                profile.host_id.clone(),
                 options.controller_supervision.clone(),
                 runtime_health.clone(),
             ),
@@ -749,13 +750,16 @@ where
 fn spawn_sleep_inhibitor_task(
     backend: ResourceBackend,
     namespace: String,
+    host_id: String,
     supervision: ControllerSupervision,
     runtime_health: RuntimeHealth,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         supervise_controller("sleep_inhibitor", supervision, runtime_health, move || {
             let convoys = backend.clone().using::<Convoy>(&namespace);
-            async move { sleep_inhibitor::run(convoys).await }
+            let hosts = backend.clone().using::<Host>(&namespace);
+            let host_id = host_id.clone();
+            async move { sleep_inhibitor::run(convoys, hosts, host_id).await }
         })
         .await;
     })
@@ -975,6 +979,7 @@ async fn apply_host_heartbeat_with_credentials(
         daemon_started_at: Some(health.started_at),
         disk_free_bytes,
         conditions,
+        sleep_inhibition: host.status.as_ref().map(|status| status.sleep_inhibition.clone()).unwrap_or_default(),
     };
     hosts.update_status(&profile.host_id, &host.metadata.resource_version, &status).await.map_err(|err| err.to_string())?;
     daemon.refresh_connected_peer_host_heartbeats().await;
@@ -2176,7 +2181,7 @@ mod tests {
         Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
         CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CrewSource, CrewSpec, LifecycleAuthority,
         ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, RepositorySpec, Selector, SqliteBackend,
-        TerminalAttentionState, TerminalSession, TerminalSessionPhase, TypedResolver, VesselRequirement, WorkPhase, WorkflowTemplate,
+        TerminalAttentionState, TerminalSession, TerminalSessionPhase, VesselRequirement, WorkPhase, WorkflowTemplate,
         WorkflowTemplateSpec,
     };
     use futures::StreamExt;
@@ -3367,18 +3372,6 @@ mod tests {
         }
     }
 
-    async fn wait_for_host_status(hosts: &TypedResolver<Host>, name: &str) -> HostStatus {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
-        loop {
-            let host = hosts.get(name).await.expect("host get should succeed");
-            if let Some(status) = host.status {
-                return status;
-            }
-            assert!(tokio::time::Instant::now() < deadline, "timed out waiting for host status");
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-    }
-
     fn sqlite_max_event_rowid(path: &Path) -> u64 {
         let connection = rusqlite::Connection::open(path).expect("open SQLite store for idle inspection");
         connection
@@ -3424,11 +3417,22 @@ mod tests {
         let profile = manual_profile(&host_id, false);
 
         ensure_host_exists(&daemon.resource_backend(), NAMESPACE, &host_id).await.expect("host registration should succeed");
+        let hosts = daemon.resource_backend().using::<Host>(NAMESPACE);
+        flotilla_resources::apply_status_patch(&hosts, &host_id, &flotilla_resources::HostStatusPatch::SleepInhibition {
+            health: flotilla_protocol::SleepInhibitionHealth::Failed { consecutive_failures: 3, message: "polkit denied".to_string() },
+        })
+        .await
+        .expect("seed sleep inhibition health");
         let heartbeat =
             spawn_heartbeat_task(Arc::clone(&daemon), NAMESPACE.to_string(), profile, test_health_identity(), Duration::from_millis(20));
-        let hosts = daemon.resource_backend().using::<Host>(NAMESPACE);
 
-        let status = wait_for_host_status(&hosts, &host_id).await;
+        wait_until(|| {
+            let hosts = hosts.clone();
+            let host_id = host_id.clone();
+            async move { hosts.get(&host_id).await.ok().and_then(|host| host.status).is_some_and(|status| status.ready) }
+        })
+        .await;
+        let status = hosts.get(&host_id).await.expect("get host").status.expect("host status");
         assert!(status.ready, "heartbeat should mark host ready");
         assert_eq!(status.agent_adapters().expect("valid agent adapter capability"), BTreeSet::new());
         assert_eq!(status.capabilities.get("docker"), Some(&json!(false)));
@@ -3437,6 +3441,7 @@ mod tests {
         assert_eq!(status.daemon_version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
         assert!(status.daemon_started_at.is_some());
         assert!(status.disk_free_bytes.is_some());
+        assert!(matches!(status.sleep_inhibition, flotilla_protocol::SleepInhibitionHealth::Failed { consecutive_failures: 3, .. }));
         assert!(
             status.resource_store.expect("heartbeat should publish resource store diagnostics").event_log_within_retention(),
             "heartbeat should report a bounded resource event log"

--- a/crates/flotilla-daemon/src/sleep_inhibitor.rs
+++ b/crates/flotilla-daemon/src/sleep_inhibitor.rs
@@ -267,6 +267,13 @@ impl SystemSleepInhibitor {
                 return Err(error);
             }
         }
+        if let Some(mut stderr) = child.stderr.take() {
+            tokio::spawn(async move {
+                if let Err(error) = tokio::io::copy(&mut stderr, &mut tokio::io::sink()).await {
+                    warn!(%error, "failed to drain sleep inhibitor error output");
+                }
+            });
+        }
         self.child = Some(child);
         info!(program = %command_spec.program, reason = INHIBITOR_REASON, "acquired system sleep inhibitor");
         Ok(())

--- a/crates/flotilla-daemon/src/sleep_inhibitor.rs
+++ b/crates/flotilla-daemon/src/sleep_inhibitor.rs
@@ -1,28 +1,42 @@
 use std::{collections::BTreeSet, process::Stdio, time::Duration};
 
 use async_trait::async_trait;
-use flotilla_resources::{Convoy, ConvoyPhase, ResourceError, ResourceObject, TypedResolver, WatchEvent, WatchStart};
+use flotilla_protocol::SleepInhibitionHealth;
+use flotilla_resources::{
+    apply_status_patch, Convoy, ConvoyPhase, Host, HostStatusPatch, ResourceError, ResourceObject, TypedResolver, WatchEvent, WatchStart,
+};
 use futures::StreamExt;
-use tokio::process::{Child, Command};
-use tracing::{info, warn};
+use tokio::{
+    io::AsyncReadExt,
+    process::{Child, Command},
+};
+use tracing::{error, info, warn};
 
-const RECHECK_INTERVAL: Duration = Duration::from_secs(30);
+const RECHECK_INTERVAL: Duration = Duration::from_secs(5);
+const ACQUISITION_CONFIRMATION: Duration = Duration::from_millis(250);
+const KDE_INHIBITION_ENFORCEMENT_DELAY: Duration = Duration::from_millis(5_250);
+const FAILURE_THRESHOLD: u32 = 3;
 const INHIBITOR_REASON: &str = "Flotilla vessel crew is active";
 
 #[async_trait]
 trait SleepInhibitor: Send {
-    async fn maintain(&mut self, required: bool) -> Result<(), String>;
+    async fn maintain(&mut self, required: bool) -> Result<SleepInhibitionHealth, String>;
 }
 
-pub(super) async fn run(convoys: TypedResolver<Convoy>) -> Result<(), ResourceError> {
-    run_with_inhibitor(convoys, SystemSleepInhibitor::default()).await
+pub(super) async fn run(convoys: TypedResolver<Convoy>, hosts: TypedResolver<Host>, host_id: String) -> Result<(), ResourceError> {
+    run_with_inhibitor(convoys, hosts, host_id, SystemSleepInhibitor::default()).await
 }
 
-async fn run_with_inhibitor<I: SleepInhibitor>(convoys: TypedResolver<Convoy>, mut inhibitor: I) -> Result<(), ResourceError> {
+async fn run_with_inhibitor<I: SleepInhibitor>(
+    convoys: TypedResolver<Convoy>,
+    hosts: TypedResolver<Host>,
+    host_id: String,
+    mut inhibitor: I,
+) -> Result<(), ResourceError> {
     let listed = convoys.list().await?;
     let mut active = ActiveConvoys::from_objects(&listed.items);
-    let mut last_error = None;
-    maintain_and_log(&mut inhibitor, active.required(), &mut last_error).await;
+    let mut health = InhibitionHealthTracker::default();
+    maintain_and_publish(&mut inhibitor, active.required(), &mut health, &hosts, &host_id).await?;
 
     let mut watch = convoys.watch(WatchStart::resuming_from(&listed)).await?;
     let mut recheck = tokio::time::interval(RECHECK_INTERVAL);
@@ -35,28 +49,99 @@ async fn run_with_inhibitor<I: SleepInhibitor>(convoys: TypedResolver<Convoy>, m
                 match event {
                     Some(Ok(event)) => {
                         active.apply(event);
-                        maintain_and_log(&mut inhibitor, active.required(), &mut last_error).await;
+                        maintain_and_publish(&mut inhibitor, active.required(), &mut health, &hosts, &host_id).await?;
                     }
                     Some(Err(error)) => return Err(error),
                     None => return Err(ResourceError::other("sleep inhibitor convoy watch ended")),
                 }
             }
             _ = recheck.tick() => {
-                maintain_and_log(&mut inhibitor, active.required(), &mut last_error).await;
+                maintain_and_publish(&mut inhibitor, active.required(), &mut health, &hosts, &host_id).await?;
             }
         }
     }
 }
 
-async fn maintain_and_log(inhibitor: &mut impl SleepInhibitor, required: bool, last_error: &mut Option<String>) {
-    match inhibitor.maintain(required).await {
-        Ok(()) => *last_error = None,
-        Err(error) if last_error.as_ref() == Some(&error) => {}
-        Err(error) => {
-            warn!(%error, required, "failed to update system sleep inhibitor");
-            *last_error = Some(error);
+async fn maintain_and_publish(
+    inhibitor: &mut impl SleepInhibitor,
+    required: bool,
+    tracker: &mut InhibitionHealthTracker,
+    hosts: &TypedResolver<Host>,
+    host_id: &str,
+) -> Result<(), ResourceError> {
+    let result = inhibitor.maintain(required).await;
+    let observation = tracker.observe(result);
+    match observation.log {
+        FailureLog::None => {}
+        FailureLog::First => {
+            warn!(error = observation.error.as_deref().unwrap_or_default(), required, "system sleep inhibition failed; retrying")
         }
+        FailureLog::Degraded => error!(
+            error = observation.error.as_deref().unwrap_or_default(),
+            consecutive_failures = FAILURE_THRESHOLD,
+            "system sleep inhibition is degraded"
+        ),
     }
+    if let Some(health) = observation.changed {
+        apply_status_patch(hosts, host_id, &HostStatusPatch::SleepInhibition { health }).await?;
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct InhibitionHealthTracker {
+    consecutive_failures: u32,
+    last_error: Option<String>,
+    published: Option<SleepInhibitionHealth>,
+}
+
+impl InhibitionHealthTracker {
+    fn observe(&mut self, result: Result<SleepInhibitionHealth, String>) -> HealthObservation {
+        let (health, log, error) = match result {
+            Ok(health) => {
+                self.consecutive_failures = 0;
+                self.last_error = None;
+                (health, FailureLog::None, None)
+            }
+            Err(error) => {
+                self.consecutive_failures = self.consecutive_failures.saturating_add(1).min(FAILURE_THRESHOLD);
+                let error_changed = self.last_error.as_ref() != Some(&error);
+                self.last_error = Some(error.clone());
+                let health = if self.consecutive_failures >= FAILURE_THRESHOLD {
+                    SleepInhibitionHealth::Failed { consecutive_failures: self.consecutive_failures, message: error.clone() }
+                } else {
+                    SleepInhibitionHealth::Acquiring { consecutive_failures: self.consecutive_failures, message: error.clone() }
+                };
+                let log = if self.consecutive_failures == FAILURE_THRESHOLD
+                    && !matches!(self.published, Some(SleepInhibitionHealth::Failed { .. }))
+                {
+                    FailureLog::Degraded
+                } else if self.consecutive_failures == 1 || error_changed {
+                    FailureLog::First
+                } else {
+                    FailureLog::None
+                };
+                (health, log, Some(error))
+            }
+        };
+        let changed = (self.published.as_ref() != Some(&health)).then(|| {
+            self.published = Some(health.clone());
+            health
+        });
+        HealthObservation { changed, log, error }
+    }
+}
+
+struct HealthObservation {
+    changed: Option<SleepInhibitionHealth>,
+    log: FailureLog,
+    error: Option<String>,
+}
+
+enum FailureLog {
+    None,
+    First,
+    Degraded,
 }
 
 #[derive(Default)]
@@ -104,34 +189,70 @@ struct SystemSleepInhibitor {
 
 #[async_trait]
 impl SleepInhibitor for SystemSleepInhibitor {
-    async fn maintain(&mut self, required: bool) -> Result<(), String> {
+    async fn maintain(&mut self, required: bool) -> Result<SleepInhibitionHealth, String> {
         if let Some(child) = self.child.as_mut() {
             match child.try_wait().map_err(|error| format!("check sleep inhibitor process: {error}"))? {
                 Some(status) => {
                     warn!(%status, "system sleep inhibitor process exited; reacquiring if still required");
                     self.child = None;
                 }
-                None if required => return Ok(()),
+                None if required => return Ok(SleepInhibitionHealth::Held),
                 None => {}
             }
         }
 
         if required {
-            self.acquire()
+            self.acquire().await?;
+            Ok(SleepInhibitionHealth::Held)
         } else {
-            self.release().await
+            self.release().await?;
+            Ok(SleepInhibitionHealth::NotRequired)
         }
     }
 }
 
 impl SystemSleepInhibitor {
-    fn acquire(&mut self) -> Result<(), String> {
-        let command_spec = platform_inhibitor_command(std::process::id())?;
-        let mut command = Command::new(command_spec.program);
-        command.args(&command_spec.args).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null()).kill_on_drop(true);
-        let child = command.spawn().map_err(|error| format!("start {}: {error}", command_spec.program))?;
+    async fn acquire(&mut self) -> Result<(), String> {
+        let mut failures = Vec::new();
+        for command_spec in platform_inhibitor_commands(std::process::id())? {
+            let program = command_spec.program.clone();
+            match self.acquire_command(command_spec).await {
+                Ok(()) => return Ok(()),
+                Err(error) => failures.push(format!("{program}: {error}")),
+            }
+        }
+        Err(format!("all system sleep inhibitor strategies failed: {}", failures.join("; ")))
+    }
+
+    async fn acquire_command(&mut self, command_spec: InhibitorCommand) -> Result<(), String> {
+        let mut command = Command::new(&command_spec.program);
+        command.args(&command_spec.args).stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::piped()).kill_on_drop(true);
+        let mut child = command.spawn().map_err(|error| format!("start {}: {error}", command_spec.program))?;
+        tokio::time::sleep(ACQUISITION_CONFIRMATION).await;
+        if let Some(status) = child.try_wait().map_err(|error| format!("confirm sleep inhibitor process: {error}"))? {
+            let mut stderr = String::new();
+            if let Some(mut stream) = child.stderr.take() {
+                stream.read_to_string(&mut stderr).await.map_err(|error| format!("read sleep inhibitor error output: {error}"))?;
+            }
+            let detail = stderr.trim();
+            return Err(if detail.is_empty() {
+                format!("{} exited during acquisition confirmation with {status}", command_spec.program)
+            } else {
+                format!("{} exited during acquisition confirmation with {status}: {detail}", command_spec.program)
+            });
+        }
+        if command_spec.verification == InhibitorVerification::KdePowerManagement {
+            tokio::time::sleep(KDE_INHIBITION_ENFORCEMENT_DELAY).await;
+            if let Err(error) = verify_kde_power_inhibition().await {
+                child
+                    .kill()
+                    .await
+                    .map_err(|kill_error| format!("{error}; stop unverified {} process: {kill_error}", command_spec.program))?;
+                return Err(error);
+            }
+        }
         self.child = Some(child);
-        info!(program = command_spec.program, reason = INHIBITOR_REASON, "acquired system sleep inhibitor");
+        info!(program = %command_spec.program, reason = INHIBITOR_REASON, "acquired system sleep inhibitor");
         Ok(())
     }
 
@@ -146,34 +267,74 @@ impl SystemSleepInhibitor {
 }
 
 struct InhibitorCommand {
-    program: &'static str,
+    program: String,
     args: Vec<String>,
+    verification: InhibitorVerification,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InhibitorVerification {
+    ProcessAlive,
+    KdePowerManagement,
+}
+
+async fn verify_kde_power_inhibition() -> Result<(), String> {
+    let output = Command::new("qdbus6")
+        .args([
+            "org.freedesktop.PowerManagement.Inhibit",
+            "/org/freedesktop/PowerManagement/Inhibit",
+            "org.freedesktop.PowerManagement.Inhibit.HasInhibit",
+        ])
+        .output()
+        .await
+        .map_err(|error| format!("verify KDE power inhibition with qdbus6: {error}"))?;
+    if !output.status.success() {
+        return Err(format!("verify KDE power inhibition with qdbus6: {}", String::from_utf8_lossy(&output.stderr).trim()));
+    }
+    if String::from_utf8_lossy(&output.stdout).trim() != "true" {
+        return Err("KDE power inhibition was not active after its enforcement delay".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn platform_inhibitor_command(daemon_pid: u32) -> Result<InhibitorCommand, String> {
-    Ok(InhibitorCommand {
-        program: "systemd-inhibit",
-        args: vec![
-            "--what=sleep".to_string(),
-            "--who=flotillad".to_string(),
-            format!("--why={INHIBITOR_REASON}"),
-            "--mode=block".to_string(),
-            "tail".to_string(),
-            format!("--pid={daemon_pid}"),
-            "-f".to_string(),
-            "/dev/null".to_string(),
-        ],
-    })
+fn platform_inhibitor_commands(daemon_pid: u32) -> Result<Vec<InhibitorCommand>, String> {
+    let payload = || vec!["tail".to_string(), format!("--pid={daemon_pid}"), "-f".to_string(), "/dev/null".to_string()];
+    let systemd = |what: &str| {
+        let mut args =
+            vec![format!("--what={what}"), "--who=flotillad".to_string(), format!("--why={INHIBITOR_REASON}"), "--mode=block".to_string()];
+        args.extend(payload());
+        InhibitorCommand { program: "systemd-inhibit".to_string(), args, verification: InhibitorVerification::ProcessAlive }
+    };
+    // kde-inhibit waits for its payload, so make the payload watch both the
+    // daemon and kde-inhibit itself. This prevents an orphan if verification
+    // fails and we have to kill the wrapper.
+    let kde_args = vec![
+        "--power".to_string(),
+        "sh".to_string(),
+        "-c".to_string(),
+        "wrapper=$PPID; while kill -0 \"$1\" 2>/dev/null && kill -0 \"$wrapper\" 2>/dev/null; do sleep 1; done".to_string(),
+        "flotilla-sleep-inhibitor".to_string(),
+        daemon_pid.to_string(),
+    ];
+    Ok(vec![
+        systemd("sleep"),
+        InhibitorCommand { program: "kde-inhibit".to_string(), args: kde_args, verification: InhibitorVerification::KdePowerManagement },
+        systemd("idle"),
+    ])
 }
 
 #[cfg(target_os = "macos")]
-fn platform_inhibitor_command(daemon_pid: u32) -> Result<InhibitorCommand, String> {
-    Ok(InhibitorCommand { program: "caffeinate", args: vec!["-i".to_string(), "-w".to_string(), daemon_pid.to_string()] })
+fn platform_inhibitor_commands(daemon_pid: u32) -> Result<Vec<InhibitorCommand>, String> {
+    Ok(vec![InhibitorCommand {
+        program: "caffeinate".to_string(),
+        args: vec!["-i".to_string(), "-w".to_string(), daemon_pid.to_string()],
+        verification: InhibitorVerification::ProcessAlive,
+    }])
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn platform_inhibitor_command(_daemon_pid: u32) -> Result<InhibitorCommand, String> {
+fn platform_inhibitor_commands(_daemon_pid: u32) -> Result<Vec<InhibitorCommand>, String> {
     Err("system sleep inhibition is unsupported on this platform".to_string())
 }
 
@@ -182,7 +343,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use flotilla_protocol::PrincipalRef;
-    use flotilla_resources::{ConvoySpec, ConvoyStatus, InMemoryBackend, InputMeta, ResourceBackend};
+    use flotilla_resources::{ConvoySpec, ConvoyStatus, HostSpec, InMemoryBackend, InputMeta, ResourceBackend};
     use tokio::sync::mpsc;
 
     use super::*;
@@ -193,10 +354,20 @@ mod tests {
         states: mpsc::UnboundedSender<bool>,
     }
 
+    struct FailingInhibitor;
+
     #[async_trait]
     impl SleepInhibitor for RecordingInhibitor {
-        async fn maintain(&mut self, required: bool) -> Result<(), String> {
-            self.states.send(required).map_err(|_| "test receiver closed".to_string())
+        async fn maintain(&mut self, required: bool) -> Result<SleepInhibitionHealth, String> {
+            self.states.send(required).map_err(|_| "test receiver closed".to_string())?;
+            Ok(if required { SleepInhibitionHealth::Held } else { SleepInhibitionHealth::NotRequired })
+        }
+    }
+
+    #[async_trait]
+    impl SleepInhibitor for FailingInhibitor {
+        async fn maintain(&mut self, _required: bool) -> Result<SleepInhibitionHealth, String> {
+            Err("polkit denied".to_string())
         }
     }
 
@@ -223,6 +394,10 @@ mod tests {
             .expect("update convoy status")
     }
 
+    async fn create_host(hosts: &TypedResolver<Host>) {
+        hosts.create(&InputMeta::builder().name("test-host".to_string()).build(), &HostSpec {}).await.expect("create host");
+    }
+
     async fn next_state(states: &mut mpsc::UnboundedReceiver<bool>) -> bool {
         tokio::time::timeout(Duration::from_secs(1), states.recv())
             .await
@@ -234,12 +409,18 @@ mod tests {
     async fn startup_reacquires_for_an_existing_active_convoy() {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
         let convoys = backend.using::<Convoy>(NAMESPACE);
+        let hosts = backend.using::<Host>(NAMESPACE);
+        create_host(&hosts).await;
         create_convoy(&convoys, "active", ConvoyPhase::Active).await;
         let (tx, mut rx) = mpsc::unbounded_channel();
 
-        let task = tokio::spawn(run_with_inhibitor(convoys, RecordingInhibitor { states: tx }));
+        let task = tokio::spawn(run_with_inhibitor(convoys, hosts.clone(), "test-host".to_string(), RecordingInhibitor { states: tx }));
 
         assert!(next_state(&mut rx).await);
+        assert_eq!(
+            hosts.get("test-host").await.expect("get host").status.expect("host status").sleep_inhibition,
+            SleepInhibitionHealth::Held
+        );
         task.abort();
     }
 
@@ -247,10 +428,12 @@ mod tests {
     async fn releases_only_after_the_last_convoy_becomes_terminal() {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
         let convoys = backend.using::<Convoy>(NAMESPACE);
+        let hosts = backend.using::<Host>(NAMESPACE);
+        create_host(&hosts).await;
         let first = create_convoy(&convoys, "first", ConvoyPhase::Active).await;
         let second = create_convoy(&convoys, "second", ConvoyPhase::Active).await;
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let task = tokio::spawn(run_with_inhibitor(convoys.clone(), RecordingInhibitor { states: tx }));
+        let task = tokio::spawn(run_with_inhibitor(convoys.clone(), hosts, "test-host".to_string(), RecordingInhibitor { states: tx }));
         assert!(next_state(&mut rx).await);
 
         convoys
@@ -274,14 +457,77 @@ mod tests {
     }
 
     #[test]
+    fn three_consecutive_failures_escalate_sleep_inhibition_health() {
+        let mut tracker = InhibitionHealthTracker::default();
+
+        let first = tracker.observe(Err("polkit denied".to_string())).changed.expect("first failure should publish");
+        assert!(matches!(first, SleepInhibitionHealth::Acquiring { consecutive_failures: 1, .. }));
+
+        let second = tracker.observe(Err("polkit denied".to_string())).changed.expect("second failure should publish");
+        assert!(matches!(second, SleepInhibitionHealth::Acquiring { consecutive_failures: 2, .. }));
+
+        let third = tracker.observe(Err("polkit denied".to_string())).changed.expect("third failure should publish");
+        assert_eq!(third, SleepInhibitionHealth::Failed { consecutive_failures: FAILURE_THRESHOLD, message: "polkit denied".to_string() });
+
+        assert!(tracker.observe(Err("polkit denied".to_string())).changed.is_none(), "identical failures should stay deduplicated");
+    }
+
+    #[tokio::test]
+    async fn three_consecutive_failures_publish_a_failed_host_condition() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let hosts = backend.using::<Host>(NAMESPACE);
+        create_host(&hosts).await;
+        let mut inhibitor = FailingInhibitor;
+        let mut tracker = InhibitionHealthTracker::default();
+
+        for _ in 0..FAILURE_THRESHOLD {
+            maintain_and_publish(&mut inhibitor, true, &mut tracker, &hosts, "test-host").await.expect("publish sleep inhibition health");
+        }
+
+        assert_eq!(
+            hosts.get("test-host").await.expect("get host").status.expect("host status").sleep_inhibition,
+            SleepInhibitionHealth::Failed { consecutive_failures: FAILURE_THRESHOLD, message: "polkit denied".to_string() }
+        );
+    }
+
+    #[tokio::test]
+    async fn immediate_child_exit_is_an_acquisition_failure_with_stderr() {
+        let mut inhibitor = SystemSleepInhibitor::default();
+
+        let error = inhibitor
+            .acquire_command(InhibitorCommand {
+                program: "sh".to_string(),
+                args: vec!["-c".to_string(), "echo 'polkit denied' >&2; exit 1".to_string()],
+                verification: InhibitorVerification::ProcessAlive,
+            })
+            .await
+            .expect_err("immediate exit should fail acquisition");
+
+        assert!(error.contains("exited during acquisition confirmation with exit status: 1"), "{error}");
+        assert!(error.contains("polkit denied"), "{error}");
+        assert!(inhibitor.child.is_none());
+    }
+
+    #[test]
     #[cfg(target_os = "linux")]
-    fn linux_uses_a_visible_logind_block_inhibitor() {
-        let command = platform_inhibitor_command(42).expect("Linux inhibitor command");
-        assert_eq!(command.program, "systemd-inhibit");
-        assert!(command.args.iter().any(|arg| arg == "--what=sleep"));
-        assert!(command.args.iter().any(|arg| arg == "--mode=block"));
-        assert!(command.args.iter().any(|arg| arg == "--who=flotillad"));
-        assert!(command.args.iter().any(|arg| arg == &format!("--why={INHIBITOR_REASON}")));
-        assert!(command.args.iter().any(|arg| arg == "--pid=42"));
+    fn linux_falls_back_from_logind_sleep_to_desktop_and_idle_inhibition() {
+        let commands = platform_inhibitor_commands(42).expect("Linux inhibitor commands");
+        assert_eq!(commands.len(), 3);
+
+        assert_eq!(commands[0].program, "systemd-inhibit");
+        assert!(commands[0].args.iter().any(|arg| arg == "--what=sleep"));
+        assert!(commands[0].args.iter().any(|arg| arg == "--mode=block"));
+
+        assert_eq!(commands[1].program, "kde-inhibit");
+        assert!(commands[1].args.iter().any(|arg| arg == "--power"));
+        assert!(commands[1].args.iter().any(|arg| arg == "42"));
+        assert_eq!(commands[1].verification, InhibitorVerification::KdePowerManagement);
+
+        assert_eq!(commands[2].program, "systemd-inhibit");
+        assert!(commands[2].args.iter().any(|arg| arg == "--what=idle"));
+
+        for command in [&commands[0], &commands[2]] {
+            assert!(command.args.iter().any(|arg| arg == "--pid=42"));
+        }
     }
 }

--- a/crates/flotilla-daemon/src/sleep_inhibitor.rs
+++ b/crates/flotilla-daemon/src/sleep_inhibitor.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeSet, process::Stdio, time::Duration};
+use std::{
+    collections::BTreeSet,
+    process::{Output, Stdio},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use flotilla_protocol::SleepInhibitionHealth;
@@ -12,9 +16,12 @@ use tokio::{
 };
 use tracing::{error, info, warn};
 
-const RECHECK_INTERVAL: Duration = Duration::from_secs(5);
+const HEALTHY_RECHECK_INTERVAL: Duration = Duration::from_secs(30);
+const ACQUISITION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const FAILED_RETRY_INTERVAL: Duration = Duration::from_secs(300);
 const ACQUISITION_CONFIRMATION: Duration = Duration::from_millis(250);
 const KDE_INHIBITION_ENFORCEMENT_DELAY: Duration = Duration::from_millis(5_250);
+const KDE_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(3);
 const FAILURE_THRESHOLD: u32 = 3;
 const INHIBITOR_REASON: &str = "Flotilla vessel crew is active";
 
@@ -39,9 +46,8 @@ async fn run_with_inhibitor<I: SleepInhibitor>(
     maintain_and_publish(&mut inhibitor, active.required(), &mut health, &hosts, &host_id).await?;
 
     let mut watch = convoys.watch(WatchStart::resuming_from(&listed)).await?;
-    let mut recheck = tokio::time::interval(RECHECK_INTERVAL);
-    recheck.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    recheck.tick().await;
+    let recheck = tokio::time::sleep(health.recheck_interval());
+    tokio::pin!(recheck);
 
     loop {
         tokio::select! {
@@ -50,13 +56,15 @@ async fn run_with_inhibitor<I: SleepInhibitor>(
                     Some(Ok(event)) => {
                         active.apply(event);
                         maintain_and_publish(&mut inhibitor, active.required(), &mut health, &hosts, &host_id).await?;
+                        recheck.as_mut().reset(tokio::time::Instant::now() + health.recheck_interval());
                     }
                     Some(Err(error)) => return Err(error),
                     None => return Err(ResourceError::other("sleep inhibitor convoy watch ended")),
                 }
             }
-            _ = recheck.tick() => {
+            _ = &mut recheck => {
                 maintain_and_publish(&mut inhibitor, active.required(), &mut health, &hosts, &host_id).await?;
+                recheck.as_mut().reset(tokio::time::Instant::now() + health.recheck_interval());
             }
         }
     }
@@ -113,7 +121,7 @@ impl InhibitionHealthTracker {
                     SleepInhibitionHealth::Acquiring { consecutive_failures: self.consecutive_failures, message: error.clone() }
                 };
                 let log = if self.consecutive_failures == FAILURE_THRESHOLD
-                    && !matches!(self.published, Some(SleepInhibitionHealth::Failed { .. }))
+                    && (!matches!(self.published, Some(SleepInhibitionHealth::Failed { .. })) || error_changed)
                 {
                     FailureLog::Degraded
                 } else if self.consecutive_failures == 1 || error_changed {
@@ -129,6 +137,14 @@ impl InhibitionHealthTracker {
             health
         });
         HealthObservation { changed, log, error }
+    }
+
+    fn recheck_interval(&self) -> Duration {
+        match self.published.as_ref() {
+            Some(SleepInhibitionHealth::Acquiring { .. }) => ACQUISITION_RETRY_INTERVAL,
+            Some(SleepInhibitionHealth::Failed { .. }) => FAILED_RETRY_INTERVAL,
+            _ => HEALTHY_RECHECK_INTERVAL,
+        }
     }
 }
 
@@ -279,15 +295,13 @@ enum InhibitorVerification {
 }
 
 async fn verify_kde_power_inhibition() -> Result<(), String> {
-    let output = Command::new("qdbus6")
-        .args([
-            "org.freedesktop.PowerManagement.Inhibit",
-            "/org/freedesktop/PowerManagement/Inhibit",
-            "org.freedesktop.PowerManagement.Inhibit.HasInhibit",
-        ])
-        .output()
-        .await
-        .map_err(|error| format!("verify KDE power inhibition with qdbus6: {error}"))?;
+    let mut command = Command::new("qdbus6");
+    command.args([
+        "org.freedesktop.PowerManagement.Inhibit",
+        "/org/freedesktop/PowerManagement/Inhibit",
+        "org.freedesktop.PowerManagement.Inhibit.HasInhibit",
+    ]);
+    let output = command_output_with_timeout(command, KDE_VERIFICATION_TIMEOUT, "verify KDE power inhibition with qdbus6").await?;
     if !output.status.success() {
         return Err(format!("verify KDE power inhibition with qdbus6: {}", String::from_utf8_lossy(&output.stderr).trim()));
     }
@@ -295,6 +309,14 @@ async fn verify_kde_power_inhibition() -> Result<(), String> {
         return Err("KDE power inhibition was not active after its enforcement delay".to_string());
     }
     Ok(())
+}
+
+async fn command_output_with_timeout(mut command: Command, timeout: Duration, description: &str) -> Result<Output, String> {
+    command.kill_on_drop(true);
+    tokio::time::timeout(timeout, command.output())
+        .await
+        .map_err(|_| format!("{description}: timed out after {}s", timeout.as_secs_f64()))?
+        .map_err(|error| format!("{description}: {error}"))
 }
 
 #[cfg(target_os = "linux")]
@@ -470,6 +492,7 @@ mod tests {
         assert_eq!(third, SleepInhibitionHealth::Failed { consecutive_failures: FAILURE_THRESHOLD, message: "polkit denied".to_string() });
 
         assert!(tracker.observe(Err("polkit denied".to_string())).changed.is_none(), "identical failures should stay deduplicated");
+        assert_eq!(tracker.recheck_interval(), FAILED_RETRY_INTERVAL);
     }
 
     #[tokio::test]
@@ -506,6 +529,18 @@ mod tests {
         assert!(error.contains("exited during acquisition confirmation with exit status: 1"), "{error}");
         assert!(error.contains("polkit denied"), "{error}");
         assert!(inhibitor.child.is_none());
+    }
+
+    #[tokio::test]
+    async fn external_verification_command_is_bounded_by_a_timeout() {
+        let mut command = Command::new("sh");
+        command.args(["-c", "sleep 30"]);
+
+        let error = command_output_with_timeout(command, Duration::from_millis(10), "test verification")
+            .await
+            .expect_err("slow verification should time out");
+
+        assert!(error.contains("test verification: timed out"), "{error}");
     }
 
     #[test]

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -125,7 +125,7 @@ pub use query::{
     FleetListResponse, FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry,
     HostListResponse, HostProvidersResponse, HostStatusResponse, PeerReconnectStatus, ProjectListEntry, ProjectListRepository,
     ProjectListResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse, RepoProvidersResponse, RepoSummary, RepoWorkResponse,
-    StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
+    SleepInhibitionHealth, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
 };
 pub use repository::{RepositoryRelation, RepositoryUpstream};
 pub use resource_ref::ResourceRef;

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -202,6 +202,22 @@ pub struct FleetHealthResponse {
     pub hosts: Vec<FleetHostRow>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SleepInhibitionHealth {
+    #[default]
+    NotRequired,
+    Held,
+    Acquiring {
+        consecutive_failures: u32,
+        message: String,
+    },
+    Failed {
+        consecutive_failures: u32,
+        message: String,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 #[builder(on(String, into))]
 pub struct FleetHostRow {
@@ -225,6 +241,9 @@ pub struct FleetHostRow {
     pub convoy_count: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disk_free_bytes: Option<u64>,
+    #[serde(default)]
+    #[builder(default)]
+    pub sleep_inhibition: SleepInhibitionHealth,
     pub staleness: FleetHostStaleness,
     pub observation_agreement: FleetObservationAgreement,
     #[builder(default)]

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
+use flotilla_protocol::SleepInhibitionHealth;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -38,6 +39,9 @@ pub struct HostStatus {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub conditions: Vec<HostCondition>,
+    #[serde(default)]
+    #[builder(default)]
+    pub sleep_inhibition: SleepInhibitionHealth,
 }
 
 impl HostStatus {
@@ -88,6 +92,9 @@ pub enum HostStatusPatch {
         daemon_started_at: Option<DateTime<Utc>>,
         disk_free_bytes: Option<u64>,
     },
+    SleepInhibition {
+        health: SleepInhibitionHealth,
+    },
 }
 
 impl StatusPatch<HostStatus> for HostStatusPatch {
@@ -110,6 +117,7 @@ impl StatusPatch<HostStatus> for HostStatusPatch {
                 status.daemon_started_at = *daemon_started_at;
                 status.disk_free_bytes = *disk_free_bytes;
             }
+            Self::SleepInhibition { health } => status.sleep_inhibition.clone_from(health),
         }
     }
 }

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -1,4 +1,5 @@
 use chrono::{TimeZone, Utc};
+use flotilla_protocol::SleepInhibitionHealth;
 use flotilla_resources::{
     CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutStatus, CheckoutStatusPatch, ClonePhase, CloneStatus,
     CloneStatusPatch, ConditionValue, EnvironmentPhase, EnvironmentStatus, EnvironmentStatusPatch, HostStatus, HostStatusPatch,
@@ -23,6 +24,13 @@ fn host_status_patch_updates_heartbeat_snapshot() {
     assert_eq!(status.capabilities.get("docker"), Some(&serde_json::Value::Bool(true)));
     assert!(status.heartbeat_at.is_some());
     assert!(status.ready);
+
+    HostStatusPatch::SleepInhibition {
+        health: SleepInhibitionHealth::Failed { consecutive_failures: 3, message: "polkit denied".to_string() },
+    }
+    .apply(&mut status);
+
+    assert_eq!(status.sleep_inhibition, SleepInhibitionHealth::Failed { consecutive_failures: 3, message: "polkit denied".to_string() });
 }
 
 #[test]

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -224,9 +224,8 @@ pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> Strin
         }
         let diagnosis = if diagnoses.is_empty() {
             match host.observation_agreement {
-                FleetObservationAgreement::Agree => "agree".to_string(),
-                FleetObservationAgreement::Disagree => unreachable!("disagreement should have produced a diagnosis"),
                 FleetObservationAgreement::Unknown => "unknown".to_string(),
+                FleetObservationAgreement::Agree | FleetObservationAgreement::Disagree => "agree".to_string(),
             }
         } else {
             diagnoses.join("; ")

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -169,6 +169,19 @@ fn format_disk_free(bytes: Option<u64>) -> String {
     bytes.map_or_else(|| "-".to_string(), |bytes| format!("{:.1} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0)))
 }
 
+fn format_sleep_inhibition(health: &flotilla_protocol::SleepInhibitionHealth) -> String {
+    match health {
+        flotilla_protocol::SleepInhibitionHealth::NotRequired => "not required".to_string(),
+        flotilla_protocol::SleepInhibitionHealth::Held => "held".to_string(),
+        flotilla_protocol::SleepInhibitionHealth::Acquiring { consecutive_failures, .. } => {
+            format!("acquiring ({consecutive_failures} failures)")
+        }
+        flotilla_protocol::SleepInhibitionHealth::Failed { consecutive_failures, message } => {
+            format!("FAILED ({consecutive_failures}): {message}")
+        }
+    }
+}
+
 pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> String {
     if response.hosts.is_empty() {
         return "No hosts known.\n".to_string();
@@ -188,6 +201,7 @@ pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> Strin
         "Crew",
         "Convoys",
         "Disk Free",
+        "Sleep Inhibition",
         "Staleness",
         "Diagnosis",
     ]);
@@ -219,6 +233,7 @@ pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> Strin
             Cell::new(host.crew_count),
             Cell::new(host.convoy_count),
             Cell::new(format_disk_free(host.disk_free_bytes)),
+            Cell::new(format_sleep_inhibition(&host.sleep_inhibition)),
             Cell::new(row),
             Cell::new(diagnosis),
         ]);

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -212,14 +212,24 @@ pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> Strin
             FleetHostStaleness::Stale => "STALE",
             FleetHostStaleness::Unknown => "unknown",
         };
-        let diagnosis = if !host.degraded_conditions.is_empty() {
-            format!("⚠ DEGRADED: {}", host.degraded_conditions.join("; "))
-        } else {
+        let mut diagnoses = Vec::new();
+        if !host.degraded_conditions.is_empty() {
+            diagnoses.push(format!("⚠ DEGRADED: {}", host.degraded_conditions.join("; ")));
+        }
+        if matches!(&host.sleep_inhibition, flotilla_protocol::SleepInhibitionHealth::Failed { .. }) {
+            diagnoses.push("⚠ SLEEP INHIBITION FAILED".to_string());
+        }
+        if host.observation_agreement == FleetObservationAgreement::Disagree {
+            diagnoses.push("⚠ DISAGREE".to_string());
+        }
+        let diagnosis = if diagnoses.is_empty() {
             match host.observation_agreement {
                 FleetObservationAgreement::Agree => "agree".to_string(),
-                FleetObservationAgreement::Disagree => "⚠ DISAGREE".to_string(),
+                FleetObservationAgreement::Disagree => unreachable!("disagreement should have produced a diagnosis"),
                 FleetObservationAgreement::Unknown => "unknown".to_string(),
             }
+        } else {
+            diagnoses.join("; ")
         };
         table.add_row(vec![
             Cell::new(name),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -700,6 +700,7 @@ mod command_result_human {
             "42.0 GiB",
             "FAILED (3): polkit denied",
             "STALE",
+            "⚠ SLEEP INHIBITION FAILED",
             "⚠ DISAGREE",
         ] {
             assert!(output.contains(expected), "expected fleet health output to contain {expected:?}:\n{output}");

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -679,6 +679,10 @@ mod command_result_human {
                 .crew_count(3)
                 .convoy_count(2)
                 .disk_free_bytes(42 * 1024 * 1024 * 1024)
+                .sleep_inhibition(flotilla_protocol::SleepInhibitionHealth::Failed {
+                    consecutive_failures: 3,
+                    message: "polkit denied".to_string(),
+                })
                 .staleness(FleetHostStaleness::Stale)
                 .observation_agreement(FleetObservationAgreement::Disagree)
                 .build()],
@@ -686,7 +690,18 @@ mod command_result_human {
 
         let output = format_command_result(&result);
 
-        for expected in ["feta", "connected", "old-generation", "new-generation", "0.9.0", "7200s", "42.0 GiB", "STALE", "⚠ DISAGREE"] {
+        for expected in [
+            "feta",
+            "connected",
+            "old-generation",
+            "new-generation",
+            "0.9.0",
+            "7200s",
+            "42.0 GiB",
+            "FAILED (3): polkit denied",
+            "STALE",
+            "⚠ DISAGREE",
+        ] {
             assert!(output.contains(expected), "expected fleet health output to contain {expected:?}:\n{output}");
         }
     }

--- a/crates/flotilla-tui/src/widgets/event_log.rs
+++ b/crates/flotilla-tui/src/widgets/event_log.rs
@@ -2,7 +2,7 @@ use std::{any::Any, collections::HashMap};
 
 use chrono::{DateTime, Utc};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
-use flotilla_protocol::{FleetHostRow, FleetHostStaleness, FleetObservationAgreement, PeerConnectionState};
+use flotilla_protocol::{FleetHostRow, FleetHostStaleness, FleetObservationAgreement, PeerConnectionState, SleepInhibitionHealth};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
@@ -389,14 +389,15 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
     let rows = hosts.iter().map(|host| {
         let degraded = !host.degraded_conditions.is_empty();
         let disagreement = host.observation_agreement == FleetObservationAgreement::Disagree;
-        let icon = if degraded || disagreement {
+        let inhibition_failed = matches!(host.sleep_inhibition, SleepInhibitionHealth::Failed { .. });
+        let icon = if degraded || disagreement || inhibition_failed {
             "⚠"
         } else if host.staleness == FleetHostStaleness::Current {
             "●"
         } else {
             "○"
         };
-        let style = if degraded || disagreement {
+        let style = if degraded || disagreement || inhibition_failed {
             Style::default().fg(theme.warning)
         } else if host.staleness == FleetHostStaleness::Current {
             Style::default().fg(theme.status_ok)
@@ -429,6 +430,12 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
                 FleetHostStaleness::Unknown => "unknown",
             }
         };
+        let sleep = match &host.sleep_inhibition {
+            SleepInhibitionHealth::NotRequired => "-",
+            SleepInhibitionHealth::Held => "held",
+            SleepInhibitionHealth::Acquiring { .. } => "acquiring",
+            SleepInhibitionHealth::Failed { .. } => "FAILED",
+        };
         Row::new(vec![
             Cell::from(Span::styled(icon, style)),
             Cell::from(name),
@@ -438,6 +445,7 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
             Cell::from(replica),
             Cell::from(format!("{}/{}", host.crew_count, host.convoy_count)),
             Cell::from(disk),
+            Cell::from(sleep),
             Cell::from(stale),
         ])
     });
@@ -450,10 +458,12 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
         Constraint::Length(19),
         Constraint::Length(9),
         Constraint::Length(9),
+        Constraint::Length(10),
         Constraint::Length(8),
     ];
-    let header = Row::new(["", "Host", "Daemon v/gen/up", "Link", "Heartbeat", "Replica sync/gen", "Crew/Conv", "Disk", "Staleness"])
-        .style(theme.header_style());
+    let header =
+        Row::new(["", "Host", "Daemon v/gen/up", "Link", "Heartbeat", "Replica sync/gen", "Crew/Conv", "Disk", "Sleep", "Staleness"])
+            .style(theme.header_style());
     let table = Table::new(rows, widths).header(header).block(Block::bordered().style(theme.block_style()).title(" Fleet Health "));
     frame.render_widget(table, area);
 }


### PR DESCRIPTION
## What changed

- confirm inhibitor helper processes survive startup before reporting acquisition
- on Linux, try the broad logind sleep inhibitor first, then use a verified PowerDevil `kde-inhibit --power` fallback, with logind idle inhibition as the non-desktop fallback
- escalate three consecutive acquisition failures into a durable `sleep_inhibition: failed` Host status condition
- project sleep-inhibition health into the fleet-health protocol, CLI table, and TUI fleet panel
- preserve the condition across periodic Host heartbeat updates

## Root cause

Reproducing on feta showed `systemd-inhibit --what=sleep --mode=block` exits immediately with status 1 because flotillad belongs to a remote logind session. Feta's polkit policy challenges remote-session callers for block-sleep, while `systemd-inhibit` does not enable interactive authentication. PowerDevil runs in the active local Wayland session and owns feta's five-hour auto-suspend policy.

An idle-only logind lock was tested and rejected as insufficient: PowerDevil maps it to screen-management inhibition, while its auto-suspend path requires an interrupt-session inhibition. The verified KDE fallback becomes an active PowerDevil sleep inhibition after its enforcement delay and releases with the daemon-bound payload.

## Impact

Active crews on feta now obtain a session-compatible sleep inhibitor instead of silently running without protection. If every strategy fails, the daemon stops emitting misleading acquisition messages, records the failure after three consecutive attempts, and exposes it in fleet health.

## Validation

- live reproduction on feta of the original exit-1/polkit error
- live verification that the generated KDE fallback appears as an active PowerDevil sleep inhibition and releases cleanly
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1181