### PR TITLE
fix: set PATH in cargo-sweep systemd unit

### DIFF
--- a/config/launchd/org.flotilla.cargo-sweep-mtime.plist
+++ b/config/launchd/org.flotilla.cargo-sweep-mtime.plist
@@ -8,7 +8,7 @@
   <array>
     <string>/bin/sh</string>
     <string>-c</string>
-    <string>exec "$HOME/.local/libexec/flotilla/cargo-sweep-mtime.sh"</string>
+    <string>PATH="$HOME/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" exec "$HOME/.local/libexec/flotilla/cargo-sweep-mtime.sh"</string>
   </array>
   <key>StartCalendarInterval</key>
   <dict>

--- a/config/systemd/user/flotilla-cargo-sweep-mtime.service
+++ b/config/systemd/user/flotilla-cargo-sweep-mtime.service
@@ -3,4 +3,6 @@ Description=Flotilla mtime-based Cargo artifact sweep
 
 [Service]
 Type=oneshot
+# cargo-sweep spawns `cargo`; the systemd user manager's PATH has no ~/.cargo/bin unless the host configures environment.d
+Environment=PATH=%h/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 ExecStart=%h/.local/libexec/flotilla/cargo-sweep-mtime.sh

--- a/config/systemd/user/flotilla-cargo-sweep-mtime.service
+++ b/config/systemd/user/flotilla-cargo-sweep-mtime.service
@@ -4,5 +4,5 @@ Description=Flotilla mtime-based Cargo artifact sweep
 [Service]
 Type=oneshot
 # cargo-sweep spawns `cargo`; the systemd user manager's PATH has no ~/.cargo/bin unless the host configures environment.d
-Environment=PATH=%h/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=PATH=%h/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart=%h/.local/libexec/flotilla/cargo-sweep-mtime.sh


### PR DESCRIPTION
The daily sweep unit invokes `cargo-sweep`, which spawns `cargo`. On hosts where the systemd user manager's PATH does not include `~/.cargo/bin` — stock Debian, LXC containers (observed on udder) — every scheduled sweep failed with `No such file or directory (os error 2)` while manual runs succeeded, because interactive shells do have the cargo path.

Carry the PATH in the unit itself so the schedule works without per-host `environment.d` configuration. Found installing the sweep schedule on udder (which had never had it — 23G target dir on a 50G rootfs).

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp