### PR TITLE
feat: observe change-request mergeability in checkout integrations

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -169,10 +169,10 @@ where
         } else if obj.status.as_ref().is_some_and(|status| status.phase == CheckoutPhase::Ready) {
             match deps {
                 CheckoutDeps::Integration { status } => {
-                    Some(CheckoutStatusPatch::UpdateIntegration { integration: status.as_ref().clone() })
+                    Some(CheckoutStatusPatch::UpdateIntegration { integration: Box::new(status.as_ref().clone()) })
                 }
                 CheckoutDeps::Failed(message) => Some(CheckoutStatusPatch::UpdateIntegration {
-                    integration: CheckoutIntegrationStatus {
+                    integration: Box::new(CheckoutIntegrationStatus {
                         clean: flotilla_resources::IntegrationCondition::builder()
                             .value(flotilla_resources::ConditionValue::Unknown)
                             .details(vec![message.clone()])
@@ -189,7 +189,8 @@ where
                             .observed_at(now.to_rfc3339())
                             .build(),
                         landed_evidence: None,
-                    },
+                        change_request: None,
+                    }),
                 }),
                 CheckoutDeps::None | CheckoutDeps::Ready { .. } | CheckoutDeps::Waiting => None,
             }

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -65,6 +65,7 @@ impl CheckoutRuntime for RecordingCheckoutRuntime {
                 .details(vec!["no change request provider".to_string()])
                 .build(),
             landed_evidence: None,
+            change_request: None,
         })
     }
 
@@ -312,6 +313,7 @@ async fn ready_checkout_reconciler_skips_fresh_integration_probe() {
                 pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
                 landed: IntegrationCondition::builder().value(ConditionValue::False).observed_at(observed_at).build(),
                 landed_evidence: None,
+                change_request: None,
             },
             message: None,
         })

--- a/crates/flotilla-controllers/tests/liveness_contract.rs
+++ b/crates/flotilla-controllers/tests/liveness_contract.rs
@@ -65,6 +65,7 @@ impl CheckoutRuntime for HarnessRuntime {
             pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
             landed: IntegrationCondition::builder().value(ConditionValue::False).observed_at(observed_at).build(),
             landed_evidence: None,
+            change_request: None,
         })
     }
 
@@ -348,6 +349,7 @@ impl WorldBuilder for ConvoyWorldBuilder {
                     pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observation_time.to_rfc3339()).build(),
                     landed: IntegrationCondition::builder().value(ConditionValue::False).observed_at(observation_time.to_rfc3339()).build(),
                     landed_evidence: None,
+                    change_request: None,
                 },
                 message: None,
             })

--- a/crates/flotilla-core/src/checkout_integration.rs
+++ b/crates/flotilla-core/src/checkout_integration.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use chrono::Utc;
-use flotilla_resources::{CheckoutIntegrationStatus, CheckoutSpec, CheckoutStatus, ConditionValue, IntegrationCondition, LandedEvidence};
+use flotilla_resources::{
+    ChangeRequestMergeability, ChangeRequestObservation, ChangeRequestState, CheckoutIntegrationStatus, CheckoutSpec, CheckoutStatus,
+    ConditionValue, IntegrationCondition, LandedEvidence,
+};
 
 use crate::providers::{ChannelLabel, CommandRunner};
 
@@ -63,7 +66,7 @@ pub async fn inspect_checkout_integration(
     let observed_at = Utc::now().to_rfc3339();
     let clean = inspect_clean(runner, checkout_path, &observed_at).await;
     let pushed = inspect_pushed(runner, checkout_path, &observed_at).await;
-    let (landed, landed_evidence) = inspect_landed(
+    let (landed, landed_evidence, change_request) = inspect_landed(
         runner,
         checkout_path,
         checkout_branch_from_spec(spec),
@@ -72,7 +75,7 @@ pub async fn inspect_checkout_integration(
         &observed_at,
     )
     .await;
-    CheckoutIntegrationStatus { clean, pushed, landed, landed_evidence }
+    CheckoutIntegrationStatus { clean, pushed, landed, landed_evidence, change_request }
 }
 
 async fn inspect_clean(runner: &dyn CommandRunner, checkout_path: &Path, observed_at: &str) -> IntegrationCondition {
@@ -242,7 +245,7 @@ async fn inspect_landed(
     base_ref: Option<&str>,
     change_request_id: Option<&str>,
     observed_at: &str,
-) -> (IntegrationCondition, Option<LandedEvidence>) {
+) -> (IntegrationCondition, Option<LandedEvidence>, Option<ChangeRequestObservation>) {
     // Git evidence first: a branch with no commits beyond its base has
     // nothing to land, so it counts as landed without consulting the forge at
     // all. This keeps untouched checkouts landable in environments where `gh`
@@ -257,12 +260,15 @@ async fn inspect_landed(
                     .observed_at(observed_at.to_string())
                     .build(),
                 None,
+                None,
             );
         }
     }
     let args = match change_request_id {
-        Some(id) => vec!["pr", "view", id, "--json", "number,state,mergedAt,baseRefName"],
-        None => vec!["pr", "list", "--head", branch, "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+        Some(id) => vec!["pr", "view", id, "--json", "number,state,mergedAt,baseRefName,mergeable"],
+        None => {
+            vec!["pr", "list", "--head", branch, "--state", "all", "--json", "number,state,mergedAt,baseRefName,mergeable", "--limit", "1"]
+        }
     };
     match runner.run_output("gh", &args, checkout_path, &ChannelLabel::Noop).await {
         Ok(output) if output.success => match serde_json::from_str::<serde_json::Value>(&output.stdout) {
@@ -279,8 +285,27 @@ async fn inspect_landed(
                         let state = item.get("state").and_then(serde_json::Value::as_str).unwrap_or("unknown");
                         let merged_at = item.get("mergedAt").and_then(serde_json::Value::as_str).filter(|value| !value.is_empty());
                         let target_ref = item.get("baseRefName").and_then(serde_json::Value::as_str).filter(|value| !value.is_empty());
-                        if state.eq_ignore_ascii_case("MERGED") || state.eq_ignore_ascii_case("CLOSED") || merged_at.is_some() {
-                            let outcome = if state.eq_ignore_ascii_case("CLOSED") && merged_at.is_none() { "closed" } else { "merged" };
+                        let state = if state.eq_ignore_ascii_case("MERGED") || merged_at.is_some() {
+                            ChangeRequestState::Merged
+                        } else if state.eq_ignore_ascii_case("CLOSED") {
+                            ChangeRequestState::Closed
+                        } else {
+                            ChangeRequestState::Open
+                        };
+                        let mergeability = match item.get("mergeable").and_then(serde_json::Value::as_str) {
+                            Some(value) if value.eq_ignore_ascii_case("MERGEABLE") => ChangeRequestMergeability::Mergeable,
+                            Some(value) if value.eq_ignore_ascii_case("CONFLICTING") => ChangeRequestMergeability::Conflicting,
+                            _ => ChangeRequestMergeability::Unknown,
+                        };
+                        let observation = ChangeRequestObservation::builder()
+                            .id(number.clone())
+                            .state(state)
+                            .mergeability(mergeability)
+                            .maybe_target_ref(target_ref.map(str::to_string))
+                            .observed_at(observed_at.to_string())
+                            .build();
+                        if state != ChangeRequestState::Open {
+                            let outcome = if state == ChangeRequestState::Closed { "closed" } else { "merged" };
                             (
                                 IntegrationCondition::builder()
                                     .value(ConditionValue::True)
@@ -294,19 +319,21 @@ async fn inspect_landed(
                                         .maybe_target_ref(if outcome == "merged" { target_ref.map(str::to_string) } else { None })
                                         .build(),
                                 ),
+                                Some(observation),
                             )
                         } else {
                             (
                                 IntegrationCondition::builder()
                                     .value(ConditionValue::False)
-                                    .details(vec![format!("PR #{number} {state}, not merged")])
+                                    .details(vec![format!("PR #{number} OPEN, not merged")])
                                     .observed_at(observed_at.to_string())
                                     .build(),
                                 None,
+                                Some(observation),
                             )
                         }
                     }
-                    None => (landed_without_change_request(&comparison, observed_at), None),
+                    None => (landed_without_change_request(&comparison, observed_at), None, None),
                 }
             }
             Err(_) => (
@@ -315,6 +342,7 @@ async fn inspect_landed(
                     .details(vec!["could not parse gh PR lookup output".to_string()])
                     .observed_at(observed_at.to_string())
                     .build(),
+                None,
                 None,
             ),
         },
@@ -325,6 +353,7 @@ async fn inspect_landed(
                 .observed_at(observed_at.to_string())
                 .build(),
             None,
+            None,
         ),
         Err(error) => (
             IntegrationCondition::builder()
@@ -332,6 +361,7 @@ async fn inspect_landed(
                 .details(vec![format!("gh PR lookup could not run: {error}")])
                 .observed_at(observed_at.to_string())
                 .build(),
+            None,
             None,
         ),
     }
@@ -408,7 +438,7 @@ mod tests {
 
     async fn landed_with_responses(responses: Vec<Result<String, String>>) -> IntegrationCondition {
         let runner = MockRunner::new(responses);
-        let (landed, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
+        let (landed, _, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
         landed
     }
 
@@ -448,12 +478,13 @@ mod tests {
             Ok("0".into()),
             Ok(r#"{"number":1071,"state":"MERGED","mergedAt":"2026-07-27T12:00:00Z","baseRefName":"main"}"#.into()),
         ]);
-        let (landed, evidence) =
+        let (landed, evidence, change_request) =
             inspect_landed(&runner, Path::new("/checkout"), "renamed-head", Some("main"), Some("1071"), "2026-07-27T00:00:00Z").await;
 
         assert_eq!(landed.value, ConditionValue::True);
         assert_eq!(evidence.as_ref().map(|evidence| evidence.change_request_id.as_str()), Some("1071"));
         assert_eq!(evidence.as_ref().and_then(|evidence| evidence.target_ref.as_deref()), Some("main"));
+        assert_eq!(change_request.expect("bound change request should be observed").state, ChangeRequestState::Merged);
         assert_eq!(
             runner.calls()[1],
             ("gh".to_string(), vec![
@@ -461,9 +492,22 @@ mod tests {
                 "view".to_string(),
                 "1071".to_string(),
                 "--json".to_string(),
-                "number,state,mergedAt,baseRefName".to_string(),
+                "number,state,mergedAt,baseRefName,mergeable".to_string(),
             ],)
         );
+    }
+
+    #[tokio::test]
+    async fn conflicting_change_request_is_part_of_the_integration_observation() {
+        let runner = MockRunner::new(vec![
+            Ok("2".into()),
+            Ok(r#"[{"number": 1162, "state": "OPEN", "mergedAt": null, "baseRefName": "main", "mergeable": "CONFLICTING"}]"#.into()),
+        ]);
+
+        let (_, _, change_request) =
+            inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
+
+        assert_eq!(change_request.expect("open change request should be observed").mergeability, ChangeRequestMergeability::Conflicting);
     }
 
     #[tokio::test]
@@ -479,7 +523,7 @@ mod tests {
     #[tokio::test]
     async fn indeterminate_base_without_change_request_is_unknown() {
         let runner = MockRunner::new(vec![Err("fatal: ambiguous argument".into()), Ok("[]".into())]);
-        let (landed, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", None, None, "2026-07-27T00:00:00Z").await;
+        let (landed, _, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", None, None, "2026-07-27T00:00:00Z").await;
         assert_eq!(landed.value, ConditionValue::Unknown);
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5954,13 +5954,16 @@ impl InProcessDaemon {
                 Ok(runner) => runner,
                 Err(_) => return Ok(false),
             };
-            let integration = inspect_checkout_integration(
+            let mut integration = inspect_checkout_integration(
                 &*runner,
                 &path,
                 &checkout.spec,
                 checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
             )
             .await;
+            if let Some(existing) = checkout.status.as_ref() {
+                latch_evidence_backed_integration(&existing.integration, &mut integration);
+            }
             if let Err(error) = apply_resource_status_patch(
                 &checkouts,
                 &checkout.metadata.name,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6058,15 +6058,8 @@ impl InProcessDaemon {
                 checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
             )
             .await;
-            if let Some(existing) = checkout
-                .status
-                .as_ref()
-                .filter(|status| status.integration.landed.value == ConditionValue::True && status.integration.landed_evidence.is_some())
-            {
-                integration.landed.value = ConditionValue::True;
-                if integration.landed_evidence.is_none() {
-                    integration.landed_evidence = existing.integration.landed_evidence.clone();
-                }
+            if let Some(existing) = checkout.status.as_ref() {
+                latch_evidence_backed_integration(&existing.integration, &mut integration);
             }
             if !checkout.status.as_ref().is_some_and(|status| integration_observation_matches(&status.integration, &integration)) {
                 if let Err(error) = apply_resource_status_patch(

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1612,6 +1612,16 @@ fn integration_observation_matches(left: &CheckoutIntegrationStatus, right: &Che
         .into_iter()
         .all(|(left, right)| left.value == right.value && left.details == right.details)
         && left.landed_evidence == right.landed_evidence
+        && match (&left.change_request, &right.change_request) {
+            (Some(left), Some(right)) => {
+                left.id == right.id
+                    && left.state == right.state
+                    && left.mergeability == right.mergeability
+                    && left.target_ref == right.target_ref
+            }
+            (None, None) => true,
+            _ => false,
+        }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2273,7 +2283,7 @@ impl InProcessDaemon {
                 }
             }
             apply_resource_status_patch(&checkouts, &checkout.metadata.name, &flotilla_resources::CheckoutStatusPatch::UpdateIntegration {
-                integration,
+                integration: Box::new(integration),
             })
             .await
             .map_err(|error| error.to_string())?;
@@ -5947,7 +5957,7 @@ impl InProcessDaemon {
             if let Err(error) = apply_resource_status_patch(
                 &checkouts,
                 &checkout.metadata.name,
-                &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: integration.clone() },
+                &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration.clone()) },
             )
             .await
             {
@@ -6055,7 +6065,7 @@ impl InProcessDaemon {
                 if let Err(error) = apply_resource_status_patch(
                     &checkouts,
                     &checkout.metadata.name,
-                    &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: integration.clone() },
+                    &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration.clone()) },
                 )
                 .await
                 {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1624,6 +1624,20 @@ fn integration_observation_matches(left: &CheckoutIntegrationStatus, right: &Che
         }
 }
 
+fn latch_evidence_backed_integration(existing: &CheckoutIntegrationStatus, observed: &mut CheckoutIntegrationStatus) {
+    if existing.landed.value != ConditionValue::True || existing.landed_evidence.is_none() {
+        return;
+    }
+    observed.landed.value = ConditionValue::True;
+    if observed.landed_evidence.is_none() {
+        observed.landed_evidence = existing.landed_evidence.clone();
+    }
+    if observed.change_request.is_none() {
+        observed.change_request =
+            existing.change_request.clone().filter(|change_request| change_request.state != flotilla_resources::ChangeRequestState::Open);
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExistingConvoyTarget {
     pub home: HostName,
@@ -2272,15 +2286,8 @@ impl InProcessDaemon {
                 checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
             )
             .await;
-            if let Some(existing) = checkout
-                .status
-                .as_ref()
-                .filter(|status| status.integration.landed.value == ConditionValue::True && status.integration.landed_evidence.is_some())
-            {
-                integration.landed.value = ConditionValue::True;
-                if integration.landed_evidence.is_none() {
-                    integration.landed_evidence = existing.integration.landed_evidence.clone();
-                }
+            if let Some(existing) = checkout.status.as_ref() {
+                latch_evidence_backed_integration(&existing.integration, &mut integration);
             }
             apply_resource_status_patch(&checkouts, &checkout.metadata.name, &flotilla_resources::CheckoutStatusPatch::UpdateIntegration {
                 integration: Box::new(integration),

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -5113,6 +5113,78 @@ async fn teardown_gate_does_not_rewrite_a_latched_terminal_change_request() {
 }
 
 #[tokio::test]
+async fn landing_settlement_uses_latched_terminal_change_request_after_stale_reprobe() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/merged\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/merged..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("1\n".into()))
+        .on_run(
+            "gh",
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/merged",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName,mergeable",
+                "--limit",
+                "1",
+            ],
+            Ok("[]".into()),
+        )
+        .build();
+    let daemon = InProcessDaemon::new(
+        vec![],
+        Arc::new(ConfigStore::with_base(&config_base)),
+        fake_discovery_with_runner(false, Arc::new(runner)),
+        HostName::local(),
+    )
+    .await;
+    create_ready_observed_checkout_for_convoy(&daemon, "flotilla", "merged-convoy", "checkout-merged", "/repo", "feature/merged").await;
+
+    let observed_at = (chrono::Utc::now() - chrono::Duration::minutes(10)).to_rfc3339();
+    let condition = || IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build();
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let checkout = checkouts.get("checkout-merged").await.expect("ready checkout");
+    let mut status = checkout.status.expect("ready checkout status");
+    status.integration = CheckoutIntegrationStatus {
+        clean: condition(),
+        pushed: condition(),
+        landed: condition(),
+        landed_evidence: Some(flotilla_resources::LandedEvidence::builder().change_request_id("1162".to_string()).build()),
+        change_request: Some(
+            flotilla_resources::ChangeRequestObservation::builder()
+                .id("1162".to_string())
+                .state(flotilla_resources::ChangeRequestState::Merged)
+                .mergeability(flotilla_resources::ChangeRequestMergeability::Unknown)
+                .observed_at(observed_at)
+                .build(),
+        ),
+    };
+    checkouts.update_status("checkout-merged", &checkout.metadata.resource_version, &status).await.expect("persist landed checkout");
+
+    assert!(
+        daemon.convoy_change_requests_settled("flotilla", "merged-convoy").await.expect("landing evaluation"),
+        "evidence-backed landed status must survive a stale reprobe that can no longer discover the merged PR"
+    );
+    let stored = checkouts.get("checkout-merged").await.expect("checkout after landing evaluation");
+    assert_eq!(
+        stored.status.expect("checkout status").integration.change_request.unwrap().state,
+        flotilla_resources::ChangeRequestState::Merged
+    );
+}
+
+#[tokio::test]
 async fn convoy_reclaim_allows_managed_checkout_whose_path_is_already_gone() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4835,7 +4835,7 @@ async fn convoy_delete_refuses_completed_convoy_with_unpushed_checkout_until_for
                 "--state",
                 "all",
                 "--json",
-                "number,state,mergedAt,baseRefName",
+                "number,state,mergedAt,baseRefName,mergeable",
                 "--limit",
                 "1",
             ],
@@ -4932,7 +4932,18 @@ async fn convoy_delete_refuses_diverged_checkout_without_a_change_request() {
         .on_run("git", &["rev-list", "--count", "origin/feature/diverged..HEAD"], Ok("0\n".into()))
         .on_run(
             "gh",
-            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/diverged",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName,mergeable",
+                "--limit",
+                "1",
+            ],
             Ok("[]".into()),
         )
         .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
@@ -4973,12 +4984,34 @@ async fn repeated_identical_reclaim_refusal_does_not_rewrite_checkout_status() {
         .on_run("git", &["rev-list", "--count", "origin/feature/diverged..HEAD"], Ok("0\n".into()))
         .on_run(
             "gh",
-            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/diverged",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName,mergeable",
+                "--limit",
+                "1",
+            ],
             Ok("[]".into()),
         )
         .on_run(
             "gh",
-            &["pr", "list", "--head", "feature/diverged", "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/diverged",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName,mergeable",
+                "--limit",
+                "1",
+            ],
             Ok("[]".into()),
         )
         .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
@@ -5070,7 +5103,7 @@ async fn convoy_delete_allows_multi_repo_convoy_with_work_on_only_one_side() {
                 "--state",
                 "all",
                 "--json",
-                "number,state,mergedAt,baseRefName",
+                "number,state,mergedAt,baseRefName,mergeable",
                 "--limit",
                 "1",
             ],
@@ -5934,7 +5967,18 @@ async fn landing_holds_when_fresh_probe_contradicts_stale_vacuous_landed() {
         .on_run("git", &["rev-list", "--count", "main..HEAD"], Ok("2".into()))
         .on_run(
             "gh",
-            &["pr", "list", "--head", "feature/split", "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/split",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName,mergeable",
+                "--limit",
+                "1",
+            ],
             Ok(r#"[{"number": 1162, "state": "OPEN", "mergedAt": null, "baseRefName": "main"}]"#.into()),
         )
         .on_run("git", &["status", "--porcelain"], Ok(String::new()))
@@ -5982,6 +6026,7 @@ async fn landing_holds_when_fresh_probe_contradicts_stale_vacuous_landed() {
                 pushed: stale_vacuous.clone(),
                 landed: stale_vacuous,
                 landed_evidence: None,
+                change_request: None,
             },
             message: None,
         })

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -5046,6 +5046,39 @@ async fn repeated_identical_reclaim_refusal_does_not_rewrite_checkout_status() {
     );
 }
 
+#[test]
+fn teardown_latch_normalization_preserves_terminal_change_request_for_dedup() {
+    let condition = |value, observed_at: &str| IntegrationCondition::builder().value(value).observed_at(observed_at.to_string()).build();
+    let evidence = flotilla_resources::LandedEvidence::builder().change_request_id("1162".to_string()).build();
+    let change_request = flotilla_resources::ChangeRequestObservation::builder()
+        .id("1162".to_string())
+        .state(flotilla_resources::ChangeRequestState::Merged)
+        .mergeability(flotilla_resources::ChangeRequestMergeability::Unknown)
+        .observed_at("2026-07-28T00:00:00Z".to_string())
+        .build();
+    let existing = CheckoutIntegrationStatus {
+        clean: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
+        pushed: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
+        landed: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
+        landed_evidence: Some(evidence),
+        change_request: Some(change_request),
+    };
+    let mut observed = CheckoutIntegrationStatus {
+        clean: condition(ConditionValue::True, "2026-07-28T00:01:00Z"),
+        pushed: condition(ConditionValue::True, "2026-07-28T00:01:00Z"),
+        landed: condition(ConditionValue::True, "2026-07-28T00:01:00Z"),
+        landed_evidence: None,
+        change_request: None,
+    };
+
+    latch_evidence_backed_integration(&existing, &mut observed);
+
+    assert!(
+        integration_observation_matches(&existing, &observed),
+        "a timestamp-only refresh must not rewrite a latched terminal change request"
+    );
+}
+
 #[tokio::test]
 async fn convoy_reclaim_allows_managed_checkout_whose_path_is_already_gone() {
     let temp = tempfile::tempdir().expect("create tempdir");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -5046,8 +5046,42 @@ async fn repeated_identical_reclaim_refusal_does_not_rewrite_checkout_status() {
     );
 }
 
-#[test]
-fn teardown_latch_normalization_preserves_terminal_change_request_for_dedup() {
+#[tokio::test]
+async fn teardown_gate_does_not_rewrite_a_latched_terminal_change_request() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/merged\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/merged\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/merged..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/merged..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("0\n".into()))
+        .build();
+    let daemon = InProcessDaemon::new(
+        vec![],
+        Arc::new(ConfigStore::with_base(&config_base)),
+        fake_discovery_with_runner(false, Arc::new(runner)),
+        HostName::local(),
+    )
+    .await;
+    daemon
+        .resource_backend()
+        .using::<Convoy>("flotilla")
+        .create(&empty_input_meta("merged-convoy"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+        .await
+        .expect("convoy create should succeed");
+    create_ready_observed_checkout_for_convoy(&daemon, "flotilla", "merged-convoy", "checkout-merged", "/repo", "feature/merged").await;
+
     let condition = |value, observed_at: &str| IntegrationCondition::builder().value(value).observed_at(observed_at.to_string()).build();
     let evidence = flotilla_resources::LandedEvidence::builder().change_request_id("1162".to_string()).build();
     let change_request = flotilla_resources::ChangeRequestObservation::builder()
@@ -5056,26 +5090,25 @@ fn teardown_latch_normalization_preserves_terminal_change_request_for_dedup() {
         .mergeability(flotilla_resources::ChangeRequestMergeability::Unknown)
         .observed_at("2026-07-28T00:00:00Z".to_string())
         .build();
-    let existing = CheckoutIntegrationStatus {
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let checkout = checkouts.get("checkout-merged").await.expect("ready checkout");
+    let mut status = checkout.status.expect("ready checkout status");
+    status.integration = CheckoutIntegrationStatus {
         clean: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
         pushed: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
         landed: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
         landed_evidence: Some(evidence),
         change_request: Some(change_request),
     };
-    let mut observed = CheckoutIntegrationStatus {
-        clean: condition(ConditionValue::True, "2026-07-28T00:01:00Z"),
-        pushed: condition(ConditionValue::True, "2026-07-28T00:01:00Z"),
-        landed: condition(ConditionValue::True, "2026-07-28T00:01:00Z"),
-        landed_evidence: None,
-        change_request: None,
-    };
+    checkouts.update_status("checkout-merged", &checkout.metadata.resource_version, &status).await.expect("persist landed checkout");
 
-    latch_evidence_backed_integration(&existing, &mut observed);
-
-    assert!(
-        integration_observation_matches(&existing, &observed),
-        "a timestamp-only refresh must not rewrite a latched terminal change request"
+    daemon.verify_convoy_teardown_gate("flotilla", "merged-convoy", false).await.expect("landed checkout should pass teardown");
+    let first = checkouts.get("checkout-merged").await.expect("checkout after first teardown gate");
+    daemon.verify_convoy_teardown_gate("flotilla", "merged-convoy", false).await.expect("landed checkout should still pass teardown");
+    let second = checkouts.get("checkout-merged").await.expect("checkout after second teardown gate");
+    assert_eq!(
+        second.metadata.resource_version, first.metadata.resource_version,
+        "a repeated timestamp-only teardown probe must not rewrite a latched terminal change request"
     );
 }
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -6805,6 +6805,7 @@ async fn convoy_landing_reprobes_after_injected_clock_crosses_evidence_ttl() {
                 pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
                 landed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at).build(),
                 landed_evidence: None,
+                change_request: None,
             },
             message: None,
         })

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -4939,7 +4939,7 @@ mod tests {
         flotilla_resources::apply_status_patch(
             &checkouts,
             &checkout.metadata.name,
-            &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration },
+            &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration) },
         )
         .await
         .expect("record observed absence of a change request");

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -134,6 +134,8 @@ pub struct CheckoutIntegrationStatus {
     pub landed: IntegrationCondition,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub landed_evidence: Option<LandedEvidence>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_request: Option<ChangeRequestObservation>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
@@ -169,13 +171,39 @@ pub struct LandedEvidence {
     pub target_ref: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct ChangeRequestObservation {
+    pub id: String,
+    pub state: ChangeRequestState,
+    pub mergeability: ChangeRequestMergeability,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_ref: Option<String>,
+    pub observed_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeRequestState {
+    Open,
+    Closed,
+    Merged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeRequestMergeability {
+    Mergeable,
+    Conflicting,
+    Unknown,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckoutStatusPatch {
     MarkPreparing,
     MarkReady { path: String, commit: Option<String>, branch_provenance: CheckoutBranchProvenance },
     MarkTerminating,
     MarkFailed { message: String },
-    UpdateIntegration { integration: CheckoutIntegrationStatus },
+    UpdateIntegration { integration: Box<CheckoutIntegrationStatus> },
 }
 
 impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
@@ -209,7 +237,7 @@ impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
                 let landed_was_latched =
                     status.integration.landed.value == ConditionValue::True && status.integration.landed_evidence.is_some();
                 let landed_evidence = status.integration.landed_evidence.clone();
-                status.integration = integration.clone();
+                status.integration = integration.as_ref().clone();
                 if landed_was_latched {
                     status.integration.landed.value = ConditionValue::True;
                     if status.integration.landed_evidence.is_none() {
@@ -235,6 +263,7 @@ mod tests {
             pushed: condition(ConditionValue::True),
             landed: condition(landed),
             landed_evidence,
+            change_request: None,
         }
     }
 
@@ -244,7 +273,7 @@ mod tests {
         // untouched branch) is not a landing fact; a later observation that
         // finds an open change request must lower it (#1163).
         let mut status = CheckoutStatus { integration: integration(ConditionValue::True, None), ..Default::default() };
-        CheckoutStatusPatch::UpdateIntegration { integration: integration(ConditionValue::False, None) }.apply(&mut status);
+        CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration(ConditionValue::False, None)) }.apply(&mut status);
         assert_eq!(status.integration.landed.value, ConditionValue::False);
     }
 
@@ -254,7 +283,7 @@ mod tests {
         // stay landed even if a later probe cannot see the change request.
         let evidence = LandedEvidence::builder().change_request_id("1162".to_string()).build();
         let mut status = CheckoutStatus { integration: integration(ConditionValue::True, Some(evidence.clone())), ..Default::default() };
-        CheckoutStatusPatch::UpdateIntegration { integration: integration(ConditionValue::False, None) }.apply(&mut status);
+        CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration(ConditionValue::False, None)) }.apply(&mut status);
         assert_eq!(status.integration.landed.value, ConditionValue::True);
         assert_eq!(status.integration.landed_evidence, Some(evidence));
     }

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -237,11 +237,16 @@ impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
                 let landed_was_latched =
                     status.integration.landed.value == ConditionValue::True && status.integration.landed_evidence.is_some();
                 let landed_evidence = status.integration.landed_evidence.clone();
+                let terminal_change_request =
+                    status.integration.change_request.clone().filter(|change_request| change_request.state != ChangeRequestState::Open);
                 status.integration = integration.as_ref().clone();
                 if landed_was_latched {
                     status.integration.landed.value = ConditionValue::True;
                     if status.integration.landed_evidence.is_none() {
                         status.integration.landed_evidence = landed_evidence;
+                    }
+                    if status.integration.change_request.is_none() {
+                        status.integration.change_request = terminal_change_request;
                     }
                 }
             }
@@ -282,9 +287,18 @@ mod tests {
         // A merged change request does not unmerge: evidence-backed landings
         // stay landed even if a later probe cannot see the change request.
         let evidence = LandedEvidence::builder().change_request_id("1162".to_string()).build();
-        let mut status = CheckoutStatus { integration: integration(ConditionValue::True, Some(evidence.clone())), ..Default::default() };
+        let observation = ChangeRequestObservation::builder()
+            .id("1162".to_string())
+            .state(ChangeRequestState::Merged)
+            .mergeability(ChangeRequestMergeability::Unknown)
+            .observed_at("2026-07-27T00:00:00Z".to_string())
+            .build();
+        let mut initial = integration(ConditionValue::True, Some(evidence.clone()));
+        initial.change_request = Some(observation.clone());
+        let mut status = CheckoutStatus { integration: initial, ..Default::default() };
         CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration(ConditionValue::False, None)) }.apply(&mut status);
         assert_eq!(status.integration.landed.value, ConditionValue::True);
         assert_eq!(status.integration.landed_evidence, Some(evidence));
+        assert_eq!(status.integration.change_request, Some(observation));
     }
 }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -35,8 +35,9 @@ mod workflow_template;
 
 pub use backend::{ReplicaReadResolver, ReplicaWriter, ResourceBackend, TypedResolver};
 pub use checkout::{
-    Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch,
-    CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec, IntegrationCondition, LandedEvidence, ObservedCheckoutSpec,
+    ChangeRequestMergeability, ChangeRequestObservation, ChangeRequestState, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus,
+    CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec,
+    IntegrationCondition, LandedEvidence, ObservedCheckoutSpec,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use clock::VirtualClock;

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -156,6 +156,7 @@ async fn reconcile_landing_with_observed_change_request(
                     landed_evidence: observed_target_ref.map(|target_ref| {
                         LandedEvidence::builder().change_request_id("42".to_string()).target_ref(target_ref.to_string()).build()
                     }),
+                    change_request: None,
                 },
                 message: None,
             })

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -94,14 +94,15 @@ fn checkout_integration_patch_updates_conditions_and_latches_landed() {
     let mut status = CheckoutStatus::default();
 
     CheckoutStatusPatch::UpdateIntegration {
-        integration: CheckoutIntegrationStatus {
+        integration: Box::new(CheckoutIntegrationStatus {
             clean: IntegrationCondition::builder().value(ConditionValue::True).build(),
             pushed: IntegrationCondition::builder().value(ConditionValue::False).details(vec!["2 unpushed commits".to_string()]).build(),
             landed: IntegrationCondition::builder().value(ConditionValue::True).build(),
             landed_evidence: Some(
                 LandedEvidence::builder().change_request_id("815".to_string()).merged_at("2026-07-21T23:15:00Z".to_string()).build(),
             ),
-        },
+            change_request: None,
+        }),
     }
     .apply(&mut status);
 
@@ -111,12 +112,13 @@ fn checkout_integration_patch_updates_conditions_and_latches_landed() {
     assert_eq!(status.integration.landed_evidence.as_ref().map(|evidence| evidence.change_request_id.as_str()), Some("815"));
 
     CheckoutStatusPatch::UpdateIntegration {
-        integration: CheckoutIntegrationStatus {
+        integration: Box::new(CheckoutIntegrationStatus {
             clean: IntegrationCondition::builder().value(ConditionValue::True).build(),
             pushed: IntegrationCondition::builder().value(ConditionValue::True).build(),
             landed: IntegrationCondition::builder().value(ConditionValue::False).details(vec!["no PR found".to_string()]).build(),
             landed_evidence: None,
-        },
+            change_request: None,
+        }),
     }
     .apply(&mut status);
 


### PR DESCRIPTION
## Summary

- persist change-request identity, state, mergeability, and target ref in checkout integration observations
- treat semantic change-request transitions as status changes while ignoring timestamp-only refreshes
- query forge mergeability during periodic checkout integration inspection, with coverage for conflicting observations

This is the mechanism-neutral observation slice needed by the future declarative workflow and state-event substrates in #1232 and #1233. Delivery semantics are intentionally out of scope here.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Part of #1150
