### PR TITLE
feat: adopt existing pull requests into convoys

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -58,6 +58,9 @@ pub enum ConvoyVerb {
         /// Project whose definitions and repository set admission snapshots
         #[arg(long)]
         project: String,
+        /// Existing pull request number to adopt
+        #[arg(long = "pr", conflicts_with = "branch", value_parser = parse_pr_number)]
+        change_request: Option<String>,
         /// Opaque external issue ID
         #[arg(long)]
         issue: Option<String>,
@@ -124,6 +127,13 @@ fn parse_input_kv(raw: &str) -> Result<(String, String), String> {
         return Err(format!("input key cannot be empty: {raw}"));
     }
     Ok((key.to_string(), value.to_string()))
+}
+
+fn parse_pr_number(raw: &str) -> Result<String, String> {
+    match raw.parse::<u64>() {
+        Ok(number) if number > 0 => Ok(number.to_string()),
+        _ => Err(format!("pull request number must be a positive integer: {raw}")),
+    }
 }
 
 fn resolve_adopted_checkout(path: PathBuf) -> Result<Box<PathBuf>, String> {
@@ -225,6 +235,7 @@ impl ConvoyNoun {
             }
             ConvoyVerb::Start {
                 project,
+                change_request,
                 issue,
                 issue_service,
                 issue_scope,
@@ -262,6 +273,7 @@ impl ConvoyNoun {
                             intent: Box::new(ConvoyStartIntent {
                                 namespace: None,
                                 project_ref: project,
+                                change_request,
                                 issues,
                                 name,
                                 branch,
@@ -294,6 +306,7 @@ impl ConvoyNoun {
                                 intent: Box::new(ConvoyStartIntent {
                                     namespace: None,
                                     project_ref: project_ref.clone(),
+                                    change_request: None,
                                     issues: Vec::new(),
                                     name: Some(name),
                                     branch: r#ref,
@@ -374,6 +387,7 @@ impl std::fmt::Display for ConvoyNoun {
             }
             ConvoyVerb::Start {
                 project,
+                change_request,
                 issue,
                 issue_service,
                 issue_scope,
@@ -387,6 +401,9 @@ impl std::fmt::Display for ConvoyNoun {
                 attach,
             } => {
                 write!(f, " start --project {}", quote_value(project))?;
+                if let Some(change_request) = change_request {
+                    write!(f, " --pr {}", quote_value(change_request))?;
+                }
                 if let Some(issue) = issue {
                     write!(f, " --issue {}", quote_value(issue))?;
                 }
@@ -611,6 +628,7 @@ mod tests {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: None,
                         project_ref: "widgets".into(),
+                        change_request: None,
                         issues: vec![IssueSelector::Reference(IssueRef {
                             source: IssueSource { service: "https://linear.app".into(), scope: "WIDGET".into() },
                             id: "WIDGET-732".into(),
@@ -645,6 +663,7 @@ mod tests {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: None,
                         project_ref: "flotilla".into(),
+                        change_request: None,
                         issues: vec![IssueSelector::Id("834".into())],
                         name: None,
                         branch: None,
@@ -674,6 +693,7 @@ mod tests {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: None,
                         project_ref: "flotilla".into(),
+                        change_request: None,
                         issues: vec![IssueSelector::Id("834".into())],
                         name: None,
                         branch: None,
@@ -688,6 +708,41 @@ mod tests {
             repo: RepoContext::None,
             host: HostResolution::Local,
         });
+    }
+
+    #[test]
+    fn convoy_start_pr_adoption_resolves_without_branch_discovery() {
+        let resolved =
+            parse(&["convoy", "start", "--project", "flotilla", "--pr", "1071", "--no-attach"]).resolve().expect("resolve PR adoption");
+
+        assert_eq!(resolved, Resolved::NeedsContext {
+            command: Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ConvoyStart {
+                    intent: Box::new(ConvoyStartIntent {
+                        namespace: None,
+                        project_ref: "flotilla".into(),
+                        change_request: Some("1071".into()),
+                        issues: Vec::new(),
+                        name: None,
+                        branch: None,
+                        workflow_ref: None,
+                        inputs: Vec::new(),
+                        instruction: None,
+                        placement_policy: None,
+                        auto_attach: ConvoyAutoAttach::Never,
+                    }),
+                },
+            },
+            repo: RepoContext::None,
+            host: HostResolution::Local,
+        });
+        assert!(
+            ConvoyNoun::try_parse_from(["convoy", "start", "--project", "flotilla", "--pr", "1071", "--branch", "feat/wrong",]).is_err(),
+            "--pr must be the branch identity authority"
+        );
     }
 
     #[test]
@@ -793,6 +848,7 @@ mod tests {
             intent: Box::new(ConvoyStartIntent {
                 namespace: None,
                 project_ref: "widgets".into(),
+                change_request: None,
                 issues: Vec::new(),
                 name: Some("project-work".into()),
                 branch: Some("fix/widgets".into()),

--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -59,7 +59,11 @@ pub enum ConvoyVerb {
         #[arg(long)]
         project: String,
         /// Existing pull request number to adopt
-        #[arg(long = "pr", conflicts_with = "branch", value_parser = parse_pr_number)]
+        #[arg(
+            long = "pr",
+            conflicts_with_all = ["branch", "issue", "issue_service", "issue_scope"],
+            value_parser = parse_pr_number
+        )]
         change_request: Option<String>,
         /// Opaque external issue ID
         #[arg(long)]
@@ -742,6 +746,10 @@ mod tests {
         assert!(
             ConvoyNoun::try_parse_from(["convoy", "start", "--project", "flotilla", "--pr", "1071", "--branch", "feat/wrong",]).is_err(),
             "--pr must be the branch identity authority"
+        );
+        assert!(
+            ConvoyNoun::try_parse_from(["convoy", "start", "--project", "flotilla", "--pr", "1071", "--issue", "42"]).is_err(),
+            "--pr adoption must remain PR-first"
         );
     }
 

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -21,7 +21,7 @@ use flotilla_resources::{
     HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy, PlacementPolicySpec, Repository,
     RepositoryIdentity, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, Stance, TerminalSession,
     TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, WorkPhase,
-    CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REFS_ENV, VESSEL_REF_LABEL,
+    CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REFS_ENV, VESSEL_REF_LABEL,
 };
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -527,7 +527,7 @@ impl Reconciler for VesselReconciler {
                             })
                         }
                         PlacementStrategy::DockerFreshCloneInContainer { .. } => CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
-                            repo_ref: repository_key,
+                            repo_ref: repository_key.clone(),
                             env_ref: precreated_environment
                                 .as_ref()
                                 .map(|(environment_ref, _)| environment_ref.clone())
@@ -539,7 +539,12 @@ impl Reconciler for VesselReconciler {
                         }),
                     };
                     let env_ref = spec.env_ref().expect("managed checkout should have an env_ref").to_string();
-                    let labels = BTreeMap::from([(ENV_LABEL.to_string(), env_ref), (REPO_KEY_LABEL.to_string(), repo_key)]);
+                    let mut labels = BTreeMap::from([(ENV_LABEL.to_string(), env_ref), (REPO_KEY_LABEL.to_string(), repo_key)]);
+                    if let Some(change_request) =
+                        convoy.spec.change_request.as_ref().filter(|change_request| change_request.repository_ref == repository_key)
+                    {
+                        labels.insert(CHANGE_REQUEST_ID_LABEL.to_string(), change_request.id.clone());
+                    }
                     let meta = match &strategy {
                         PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
                             convoy_owned_child_meta(&checkout_name, &convoy, labels)
@@ -768,6 +773,7 @@ impl Reconciler for VesselReconciler {
                             let assignment = match prompt.as_deref() {
                                 Some(prompt) => CrewAssignment::Prompt(prompt),
                                 None if !convoy.spec.issues.is_empty() => CrewAssignment::CarriedIssue,
+                                None if convoy.spec.change_request.is_some() => CrewAssignment::CarriedChangeRequest,
                                 None => CrewAssignment::Unassigned,
                             };
                             let render_options = self.brief_templates.render_options_with_fork_stance(

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -93,6 +93,7 @@ pub async fn create_convoy_with_single_task(
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -388,6 +388,7 @@ async fn controller_materializes_a_missing_repository_for_a_multi_repository_con
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -17,15 +17,15 @@ use flotilla_protocol::{IssueRef, IssueSource, IssueState};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key,
     controller::{Actuation, Reconciler},
-    ensure_repository, interactive_single_workflow_spec, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec,
-    Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyTeardownRuntime, CrewSource,
-    CrewSpec, CrewWorkPhase, CrewWorkState, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy,
-    DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, IssueSnapshot, LifecycleAuthority, ObservedCheckoutSpec,
-    PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend, ResourceError, Selector, Stance, TerminalBrief, TerminalCrewContext,
-    TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel, VesselPhase,
-    VesselRequirement, VesselSpec, VesselStatus, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
-    CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    ensure_repository, interactive_single_workflow_spec, BoundChangeRequest, Checkout, CheckoutPhase, CheckoutSpec, CheckoutStatus,
+    CheckoutWorktreeSpec, Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
+    ConvoyTeardownRuntime, CrewSource, CrewSpec, CrewWorkPhase, CrewWorkState, DockerCheckoutStrategy, DockerEnvironmentSpec,
+    DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, HostDirectEnvironmentSpec,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InnerCommandStatus, InputMeta, IssueSnapshot, LifecycleAuthority,
+    ObservedCheckoutSpec, PlacementPolicySpec, Repository, RepositorySpec, ResourceBackend, ResourceError, Selector, Stance, TerminalBrief,
+    TerminalCrewContext, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, Vessel,
+    VesselPhase, VesselRequirement, VesselSpec, VesselStatus, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
+    CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL, CREW_ORDINAL_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 use rstest::rstest;
 
@@ -59,6 +59,7 @@ async fn repositoryless_vessel_runs_tools_without_provisioning_a_checkout() {
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await
@@ -205,6 +206,15 @@ async fn sequential_vessels_share_a_convoy_owned_worktree_checkout() {
         .update_status("convoy-shared", &convoy.metadata.resource_version, &status)
         .await
         .expect("second vessel should be recorded");
+    let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+    let current = convoys.get("convoy-shared").await.expect("convoy after status update");
+    let mut spec = current.spec.clone();
+    spec.change_request = Some(BoundChangeRequest {
+        id: "1071".to_string(),
+        repository_ref: spec.repositories[0].repo_ref.clone(),
+        title: "Existing PR".to_string(),
+    });
+    convoys.update(&InputMeta::from(&current.metadata), &current.metadata.resource_version, &spec).await.expect("bind change request");
     create_host_direct_policy(&backend, NAMESPACE, "policy-shared", HOST_REF, "cleat").await;
     create_ready_host_direct_environment(&backend, NAMESPACE, HOST_REF, "/Users/alice/dev/flotilla-repos").await;
     let clone_name =
@@ -228,6 +238,7 @@ async fn sequential_vessels_share_a_convoy_owned_worktree_checkout() {
         .expect("first vessel should create the shared checkout");
     assert_eq!(checkout_meta.name, "checkout-convoy-shared");
     assert_eq!(checkout_meta.labels.get(CONVOY_LABEL).map(String::as_str), Some("convoy-shared"));
+    assert_eq!(checkout_meta.labels.get(CHANGE_REQUEST_ID_LABEL).map(String::as_str), Some("1071"));
     assert!(!checkout_meta.labels.contains_key(VESSEL_REF_LABEL));
 
     let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
@@ -422,6 +433,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
                     },
                 },
             ],
+            change_request: None,
             instruction: Some("Keep the public seam stable.".into()),
         })
         .await
@@ -599,6 +611,7 @@ async fn multi_repository_docker_mounts_the_shared_workspace_root_once() {
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await
@@ -754,6 +767,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await
@@ -869,6 +883,7 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
             project_ref: Some("flotilla-suite".to_string()),
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await
@@ -1694,6 +1709,7 @@ async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
                     as_of: "2026-07-22T09:30:00Z".parse().expect("timestamp"),
                 },
             }],
+            change_request: None,
             instruction: None,
         })
         .await
@@ -2092,6 +2108,7 @@ async fn create_convoy_with_labeled_processes(
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -21,6 +21,7 @@ pub const DEFAULT_CREW_BRIEF_TEMPLATE: &str = "crew.md";
 const BUILTIN_CREW_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/crew.md");
 const BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/interactive-session.md");
 const BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/diff-review.md");
+const BUILTIN_SHEPHERD_BRIEF_TEMPLATE: &str = include_str!("agent_adapter/templates/shepherd.md");
 const BUILTIN_FORK_STANCE_BRIEF_LAYER: &str = include_str!("agent_adapter/templates/fork-stance.md");
 const BRIEF_TEMPLATE_DIR: &str = "brief-templates";
 
@@ -51,6 +52,9 @@ pub enum CrewAssignment<'a> {
     /// The convoy carries issue snapshots appended below the brief; those issues
     /// are the assignment.
     CarriedIssue,
+    /// The convoy carries an explicitly bound change request in its work
+    /// context; that request is the assignment.
+    CarriedChangeRequest,
     /// Nothing was provided.
     Unassigned,
 }
@@ -85,6 +89,7 @@ impl CrewBriefTemplateResolver {
         let override_filename = match template {
             "interactive-session" => "interactive-session.md",
             "diff-review" => "diff-review.md",
+            "shepherd" => "shepherd.md",
             other => other,
         };
         let mut overrides = Vec::new();
@@ -165,6 +170,8 @@ pub fn build_crew_brief_with_options(
         CrewAssignment::Prompt(prompt) => prompt,
         CrewAssignment::CarriedIssue =>
             "Your assignment is the issue snapshot section below. Its body is the contract: work it to completion and deliver as described above.",
+        CrewAssignment::CarriedChangeRequest =>
+            "Your assignment is the bound pull request in the work context below. Work that pull request to the completion standard described above.",
         CrewAssignment::Unassigned =>
             "No assignment was provided with this dispatch. Check `## Human instruction` below if present; otherwise report via `flotilla crew fail` rather than inventing work.",
     };
@@ -191,11 +198,14 @@ fn render_crew_brief_template(options: &CrewBriefRenderOptions, context: &CrewBr
         .map_err(|err| format!("load built-in interactive-session brief template: {err}"))?;
     env.add_template(BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE_NAME, BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE)
         .map_err(|err| format!("load built-in diff-review brief template: {err}"))?;
+    env.add_template(BUILTIN_SHEPHERD_BRIEF_TEMPLATE_NAME, BUILTIN_SHEPHERD_BRIEF_TEMPLATE)
+        .map_err(|err| format!("load built-in shepherd brief template: {err}"))?;
     let mut skip_overrides = 0;
     let mut current_template = match options.template.as_str() {
         DEFAULT_CREW_BRIEF_TEMPLATE => BUILTIN_CREW_BRIEF_TEMPLATE_NAME.to_string(),
         "interactive-session" | "interactive-session.md" => BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME.to_string(),
         "diff-review" | "diff-review.md" => BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE_NAME.to_string(),
+        "shepherd" | "shepherd.md" => BUILTIN_SHEPHERD_BRIEF_TEMPLATE_NAME.to_string(),
         custom if !options.overrides.is_empty() => {
             let first = &options.overrides[0];
             if is_block_only_override(&first.source) {
@@ -231,6 +241,7 @@ fn render_crew_brief_template(options: &CrewBriefRenderOptions, context: &CrewBr
 const BUILTIN_CREW_BRIEF_TEMPLATE_NAME: &str = "builtin/crew.md";
 const BUILTIN_INTERACTIVE_SESSION_BRIEF_TEMPLATE_NAME: &str = "builtin/interactive-session.md";
 const BUILTIN_DIFF_REVIEW_BRIEF_TEMPLATE_NAME: &str = "builtin/diff-review.md";
+const BUILTIN_SHEPHERD_BRIEF_TEMPLATE_NAME: &str = "builtin/shepherd.md";
 
 fn layered_override_source(parent: &str, source: &str) -> String {
     if !is_block_only_override(source) {
@@ -263,6 +274,12 @@ pub fn append_convoy_work_context(
     content.push_str("- Repositories:\n");
     for repository in convoy.spec.repositories.iter().filter(|repository| repository_refs.contains(&repository.repo_ref)) {
         content.push_str(&format!("  - `{}` — {} (target `{}`)\n", repository.repo_ref, repository.url, repository.target_ref));
+    }
+    if let Some(change_request) = &convoy.spec.change_request {
+        content.push_str(&format!(
+            "- Bound pull request: `#{}` — {} (`{}`)\n",
+            change_request.id, change_request.title, change_request.repository_ref
+        ));
     }
     if !convoy.spec.issues.is_empty() {
         let header = if convoy.spec.issues.len() == 1 { "Issue snapshot" } else { "Issue snapshots" };
@@ -794,6 +811,32 @@ mod tests {
     }
 
     #[test]
+    fn shepherd_template_processes_exactly_one_round_and_yields() {
+        let brief = build_crew_brief_with_options(
+            &TerminalCrewContext {
+                namespace: "flotilla".to_string(),
+                convoy: "adopt-1071".to_string(),
+                vessel_ref: "adopt-1071-work".to_string(),
+            },
+            "work",
+            "shepherd",
+            CrewAssignment::Unassigned,
+            &[CrewBriefMember { role: "shepherd".to_string(), state: "active".to_string(), is_agent: true }],
+            &CrewBriefRenderOptions { template: "shepherd".to_string(), overrides: Vec::new(), fork_stance: false },
+        )
+        .expect("render shepherd brief")
+        .content;
+
+        assert!(brief.contains("exactly one review and CI round"));
+        assert!(brief.contains("Finish, don't redo"));
+        assert!(brief.contains("`pr-shepherd` skill"));
+        assert!(brief.contains("Future events belong to a later engagement"));
+        assert!(brief.contains("flotilla crew complete --message '<PR URL>'"));
+        assert!(!brief.contains("wait-for-checks"));
+        assert!(!brief.contains("No assignment was provided"));
+    }
+
+    #[test]
     fn extensionless_interactive_template_uses_markdown_override_filename() {
         let temp = tempfile::tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
@@ -889,6 +932,13 @@ mod tests {
     }
 
     #[test]
+    fn carried_change_request_assignment_points_at_the_bound_pr() {
+        let content = brief_for(CrewAssignment::CarriedChangeRequest);
+        assert!(content.contains("Your assignment is the bound pull request in the work context below."));
+        assert!(!content.contains("No assignment was provided"));
+    }
+
+    #[test]
     fn convoy_work_context_separates_multiple_issue_snapshots() {
         let repo_ref = RepositoryKey("repo_widgets".to_string());
         let source = IssueSource { service: "https://github.com".to_string(), scope: "flotilla-org/flotilla".to_string() };
@@ -933,6 +983,11 @@ mod tests {
                 project_ref: None,
                 adopted_checkout_refs: BTreeMap::new(),
                 issues: vec![issue("809", "First issue", "First issue body."), issue("810", "Second issue", "Second issue body.")],
+                change_request: Some(flotilla_resources::BoundChangeRequest {
+                    id: "1071".to_string(),
+                    repository_ref: repo_ref.clone(),
+                    title: "Existing pull request".to_string(),
+                }),
                 instruction: None,
             },
             status: None,
@@ -941,6 +996,7 @@ mod tests {
         append_convoy_work_context(&mut content, &convoy, &[repo_ref]);
 
         assert!(content.contains("- `repo_widgets` — https://github.com/flotilla-org/flotilla (target `main`)"));
+        assert!(content.contains("- Bound pull request: `#1071` — Existing pull request (`repo_widgets`)"));
         assert!(content.contains("First issue body.\n\nSource-qualified reference: `https://github.com` / `flotilla-org/flotilla` / `810`"));
     }
 

--- a/crates/flotilla-core/src/agent_adapter/templates/shepherd.md
+++ b/crates/flotilla-core/src/agent_adapter/templates/shepherd.md
@@ -1,0 +1,5 @@
+{% extends "builtin/crew.md" %}
+{% block operating_instructions %}{{ super() }}This engagement is exactly one review and CI round. Finish, don't redo: use the `pr-shepherd` skill to process the reviews, check results, conflicts, and fixes that are present when this engagement begins. Future events belong to a later engagement.
+{% endblock %}
+{% block delivery %}Report what this round changed and the bound pull request's current readiness, then yield with `flotilla crew complete --message '<PR URL>'`. Do not merge the pull request. Run the completion command as your final act so the convoy returns to Landing.{% endblock %}
+{% block assignment %}Finish, don't redo. Process this round's reviews and CI for the bound pull request using the `pr-shepherd` skill, report the result, and yield.{% endblock %}

--- a/crates/flotilla-core/src/checkout_integration.rs
+++ b/crates/flotilla-core/src/checkout_integration.rs
@@ -58,12 +58,20 @@ pub async fn inspect_checkout_integration(
     runner: &dyn CommandRunner,
     checkout_path: &Path,
     spec: &CheckoutSpec,
+    change_request_id: Option<&str>,
 ) -> CheckoutIntegrationStatus {
     let observed_at = Utc::now().to_rfc3339();
     let clean = inspect_clean(runner, checkout_path, &observed_at).await;
     let pushed = inspect_pushed(runner, checkout_path, &observed_at).await;
-    let (landed, landed_evidence) =
-        inspect_landed(runner, checkout_path, checkout_branch_from_spec(spec), checkout_base_ref_from_spec(spec), &observed_at).await;
+    let (landed, landed_evidence) = inspect_landed(
+        runner,
+        checkout_path,
+        checkout_branch_from_spec(spec),
+        checkout_base_ref_from_spec(spec),
+        change_request_id,
+        &observed_at,
+    )
+    .await;
     CheckoutIntegrationStatus { clean, pushed, landed, landed_evidence }
 }
 
@@ -232,6 +240,7 @@ async fn inspect_landed(
     checkout_path: &Path,
     branch: &str,
     base_ref: Option<&str>,
+    change_request_id: Option<&str>,
     observed_at: &str,
 ) -> (IntegrationCondition, Option<LandedEvidence>) {
     // Git evidence first: a branch with no commits beyond its base has
@@ -239,63 +248,68 @@ async fn inspect_landed(
     // all. This keeps untouched checkouts landable in environments where `gh`
     // is absent or unauthenticated.
     let comparison = compare_branch_to_base(runner, checkout_path, base_ref).await;
-    if let BaseComparison::Counted { base_ref, count: 0 } = &comparison {
-        return (
-            IntegrationCondition::builder()
-                .value(ConditionValue::True)
-                .details(vec![format!("branch has no commits beyond {base_ref}")])
-                .observed_at(observed_at.to_string())
-                .build(),
-            None,
-        );
+    if change_request_id.is_none() {
+        if let BaseComparison::Counted { base_ref, count: 0 } = &comparison {
+            return (
+                IntegrationCondition::builder()
+                    .value(ConditionValue::True)
+                    .details(vec![format!("branch has no commits beyond {base_ref}")])
+                    .observed_at(observed_at.to_string())
+                    .build(),
+                None,
+            );
+        }
     }
-    match runner
-        .run_output(
-            "gh",
-            &["pr", "list", "--head", branch, "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
-            checkout_path,
-            &ChannelLabel::Noop,
-        )
-        .await
-    {
+    let args = match change_request_id {
+        Some(id) => vec!["pr", "view", id, "--json", "number,state,mergedAt,baseRefName"],
+        None => vec!["pr", "list", "--head", branch, "--state", "all", "--json", "number,state,mergedAt,baseRefName", "--limit", "1"],
+    };
+    match runner.run_output("gh", &args, checkout_path, &ChannelLabel::Noop).await {
         Ok(output) if output.success => match serde_json::from_str::<serde_json::Value>(&output.stdout) {
-            Ok(serde_json::Value::Array(items)) => match items.first() {
-                Some(item) => {
-                    let number =
-                        item.get("number").and_then(serde_json::Value::as_i64).map(|number| number.to_string()).unwrap_or_default();
-                    let state = item.get("state").and_then(serde_json::Value::as_str).unwrap_or("unknown");
-                    let merged_at = item.get("mergedAt").and_then(serde_json::Value::as_str).filter(|value| !value.is_empty());
-                    let target_ref = item.get("baseRefName").and_then(serde_json::Value::as_str).filter(|value| !value.is_empty());
-                    if state.eq_ignore_ascii_case("MERGED") || state.eq_ignore_ascii_case("CLOSED") || merged_at.is_some() {
-                        let outcome = if state.eq_ignore_ascii_case("CLOSED") && merged_at.is_none() { "closed" } else { "merged" };
-                        (
-                            IntegrationCondition::builder()
-                                .value(ConditionValue::True)
-                                .details(vec![format!("PR #{number} {outcome}")])
-                                .observed_at(observed_at.to_string())
-                                .build(),
-                            Some(
-                                LandedEvidence::builder()
-                                    .change_request_id(number)
-                                    .maybe_merged_at(merged_at.map(str::to_string))
-                                    .maybe_target_ref(if outcome == "merged" { target_ref.map(str::to_string) } else { None })
+            Ok(value) => {
+                let item = match value {
+                    serde_json::Value::Array(items) => items.into_iter().next(),
+                    serde_json::Value::Object(_) => Some(value),
+                    _ => None,
+                };
+                match item {
+                    Some(item) => {
+                        let number =
+                            item.get("number").and_then(serde_json::Value::as_i64).map(|number| number.to_string()).unwrap_or_default();
+                        let state = item.get("state").and_then(serde_json::Value::as_str).unwrap_or("unknown");
+                        let merged_at = item.get("mergedAt").and_then(serde_json::Value::as_str).filter(|value| !value.is_empty());
+                        let target_ref = item.get("baseRefName").and_then(serde_json::Value::as_str).filter(|value| !value.is_empty());
+                        if state.eq_ignore_ascii_case("MERGED") || state.eq_ignore_ascii_case("CLOSED") || merged_at.is_some() {
+                            let outcome = if state.eq_ignore_ascii_case("CLOSED") && merged_at.is_none() { "closed" } else { "merged" };
+                            (
+                                IntegrationCondition::builder()
+                                    .value(ConditionValue::True)
+                                    .details(vec![format!("PR #{number} {outcome}")])
+                                    .observed_at(observed_at.to_string())
                                     .build(),
-                            ),
-                        )
-                    } else {
-                        (
-                            IntegrationCondition::builder()
-                                .value(ConditionValue::False)
-                                .details(vec![format!("PR #{number} {state}, not merged")])
-                                .observed_at(observed_at.to_string())
-                                .build(),
-                            None,
-                        )
+                                Some(
+                                    LandedEvidence::builder()
+                                        .change_request_id(number)
+                                        .maybe_merged_at(merged_at.map(str::to_string))
+                                        .maybe_target_ref(if outcome == "merged" { target_ref.map(str::to_string) } else { None })
+                                        .build(),
+                                ),
+                            )
+                        } else {
+                            (
+                                IntegrationCondition::builder()
+                                    .value(ConditionValue::False)
+                                    .details(vec![format!("PR #{number} {state}, not merged")])
+                                    .observed_at(observed_at.to_string())
+                                    .build(),
+                                None,
+                            )
+                        }
                     }
+                    None => (landed_without_change_request(&comparison, observed_at), None),
                 }
-                None => (landed_without_change_request(&comparison, observed_at), None),
-            },
-            Ok(_) | Err(_) => (
+            }
+            Err(_) => (
                 IntegrationCondition::builder()
                     .value(ConditionValue::Unknown)
                     .details(vec!["could not parse gh PR lookup output".to_string()])
@@ -394,7 +408,7 @@ mod tests {
 
     async fn landed_with_responses(responses: Vec<Result<String, String>>) -> IntegrationCondition {
         let runner = MockRunner::new(responses);
-        let (landed, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), "2026-07-27T00:00:00Z").await;
+        let (landed, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
         landed
     }
 
@@ -429,6 +443,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bound_change_request_landing_is_keyed_by_id_instead_of_branch() {
+        let runner = MockRunner::new(vec![
+            Ok("0".into()),
+            Ok(r#"{"number":1071,"state":"MERGED","mergedAt":"2026-07-27T12:00:00Z","baseRefName":"main"}"#.into()),
+        ]);
+        let (landed, evidence) =
+            inspect_landed(&runner, Path::new("/checkout"), "renamed-head", Some("main"), Some("1071"), "2026-07-27T00:00:00Z").await;
+
+        assert_eq!(landed.value, ConditionValue::True);
+        assert_eq!(evidence.as_ref().map(|evidence| evidence.change_request_id.as_str()), Some("1071"));
+        assert_eq!(evidence.as_ref().and_then(|evidence| evidence.target_ref.as_deref()), Some("main"));
+        assert_eq!(
+            runner.calls()[1],
+            ("gh".to_string(), vec![
+                "pr".to_string(),
+                "view".to_string(),
+                "1071".to_string(),
+                "--json".to_string(),
+                "number,state,mergedAt,baseRefName".to_string(),
+            ],)
+        );
+    }
+
+    #[tokio::test]
     async fn merged_change_request_is_landed() {
         let landed = landed_with_responses(vec![
             Ok("2".into()),
@@ -441,7 +479,7 @@ mod tests {
     #[tokio::test]
     async fn indeterminate_base_without_change_request_is_unknown() {
         let runner = MockRunner::new(vec![Err("fatal: ambiguous argument".into()), Ok("[]".into())]);
-        let (landed, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", None, "2026-07-27T00:00:00Z").await;
+        let (landed, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", None, None, "2026-07-27T00:00:00Z").await;
         assert_eq!(landed.value, ConditionValue::Unknown);
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4133,6 +4133,9 @@ impl InProcessDaemon {
         if intent.change_request.is_some() && intent.branch.is_some() {
             return Err("change request adoption derives the branch from --pr; do not also provide a branch".to_string());
         }
+        if intent.change_request.is_some() && !intent.issues.is_empty() {
+            return Err("change request adoption is PR-first; do not also provide issues".to_string());
+        }
         let change_request = match intent.change_request.as_deref() {
             Some(id) => {
                 let id = required_admission_value(id, "change request")?;

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -36,18 +36,19 @@ use flotilla_resources::{
     apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
     list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
     resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
-    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
-    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Clock,
-    ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant,
-    CredentialSpec, CrewSource, Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta,
-    InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
-    ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
-    SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
-    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
-    Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
-    CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
+    CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
+    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewSource, Environment as ResourceEnvironment, EnvironmentPhase,
+    Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
+    InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
+    ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
+    ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
+    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL,
+    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -1350,6 +1351,7 @@ fn handoff_crew_brief(
     let assignment = match prompt {
         Some(prompt) => crate::agent_adapter::CrewAssignment::Prompt(prompt),
         None if !convoy.spec.issues.is_empty() => crate::agent_adapter::CrewAssignment::CarriedIssue,
+        None if convoy.spec.change_request.is_some() => crate::agent_adapter::CrewAssignment::CarriedChangeRequest,
         None => crate::agent_adapter::CrewAssignment::Unassigned,
     };
     let brief = crate::agent_adapter::build_crew_brief_with_options(
@@ -1472,6 +1474,7 @@ struct ConvoyStartKey {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum ConvoyStartSubject {
+    ChangeRequest(String),
     Issues(Vec<flotilla_protocol::IssueSelector>),
     Name(String),
     Anonymous {
@@ -1485,7 +1488,9 @@ enum ConvoyStartSubject {
 
 impl ConvoyStartKey {
     fn new(namespace: String, intent: &flotilla_protocol::ConvoyStartIntent) -> Self {
-        let subject = if intent.issues.is_empty() {
+        let subject = if let Some(change_request) = &intent.change_request {
+            ConvoyStartSubject::ChangeRequest(change_request.clone())
+        } else if intent.issues.is_empty() {
             match &intent.name {
                 Some(name) => ConvoyStartSubject::Name(name.clone()),
                 None => ConvoyStartSubject::Anonymous {
@@ -1501,6 +1506,12 @@ impl ConvoyStartKey {
         };
         Self { namespace, project_ref: intent.project_ref.clone(), subject }
     }
+}
+
+struct ResolvedConvoyChangeRequestAdmission {
+    binding: BoundChangeRequest,
+    branch: String,
+    base_ref: String,
 }
 
 fn convoy_start_failure(convoy: &ResourceObject<ResourceConvoy>) -> Option<String> {
@@ -2213,7 +2224,13 @@ impl InProcessDaemon {
                 continue;
             };
             let runner = self.runner_for_resource_checkout(&checkout).await?;
-            let mut integration = inspect_checkout_integration(&*runner, Path::new(path), &checkout.spec).await;
+            let mut integration = inspect_checkout_integration(
+                &*runner,
+                Path::new(path),
+                &checkout.spec,
+                checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
+            )
+            .await;
             if let Some(existing) = checkout
                 .status
                 .as_ref()
@@ -2815,12 +2832,86 @@ impl InProcessDaemon {
         Some((providers, state.local_data_version()))
     }
 
+    /// Resolve an explicitly requested change request across the project's
+    /// snapshotted repositories and capture its admission identity.
+    async fn resolve_convoy_change_request_admission(
+        &self,
+        repository_keys: &[RepositoryKey],
+        requested_id: &str,
+    ) -> Result<ResolvedConvoyChangeRequestAdmission, String> {
+        let candidates = {
+            let keys_by_path = self.repository_keys_by_path.read().await;
+            let repos = self.repos.read().await;
+            let order = self.repo_order.read().await;
+            let mut seen = HashSet::new();
+            let mut candidates = Vec::new();
+            for identity in order.iter() {
+                let Some(state) = repos.get(identity) else { continue };
+                for root in &state.roots {
+                    let Some(repository) = keys_by_path.get(&root.path).filter(|repository| repository_keys.contains(repository)) else {
+                        continue;
+                    };
+                    if seen.contains(repository) {
+                        continue;
+                    }
+                    let providers =
+                        root.model.registry.change_requests.iter().map(|(_, provider)| Arc::clone(provider)).collect::<Vec<_>>();
+                    if !providers.is_empty() {
+                        seen.insert(repository.clone());
+                        candidates.push((repository.clone(), root.path.clone(), providers));
+                    }
+                }
+            }
+            candidates
+        };
+
+        let mut matches = Vec::new();
+        let mut failures = Vec::new();
+        for (repository, path, providers) in candidates {
+            let mut matched = None;
+            for provider in providers {
+                match provider.get_change_request_for_admission(&path, requested_id).await {
+                    Ok(admission) => {
+                        let Some(base_ref) = admission.base_ref else {
+                            failures.push(format!("repository {repository}: change request {} did not report a base ref", admission.id));
+                            continue;
+                        };
+                        matched = Some(ResolvedConvoyChangeRequestAdmission {
+                            binding: BoundChangeRequest {
+                                id: admission.id,
+                                repository_ref: repository.clone(),
+                                title: admission.change_request.title,
+                            },
+                            branch: admission.change_request.branch,
+                            base_ref,
+                        });
+                        break;
+                    }
+                    Err(error) => failures.push(format!("repository {repository}: {error}")),
+                }
+            }
+            if let Some(matched) = matched {
+                matches.push(matched);
+            }
+        }
+
+        match matches.len() {
+            1 => Ok(matches.remove(0)),
+            0 => Err(format!(
+                "change request {requested_id} was not found in project repositories{}",
+                if failures.is_empty() { String::new() } else { format!(": {}", failures.join("; ")) }
+            )),
+            count => Err(format!("change request {requested_id} is ambiguous across {count} project repositories")),
+        }
+    }
+
     /// Resolve the first change request whose head matches a convoy branch
     /// across the convoy's snapshotted repositories.
     pub async fn resolve_convoy_change_request(
         &self,
         repository_keys: &[RepositoryKey],
         branch: &str,
+        change_request_id: Option<&str>,
     ) -> Result<Option<ConvoyChangeRequest>, String> {
         let (live_candidates, cached_candidates) = {
             let keys_by_path = self.repository_keys_by_path.read().await;
@@ -2855,9 +2946,10 @@ impl InProcessDaemon {
                     }
                 }
 
-                if let Some((id, request)) =
-                    state.cached_snapshot().and_then(|snapshot| cached_change_request_by_branch(&snapshot.providers, branch))
-                {
+                if let Some((id, request)) = state.cached_snapshot().and_then(|snapshot| match change_request_id {
+                    Some(id) => snapshot.providers.change_requests.get(id).cloned().map(|request| (id.to_string(), request)),
+                    None => cached_change_request_by_branch(&snapshot.providers, branch),
+                }) {
                     cached_by_key.entry(repository).or_insert((id, request));
                 }
             }
@@ -2876,7 +2968,11 @@ impl InProcessDaemon {
         let mut first_error = None;
         for (repository, path, providers) in live_candidates {
             for provider in providers {
-                match provider.find_change_request_by_branch(&path, branch).await {
+                let resolved = match change_request_id {
+                    Some(id) => provider.get_change_request(&path, id).await.map(Some),
+                    None => provider.find_change_request_by_branch(&path, branch).await,
+                };
+                match resolved {
                     Ok(Some((id, request))) => {
                         return Ok(Some(ConvoyChangeRequest { id, status: request.status, repository_key: repository }));
                     }
@@ -3395,6 +3491,7 @@ async fn ensure_default_workflows(backend: &ResourceBackend, namespace: &str) ->
     let templates = backend.clone().using::<WorkflowTemplate>(namespace);
     for (name, spec) in [
         ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
+        ("single-agent-shepherd", flotilla_resources::single_agent_shepherd_workflow_spec()),
         ("single-agent-trusted", flotilla_resources::single_agent_trusted_workflow_spec()),
         ("implement-review", flotilla_resources::implement_review_workflow_spec()),
     ] {
@@ -4032,7 +4129,29 @@ impl InProcessDaemon {
             .get(project_ref)
             .await
             .map_err(|error| project_not_ready_error(namespace, project_ref, error))?;
-        let repositories = self.snapshot_project_repositories(namespace, project_ref).await?;
+        let mut repositories = self.snapshot_project_repositories(namespace, project_ref).await?;
+        if intent.change_request.is_some() && intent.branch.is_some() {
+            return Err("change request adoption derives the branch from --pr; do not also provide a branch".to_string());
+        }
+        let change_request = match intent.change_request.as_deref() {
+            Some(id) => {
+                let id = required_admission_value(id, "change request")?;
+                let resolved = self
+                    .resolve_convoy_change_request_admission(
+                        &repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<Vec<_>>(),
+                        id,
+                    )
+                    .await?;
+                let repository = repositories
+                    .iter_mut()
+                    .find(|repository| repository.repo_ref == resolved.binding.repository_ref)
+                    .expect("admission resolution only returns project repositories");
+                repository.source_ref = resolved.base_ref.clone();
+                repository.target_ref = resolved.base_ref.clone();
+                Some(resolved)
+            }
+            None => None,
+        };
         let mut seen_issue_selectors = HashSet::new();
         let mut issues = Vec::with_capacity(intent.issues.len());
         for selector in &intent.issues {
@@ -4042,6 +4161,7 @@ impl InProcessDaemon {
         }
         let workflow_ref = match intent.workflow_ref.as_deref() {
             Some(workflow_ref) => required_admission_value(workflow_ref, "workflow")?.to_string(),
+            None if change_request.is_some() => "single-agent-shepherd".to_string(),
             None => project.spec.default_workflow_ref.clone(),
         };
         let mut workflow = self
@@ -4054,8 +4174,11 @@ impl InProcessDaemon {
         validate_fork_workflow_admission(&self.resource_backend, namespace, &repositories, &workflow_ref, &workflow.spec).await?;
         resolve_workflow_credentials(&self.resource_backend, namespace, Some(project_ref), &repositories, &mut workflow.spec).await?;
 
-        let fallback_slug = convoy_issues_fallback_slug(&issues, &project.spec.display_name, project_ref);
-        let generated = if intent.name.is_none() || intent.branch.is_none() {
+        let fallback_slug = change_request
+            .as_ref()
+            .map(|change_request| convoy_fallback_slug(&change_request.binding.title, &change_request.binding.id))
+            .unwrap_or_else(|| convoy_issues_fallback_slug(&issues, &project.spec.display_name, project_ref));
+        let generated = if change_request.is_none() && (intent.name.is_none() || intent.branch.is_none()) {
             let issue_context = (!issues.is_empty()).then(|| issues.iter().map(convoy_issue_name_context).collect::<Vec<_>>().join("\n\n"));
             let context = [
                 Some(format!("Project: {}", project.spec.display_name)),
@@ -4081,9 +4204,11 @@ impl InProcessDaemon {
             .transpose()?
             .unwrap_or_else(|| convoy_fallback_slug(&generated.name, "").trim_end_matches('-').to_string());
         validate_convoy_name(&name)?;
-        let branch = match intent.branch.as_deref() {
-            Some(branch) => required_admission_value(branch, "branch")?.to_string(),
-            None => required_admission_value(&generated.branch, "generated branch")?.to_string(),
+        let branch = match (change_request.as_ref(), intent.branch.as_deref()) {
+            (Some(change_request), None) => change_request.branch.clone(),
+            (Some(_), Some(_)) => unreachable!("change request plus branch was rejected"),
+            (None, Some(branch)) => required_admission_value(branch, "branch")?.to_string(),
+            (None, None) => required_admission_value(&generated.branch, "generated branch")?.to_string(),
         };
         validate_convoy_branch(&branch)?;
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
@@ -4112,6 +4237,7 @@ impl InProcessDaemon {
             project_ref: Some(project_ref.to_string()),
             adopted_checkout_refs: BTreeMap::new(),
             issues,
+            change_request: change_request.map(|change_request| change_request.binding),
             instruction: intent.instruction.clone(),
         };
         Ok(ConvoyAdmission::builder()
@@ -5776,7 +5902,13 @@ impl InProcessDaemon {
                 Ok(runner) => runner,
                 Err(_) => return Ok(false),
             };
-            let integration = inspect_checkout_integration(&*runner, &path, &checkout.spec).await;
+            let integration = inspect_checkout_integration(
+                &*runner,
+                &path,
+                &checkout.spec,
+                checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
+            )
+            .await;
             if let Err(error) = apply_resource_status_patch(
                 &checkouts,
                 &checkout.metadata.name,
@@ -5867,7 +5999,13 @@ impl InProcessDaemon {
                     continue;
                 }
             }
-            let mut integration = inspect_checkout_integration(&*runner, &path, &checkout.spec).await;
+            let mut integration = inspect_checkout_integration(
+                &*runner,
+                &path,
+                &checkout.spec,
+                checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
+            )
+            .await;
             if let Some(existing) = checkout
                 .status
                 .as_ref()
@@ -7497,6 +7635,7 @@ impl InProcessDaemon {
                 project_ref: project_ref.clone(),
                 adopted_checkout_refs,
                 issues: Vec::new(),
+                change_request: None,
                 instruction: None,
             };
             let result = match self

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1039,6 +1039,7 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await
@@ -3898,7 +3899,7 @@ async fn convoy_change_request_resolves_from_peer_data_for_virtual_repo() {
         .expect("add virtual repo");
 
     let resolved = daemon
-        .resolve_convoy_change_request(std::slice::from_ref(&repository_key), "fix/remote-pr-ref")
+        .resolve_convoy_change_request(std::slice::from_ref(&repository_key), "fix/remote-pr-ref", None)
         .await
         .expect("resolve change request")
         .expect("peer-backed change request");
@@ -4100,6 +4101,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await
@@ -4666,6 +4668,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await

--- a/crates/flotilla-core/src/providers/change_request/github.rs
+++ b/crates/flotilla-core/src/providers/change_request/github.rs
@@ -22,6 +22,7 @@ struct GhPr {
     number: i64,
     title: String,
     head_ref_name: String,
+    base_ref_name: Option<String>,
     state: String,
     body: Option<String>,
     is_draft: bool,
@@ -72,6 +73,7 @@ impl GitHubChangeRequest {
                 .number(value["number"].as_i64()?)
                 .title(value["title"].as_str()?.to_string())
                 .head_ref_name(value["head"]["ref"].as_str()?.to_string())
+                .maybe_base_ref_name(value["base"]["ref"].as_str().map(str::to_string))
                 .state(value["state"].as_str().unwrap_or("open").to_string())
                 .maybe_body(value["body"].as_str().map(str::to_string))
                 .is_draft(value["draft"].as_bool().unwrap_or(false))
@@ -155,6 +157,15 @@ impl super::ChangeRequestTracker for GitHubChangeRequest {
 
         let pr = Self::parse_pull_request(&v).ok_or("malformed pull request")?;
         Ok(self.gh_pr_to_change_request(&pr))
+    }
+
+    async fn get_change_request_for_admission(&self, repo_root: &Path, id: &str) -> Result<super::ChangeRequestAdmission, String> {
+        let endpoint = format!("repos/{}/pulls/{}", self.repo_slug, id);
+        let body = gh_api_get!(self.api, &endpoint, repo_root)?;
+        let value: serde_json::Value = serde_json::from_str(&body).map_err(|error| error.to_string())?;
+        let pull_request = Self::parse_pull_request(&value).ok_or("malformed pull request")?;
+        let (id, change_request) = self.gh_pr_to_change_request(&pull_request);
+        Ok(super::ChangeRequestAdmission { id, change_request, base_ref: pull_request.base_ref_name })
     }
 
     async fn open_in_browser(&self, repo_root: &Path, id: &str) -> Result<(), String> {
@@ -403,6 +414,7 @@ mod tests {
             .number(number)
             .title("Add feature".to_string())
             .head_ref_name("feat/add-feature".to_string())
+            .base_ref_name("main".to_string())
             .state("OPEN".to_string())
             .is_draft(false)
             .build()

--- a/crates/flotilla-core/src/providers/change_request/mod.rs
+++ b/crates/flotilla-core/src/providers/change_request/mod.rs
@@ -6,6 +6,13 @@ use async_trait::async_trait;
 
 use crate::providers::types::ChangeRequest;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeRequestAdmission {
+    pub id: String,
+    pub change_request: ChangeRequest,
+    pub base_ref: Option<String>,
+}
+
 #[async_trait]
 pub trait ChangeRequestTracker: Send + Sync {
     async fn list_change_requests(&self, repo_root: &Path, limit: usize) -> Result<Vec<(String, ChangeRequest)>, String>;
@@ -18,6 +25,13 @@ pub trait ChangeRequestTracker: Send + Sync {
     }
     #[allow(dead_code)]
     async fn get_change_request(&self, repo_root: &Path, id: &str) -> Result<(String, ChangeRequest), String>;
+    /// Resolve the immutable identity required to admit an existing change
+    /// request as a convoy. Providers that expose the base ref should
+    /// override this method so admission can provision the exact PR shape.
+    async fn get_change_request_for_admission(&self, repo_root: &Path, id: &str) -> Result<ChangeRequestAdmission, String> {
+        let (id, change_request) = self.get_change_request(repo_root, id).await?;
+        Ok(ChangeRequestAdmission { id, change_request, base_ref: None })
+    }
     async fn open_in_browser(&self, repo_root: &Path, id: &str) -> Result<(), String>;
     async fn close_change_request(&self, repo_root: &Path, id: &str) -> Result<(), String>;
     async fn merge_change_request(&self, repo_root: &Path, id: &str) -> Result<(), String>;

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -752,6 +752,7 @@ impl CheckoutManager for FakeCheckoutManager {
 pub struct FakeChangeRequest {
     pub change_requests: Arc<TokioMutex<Vec<(String, ChangeRequest)>>>,
     pub merged_branches: Arc<TokioMutex<Vec<String>>>,
+    pub admission_base_ref: String,
 }
 
 pub struct FakePresentationManager {
@@ -919,7 +920,11 @@ impl Default for FakeChangeRequest {
 
 impl FakeChangeRequest {
     pub fn new() -> Self {
-        Self { change_requests: Arc::new(TokioMutex::new(Vec::new())), merged_branches: Arc::new(TokioMutex::new(Vec::new())) }
+        Self {
+            change_requests: Arc::new(TokioMutex::new(Vec::new())),
+            merged_branches: Arc::new(TokioMutex::new(Vec::new())),
+            admission_base_ref: "main".to_string(),
+        }
     }
 
     pub async fn add_change_requests(&self, crs: Vec<(String, ChangeRequest)>) {
@@ -937,6 +942,15 @@ impl ChangeRequestTracker for FakeChangeRequest {
     async fn get_change_request(&self, _repo_root: &Path, id: &str) -> Result<(String, ChangeRequest), String> {
         let store = self.change_requests.lock().await;
         store.iter().find(|(cr_id, _)| cr_id == id).cloned().ok_or_else(|| format!("change request {id} not found"))
+    }
+
+    async fn get_change_request_for_admission(
+        &self,
+        repo_root: &Path,
+        id: &str,
+    ) -> Result<super::super::change_request::ChangeRequestAdmission, String> {
+        let (id, change_request) = self.get_change_request(repo_root, id).await?;
+        Ok(super::super::change_request::ChangeRequestAdmission { id, change_request, base_ref: Some(self.admission_base_ref.clone()) })
     }
 
     async fn open_in_browser(&self, _repo_root: &Path, _id: &str) -> Result<(), String> {

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -983,6 +983,7 @@ async fn fork_stance_refuses_reviewless_dispatch_and_admits_implement_review() {
             intent: Box::new(ConvoyStartIntent {
                 namespace: None,
                 project_ref: "zellij".into(),
+                change_request: None,
                 issues: Vec::new(),
                 name: Some(name.to_string()),
                 branch: Some(format!("stack/{name}")),
@@ -1031,6 +1032,90 @@ async fn fork_stance_refuses_reviewless_dispatch_and_admits_implement_review() {
         flotilla_resources::CrewSource::Agent { selector, brief_template: Some(template), .. }
             if selector.capability == "code-review" && template == "diff-review"
     ));
+}
+
+#[tokio::test]
+async fn convoy_start_adopts_pr_identity_and_defaults_to_shepherd_workflow() {
+    let provider = Arc::new(FakeChangeRequest::new());
+    provider
+        .add_change_requests(vec![("1071".to_string(), ChangeRequest {
+            title: "Convoy adoption of an existing PR".to_string(),
+            branch: "feat/existing-pr".to_string(),
+            status: flotilla_protocol::ChangeRequestStatus::Open,
+            body: Some("Existing implementation work.".to_string()),
+            correlation_keys: Vec::new(),
+            association_keys: Vec::new(),
+            provider_name: "fake-cr".to_string(),
+            provider_display_name: "Fake PRs".to_string(),
+        })])
+        .await;
+    let discovery =
+        fake_discovery_with_provider_set(FakeDiscoveryProviders::new().with_change_request(provider as Arc<dyn ChangeRequestTracker>));
+    let (_temp, repo, daemon) = daemon_for_plain_dir_with_discovery(discovery).await;
+    daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("refresh repository");
+    let repository_key = daemon.repository_key_for_path(&repo).await.expect("repository key");
+    let backend = daemon.resource_backend();
+    create_test_contained_policy(&backend, "flotilla-test", BTreeSet::from(["codex".to_string()])).await;
+    backend
+        .clone()
+        .using::<Project>("flotilla")
+        .create(&InputMeta::builder().name("flotilla".to_string()).build(), &ProjectSpec {
+            display_name: "Flotilla".to_string(),
+            default_workflow_ref: "single-agent-contained".to_string(),
+            issue_source: None,
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository_key.clone(),
+                subpath: None,
+                default_branch: Some("trunk".to_string()),
+            }],
+        })
+        .await
+        .expect("project create");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".to_string(),
+                    change_request: Some("1071".to_string()),
+                    issues: Vec::new(),
+                    name: None,
+                    branch: None,
+                    workflow_ref: None,
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
+                }),
+            },
+        })
+        .await
+        .expect("PR adoption command accepted");
+
+    assert_eq!(recv_command_finished(&mut events, command_id).await, CommandValue::ConvoyStarted {
+        name: "convoy-adoption-of-an-existing-pr-1071".to_string(),
+        attach_plan: None,
+        binding: None,
+    });
+    let convoy =
+        backend.using::<ResourceConvoy>("flotilla").get("convoy-adoption-of-an-existing-pr-1071").await.expect("persisted adopted convoy");
+    assert_eq!(convoy.spec.workflow_ref, "single-agent-shepherd");
+    assert_eq!(convoy.spec.r#ref.as_deref(), Some("feat/existing-pr"));
+    assert_eq!(
+        convoy.spec.change_request,
+        Some(flotilla_resources::BoundChangeRequest {
+            id: "1071".to_string(),
+            repository_ref: repository_key,
+            title: "Convoy adoption of an existing PR".to_string(),
+        })
+    );
+    assert_eq!(convoy.spec.repositories[0].source_ref, "main");
+    assert_eq!(convoy.spec.repositories[0].target_ref, "main");
 }
 
 #[tokio::test]
@@ -1166,6 +1251,7 @@ async fn bare_convoy_start_uses_the_viable_local_host_direct_policy() {
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("local-default".into()),
                     branch: Some("fix/local-default".into()),
@@ -1238,6 +1324,7 @@ async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("missing-adapter".into()),
                     branch: Some("fix/missing-adapter".into()),
@@ -1369,6 +1456,7 @@ async fn convoy_start_accepts_project_list_identifier() {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: None,
                         project_ref,
+                        change_request: None,
                         issues: Vec::new(),
                         name: Some(name.clone()),
                         branch: Some(format!("fix/{name}")),
@@ -1409,6 +1497,7 @@ async fn convoy_start_unknown_project_reports_resolved_reference_tried() {
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "missing".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("unknown-project".into()),
                     branch: Some("fix/unknown-project".into()),
@@ -1486,6 +1575,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: vec![IssueSelector::Reference(reference.clone())],
                     name: Some("issue-732".into()),
                     branch: Some("fix/issue-732".into()),
@@ -1541,6 +1631,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("default-regard".into()),
                     branch: Some("fix/default-regard".into()),
@@ -1576,6 +1667,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: vec![
                         IssueSelector::Reference(reference.clone()),
                         IssueSelector::Reference(reference_two.clone()),
@@ -1624,6 +1716,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: vec![IssueSelector::Reference(reference)],
                     name: None,
                     branch: None,
@@ -1677,6 +1770,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: Some("flotilla".into()),
                     project_ref: "explicit-workflow".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("explicit-workflow".into()),
                     branch: Some("fix/explicit-workflow".into()),
@@ -1712,6 +1806,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: Some("other".into()),
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("wrong-namespace".into()),
                     branch: Some("fix/wrong-namespace".into()),
@@ -1751,6 +1846,7 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("invalid-branch".into()),
                     branch: Some("bad branch".into()),
@@ -1827,6 +1923,7 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: None,
                     branch: None,
@@ -1879,6 +1976,7 @@ async fn convoy_start_acknowledges_while_admission_is_in_flight() {
                         intent: Box::new(ConvoyStartIntent {
                             namespace: None,
                             project_ref: "flotilla".into(),
+                            change_request: None,
                             issues: Vec::new(),
                             name: None,
                             branch: None,
@@ -1943,6 +2041,7 @@ async fn convoy_start_rejects_the_same_project_start_while_admission_is_in_fligh
             intent: Box::new(ConvoyStartIntent {
                 namespace: None,
                 project_ref: "flotilla".into(),
+                change_request: None,
                 issues: vec![IssueSelector::Reference(reference)],
                 name: None,
                 branch: None,
@@ -2037,6 +2136,7 @@ async fn convoy_start_reports_failed_work_without_waiting_for_auto_attach_timeou
                 intent: Box::new(ConvoyStartIntent {
                     namespace: None,
                     project_ref: "flotilla".into(),
+                    change_request: None,
                     issues: Vec::new(),
                     name: Some("bootstrap-failure".into()),
                     branch: Some("fix/bootstrap-failure".into()),

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -126,13 +126,23 @@ pub(crate) trait AttachCapabilityResolver: Send + Sync {
 
 #[async_trait]
 pub(crate) trait ConvoyChangeRequestResolver: Send + Sync {
-    async fn resolve_change_request(&self, repositories: &[RepositoryKey], branch: &str) -> Result<Option<ConvoyChangeRequest>, String>;
+    async fn resolve_change_request(
+        &self,
+        repositories: &[RepositoryKey],
+        branch: &str,
+        change_request_id: Option<&str>,
+    ) -> Result<Option<ConvoyChangeRequest>, String>;
 }
 
 #[async_trait]
 impl ConvoyChangeRequestResolver for InProcessDaemon {
-    async fn resolve_change_request(&self, repositories: &[RepositoryKey], branch: &str) -> Result<Option<ConvoyChangeRequest>, String> {
-        self.resolve_convoy_change_request(repositories, branch).await
+    async fn resolve_change_request(
+        &self,
+        repositories: &[RepositoryKey],
+        branch: &str,
+        change_request_id: Option<&str>,
+    ) -> Result<Option<ConvoyChangeRequest>, String> {
+        self.resolve_convoy_change_request(repositories, branch, change_request_id).await
     }
 }
 
@@ -911,8 +921,8 @@ impl Aggregator {
     }
 
     fn convoy_association_changed(previous: Option<&ResourceObject<Convoy>>, current: Option<&ResourceObject<Convoy>>) -> bool {
-        previous.map(|convoy| (&convoy.spec.r#ref, &convoy.spec.repositories))
-            != current.map(|convoy| (&convoy.spec.r#ref, &convoy.spec.repositories))
+        previous.map(|convoy| (&convoy.spec.r#ref, &convoy.spec.repositories, &convoy.spec.change_request))
+            != current.map(|convoy| (&convoy.spec.r#ref, &convoy.spec.repositories, &convoy.spec.change_request))
     }
 
     fn convoy_phase_changed(previous: Option<&ResourceObject<Convoy>>, current: Option<&ResourceObject<Convoy>>) -> bool {
@@ -939,7 +949,10 @@ impl Aggregator {
             self.convoy_change_requests.remove(&reference);
             return;
         };
-        let repositories = convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<Vec<_>>();
+        let (repositories, change_request_id) = match &convoy.spec.change_request {
+            Some(change_request) => (vec![change_request.repository_ref.clone()], Some(change_request.id.clone())),
+            None => (convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<Vec<_>>(), None),
+        };
         if repositories.is_empty() {
             self.convoy_change_requests.remove(&reference);
             return;
@@ -950,7 +963,7 @@ impl Aggregator {
         let refresh_tx = self.change_request_refresh_queue.tx.clone();
         let task_reference = reference.clone();
         let task = tokio::spawn(async move {
-            let result = resolver.resolve_change_request(&repositories, &branch).await;
+            let result = resolver.resolve_change_request(&repositories, &branch, change_request_id.as_deref()).await;
             let _ = refresh_tx.send(ChangeRequestResolution { reference: task_reference, generation, branch, result });
         });
         self.change_request_refresh_tasks.insert(reference, task);
@@ -994,7 +1007,7 @@ impl Aggregator {
     fn schedule_change_request_refresh_pass(&mut self, convoys: impl IntoIterator<Item = (ResourceRef, ResourceObject<Convoy>)>) {
         // Repository order is resolver precedence, so only identical ordered
         // repository lists may safely share one lookup.
-        let mut lookups = HashMap::<(Vec<RepositoryKey>, String), Vec<(ResourceRef, uuid::Uuid)>>::new();
+        let mut lookups = HashMap::<(Vec<RepositoryKey>, String, Option<String>), Vec<(ResourceRef, uuid::Uuid)>>::new();
         for (reference, convoy) in convoys {
             let generation = uuid::Uuid::new_v4();
             self.change_request_refresh_generations.insert(reference.clone(), generation);
@@ -1005,21 +1018,26 @@ impl Aggregator {
                 self.convoy_change_requests.remove(&reference);
                 continue;
             };
-            let repositories = convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<Vec<_>>();
+            let (repositories, change_request_id) = match &convoy.spec.change_request {
+                Some(change_request) => (vec![change_request.repository_ref.clone()], Some(change_request.id.clone())),
+                None => (convoy.spec.repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<Vec<_>>(), None),
+            };
             if repositories.is_empty() {
                 self.convoy_change_requests.remove(&reference);
                 continue;
             }
-            lookups.entry((repositories, branch)).or_default().push((reference, generation));
+            lookups.entry((repositories, branch, change_request_id)).or_default().push((reference, generation));
         }
 
         let Some(resolver) = self.change_request_resolver.clone() else {
             return;
         };
-        for ((repositories, branch), targets) in lookups {
+        for ((repositories, branch, change_request_id), targets) in lookups {
             let resolver = Arc::clone(&resolver);
             let lookup_branch = branch.clone();
-            let lookup = async move { resolver.resolve_change_request(&repositories, &lookup_branch).await }.boxed().shared();
+            let lookup = async move { resolver.resolve_change_request(&repositories, &lookup_branch, change_request_id.as_deref()).await }
+                .boxed()
+                .shared();
             for (reference, generation) in targets {
                 let lookup = lookup.clone();
                 let refresh_tx = self.change_request_refresh_queue.tx.clone();
@@ -1976,11 +1994,11 @@ mod tests {
         PrincipalRef,
     };
     use flotilla_resources::{
-        ConvoyRepositorySpec, ConvoySpec, CrewSpec, DemandKind, DemandSpec, DemandStatus, DemandTransition, EnvironmentSpec,
-        HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta, ObservedCheckoutSpec, PlacementStatus, PresentationPhase,
-        PresentationSpec, PresentationStatus, PrincipalRef as AttentionPrincipalRef, ProjectSpec, RegardSource, RegardSpec, RegardStatus,
-        RepositorySpec, ResourceBackend, Stance, TerminalAttention, TerminalAttentionSource, TerminalSessionSource, TerminalSessionSpec,
-        TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
+        BoundChangeRequest, ConvoyRepositorySpec, ConvoySpec, CrewSpec, DemandKind, DemandSpec, DemandStatus, DemandTransition,
+        EnvironmentSpec, HostDirectEnvironmentSpec, InMemoryBackend, InputMeta, ObjectMeta, ObservedCheckoutSpec, PlacementStatus,
+        PresentationPhase, PresentationSpec, PresentationStatus, PrincipalRef as AttentionPrincipalRef, ProjectSpec, RegardSource,
+        RegardSpec, RegardStatus, RepositorySpec, ResourceBackend, Stance, TerminalAttention, TerminalAttentionSource,
+        TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, VesselRequirement, WorkflowSnapshot,
     };
     use futures::stream;
     use tokio::{sync::Mutex, time::timeout};
@@ -2490,6 +2508,12 @@ mod tests {
 
     struct BlockingChangeRequestResolver;
 
+    type BoundChangeRequestLookup = (Vec<RepositoryKey>, String, Option<String>);
+
+    struct RecordingBoundChangeRequestResolver {
+        calls: Mutex<Vec<BoundChangeRequestLookup>>,
+    }
+
     impl CountingAttachResolver {
         fn new() -> Self {
             Self { calls: AtomicUsize::new(0), origin_hosts: HashMap::new() }
@@ -2509,6 +2533,7 @@ mod tests {
             &self,
             _repositories: &[RepositoryKey],
             _branch: &str,
+            _change_request_id: Option<&str>,
         ) -> Result<Option<flotilla_protocol::ConvoyChangeRequest>, String> {
             std::future::pending().await
         }
@@ -2520,11 +2545,29 @@ mod tests {
             &self,
             repositories: &[RepositoryKey],
             branch: &str,
+            _change_request_id: Option<&str>,
         ) -> Result<Option<flotilla_protocol::ConvoyChangeRequest>, String> {
             assert_eq!(repositories, [RepositoryKey("repo_flotilla".into())]);
             self.branches.lock().await.push(branch.to_string());
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.results.lock().await.pop_front().unwrap_or(Ok(None))
+        }
+    }
+
+    #[async_trait]
+    impl ConvoyChangeRequestResolver for RecordingBoundChangeRequestResolver {
+        async fn resolve_change_request(
+            &self,
+            repositories: &[RepositoryKey],
+            branch: &str,
+            change_request_id: Option<&str>,
+        ) -> Result<Option<flotilla_protocol::ConvoyChangeRequest>, String> {
+            self.calls.lock().await.push((repositories.to_vec(), branch.to_string(), change_request_id.map(str::to_string)));
+            Ok(Some(flotilla_protocol::ConvoyChangeRequest {
+                id: change_request_id.expect("bound lookup should carry an id").to_string(),
+                status: flotilla_protocol::ChangeRequestStatus::Open,
+                repository_key: repositories[0].clone(),
+            }))
         }
     }
 
@@ -3198,6 +3241,34 @@ mod tests {
             flotilla_protocol::ChangeRequestStatus::Merged
         );
         assert_eq!(resolver.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn bound_convoy_enrichment_looks_up_the_admitted_pr_by_id() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, mut event_rx) = broadcast::channel(4);
+        let resolver = Arc::new(RecordingBoundChangeRequestResolver { calls: Mutex::new(Vec::new()) });
+        let mut aggregator = Aggregator::new(state, HostName::new("local"), event_tx).with_change_request_resolver(Arc::clone(&resolver));
+        let mut convoy = convoy_with_branch("convoy-a").await;
+        convoy.spec.change_request = Some(BoundChangeRequest {
+            id: "1071".to_string(),
+            repository_ref: RepositoryKey("repo_flotilla".to_string()),
+            title: "Existing PR".to_string(),
+        });
+
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy)).await;
+        let _ = event_rx.recv().await.expect("initial result set");
+        apply_next_change_request_resolution(&mut aggregator).await;
+        let DaemonEvent::ResultDelta(delta) = event_rx.recv().await.expect("bound PR delta") else {
+            panic!("expected result delta");
+        };
+
+        assert_eq!(delta.changes.as_convoys().expect("convoy changes")[0].change_request.as_ref().expect("bound PR").id, "1071");
+        assert_eq!(resolver.calls.lock().await.as_slice(), &[(
+            vec![RepositoryKey("repo_flotilla".to_string())],
+            "feat/convoy".to_string(),
+            Some("1071".to_string()),
+        )]);
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -567,6 +567,7 @@ fn builtin_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
         ("implement-review", flotilla_resources::implement_review_workflow_spec()),
         ("interactive-single", flotilla_resources::interactive_single_workflow_spec()),
         ("single-agent-contained", flotilla_resources::single_agent_contained_workflow_spec()),
+        ("single-agent-shepherd", flotilla_resources::single_agent_shepherd_workflow_spec()),
         ("single-agent-trusted", flotilla_resources::single_agent_trusted_workflow_spec()),
     ]
 }
@@ -1732,7 +1733,13 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
     }
 
     async fn inspect_integration(&self, checkout: &ResourceObject<Checkout>) -> Result<CheckoutIntegrationStatus, String> {
-        Ok(inspect_checkout_integration(&*self.local_runner()?, Path::new(self.checkout_path(checkout)?), &checkout.spec).await)
+        Ok(inspect_checkout_integration(
+            &*self.local_runner()?,
+            Path::new(self.checkout_path(checkout)?),
+            &checkout.spec,
+            checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
+        )
+        .await)
     }
 
     async fn remove_checkout(&self, removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {
@@ -3191,6 +3198,19 @@ mod tests {
         assert_eq!(unchanged.metadata.resource_version, labelled.metadata.resource_version);
     }
 
+    #[tokio::test]
+    async fn startup_reconciles_owned_single_agent_shepherd_builtin() {
+        let backend = ResourceBackend::InMemory(Default::default());
+
+        reconcile_builtin_workflow_templates(&backend, NAMESPACE).await.expect("builtin reconciliation should succeed");
+
+        let shepherd =
+            backend.using::<WorkflowTemplate>(NAMESPACE).get("single-agent-shepherd").await.expect("shepherd builtin should exist");
+        assert_eq!(shepherd.spec, flotilla_resources::single_agent_shepherd_workflow_spec());
+        assert_eq!(shepherd.spec.vessels[0].stance, Stance::Trusted);
+        assert_eq!(shepherd.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some(BUILTIN_MANAGED_BY_VALUE));
+    }
+
     fn manual_profile(host_id: &str, docker_available: bool) -> LocalProvisioningProfile {
         LocalProvisioningProfile {
             host_id: host_id.to_string(),
@@ -3424,6 +3444,7 @@ mod tests {
                 project_ref: None,
                 adopted_checkout_refs: BTreeMap::new(),
                 issues: Vec::new(),
+                change_request: None,
                 instruction: None,
             })
             .await

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -709,6 +709,7 @@ async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: Vec::new(),
+            change_request: None,
             instruction: None,
         })
         .await

--- a/crates/flotilla-daemon/src/sleep_inhibitor.rs
+++ b/crates/flotilla-daemon/src/sleep_inhibitor.rs
@@ -411,6 +411,7 @@ mod tests {
             project_ref: None,
             adopted_checkout_refs: BTreeMap::new(),
             issues: vec![],
+            change_request: None,
             instruction: None,
         }
     }

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -59,6 +59,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
         issues: Vec::new(),
+        change_request: None,
         instruction: None,
     }
 }

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -184,6 +184,10 @@ pub struct ConvoyStartIntent {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     pub project_ref: String,
+    /// Existing change request to adopt. Admission resolves all remaining
+    /// checkout identity from this provider-native ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_request: Option<String>,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub issues: Vec<IssueSelector>,

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -809,8 +809,9 @@ pub struct ConvoyRow {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub issues: Vec<ConvoyIssueRow>,
-    /// Shallow forge lookup for the convoy branch. This is display/reference
-    /// data, not a Flotilla-managed resource.
+    /// Shallow forge lookup for the explicitly bound change request, or for
+    /// the convoy branch on legacy convoys. This is display/reference data,
+    /// not a Flotilla-managed resource.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub change_request: Option<ConvoyChangeRequest>,
     /// Vessels from the convoy's workflow snapshot.
@@ -828,7 +829,7 @@ pub struct ConvoyIssueRow {
     pub state: IssueState,
 }
 
-/// The external change request currently associated with a convoy branch.
+/// The external change request currently associated with a convoy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConvoyChangeRequest {
     pub id: String,

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -54,6 +54,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         project_ref: None,
         adopted_checkout_refs: Default::default(),
         issues: Vec::new(),
+        change_request: None,
         instruction: None,
     }
 }

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -41,6 +41,9 @@ pub struct ConvoySpec {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub issues: Vec<ConvoyIssue>,
+    /// Change request explicitly bound when the convoy was admitted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_request: Option<BoundChangeRequest>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instruction: Option<String>,
 }
@@ -90,6 +93,13 @@ pub struct IssueSnapshot {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<String>,
     pub as_of: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct BoundChangeRequest {
+    pub id: String,
+    pub repository_ref: RepositoryKey,
+    pub title: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]

--- a/crates/flotilla-resources/src/crds/convoy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/convoy.crd.yaml
@@ -85,6 +85,22 @@ spec:
                   additionalProperties:
                     type: string
                     minLength: 1
+                change_request:
+                  type: object
+                  required: [id, repository_ref, title]
+                  properties:
+                    id:
+                      type: string
+                      minLength: 1
+                    repository_ref:
+                      type: string
+                      minLength: 1
+                    title:
+                      type: string
+                      minLength: 1
+                  x-kubernetes-validations:
+                    - rule: "self == oldSelf"
+                      message: "change_request is immutable after creation"
                 issue:
                   type: object
                   required: [reference, snapshot]

--- a/crates/flotilla-resources/src/labels.rs
+++ b/crates/flotilla-resources/src/labels.rs
@@ -10,4 +10,5 @@ pub const VESSEL_ORDINAL_LABEL: &str = "flotilla.work/vessel_ordinal";
 pub const CREW_ORDINAL_LABEL: &str = "flotilla.work/crew_ordinal";
 pub const MANAGED_BY_LABEL: &str = "flotilla.work/managed-by";
 pub const REPO_LABEL: &str = "flotilla.work/repo";
+pub const CHANGE_REQUEST_ID_LABEL: &str = "flotilla.work/change-request-id";
 pub const RESERVED_PREFIX: &str = "flotilla.work/";

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -44,9 +44,9 @@ pub use clock::{Clock, SystemClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
     controller_patches, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches,
-    reconcile, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
-    ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot, PlacementStatus, ReconcileOutcome,
-    TargetMismatch, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION,
+    reconcile, BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec,
+    ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot, PlacementStatus,
+    ReconcileOutcome, TargetMismatch, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION,
     PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use credential::{
@@ -68,8 +68,8 @@ pub use host::{
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;
 pub use labels::{
-    LifecycleAuthority, AUTHORITY_LABEL, CONVOY_LABEL, CREW_ORDINAL_LABEL, MANAGED_BY_LABEL, REPO_KEY_LABEL, REPO_LABEL, RESERVED_PREFIX,
-    ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    LifecycleAuthority, AUTHORITY_LABEL, CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL, CREW_ORDINAL_LABEL, MANAGED_BY_LABEL, REPO_KEY_LABEL,
+    REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 pub use placement_policy::{
     DockerCheckoutStrategy, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, HostDirectPlacementPolicyCheckout,
@@ -141,6 +141,7 @@ macro_rules! for_each_registered_resource {
 }
 pub use workflow_template::{
     implement_review_workflow_spec, interactive_single_workflow_spec, single_agent_contained_workflow_spec,
-    single_agent_trusted_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition, InterpolationField, InterpolationLocation,
-    Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
+    single_agent_shepherd_workflow_spec, single_agent_trusted_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition,
+    InterpolationField, InterpolationLocation, Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate,
+    WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -143,6 +143,23 @@ pub fn single_agent_trusted_workflow_spec() -> WorkflowTemplateSpec {
         .build()
 }
 
+pub fn single_agent_shepherd_workflow_spec() -> WorkflowTemplateSpec {
+    WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Trusted)
+            .crew(vec![CrewSpec::builder()
+                .role("shepherd".to_string())
+                .source(CrewSource::Agent {
+                    selector: Selector { capability: "code".to_string() },
+                    prompt: None,
+                    brief_template: Some("shepherd".to_string()),
+                })
+                .build()])
+            .build()])
+        .build()
+}
+
 pub fn interactive_single_workflow_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
         .vessels(vec![VesselRequirement::builder()

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -212,6 +212,7 @@ pub fn valid_convoy_spec() -> RealConvoySpec {
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
         issues: Vec::new(),
+        change_request: None,
         instruction: None,
     }
 }

--- a/crates/flotilla-resources/tests/k8s_integration.rs
+++ b/crates/flotilla-resources/tests/k8s_integration.rs
@@ -41,6 +41,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         project_ref: None,
         adopted_checkout_refs: Default::default(),
         issues: Vec::new(),
+        change_request: None,
         instruction: None,
     }
 }

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -493,6 +493,7 @@ impl App {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: Some(namespace),
                         project_ref: project,
+                        change_request: None,
                         issues: vec![IssueSelector::Reference(issue.issue)],
                         name: None,
                         branch: None,
@@ -512,6 +513,7 @@ impl App {
                         intent: Box::new(ConvoyStartIntent {
                             namespace: Some(namespace.clone()),
                             project_ref: project.clone(),
+                            change_request: None,
                             issues: vec![IssueSelector::Reference(issue.issue.clone())],
                             name: None,
                             branch: None,
@@ -546,6 +548,7 @@ impl App {
                     intent: Box::new(ConvoyStartIntent {
                         namespace: Some(namespace),
                         project_ref: project,
+                        change_request: None,
                         issues: issues.into_iter().map(|issue| IssueSelector::Reference(issue.issue)).collect(),
                         name: None,
                         branch: None,

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -49,6 +49,7 @@ fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
         project_ref: None,
         adopted_checkout_refs: BTreeMap::new(),
         issues: Vec::new(),
+        change_request: None,
         instruction: None,
     }
 }


### PR DESCRIPTION
Closes #1071

## Summary

- add `flotilla convoy start --project X --pr N`, deriving the branch, base ref, title, and default convoy name from the selected pull request
- persist an immutable PR binding at admission, then use its repository and number for rail enrichment and checkout landing evidence instead of branch discovery
- add the trusted, ownership-managed `single-agent-shepherd` builtin and a one-round `shepherd` brief that processes the current review/CI state and yields without polling or merging
- cover CLI resolution, real admission/provisioning flow, direct PR lookup, checkout labels, landing evidence, rail enrichment, startup reconciliation, and brief semantics

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
