### PR TITLE
Make placement decisions legible and add raw resource deletion

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use flotilla_core::agent_adapter::{
     append_convoy_work_context, build_crew_brief_with_options, CrewAssignment, CrewBriefMember, CrewBriefTemplateResolver,
 };
+use flotilla_protocol::PlacementDecision;
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{
@@ -104,9 +105,11 @@ enum PlannedPatch {
     Provisioning {
         observed_policy_ref: String,
         observed_policy_version: String,
+        placement_decision: Option<PlacementDecision>,
         waiting_for: String,
     },
     Ready {
+        placement_decision: Option<PlacementDecision>,
         environment_ref: String,
         image: Option<ImageStamp>,
         checkout_refs: BTreeMap<RepositoryKey, String>,
@@ -142,25 +145,15 @@ impl VesselDeps {
 
     fn provisioning(
         placement_policy: &ResourceObject<PlacementPolicy>,
+        placement_decision: Option<PlacementDecision>,
         waiting_for: impl Into<String>,
         actuations: Vec<Actuation>,
     ) -> Self {
-        Self { patch: provisioning_patch(placement_policy, waiting_for.into()), actuations }
-    }
-
-    fn ready(
-        environment_ref: String,
-        image: Option<ImageStamp>,
-        checkout_refs: BTreeMap<RepositoryKey, String>,
-        terminal_session_refs: Vec<String>,
-        requested_stance: Stance,
-        effective_stance: Stance,
-        actuations: Vec<Actuation>,
-    ) -> Self {
-        Self {
-            patch: PlannedPatch::Ready { environment_ref, image, checkout_refs, terminal_session_refs, requested_stance, effective_stance },
-            actuations,
+        let mut waiting_for = waiting_for.into();
+        if let Some(decision) = &placement_decision {
+            waiting_for = waiting_for.replace(&decision.target_host.reference, &decision.target_host.display_name);
         }
+        Self { patch: provisioning_patch(placement_policy, placement_decision, waiting_for), actuations }
     }
 
     fn failed(message: impl Into<String>) -> Self {
@@ -202,6 +195,7 @@ impl Reconciler for VesselReconciler {
             }
             Err(err) => return Err(err),
         };
+        let placement_decision = convoy.status.as_ref().and_then(|status| status.placement_decision.clone());
         let strategy = match placement_strategy(&placement_policy.spec) {
             Ok(strategy) => strategy,
             Err(message) => return Ok(VesselDeps::failed(message)),
@@ -284,7 +278,12 @@ impl Reconciler for VesselReconciler {
                 None => return Ok(VesselDeps::failed(format!("environment {clone_env_ref} is not a host_direct environment"))),
             };
             if clone_env.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                return Ok(VesselDeps::provisioning(&placement_policy, format!("environment {clone_env_ref} to become ready"), actuations));
+                return Ok(VesselDeps::provisioning(
+                    &placement_policy,
+                    placement_decision.clone(),
+                    format!("environment {clone_env_ref} to become ready"),
+                    actuations,
+                ));
             }
             Some(clone_env_spec.repo_default_dir.clone())
         } else {
@@ -307,6 +306,7 @@ impl Reconciler for VesselReconciler {
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
                             return Ok(VesselDeps::provisioning(
                                 &placement_policy,
+                                placement_decision.clone(),
                                 format!("environment {env_name} to become ready"),
                                 actuations,
                             ));
@@ -333,6 +333,7 @@ impl Reconciler for VesselReconciler {
                         });
                         return Ok(VesselDeps::provisioning(
                             &placement_policy,
+                            placement_decision.clone(),
                             format!("environment {env_name} to become ready"),
                             actuations,
                         ));
@@ -558,6 +559,7 @@ impl Reconciler for VesselReconciler {
             let checkout_label = if waiting_for_checkouts.len() == 1 { "checkout" } else { "checkouts" };
             return Ok(VesselDeps::provisioning(
                 &placement_policy,
+                placement_decision.clone(),
                 format!("{checkout_label} {} to become ready", waiting_for_checkouts.join(", ")),
                 actuations,
             ));
@@ -585,7 +587,12 @@ impl Reconciler for VesselReconciler {
                     return Ok(VesselDeps::failed(format!("environment {env_name} failed")));
                 }
                 if environment.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
-                    return Ok(VesselDeps::provisioning(&placement_policy, format!("environment {env_name} to become ready"), actuations));
+                    return Ok(VesselDeps::provisioning(
+                        &placement_policy,
+                        placement_decision.clone(),
+                        format!("environment {env_name} to become ready"),
+                        actuations,
+                    ));
                 }
                 (env_name, None)
             }
@@ -604,6 +611,7 @@ impl Reconciler for VesselReconciler {
                         if existing.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
                             return Ok(VesselDeps::provisioning(
                                 &placement_policy,
+                                placement_decision.clone(),
                                 format!("environment {env_name} to become ready"),
                                 actuations,
                             ));
@@ -637,6 +645,7 @@ impl Reconciler for VesselReconciler {
                         });
                         return Ok(VesselDeps::provisioning(
                             &placement_policy,
+                            placement_decision.clone(),
                             format!("environment {env_name} to become ready"),
                             actuations,
                         ));
@@ -729,6 +738,7 @@ impl Reconciler for VesselReconciler {
                     if phase == Some(TerminalSessionPhase::Starting) || (should_start && phase != Some(TerminalSessionPhase::Running)) {
                         return Ok(VesselDeps::provisioning(
                             &placement_policy,
+                            placement_decision.clone(),
                             format!("terminal session {terminal_name} to become running"),
                             actuations,
                         ));
@@ -802,6 +812,7 @@ impl Reconciler for VesselReconciler {
                     });
                     return Ok(VesselDeps::provisioning(
                         &placement_policy,
+                        placement_decision.clone(),
                         format!("terminal session {terminal_name} to become running"),
                         actuations,
                     ));
@@ -810,15 +821,18 @@ impl Reconciler for VesselReconciler {
             }
         }
 
-        Ok(VesselDeps::ready(
-            resolved_environment_ref,
-            image,
-            checkout_refs,
-            terminal_refs,
-            requirement.stance,
-            effective_stance,
+        Ok(VesselDeps {
+            patch: PlannedPatch::Ready {
+                placement_decision,
+                environment_ref: resolved_environment_ref,
+                image,
+                checkout_refs,
+                terminal_session_refs: terminal_refs,
+                requested_stance: requirement.stance,
+                effective_stance,
+            },
             actuations,
-        ))
+        })
     }
 
     fn reconcile(
@@ -829,26 +843,34 @@ impl Reconciler for VesselReconciler {
     ) -> ReconcileOutcome<Self::Resource> {
         let patch = match &deps.patch {
             PlannedPatch::None => None,
-            PlannedPatch::Provisioning { observed_policy_ref, observed_policy_version, waiting_for } => {
+            PlannedPatch::Provisioning { observed_policy_ref, observed_policy_version, placement_decision, waiting_for } => {
                 Some(VesselStatusPatch::MarkProvisioning {
                     observed_policy_ref: observed_policy_ref.clone(),
                     observed_policy_version: observed_policy_version.clone(),
+                    placement_decision: placement_decision.clone(),
                     started_at: now,
                     message: provisioning_stuck_message(obj, waiting_for, now),
                 })
             }
-            PlannedPatch::Ready { environment_ref, image, checkout_refs, terminal_session_refs, requested_stance, effective_stance } => {
-                Some(VesselStatusPatch::MarkReady {
-                    environment_ref: Some(environment_ref.clone()),
-                    image_ref: image.as_ref().map(|image| image.image_ref.clone()),
-                    image_digest: image.as_ref().map(|image| image.image_digest.clone()),
-                    checkout_refs: checkout_refs.clone(),
-                    terminal_session_refs: terminal_session_refs.clone(),
-                    requested_stance: *requested_stance,
-                    effective_stance: *effective_stance,
-                    ready_at: now,
-                })
-            }
+            PlannedPatch::Ready {
+                placement_decision,
+                environment_ref,
+                image,
+                checkout_refs,
+                terminal_session_refs,
+                requested_stance,
+                effective_stance,
+            } => Some(VesselStatusPatch::MarkReady {
+                placement_decision: placement_decision.clone(),
+                environment_ref: Some(environment_ref.clone()),
+                image_ref: image.as_ref().map(|image| image.image_ref.clone()),
+                image_digest: image.as_ref().map(|image| image.image_digest.clone()),
+                checkout_refs: checkout_refs.clone(),
+                terminal_session_refs: terminal_session_refs.clone(),
+                requested_stance: *requested_stance,
+                effective_stance: *effective_stance,
+                ready_at: now,
+            }),
             PlannedPatch::Interrupted { roles, message }
                 if obj.status.as_ref().is_none_or(|status| {
                     status.phase != VesselPhase::Interrupted
@@ -936,10 +958,15 @@ fn placement_strategy(spec: &PlacementPolicySpec) -> Result<PlacementStrategy, S
     Err("placement policy must define exactly one supported strategy".to_string())
 }
 
-fn provisioning_patch(placement_policy: &ResourceObject<PlacementPolicy>, waiting_for: String) -> PlannedPatch {
+fn provisioning_patch(
+    placement_policy: &ResourceObject<PlacementPolicy>,
+    placement_decision: Option<PlacementDecision>,
+    waiting_for: String,
+) -> PlannedPatch {
     PlannedPatch::Provisioning {
         observed_policy_ref: placement_policy.metadata.name.clone(),
         observed_policy_version: placement_policy.metadata.resource_version.clone(),
+        placement_decision,
         waiting_for,
     }
 }

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -149,10 +149,7 @@ impl VesselDeps {
         waiting_for: impl Into<String>,
         actuations: Vec<Actuation>,
     ) -> Self {
-        let mut waiting_for = waiting_for.into();
-        if let Some(decision) = &placement_decision {
-            waiting_for = waiting_for.replace(&decision.target_host.reference, &decision.target_host.display_name);
-        }
+        let waiting_for = legible_waiting_for(waiting_for.into(), placement_decision.as_ref());
         Self { patch: provisioning_patch(placement_policy, placement_decision, waiting_for), actuations }
     }
 
@@ -981,6 +978,15 @@ fn host_direct_environment_name(host_ref: &str) -> String {
     format!("host-direct-{host_ref}")
 }
 
+fn legible_waiting_for(mut waiting_for: String, placement_decision: Option<&PlacementDecision>) -> String {
+    if let Some(decision) = placement_decision {
+        let target_environment = host_direct_environment_name(&decision.target_host.reference);
+        let display_environment = host_direct_environment_name(&decision.target_host.display_name);
+        waiting_for = waiting_for.replace(&target_environment, &display_environment);
+    }
+    waiting_for
+}
+
 fn environment_name(vessel_name: &str) -> String {
     format!("env-{vessel_name}")
 }
@@ -1096,5 +1102,31 @@ impl PlacementStrategy {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flotilla_protocol::{PlacementDecision, PlacementTargetHost};
+
+    use super::legible_waiting_for;
+
+    #[test]
+    fn waiting_message_replaces_the_structured_host_direct_environment_name() {
+        let decision = PlacementDecision {
+            policy_name: "host-direct-test".to_string(),
+            target_host: PlacementTargetHost { reference: "01HXYZ".to_string(), display_name: "kiwi".to_string() },
+            refused_candidates: Vec::new(),
+        };
+
+        assert_eq!(
+            legible_waiting_for("environment host-direct-01HXYZ to become ready".to_string(), Some(&decision)),
+            "environment host-direct-kiwi to become ready"
+        );
+        assert_eq!(
+            legible_waiting_for("checkout checkout-01HXYZ to become ready".to_string(), Some(&decision)),
+            "checkout checkout-01HXYZ to become ready",
+            "unrelated names containing the host ref must not be rewritten"
+        );
     }
 }

--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -681,7 +681,7 @@ fn temp_config_base() -> DaemonHostPath {
 
 async fn create_ready_host(backend: &ResourceBackend, name: &str) {
     let hosts = backend.clone().using::<Host>(NAMESPACE);
-    let created = hosts.create(&meta(name), &HostSpec {}).await.expect("host create should succeed");
+    let created = hosts.create(&meta(name), &HostSpec::default()).await.expect("host create should succeed");
     let mut status = HostStatus::default();
     HostStatusPatch::Heartbeat {
         capabilities: BTreeMap::new(),

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -1038,7 +1038,7 @@ fn full_controller_harness(backend: ResourceBackend) -> ControllerLoopHarness {
 
 async fn create_ready_host(backend: &ResourceBackend, name: &str) {
     let hosts = backend.clone().using::<Host>(NAMESPACE);
-    let created = hosts.create(&controller_meta().name(name).call(), &HostSpec {}).await.expect("host create should succeed");
+    let created = hosts.create(&controller_meta().name(name).call(), &HostSpec::default()).await.expect("host create should succeed");
     hosts
         .update_status(name, &created.metadata.resource_version, &HostStatus {
             capabilities: Default::default(),

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -171,6 +171,7 @@ pub async fn build_plan(
         CommandAction::QueryResourceList { .. }
         | CommandAction::QueryResourceGet { .. }
         | CommandAction::ResourceApply { .. }
+        | CommandAction::ResourceDelete { .. }
         | CommandAction::ResourceWatch { .. } => {
             Err(CommandValue::Error { message: "resource commands should be handled by the daemon resource dispatcher".to_string() })
         }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -24,11 +24,12 @@ use flotilla_protocol::{
     AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, CorrelationKey, CrewCommandContext, CrewListMember,
     CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse,
     FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
-    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PrincipalRef,
-    ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse,
-    RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan,
-    ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo,
-    ToolInventory, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PlacementDecision,
+    PlacementRefusal, PlacementTargetHost, PrincipalRef, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData,
+    ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary,
+    RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse,
+    StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
+    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
@@ -595,6 +596,7 @@ fn append_crewless_convoy_rows(
                     .crew("-")
                     .crew_state(convoy_state_label(row))
                     .host(host.clone())
+                    .maybe_placement_decision(row.placement_decision.clone())
                     .namespace(target_namespace)
                     .staleness(staleness.clone())
                     .build(),
@@ -926,26 +928,69 @@ async fn persist_adopted_checkout(
     }
 }
 
+#[derive(Debug)]
+struct PlacementResolution {
+    selected: Option<ResourceObject<PlacementPolicy>>,
+    refused_candidates: Vec<PlacementRefusal>,
+}
+
+fn placement_host_ref(policy: &ResourceObject<PlacementPolicy>) -> Option<&str> {
+    policy
+        .spec
+        .host_direct
+        .as_ref()
+        .map(|spec| spec.host_ref.as_str())
+        .or_else(|| policy.spec.docker_per_vessel.as_ref().map(|spec| spec.host_ref.as_str()))
+}
+
+async fn placement_target_host(
+    backend: &ResourceBackend,
+    namespace: &str,
+    policy: &ResourceObject<PlacementPolicy>,
+) -> Result<PlacementTargetHost, String> {
+    let host_ref = placement_host_ref(policy).ok_or_else(|| format!("placement `{}` has no target host", policy.metadata.name))?;
+    let display_name = backend
+        .clone()
+        .using::<ResourceHost>(namespace)
+        .get(host_ref)
+        .await
+        .ok()
+        .and_then(|host| (!host.spec.display_name.is_empty()).then_some(host.spec.display_name))
+        .unwrap_or_else(|| host_ref.to_string());
+    Ok(PlacementTargetHost { reference: host_ref.to_string(), display_name })
+}
+
 async fn default_convoy_placement_policy(
     backend: &ResourceBackend,
     namespace: &str,
     workflow: &WorkflowTemplateSpec,
     local_host_ref: Option<&str>,
-) -> Result<Option<ResourceObject<PlacementPolicy>>, String> {
+) -> Result<PlacementResolution, String> {
     let contained = workflow.vessels.iter().any(|vessel| vessel.stance == flotilla_resources::Stance::Contained);
     let mut policies = match backend.clone().using::<PlacementPolicy>(namespace).list().await {
         Ok(list) => list.items,
         Err(err) => {
             warn!(%namespace, error = %err, "failed to list placement policies; convoy will remain Pending until one is registered");
-            return Ok(None);
+            return Ok(PlacementResolution { selected: None, refused_candidates: Vec::new() });
         }
     };
     policies.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
-    let candidates = policies.into_iter().filter(|policy| !contained || policy.spec.docker_per_vessel.is_some()).collect::<Vec<_>>();
-    let candidate_names = candidates.iter().map(|policy| policy.metadata.name.clone()).collect::<Vec<_>>();
+    let candidate_names = policies.iter().map(|policy| policy.metadata.name.clone()).collect::<Vec<_>>();
     let mut viable = Vec::new();
-    for policy in candidates {
-        if validate_workflow_agent_adapters(backend, namespace, workflow, Some(&policy)).await.is_ok() {
+    let mut refused_candidates = Vec::new();
+    for policy in policies {
+        let refusal = if contained && policy.spec.docker_per_vessel.is_none() {
+            Some(format!("contained workflow requires a docker placement policy, but {} is not contained", policy.metadata.name))
+        } else if let Err(reason) = validate_workflow_agent_adapters(backend, namespace, workflow, Some(&policy)).await {
+            Some(reason)
+        } else {
+            validate_workflow_credentials(backend, namespace, workflow, Some(&policy)).await.err()
+        };
+        if let Some(reason) = refusal {
+            if let Ok(target_host) = placement_target_host(backend, namespace, &policy).await {
+                refused_candidates.push(PlacementRefusal { policy_name: policy.metadata.name.clone(), target_host, reason });
+            }
+        } else {
             viable.push(policy);
         }
     }
@@ -961,7 +1006,7 @@ async fn default_convoy_placement_policy(
         (!is_local, !is_host_direct, policy.metadata.name.clone())
     });
     if let Some(policy) = viable.into_iter().next() {
-        return Ok(Some(policy));
+        return Ok(PlacementResolution { selected: Some(policy), refused_candidates });
     }
 
     let required_adapters = required_workflow_agent_adapters(workflow)?;
@@ -978,7 +1023,7 @@ async fn default_convoy_placement_policy(
     if candidate_names.is_empty() {
         warn!(%namespace, "no placement policy found; convoy will remain Pending until one is registered");
     }
-    Ok(None)
+    Ok(PlacementResolution { selected: None, refused_candidates })
 }
 
 fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {
@@ -1400,6 +1445,7 @@ struct ConvoyAdmission {
     spec: ConvoySpec,
     workflow: WorkflowTemplateSpec,
     placement_policy: Option<PlacementPolicySpec>,
+    placement_decision: Option<PlacementDecision>,
 }
 
 /// An issue body is the crew's contract, so admission may only reuse a
@@ -2326,9 +2372,17 @@ impl InProcessDaemon {
         let hosts = self.resource_backend.clone().using::<ResourceHost>(&namespace);
         let host_name = host_id.to_string();
         let host = match hosts.get(&host_name).await {
-            Ok(host) => host,
+            Ok(host) if host.spec.display_name == summary.node.display_name => host,
+            Ok(host) => hosts
+                .update(&InputMeta::from(&host.metadata), &host.metadata.resource_version, &flotilla_resources::HostSpec {
+                    display_name: summary.node.display_name.clone(),
+                })
+                .await
+                .map_err(|error| error.to_string())?,
             Err(ResourceError::NotFound { .. }) => hosts
-                .create(&InputMeta::builder().name(host_name.clone()).build(), &flotilla_resources::HostSpec {})
+                .create(&InputMeta::builder().name(host_name.clone()).build(), &flotilla_resources::HostSpec {
+                    display_name: summary.node.display_name.clone(),
+                })
                 .await
                 .map_err(|error| error.to_string())?,
             Err(error) => return Err(error.to_string()),
@@ -2494,6 +2548,7 @@ impl InProcessDaemon {
             .workflow_spec(workflow_value)
             .maybe_placement_policy_name(placement_policy_name)
             .maybe_placement_policy_spec(placement_policy_spec)
+            .maybe_placement_decision(admission.placement_decision)
             .auto_attach(self.should_auto_attach(intent.auto_attach))
             .dispatch_regard(intent.auto_attach.into())
             .build())
@@ -3698,19 +3753,20 @@ async fn validate_workflow_credentials(
         .using::<ResourceHost>(namespace)
         .get(host_ref)
         .await
-        .map_err(|error| format!("placement `{}` host `{host_ref}` is not ready: {error}", placement.metadata.name))?;
+        .map_err(|error| format!("placement `{}` target host is not ready: {error}", placement.metadata.name))?;
+    let host_label = if host.spec.display_name.is_empty() { host_ref.to_string() } else { host.spec.display_name.clone() };
     let mut status =
-        host.status.ok_or_else(|| format!("placement `{}` host `{host_ref}` has no observed status", placement.metadata.name))?;
+        host.status.ok_or_else(|| format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name))?;
     status.apply_heartbeat_readiness(Utc::now());
     if !status.ready {
-        return Err(format!("placement `{}` host `{host_ref}` is not ready", placement.metadata.name));
+        return Err(format!("placement `{}` host `{host_label}` is not ready", placement.metadata.name));
     }
     let held = status.held_credentials().map_err(|error| {
-        format!("placement `{}` host `{host_ref}` has invalid held-credential capability: {error}", placement.metadata.name)
+        format!("placement `{}` host `{host_label}` has invalid held-credential capability: {error}", placement.metadata.name)
     })?;
     if let Some(missing) = required.iter().find(|credential| !held.contains(*credential)) {
         return Err(format!(
-            "workflow requires credential `{missing}`, which placement `{}` host `{host_ref}` does not hold",
+            "workflow requires credential `{missing}`, which placement `{}` host `{host_label}` does not hold",
             placement.metadata.name
         ));
     }
@@ -3736,24 +3792,23 @@ async fn placement_agent_adapters(
     if let Some(docker) = &placement.spec.docker_per_vessel {
         Ok((docker.agent_adapters.clone(), format!("image `{}`", docker.image)))
     } else if let Some(host_direct) = &placement.spec.host_direct {
-        let host =
-            backend.clone().using::<ResourceHost>(namespace).get(&host_direct.host_ref).await.map_err(|error| {
-                format!("placement `{}` host `{}` is not ready: {error}", placement.metadata.name, host_direct.host_ref)
-            })?;
-        let mut status = host
-            .status
-            .ok_or_else(|| format!("placement `{}` host `{}` has no observed status", placement.metadata.name, host_direct.host_ref))?;
+        let host = backend
+            .clone()
+            .using::<ResourceHost>(namespace)
+            .get(&host_direct.host_ref)
+            .await
+            .map_err(|error| format!("placement `{}` target host is not ready: {error}", placement.metadata.name))?;
+        let host_label = if host.spec.display_name.is_empty() { host_direct.host_ref.clone() } else { host.spec.display_name.clone() };
+        let mut status =
+            host.status.ok_or_else(|| format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name))?;
         status.apply_heartbeat_readiness(Utc::now());
         if !status.ready {
-            return Err(format!("placement `{}` host `{}` is not ready", placement.metadata.name, host_direct.host_ref));
+            return Err(format!("placement `{}` host `{host_label}` is not ready", placement.metadata.name));
         }
         let available_adapters = status.agent_adapters().map_err(|error| {
-            format!(
-                "placement `{}` host `{}` has invalid agent adapter capabilities: {error}",
-                placement.metadata.name, host_direct.host_ref
-            )
+            format!("placement `{}` host `{}` has invalid agent adapter capabilities: {error}", placement.metadata.name, host_label)
         })?;
-        Ok((available_adapters, format!("host `{}`", host_direct.host_ref)))
+        Ok((available_adapters, format!("host `{host_label}`")))
     } else {
         Ok((BTreeSet::new(), "unknown target environment".to_string()))
     }
@@ -3984,7 +4039,15 @@ impl InProcessDaemon {
             Err(error) => return Err(error.to_string()),
         }
         let placement = self.resolve_and_validate_convoy_placement(namespace, &workflow.spec, intent.placement_policy.as_deref()).await?;
-        let placement_policy = placement.as_ref().map(|placement| placement.metadata.name.clone());
+        let placement_policy = placement.selected.as_ref().map(|placement| placement.metadata.name.clone());
+        let placement_decision = match placement.selected.as_ref() {
+            Some(selected) => Some(PlacementDecision {
+                policy_name: selected.metadata.name.clone(),
+                target_host: placement_target_host(&self.resource_backend, namespace, selected).await?,
+                refused_candidates: placement.refused_candidates,
+            }),
+            None => None,
+        };
         let spec = ConvoySpec {
             workflow_ref,
             dispatching_principal_ref: dispatching_principal_ref.clone(),
@@ -4001,7 +4064,8 @@ impl InProcessDaemon {
             .name(name)
             .spec(spec)
             .workflow(workflow.spec)
-            .maybe_placement_policy(placement.map(|placement| placement.spec))
+            .maybe_placement_policy(placement.selected.map(|placement| placement.spec))
+            .maybe_placement_decision(placement_decision)
             .build())
     }
 
@@ -4018,6 +4082,7 @@ impl InProcessDaemon {
             &admission.name,
             &admission.spec,
             &admission.workflow,
+            admission.placement_decision,
             intent.auto_attach.into(),
         )
         .await?;
@@ -4047,6 +4112,7 @@ impl InProcessDaemon {
         name: &str,
         spec: &ConvoySpec,
         workflow: &WorkflowTemplateSpec,
+        placement_decision: Option<PlacementDecision>,
         dispatch_regard: ConvoyDispatchRegard,
     ) -> Result<(), String> {
         let workflow_value = serde_json::to_value(workflow).map_err(|error| error.to_string())?;
@@ -4056,6 +4122,7 @@ impl InProcessDaemon {
             namespace,
             name,
             spec,
+            placement_decision,
             dispatch_regard,
             BTreeMap::from([(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_name)]),
         )
@@ -4067,14 +4134,24 @@ impl InProcessDaemon {
         namespace: &str,
         name: &str,
         spec: &ConvoySpec,
+        placement_decision: Option<PlacementDecision>,
         dispatch_regard: ConvoyDispatchRegard,
         annotations: BTreeMap<String, String>,
     ) -> Result<(), String> {
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
-        convoys
+        let convoy = convoys
             .create(&InputMeta::builder().name(name.to_string()).annotations(annotations).build(), spec)
             .await
             .map_err(|error| error.to_string())?;
+        if let Some(placement_decision) = placement_decision {
+            convoys
+                .update_status(name, &convoy.metadata.resource_version, &flotilla_resources::ConvoyStatus {
+                    placement_decision: Some(placement_decision),
+                    ..flotilla_resources::ConvoyStatus::default()
+                })
+                .await
+                .map_err(|error| error.to_string())?;
+        }
         if dispatch_regard == ConvoyDispatchRegard::Emit {
             if let Err(error) = self.emit_implicit_convoy_regard(namespace, name, &spec.dispatching_principal_ref).await {
                 warn!(%error, %namespace, %name, "failed to emit convoy dispatch regard");
@@ -4103,7 +4180,7 @@ impl InProcessDaemon {
         namespace: &str,
         workflow: &WorkflowTemplateSpec,
         placement_policy: Option<&str>,
-    ) -> Result<Option<ResourceObject<PlacementPolicy>>, String> {
+    ) -> Result<PlacementResolution, String> {
         let contained = workflow.vessels.iter().any(|vessel| vessel.stance == flotilla_resources::Stance::Contained);
         let placement = match placement_policy {
             Some(policy) => {
@@ -4118,7 +4195,7 @@ impl InProcessDaemon {
                 if contained && resolved.spec.docker_per_vessel.is_none() {
                     return Err(format!("contained workflow requires a docker placement policy, but {policy} is not contained"));
                 }
-                Some(resolved)
+                PlacementResolution { selected: Some(resolved), refused_candidates: Vec::new() }
             }
             None => {
                 let local_host_id = self.local_host_id();
@@ -4129,14 +4206,14 @@ impl InProcessDaemon {
                     local_host_id.as_ref().map(HostId::as_str),
                 )
                 .await?;
-                if contained && placement.is_none() {
+                if contained && placement.selected.is_none() {
                     return Err("contained workflow requires an available docker placement policy".to_string());
                 }
                 placement
             }
         };
-        validate_workflow_agent_adapters(&self.resource_backend, namespace, workflow, placement.as_ref()).await?;
-        validate_workflow_credentials(&self.resource_backend, namespace, workflow, placement.as_ref()).await?;
+        validate_workflow_agent_adapters(&self.resource_backend, namespace, workflow, placement.selected.as_ref()).await?;
+        validate_workflow_credentials(&self.resource_backend, namespace, workflow, placement.selected.as_ref()).await?;
         Ok(placement)
     }
 
@@ -4239,6 +4316,7 @@ impl InProcessDaemon {
             &namespace,
             &start.name,
             &convoy_spec,
+            start.placement_decision.clone(),
             flotilla_protocol::ConvoyDispatchRegard::Suppress,
             annotations,
         )
@@ -6179,6 +6257,13 @@ impl InProcessDaemon {
 
         let session_list = terminal_sessions.list().await.map_err(|err| err.to_string())?;
         let observed_generation = observed_checkouts.list().await.map_err(|err| err.to_string())?.generation;
+        let result_sets = self.aggregator_projection_state().await.local_result_sets().await;
+        let placement_by_convoy = result_sets
+            .iter()
+            .filter_map(|result_set| result_set.rows.as_convoys())
+            .flatten()
+            .filter_map(|convoy| convoy.placement_decision.clone().map(|decision| (convoy.name.clone(), decision)))
+            .collect::<HashMap<_, _>>();
         let environment_map: HashMap<_, _> = environments
             .list()
             .await
@@ -6225,13 +6310,13 @@ impl InProcessDaemon {
                     .crew(crew)
                     .crew_state(session_status_label(session.status.as_ref().map(|status| status.phase)))
                     .host(host)
+                    .maybe_placement_decision(placement_by_convoy.get(&convoy).cloned())
                     .namespace(session.metadata.namespace.clone())
                     .session(session.metadata.name.clone())
                     .staleness(FleetStaleness::Local)
                     .build(),
             );
         }
-        let result_sets = self.aggregator_projection_state().await.local_result_sets().await;
         append_crewless_convoy_rows(&mut rows, namespace, &result_sets, &self.host_name, FleetStaleness::Local);
         rows.sort_by(|left, right| {
             (&left.convoy, left.host.as_str(), &left.vessel, &left.crew).cmp(&(
@@ -6802,6 +6887,21 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
+        if let flotilla_protocol::CommandAction::ResourceDelete { namespace, kind, name } = &command.action {
+            let empty_identity = self.start_context_free_command(id, command.description().to_string());
+            let result = match flotilla_resources::delete_resource_kind(&self.resource_backend, namespace, kind, name).await {
+                Ok(deleted) => flotilla_protocol::CommandValue::ResourceDeleted(Box::new(ResourceJsonResponse {
+                    kind: deleted.kind,
+                    plural: deleted.plural,
+                    namespace: deleted.namespace,
+                    value: deleted.value,
+                })),
+                Err(error) => flotilla_protocol::CommandValue::Error { message: error.to_string() },
+            };
+            self.finish_context_free_command(id, empty_identity, result);
+            return Ok(id);
+        }
+
         if let flotilla_protocol::CommandAction::ResourceWatch { namespace, kind, include_replicas, replica_sources, cursor } =
             command.action
         {
@@ -7299,9 +7399,27 @@ impl InProcessDaemon {
                 });
                 return Ok(id);
             }
-            let placement_policy =
-                match self.resolve_and_validate_convoy_placement(&namespace, &workflow.spec, placement_policy.as_deref()).await {
-                    Ok(placement) => placement.map(|placement| placement.metadata.name),
+            let placement = match self.resolve_and_validate_convoy_placement(&namespace, &workflow.spec, placement_policy.as_deref()).await
+            {
+                Ok(placement) => placement,
+                Err(message) => {
+                    let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                        command_id: id,
+                        node_id: self.node_id.clone(),
+                        repo_identity: empty_identity,
+                        repo: None,
+                        result: flotilla_protocol::CommandValue::Error { message },
+                    });
+                    return Ok(id);
+                }
+            };
+            let placement_decision = match placement.selected.as_ref() {
+                Some(selected) => match placement_target_host(&self.resource_backend, &namespace, selected).await {
+                    Ok(target_host) => Some(PlacementDecision {
+                        policy_name: selected.metadata.name.clone(),
+                        target_host,
+                        refused_candidates: placement.refused_candidates,
+                    }),
                     Err(message) => {
                         let _ = self.event_tx.send(DaemonEvent::CommandFinished {
                             command_id: id,
@@ -7312,7 +7430,10 @@ impl InProcessDaemon {
                         });
                         return Ok(id);
                     }
-                };
+                },
+                None => None,
+            };
+            let placement_policy = placement.selected.map(|placement| placement.metadata.name);
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),
                 dispatching_principal_ref: dispatching_principal_ref
@@ -7328,7 +7449,14 @@ impl InProcessDaemon {
                 instruction: None,
             };
             let result = match self
-                .create_convoy_with_workflow_snapshot(&namespace, name, &spec, &workflow.spec, ConvoyDispatchRegard::Emit)
+                .create_convoy_with_workflow_snapshot(
+                    &namespace,
+                    name,
+                    &spec,
+                    &workflow.spec,
+                    placement_decision,
+                    ConvoyDispatchRegard::Emit,
+                )
                 .await
             {
                 Ok(()) => flotilla_protocol::CommandValue::ConvoyCreated { name: name.clone() },

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6300,7 +6300,9 @@ impl InProcessDaemon {
             .iter()
             .filter_map(|result_set| result_set.rows.as_convoys())
             .flatten()
-            .filter_map(|convoy| convoy.placement_decision.clone().map(|decision| (convoy.name.clone(), decision)))
+            .filter_map(|convoy| {
+                convoy.placement_decision.clone().map(|decision| ((convoy.resource.namespace.clone(), convoy.name.clone()), decision))
+            })
             .collect::<HashMap<_, _>>();
         let environment_map: HashMap<_, _> = environments
             .list()
@@ -6335,6 +6337,7 @@ impl InProcessDaemon {
                 Some(task) => format!("{task}/{role}"),
                 None => role,
             };
+            let convoy_key = (session.metadata.namespace.clone(), convoy.clone());
             let host = environment_map
                 .get(&session.spec.env_ref)
                 .and_then(|environment| resource_environment_host_ref(environment))
@@ -6348,7 +6351,7 @@ impl InProcessDaemon {
                     .crew(crew)
                     .crew_state(session_status_label(session.status.as_ref().map(|status| status.phase)))
                     .host(host)
-                    .maybe_placement_decision(placement_by_convoy.get(&convoy).cloned())
+                    .maybe_placement_decision(placement_by_convoy.get(&convoy_key).cloned())
                     .namespace(session.metadata.namespace.clone())
                     .session(session.metadata.name.clone())
                     .staleness(FleetStaleness::Local)

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4180,16 +4180,12 @@ impl InProcessDaemon {
         annotations: BTreeMap<String, String>,
     ) -> Result<(), String> {
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
-        let convoy = convoys
+        convoys
             .create(&InputMeta::builder().name(name.to_string()).annotations(annotations).build(), spec)
             .await
             .map_err(|error| error.to_string())?;
         if let Some(placement_decision) = placement_decision {
-            convoys
-                .update_status(name, &convoy.metadata.resource_version, &flotilla_resources::ConvoyStatus {
-                    placement_decision: Some(placement_decision),
-                    ..flotilla_resources::ConvoyStatus::default()
-                })
+            apply_resource_status_patch(&convoys, name, &ConvoyStatusPatch::SetPlacementDecision { placement_decision })
                 .await
                 .map_err(|error| error.to_string())?;
         }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -987,9 +987,10 @@ async fn default_convoy_placement_policy(
             validate_workflow_credentials(backend, namespace, workflow, Some(&policy)).await.err()
         };
         if let Some(reason) = refusal {
-            if let Ok(target_host) = placement_target_host(backend, namespace, &policy).await {
-                refused_candidates.push(PlacementRefusal { policy_name: policy.metadata.name.clone(), target_host, reason });
-            }
+            let target_host = placement_target_host(backend, namespace, &policy)
+                .await
+                .unwrap_or_else(|_| PlacementTargetHost { reference: String::new(), display_name: "no target host".to_string() });
+            refused_candidates.push(PlacementRefusal { policy_name: policy.metadata.name.clone(), target_host, reason });
         } else {
             viable.push(policy);
         }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -290,7 +290,7 @@ fn prepared_snapshot_names_are_content_addressed_for_safe_convoy_name_reuse() {
 async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_required_adapter() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
-    let host = hosts.create(&InputMeta::builder().name("host-test".to_string()).build(), &HostSpec {}).await.expect("host create");
+    let host = hosts.create(&InputMeta::builder().name("host-test".to_string()).build(), &HostSpec::default()).await.expect("host create");
     hosts
         .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
             capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["claude-code"]))].into_iter().collect(),
@@ -330,7 +330,7 @@ async fn agent_adapter_admission_rejects_a_host_that_does_not_advertise_the_requ
 async fn agent_adapter_admission_rejects_a_host_with_stale_heartbeat() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
-    let host = hosts.create(&InputMeta::builder().name("host-test".to_string()).build(), &HostSpec {}).await.expect("host create");
+    let host = hosts.create(&InputMeta::builder().name("host-test".to_string()).build(), &HostSpec::default()).await.expect("host create");
     hosts
         .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
             capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["codex"]))].into_iter().collect(),
@@ -368,7 +368,7 @@ async fn agent_adapter_admission_rejects_a_host_with_stale_heartbeat() {
 
 async fn create_host_direct_placement(backend: &ResourceBackend, policy_name: &str, host_ref: &str, agent_adapters: BTreeSet<String>) {
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
-    let host = hosts.create(&empty_input_meta(host_ref), &HostSpec {}).await.expect("host create");
+    let host = hosts.create(&empty_input_meta(host_ref), &HostSpec { display_name: host_ref.to_string() }).await.expect("host create");
     hosts
         .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
             capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(agent_adapters))].into_iter().collect(),
@@ -411,6 +411,7 @@ async fn default_placement_prefers_the_viable_local_host() {
     let placement = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("local-host"))
         .await
         .expect("default placement")
+        .selected
         .expect("viable placement");
 
     assert_eq!(placement.metadata.name, "host-direct-z-local");
@@ -422,12 +423,18 @@ async fn default_placement_never_selects_a_host_without_the_required_adapter() {
     create_host_direct_placement(&backend, "host-direct-a-no-adapters", "empty-host", BTreeSet::new()).await;
     create_host_direct_placement(&backend, "host-direct-z-codex", "codex-host", BTreeSet::from(["codex".to_string()])).await;
 
-    let placement = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("unrelated-local-host"))
+    let resolution = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("unrelated-local-host"))
         .await
-        .expect("default placement")
-        .expect("viable placement");
+        .expect("default placement");
+    let placement = resolution.selected.expect("viable placement");
 
     assert_eq!(placement.metadata.name, "host-direct-z-codex");
+    assert_eq!(resolution.refused_candidates.len(), 1);
+    assert_eq!(resolution.refused_candidates[0].policy_name, "host-direct-a-no-adapters");
+    assert_eq!(
+        resolution.refused_candidates[0].reason,
+        "workflow requires agent adapter `codex`, which is not available in placement `host-direct-a-no-adapters` (host `empty-host`)"
+    );
 }
 
 #[tokio::test]
@@ -1859,7 +1866,7 @@ async fn fleet_health_keeps_link_heartbeat_and_generation_disagreements_visible(
     let source = ResourceBackend::InMemory(InMemoryBackend::default());
     let source_hosts = source.using::<ResourceHost>("flotilla");
     let remote = source_hosts
-        .create(&InputMeta::builder().name("feta-feta-host".to_string()).build(), &HostSpec {})
+        .create(&InputMeta::builder().name("feta-feta-host".to_string()).build(), &HostSpec::default())
         .await
         .expect("create source host");
     let frozen_heartbeat = Utc::now() - ChronoDuration::seconds(HEARTBEAT_READY_TTL_SECS + 1);
@@ -3980,6 +3987,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
         .expect("convoy create should succeed");
     convoys
         .update_status("convoy-a", &created.metadata.resource_version, &ConvoyStatus {
+            placement_decision: None,
             phase: ConvoyPhase::Active,
             workflow_snapshot: None,
             work: [("implement".to_string(), WorkState {
@@ -4545,6 +4553,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
         .expect("convoy create should succeed");
     convoys
         .update_status("convoy-a", &created.metadata.resource_version, &ConvoyStatus {
+            placement_decision: None,
             phase: ConvoyPhase::Active,
             workflow_snapshot: None,
             work: [("implement".to_string(), WorkState {
@@ -4695,6 +4704,7 @@ async fn convoy_delete_refuses_completed_convoy_with_unpushed_checkout_until_for
     let created = convoys.create(&empty_input_meta("completed-convoy"), &convoy_spec).await.expect("convoy create should succeed");
     convoys
         .update_status("completed-convoy", &created.metadata.resource_version, &ConvoyStatus {
+            placement_decision: None,
             phase: ConvoyPhase::Landed,
             workflow_snapshot: None,
             work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -5142,6 +5152,7 @@ async fn convoy_abandon_command_archives_and_retains_terminal_record() {
     let created = convoys.create(&empty_input_meta("active-convoy"), &convoy_spec).await.expect("convoy create should succeed");
     convoys
         .update_status("active-convoy", &created.metadata.resource_version, &ConvoyStatus {
+            placement_decision: None,
             phase: ConvoyPhase::Active,
             workflow_snapshot: None,
             work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -5570,7 +5581,7 @@ async fn contained_workflow_grants_default_deny_and_admission_names_an_unheld_cr
     assert!(workflow.vessels[1].credential_refs.is_empty(), "uncontained workflow behavior remains unchanged");
 
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
-    let host = hosts.create(&InputMeta::builder().name("host-a".to_string()).build(), &HostSpec {}).await.expect("create host");
+    let host = hosts.create(&InputMeta::builder().name("host-a".to_string()).build(), &HostSpec::default()).await.expect("create host");
     hosts
         .update_status("host-a", &host.metadata.resource_version, &HostStatus {
             ready: true,
@@ -5660,7 +5671,7 @@ async fn local_convoy_admission_pins_the_grant_resolved_workflow() {
         .await
         .expect("create credential grant");
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
-    let host = hosts.create(&empty_input_meta("host-a"), &HostSpec {}).await.expect("create host");
+    let host = hosts.create(&empty_input_meta("host-a"), &HostSpec { display_name: "kiwi".to_string() }).await.expect("create host");
     hosts
         .update_status("host-a", &host.metadata.resource_version, &HostStatus {
             ready: true,
@@ -5702,6 +5713,15 @@ async fn local_convoy_admission_pins_the_grant_resolved_workflow() {
     daemon.admit_convoy_start("flotilla", &intent, &PrincipalRef::implicit_for_namespace("flotilla")).await.expect("admit local convoy");
 
     let convoy = backend.using::<Convoy>("flotilla").get("credential-convoy").await.expect("get convoy");
+    let decision = convoy
+        .status
+        .as_ref()
+        .and_then(|status| status.placement_decision.as_ref())
+        .expect("admission should write the placement decision");
+    assert_eq!(decision.policy_name, "docker-host-a");
+    assert_eq!(decision.target_host.reference, "host-a");
+    assert_eq!(decision.target_host.display_name, "kiwi");
+    assert!(decision.refused_candidates.is_empty());
     let snapshot_ref = convoy
         .metadata
         .annotations

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -15,8 +15,9 @@ use flotilla_protocol::{
     test_support::TestIssue,
     AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent,
     CrewCommandContext, DaemonEvent, EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostProviderStatus, HostSummary, ImageId,
-    Issue, IssueRef, IssueSource, IssueState, QueryCursor, QueryScope, RepoSelector, RepositoryKey, ResourceRef, ResultSetCondition,
-    SystemInfo, ToolInventory, TopologyRoute, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    Issue, IssueRef, IssueSource, IssueState, PlacementDecision, PlacementTargetHost, QueryCursor, QueryScope, RepoSelector, RepositoryKey,
+    ResourceRef, ResultSetCondition, SystemInfo, ToolInventory, TopologyRoute, AGENT_ADAPTER_PROVIDER_CATEGORY,
+    TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
@@ -2058,6 +2059,36 @@ async fn fleet_list_does_not_add_crewless_row_when_convoy_has_crew() {
     assert_eq!(response.rows[0].convoy, "convoy-a");
     assert_eq!(response.rows[0].crew, "implement/coder");
     assert_eq!(response.rows[0].crew_state, "running");
+}
+
+#[tokio::test]
+async fn fleet_list_scopes_crew_session_placement_decisions_by_namespace_and_convoy() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(&daemon, &env_ref, "terminal-shared-implement-coder", "session-a", "shared", "implement", "coder").await;
+    let placement = |policy: &str, host: &str| PlacementDecision {
+        policy_name: policy.to_string(),
+        target_host: PlacementTargetHost { reference: format!("{host}-id"), display_name: host.to_string() },
+        refused_candidates: Vec::new(),
+    };
+    let mut local = convoy_row("flotilla", "shared", WireConvoyPhase::Active, None);
+    local.placement_decision = Some(placement("local-policy", "kiwi"));
+    let mut other = convoy_row("zzz", "shared", WireConvoyPhase::Active, None);
+    other.placement_decision = Some(placement("other-policy", "feta"));
+    set_local_convoy_rows(&daemon, 1, vec![local, other]).await;
+
+    let (rows, _) = daemon.local_fleet_rows("flotilla").await.expect("local fleet rows");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].namespace, "flotilla");
+    let decision = rows[0].placement_decision.as_ref().expect("placement decision");
+    assert_eq!(decision.policy_name, "local-policy");
+    assert_eq!(decision.target_host.display_name, "kiwi");
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -396,6 +396,43 @@ async fn create_host_direct_placement(backend: &ResourceBackend, policy_name: &s
         .expect("placement create");
 }
 
+async fn create_docker_placement(backend: &ResourceBackend, policy_name: &str, host_ref: &str, held_credentials: BTreeSet<String>) {
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = hosts.create(&empty_input_meta(host_ref), &HostSpec { display_name: host_ref.to_string() }).await.expect("host create");
+    hosts
+        .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
+            capabilities: [(flotilla_resources::HELD_CREDENTIALS_CAPABILITY.to_string(), serde_json::json!(held_credentials))]
+                .into_iter()
+                .collect(),
+            heartbeat_at: Some(Utc::now()),
+            ready: true,
+            resource_store: None,
+            ..HostStatus::default()
+        })
+        .await
+        .expect("host status update");
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta(policy_name),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .docker_per_vessel(flotilla_resources::DockerPerVesselPlacementPolicySpec {
+                    host_ref: host_ref.to_string(),
+                    image: "crew:latest".to_string(),
+                    pull_policy: Default::default(),
+                    agent_adapters: BTreeSet::from(["codex".to_string()]),
+                    default_cwd: None,
+                    env: BTreeMap::new(),
+                    checkout: flotilla_resources::DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },
+                })
+                .build(),
+        )
+        .await
+        .expect("placement create");
+}
+
 fn trusted_codex_workflow() -> WorkflowTemplateSpec {
     let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
     workflow.vessels[0].stance = Stance::Trusted;
@@ -434,6 +471,49 @@ async fn default_placement_never_selects_a_host_without_the_required_adapter() {
     assert_eq!(
         resolution.refused_candidates[0].reason,
         "workflow requires agent adapter `codex`, which is not available in placement `host-direct-a-no-adapters` (host `empty-host`)"
+    );
+}
+
+#[tokio::test]
+async fn default_placement_preserves_a_refusal_for_a_policy_without_a_target_host() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    backend
+        .clone()
+        .using::<PlacementPolicy>("flotilla")
+        .create(&empty_input_meta("a-malformed"), &PlacementPolicySpec::builder().pool("passthrough".to_string()).build())
+        .await
+        .expect("malformed placement create");
+    create_host_direct_placement(&backend, "z-viable", "codex-host", BTreeSet::from(["codex".to_string()])).await;
+
+    let resolution =
+        default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), None).await.expect("default placement");
+
+    assert_eq!(resolution.selected.expect("viable placement").metadata.name, "z-viable");
+    assert_eq!(resolution.refused_candidates.len(), 1);
+    assert_eq!(resolution.refused_candidates[0].policy_name, "a-malformed");
+    assert_eq!(resolution.refused_candidates[0].target_host.display_name, "no target host");
+    assert_eq!(
+        resolution.refused_candidates[0].reason,
+        "workflow requires agent adapter `codex`, which is not available in placement `a-malformed` (unknown target environment)"
+    );
+}
+
+#[tokio::test]
+async fn default_placement_falls_back_after_a_credential_refusal_and_records_the_exact_reason() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_docker_placement(&backend, "a-missing-credential", "empty-host", BTreeSet::new()).await;
+    create_docker_placement(&backend, "z-holds-credential", "credential-host", BTreeSet::from(["model-api".to_string()])).await;
+    let mut workflow = flotilla_resources::single_agent_contained_workflow_spec();
+    workflow.vessels[0].credential_refs = BTreeSet::from(["model-api".to_string()]);
+
+    let resolution = default_convoy_placement_policy(&backend, "flotilla", &workflow, None).await.expect("default placement");
+
+    assert_eq!(resolution.selected.expect("credential-capable placement").metadata.name, "z-holds-credential");
+    assert_eq!(resolution.refused_candidates.len(), 1);
+    assert_eq!(resolution.refused_candidates[0].policy_name, "a-missing-credential");
+    assert_eq!(
+        resolution.refused_candidates[0].reason,
+        "workflow requires credential `model-api`, which placement `a-missing-credential` host `empty-host` does not hold"
     );
 }
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1087,7 +1087,7 @@ async fn create_test_host_direct_policy(
     agent_adapters: BTreeSet<String>,
 ) {
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
-    let host = hosts.create(&InputMeta::builder().name(host_ref.to_string()).build(), &HostSpec {}).await.expect("host create");
+    let host = hosts.create(&InputMeta::builder().name(host_ref.to_string()).build(), &HostSpec::default()).await.expect("host create");
     hosts
         .update_status(&host.metadata.name, &host.metadata.resource_version, &HostStatus {
             capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(agent_adapters))].into_iter().collect(),

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1676,7 +1676,14 @@ impl Aggregator {
     fn vessel_host(&self, convoy_ref: &ResourceRef, state: Option<&WorkState>) -> HostName {
         state
             .and_then(|state| state.placement.as_ref())
-            .and_then(|placement| placement.fields.get("host"))
+            .and_then(|placement| {
+                placement
+                    .fields
+                    .get("placement_decision")
+                    .and_then(|decision| decision.get("target_host"))
+                    .and_then(|host| host.get("display_name"))
+                    .or_else(|| placement.fields.get("host"))
+            })
             .and_then(serde_json::Value::as_str)
             .map(HostName::new)
             .or_else(|| convoy_ref.host.clone())
@@ -1722,6 +1729,7 @@ impl Aggregator {
             .workflow_ref(&convoy.spec.workflow_ref)
             .dispatching_principal_ref(convoy.spec.dispatching_principal_ref.clone())
             .phase(convoy_phase(phase))
+            .maybe_placement_decision(status.and_then(|status| status.placement_decision.clone()))
             .initializing(convoy_is_initializing(status))
             .maybe_message(status.and_then(|status| status.message.clone()))
             .maybe_repo(self.convoy_repo_fact(convoy).map(flotilla_protocol::RepoKey))
@@ -1758,6 +1766,9 @@ impl Aggregator {
     fn summarize_vessel(&self, convoy_ref: &ResourceRef, definition: &VesselRequirement, state: Option<&WorkState>) -> VesselRow {
         let requested_stance = definition.stance.to_string();
         let placement = state.and_then(|state| state.placement.as_ref());
+        let placement_decision = placement
+            .and_then(|placement| placement.fields.get("placement_decision"))
+            .and_then(|value| serde_json::from_value(value.clone()).ok());
         let vessel_host = self.vessel_host(convoy_ref, state);
         let vessel_resource =
             placement.and_then(|placement| placement.fields.get("vessel_ref")).and_then(serde_json::Value::as_str).map(|name| {
@@ -1808,6 +1819,7 @@ impl Aggregator {
             .maybe_vessel_resource(vessel_resource)
             .name(&definition.name)
             .phase(work_phase(state.map(|state| state.phase).unwrap_or(ResourceWorkPhase::Pending)))
+            .maybe_placement_decision(placement_decision)
             .crew(crew)
             .maybe_ready_at(state.and_then(|state| state.ready_at))
             .maybe_started_at(state.and_then(|state| state.started_at))

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -316,6 +316,7 @@ impl Drop for DaemonRuntime {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LocalProvisioningProfile {
     host_id: String,
+    display_name: String,
     repo_default_dir: String,
     host_direct_pool: String,
     docker_pool: String,
@@ -433,6 +434,7 @@ fn build_local_profile(daemon: &Arc<InProcessDaemon>, local_registry: &ProviderR
 
     Ok(LocalProvisioningProfile {
         host_id,
+        display_name: daemon.host_name().to_string(),
         repo_default_dir,
         host_direct_pool,
         docker_pool,
@@ -448,7 +450,7 @@ async fn register_startup_resources(
     profile: &LocalProvisioningProfile,
 ) -> Result<(), String> {
     let backend = daemon.resource_backend();
-    ensure_host_exists(&backend, namespace, &profile.host_id).await?;
+    ensure_host_exists(&backend, namespace, &profile.host_id, &profile.display_name).await?;
     ensure_host_direct_environment_exists(&backend, namespace, profile).await?;
     discover_local_clones(daemon, &backend, namespace, profile).await?;
     ensure_default_policies(&backend, namespace, profile).await?;
@@ -525,14 +527,27 @@ async fn reconcile_builtin_workflow_templates(backend: &ResourceBackend, namespa
     Ok(())
 }
 
-async fn ensure_host_exists(backend: &ResourceBackend, namespace: &str, host_name: &str) -> Result<(), String> {
+async fn ensure_host_exists(backend: &ResourceBackend, namespace: &str, host_name: &str, display_name: &str) -> Result<(), String> {
     let hosts = backend.clone().using::<Host>(namespace);
     match hosts.get(host_name).await {
-        Ok(_) => return Ok(()),
+        Ok(existing) if existing.spec.display_name == display_name => return Ok(()),
+        Ok(existing) => {
+            return hosts
+                .update(&InputMeta::from(&existing.metadata), &existing.metadata.resource_version, &HostSpec {
+                    display_name: display_name.to_string(),
+                })
+                .await
+                .map(|_| ())
+                .map_err(|err| err.to_string())
+        }
         Err(ResourceError::NotFound { .. }) => {}
         Err(err) => return Err(format!("check host {host_name}: {err}")),
     }
-    hosts.create(&empty_meta(host_name), &HostSpec {}).await.map(|_| ()).map_err(|err| err.to_string())
+    hosts
+        .create(&empty_meta(host_name), &HostSpec { display_name: display_name.to_string() })
+        .await
+        .map(|_| ())
+        .map_err(|err| err.to_string())
 }
 
 async fn ensure_host_direct_environment_exists(
@@ -801,7 +816,7 @@ async fn apply_host_heartbeat_with_credentials(
     credential_store: Option<&CredentialStore>,
     health: &DaemonHealthIdentity,
 ) -> Result<(), String> {
-    ensure_host_exists(&daemon.resource_backend(), namespace, &profile.host_id).await?;
+    ensure_host_exists(&daemon.resource_backend(), namespace, &profile.host_id, &profile.display_name).await?;
     let backend = daemon.resource_backend();
     let hosts = backend.using::<Host>(namespace);
     let host = hosts.get(&profile.host_id).await.map_err(|err| err.to_string())?;
@@ -2840,6 +2855,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn deleted_code_owned_builtin_is_reconciled_back() {
+        let backend = ResourceBackend::InMemory(Default::default());
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("initial builtin reconciliation should succeed");
+
+        let deleted = flotilla_resources::delete_resource_kind(&backend, NAMESPACE, "workflowtemplates", "single-agent-contained")
+            .await
+            .expect("raw delete should remove builtin");
+        assert_eq!(deleted.value["metadata"]["name"], "single-agent-contained");
+        assert!(matches!(
+            backend.using::<WorkflowTemplate>(NAMESPACE).get("single-agent-contained").await,
+            Err(ResourceError::NotFound { .. })
+        ));
+
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("level-triggered reconciliation should recreate builtin");
+        let recreated =
+            backend.using::<WorkflowTemplate>(NAMESPACE).get("single-agent-contained").await.expect("builtin should be recreated");
+        assert_eq!(recreated.spec, flotilla_resources::single_agent_contained_workflow_spec());
+        assert_eq!(recreated.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some(BUILTIN_MANAGED_BY_VALUE));
+    }
+
+    #[tokio::test]
     async fn startup_seeding_labels_matching_unlabelled_builtin_template_once() {
         const NAMESPACE: &str = "test";
         let backend = ResourceBackend::InMemory(Default::default());
@@ -2865,6 +2901,7 @@ mod tests {
     fn manual_profile(host_id: &str, docker_available: bool) -> LocalProvisioningProfile {
         LocalProvisioningProfile {
             host_id: host_id.to_string(),
+            display_name: "kiwi".to_string(),
             repo_default_dir: "/Users/tester/dev/flotilla-repos".to_string(),
             host_direct_pool: "passthrough".to_string(),
             docker_pool: "passthrough".to_string(),
@@ -3209,7 +3246,7 @@ mod tests {
         let host_id = daemon.local_host_id().expect("local host id").to_string();
         let profile = manual_profile(&host_id, false);
 
-        ensure_host_exists(&daemon.resource_backend(), NAMESPACE, &host_id).await.expect("host registration should succeed");
+        ensure_host_exists(&daemon.resource_backend(), NAMESPACE, &host_id, "kiwi").await.expect("host registration should succeed");
         let heartbeat =
             spawn_heartbeat_task(Arc::clone(&daemon), NAMESPACE.to_string(), profile, test_health_identity(), Duration::from_millis(20));
         let hosts = daemon.resource_backend().using::<Host>(NAMESPACE);

--- a/crates/flotilla-daemon/tests/overlay_replication.rs
+++ b/crates/flotilla-daemon/tests/overlay_replication.rs
@@ -39,7 +39,7 @@ async fn sqlite_daemons_expose_remote_host_self_report_in_fleet_health() {
     let heartbeat_at = chrono::Utc::now();
     let feta_hosts = feta.resource_backend().using::<Host>("flotilla");
     let feta_host = feta_hosts
-        .create(&InputMeta::builder().name(feta_host_id.clone()).build(), &HostSpec {})
+        .create(&InputMeta::builder().name(feta_host_id.clone()).build(), &HostSpec::default())
         .await
         .expect("create feta host self-report");
     feta_hosts

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -222,6 +222,8 @@ pub struct PreparedConvoyStart {
     pub placement_policy_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placement_policy_spec: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_decision: Option<crate::PlacementDecision>,
     #[builder(default)]
     #[serde(default)]
     pub auto_attach: bool,
@@ -462,6 +464,11 @@ pub enum CommandAction {
         namespace: String,
         document: serde_json::Value,
     },
+    ResourceDelete {
+        namespace: String,
+        kind: String,
+        name: String,
+    },
     ResourceWatch {
         namespace: String,
         kind: String,
@@ -559,6 +566,7 @@ impl Command {
             CommandAction::QueryResourceList { .. } => "query resource list",
             CommandAction::QueryResourceGet { .. } => "query resource get",
             CommandAction::ResourceApply { .. } => "apply resource",
+            CommandAction::ResourceDelete { .. } => "delete resource",
             CommandAction::ResourceWatch { .. } => "watch resources",
         }
     }
@@ -673,6 +681,7 @@ pub enum CommandValue {
     },
     ResourceList(Box<ResourceJsonResponse>),
     ResourceObject(Box<ResourceJsonResponse>),
+    ResourceDeleted(Box<ResourceJsonResponse>),
     ResourceWatchEvent(Box<ResourceWatchResponse>),
     EnvironmentSpecRead {
         spec: crate::EnvironmentSpec,

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -11,6 +11,7 @@ mod lifecycle;
 pub mod output;
 pub mod path_context;
 pub mod peer;
+mod placement;
 pub mod provider_data;
 mod provisioning_target;
 pub mod qualified_path;
@@ -37,6 +38,7 @@ pub use host_summary::{
 pub use lifecycle::LifecycleAuthority;
 pub use path_context::{DaemonHostPath, ExecutionEnvironmentPath};
 pub use peer::{CommandPeerEvent, GoodbyeReason, PeerDataKind, PeerDataMessage, PeerWireMessage, RoutedPeerMessage, VectorClock};
+pub use placement::{PlacementDecision, PlacementRefusal, PlacementTargetHost};
 pub use provisioning_target::ProvisioningTarget;
 pub use repository::{RepositoryKey, UNKNOWN_REPOSITORY_LABEL};
 pub use step::{CheckoutIntent, Step, StepAction, StepExecutionContext, StepOutcome};

--- a/crates/flotilla-protocol/src/placement.rs
+++ b/crates/flotilla-protocol/src/placement.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct PlacementTargetHost {
+    #[serde(rename = "ref")]
+    pub reference: String,
+    pub display_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct PlacementRefusal {
+    pub policy_name: String,
+    pub target_host: PlacementTargetHost,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct PlacementDecision {
+    pub policy_name: String,
+    pub target_host: PlacementTargetHost,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub refused_candidates: Vec<PlacementRefusal>,
+}

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -262,6 +262,8 @@ pub struct FleetListRow {
     pub crew: String,
     pub crew_state: String,
     pub host: HostName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_decision: Option<crate::PlacementDecision>,
     /// Namespace the crew session lives in on its owning host.
     pub namespace: String,
     /// Crew session name — with `host` and `namespace` this is the

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -787,6 +787,8 @@ pub struct ConvoyRow {
     #[serde(default)]
     pub dispatching_principal_ref: PrincipalRef,
     pub phase: ConvoyPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_decision: Option<crate::PlacementDecision>,
     /// The convoy has no workflow snapshot yet and is not terminal.
     #[builder(default)]
     pub initializing: bool,
@@ -846,6 +848,8 @@ pub struct VesselRow {
     pub vessel_resource: Option<ResourceRef>,
     pub name: String,
     pub phase: WorkPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_decision: Option<crate::PlacementDecision>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub crew: Vec<CrewMemberSummary>,

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -119,6 +119,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("updating convoy status");
     let updated_convoy = convoy_resolver
         .update_status(&created_convoy.metadata.name, &created_convoy.metadata.resource_version, &ConvoyStatus {
+            placement_decision: None,
             phase: ConvoyPhase::Active,
             workflow_snapshot: None,
             work: Default::default(),

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -259,6 +259,9 @@ pub struct PlacementStatus {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConvoyStatusPatch {
+    SetPlacementDecision {
+        placement_decision: PlacementDecision,
+    },
     Bootstrap {
         workflow_snapshot: WorkflowSnapshot,
         observed_workflow_ref: String,
@@ -366,6 +369,9 @@ pub enum ConvoyStatusPatch {
 impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
     fn apply(&self, status: &mut ConvoyStatus) {
         match self {
+            Self::SetPlacementDecision { placement_decision } => {
+                status.placement_decision.get_or_insert_with(|| placement_decision.clone());
+            }
             Self::Bootstrap { workflow_snapshot, observed_workflow_ref, observed_workflows, work, crew_work, phase, started_at } => {
                 status.workflow_snapshot = Some(workflow_snapshot.clone());
                 status.observed_workflow_ref = Some(observed_workflow_ref.clone());

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
-use flotilla_protocol::{IssueRef, IssueState, PrincipalRef};
+use flotilla_protocol::{IssueRef, IssueState, PlacementDecision, PrincipalRef};
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement, ReplicationClass, RepositoryKey};
@@ -114,6 +114,8 @@ pub enum InputValue {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ConvoyStatus {
     pub phase: ConvoyPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_decision: Option<PlacementDecision>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow_snapshot: Option<WorkflowSnapshot>,
     /// Work aboard each declared vessel, keyed by vessel (requirement) name.

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -1039,6 +1039,9 @@ fn vessel_failure_message(vessel: &ResourceObject<Vessel>) -> String {
 fn placement_status(workspace: &ResourceObject<Vessel>) -> PlacementStatus {
     let mut fields = BTreeMap::from([("vessel_ref".to_string(), json!(workspace.metadata.name))]);
     if let Some(status) = workspace.status.as_ref() {
+        if let Some(decision) = &status.placement_decision {
+            fields.insert("placement_decision".to_string(), json!(decision));
+        }
         insert_optional_field(&mut fields, "environment_ref", status.environment_ref.clone());
         insert_optional_field(&mut fields, "image_ref", status.image_ref.clone());
         insert_optional_field(&mut fields, "image_digest", status.image_digest.clone());

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -13,7 +13,10 @@ pub const TERMINAL_POOLS_CAPABILITY: &str = "terminal_pools";
 pub const HEARTBEAT_READY_TTL_SECS: i64 = 60;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HostSpec {}
+pub struct HostSpec {
+    #[serde(default)]
+    pub display_name: String,
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct HostStatus {

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -84,7 +84,7 @@ pub use project::{
 };
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
-    apply_resource_document, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas,
+    apply_resource_document, delete_resource_kind, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas,
     list_resource_kind_replica_sources, resource_list_api_version, watch_resource_kind, watch_resource_kind_from,
     watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList, DynamicResourceObject,
     DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -190,6 +190,15 @@ pub async fn get_resource_kind(
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, get_typed(backend, namespace, name).await)
 }
 
+pub async fn delete_resource_kind(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+    name: &str,
+) -> Result<DynamicResourceObject, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, delete_typed(backend, namespace, name).await)
+}
+
 pub async fn watch_resource_kind(
     backend: &ResourceBackend,
     namespace: &str,
@@ -363,6 +372,18 @@ async fn get_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name
     } else {
         backend.using::<T>(namespace).get(name).await?
     };
+    Ok(DynamicResourceObject {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value: object_value(&object)?,
+    })
+}
+
+async fn delete_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name: &str) -> Result<DynamicResourceObject, ResourceError> {
+    let resolver = backend.using::<T>(namespace);
+    let object = resolver.get(name).await?;
+    resolver.delete(name).await?;
     Ok(DynamicResourceObject {
         kind: T::API_PATHS.kind.to_string(),
         plural: T::API_PATHS.plural.to_string(),
@@ -611,10 +632,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dynamic_delete_emits_the_normal_event_and_drops_an_in_memory_peer_replica() {
+        let source = ResourceBackend::InMemory(InMemoryBackend::default());
+        let peer = ResourceBackend::InMemory(InMemoryBackend::default());
+        let convoys = source.using::<Convoy>("flotilla");
+        convoys
+            .create(&InputMeta::builder().name("ghost".to_string()).build(), &ConvoySpec::builder().workflow_ref("wf".to_string()).build())
+            .await
+            .expect("create source convoy");
+        let listed = convoys.list().await.expect("list source convoys");
+        let origin = NodeId::new("kiwi-root");
+        let replica = peer.replica_writer::<Convoy>(origin, "flotilla");
+        replica.replace(&listed, Utc::now()).await.expect("seed peer replica");
+        let mut watch = convoys.watch(WatchStart::resuming_from(&listed)).await.expect("watch source");
+
+        let deleted = delete_resource_kind(&source, "flotilla", "convoys", "ghost").await.expect("delete exact convoy");
+        assert_eq!(deleted.value["metadata"]["name"], "ghost");
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), watch.next())
+            .await
+            .expect("delete watch event timeout")
+            .expect("delete watch ended")
+            .expect("delete watch event");
+        assert!(matches!(event, WatchEvent::Deleted(ref object) if object.metadata.name == "ghost"));
+        replica.apply(event, Utc::now()).await.expect("apply delete to peer");
+
+        let replicas = peer.including_replicas::<Convoy>("flotilla").list().await.expect("list peer replicas");
+        assert!(replicas.items.is_empty(), "normal delete propagation must remove the peer replica");
+    }
+
+    #[tokio::test]
     async fn host_resource_list_marks_stale_heartbeat_not_ready() {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
         let hosts = backend.using::<Host>("flotilla");
-        let host = hosts.create(&InputMeta::builder().name("feta".to_string()).build(), &HostSpec {}).await.expect("create host");
+        let host = hosts.create(&InputMeta::builder().name("feta".to_string()).build(), &HostSpec::default()).await.expect("create host");
         hosts
             .update_status("feta", &host.metadata.resource_version, &HostStatus {
                 capabilities: BTreeMap::new(),
@@ -636,8 +686,10 @@ mod tests {
     async fn host_replica_resource_list_derives_ready_from_origin_heartbeat() {
         let source = ResourceBackend::InMemory(InMemoryBackend::default());
         let source_hosts = source.using::<Host>("flotilla");
-        let host =
-            source_hosts.create(&InputMeta::builder().name("feta".to_string()).build(), &HostSpec {}).await.expect("create source host");
+        let host = source_hosts
+            .create(&InputMeta::builder().name("feta".to_string()).build(), &HostSpec::default())
+            .await
+            .expect("create source host");
         source_hosts
             .update_status("feta", &host.metadata.resource_version, &HostStatus {
                 capabilities: BTreeMap::new(),

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
+use flotilla_protocol::PlacementDecision;
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::StatusPatch, ReplicationClass, RepositoryKey, Stance};
@@ -31,6 +32,8 @@ pub enum VesselPhase {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VesselStatus {
     pub phase: VesselPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement_decision: Option<PlacementDecision>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -64,10 +67,12 @@ pub enum VesselStatusPatch {
     MarkProvisioning {
         observed_policy_ref: String,
         observed_policy_version: String,
+        placement_decision: Option<PlacementDecision>,
         started_at: DateTime<Utc>,
         message: Option<String>,
     },
     MarkReady {
+        placement_decision: Option<PlacementDecision>,
         environment_ref: Option<String>,
         image_ref: Option<String>,
         image_digest: Option<String>,
@@ -90,14 +95,18 @@ pub enum VesselStatusPatch {
 impl StatusPatch<VesselStatus> for VesselStatusPatch {
     fn apply(&self, status: &mut VesselStatus) {
         match self {
-            Self::MarkProvisioning { observed_policy_ref, observed_policy_version, started_at, message } => {
+            Self::MarkProvisioning { observed_policy_ref, observed_policy_version, placement_decision, started_at, message } => {
                 status.phase = VesselPhase::Provisioning;
                 status.observed_policy_ref = Some(observed_policy_ref.clone());
                 status.observed_policy_version = Some(observed_policy_version.clone());
+                if let Some(placement_decision) = placement_decision {
+                    status.placement_decision.get_or_insert_with(|| placement_decision.clone());
+                }
                 status.started_at.get_or_insert(*started_at);
                 status.message = message.clone();
             }
             Self::MarkReady {
+                placement_decision,
                 environment_ref,
                 image_ref,
                 image_digest,
@@ -108,6 +117,9 @@ impl StatusPatch<VesselStatus> for VesselStatusPatch {
                 ready_at,
             } => {
                 status.phase = VesselPhase::Ready;
+                if let Some(placement_decision) = placement_decision {
+                    status.placement_decision.get_or_insert_with(|| placement_decision.clone());
+                }
                 status.environment_ref = environment_ref.clone();
                 status.image_ref = image_ref.clone();
                 status.image_digest = image_digest.clone();

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -95,6 +95,7 @@ pub fn convoy_spec(workflow_ref: &str) -> RealConvoySpec {
 
 pub fn convoy_status(phase: flotilla_resources::ConvoyPhase) -> RealConvoyStatus {
     RealConvoyStatus {
+        placement_decision: None,
         phase,
         workflow_snapshot: None,
         work: Default::default(),
@@ -300,6 +301,7 @@ pub fn bootstrapped_convoy_status() -> RealConvoyStatus {
     ]);
 
     RealConvoyStatus {
+        placement_decision: None,
         phase: flotilla_resources::ConvoyPhase::Pending,
         workflow_snapshot: Some(snapshot),
         work,
@@ -391,6 +393,7 @@ pub fn bootstrapped_tool_only_convoy_status() -> RealConvoyStatus {
     let crew_work = BTreeMap::from([("implement".to_string(), BTreeMap::new()), ("review".to_string(), BTreeMap::new())]);
 
     RealConvoyStatus {
+        placement_decision: None,
         phase: flotilla_resources::ConvoyPhase::Pending,
         workflow_snapshot: Some(snapshot),
         work,

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -249,6 +249,7 @@ async fn controller_loop_advances_task_via_vessel_secondary_watch() {
     let workspace = workspaces.get("convoy-stage4a-implement").await.expect("workspace get should succeed");
     workspaces
         .update_status("convoy-stage4a-implement", &workspace.metadata.resource_version, &VesselStatus {
+            placement_decision: None,
             phase: VesselPhase::Ready,
             message: None,
             observed_policy_ref: Some("laptop-docker".to_string()),

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -215,6 +215,7 @@ fn vessel_object_with_image_digest(
             adopted_checkout_refs: Default::default(),
         },
         status: Some(VesselStatus {
+            placement_decision: None,
             phase,
             message: message.map(str::to_string),
             observed_policy_ref: Some("laptop-docker".to_string()),

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -76,6 +76,7 @@ fn crew_work(phase: CrewWorkPhase) -> CrewWorkState {
 #[test]
 fn abandon_convoy_stamps_convoy_and_open_work() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([
@@ -107,6 +108,7 @@ fn abandon_convoy_stamps_convoy_and_open_work() {
 #[test]
 fn crew_completion_updates_only_the_calling_agent() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -149,6 +151,7 @@ fn crew_completion_updates_only_the_calling_agent() {
 #[test]
 fn final_crew_completion_claim_enters_landing_idempotently() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -180,6 +183,7 @@ fn final_crew_completion_claim_enters_landing_idempotently() {
 #[test]
 fn crew_failure_records_terminal_state_and_message() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::new(),
@@ -209,6 +213,7 @@ fn handoff_to_done_crew_reopens_target_and_marks_sender_handed_back() {
     let mut coder = crew_work(CrewWorkPhase::Done);
     coder.finished_at = Some(ts(15));
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Landed,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -255,6 +260,7 @@ fn resume_reopens_completed_crew_without_restarting_its_timeline() {
     coder.finished_at = Some(ts(15));
     coder.message = Some("ready".to_string());
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Landed,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -289,6 +295,7 @@ fn running_vessel_work_starts_pending_agents_without_reopening_done_agents() {
     let mut pending_coder = crew_work(CrewWorkPhase::Pending);
     pending_coder.started_at = None;
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -323,6 +330,7 @@ fn running_vessel_work_starts_pending_agents_without_reopening_done_agents() {
 #[test]
 fn running_vessel_work_leaves_latent_agents_pending() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -393,6 +401,7 @@ fn bootstrap_sets_snapshot_and_initial_work_map() {
 #[test]
 fn advance_work_to_ready_updates_only_selected_vessels() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Pending,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([
@@ -428,6 +437,7 @@ fn advance_work_to_ready_updates_only_selected_vessels() {
 #[test]
 fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([
@@ -482,6 +492,7 @@ fn roll_up_phase_only_touches_convoy_level_fields() {
         placement: None,
     };
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Pending,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("review".to_string(), review.clone())]),
@@ -506,6 +517,7 @@ fn roll_up_phase_only_touches_convoy_level_fields() {
 #[test]
 fn forced_work_completion_claim_enters_landing() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("review".to_string(), WorkState {
@@ -540,6 +552,7 @@ fn forced_work_completion_claim_enters_landing() {
 #[test]
 fn forced_work_completion_preserves_agent_owned_state() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), WorkState {
@@ -578,6 +591,7 @@ fn forced_work_completion_preserves_agent_owned_state() {
 #[test]
 fn convoy_lifecycle_timestamps_are_set_once_per_transition() {
     let mut status = ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Pending,
         workflow_snapshot: Some(sample_snapshot()),
         work: BTreeMap::from([("implement".to_string(), pending_work())]),

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{TimeZone, Utc};
+use flotilla_protocol::{PlacementDecision, PlacementTargetHost};
 use flotilla_resources::{
     controller_patches, external_patches, provisioning_patches, ConvoyPhase, ConvoyStatus, ConvoyStatusPatch, CrewSource, CrewSpec,
     CrewWorkPhase, CrewWorkState, Selector, StatusPatch, VesselRequirement, WorkCompletionAuthority, WorkPhase, WorkState,
@@ -71,6 +72,29 @@ fn pending_work() -> WorkState {
 
 fn crew_work(phase: CrewWorkPhase) -> CrewWorkState {
     CrewWorkState::builder().phase(phase).started_at(ts(10)).build()
+}
+
+#[test]
+fn placement_decision_is_written_once_without_overwriting_concurrent_status() {
+    let first = PlacementDecision {
+        policy_name: "host-direct-kiwi".to_string(),
+        target_host: PlacementTargetHost { reference: "kiwi-id".to_string(), display_name: "kiwi".to_string() },
+        refused_candidates: Vec::new(),
+    };
+    let second = PlacementDecision {
+        policy_name: "host-direct-feta".to_string(),
+        target_host: PlacementTargetHost { reference: "feta-id".to_string(), display_name: "feta".to_string() },
+        refused_candidates: Vec::new(),
+    };
+    let mut status =
+        ConvoyStatus { phase: ConvoyPhase::Active, observed_workflow_ref: Some("scratch".to_string()), ..ConvoyStatus::default() };
+
+    ConvoyStatusPatch::SetPlacementDecision { placement_decision: first.clone() }.apply(&mut status);
+    ConvoyStatusPatch::SetPlacementDecision { placement_decision: second }.apply(&mut status);
+
+    assert_eq!(status.placement_decision, Some(first));
+    assert_eq!(status.phase, ConvoyPhase::Active);
+    assert_eq!(status.observed_workflow_ref.as_deref(), Some("scratch"));
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -48,6 +48,7 @@ macro_rules! define_patch_kinds {
 }
 
 define_patch_kinds! {
+    ConvoySetPlacementDecision => NONE,
     ConvoyBootstrap => DUPLICATE,
     ConvoyBackfillCrewWork => NONE,
     ConvoyFailInit => DUPLICATE,
@@ -85,6 +86,7 @@ define_patch_kinds! {
 
 fn convoy_patch_kind(patch: &ConvoyStatusPatch) -> PatchKind {
     match patch {
+        ConvoyStatusPatch::SetPlacementDecision { .. } => PatchKind::ConvoySetPlacementDecision,
         ConvoyStatusPatch::Bootstrap { .. } => PatchKind::ConvoyBootstrap,
         ConvoyStatusPatch::BackfillCrewWork { .. } => PatchKind::ConvoyBackfillCrewWork,
         ConvoyStatusPatch::FailInit { .. } => PatchKind::ConvoyFailInit,

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -187,6 +187,7 @@ fn crew_state(phase: CrewWorkPhase, started_at: Option<DateTime<Utc>>, finished_
 
 fn active_convoy_status() -> ConvoyStatus {
     ConvoyStatus {
+        placement_decision: None,
         phase: ConvoyPhase::Active,
         workflow_snapshot: None,
         work: BTreeMap::from([("implement".to_string(), work_state(WorkPhase::Running, Some(ts(10)), None))]),
@@ -246,6 +247,7 @@ fn patch_variants_exhaustively_declare_their_lifecycle_classes() {
     assert_eq!(terminal_session_patch_kind(&TerminalSessionStatusPatch::MarkStarting), PatchKind::TerminalMarkStarting);
     assert_eq!(
         vessel_patch_kind(&VesselStatusPatch::MarkProvisioning {
+            placement_decision: None,
             observed_policy_ref: "docker".to_string(),
             observed_policy_version: "2".to_string(),
             started_at: ts(30),
@@ -602,6 +604,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                 let mut status = VesselStatus { phase: VesselPhase::Provisioning, started_at: Some(ts(10)), ..VesselStatus::default() };
                 let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };
                 let patch = VesselStatusPatch::MarkProvisioning {
+                    placement_decision: None,
                     observed_policy_ref: "docker".to_string(),
                     observed_policy_version: "2".to_string(),
                     started_at: ts(30),
@@ -620,6 +623,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                     VesselStatus { phase: VesselPhase::Ready, started_at: Some(ts(10)), ready_at: Some(ts(20)), ..VesselStatus::default() };
                 let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.ready_at };
                 let patch = VesselStatusPatch::MarkReady {
+                    placement_decision: None,
                     environment_ref: Some("env-a".to_string()),
                     image_ref: Some("registry.example/crew:latest".to_string()),
                     image_digest: Some("sha256:test-image".to_string()),

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -72,6 +72,7 @@ async fn vessel_metadata_and_status_roundtrip() {
     let created = resolver.create(&vessel_meta("convoy-fix-bug-123-implement"), &spec).await.expect("create should succeed");
     let updated = resolver
         .update_status("convoy-fix-bug-123-implement", &created.metadata.resource_version, &VesselStatus {
+            placement_decision: None,
             phase: VesselPhase::Ready,
             message: None,
             observed_policy_ref: Some("docker-on-01HXYZ".to_string()),

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -1,4 +1,5 @@
 use chrono::{TimeZone, Utc};
+use flotilla_protocol::{PlacementDecision, PlacementTargetHost};
 use flotilla_resources::{
     CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutStatus, CheckoutStatusPatch, ClonePhase, CloneStatus,
     CloneStatusPatch, ConditionValue, EnvironmentPhase, EnvironmentStatus, EnvironmentStatusPatch, HostStatus, HostStatusPatch,
@@ -187,8 +188,14 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
     let mut status = VesselStatus::default();
     let started_at = Utc.timestamp_opt(10, 0).single().expect("timestamp");
     let ready_at = Utc.timestamp_opt(20, 0).single().expect("timestamp");
+    let placement_decision = PlacementDecision {
+        policy_name: "docker-on-01HXYZ".to_string(),
+        target_host: PlacementTargetHost { reference: "01HXYZ".to_string(), display_name: "kiwi".to_string() },
+        refused_candidates: Vec::new(),
+    };
 
     VesselStatusPatch::MarkProvisioning {
+        placement_decision: Some(placement_decision.clone()),
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
         observed_policy_version: "12".to_string(),
         started_at,
@@ -197,8 +204,14 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
     .apply(&mut status);
     assert_eq!(status.phase, VesselPhase::Provisioning);
     assert_eq!(status.observed_policy_ref.as_deref(), Some("docker-on-01HXYZ"));
+    assert_eq!(status.placement_decision.as_ref(), Some(&placement_decision));
 
     VesselStatusPatch::MarkProvisioning {
+        placement_decision: Some(PlacementDecision {
+            policy_name: "replacement-must-not-win".to_string(),
+            target_host: PlacementTargetHost { reference: "other".to_string(), display_name: "feta".to_string() },
+            refused_candidates: Vec::new(),
+        }),
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
         observed_policy_version: "13".to_string(),
         started_at: Utc.timestamp_opt(11, 0).single().expect("timestamp"),
@@ -207,8 +220,10 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
     .apply(&mut status);
     assert_eq!(status.started_at, Some(started_at), "reconcile must not restamp an in-progress transition");
     assert_eq!(status.message.as_deref(), Some("still waiting"));
+    assert_eq!(status.placement_decision.as_ref(), Some(&placement_decision), "placement decision is write-once");
 
     VesselStatusPatch::MarkReady {
+        placement_decision: None,
         environment_ref: Some("env-a".to_string()),
         image_ref: Some("registry.example/crew:latest".to_string()),
         image_digest: Some("sha256:test-image".to_string()),
@@ -225,6 +240,7 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
     assert_eq!(status.image_digest.as_deref(), Some("sha256:test-image"));
 
     VesselStatusPatch::MarkReady {
+        placement_decision: None,
         environment_ref: Some("env-a".to_string()),
         image_ref: Some("registry.example/crew:latest".to_string()),
         image_digest: Some("sha256:test-image".to_string()),

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -271,6 +271,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         | CommandValue::DaemonLogs { .. }
         | CommandValue::ResourceList(_)
         | CommandValue::ResourceObject(_)
+        | CommandValue::ResourceDeleted(_)
         | CommandValue::ResourceWatchEvent(_) => {
             tracing::warn!("query result reached TUI handler — should be handled by CLI");
         }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1874,6 +1874,7 @@ fn test_convoy(
     initializing: bool,
 ) -> crate::convoy_model::ConvoySummary {
     crate::convoy_model::ConvoySummary {
+        placement_decision: None,
         id: crate::convoy_model::ConvoyId::new(namespace, name),
         namespace: namespace.into(),
         name: name.into(),
@@ -2289,6 +2290,7 @@ fn convoy_with_vessels(name: &str, vessel_names: &[&str]) -> crate::convoy_model
     convoy.vessels = vessel_names
         .iter()
         .map(|vessel_name| crate::convoy_model::VesselSummary {
+            placement_decision: None,
             name: (*vessel_name).into(),
             depends_on: vec![],
             phase: crate::convoy_model::WorkPhase::Running,

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -388,7 +388,7 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
     } else {
         let mut table = Table::new();
         table.load_preset(UTF8_FULL_CONDENSED);
-        table.set_header(vec!["Convoy", "Vessel", "Crew", "State", "Host", "Staleness"]);
+        table.set_header(vec!["Convoy", "Vessel", "Crew", "State", "Host", "Placement", "Staleness"]);
         for row in &response.rows {
             let vessel = match &row.authority {
                 Some(authority) => format!("{} ({authority})", row.vessel),
@@ -400,6 +400,17 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
                 Cell::new(&row.crew),
                 Cell::new(&row.crew_state),
                 Cell::new(row.host.as_str()),
+                Cell::new(row.placement_decision.as_ref().map_or_else(
+                    || "-".to_string(),
+                    |decision| {
+                        let refusals = if decision.refused_candidates.is_empty() {
+                            String::new()
+                        } else {
+                            format!("; {} refused", decision.refused_candidates.len())
+                        };
+                        format!("{} on {}{refusals}", decision.policy_name, decision.target_host.display_name)
+                    },
+                )),
                 Cell::new(format_fleet_staleness(&row.staleness)),
             ]);
         }
@@ -544,6 +555,11 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::DaemonLogs { lines } => lines.join("\n"),
         CommandValue::ResourceList(response) | CommandValue::ResourceObject(response) => {
             flotilla_protocol::output::json_pretty(&response.value)
+        }
+        CommandValue::ResourceDeleted(response) => {
+            let name = response.value["metadata"]["name"].as_str().unwrap_or("<unknown>");
+            let api_version = response.value["apiVersion"].as_str().unwrap_or("<unknown>");
+            format!("deleted {api_version}/{}/{}/{name}\nControllers may recreate code-owned objects.", response.kind, response.namespace,)
         }
         CommandValue::ResourceWatchEvent(response) => flotilla_protocol::output::json_pretty(&response.event),
         CommandValue::EnvironmentSpecRead { .. } => "environment spec read".to_string(),

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -4,7 +4,7 @@
 //! ([`flotilla_protocol::result_set`]). This adapter model is intentionally
 //! surface-owned and may evolve with consumer-side view requirements.
 
-use flotilla_protocol::{result_set as wire, CheckoutRef, HostName, PrincipalRef, RepoKey, ResourceRef};
+use flotilla_protocol::{result_set as wire, CheckoutRef, HostName, PlacementDecision, PrincipalRef, RepoKey, ResourceRef};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ConvoyId(String);
@@ -143,6 +143,7 @@ pub struct VesselSummary {
     pub name: String,
     pub depends_on: Vec<String>,
     pub phase: WorkPhase,
+    pub placement_decision: Option<PlacementDecision>,
     pub crew: Vec<ProcessSummary>,
     pub host: Option<HostName>,
     pub checkout: Option<CheckoutRef>,
@@ -167,6 +168,7 @@ pub struct ConvoySummary {
     #[builder(default)]
     pub dispatching_principal_ref: PrincipalRef,
     pub phase: ConvoyPhase,
+    pub placement_decision: Option<PlacementDecision>,
     pub message: Option<String>,
     pub repo_hint: Option<RepoKey>,
     /// The Project this convoy belongs to (`ConvoySpec.project_ref`).
@@ -193,6 +195,7 @@ impl From<&wire::ConvoyRow> for ConvoySummary {
             workflow_ref: row.workflow_ref.clone(),
             dispatching_principal_ref: row.dispatching_principal_ref.clone(),
             phase: row.phase.into(),
+            placement_decision: row.placement_decision.clone(),
             message: row.message.clone(),
             repo_hint: row.repo.clone(),
             project_ref: row.project_ref.clone(),
@@ -218,6 +221,7 @@ fn vessel_summary(row: &wire::ConvoyRow, vessel: &wire::VesselRow) -> VesselSumm
         name: vessel.name.clone(),
         depends_on: vessel.depends_on.clone(),
         phase: vessel.phase.into(),
+        placement_decision: vessel.placement_decision.clone(),
         crew,
         host: Some(vessel.host.clone()),
         // The convoys query does not yet expose checkout allocation.

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -806,6 +806,7 @@ mod tests {
     fn namespaces_with_convoy(name: &str, vessels: &[&str]) -> crate::app::NamespaceMap {
         use crate::convoy_model::{ConvoyId, ConvoyPhase, ConvoySummary, VesselSummary, WorkPhase};
         let convoy = ConvoySummary {
+            placement_decision: None,
             id: ConvoyId::new("flotilla", name),
             namespace: "flotilla".into(),
             name: name.into(),
@@ -821,6 +822,7 @@ mod tests {
             vessels: vessels
                 .iter()
                 .map(|t| VesselSummary {
+                    placement_decision: None,
                     name: (*t).into(),
                     depends_on: vec![],
                     phase: WorkPhase::Pending,

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -1125,6 +1125,21 @@ fn convoy_description(row: &ConvoySummary) -> Vec<DetailField> {
         DetailField { label: "Message", value: row.message.clone().unwrap_or_default() },
         DetailField { label: "Vessels", value: convoy_progress(row).text },
     ];
+    if let Some(decision) = &row.placement_decision {
+        fields
+            .push(DetailField { label: "Placement", value: format!("{} on {}", decision.policy_name, decision.target_host.display_name) });
+        if !decision.refused_candidates.is_empty() {
+            fields.push(DetailField {
+                label: "Placement refusals",
+                value: decision
+                    .refused_candidates
+                    .iter()
+                    .map(|refusal| format!("{} on {}: {}", refusal.policy_name, refusal.target_host.display_name, refusal.reason))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            });
+        }
+    }
     if let Some(change_request) = &row.change_request {
         fields.push(DetailField { label: "Pull request", value: format!("#{} · {}", change_request.id, change_request.status) });
     }
@@ -1254,7 +1269,7 @@ fn vessel_phase(row: &VesselProjection) -> CellValue {
 }
 
 fn vessel_description(row: &VesselProjection) -> Vec<DetailField> {
-    vec![
+    let mut fields = vec![
         DetailField { label: "Namespace", value: row.namespace.to_string() },
         DetailField { label: "Convoy", value: row.convoy.to_string() },
         DetailField { label: "Vessel", value: row.vessel.name.clone() },
@@ -1265,7 +1280,23 @@ fn vessel_description(row: &VesselProjection) -> Vec<DetailField> {
         DetailField { label: "Image ref", value: row.vessel.image_ref.clone().unwrap_or_default() },
         DetailField { label: "Image digest", value: row.vessel.image_digest.clone().unwrap_or_default() },
         DetailField { label: "Message", value: row.vessel.message.clone().unwrap_or_default() },
-    ]
+    ];
+    if let Some(decision) = &row.vessel.placement_decision {
+        fields
+            .push(DetailField { label: "Placement", value: format!("{} on {}", decision.policy_name, decision.target_host.display_name) });
+        if !decision.refused_candidates.is_empty() {
+            fields.push(DetailField {
+                label: "Placement refusals",
+                value: decision
+                    .refused_candidates
+                    .iter()
+                    .map(|refusal| format!("{} on {}: {}", refusal.policy_name, refusal.target_host.display_name, refusal.reason))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            });
+        }
+    }
+    fields
 }
 
 fn attach_vessel(row: &VesselProjection) -> Option<TableIntent> {
@@ -1340,6 +1371,7 @@ mod tests {
 
     fn vessel(name: &str, depends_on: &[&str], phase: WorkPhase) -> VesselSummary {
         VesselSummary {
+            placement_decision: None,
             name: name.into(),
             depends_on: depends_on.iter().map(ToString::to_string).collect(),
             phase,
@@ -1360,6 +1392,7 @@ mod tests {
 
     fn convoy(vessels: Vec<VesselSummary>) -> ConvoySummary {
         ConvoySummary {
+            placement_decision: None,
             id: ConvoyId::new("dev", "tables"),
             namespace: "dev".into(),
             name: "tables".into(),
@@ -1405,6 +1438,32 @@ mod tests {
         assert_eq!(view.rows[0].cells[2], CellValue::toned("failed", CellTone::Error));
         assert_eq!(view.rows[0].cells[6].text, "workspace launch failed: disk full");
         assert_eq!(view.rows[0].drill, Some("convoy/dev/tables".parse().expect("valid address")));
+    }
+
+    #[test]
+    fn convoy_and_vessel_details_render_placement_decisions_with_refusals() {
+        let decision = flotilla_protocol::PlacementDecision {
+            policy_name: "host-direct-kiwi".into(),
+            target_host: flotilla_protocol::PlacementTargetHost { reference: "01HXYZ".into(), display_name: "kiwi".into() },
+            refused_candidates: vec![flotilla_protocol::PlacementRefusal {
+                policy_name: "host-direct-feta".into(),
+                target_host: flotilla_protocol::PlacementTargetHost { reference: "02HXYZ".into(), display_name: "feta".into() },
+                reason: "disk below admission floor".into(),
+            }],
+        };
+        let mut vessel = vessel("implement", &[], WorkPhase::Running);
+        vessel.placement_decision = Some(decision.clone());
+        let mut convoy = convoy(vec![vessel]);
+        convoy.placement_decision = Some(decision);
+
+        let convoy_view = project_convoys("convoys/dev", &[&convoy]).expect("convoy table");
+        assert!(convoy_view.rows[0].describe.contains(&DetailField { label: "Placement", value: "host-direct-kiwi on kiwi".into() }));
+        assert!(convoy_view.rows[0]
+            .describe
+            .contains(&DetailField { label: "Placement refusals", value: "host-direct-feta on feta: disk below admission floor".into() }));
+
+        let vessel_view = project_convoys("vessel/dev/tables/implement", &[&convoy]).expect("vessel table");
+        assert!(vessel_view.rows[0].describe.contains(&DetailField { label: "Placement", value: "host-direct-kiwi on kiwi".into() }));
     }
 
     #[test]

--- a/docs/charters/governor.md
+++ b/docs/charters/governor.md
@@ -56,6 +56,8 @@ sharp recovery tool for deleting one exact object. It bypasses lifecycle and
 teardown gates, but still uses the resource store's normal watch, tombstone,
 and replication path. Prefer the orchestrated verbs in routine operation.
 Controllers may recreate code-owned objects after a raw delete.
+The verb currently targets the connected daemon's local store; peer command
+routing remains part of the federation work tracked in #1188.
 
 ## Dispatching
 

--- a/docs/charters/governor.md
+++ b/docs/charters/governor.md
@@ -51,6 +51,12 @@ Fleet truth comes from daemon surfaces, never from reading a local store
 directly — remote-placed convoys are home-bound in their placement host's
 store, and a local view is not the fleet.
 
+`flotilla resource delete <kind> <name> [--namespace <namespace>]` is the
+sharp recovery tool for deleting one exact object. It bypasses lifecycle and
+teardown gates, but still uses the resource store's normal watch, tombstone,
+and replication path. Prefer the orchestrated verbs in routine operation.
+Controllers may recreate code-owned objects after a raw delete.
+
 ## Dispatching
 
 1. **The issue body alone must be a dispatchable contract** — scope,

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,6 +250,8 @@ enum ResourceSubCommand {
     Apply(ResourceApplyArgs),
     /// Get one resource by name
     Get(ResourceGetArgs),
+    /// Delete exactly one raw resource object, bypassing lifecycle gates
+    Delete(ResourceDeleteArgs),
     /// Watch resources of a kind
     Watch(ResourceListArgs),
 }
@@ -281,6 +283,17 @@ struct ResourceGetArgs {
     /// Route the query to a peer host
     #[arg(long)]
     host: Option<String>,
+}
+
+#[derive(clap::Args)]
+struct ResourceDeleteArgs {
+    /// Exact resource kind or plural name
+    kind: String,
+    /// Exact resource name
+    name: String,
+    /// Resource namespace
+    #[arg(long, default_value = "flotilla")]
+    namespace: String,
 }
 
 #[derive(clap::Args)]
@@ -894,7 +907,7 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
             let result = daemon
                 .execute_query(
                     Command {
-                        node_id,
+                        node_id: node_id.clone(),
                         provisioning_target: None,
                         context_repo: None,
                         action: CommandAction::QueryResourceList {
@@ -907,7 +920,7 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
                 )
                 .await
                 .map_err(|e| color_eyre::eyre::eyre!(e))?;
-            print_resource_query_result(result, format)
+            print_resource_query_result(daemon.as_ref(), node_id, result, format).await
         }
         ResourceSubCommand::Get(args) => {
             let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
@@ -915,7 +928,7 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
             let result = daemon
                 .execute_query(
                     Command {
-                        node_id,
+                        node_id: node_id.clone(),
                         provisioning_target: None,
                         context_repo: None,
                         action: CommandAction::QueryResourceGet { namespace: args.namespace, kind: args.kind, name: args.name },
@@ -924,7 +937,7 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
                 )
                 .await
                 .map_err(|e| color_eyre::eyre::eyre!(e))?;
-            print_resource_query_result(result, format)
+            print_resource_query_result(daemon.as_ref(), node_id, result, format).await
         }
         ResourceSubCommand::Apply(args) => {
             let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
@@ -944,6 +957,19 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
             )
             .await
         }
+        ResourceSubCommand::Delete(args) => {
+            run_control_command(
+                cli,
+                Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::ResourceDelete { namespace: args.namespace, kind: args.kind, name: args.name },
+                },
+                format,
+            )
+            .await
+        }
         ResourceSubCommand::Watch(args) => run_resource_watch(cli, args, format).await,
     }
 }
@@ -958,14 +984,19 @@ async fn resolve_optional_host_node(cli: &Cli, host: Option<&str>) -> Result<Opt
     }
 }
 
-fn print_resource_query_result(result: CommandValue, format: OutputFormat) -> Result<()> {
+async fn print_resource_query_result(
+    daemon: &dyn DaemonHandle,
+    node_id: Option<flotilla_protocol::NodeId>,
+    result: CommandValue,
+    format: OutputFormat,
+) -> Result<()> {
     match result {
         CommandValue::ResourceList(response) => {
-            println!("{}", flotilla_protocol::output::json_pretty(&response.value));
+            println!("{}", format_resource_value(daemon, node_id, response.value, format).await?);
             Ok(())
         }
         CommandValue::ResourceObject(response) => {
-            println!("{}", flotilla_protocol::output::json_pretty(&response.value));
+            println!("{}", format_resource_value(daemon, node_id, response.value, format).await?);
             Ok(())
         }
         CommandValue::Error { message } => match format {
@@ -976,6 +1007,59 @@ fn print_resource_query_result(result: CommandValue, format: OutputFormat) -> Re
             OutputFormat::Human => Err(color_eyre::eyre::eyre!(message)),
         },
         other => Err(color_eyre::eyre::eyre!("unexpected resource response: {other:?}")),
+    }
+}
+
+async fn format_resource_value(
+    daemon: &dyn DaemonHandle,
+    node_id: Option<flotilla_protocol::NodeId>,
+    mut value: serde_json::Value,
+    format: OutputFormat,
+) -> Result<String> {
+    if format == OutputFormat::Json {
+        return Ok(flotilla_protocol::output::json_pretty(&value));
+    }
+    let hosts = daemon
+        .execute_query(
+            Command { node_id, provisioning_target: None, context_repo: None, action: CommandAction::QueryHostList {} },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .map_err(|error| color_eyre::eyre::eyre!(error))?;
+    let CommandValue::HostList(hosts) = hosts else {
+        return Ok(flotilla_protocol::output::json_pretty(&value));
+    };
+    let names = hosts
+        .hosts
+        .iter()
+        .filter_map(|host| {
+            let host_id = host.environment_id.as_ref()?.host_id()?.to_string();
+            let display_name = host.node.as_ref().map(|node| node.display_name.clone()).unwrap_or_else(|| host.host_name.to_string());
+            Some((host_id, display_name))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+    replace_host_ids(&mut value, &names);
+    Ok(flotilla_protocol::output::json_pretty(&value))
+}
+
+fn replace_host_ids(value: &mut serde_json::Value, names: &std::collections::HashMap<String, String>) {
+    match value {
+        serde_json::Value::String(text) => {
+            if let Some(display_name) = names.get(text) {
+                *text = display_name.clone();
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                replace_host_ids(value, names);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            for value in fields.values_mut() {
+                replace_host_ids(value, names);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -1649,9 +1733,10 @@ mod tests {
     };
 
     use super::{
-        attach_exit_disposition, confirm_command, default_project_landing, provisioning_target_for_environment, run_replica_snapshot,
-        select_host_target, select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition,
-        Cli, ResourceApplyArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
+        attach_exit_disposition, confirm_command, default_project_landing, provisioning_target_for_environment, replace_host_ids,
+        run_replica_snapshot, select_host_target, select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash,
+        AttachExitDisposition, Cli, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand,
+        SubCommand,
     };
 
     fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
@@ -1872,6 +1957,15 @@ mod tests {
             }) if kind == "convoys" && name == "demo" && namespace == "ops"
         ));
 
+        let delete = Cli::try_parse_from(["flotilla", "resource", "delete", "workflowtemplates", "scratch", "--namespace", "ops"])
+            .expect("resource delete should parse");
+        assert!(matches!(
+            delete.command,
+            Some(SubCommand::Resource {
+                command: ResourceSubCommand::Delete(ResourceDeleteArgs { kind, name, namespace })
+            }) if kind == "workflowtemplates" && name == "scratch" && namespace == "ops"
+        ));
+
         let apply = Cli::try_parse_from(["flotilla", "resource", "apply", "-f", "demand.yaml", "--namespace", "ops"])
             .expect("resource apply should parse");
         assert!(matches!(
@@ -1890,6 +1984,20 @@ mod tests {
                 command: ResourceSubCommand::Watch(ResourceListArgs { kind, namespace, host: None, include_replicas: false })
             }) if kind == "terminalsessions" && namespace == "flotilla"
         ));
+    }
+
+    #[test]
+    fn human_resource_rendering_replaces_exact_host_ids_but_not_embedded_object_names() {
+        let mut value = serde_json::json!({
+            "spec": {"host_ref": "01HXYZ"},
+            "metadata": {"name": "host-direct-01HXYZ"},
+            "status": {"placement_decision": {"target_host": {"ref": "01HXYZ", "display_name": "kiwi"}}}
+        });
+        replace_host_ids(&mut value, &std::collections::HashMap::from([("01HXYZ".to_string(), "kiwi".to_string())]));
+
+        assert_eq!(value["spec"]["host_ref"], "kiwi");
+        assert_eq!(value["status"]["placement_decision"]["target_host"]["ref"], "kiwi");
+        assert_eq!(value["metadata"]["name"], "host-direct-01HXYZ");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1013,7 +1013,7 @@ async fn print_resource_query_result(
 async fn format_resource_value(
     daemon: &dyn DaemonHandle,
     node_id: Option<flotilla_protocol::NodeId>,
-    mut value: serde_json::Value,
+    value: serde_json::Value,
     format: OutputFormat,
 ) -> Result<String> {
     if format == OutputFormat::Json {
@@ -1024,10 +1024,13 @@ async fn format_resource_value(
             Command { node_id, provisioning_target: None, context_repo: None, action: CommandAction::QueryHostList {} },
             uuid::Uuid::new_v4(),
         )
-        .await
-        .map_err(|error| color_eyre::eyre::eyre!(error))?;
-    let CommandValue::HostList(hosts) = hosts else {
-        return Ok(flotilla_protocol::output::json_pretty(&value));
+        .await;
+    Ok(format_human_resource_value(value, hosts))
+}
+
+fn format_human_resource_value<E>(mut value: serde_json::Value, hosts: std::result::Result<CommandValue, E>) -> String {
+    let Ok(CommandValue::HostList(hosts)) = hosts else {
+        return flotilla_protocol::output::json_pretty(&value);
     };
     let names = hosts
         .hosts
@@ -1039,7 +1042,7 @@ async fn format_resource_value(
         })
         .collect::<std::collections::HashMap<_, _>>();
     replace_host_ids(&mut value, &names);
-    Ok(flotilla_protocol::output::json_pretty(&value))
+    flotilla_protocol::output::json_pretty(&value)
 }
 
 fn replace_host_ids(value: &mut serde_json::Value, names: &std::collections::HashMap<String, String>) {
@@ -1733,10 +1736,10 @@ mod tests {
     };
 
     use super::{
-        attach_exit_disposition, confirm_command, default_project_landing, provisioning_target_for_environment, replace_host_ids,
-        run_replica_snapshot, select_host_target, select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash,
-        AttachExitDisposition, Cli, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand,
-        SubCommand,
+        attach_exit_disposition, confirm_command, default_project_landing, format_human_resource_value,
+        provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target, select_startup_repo_roots,
+        should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition, Cli, CommandValue, ResourceApplyArgs,
+        ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
     };
 
     fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
@@ -1998,6 +2001,18 @@ mod tests {
         assert_eq!(value["spec"]["host_ref"], "kiwi");
         assert_eq!(value["status"]["placement_decision"]["target_host"]["ref"], "kiwi");
         assert_eq!(value["metadata"]["name"], "host-direct-01HXYZ");
+    }
+
+    #[test]
+    fn human_resource_rendering_falls_back_to_raw_json_when_host_lookup_fails() {
+        let value = serde_json::json!({
+            "spec": {"host_ref": "01HXYZ"},
+            "metadata": {"name": "demo"}
+        });
+
+        let rendered = format_human_resource_value(value.clone(), Err::<CommandValue, _>("transient host lookup failure"));
+
+        assert_eq!(rendered, flotilla_protocol::output::json_pretty(&value));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- preserve stable host IDs in machine-readable JSON while rendering human-facing host names in resource, fleet, and TUI views
- record a shared placement decision on convoys and vessels, including the chosen policy and host plus exact refused-candidate reasons
- add `flotilla resource delete <kind> <name> [--namespace]` through the normal resource deletion, tombstone, watch, and replication path, with a warning that controllers can recreate code-owned resources
- cover placement propagation, legible presentation, replica deletion, and builtin policy recreation

## Impact

Operators can now understand where and why work was placed without decoding host UUIDs, inspect rejected placement candidates, and use an explicit sharp recovery command to remove an exact resource object.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1209