### PR TITLE
fix: enforce client wire generation handshake

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -89,11 +89,22 @@ async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<
         Some(Message::Hello { protocol_version, display_name, .. }) if protocol_version != PROTOCOL_VERSION => {
             let daemon_build = flotilla_protocol::hello_build_id(&display_name).unwrap_or("unknown");
             Err(format!(
-                "daemon protocol version mismatch: daemon has {protocol_version} ({daemon_build}), client has {PROTOCOL_VERSION} ({})",
-                BUILD_ID
+                "daemon protocol version mismatch: client generation {} uses protocol {PROTOCOL_VERSION}, daemon generation \
+                 {daemon_build} uses protocol {protocol_version} — rebuild or use the daemon's paired CLI",
+                BUILD_ID,
             ))
         }
-        Some(Message::Hello { display_name, .. }) => Ok(flotilla_protocol::hello_build_id(&display_name).map(str::to_owned)),
+        Some(Message::Hello { display_name, .. }) => {
+            let daemon_generation = flotilla_protocol::hello_build_id(&display_name).unwrap_or("unknown");
+            if daemon_generation != BUILD_ID {
+                return Err(format!(
+                    "wire generation mismatch: client generation {}, daemon generation {daemon_generation} — rebuild or use the \
+                     daemon's paired CLI",
+                    BUILD_ID,
+                ));
+            }
+            Ok(Some(daemon_generation.to_owned()))
+        }
         Some(other) => Err(format!("expected Hello reply, got: {other:?}")),
         None => Err("connection closed before Hello reply".into()),
     }
@@ -231,6 +242,16 @@ impl SocketDaemon {
         });
 
         Ok(daemon)
+    }
+
+    /// Deliver a one-shot agent hook through the same generation-checked
+    /// connection used by CLI and TUI requests.
+    pub async fn send_agent_hook(&self, event: flotilla_protocol::AgentHookEvent) -> Result<(), String> {
+        let result = send_request(&self.session, &self.pending, &self.next_id, Request::AgentHook { event }).await?;
+        match into_success_response(result)? {
+            Response::AgentHook => Ok(()),
+            other => Err(format!("unexpected agent hook response: {other:?}")),
+        }
     }
 
     /// Send a request to the daemon and wait for the matching response.

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -96,7 +96,7 @@ async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<
         }
         Some(Message::Hello { display_name, .. }) => {
             let daemon_generation = flotilla_protocol::hello_build_id(&display_name).unwrap_or("unknown");
-            if daemon_generation != BUILD_ID {
+            if !flotilla_protocol::wire_generations_match(daemon_generation, BUILD_ID) {
                 return Err(format!(
                     "wire generation mismatch: client generation {}, daemon generation {daemon_generation} — rebuild or use the \
                      daemon's paired CLI",

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -269,13 +269,39 @@ async fn client_hello_rejects_daemon_protocol_version_mismatch() {
 }
 
 #[tokio::test]
-async fn connect_rejects_daemon_protocol_version_mismatch() {
+async fn client_hello_rejects_daemon_wire_generation_mismatch() {
+    let (client, server) = message_session_pair();
+    let server_task = tokio::spawn(async move {
+        let hello = server.read().await.expect("read client hello").expect("client hello");
+        assert!(matches!(hello, Message::Hello { protocol_version: PROTOCOL_VERSION, .. }));
+        server
+            .write(Message::Hello {
+                protocol_version: PROTOCOL_VERSION,
+                node_id: NodeId::new("daemon"),
+                display_name: flotilla_protocol::hello_display_name("daemon", "stale-daemon-generation"),
+                session_id: uuid::Uuid::new_v4(),
+                connection_role: Some(ConnectionRole::Client),
+                surface: None,
+            })
+            .await
+            .expect("write stale daemon hello");
+    });
+
+    let error = do_client_hello(&client).await.expect_err("wire generation mismatch should reject the daemon");
+    assert!(error.contains(&format!("client generation {BUILD_ID}")), "error should report the client generation: {error}");
+    assert!(error.contains("daemon generation stale-daemon-generation"), "error should report the daemon generation: {error}");
+    assert!(error.contains("rebuild or use the daemon's paired CLI"), "error should provide an actionable recovery: {error}");
+    assert!(!error.contains("failed to parse message"), "error should come from the handshake: {error}");
+    server_task.await.expect("join server task");
+}
+
+async fn assert_connect_rejects_daemon_hello(protocol_version: u32, display_name: String, expected_error: &str) {
     let dir = TestSocketDir::new();
     let socket_path = dir.socket_path("daemon.sock");
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
-            eprintln!("skipping connect_rejects_daemon_protocol_version_mismatch: unix socket bind not permitted: {err}");
+            eprintln!("skipping daemon hello rejection test: unix socket bind not permitted: {err}");
             return;
         }
         Err(err) => panic!("bind listener: {err}"),
@@ -288,9 +314,9 @@ async fn connect_rejects_daemon_protocol_version_mismatch() {
         assert!(matches!(hello, Message::Hello { protocol_version: PROTOCOL_VERSION, .. }));
         session
             .write(Message::Hello {
-                protocol_version: PROTOCOL_VERSION - 1,
+                protocol_version,
                 node_id: NodeId::new("stale-daemon"),
-                display_name: "stale daemon".into(),
+                display_name,
                 session_id: uuid::Uuid::new_v4(),
                 connection_role: Some(ConnectionRole::Client),
                 surface: None,
@@ -306,8 +332,25 @@ async fn connect_rejects_daemon_protocol_version_mismatch() {
         }
         Err(error) => error,
     };
-    assert!(error.contains("protocol version mismatch"), "unexpected error: {error}");
+    assert!(error.contains(expected_error), "unexpected error: {error}");
+    assert!(error.contains("rebuild or use the daemon's paired CLI"), "error should provide an actionable recovery: {error}");
+    assert!(!error.contains("failed to parse message"), "error should come from the handshake: {error}");
     server_task.await.expect("join server task");
+}
+
+#[tokio::test]
+async fn connect_rejects_daemon_protocol_version_mismatch() {
+    assert_connect_rejects_daemon_hello(PROTOCOL_VERSION - 1, "stale daemon".into(), "protocol version mismatch").await;
+}
+
+#[tokio::test]
+async fn connect_rejects_daemon_wire_generation_mismatch() {
+    assert_connect_rejects_daemon_hello(
+        PROTOCOL_VERSION,
+        flotilla_protocol::hello_display_name("stale daemon", "stale-daemon-generation"),
+        "wire generation mismatch",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -490,7 +533,7 @@ async fn dropping_socket_daemon_closes_connection_promptly() {
             .write(Message::Hello {
                 protocol_version: PROTOCOL_VERSION,
                 node_id: NodeId::new("daemon"),
-                display_name: "daemon".into(),
+                display_name: flotilla_protocol::hello_display_name("daemon", BUILD_ID),
                 session_id: uuid::Uuid::new_v4(),
                 connection_role: Some(ConnectionRole::Client),
                 surface: None,

--- a/crates/flotilla-client/src/reconnect.rs
+++ b/crates/flotilla-client/src/reconnect.rs
@@ -1,8 +1,5 @@
 use std::{future::Future, time::Duration};
 
-use flotilla_core::daemon::DaemonHandle;
-use tracing::warn;
-
 const INITIAL_DELAY: Duration = Duration::from_millis(500);
 const MAX_DELAY: Duration = Duration::from_secs(30);
 pub const REEXEC_BUILD_ENV: &str = "FLOTILLA_REEXEC_BUILD";
@@ -46,11 +43,6 @@ pub fn is_incompatible_daemon_error(error: &str) -> bool {
     error.contains("protocol version mismatch") || error.contains("wire generation mismatch")
 }
 
-pub fn build_mismatch(daemon: &dyn DaemonHandle) -> Option<String> {
-    let daemon_build = daemon.build_id()?;
-    (daemon_build != crate::BUILD_ID).then(|| format!("daemon build {daemon_build} differs from this client ({})", crate::BUILD_ID))
-}
-
 /// Connect to a daemon with the shared retry policy used by every long-lived
 /// client. Callers choose how to narrate each attempt.
 pub async fn connect_with_retry<Connect, ConnectFuture, Connected, Notify>(
@@ -79,12 +71,6 @@ where
                 attempt += 1;
             }
         }
-    }
-}
-
-pub fn warn_on_build_mismatch(daemon: &dyn DaemonHandle) {
-    if let Some(message) = build_mismatch(daemon) {
-        warn!(%message, "connected daemon and client builds differ");
     }
 }
 

--- a/crates/flotilla-client/src/reconnect.rs
+++ b/crates/flotilla-client/src/reconnect.rs
@@ -43,7 +43,7 @@ pub enum ReconnectNotice {
 }
 
 pub fn is_incompatible_daemon_error(error: &str) -> bool {
-    error.contains("protocol version mismatch")
+    error.contains("protocol version mismatch") || error.contains("wire generation mismatch")
 }
 
 pub fn build_mismatch(daemon: &dyn DaemonHandle) -> Option<String> {
@@ -136,5 +136,22 @@ mod tests {
             ReconnectNotice::Retry { attempt: 2, .. },
             ReconnectNotice::Attempt { attempt: 3 },
         ]));
+    }
+
+    #[tokio::test]
+    async fn wire_generation_mismatch_is_refused_without_retrying() {
+        let mut attempts = 0;
+        let error = connect_with_retry(
+            || {
+                attempts += 1;
+                async { Err::<(), _>("wire generation mismatch: client generation old, daemon generation new".to_string()) }
+            },
+            |_| {},
+        )
+        .await
+        .expect_err("incompatible generations should be terminal");
+
+        assert_eq!(attempts, 1);
+        assert!(error.contains("wire generation mismatch"));
     }
 }

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -544,7 +544,7 @@ async fn handle_client_session(
                     warn!(expected = PROTOCOL_VERSION, got = protocol_version, %node_id, "rejecting client with protocol version mismatch");
                     return;
                 }
-                if client_generation != BUILD_ID {
+                if !flotilla_protocol::wire_generations_match(client_generation, BUILD_ID) {
                     warn!(
                         expected = BUILD_ID,
                         got = client_generation,

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -514,11 +514,6 @@ async fn handle_client_session(
     };
 
     match first_msg {
-        Message::Request { id, request } => {
-            ClientConnection::new(daemon, shutdown_rx, remote_command_router, client_count, client_notify, agent_state_store)
-                .run(Arc::clone(&session), id, request)
-                .await;
-        }
         Message::Hello { protocol_version, node_id, display_name, session_id, connection_role, surface } => {
             if environment_context.is_some() {
                 warn!("peer/client hello on per-environment socket is unsupported");
@@ -528,8 +523,8 @@ async fn handle_client_session(
             if connection_role == Some(ConnectionRole::Client) {
                 // Stateful client handshake: reply with server Hello, then enter
                 // stateful client loop (session_id used for cursor ownership).
-                // The reply is sent even on version mismatch so the client can
-                // report which versions disagreed.
+                // The reply is sent even on a generation/version mismatch so
+                // the client can report which two binaries disagreed.
                 if session
                     .write(Message::Hello {
                         protocol_version: PROTOCOL_VERSION,
@@ -544,8 +539,18 @@ async fn handle_client_session(
                 {
                     return;
                 }
+                let client_generation = flotilla_protocol::hello_build_id(&display_name).unwrap_or("unknown");
                 if protocol_version != PROTOCOL_VERSION {
                     warn!(expected = PROTOCOL_VERSION, got = protocol_version, %node_id, "rejecting client with protocol version mismatch");
+                    return;
+                }
+                if client_generation != BUILD_ID {
+                    warn!(
+                        expected = BUILD_ID,
+                        got = client_generation,
+                        %node_id,
+                        "rejecting client with wire generation mismatch"
+                    );
                     return;
                 }
                 let surface = match surface {
@@ -563,7 +568,7 @@ async fn handle_client_session(
             }
         }
         other => {
-            warn!(msg = ?other, "unexpected first message type from client");
+            warn!(msg = ?other, "rejecting connection without Hello handshake");
         }
     }
 }

--- a/crates/flotilla-daemon/src/server/client_connection.rs
+++ b/crates/flotilla-daemon/src/server/client_connection.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use flotilla_core::{agents::SharedAgentStateStore, daemon::DaemonHandle, in_process::InProcessDaemon};
-use flotilla_protocol::{DaemonEvent, Message, QueryId, Request, SurfaceDeclaration};
+use flotilla_protocol::{DaemonEvent, Message, QueryId, SurfaceDeclaration};
 use flotilla_transport::message::MessageSession;
 use tokio::sync::{watch, Notify};
 use tracing::{error, info, warn};
@@ -37,10 +37,6 @@ pub(super) struct ClientConnection {
 }
 
 impl ClientConnection {
-    async fn default_surface(&self) -> SurfaceDeclaration {
-        SurfaceDeclaration::focal_for_namespace(self.daemon.provisioning_namespace().await)
-    }
-
     pub(super) fn new(
         daemon: Arc<InProcessDaemon>,
         shutdown_rx: watch::Receiver<bool>,
@@ -52,24 +48,10 @@ impl ClientConnection {
         Self { daemon, shutdown_rx, remote_command_router, client_count, client_notify, agent_state_store }
     }
 
-    pub(super) async fn run(self, session: Arc<MessageSession>, first_id: u64, first_request: Request) {
-        // Legacy clients without Hello handshake get a random session ID.
-        let session_id = uuid::Uuid::new_v4();
-        let surface = self.default_surface().await;
-        let (event_task, request_dispatcher, mut shutdown_rx) = self.start_session(&session, session_id, surface);
-
-        let first_response = request_dispatcher.dispatch(first_id, first_request).await;
-        if session.write(first_response).await.is_ok() {
-            request_loop(&session, &request_dispatcher, &mut shutdown_rx).await;
-        }
-
-        self.finish_session(event_task, session_id).await;
-    }
-
     /// Run a stateful client session that began with a Hello handshake.
     ///
-    /// Unlike `run`, the first message (Hello) has already been consumed and
-    /// replied to, so the loop starts by awaiting the next message.
+    /// The first message (Hello) has already been consumed and replied to, so
+    /// the loop starts by awaiting the next message.
     pub(super) async fn run_stateful(self, session: Arc<MessageSession>, client_session_id: uuid::Uuid, surface: SurfaceDeclaration) {
         let (event_task, request_dispatcher, mut shutdown_rx) = self.start_session(&session, client_session_id, surface);
         request_loop(&session, &request_dispatcher, &mut shutdown_rx).await;

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -64,70 +64,7 @@ pub async fn spawn_in_memory_request_topology(
     leader: Arc<InProcessDaemon>,
     follower: Arc<InProcessDaemon>,
 ) -> Result<InMemoryRequestTopology, String> {
-    let leader_host = leader.host_name().clone();
-    let follower_host = follower.host_name().clone();
-
-    let leader_peer_manager = Arc::new(Mutex::new(PeerManager::new(leader.node_id().clone())));
-    let follower_peer_manager = Arc::new(Mutex::new(PeerManager::new(follower.node_id().clone())));
-
-    let (leader_transport, follower_transport) = channel_transport_pair_with_nodes(
-        NodeInfo::new(leader.node_id().clone(), leader_host.to_string()),
-        NodeInfo::new(follower.node_id().clone(), follower_host.to_string()),
-    );
-    {
-        let mut pm = leader_peer_manager.lock().await;
-        pm.add_configured_target(
-            flotilla_protocol::ConfigLabel("follower".into()),
-            follower_host.clone(),
-            None,
-            Box::new(leader_transport),
-        );
-    }
-    {
-        let mut pm = follower_peer_manager.lock().await;
-        pm.add_configured_target(flotilla_protocol::ConfigLabel("leader".into()), leader_host.clone(), None, Box::new(follower_transport));
-    }
-
-    let (leader_peer_data_tx, leader_peer_data_rx) = mpsc::channel(256);
-    let (follower_peer_data_tx, follower_peer_data_rx) = mpsc::channel(256);
-    let leader_remote_router = build_remote_command_router(&leader, &leader_peer_manager);
-    let follower_remote_router = build_remote_command_router(&follower, &follower_peer_manager);
-
-    let (leader_runtime_handle, _leader_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) =
-        spawn_peer_networking_runtime(
-            Arc::clone(&leader),
-            Arc::clone(&leader_peer_manager),
-            Some(leader_peer_data_rx),
-            leader_peer_data_tx.clone(),
-            leader_remote_router.clone(),
-            None,
-        );
-    let (follower_runtime_handle, _follower_peer_connected_tx): (tokio::task::JoinHandle<()>, mpsc::UnboundedSender<PeerConnectionEvent>) =
-        spawn_peer_networking_runtime(
-            Arc::clone(&follower),
-            Arc::clone(&follower_peer_manager),
-            Some(follower_peer_data_rx),
-            follower_peer_data_tx,
-            follower_remote_router,
-            None,
-        );
-
-    let (client_session, server_session) = flotilla_transport::message::message_session_pair();
-    let client = SocketDaemon::from_session(client_session)?;
-    spawn_topology_with_client(
-        leader,
-        follower,
-        leader_host,
-        follower_host,
-        leader_peer_manager,
-        leader_peer_data_tx,
-        leader_remote_router,
-        leader_runtime_handle,
-        follower_runtime_handle,
-        server_session,
-        client,
-    )
-    .await
+    spawn_in_memory_request_topology_stateful(leader, follower).await
 }
 
 /// Like [`spawn_in_memory_request_topology`] but performs a Hello handshake so
@@ -237,77 +174,6 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
         Some(surface) => SocketDaemon::from_session_stateful_with_surface(client_session, surface).await?,
         None => SocketDaemon::from_session_stateful(client_session).await?,
     };
-
-    tokio::time::timeout(Duration::from_secs(5), async {
-        loop {
-            let leader_topology = leader.get_topology().await.map_err(|e| e.to_string())?;
-            let follower_topology = follower.get_topology().await.map_err(|e| e.to_string())?;
-            let leader_ready =
-                leader_topology.routes.iter().any(|route| route.target.node_id == follower.node_id().clone() && route.connected);
-            let follower_ready =
-                follower_topology.routes.iter().any(|route| route.target.node_id == leader.node_id().clone() && route.connected);
-            if leader_ready && follower_ready {
-                return Ok::<(), String>(());
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .map_err(|_| "timed out waiting for in-memory request topology to connect".to_string())??;
-
-    Ok(InMemoryRequestTopology {
-        leader,
-        follower,
-        client,
-        leader_host,
-        follower_host,
-        shutdown_tx,
-        _tasks: vec![leader_runtime_handle, follower_runtime_handle, client_session_handle],
-    })
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn spawn_topology_with_client(
-    leader: Arc<InProcessDaemon>,
-    follower: Arc<InProcessDaemon>,
-    leader_host: HostName,
-    follower_host: HostName,
-    leader_peer_manager: Arc<Mutex<PeerManager>>,
-    leader_peer_data_tx: mpsc::Sender<super::InboundPeerEnvelope>,
-    leader_remote_router: super::remote_commands::RemoteCommandRouter,
-    leader_runtime_handle: tokio::task::JoinHandle<()>,
-    follower_runtime_handle: tokio::task::JoinHandle<()>,
-    server_session: flotilla_transport::message::MessageSession,
-    client: Arc<SocketDaemon>,
-) -> Result<InMemoryRequestTopology, String> {
-    let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let client_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let client_notify = Arc::new(Notify::new());
-    // The in-memory request topology only needs the sender side because readiness is polled from
-    // each daemon's topology view below; peer-connected notices are intentionally ignored here.
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
-    let leader_for_client = Arc::clone(&leader);
-    let leader_peer_manager_for_client = Arc::clone(&leader_peer_manager);
-    let leader_peer_data_tx_for_client = leader_peer_data_tx;
-    let leader_remote_router_for_client = leader_remote_router;
-    let client_count_for_task = Arc::clone(&client_count);
-    let client_notify_for_task = Arc::clone(&client_notify);
-    let client_session_handle = tokio::spawn(async move {
-        handle_client_session(
-            server_session,
-            leader_for_client,
-            shutdown_rx,
-            leader_peer_data_tx_for_client,
-            leader_peer_manager_for_client,
-            leader_remote_router_for_client,
-            client_count_for_task,
-            client_notify_for_task,
-            peer_connected_tx,
-            flotilla_core::agents::shared_in_memory_agent_state_store(),
-            None,
-        )
-        .await;
-    });
 
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -430,6 +430,22 @@ async fn read_session_message(session: &MessageSession) -> Message {
     session.read().await.expect("read session message").expect("session message")
 }
 
+fn current_client_hello() -> Message {
+    Message::Hello {
+        protocol_version: PROTOCOL_VERSION,
+        node_id: NodeId::new("client"),
+        display_name: flotilla_protocol::hello_display_name("client", env!("FLOTILLA_BUILD_ID")),
+        session_id: uuid::Uuid::nil(),
+        connection_role: Some(flotilla_protocol::ConnectionRole::Client),
+        surface: None,
+    }
+}
+
+async fn complete_client_hello(session: &MessageSession) {
+    session.write(current_client_hello()).await.expect("write client hello");
+    assert!(matches!(read_session_message(session).await, Message::Hello { protocol_version: PROTOCOL_VERSION, .. }));
+}
+
 async fn empty_daemon() -> (tempfile::TempDir, Arc<InProcessDaemon>) {
     empty_daemon_named("local").await
 }
@@ -3104,6 +3120,13 @@ async fn handle_client_streams_daemon_events_to_request_clients() {
     let mut reader = BufReader::new(read_half).lines();
     let mut writer = BufWriter::new(write_half);
 
+    flotilla_protocol::framing::write_message_line(&mut writer, &current_client_hello()).await.expect("write client hello");
+    let hello_line = reader.next_line().await.expect("read hello response").expect("hello response line");
+    assert!(matches!(serde_json::from_str::<Message>(&hello_line).expect("parse hello response"), Message::Hello {
+        protocol_version: PROTOCOL_VERSION,
+        ..
+    }));
+
     let request = Message::Request { id: 1, request: Request::ListRepos };
     flotilla_protocol::framing::write_message_line(&mut writer, &request).await.expect("write request");
 
@@ -3182,6 +3205,7 @@ async fn handle_client_session_dispatches_request_messages() {
         .await;
     });
 
+    complete_client_hello(&client_session).await;
     client_session.write(Message::Request { id: 1, request: Request::ListRepos }).await.expect("write request");
 
     match ok_response(read_session_message(&client_session).await, 1) {
@@ -3226,6 +3250,7 @@ async fn handle_client_session_streams_daemon_events_to_request_clients() {
         .await;
     });
 
+    complete_client_hello(&client_session).await;
     client_session.write(Message::Request { id: 1, request: Request::ListRepos }).await.expect("write request");
 
     match ok_response(read_session_message(&client_session).await, 1) {
@@ -3262,8 +3287,7 @@ async fn handle_client_session_streams_daemon_events_to_request_clients() {
     assert_eq!(client_count.load(Ordering::SeqCst), 0, "request client should be removed after disconnect");
 }
 
-#[tokio::test]
-async fn handle_client_rejects_client_hello_with_version_mismatch() {
+async fn assert_client_hello_rejected(protocol_version: u32, display_name: String, mismatch: &str) {
     let (_tmp, daemon) = empty_daemon().await;
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
@@ -3300,9 +3324,9 @@ async fn handle_client_rejects_client_hello_with_version_mismatch() {
     let mut writer = BufWriter::new(write_half);
 
     let hello = Message::Hello {
-        protocol_version: PROTOCOL_VERSION + 1,
+        protocol_version,
         node_id: NodeId::new("client"),
-        display_name: "client".into(),
+        display_name,
         session_id: uuid::Uuid::nil(),
         connection_role: Some(flotilla_protocol::ConnectionRole::Client),
         surface: None,
@@ -3322,8 +3346,23 @@ async fn handle_client_rejects_client_hello_with_version_mismatch() {
         .await
         .expect("server should close the mismatched connection promptly")
         .expect("read after hello");
-    assert!(eof.is_none(), "expected EOF after version-mismatch hello, got {eof:?}");
+    assert!(eof.is_none(), "expected EOF after {mismatch}-mismatch hello, got {eof:?}");
     let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+}
+
+#[tokio::test]
+async fn handle_client_rejects_client_hello_with_version_mismatch() {
+    assert_client_hello_rejected(PROTOCOL_VERSION + 1, "client".into(), "version").await;
+}
+
+#[tokio::test]
+async fn handle_client_rejects_client_hello_with_wire_generation_mismatch() {
+    assert_client_hello_rejected(
+        PROTOCOL_VERSION,
+        flotilla_protocol::hello_display_name("client", "stale-client-generation"),
+        "wire generation",
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -3359,7 +3398,8 @@ async fn handle_client_session_filters_query_events_until_subscribed() {
         .await;
     });
 
-    // Establish the session (and thus the event relay) with a first request.
+    complete_client_hello(&client_session).await;
+    // Establish the event relay with a first request.
     client_session.write(Message::Request { id: 1, request: Request::ListRepos }).await.expect("write request");
     match ok_response(read_session_message(&client_session).await, 1) {
         Response::ListRepos(_) => {}

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -195,6 +195,13 @@ pub fn hello_build_id(display_name: &str) -> Option<&str> {
     display_name.rsplit_once(BUILD_ID_SEPARATOR).map(|(_, build_id)| build_id).filter(|build_id| !build_id.is_empty())
 }
 
+/// Whether two build stamps identify the same known wire generation.
+///
+/// An unknown stamp cannot prove compatibility, even when both sides report it.
+pub fn wire_generations_match(left: &str, right: &str) -> bool {
+    left != "unknown" && right != "unknown" && left == right
+}
+
 /// Key for identifying an event stream in replay cursors.
 /// Each stream has its own independent sequence counter.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/flotilla-protocol/src/lib/tests.rs
+++ b/crates/flotilla-protocol/src/lib/tests.rs
@@ -704,3 +704,11 @@ fn hello_display_name_carries_build_identity_without_changing_the_envelope() {
     assert_eq!(hello_build_id(&display_name), Some("abc123"));
     assert_eq!(hello_build_id("legacy-daemon"), None);
 }
+
+#[test]
+fn wire_generation_match_requires_equal_known_stamps() {
+    assert!(wire_generations_match("abc123", "abc123"));
+    assert!(!wire_generations_match("abc123", "def456"));
+    assert!(!wire_generations_match("unknown", "unknown"));
+    assert!(!wire_generations_match("abc123", "unknown"));
+}

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -651,7 +651,6 @@ impl App {
         views.bind_repository_keys(&repository_keys);
         model.active_repo = views.active_repo_identity().cloned();
         let mut ui = UiState::new(&model.repo_order);
-        ui.command_echo = flotilla_client::reconnect::build_mismatch(daemon.as_ref());
         let loaded_config = config.load_config();
         ui.view_layout = match loaded_config.ui.preview.layout {
             RepoViewLayoutConfig::Auto => RepoViewLayout::Auto,
@@ -801,9 +800,7 @@ impl App {
         self.pending_cancel = None;
         self.subscriptions_dirty = true;
 
-        let reconnect_note = flotilla_client::reconnect::build_mismatch(self.daemon.as_ref())
-            .map_or_else(|| "Reconnected to daemon".to_string(), |mismatch| format!("Reconnected — {mismatch}"));
-        self.ui.command_echo = Some(reconnect_note);
+        self.ui.command_echo = Some("Reconnected to daemon".to_string());
     }
 
     /// Construct an `App` in scoped mode: exactly the one View at `address`,

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -858,7 +858,6 @@ pub async fn run_watch(socket_path: &Path, format: OutputFormat) -> Result<(), S
             },
         )
         .await?;
-        flotilla_client::reconnect::warn_on_build_mismatch(daemon.as_ref());
         if let Err(error) = run_watch_connection(daemon, format).await {
             eprintln!("{error}; reconnecting...");
         }

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -55,7 +55,6 @@ where
             }
         })
         .await?;
-        flotilla_client::reconnect::warn_on_build_mismatch(daemon.as_ref());
         info!("connected to daemon");
         if let Err(error) = run_connected(daemon).await {
             info!(%error, "daemon connection ended; reconnecting");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1500,35 +1500,10 @@ async fn run_hook(cli: &Cli, harness: &str, event_type: &str) -> Result<()> {
 
 /// One-shot client: connect to daemon, send an AgentHook request, read one response, exit.
 async fn send_hook_event(socket_path: &std::path::Path, event: AgentHookEvent) -> Result<()> {
-    use flotilla_protocol::{framing, Message, Request, ResponseResult};
-    use tokio::{
-        io::{AsyncBufReadExt, BufReader},
-        net::UnixStream,
-    };
-
-    let stream = UnixStream::connect(socket_path)
+    let daemon = flotilla_tui::socket::SocketDaemon::connect(socket_path)
         .await
-        .map_err(|e| color_eyre::eyre::eyre!("failed to connect to daemon at {}: {e}", socket_path.display()))?;
-
-    let (reader, mut writer) = stream.into_split();
-
-    // Send request
-    let msg = Message::Request { id: 1, request: Request::AgentHook { event } };
-    framing::write_message_line(&mut writer, &msg).await.map_err(|e| color_eyre::eyre::eyre!("write error: {e}"))?;
-
-    // Read response
-    let mut buf_reader = BufReader::new(reader);
-    let mut line = String::new();
-    buf_reader.read_line(&mut line).await.map_err(|e| color_eyre::eyre::eyre!("read error: {e}"))?;
-
-    let response: Message = serde_json::from_str(line.trim()).map_err(|e| color_eyre::eyre::eyre!("parse response: {e}"))?;
-    match response {
-        Message::Response { response, .. } => match *response {
-            ResponseResult::Ok { .. } => Ok(()),
-            ResponseResult::Err { message } => Err(color_eyre::eyre::eyre!("daemon error: {message}")),
-        },
-        other => Err(color_eyre::eyre::eyre!("unexpected response: {other:?}")),
-    }
+        .map_err(|error| color_eyre::eyre::eyre!("failed to connect to daemon at {}: {error}", socket_path.display()))?;
+    daemon.send_agent_hook(event).await.map_err(|error| color_eyre::eyre::eyre!("daemon error: {error}"))
 }
 
 async fn run_hooks_command(command: &HooksSubCommand) -> Result<()> {


### PR DESCRIPTION
## Summary

- require the existing Hello exchange and matching build generation before accepting any client RPC payloads
- report both client and daemon generations with an actionable rebuild/paired-CLI recovery
- route one-shot agent hooks through the same generation-checked client used by CLI and TUI connections
- remove the legacy request-first server path while preserving the peer protocol handshake

## Why

A protocol version only changes when someone remembers to bump it, so independently built client and daemon binaries could deserialize the same wire payload differently. The Hello exchange already carries each binary's build stamp; this makes that stamp the mandatory wire generation and refuses mismatches before dispatch.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1195
