### PR TITLE
test: add reconciler liveness contract harness

### DIFF
--- a/crates/flotilla-controllers/Cargo.toml
+++ b/crates/flotilla-controllers/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = "0.10"
 serde_json = { workspace = true }
 
 [dev-dependencies]
+flotilla-resources = { path = "../flotilla-resources", features = ["test-support"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 rstest = { workspace = true }
 tempfile = "3"

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     controller::{ReconcileOutcome, Reconciler},
-    Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, Clone,
-    ClonePhase, IntegrationCondition, ResourceBackend, ResourceError, ResourceObject, TypedResolver,
+    Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, Clock,
+    Clone, ClonePhase, IntegrationCondition, ResourceBackend, ResourceError, ResourceObject, SystemClock, TypedResolver,
 };
 use tracing::warn;
 
@@ -60,11 +60,16 @@ pub trait CheckoutRuntime: Send + Sync {
 pub struct CheckoutReconciler<R> {
     runtime: Arc<R>,
     clones: TypedResolver<Clone>,
+    clock: Arc<dyn Clock>,
 }
 
 impl<R> CheckoutReconciler<R> {
     pub fn new(runtime: Arc<R>, backend: ResourceBackend, namespace: &str) -> Self {
-        Self { runtime, clones: backend.using::<Clone>(namespace) }
+        Self::with_clock(runtime, backend, namespace, Arc::new(SystemClock))
+    }
+
+    pub fn with_clock(runtime: Arc<R>, backend: ResourceBackend, namespace: &str, clock: Arc<dyn Clock>) -> Self {
+        Self { runtime, clones: backend.using::<Clone>(namespace), clock }
     }
 }
 
@@ -101,7 +106,11 @@ where
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
         if obj.status.as_ref().map(|status| status.phase).unwrap_or(CheckoutPhase::Pending) != CheckoutPhase::Pending {
-            if obj.status.as_ref().is_some_and(|status| status.phase == CheckoutPhase::Ready && !integration_is_fresh(status, Utc::now())) {
+            if obj
+                .status
+                .as_ref()
+                .is_some_and(|status| status.phase == CheckoutPhase::Ready && !integration_is_fresh(status, self.clock.now()))
+            {
                 return Ok(match self.runtime.inspect_integration(obj).await {
                     Ok(status) => CheckoutDeps::Integration { status: Box::new(status) },
                     Err(err) => CheckoutDeps::Failed(err),

--- a/crates/flotilla-controllers/tests/liveness_contract.rs
+++ b/crates/flotilla-controllers/tests/liveness_contract.rs
@@ -287,6 +287,7 @@ struct ConvoyWorld {
     reconciler: ConvoyReconciler,
     runtime: Arc<LandingRuntime>,
     contradictory: bool,
+    passes: usize,
 }
 
 struct ConvoyWorldBuilder {
@@ -364,7 +365,7 @@ impl WorldBuilder for ConvoyWorldBuilder {
         let reconciler = ConvoyReconciler::new(inner.using(NAMESPACE))
             .with_checkouts(inner.using(NAMESPACE))
             .with_teardown_runtime(Arc::clone(&runtime) as Arc<dyn ConvoyTeardownRuntime>);
-        Ok(ConvoyWorld { backend, current, reconciler, runtime, contradictory })
+        Ok(ConvoyWorld { backend, current, reconciler, runtime, contradictory, passes: 0 })
     }
 }
 
@@ -378,6 +379,7 @@ impl ReconcileStep<ConvoyWorld> for ConvoyStep {
     async fn reconcile_step(&self, world: &mut ConvoyWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
         let deps = world.reconciler.fetch_dependencies(&world.current).await.map_err(|error| error.to_string())?;
         let outcome = world.reconciler.reconcile(&world.current, &deps, world.runtime.clock.now());
+        world.passes += 1;
         Ok(LivenessStep::new(outcome.patch, outcome.actuations))
     }
 
@@ -397,6 +399,7 @@ struct ConvoyFixpoint;
 impl FixpointPredicate<ConvoyWorld> for ConvoyFixpoint {
     fn at_fixpoint(&self, world: &ConvoyWorld) -> bool {
         !world.contradictory
+            && world.passes > 0
             && world.current.status.as_ref().is_some_and(|status| matches!(status.phase, ConvoyPhase::Landing | ConvoyPhase::Landed))
     }
 

--- a/crates/flotilla-controllers/tests/liveness_contract.rs
+++ b/crates/flotilla-controllers/tests/liveness_contract.rs
@@ -1,0 +1,446 @@
+mod common;
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, TimeZone, Utc};
+use flotilla_controllers::reconcilers::{
+    checkout::{CheckoutDeps, CheckoutReconciler},
+    CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout,
+};
+use flotilla_resources::{
+    controller::{Actuation, Reconciler},
+    test_support::{
+        assert_actuation_drop_recovery, assert_bounded_convergence, assert_degradation_not_wedging, assert_quiescence_at_fixpoint,
+        assert_staleness_edges, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, WorldBuilder,
+        WriteCountingBackend,
+    },
+    Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, Clock,
+    ConditionValue, Convoy, ConvoyPhase, ConvoyReconciler, ConvoyStatusPatch, ConvoyTeardownRuntime, FreshCloneCheckoutSpec, InputMeta,
+    IntegrationCondition, RepositoryKey, ResourceObject, VirtualClock, WorkPhase, CONVOY_LABEL,
+};
+
+const NAMESPACE: &str = "flotilla";
+const INTEGRATION_TTL: Duration = Duration::hours(6);
+
+struct HarnessRuntime {
+    clock: Arc<VirtualClock>,
+    inspections: AtomicUsize,
+    fail_inspection: bool,
+}
+
+#[async_trait]
+impl CheckoutRuntime for HarnessRuntime {
+    async fn create_worktree(
+        &self,
+        _clone_path: &str,
+        _branch: &str,
+        _base_ref: Option<&str>,
+        _target_path: &str,
+    ) -> Result<PreparedCheckout, String> {
+        unreachable!("the liveness fixture uses a fresh clone")
+    }
+
+    async fn create_fresh_clone(
+        &self,
+        _repo_url: &str,
+        _branch: &str,
+        _base_ref: Option<&str>,
+        _target_path: &str,
+    ) -> Result<PreparedCheckout, String> {
+        Ok(PreparedCheckout { commit: Some("abc123".to_string()), branch_provenance: CheckoutBranchProvenance::CreatedForConvoy })
+    }
+
+    async fn inspect_integration(&self, _checkout: &ResourceObject<Checkout>) -> Result<CheckoutIntegrationStatus, String> {
+        self.inspections.fetch_add(1, Ordering::SeqCst);
+        if self.fail_inspection {
+            return Err("resource says Ready but checkout path is missing".to_string());
+        }
+        let observed_at = self.clock.now().to_rfc3339();
+        Ok(CheckoutIntegrationStatus {
+            clean: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+            pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+            landed: IntegrationCondition::builder().value(ConditionValue::False).observed_at(observed_at).build(),
+            landed_evidence: None,
+        })
+    }
+
+    async fn remove_checkout(&self, _removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {
+        Ok(CheckoutRemovalOutcome::Removed)
+    }
+}
+
+struct CheckoutWorld {
+    backend: WriteCountingBackend,
+    current: ResourceObject<Checkout>,
+    reconciler: CheckoutReconciler<HarnessRuntime>,
+    runtime: Arc<HarnessRuntime>,
+}
+
+struct CheckoutWorldBuilder {
+    clock: Arc<VirtualClock>,
+}
+
+#[async_trait]
+impl WorldBuilder for CheckoutWorldBuilder {
+    type World = CheckoutWorld;
+
+    async fn build(&self, scenario: LivenessScenario) -> Result<Self::World, String> {
+        self.clock.set(timestamp());
+        let backend = WriteCountingBackend::in_memory();
+        let resolver = backend.using::<Checkout>(NAMESPACE);
+        let created = resolver
+            .create(
+                &InputMeta { name: "checkout-a".to_string(), ..Default::default() },
+                &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                    repo_ref: RepositoryKey("repo-a".to_string()),
+                    env_ref: "env-a".to_string(),
+                    r#ref: "feature/liveness".to_string(),
+                    base_ref: Some("main".to_string()),
+                    target_path: "/work/checkout-a".to_string(),
+                    url: "https://example.com/repo-a".to_string(),
+                }),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        let fail_inspection = scenario == LivenessScenario::Contradictory;
+        let current = if fail_inspection {
+            resolver
+                .update_status("checkout-a", &created.metadata.resource_version, &CheckoutStatus {
+                    phase: CheckoutPhase::Ready,
+                    path: None,
+                    commit: Some("abc123".to_string()),
+                    branch_provenance: CheckoutBranchProvenance::CreatedForConvoy,
+                    integration: CheckoutIntegrationStatus::default(),
+                    message: None,
+                })
+                .await
+                .map_err(|error| error.to_string())?
+        } else {
+            created
+        };
+        backend.reset_writes();
+        let runtime = Arc::new(HarnessRuntime { clock: Arc::clone(&self.clock), inspections: AtomicUsize::new(0), fail_inspection });
+        let reconciler = CheckoutReconciler::with_clock(
+            Arc::clone(&runtime),
+            backend.inner(),
+            NAMESPACE,
+            self.clock.clone() as Arc<dyn flotilla_resources::Clock>,
+        );
+        Ok(CheckoutWorld { backend, current, reconciler, runtime })
+    }
+}
+
+struct CheckoutStep {
+    broken_freshness_latch: bool,
+}
+
+#[async_trait]
+impl ReconcileStep<CheckoutWorld> for CheckoutStep {
+    type Patch = ();
+    type Actuation = CheckoutStatusPatch;
+
+    async fn reconcile_step(&self, world: &mut CheckoutWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
+        let has_observation = world.current.status.as_ref().is_some_and(|status| status.integration.clean.observed_at.is_some());
+        let deps = if self.broken_freshness_latch && has_observation {
+            // Deliberately re-broken #1163-style variant: once an observation
+            // exists, trust it forever instead of consulting the injected clock.
+            CheckoutDeps::None
+        } else {
+            world.reconciler.fetch_dependencies(&world.current).await.map_err(|error| error.to_string())?
+        };
+        let outcome = world.reconciler.reconcile(&world.current, &deps, world.reconciler_clock_now());
+        Ok(LivenessStep::new(None, outcome.patch.into_iter().collect()))
+    }
+
+    async fn apply_patch(&self, _world: &mut CheckoutWorld, _patch: Self::Patch) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn apply_actuation(&self, world: &mut CheckoutWorld, actuation: Self::Actuation) -> Result<(), String> {
+        world.current = world
+            .backend
+            .using::<Checkout>(NAMESPACE)
+            .apply_status_patch("checkout-a", &actuation)
+            .await
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+}
+
+trait CheckoutWorldClock {
+    fn reconciler_clock_now(&self) -> DateTime<Utc>;
+}
+
+impl CheckoutWorldClock for CheckoutWorld {
+    fn reconciler_clock_now(&self) -> DateTime<Utc> {
+        self.runtime.clock.now()
+    }
+}
+
+struct CheckoutFixpoint;
+
+impl FixpointPredicate<CheckoutWorld> for CheckoutFixpoint {
+    fn at_fixpoint(&self, world: &CheckoutWorld) -> bool {
+        world.current.status.as_ref().is_some_and(|status| {
+            status.phase == CheckoutPhase::Ready
+                && status.integration.clean.observed_at.as_deref().is_some_and(|observed_at| {
+                    DateTime::parse_from_rfc3339(observed_at)
+                        .is_ok_and(|observed_at| world.runtime.clock.now().signed_duration_since(observed_at) < INTEGRATION_TTL)
+                })
+        })
+    }
+
+    fn write_count(&self, world: &CheckoutWorld) -> usize {
+        world.backend.writes()
+    }
+
+    fn reset_write_count(&self, world: &CheckoutWorld) {
+        world.backend.reset_writes();
+    }
+
+    fn held(&self, world: &CheckoutWorld) -> bool {
+        world.current.status.as_ref().is_some_and(|status| {
+            status.integration.clean.value == ConditionValue::Unknown
+                && status.integration.clean.details.iter().any(|detail| detail.contains("path is missing"))
+        })
+    }
+
+    fn probe_count(&self, world: &CheckoutWorld) -> usize {
+        world.runtime.inspections.load(Ordering::SeqCst)
+    }
+}
+
+fn timestamp() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 28, 12, 0, 0).single().expect("valid timestamp")
+}
+
+fn checkout_enrollment(broken_freshness_latch: bool) -> LivenessEnrollment<CheckoutWorldBuilder, CheckoutStep, CheckoutFixpoint> {
+    let clock = Arc::new(VirtualClock::new(timestamp()));
+    LivenessEnrollment::new(
+        CheckoutWorldBuilder { clock: Arc::clone(&clock) },
+        CheckoutStep { broken_freshness_latch },
+        CheckoutFixpoint,
+        clock,
+    )
+    .with_staleness_edges([INTEGRATION_TTL])
+}
+
+#[tokio::test]
+async fn checkout_reconciler_satisfies_liveness_battery() {
+    let enrollment = checkout_enrollment(false);
+    assert_bounded_convergence(&enrollment).await;
+    assert_quiescence_at_fixpoint(&enrollment).await;
+    assert_staleness_edges(&enrollment).await;
+    assert_actuation_drop_recovery(&enrollment).await;
+    assert_degradation_not_wedging(&enrollment).await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "did not re-probe stale state")]
+async fn checkout_staleness_property_bites_a_rebroken_freshness_latch() {
+    assert_staleness_edges(&checkout_enrollment(true)).await;
+}
+
+const LANDING_TTL: Duration = Duration::seconds(30);
+
+struct LandingRuntime {
+    clock: Arc<VirtualClock>,
+    probes: AtomicUsize,
+    contradictory: bool,
+    trust_observation_forever: bool,
+}
+
+#[async_trait]
+impl ConvoyTeardownRuntime for LandingRuntime {
+    async fn no_change_request_outstanding(
+        &self,
+        _convoy: &ResourceObject<Convoy>,
+        checkouts: &[ResourceObject<Checkout>],
+    ) -> Result<bool, String> {
+        let landed =
+            &checkouts.first().ok_or_else(|| "checkout missing".to_string())?.status.as_ref().ok_or("status missing")?.integration.landed;
+        let observed_at = landed
+            .observed_at
+            .as_deref()
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .ok_or_else(|| "landing observation missing".to_string())?;
+        let fresh = self.clock.now().signed_duration_since(observed_at) < LANDING_TTL;
+        if fresh || self.trust_observation_forever {
+            return Ok(landed.value == ConditionValue::True);
+        }
+        self.probes.fetch_add(1, Ordering::SeqCst);
+        Ok(!self.contradictory)
+    }
+
+    async fn verify_reclaim(&self, _convoy: &ResourceObject<Convoy>) -> Result<(), String> {
+        Err("not terminal".to_string())
+    }
+}
+
+struct ConvoyWorld {
+    backend: WriteCountingBackend,
+    current: ResourceObject<Convoy>,
+    reconciler: ConvoyReconciler,
+    runtime: Arc<LandingRuntime>,
+    contradictory: bool,
+}
+
+struct ConvoyWorldBuilder {
+    clock: Arc<VirtualClock>,
+    trust_observation_forever: bool,
+}
+
+#[async_trait]
+impl WorldBuilder for ConvoyWorldBuilder {
+    type World = ConvoyWorld;
+
+    async fn build(&self, scenario: LivenessScenario) -> Result<Self::World, String> {
+        self.clock.set(timestamp());
+        let backend = WriteCountingBackend::in_memory();
+        let inner = backend.inner();
+        let created =
+            common::create_convoy_with_single_task(&inner, NAMESPACE, "convoy-a", "work", "https://example.com/repo-a", "main").await;
+        let convoys = backend.using::<Convoy>(NAMESPACE);
+        let mut status = created.status.expect("convoy fixture status");
+        status.phase = ConvoyPhase::Landing;
+        status.observed_workflow_ref = Some("wf".to_string());
+        status.work.insert("work".to_string(), common::work_state().phase(WorkPhase::Complete).call());
+        let current =
+            convoys.update_status("convoy-a", &created.metadata.resource_version, &status).await.map_err(|error| error.to_string())?;
+
+        let checkouts = backend.using::<Checkout>(NAMESPACE);
+        let checkout = checkouts
+            .create(
+                &InputMeta {
+                    name: "checkout-a".to_string(),
+                    labels: [(CONVOY_LABEL.to_string(), "convoy-a".to_string())].into_iter().collect(),
+                    ..Default::default()
+                },
+                &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                    repo_ref: current.spec.repositories[0].repo_ref.clone(),
+                    env_ref: "env-a".to_string(),
+                    r#ref: "feature/liveness".to_string(),
+                    base_ref: Some("main".to_string()),
+                    target_path: "/missing/checkout-a".to_string(),
+                    url: "https://example.com/repo-a".to_string(),
+                }),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        let observation_time = if scenario == LivenessScenario::Contradictory {
+            self.clock.now() - LANDING_TTL - Duration::seconds(1)
+        } else {
+            self.clock.now()
+        };
+        checkouts
+            .update_status("checkout-a", &checkout.metadata.resource_version, &CheckoutStatus {
+                phase: CheckoutPhase::Ready,
+                path: if scenario == LivenessScenario::Contradictory { None } else { Some("/work/checkout-a".to_string()) },
+                commit: Some("abc123".to_string()),
+                branch_provenance: CheckoutBranchProvenance::CreatedForConvoy,
+                integration: CheckoutIntegrationStatus {
+                    clean: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observation_time.to_rfc3339()).build(),
+                    pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observation_time.to_rfc3339()).build(),
+                    landed: IntegrationCondition::builder().value(ConditionValue::False).observed_at(observation_time.to_rfc3339()).build(),
+                    landed_evidence: None,
+                },
+                message: None,
+            })
+            .await
+            .map_err(|error| error.to_string())?;
+        backend.reset_writes();
+
+        let contradictory = scenario == LivenessScenario::Contradictory;
+        let runtime = Arc::new(LandingRuntime {
+            clock: Arc::clone(&self.clock),
+            probes: AtomicUsize::new(0),
+            contradictory,
+            trust_observation_forever: self.trust_observation_forever,
+        });
+        let reconciler = ConvoyReconciler::new(inner.using(NAMESPACE))
+            .with_checkouts(inner.using(NAMESPACE))
+            .with_teardown_runtime(Arc::clone(&runtime) as Arc<dyn ConvoyTeardownRuntime>);
+        Ok(ConvoyWorld { backend, current, reconciler, runtime, contradictory })
+    }
+}
+
+struct ConvoyStep;
+
+#[async_trait]
+impl ReconcileStep<ConvoyWorld> for ConvoyStep {
+    type Patch = ConvoyStatusPatch;
+    type Actuation = Actuation;
+
+    async fn reconcile_step(&self, world: &mut ConvoyWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
+        let deps = world.reconciler.fetch_dependencies(&world.current).await.map_err(|error| error.to_string())?;
+        let outcome = world.reconciler.reconcile(&world.current, &deps, world.runtime.clock.now());
+        Ok(LivenessStep::new(outcome.patch, outcome.actuations))
+    }
+
+    async fn apply_patch(&self, world: &mut ConvoyWorld, patch: Self::Patch) -> Result<(), String> {
+        world.current =
+            world.backend.using::<Convoy>(NAMESPACE).apply_status_patch("convoy-a", &patch).await.map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    async fn apply_actuation(&self, _world: &mut ConvoyWorld, actuation: Self::Actuation) -> Result<(), String> {
+        Err(format!("landing fixture unexpectedly emitted {actuation:?}"))
+    }
+}
+
+struct ConvoyFixpoint;
+
+impl FixpointPredicate<ConvoyWorld> for ConvoyFixpoint {
+    fn at_fixpoint(&self, world: &ConvoyWorld) -> bool {
+        !world.contradictory
+            && world.current.status.as_ref().is_some_and(|status| matches!(status.phase, ConvoyPhase::Landing | ConvoyPhase::Landed))
+    }
+
+    fn write_count(&self, world: &ConvoyWorld) -> usize {
+        world.backend.writes()
+    }
+
+    fn reset_write_count(&self, world: &ConvoyWorld) {
+        world.backend.reset_writes();
+    }
+
+    fn held(&self, world: &ConvoyWorld) -> bool {
+        world.contradictory
+            && world.runtime.probes.load(Ordering::SeqCst) > 0
+            && world.current.status.as_ref().is_some_and(|status| status.phase == ConvoyPhase::Landing)
+    }
+
+    fn probe_count(&self, world: &ConvoyWorld) -> usize {
+        world.runtime.probes.load(Ordering::SeqCst)
+    }
+}
+
+fn convoy_enrollment(trust_observation_forever: bool) -> LivenessEnrollment<ConvoyWorldBuilder, ConvoyStep, ConvoyFixpoint> {
+    let clock = Arc::new(VirtualClock::new(timestamp()));
+    LivenessEnrollment::new(ConvoyWorldBuilder { clock: Arc::clone(&clock), trust_observation_forever }, ConvoyStep, ConvoyFixpoint, clock)
+        .with_staleness_edges([LANDING_TTL])
+}
+
+#[tokio::test]
+async fn convoy_landing_satisfies_supported_liveness_battery() {
+    let enrollment = convoy_enrollment(false);
+    assert_bounded_convergence(&enrollment).await;
+    assert_quiescence_at_fixpoint(&enrollment).await;
+    assert_staleness_edges(&enrollment).await;
+    assert_degradation_not_wedging(&enrollment).await;
+
+    // Landing's integration probe is an imperative runtime effect, not an
+    // Actuation value. Actuation-drop recovery is therefore intentionally not
+    // claimed for this enrollee; value-shaped cleanup actuations are covered
+    // independently by convoy reconcile tests.
+}
+
+#[tokio::test]
+#[should_panic(expected = "did not re-probe stale state")]
+async fn convoy_staleness_property_bites_a_rebroken_trust_forever_edge() {
+    assert_staleness_edges(&convoy_enrollment(true)).await;
+}

--- a/crates/flotilla-controllers/tests/liveness_contract.rs
+++ b/crates/flotilla-controllers/tests/liveness_contract.rs
@@ -398,8 +398,7 @@ struct ConvoyFixpoint;
 
 impl FixpointPredicate<ConvoyWorld> for ConvoyFixpoint {
     fn at_fixpoint(&self, world: &ConvoyWorld) -> bool {
-        !world.contradictory
-            && world.passes > 0
+        world.passes > 0
             && world.current.status.as_ref().is_some_and(|status| matches!(status.phase, ConvoyPhase::Landing | ConvoyPhase::Landed))
     }
 

--- a/crates/flotilla-core/Cargo.toml
+++ b/crates/flotilla-core/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 default = []
 aws-lc-provider = ["flotilla-resources/aws-lc-provider"]
 replay = []
-test-support = ["flotilla-protocol/test-support"]
+test-support = ["flotilla-protocol/test-support", "flotilla-resources/test-support"]
 
 [dependencies]
 flotilla-manifest = { path = "../flotilla-manifest" }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -36,17 +36,17 @@ use flotilla_resources::{
     list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
     resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
     watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
-    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, ConditionValue,
-    Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec,
-    CrewSource, Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
-    IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
-    PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource,
-    ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
-    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
-    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, REPO_KEY_LABEL,
-    REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Clock,
+    ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant,
+    CredentialSpec, CrewSource, Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta,
+    InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
+    ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
+    SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
+    Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+    CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, REPO_KEY_LABEL, REPO_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -89,7 +89,7 @@ use crate::{
         ChannelLabel, CommandRunner,
     },
     refresh::RefreshSnapshot,
-    regard_lifecycle::{RegardLifecycle, SurfaceGestureOutcome, DEFAULT_REGARD_REFRESH_SECONDS},
+    regard_lifecycle::{RegardLifecycle, SurfaceGestureOutcome, DEFAULT_REGARD_DECAY_SECONDS, DEFAULT_REGARD_REFRESH_SECONDS},
     repo_state::{RepoRootState, RepoState, SnapshotBuildContext},
     repository_inspection::{GitRepositoryInspector, RepositoryInspection, RepositoryInspector},
     step::{
@@ -1585,6 +1585,7 @@ pub struct InProcessDaemon {
     /// Used to inject FLOTILLA_DAEMON_SOCKET into managed terminal sessions.
     daemon_socket_path: RwLock<Option<PathBuf>>,
     resource_backend: ResourceBackend,
+    clock: Arc<dyn Clock>,
     regard_lifecycle: RegardLifecycle,
     observed_resource_backend: ResourceBackend,
     /// Serializes observed Checkout publication with repository removal so a
@@ -1661,6 +1662,17 @@ impl InProcessDaemon {
         discovery: DiscoveryRuntime,
         host_name: HostName,
         resource_backend: ResourceBackend,
+    ) -> Arc<Self> {
+        Self::new_with_resource_backend_and_clock(repo_paths, config, discovery, host_name, resource_backend, Arc::new(SystemClock)).await
+    }
+
+    pub async fn new_with_resource_backend_and_clock(
+        repo_paths: Vec<PathBuf>,
+        config: Arc<ConfigStore>,
+        discovery: DiscoveryRuntime,
+        host_name: HostName,
+        resource_backend: ResourceBackend,
+        clock: Arc<dyn Clock>,
     ) -> Arc<Self> {
         use crate::providers::discovery::DiscoveryResult;
 
@@ -1779,7 +1791,8 @@ impl InProcessDaemon {
             session_id: uuid::Uuid::new_v4(),
             agent_state_store,
             daemon_socket_path: RwLock::new(None),
-            regard_lifecycle: RegardLifecycle::with_system_clock(resource_backend.clone()),
+            clock: Arc::clone(&clock),
+            regard_lifecycle: RegardLifecycle::new(resource_backend.clone(), clock, ChronoDuration::seconds(DEFAULT_REGARD_DECAY_SECONDS)),
             resource_backend,
             observed_resource_backend: ResourceBackend::InMemory(InMemoryBackend::observed()),
             observed_checkout_reconciliation: Mutex::new(()),
@@ -5635,7 +5648,7 @@ impl InProcessDaemon {
                     .observed_at
                     .as_deref()
                     .and_then(|observed_at| chrono::DateTime::parse_from_rfc3339(observed_at).ok())
-                    .is_some_and(|observed_at| Utc::now().signed_duration_since(observed_at) < LANDING_EVIDENCE_TTL);
+                    .is_some_and(|observed_at| self.clock.now().signed_duration_since(observed_at) < LANDING_EVIDENCE_TTL);
                 if recent {
                     if condition_is_true(landed) {
                         continue;

--- a/crates/flotilla-core/src/regard_lifecycle.rs
+++ b/crates/flotilla-core/src/regard_lifecycle.rs
@@ -3,29 +3,17 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::Duration;
 use flotilla_protocol::{PrincipalRef, ResourceRef, SurfaceCharacter, SurfaceDeclaration};
 use flotilla_resources::{
     apply_status_patch, InputMeta, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RegardStatusPatch, ResourceBackend, ResourceError,
 };
+pub use flotilla_resources::{Clock, SystemClock};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 pub const DEFAULT_REGARD_DECAY_SECONDS: i64 = 300;
 pub const DEFAULT_REGARD_REFRESH_SECONDS: u64 = 60;
-
-pub trait Clock: Send + Sync {
-    fn now(&self) -> DateTime<Utc>;
-}
-
-#[derive(Debug, Default)]
-pub struct SystemClock;
-
-impl Clock for SystemClock {
-    fn now(&self) -> DateTime<Utc> {
-        Utc::now()
-    }
-}
 
 #[derive(Debug, Clone)]
 struct SurfaceState {

--- a/crates/flotilla-core/src/regard_lifecycle.rs
+++ b/crates/flotilla-core/src/regard_lifecycle.rs
@@ -43,10 +43,6 @@ impl RegardLifecycle {
         Self::builder().backend(backend).clock(clock).decay_window(decay_window).build()
     }
 
-    pub fn with_system_clock(backend: ResourceBackend) -> Self {
-        Self::new(backend, Arc::new(SystemClock), Duration::seconds(DEFAULT_REGARD_DECAY_SECONDS))
-    }
-
     pub fn connect_surface(&self, surface_id: Uuid, declaration: SurfaceDeclaration) {
         self.surfaces
             .lock()

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -47,12 +47,13 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     apply_status_patch, controller_patches as convoy_controller_patches, implement_review_workflow_spec,
-    single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase,
-    CheckoutSpec as ResourceCheckoutSpec, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
-    DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec,
-    HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
-    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositoryRelation, RepositorySpec, Stance, TypedResolver,
-    WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, REPO_KEY_LABEL, REPO_LABEL,
+    single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase,
+    CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy as ResourceConvoy, ConvoyPhase,
+    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta, IntegrationCondition, LifecycleAuthority, ObservedCheckoutSpec,
+    PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource,
+    Repository, RepositoryKey, RepositoryRelation, RepositorySpec, Stance, TypedResolver, VirtualClock, WorkPhase, WorkState,
+    WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -6646,5 +6647,69 @@ async fn two_commands_can_run_concurrently() {
     assert!(
         !matches!(archive_result, CommandValue::Error { .. }),
         "ArchiveSession should complete successfully after release, got: {archive_result:?}"
+    );
+}
+
+#[tokio::test]
+async fn convoy_landing_reprobes_after_injected_clock_crosses_evidence_ttl() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let backend = flotilla_resources::ResourceBackend::InMemory(Default::default());
+    let now = chrono::DateTime::parse_from_rfc3339("2026-07-28T12:00:00Z").expect("timestamp").with_timezone(&chrono::Utc);
+    let clock = Arc::new(VirtualClock::new(now));
+    let daemon = InProcessDaemon::new_with_resource_backend_and_clock(
+        vec![],
+        test_config_store(temp.path().join("config")),
+        fake_discovery(false),
+        HostName::local(),
+        backend.clone(),
+        clock.clone() as Arc<dyn flotilla_resources::Clock>,
+    )
+    .await;
+    let checkouts = backend.using::<ResourceCheckout>("flotilla");
+    let checkout = checkouts
+        .create(
+            &InputMeta {
+                name: "checkout-a".to_string(),
+                labels: [(CONVOY_LABEL.to_string(), "convoy-a".to_string())].into_iter().collect(),
+                ..Default::default()
+            },
+            &ResourceCheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: "feature/liveness".to_string(),
+                path: "/path/that/does/not/exist".to_string(),
+                repo_ref: RepositoryKey("repo-a".to_string()),
+                host_ref: "host-a".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("create checkout");
+    let observed_at = now.to_rfc3339();
+    checkouts
+        .update_status("checkout-a", &checkout.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            path: Some("/path/that/does/not/exist".to_string()),
+            commit: None,
+            branch_provenance: Default::default(),
+            integration: CheckoutIntegrationStatus {
+                clean: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+                pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+                landed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at).build(),
+                landed_evidence: None,
+            },
+            message: None,
+        })
+        .await
+        .expect("record cached landing evidence");
+
+    assert!(
+        daemon.convoy_change_requests_settled("flotilla", "convoy-a").await.expect("fresh decision"),
+        "fresh cached evidence should be consumed"
+    );
+
+    clock.advance(chrono::Duration::seconds(31));
+
+    assert!(
+        !daemon.convoy_change_requests_settled("flotilla", "convoy-a").await.expect("stale decision"),
+        "stale cached evidence must be re-probed and a missing path must hold Landing"
     );
 }

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 default = []
 aws-lc-provider = ["rustls/aws_lc_rs"]
 skip-no-sandbox-tests = []
+test-support = []
 
 [dependencies]
 flotilla-protocol = { path = "../flotilla-protocol" }

--- a/crates/flotilla-resources/src/clock.rs
+++ b/crates/flotilla-resources/src/clock.rs
@@ -1,6 +1,9 @@
+#[cfg(any(test, feature = "test-support"))]
 use std::sync::Mutex;
 
-use chrono::{DateTime, Duration, Utc};
+#[cfg(any(test, feature = "test-support"))]
+use chrono::Duration;
+use chrono::{DateTime, Utc};
 
 /// Supplies wall-clock time to decisions whose freshness behavior must be
 /// deterministic under test.
@@ -18,11 +21,13 @@ impl Clock for SystemClock {
 }
 
 /// A manually advanced clock for controller and decision-edge tests.
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Debug)]
 pub struct VirtualClock {
     now: Mutex<DateTime<Utc>>,
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl VirtualClock {
     pub fn new(now: DateTime<Utc>) -> Self {
         Self { now: Mutex::new(now) }
@@ -39,6 +44,7 @@ impl VirtualClock {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl Clock for VirtualClock {
     fn now(&self) -> DateTime<Utc> {
         *self.now.lock().expect("virtual clock lock poisoned")

--- a/crates/flotilla-resources/src/clock.rs
+++ b/crates/flotilla-resources/src/clock.rs
@@ -1,0 +1,46 @@
+use std::sync::Mutex;
+
+use chrono::{DateTime, Duration, Utc};
+
+/// Supplies wall-clock time to decisions whose freshness behavior must be
+/// deterministic under test.
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+#[derive(Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// A manually advanced clock for controller and decision-edge tests.
+#[derive(Debug)]
+pub struct VirtualClock {
+    now: Mutex<DateTime<Utc>>,
+}
+
+impl VirtualClock {
+    pub fn new(now: DateTime<Utc>) -> Self {
+        Self { now: Mutex::new(now) }
+    }
+
+    pub fn advance(&self, duration: Duration) -> DateTime<Utc> {
+        let mut now = self.now.lock().expect("virtual clock lock poisoned");
+        *now += duration;
+        *now
+    }
+
+    pub fn set(&self, instant: DateTime<Utc>) {
+        *self.now.lock().expect("virtual clock lock poisoned") = instant;
+    }
+}
+
+impl Clock for VirtualClock {
+    fn now(&self) -> DateTime<Utc> {
+        *self.now.lock().expect("virtual clock lock poisoned")
+    }
+}

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod checkout;
+mod clock;
 mod clone;
 pub mod controller;
 mod convoy;
@@ -25,6 +26,7 @@ mod retention;
 mod sqlite;
 mod status_patch;
 mod terminal_session;
+pub mod test_support;
 pub mod tls;
 mod vessel;
 mod watch;
@@ -35,6 +37,7 @@ pub use checkout::{
     Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch,
     CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec, IntegrationCondition, LandedEvidence, ObservedCheckoutSpec,
 };
+pub use clock::{Clock, SystemClock, VirtualClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
     controller_patches, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -26,6 +26,7 @@ mod retention;
 mod sqlite;
 mod status_patch;
 mod terminal_session;
+#[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 pub mod tls;
 mod vessel;
@@ -37,7 +38,9 @@ pub use checkout::{
     Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch,
     CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec, IntegrationCondition, LandedEvidence, ObservedCheckoutSpec,
 };
-pub use clock::{Clock, SystemClock, VirtualClock};
+#[cfg(any(test, feature = "test-support"))]
+pub use clock::VirtualClock;
+pub use clock::{Clock, SystemClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
     controller_patches, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches,

--- a/crates/flotilla-resources/src/test_support/liveness.rs
+++ b/crates/flotilla-resources/src/test_support/liveness.rs
@@ -1,0 +1,209 @@
+use std::{fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use chrono::Duration;
+
+use crate::VirtualClock;
+
+pub const DEFAULT_PASS_BOUND: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LivenessScenario {
+    Normal,
+    ActuationDrop,
+    Contradictory,
+}
+
+#[derive(Debug)]
+pub struct LivenessStep<P, A> {
+    pub patch: Option<P>,
+    pub actuations: Vec<A>,
+}
+
+impl<P, A> LivenessStep<P, A> {
+    pub fn new(patch: Option<P>, actuations: Vec<A>) -> Self {
+        Self { patch, actuations }
+    }
+}
+
+#[async_trait]
+pub trait WorldBuilder: Send + Sync {
+    type World: Send;
+
+    async fn build(&self, scenario: LivenessScenario) -> Result<Self::World, String>;
+}
+
+#[async_trait]
+pub trait ReconcileStep<W>: Send + Sync {
+    type Patch: Send;
+    type Actuation: Debug + Send;
+
+    async fn reconcile_step(&self, world: &mut W) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String>;
+    async fn apply_patch(&self, world: &mut W, patch: Self::Patch) -> Result<(), String>;
+    async fn apply_actuation(&self, world: &mut W, actuation: Self::Actuation) -> Result<(), String>;
+}
+
+pub trait FixpointPredicate<W>: Send + Sync {
+    fn at_fixpoint(&self, world: &W) -> bool;
+
+    fn write_count(&self, _world: &W) -> usize {
+        0
+    }
+
+    fn reset_write_count(&self, _world: &W) {}
+
+    fn held(&self, _world: &W) -> bool {
+        false
+    }
+
+    fn probe_count(&self, _world: &W) -> usize {
+        0
+    }
+}
+
+/// The world-builder, direct-step, and fixpoint-predicate fixture triple used
+/// by every enrolled reconciler.
+pub struct LivenessEnrollment<B, S, P> {
+    pub world_builder: B,
+    pub reconciler_step: S,
+    pub fixpoint: P,
+    pub clock: Arc<VirtualClock>,
+    pub staleness_edges: Vec<Duration>,
+    pub pass_bound: usize,
+}
+
+impl<B, S, P> LivenessEnrollment<B, S, P> {
+    pub fn new(world_builder: B, reconciler_step: S, fixpoint: P, clock: Arc<VirtualClock>) -> Self {
+        Self { world_builder, reconciler_step, fixpoint, clock, staleness_edges: Vec::new(), pass_bound: DEFAULT_PASS_BOUND }
+    }
+
+    pub fn with_staleness_edges(mut self, edges: impl IntoIterator<Item = Duration>) -> Self {
+        self.staleness_edges = edges.into_iter().collect();
+        self
+    }
+
+    pub fn with_pass_bound(mut self, pass_bound: usize) -> Self {
+        self.pass_bound = pass_bound;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PassObservation {
+    writes: usize,
+    actuations: usize,
+}
+
+async fn run_pass<B, S, P>(
+    enrollment: &LivenessEnrollment<B, S, P>,
+    world: &mut B::World,
+    drop_actuations: bool,
+) -> Result<PassObservation, String>
+where
+    B: WorldBuilder,
+    S: ReconcileStep<B::World>,
+{
+    let outcome = enrollment.reconciler_step.reconcile_step(world).await?;
+    let writes = usize::from(outcome.patch.is_some());
+    if let Some(patch) = outcome.patch {
+        enrollment.reconciler_step.apply_patch(world, patch).await?;
+    }
+    let actuations = outcome.actuations.len();
+    if !drop_actuations {
+        for actuation in outcome.actuations {
+            enrollment.reconciler_step.apply_actuation(world, actuation).await?;
+        }
+    }
+    Ok(PassObservation { writes, actuations })
+}
+
+async fn converge<B, S, P>(enrollment: &LivenessEnrollment<B, S, P>, world: &mut B::World) -> Result<usize, String>
+where
+    B: WorldBuilder,
+    S: ReconcileStep<B::World>,
+    P: FixpointPredicate<B::World>,
+{
+    for pass in 0..=enrollment.pass_bound {
+        if enrollment.fixpoint.at_fixpoint(world) {
+            return Ok(pass);
+        }
+        if pass == enrollment.pass_bound {
+            break;
+        }
+        run_pass(enrollment, world, false).await?;
+    }
+    Err(format!("did not reach a fixpoint within {} passes", enrollment.pass_bound))
+}
+
+pub async fn assert_bounded_convergence<B, S, P>(enrollment: &LivenessEnrollment<B, S, P>)
+where
+    B: WorldBuilder,
+    S: ReconcileStep<B::World>,
+    P: FixpointPredicate<B::World>,
+{
+    let mut world = enrollment.world_builder.build(LivenessScenario::Normal).await.expect("build normal liveness world");
+    converge(enrollment, &mut world).await.expect("bounded convergence");
+}
+
+pub async fn assert_quiescence_at_fixpoint<B, S, P>(enrollment: &LivenessEnrollment<B, S, P>)
+where
+    B: WorldBuilder,
+    S: ReconcileStep<B::World>,
+    P: FixpointPredicate<B::World>,
+{
+    let mut world = enrollment.world_builder.build(LivenessScenario::Normal).await.expect("build normal liveness world");
+    converge(enrollment, &mut world).await.expect("converge before quiescence check");
+    enrollment.fixpoint.reset_write_count(&world);
+    let observation = run_pass(enrollment, &mut world, false).await.expect("run quiescence pass");
+    assert_eq!(observation.writes, 0, "a fixpoint pass wrote resource state");
+    assert_eq!(observation.actuations, 0, "a fixpoint pass emitted actuations");
+    assert_eq!(enrollment.fixpoint.write_count(&world), 0, "the decorated backend observed a fixpoint write");
+}
+
+pub async fn assert_staleness_edges<B, S, P>(enrollment: &LivenessEnrollment<B, S, P>)
+where
+    B: WorldBuilder,
+    S: ReconcileStep<B::World>,
+    P: FixpointPredicate<B::World>,
+{
+    assert!(!enrollment.staleness_edges.is_empty(), "staleness contract requires at least one TTL");
+    let mut world = enrollment.world_builder.build(LivenessScenario::Normal).await.expect("build normal liveness world");
+    converge(enrollment, &mut world).await.expect("converge before staleness check");
+    for edge in &enrollment.staleness_edges {
+        let before = enrollment.fixpoint.probe_count(&world);
+        enrollment.clock.advance(*edge + Duration::milliseconds(1));
+        run_pass(enrollment, &mut world, false).await.expect("run stale decision pass");
+        let after = enrollment.fixpoint.probe_count(&world);
+        assert!(after > before, "crossing TTL {edge:?} did not re-probe stale state");
+    }
+}
+
+pub async fn assert_actuation_drop_recovery<B, S, P>(enrollment: &LivenessEnrollment<B, S, P>)
+where
+    B: WorldBuilder,
+    S: ReconcileStep<B::World>,
+    P: FixpointPredicate<B::World>,
+{
+    let mut world = enrollment.world_builder.build(LivenessScenario::ActuationDrop).await.expect("build actuation-drop world");
+    let dropped = run_pass(enrollment, &mut world, true).await.expect("run dropped-actuation pass");
+    assert!(dropped.actuations > 0, "actuation-drop scenario emitted no actuation to drop");
+    let retried = run_pass(enrollment, &mut world, false).await.expect("run actuation recovery pass");
+    assert!(retried.actuations > 0, "a dropped actuation was not re-emitted");
+}
+
+pub async fn assert_degradation_not_wedging<B, S, P>(enrollment: &LivenessEnrollment<B, S, P>)
+where
+    B: WorldBuilder,
+    S: ReconcileStep<B::World>,
+    P: FixpointPredicate<B::World>,
+{
+    let mut world = enrollment.world_builder.build(LivenessScenario::Contradictory).await.expect("build contradictory world");
+    for _ in 0..enrollment.pass_bound {
+        run_pass(enrollment, &mut world, false).await.expect("run contradictory-world pass");
+        if enrollment.fixpoint.held(&world) {
+            return;
+        }
+        assert!(!enrollment.fixpoint.at_fixpoint(&world), "contradictory world silently reached a successful fixpoint");
+    }
+    panic!("contradictory world did not become held within {} passes", enrollment.pass_bound);
+}

--- a/crates/flotilla-resources/src/test_support/mod.rs
+++ b/crates/flotilla-resources/src/test_support/mod.rs
@@ -1,0 +1,11 @@
+//! Reusable controller and resource-store test harnesses.
+
+mod liveness;
+mod write_counting;
+
+pub use liveness::{
+    assert_actuation_drop_recovery, assert_bounded_convergence, assert_degradation_not_wedging, assert_quiescence_at_fixpoint,
+    assert_staleness_edges, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, WorldBuilder,
+    DEFAULT_PASS_BOUND,
+};
+pub use write_counting::{WriteCountingBackend, WriteCountingResolver};

--- a/crates/flotilla-resources/src/test_support/write_counting.rs
+++ b/crates/flotilla-resources/src/test_support/write_counting.rs
@@ -1,0 +1,140 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use crate::{
+    apply_status_patch, InputMeta, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, StatusPatch, TypedResolver,
+};
+
+/// Decorates a resource backend with a counter for attempted mutations.
+///
+/// The decorator is deliberately independent of the liveness battery so it
+/// can also prove that a controller restart or replay is a no-op.
+#[derive(Debug, Clone)]
+pub struct WriteCountingBackend {
+    inner: ResourceBackend,
+    writes: Arc<AtomicUsize>,
+}
+
+impl WriteCountingBackend {
+    pub fn new(inner: ResourceBackend) -> Self {
+        Self { inner, writes: Arc::new(AtomicUsize::new(0)) }
+    }
+
+    pub fn in_memory() -> Self {
+        Self::new(ResourceBackend::InMemory(Default::default()))
+    }
+
+    pub fn inner(&self) -> ResourceBackend {
+        self.inner.clone()
+    }
+
+    pub fn using<T: Resource>(&self, namespace: &str) -> WriteCountingResolver<T> {
+        WriteCountingResolver { inner: self.inner.using(namespace), writes: Arc::clone(&self.writes) }
+    }
+
+    pub fn writes(&self) -> usize {
+        self.writes.load(Ordering::SeqCst)
+    }
+
+    pub fn reset_writes(&self) -> usize {
+        self.writes.swap(0, Ordering::SeqCst)
+    }
+}
+
+#[derive(Debug)]
+pub struct WriteCountingResolver<T: Resource> {
+    inner: TypedResolver<T>,
+    writes: Arc<AtomicUsize>,
+}
+
+impl<T: Resource> Clone for WriteCountingResolver<T> {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone(), writes: Arc::clone(&self.writes) }
+    }
+}
+
+impl<T: Resource> WriteCountingResolver<T> {
+    pub fn inner(&self) -> &TypedResolver<T> {
+        &self.inner
+    }
+
+    pub async fn get(&self, name: &str) -> Result<ResourceObject<T>, ResourceError> {
+        self.inner.get(name).await
+    }
+
+    pub async fn list(&self) -> Result<ResourceList<T>, ResourceError> {
+        self.inner.list().await
+    }
+
+    pub async fn create(&self, meta: &InputMeta, spec: &T::Spec) -> Result<ResourceObject<T>, ResourceError> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.create(meta, spec).await
+    }
+
+    pub async fn update(&self, meta: &InputMeta, resource_version: &str, spec: &T::Spec) -> Result<ResourceObject<T>, ResourceError> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.update(meta, resource_version, spec).await
+    }
+
+    pub async fn update_status(&self, name: &str, resource_version: &str, status: &T::Status) -> Result<ResourceObject<T>, ResourceError> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.update_status(name, resource_version, status).await
+    }
+
+    pub async fn apply_status_patch(&self, name: &str, patch: &T::StatusPatch) -> Result<ResourceObject<T>, ResourceError>
+    where
+        T::Status: Default,
+        T::StatusPatch: StatusPatch<T::Status>,
+    {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        apply_status_patch(&self.inner, name, patch).await
+    }
+
+    pub async fn delete(&self, name: &str) -> Result<(), ResourceError> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.delete(name).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        test_support::WriteCountingBackend, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, FreshCloneCheckoutSpec, InputMeta,
+        RepositoryKey,
+    };
+
+    #[tokio::test]
+    async fn counts_mutations_but_not_reads_and_can_be_reset() {
+        let backend = WriteCountingBackend::in_memory();
+        let checkouts = backend.using::<Checkout>("flotilla");
+        let created = checkouts
+            .create(
+                &InputMeta { name: "checkout-a".to_string(), ..Default::default() },
+                &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                    repo_ref: RepositoryKey("repo-a".to_string()),
+                    env_ref: "env-a".to_string(),
+                    r#ref: "main".to_string(),
+                    base_ref: None,
+                    target_path: "/work/checkout-a".to_string(),
+                    url: "https://example.com/repo-a".to_string(),
+                }),
+            )
+            .await
+            .expect("create checkout");
+        checkouts.get("checkout-a").await.expect("read checkout");
+        assert_eq!(backend.writes(), 1);
+
+        checkouts
+            .update_status("checkout-a", &created.metadata.resource_version, &CheckoutStatus {
+                phase: CheckoutPhase::Ready,
+                path: Some("/work/checkout-a".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("update checkout status");
+        assert_eq!(backend.reset_writes(), 2);
+        assert_eq!(backend.writes(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

- introduce a shared injectable clock with deterministic virtual time and thread it through checkout freshness and convoy landing decisions
- add a reusable direct-step liveness battery plus a standalone write-counting backend decorator
- enroll checkout and convoy landing with convergence, quiescence, staleness, degradation, and supported actuation-drop contracts
- prove both staleness contracts bite test-local re-broken variants and cover the production in-process landing edge

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`

Closes #1176