### PR TITLE
fix: only trigger claude tasks from issue titles, not body citations

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && contains(github.event.issue.title, '@claude'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Body citations of @claude (the pr-shepherd from-review template citing a claude review) were self-summoning the Actions runner (#1213/#1219), which then wrote unverified Rust for want of cargo in its sandbox. Narrow the issues trigger to title-only; comment/PR-review triggers unchanged. The skill template is also being de-@'d at source.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp