### PR TITLE
fix: single-flight shared clone provisioning

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/clone.rs
+++ b/crates/flotilla-controllers/src/reconcilers/clone.rs
@@ -69,7 +69,8 @@ where
         };
         Ok(match result {
             Ok(default_branch) => CloneDeps::Ready { default_branch },
-            Err(err) => CloneDeps::Retrying(err),
+            Err(err) if phase == ClonePhase::Pending => CloneDeps::Retrying(err),
+            Err(err) => CloneDeps::Failed(err),
         })
     }
 

--- a/crates/flotilla-controllers/src/reconcilers/clone.rs
+++ b/crates/flotilla-controllers/src/reconcilers/clone.rs
@@ -84,13 +84,6 @@ where
         let patch = if matches!(phase, ClonePhase::Pending | ClonePhase::Cloning) {
             match deps {
                 CloneDeps::Ready { default_branch } => Some(CloneStatusPatch::MarkReady { default_branch: default_branch.clone() }),
-                CloneDeps::Retrying(message)
-                    if obj.status.as_ref().is_some_and(|status| {
-                        status.phase == ClonePhase::Cloning && status.message.as_deref() == Some(message.as_str())
-                    }) =>
-                {
-                    None
-                }
                 CloneDeps::Retrying(message) => Some(CloneStatusPatch::MarkRetrying { message: message.clone() }),
                 CloneDeps::Failed(message) => Some(CloneStatusPatch::MarkFailed { message: message.clone() }),
                 CloneDeps::None => None,

--- a/crates/flotilla-controllers/src/reconcilers/clone.rs
+++ b/crates/flotilla-controllers/src/reconcilers/clone.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use flotilla_resources::{
@@ -6,6 +6,8 @@ use flotilla_resources::{
     controller::{ReconcileOutcome, Reconciler},
     Clone, ClonePhase, CloneStatusPatch, Repository, RepositoryIdentity, ResourceError, ResourceObject, TypedResolver,
 };
+
+const CLONE_RETRY_AFTER: Duration = Duration::from_secs(1);
 
 #[async_trait]
 pub trait CloneRuntime: Send + Sync {
@@ -27,6 +29,7 @@ impl<R> CloneReconciler<R> {
 pub enum CloneDeps {
     None,
     Ready { default_branch: Option<String> },
+    Retrying(String),
     Failed(String),
 }
 
@@ -54,7 +57,8 @@ where
         if obj.metadata.name != expected_name {
             return Ok(CloneDeps::Failed(format!("clone name mismatch: expected {expected_name}")));
         }
-        if obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending) != ClonePhase::Pending {
+        let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending);
+        if !matches!(phase, ClonePhase::Pending | ClonePhase::Cloning) {
             return Ok(CloneDeps::None);
         }
 
@@ -65,7 +69,7 @@ where
         };
         Ok(match result {
             Ok(default_branch) => CloneDeps::Ready { default_branch },
-            Err(err) => CloneDeps::Failed(err),
+            Err(err) => CloneDeps::Retrying(err),
         })
     }
 
@@ -75,9 +79,18 @@ where
         deps: &Self::Dependencies,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> ReconcileOutcome<Self::Resource> {
-        let patch = if obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending) == ClonePhase::Pending {
+        let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending);
+        let patch = if matches!(phase, ClonePhase::Pending | ClonePhase::Cloning) {
             match deps {
                 CloneDeps::Ready { default_branch } => Some(CloneStatusPatch::MarkReady { default_branch: default_branch.clone() }),
+                CloneDeps::Retrying(message)
+                    if obj.status.as_ref().is_some_and(|status| {
+                        status.phase == ClonePhase::Cloning && status.message.as_deref() == Some(message.as_str())
+                    }) =>
+                {
+                    None
+                }
+                CloneDeps::Retrying(message) => Some(CloneStatusPatch::MarkRetrying { message: message.clone() }),
                 CloneDeps::Failed(message) => Some(CloneStatusPatch::MarkFailed { message: message.clone() }),
                 CloneDeps::None => None,
             }
@@ -85,7 +98,11 @@ where
             None
         };
 
-        ReconcileOutcome::new(patch)
+        let mut outcome = ReconcileOutcome::new(patch);
+        if matches!(deps, CloneDeps::Retrying(_)) {
+            outcome.requeue_after = Some(CLONE_RETRY_AFTER);
+        }
+        outcome
     }
 
     async fn run_finalizer(&self, _obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {

--- a/crates/flotilla-controllers/tests/clone_reconciler.rs
+++ b/crates/flotilla-controllers/tests/clone_reconciler.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use async_trait::async_trait;
 use flotilla_controllers::reconcilers::{CloneReconciler, CloneRuntime};
@@ -31,6 +34,25 @@ impl CloneRuntime for FailingCloneRuntime {
 
     async fn inspect_existing(&self, _target_path: &str) -> Result<Option<String>, String> {
         Err("clone does not exist".to_string())
+    }
+}
+
+struct FailOnceCloneRuntime {
+    failed: AtomicBool,
+}
+
+#[async_trait]
+impl CloneRuntime for FailOnceCloneRuntime {
+    async fn clone_and_inspect(&self, _repo_url: &str, _target_path: &str) -> Result<Option<String>, String> {
+        if !self.failed.swap(true, Ordering::SeqCst) {
+            Err("simulated interrupted clone".to_string())
+        } else {
+            Ok(Some("main".to_string()))
+        }
+    }
+
+    async fn inspect_existing(&self, _target_path: &str) -> Result<Option<String>, String> {
+        Ok(Some("main".to_string()))
     }
 }
 
@@ -89,7 +111,7 @@ async fn alias_transport_uses_typed_repository_identity_for_clone_name() {
 }
 
 #[tokio::test]
-async fn clone_failure_remains_an_honest_failure_after_repository_registration() {
+async fn clone_failure_remains_an_honest_retrying_state_after_repository_registration() {
     let backend = ResourceBackend::InMemory(Default::default());
     let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/private").expect("repository spec");
     let repository_key = repository_spec.key();
@@ -116,6 +138,44 @@ async fn clone_failure_remains_an_honest_failure_after_repository_registration()
 
     assert!(matches!(
         outcome.patch,
-        Some(flotilla_resources::CloneStatusPatch::MarkFailed { message }) if message == "authentication failed"
+        Some(flotilla_resources::CloneStatusPatch::MarkRetrying { message }) if message == "authentication failed"
+    ));
+    assert!(outcome.requeue_after.is_some());
+}
+
+#[tokio::test]
+async fn transient_clone_failure_remains_retryable_and_converges() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    let repository_key = repository_spec.key();
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>("flotilla"), &repository_key, &repository_spec)
+        .await
+        .expect("repository create should succeed");
+    let env_ref = "host-direct-01HXYZ";
+    let clone_name = format!("clone-{}", clone_key("https://github.com/flotilla-org/flotilla", env_ref));
+    let clones = backend.clone().using::<flotilla_resources::Clone>("flotilla");
+    let clone = clones
+        .create(&meta(&clone_name), &CloneSpec {
+            repo_ref: repository_key,
+            url: "git@github.com:flotilla-org/flotilla.git".to_string(),
+            env_ref: env_ref.to_string(),
+            path: "/Users/alice/dev/flotilla".to_string(),
+        })
+        .await
+        .expect("clone should create");
+    let reconciler =
+        CloneReconciler::new(Arc::new(FailOnceCloneRuntime { failed: AtomicBool::new(false) }), backend.clone().using("flotilla"));
+
+    let failed_deps = reconciler.fetch_dependencies(&clone).await.expect("first deps should load");
+    let failed_outcome = reconciler.reconcile(&clone, &failed_deps, chrono::Utc::now());
+    let retry_patch = failed_outcome.patch.expect("transient failure should record retry state");
+    let retrying = flotilla_resources::apply_status_patch(&clones, &clone_name, &retry_patch).await.expect("retry status should apply");
+
+    let recovered_deps = reconciler.fetch_dependencies(&retrying).await.expect("retry deps should load");
+    let recovered_outcome = reconciler.reconcile(&retrying, &recovered_deps, chrono::Utc::now());
+
+    assert!(matches!(
+        recovered_outcome.patch,
+        Some(flotilla_resources::CloneStatusPatch::MarkReady { default_branch }) if default_branch.as_deref() == Some("main")
     ));
 }

--- a/crates/flotilla-controllers/tests/clone_reconciler.rs
+++ b/crates/flotilla-controllers/tests/clone_reconciler.rs
@@ -111,7 +111,7 @@ async fn alias_transport_uses_typed_repository_identity_for_clone_name() {
 }
 
 #[tokio::test]
-async fn clone_failure_remains_an_honest_retrying_state_after_repository_registration() {
+async fn clone_failure_retries_once_before_marking_failed() {
     let backend = ResourceBackend::InMemory(Default::default());
     let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/private").expect("repository spec");
     let repository_key = repository_spec.key();
@@ -133,14 +133,28 @@ async fn clone_failure_remains_an_honest_retrying_state_after_repository_registr
         .expect("clone should create");
     let reconciler = CloneReconciler::new(Arc::new(FailingCloneRuntime), backend.using("flotilla"));
 
-    let deps = reconciler.fetch_dependencies(&clone).await.expect("deps should load");
+    let deps = reconciler.fetch_dependencies(&clone).await.expect("first deps should load");
     let outcome = reconciler.reconcile(&clone, &deps, chrono::Utc::now());
 
     assert!(matches!(
-        outcome.patch,
+        outcome.patch.as_ref(),
         Some(flotilla_resources::CloneStatusPatch::MarkRetrying { message }) if message == "authentication failed"
     ));
     assert!(outcome.requeue_after.is_some());
+
+    let clones = backend.clone().using::<flotilla_resources::Clone>("flotilla");
+    let retrying =
+        flotilla_resources::apply_status_patch(&clones, &clone_name, &outcome.patch.expect("first failure should record retry state"))
+            .await
+            .expect("retry state should apply");
+    let repeated_deps = reconciler.fetch_dependencies(&retrying).await.expect("repeated deps should load");
+    let repeated_outcome = reconciler.reconcile(&retrying, &repeated_deps, chrono::Utc::now());
+
+    assert!(matches!(
+        repeated_outcome.patch,
+        Some(flotilla_resources::CloneStatusPatch::MarkFailed { message }) if message == "authentication failed"
+    ));
+    assert!(repeated_outcome.requeue_after.is_none());
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1568,10 +1568,11 @@ impl CloneRuntime for CloneControllerRuntime {
         };
         if let Err(error) = tokio::fs::rename(&staging_path, target_path).await {
             let error = cleanup_failed_checkout(&*self.runner, &staging_path, format!("publish clone: {error}")).await;
-            if let Some(inspection) = recover_existing_clone(Arc::clone(&self.runner), repo_url, target_path).await? {
-                return Ok(inspection.default_branch);
-            }
-            return Err(error);
+            return match recover_existing_clone(Arc::clone(&self.runner), repo_url, target_path).await {
+                Ok(Some(inspection)) => Ok(inspection.default_branch),
+                Ok(None) => Err(error),
+                Err(adoption_error) => Err(format!("{error}; additionally failed to adopt clone at target: {adoption_error}")),
+            };
         }
         Ok(inspection.default_branch)
     }
@@ -1592,10 +1593,15 @@ async fn recover_existing_clone(
         return Ok(None);
     }
 
+    verify_clone_origin(&*runner, repo_url, target_path, "clone target").await?;
+    GitCloneProvisioner::new(runner).inspect_clone(&ExecutionEnvironmentPath::new(target_path)).await.map(Some)
+}
+
+async fn verify_clone_origin(runner: &dyn CommandRunner, repo_url: &str, target_path: &str, target_label: &str) -> Result<(), String> {
     let origin = runner
         .run("git", &["-C", target_path, "remote", "get-url", "origin"], Path::new("/"), &ChannelLabel::Noop)
         .await
-        .map_err(|error| format!("clone target {target_path} already exists but is not a reusable clone: {error}"))?;
+        .map_err(|error| format!("{target_label} {target_path} already exists but is not a reusable clone: {error}"))?;
     let origin = origin.trim();
     let same_origin = origin == repo_url
         || canonicalize_repo_url(origin)
@@ -1603,10 +1609,10 @@ async fn recover_existing_clone(
             .zip(canonicalize_repo_url(repo_url).ok())
             .is_some_and(|(origin, expected)| origin == expected);
     if !same_origin {
-        return Err(format!("clone target {target_path} already exists with origin {origin}, expected {repo_url}"));
+        return Err(format!("{target_label} {target_path} already exists with origin {origin}, expected {repo_url}"));
     }
 
-    GitCloneProvisioner::new(runner).inspect_clone(&ExecutionEnvironmentPath::new(target_path)).await.map(Some)
+    Ok(())
 }
 
 struct CheckoutControllerRuntime {
@@ -1919,19 +1925,7 @@ async fn recover_existing_fresh_clone(
         return Ok(None);
     }
 
-    let origin = runner
-        .run("git", &["-C", target_path, "remote", "get-url", "origin"], Path::new("/"), &ChannelLabel::Noop)
-        .await
-        .map_err(|error| format!("checkout target {target_path} already exists but is not a reusable clone: {error}"))?;
-    let origin = origin.trim();
-    let same_origin = origin == repo_url
-        || canonicalize_repo_url(origin)
-            .ok()
-            .zip(canonicalize_repo_url(repo_url).ok())
-            .is_some_and(|(origin, expected)| origin == expected);
-    if !same_origin {
-        return Err(format!("checkout target {target_path} already exists with origin {origin}, expected {repo_url}"));
-    }
+    verify_clone_origin(runner, repo_url, target_path, "checkout target").await?;
 
     if branch != "HEAD" {
         let current_branch = runner
@@ -2498,6 +2492,41 @@ mod tests {
         assert_eq!(first.expect("first clone should succeed").as_deref(), Some("main"));
         assert_eq!(second.expect("second clone should succeed").as_deref(), Some("main"));
         assert_eq!(runner.clone_attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn clone_runtime_adopts_a_matching_clone_that_wins_an_external_flight() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = TestGitRepo::init(temp.path().join("source")).with_initial_commit();
+        let target = temp.path().join("clone");
+        let runner = Arc::new(BlockingCloneProcessRunner {
+            clone_attempts: AtomicUsize::new(0),
+            clone_started: Notify::new(),
+            release_clone: Notify::new(),
+        });
+        let first_runtime = Arc::new(CloneControllerRuntime { runner: runner.clone(), flights: Arc::new(CloneFlights::default()) });
+        let external_runtime = Arc::new(CloneControllerRuntime { runner: runner.clone(), flights: Arc::new(CloneFlights::default()) });
+        let repo_url = source.path().to_str().expect("utf-8 source path").to_string();
+        let target_path = target.to_str().expect("utf-8 target path").to_string();
+
+        let first = tokio::spawn({
+            let runtime = Arc::clone(&first_runtime);
+            let repo_url = repo_url.clone();
+            let target_path = target_path.clone();
+            async move { runtime.clone_and_inspect(&repo_url, &target_path).await }
+        });
+        runner.clone_started.notified().await;
+        let external = tokio::spawn({
+            let runtime = Arc::clone(&external_runtime);
+            async move { runtime.clone_and_inspect(&repo_url, &target_path).await }
+        });
+        let external = external.await.expect("external clone task should join");
+        runner.release_clone.notify_one();
+        let first = first.await.expect("first clone task should join");
+
+        assert_eq!(external.expect("external clone should succeed").as_deref(), Some("main"));
+        assert_eq!(first.expect("losing flight should adopt the external clone").as_deref(), Some("main"));
+        assert_eq!(runner.clone_attempts.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     future::Future,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex as StdMutex},
+    sync::{Arc, Mutex as StdMutex, Weak},
     time::Duration,
 };
 
@@ -27,7 +27,7 @@ use flotilla_core::{
         environment::{CreateOpts, EnvironmentHandle},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
-        vcs::{CloneProvisioner, GitCloneProvisioner},
+        vcs::{CloneInspection, CloneProvisioner, GitCloneProvisioner},
         ChannelLabel, CommandRunner,
     },
 };
@@ -435,6 +435,7 @@ struct ControllerRuntimeState {
     host_direct_environment_name: String,
     credential_store: Option<Arc<CredentialStore>>,
     provisioned_environments: Mutex<HashMap<String, ActiveProvisionedEnvironment>>,
+    clone_flights: Arc<CloneFlights>,
 }
 
 struct GhForgeDefaultBranchResolver {
@@ -474,6 +475,7 @@ impl ControllerRuntimeState {
             host_direct_environment_name,
             credential_store: None,
             provisioned_environments: Mutex::new(HashMap::new()),
+            clone_flights: Arc::new(CloneFlights::default()),
         }
     }
 
@@ -1113,12 +1115,13 @@ fn spawn_controller_loops(
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let runner = state.daemon.local_command_runner().expect("local runner should exist");
+                    let flights = Arc::clone(&state.clone_flights);
                     async move {
                         ControllerLoop {
                             primary: backend.clone().using::<Clone>(&namespace_string),
                             secondaries: vec![],
                             reconciler: CloneReconciler::new(
-                                Arc::new(CloneControllerRuntime { runner }),
+                                Arc::new(CloneControllerRuntime { runner, flights }),
                                 backend.clone().using::<Repository>(&namespace_string),
                             ),
                             resync_interval: controller_resync_interval,
@@ -1518,17 +1521,58 @@ async fn probe_provisioned_environment(
     Ok((bag, Arc::new(registry)))
 }
 
+#[derive(Default)]
+struct CloneFlights {
+    by_target: StdMutex<HashMap<String, Weak<Mutex<()>>>>,
+}
+
+impl CloneFlights {
+    fn for_target(&self, target_path: &str) -> Arc<Mutex<()>> {
+        let mut by_target = self.by_target.lock().expect("clone flights lock poisoned");
+        by_target.retain(|_, flight| flight.strong_count() > 0);
+        if let Some(flight) = by_target.get(target_path).and_then(Weak::upgrade) {
+            return flight;
+        }
+        let flight = Arc::new(Mutex::new(()));
+        by_target.insert(target_path.to_string(), Arc::downgrade(&flight));
+        flight
+    }
+}
+
 struct CloneControllerRuntime {
     runner: Arc<dyn CommandRunner>,
+    flights: Arc<CloneFlights>,
 }
 
 #[async_trait]
 impl CloneRuntime for CloneControllerRuntime {
     async fn clone_and_inspect(&self, repo_url: &str, target_path: &str) -> Result<Option<String>, String> {
+        let flight = self.flights.for_target(target_path);
+        let _flight_guard = flight.lock().await;
+        if let Some(inspection) = recover_existing_clone(Arc::clone(&self.runner), repo_url, target_path).await? {
+            return Ok(inspection.default_branch);
+        }
+
+        let staging_path = clone_staging_path(target_path);
+        remove_checkout_path(&*self.runner, &staging_path).await?;
         let provisioner = GitCloneProvisioner::new(Arc::clone(&self.runner));
-        let target_path = ExecutionEnvironmentPath::new(target_path);
-        provisioner.clone_repo(repo_url, &target_path).await?;
-        let inspection = provisioner.inspect_clone(&target_path).await?;
+        let staging = ExecutionEnvironmentPath::new(&staging_path);
+        let prepare = async {
+            provisioner.clone_repo(repo_url, &staging).await?;
+            provisioner.inspect_clone(&staging).await
+        }
+        .await;
+        let inspection = match prepare {
+            Ok(inspection) => inspection,
+            Err(error) => return Err(cleanup_failed_checkout(&*self.runner, &staging_path, error).await),
+        };
+        if let Err(error) = tokio::fs::rename(&staging_path, target_path).await {
+            let error = cleanup_failed_checkout(&*self.runner, &staging_path, format!("publish clone: {error}")).await;
+            if let Some(inspection) = recover_existing_clone(Arc::clone(&self.runner), repo_url, target_path).await? {
+                return Ok(inspection.default_branch);
+            }
+            return Err(error);
+        }
         Ok(inspection.default_branch)
     }
 
@@ -1537,6 +1581,32 @@ impl CloneRuntime for CloneControllerRuntime {
         let inspection = provisioner.inspect_clone(&ExecutionEnvironmentPath::new(target_path)).await?;
         Ok(inspection.default_branch)
     }
+}
+
+async fn recover_existing_clone(
+    runner: Arc<dyn CommandRunner>,
+    repo_url: &str,
+    target_path: &str,
+) -> Result<Option<CloneInspection>, String> {
+    if !runner.path_exists(Path::new(target_path)).await? {
+        return Ok(None);
+    }
+
+    let origin = runner
+        .run("git", &["-C", target_path, "remote", "get-url", "origin"], Path::new("/"), &ChannelLabel::Noop)
+        .await
+        .map_err(|error| format!("clone target {target_path} already exists but is not a reusable clone: {error}"))?;
+    let origin = origin.trim();
+    let same_origin = origin == repo_url
+        || canonicalize_repo_url(origin)
+            .ok()
+            .zip(canonicalize_repo_url(repo_url).ok())
+            .is_some_and(|(origin, expected)| origin == expected);
+    if !same_origin {
+        return Err(format!("clone target {target_path} already exists with origin {origin}, expected {repo_url}"));
+    }
+
+    GitCloneProvisioner::new(runner).inspect_clone(&ExecutionEnvironmentPath::new(target_path)).await.map(Some)
 }
 
 struct CheckoutControllerRuntime {
@@ -1673,7 +1743,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
         if let Some(prepared) = recover_existing_fresh_clone(&*runner, repo_url, branch, target_path).await? {
             return Ok(prepared);
         }
-        let staging_path = fresh_clone_staging_path(target_path);
+        let staging_path = clone_staging_path(target_path);
         remove_checkout_path(&*runner, &staging_path).await?;
         let clone_ref = base_ref.unwrap_or(branch);
         let prepare = async {
@@ -1726,7 +1796,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
             CheckoutRemoval::FreshClone { target_path } => {
                 let target_path = utf8_path(target_path)?;
                 remove_checkout_path(&*runner, target_path).await?;
-                remove_checkout_path(&*runner, &fresh_clone_staging_path(target_path)).await?;
+                remove_checkout_path(&*runner, &clone_staging_path(target_path)).await?;
                 Ok(CheckoutRemovalOutcome::Removed)
             }
             CheckoutRemoval::Worktree { clone_path, branch, target_path } => {
@@ -1906,7 +1976,7 @@ async fn cleanup_failed_checkout(runner: &dyn CommandRunner, target_path: &str, 
     }
 }
 
-fn fresh_clone_staging_path(target_path: &str) -> String {
+fn clone_staging_path(target_path: &str) -> String {
     format!("{target_path}.flotilla-clone-partial")
 }
 
@@ -2210,7 +2280,7 @@ mod tests {
         fs,
         process::Command as ProcessCommand,
         sync::{
-            atomic::{AtomicBool, Ordering},
+            atomic::{AtomicBool, AtomicUsize, Ordering},
             Arc,
         },
     };
@@ -2241,6 +2311,7 @@ mod tests {
     };
     use futures::StreamExt;
     use tempfile::TempDir;
+    use tokio::sync::Notify;
 
     use super::{test_git_repo::TestGitRepo, *};
 
@@ -2315,6 +2386,34 @@ mod tests {
         }
     }
 
+    struct BlockingCloneProcessRunner {
+        clone_attempts: AtomicUsize,
+        clone_started: Notify,
+        release_clone: Notify,
+    }
+
+    #[async_trait]
+    impl CommandRunner for BlockingCloneProcessRunner {
+        async fn run(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<String, String> {
+            if cmd == "git" && args.first() == Some(&"clone") {
+                let attempt = self.clone_attempts.fetch_add(1, Ordering::SeqCst);
+                self.clone_started.notify_one();
+                if attempt == 0 {
+                    self.release_clone.notified().await;
+                }
+            }
+            ProcessCommandRunner.run(cmd, args, cwd, label).await
+        }
+
+        async fn run_output(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<CommandOutput, String> {
+            ProcessCommandRunner.run_output(cmd, args, cwd, label).await
+        }
+
+        async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
+            ProcessCommandRunner.exists(cmd, args).await
+        }
+    }
+
     struct TestInteriorEnvironment {
         id: EnvironmentId,
         image: ImageId,
@@ -2361,6 +2460,64 @@ mod tests {
             self.destroyed.store(true, Ordering::SeqCst);
             Ok(())
         }
+    }
+
+    #[tokio::test]
+    async fn clone_runtime_single_flights_concurrent_requests_for_the_same_target() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = TestGitRepo::init(temp.path().join("source")).with_initial_commit();
+        let target = temp.path().join("clone");
+        let runner = Arc::new(BlockingCloneProcessRunner {
+            clone_attempts: AtomicUsize::new(0),
+            clone_started: Notify::new(),
+            release_clone: Notify::new(),
+        });
+        let flights = Arc::new(CloneFlights::default());
+        let first_runtime = Arc::new(CloneControllerRuntime { runner: runner.clone(), flights: Arc::clone(&flights) });
+        let second_runtime = Arc::new(CloneControllerRuntime { runner: runner.clone(), flights });
+        let repo_url = source.path().to_str().expect("utf-8 source path").to_string();
+        let target_path = target.to_str().expect("utf-8 target path").to_string();
+
+        let first = tokio::spawn({
+            let runtime = Arc::clone(&first_runtime);
+            let repo_url = repo_url.clone();
+            let target_path = target_path.clone();
+            async move { runtime.clone_and_inspect(&repo_url, &target_path).await }
+        });
+        runner.clone_started.notified().await;
+        let second = tokio::spawn({
+            let runtime = Arc::clone(&second_runtime);
+            async move { runtime.clone_and_inspect(&repo_url, &target_path).await }
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        runner.release_clone.notify_one();
+
+        let first = first.await.expect("first clone task should join");
+        let second = second.await.expect("second clone task should join");
+
+        assert_eq!(first.expect("first clone should succeed").as_deref(), Some("main"));
+        assert_eq!(second.expect("second clone should succeed").as_deref(), Some("main"));
+        assert_eq!(runner.clone_attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn clone_runtime_retries_after_an_interrupted_clone() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = TestGitRepo::init(temp.path().join("source")).with_initial_commit();
+        let target = temp.path().join("clone");
+        let runtime = CloneControllerRuntime {
+            runner: Arc::new(FailFirstCloneProcessRunner { failed: AtomicBool::new(false) }),
+            flights: Arc::new(CloneFlights::default()),
+        };
+        let repo_url = source.path().to_str().expect("utf-8 source path");
+        let target_path = target.to_str().expect("utf-8 target path");
+
+        runtime.clone_and_inspect(repo_url, target_path).await.expect_err("interrupted clone should fail its first actuation");
+        assert!(!target.exists(), "failed clone debris should be removed");
+
+        let default_branch = runtime.clone_and_inspect(repo_url, target_path).await.expect("redrive should replace the interrupted clone");
+
+        assert_eq!(default_branch.as_deref(), Some("main"));
     }
 
     struct TestInteriorEnvironmentProvider {
@@ -2866,7 +3023,7 @@ mod tests {
             )
             .await
             .expect_err("interrupted clone should fail its first actuation");
-        assert!(!Path::new(&fresh_clone_staging_path(target.to_str().expect("utf-8 target path"))).exists());
+        assert!(!Path::new(&clone_staging_path(target.to_str().expect("utf-8 target path"))).exists());
 
         runtime
             .create_fresh_clone(
@@ -2891,7 +3048,7 @@ mod tests {
         let temp = TempDir::new().expect("tempdir");
         let target = temp.path().join("fresh-clone");
         let target = target.to_str().expect("utf-8 target path");
-        let staging_path = fresh_clone_staging_path(target);
+        let staging_path = clone_staging_path(target);
         fs::create_dir_all(&staging_path).expect("create partial clone directory");
         fs::write(Path::new(&staging_path).join("partial"), "incomplete clone").expect("write partial clone content");
         let runtime = CheckoutControllerRuntime { runner: Arc::new(ProcessCommandRunner) };

--- a/crates/flotilla-resources/src/clone.rs
+++ b/crates/flotilla-resources/src/clone.rs
@@ -33,6 +33,7 @@ pub struct CloneStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CloneStatusPatch {
     MarkCloning,
+    MarkRetrying { message: String },
     MarkReady { default_branch: Option<String> },
     MarkFailed { message: String },
 }
@@ -43,6 +44,10 @@ impl StatusPatch<CloneStatus> for CloneStatusPatch {
             Self::MarkCloning => {
                 status.phase = ClonePhase::Cloning;
                 status.message = None;
+            }
+            Self::MarkRetrying { message } => {
+                status.phase = ClonePhase::Cloning;
+                status.message = Some(message.clone());
             }
             Self::MarkReady { default_branch } => {
                 status.phase = ClonePhase::Ready;

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -59,6 +59,10 @@ fn clone_status_patch_marks_cloning_and_ready() {
     CloneStatusPatch::MarkCloning.apply(&mut status);
     assert_eq!(status.phase, ClonePhase::Cloning);
 
+    CloneStatusPatch::MarkRetrying { message: "clone interrupted".to_string() }.apply(&mut status);
+    assert_eq!(status.phase, ClonePhase::Cloning);
+    assert_eq!(status.message.as_deref(), Some("clone interrupted"));
+
     CloneStatusPatch::MarkReady { default_branch: Some("main".to_string()) }.apply(&mut status);
     assert_eq!(status.phase, ClonePhase::Ready);
     assert_eq!(status.default_branch.as_deref(), Some("main"));


### PR DESCRIPTION
## Summary

- single-flight base-repository clone actuation by target path across controller runtime restarts
- clone through a cleaned staging sibling, atomically publish, and adopt a matching clone that wins an external race
- keep operational clone failures in a visible retrying state instead of latching the clone, vessel, and convoy Failed
- cover concurrent duplicate requests, interrupted clone cleanup/retry, and fail-once reconciler convergence

## Root cause

#1220 made per-checkout fresh clones sequentially retry-idempotent, but shared base-repository clones use `CloneControllerRuntime`. Duplicate in-flight requests on that path both invoked `git clone` against the final target; one won and the loser reported an already-existing destination. `CloneReconciler` then made every runtime error terminal, so the transient loser wedged provisioning even when the filesystem had converged.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1218