### PR TITLE
fix: make placement ordering legible

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -1119,6 +1119,7 @@ mod tests {
             policy_name: "host-direct-test".to_string(),
             target_host: PlacementTargetHost { reference: "01HXYZ".to_string(), display_name: "kiwi".to_string() },
             refused_candidates: Vec::new(),
+            viable_not_selected: Vec::new(),
         };
 
         assert_eq!(

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4,6 +4,7 @@
 //! and broadcasts events — all within the same process.
 
 use std::{
+    cmp::Reverse,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     panic::AssertUnwindSafe,
     path::{Path, PathBuf},
@@ -25,11 +26,11 @@ use flotilla_protocol::{
     CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse,
     FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
     HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PlacementDecision,
-    PlacementRefusal, PlacementTargetHost, PrincipalRef, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData,
-    ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary,
-    RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceJsonResponse, ResourceRef, ResourceWatchResponse, StatusResponse,
-    StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
-    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    PlacementRefusal, PlacementTargetHost, PlacementViableCandidate, PrincipalRef, ProjectListEntry, ProjectListRepository,
+    ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo,
+    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceJsonResponse,
+    ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory,
+    TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
@@ -932,6 +933,7 @@ async fn persist_adopted_checkout(
 struct PlacementResolution {
     selected: Option<ResourceObject<PlacementPolicy>>,
     refused_candidates: Vec<PlacementRefusal>,
+    viable_not_selected: Vec<PlacementViableCandidate>,
 }
 
 fn placement_host_ref(policy: &ResourceObject<PlacementPolicy>) -> Option<&str> {
@@ -971,7 +973,7 @@ async fn default_convoy_placement_policy(
         Ok(list) => list.items,
         Err(err) => {
             warn!(%namespace, error = %err, "failed to list placement policies; convoy will remain Pending until one is registered");
-            return Ok(PlacementResolution { selected: None, refused_candidates: Vec::new() });
+            return Ok(PlacementResolution { selected: None, refused_candidates: Vec::new(), viable_not_selected: Vec::new() });
         }
     };
     policies.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
@@ -1004,10 +1006,19 @@ async fn default_convoy_placement_policy(
             .or_else(|| policy.spec.docker_per_vessel.as_ref().map(|spec| spec.host_ref.as_str()));
         let is_local = local_host_ref.is_some_and(|local| target_host == Some(local));
         let is_host_direct = policy.spec.host_direct.is_some();
-        (!is_local, !is_host_direct, policy.metadata.name.clone())
+        (Reverse(policy.spec.priority), !is_local, !is_host_direct, policy.metadata.name.clone())
     });
-    if let Some(policy) = viable.into_iter().next() {
-        return Ok(PlacementResolution { selected: Some(policy), refused_candidates });
+    if !viable.is_empty() {
+        let selected = viable.remove(0);
+        let mut viable_not_selected = Vec::with_capacity(viable.len());
+        for policy in viable {
+            let target_host = placement_target_host(backend, namespace, &policy)
+                .await
+                .unwrap_or_else(|_| PlacementTargetHost { reference: String::new(), display_name: "no target host".to_string() });
+            let reason = placement_ordering_reason(&selected, &policy, local_host_ref);
+            viable_not_selected.push(PlacementViableCandidate { policy_name: policy.metadata.name.clone(), target_host, reason });
+        }
+        return Ok(PlacementResolution { selected: Some(selected), refused_candidates, viable_not_selected });
     }
 
     let required_adapters = required_workflow_agent_adapters(workflow)?;
@@ -1024,7 +1035,32 @@ async fn default_convoy_placement_policy(
     if candidate_names.is_empty() {
         warn!(%namespace, "no placement policy found; convoy will remain Pending until one is registered");
     }
-    Ok(PlacementResolution { selected: None, refused_candidates })
+    Ok(PlacementResolution { selected: None, refused_candidates, viable_not_selected: Vec::new() })
+}
+
+fn placement_ordering_reason(
+    selected: &ResourceObject<PlacementPolicy>,
+    candidate: &ResourceObject<PlacementPolicy>,
+    local_host_ref: Option<&str>,
+) -> String {
+    if candidate.spec.priority != selected.spec.priority {
+        return format!(
+            "priority {} is lower than selected policy `{}` priority {}",
+            candidate.spec.priority, selected.metadata.name, selected.spec.priority
+        );
+    }
+
+    let selected_host = placement_host_ref(selected);
+    let candidate_host = placement_host_ref(candidate);
+    let selected_is_local = local_host_ref.is_some_and(|local| selected_host == Some(local));
+    let candidate_is_local = local_host_ref.is_some_and(|local| candidate_host == Some(local));
+    if selected_is_local && !candidate_is_local {
+        return format!("fallback ordering preferred local policy `{}`", selected.metadata.name);
+    }
+    if selected.spec.host_direct.is_some() && candidate.spec.host_direct.is_none() {
+        return format!("fallback ordering preferred host-direct policy `{}`", selected.metadata.name);
+    }
+    format!("fallback ordering preferred policy `{}` by name", selected.metadata.name)
 }
 
 fn repo_identity_from_bag_or_path(path: &Path, bag: &EnvironmentBag) -> flotilla_protocol::RepoIdentity {
@@ -4099,6 +4135,7 @@ impl InProcessDaemon {
                 policy_name: selected.metadata.name.clone(),
                 target_host: placement_target_host(&self.resource_backend, namespace, selected).await?,
                 refused_candidates: placement.refused_candidates,
+                viable_not_selected: placement.viable_not_selected,
             }),
             None => None,
         };
@@ -4245,7 +4282,7 @@ impl InProcessDaemon {
                 if contained && resolved.spec.docker_per_vessel.is_none() {
                     return Err(format!("contained workflow requires a docker placement policy, but {policy} is not contained"));
                 }
-                PlacementResolution { selected: Some(resolved), refused_candidates: Vec::new() }
+                PlacementResolution { selected: Some(resolved), refused_candidates: Vec::new(), viable_not_selected: Vec::new() }
             }
             None => {
                 let local_host_id = self.local_host_id();
@@ -7470,6 +7507,7 @@ impl InProcessDaemon {
                         policy_name: selected.metadata.name.clone(),
                         target_host,
                         refused_candidates: placement.refused_candidates,
+                        viable_not_selected: placement.viable_not_selected,
                     }),
                     Err(message) => {
                         let _ = self.event_tx.send(DaemonEvent::CommandFinished {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -998,12 +998,7 @@ async fn default_convoy_placement_policy(
         }
     }
     viable.sort_by_key(|policy| {
-        let target_host = policy
-            .spec
-            .host_direct
-            .as_ref()
-            .map(|spec| spec.host_ref.as_str())
-            .or_else(|| policy.spec.docker_per_vessel.as_ref().map(|spec| spec.host_ref.as_str()));
+        let target_host = placement_host_ref(policy);
         let is_local = local_host_ref.is_some_and(|local| target_host == Some(local));
         let is_host_direct = policy.spec.host_direct.is_some();
         (Reverse(policy.spec.priority), !is_local, !is_host_direct, policy.metadata.name.clone())

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -367,7 +367,13 @@ async fn agent_adapter_admission_rejects_a_host_with_stale_heartbeat() {
     assert_eq!(error, "placement `host-direct-test` host `host-test` is not ready");
 }
 
-async fn create_host_direct_placement(backend: &ResourceBackend, policy_name: &str, host_ref: &str, agent_adapters: BTreeSet<String>) {
+async fn create_host_direct_placement(
+    backend: &ResourceBackend,
+    policy_name: &str,
+    host_ref: &str,
+    priority: i32,
+    agent_adapters: BTreeSet<String>,
+) {
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
     let host = hosts.create(&empty_input_meta(host_ref), &HostSpec { display_name: host_ref.to_string() }).await.expect("host create");
     hosts
@@ -387,6 +393,7 @@ async fn create_host_direct_placement(backend: &ResourceBackend, policy_name: &s
             &empty_input_meta(policy_name),
             &PlacementPolicySpec::builder()
                 .pool("passthrough".to_string())
+                .priority(priority)
                 .host_direct(HostDirectPlacementPolicySpec {
                     host_ref: host_ref.to_string(),
                     checkout: HostDirectPlacementPolicyCheckout::Worktree,
@@ -443,23 +450,41 @@ fn trusted_codex_workflow() -> WorkflowTemplateSpec {
 #[tokio::test]
 async fn default_placement_prefers_the_viable_local_host() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    create_host_direct_placement(&backend, "host-direct-a-remote", "remote-host", BTreeSet::from(["codex".to_string()])).await;
-    create_host_direct_placement(&backend, "host-direct-z-local", "local-host", BTreeSet::from(["codex".to_string()])).await;
+    create_host_direct_placement(&backend, "host-direct-a-remote", "remote-host", 0, BTreeSet::from(["codex".to_string()])).await;
+    create_host_direct_placement(&backend, "host-direct-z-local", "local-host", 0, BTreeSet::from(["codex".to_string()])).await;
 
-    let placement = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("local-host"))
+    let resolution = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("local-host"))
         .await
-        .expect("default placement")
-        .selected
-        .expect("viable placement");
+        .expect("default placement");
+    let placement = resolution.selected.expect("viable placement");
 
     assert_eq!(placement.metadata.name, "host-direct-z-local");
+    assert_eq!(resolution.viable_not_selected.len(), 1);
+    assert_eq!(resolution.viable_not_selected[0].policy_name, "host-direct-a-remote");
+    assert_eq!(resolution.viable_not_selected[0].target_host.display_name, "remote-host");
+    assert_eq!(resolution.viable_not_selected[0].reason, "fallback ordering preferred local policy `host-direct-z-local`");
+}
+
+#[tokio::test]
+async fn default_placement_priority_can_prefer_a_remote_work_host_over_the_local_desk() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_host_direct_placement(&backend, "host-direct-feta", "feta", 100, BTreeSet::from(["codex".to_string()])).await;
+    create_host_direct_placement(&backend, "host-direct-kiwi", "kiwi", -100, BTreeSet::from(["codex".to_string()])).await;
+
+    let resolution =
+        default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("kiwi")).await.expect("default placement");
+
+    assert_eq!(resolution.selected.expect("viable placement").metadata.name, "host-direct-feta");
+    assert_eq!(resolution.viable_not_selected.len(), 1);
+    assert_eq!(resolution.viable_not_selected[0].policy_name, "host-direct-kiwi");
+    assert_eq!(resolution.viable_not_selected[0].reason, "priority -100 is lower than selected policy `host-direct-feta` priority 100");
 }
 
 #[tokio::test]
 async fn default_placement_never_selects_a_host_without_the_required_adapter() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    create_host_direct_placement(&backend, "host-direct-a-no-adapters", "empty-host", BTreeSet::new()).await;
-    create_host_direct_placement(&backend, "host-direct-z-codex", "codex-host", BTreeSet::from(["codex".to_string()])).await;
+    create_host_direct_placement(&backend, "host-direct-a-no-adapters", "empty-host", 0, BTreeSet::new()).await;
+    create_host_direct_placement(&backend, "host-direct-z-codex", "codex-host", 0, BTreeSet::from(["codex".to_string()])).await;
 
     let resolution = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("unrelated-local-host"))
         .await
@@ -484,7 +509,7 @@ async fn default_placement_preserves_a_refusal_for_a_policy_without_a_target_hos
         .create(&empty_input_meta("a-malformed"), &PlacementPolicySpec::builder().pool("passthrough".to_string()).build())
         .await
         .expect("malformed placement create");
-    create_host_direct_placement(&backend, "z-viable", "codex-host", BTreeSet::from(["codex".to_string()])).await;
+    create_host_direct_placement(&backend, "z-viable", "codex-host", 0, BTreeSet::from(["codex".to_string()])).await;
 
     let resolution =
         default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), None).await.expect("default placement");
@@ -521,8 +546,8 @@ async fn default_placement_falls_back_after_a_credential_refusal_and_records_the
 #[tokio::test]
 async fn default_placement_no_viable_candidate_error_names_the_adapter_and_candidates() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    create_host_direct_placement(&backend, "host-direct-a", "host-a", BTreeSet::new()).await;
-    create_host_direct_placement(&backend, "host-direct-b", "host-b", BTreeSet::from(["claude-code".to_string()])).await;
+    create_host_direct_placement(&backend, "host-direct-a", "host-a", 0, BTreeSet::new()).await;
+    create_host_direct_placement(&backend, "host-direct-b", "host-b", 0, BTreeSet::from(["claude-code".to_string()])).await;
 
     let error = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("host-a"))
         .await
@@ -2075,6 +2100,7 @@ async fn fleet_list_scopes_crew_session_placement_decisions_by_namespace_and_con
         policy_name: policy.to_string(),
         target_host: PlacementTargetHost { reference: format!("{host}-id"), display_name: host.to_string() },
         refused_candidates: Vec::new(),
+        viable_not_selected: Vec::new(),
     };
     let mut local = convoy_row("flotilla", "shared", WireConvoyPhase::Active, None);
     local.placement_decision = Some(placement("local-policy", "kiwi"));

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1085,6 +1085,7 @@ async fn create_test_host_direct_policy(
     backend: &flotilla_resources::ResourceBackend,
     policy_name: &str,
     host_ref: &str,
+    priority: i32,
     agent_adapters: BTreeSet<String>,
 ) {
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
@@ -1106,6 +1107,7 @@ async fn create_test_host_direct_policy(
             &InputMeta::builder().name(policy_name.to_string()).build(),
             &PlacementPolicySpec::builder()
                 .pool("passthrough".to_string())
+                .priority(priority)
                 .host_direct(HostDirectPlacementPolicySpec {
                     host_ref: host_ref.to_string(),
                     checkout: HostDirectPlacementPolicyCheckout::Worktree,
@@ -1117,7 +1119,7 @@ async fn create_test_host_direct_policy(
 }
 
 #[tokio::test]
-async fn bare_convoy_start_uses_the_viable_local_host_direct_policy() {
+async fn bare_convoy_start_uses_priority_and_records_every_placement_candidate() {
     let temp = tempfile::TempDir::new().expect("tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -1152,9 +1154,9 @@ async fn bare_convoy_start_uses_the_viable_local_host_direct_policy() {
         })
         .await
         .expect("project create");
-    create_test_host_direct_policy(&backend, "host-direct-a-empty", "empty-host", BTreeSet::new()).await;
-    create_test_host_direct_policy(&backend, "host-direct-b-remote", "remote-host", BTreeSet::from(["codex".to_string()])).await;
-    create_test_host_direct_policy(&backend, "host-direct-z-local", &local_host_ref, BTreeSet::from(["codex".to_string()])).await;
+    create_test_host_direct_policy(&backend, "host-direct-a-empty", "empty-host", 200, BTreeSet::new()).await;
+    create_test_host_direct_policy(&backend, "host-direct-b-remote", "remote-host", 100, BTreeSet::from(["codex".to_string()])).await;
+    create_test_host_direct_policy(&backend, "host-direct-z-local", &local_host_ref, -100, BTreeSet::from(["codex".to_string()])).await;
 
     let mut events = daemon.subscribe();
     let command_id = daemon
@@ -1193,7 +1195,15 @@ async fn bare_convoy_start_uses_the_viable_local_host_direct_policy() {
     .expect("start command should finish");
     assert_eq!(result, CommandValue::ConvoyStarted { name: "local-default".into(), attach_plan: None, binding: None });
     let convoy = backend.using::<ResourceConvoy>("flotilla").get("local-default").await.expect("persisted convoy");
-    assert_eq!(convoy.spec.placement_policy.as_deref(), Some("host-direct-z-local"));
+    assert_eq!(convoy.spec.placement_policy.as_deref(), Some("host-direct-b-remote"));
+    let decision =
+        convoy.status.and_then(|status| status.placement_decision).expect("admission should persist the complete placement decision");
+    assert_eq!(decision.policy_name, "host-direct-b-remote");
+    assert_eq!(decision.refused_candidates.len(), 1);
+    assert_eq!(decision.refused_candidates[0].policy_name, "host-direct-a-empty");
+    assert_eq!(decision.viable_not_selected.len(), 1);
+    assert_eq!(decision.viable_not_selected[0].policy_name, "host-direct-z-local");
+    assert_eq!(decision.viable_not_selected[0].reason, "priority -100 is lower than selected policy `host-direct-b-remote` priority 100");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/resource_manifest.rs
+++ b/crates/flotilla-daemon/src/resource_manifest.rs
@@ -332,7 +332,7 @@ mod tests {
         write(&nested.join("policies.yaml"), &format!("{}---\n{}", manifest("alpha", "one"), manifest("gamma", "three")));
         write(
             &dir.path().join("beta.json"),
-            r#"{"apiVersion":"flotilla.work/v1","kind":"PlacementPolicy","metadata":{"name":"beta"},"spec":{"pool":"two"}}"#,
+            r#"{"apiVersion":"flotilla.work/v1","kind":"PlacementPolicy","metadata":{"name":"beta"},"spec":{"pool":"two","priority":100}}"#,
         );
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
         let mut reconciler = ResourceManifestReconciler::new(backend.clone(), NAMESPACE, dir.path());
@@ -352,6 +352,7 @@ mod tests {
                 )
             );
         }
+        assert_eq!(backend.using::<PlacementPolicy>(NAMESPACE).get("beta").await.expect("beta policy").spec.priority, 100);
     }
 
     #[tokio::test]

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -38,7 +38,7 @@ pub use host_summary::{
 pub use lifecycle::LifecycleAuthority;
 pub use path_context::{DaemonHostPath, ExecutionEnvironmentPath};
 pub use peer::{CommandPeerEvent, GoodbyeReason, PeerDataKind, PeerDataMessage, PeerWireMessage, RoutedPeerMessage, VectorClock};
-pub use placement::{PlacementDecision, PlacementRefusal, PlacementTargetHost};
+pub use placement::{PlacementDecision, PlacementRefusal, PlacementTargetHost, PlacementViableCandidate};
 pub use provisioning_target::ProvisioningTarget;
 pub use repository::{RepositoryKey, UNKNOWN_REPOSITORY_LABEL};
 pub use step::{CheckoutIntent, Step, StepAction, StepExecutionContext, StepOutcome};

--- a/crates/flotilla-protocol/src/placement.rs
+++ b/crates/flotilla-protocol/src/placement.rs
@@ -15,10 +15,20 @@ pub struct PlacementRefusal {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct PlacementViableCandidate {
+    pub policy_name: String,
+    pub target_host: PlacementTargetHost,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct PlacementDecision {
     pub policy_name: String,
     pub target_host: PlacementTargetHost,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub refused_candidates: Vec<PlacementRefusal>,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub viable_not_selected: Vec<PlacementViableCandidate>,
 }

--- a/crates/flotilla-resources/src/crds/placement_policy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/placement_policy.crd.yaml
@@ -17,6 +17,9 @@ spec:
         - name: Pool
           type: string
           jsonPath: .spec.pool
+        - name: Priority
+          type: integer
+          jsonPath: .spec.priority
       schema:
         openAPIV3Schema:
           type: object

--- a/crates/flotilla-resources/src/placement_policy.rs
+++ b/crates/flotilla-resources/src/placement_policy.rs
@@ -9,10 +9,17 @@ define_resource!(PlacementPolicy, "placementpolicies", PlacementPolicySpec, (), 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct PlacementPolicySpec {
     pub pool: String,
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub priority: i32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host_direct: Option<HostDirectPlacementPolicySpec>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docker_per_vessel: Option<DockerPerVesselPlacementPolicySpec>,
+}
+
+fn is_zero(value: &i32) -> bool {
+    *value == 0
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -80,11 +80,13 @@ fn placement_decision_is_written_once_without_overwriting_concurrent_status() {
         policy_name: "host-direct-kiwi".to_string(),
         target_host: PlacementTargetHost { reference: "kiwi-id".to_string(), display_name: "kiwi".to_string() },
         refused_candidates: Vec::new(),
+        viable_not_selected: Vec::new(),
     };
     let second = PlacementDecision {
         policy_name: "host-direct-feta".to_string(),
         target_host: PlacementTargetHost { reference: "feta-id".to_string(), display_name: "feta".to_string() },
         refused_candidates: Vec::new(),
+        viable_not_selected: Vec::new(),
     };
     let mut status =
         ConvoyStatus { phase: ConvoyPhase::Active, observed_workflow_ref: Some("scratch".to_string()), ..ConvoyStatus::default() };

--- a/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
+++ b/crates/flotilla-resources/tests/provisioning_resources_in_memory.rs
@@ -45,6 +45,7 @@ async fn placement_policy_roundtrips_without_status() {
     let resolver = ResourceBackend::InMemory(InMemoryBackend::default()).using::<PlacementPolicy>("flotilla");
     let spec = PlacementPolicySpec::builder()
         .pool("cleat".to_string())
+        .priority(100)
         .host_direct(HostDirectPlacementPolicySpec {
             host_ref: "01HXYZ".to_string(),
             checkout: HostDirectPlacementPolicyCheckout::Worktree,
@@ -57,6 +58,7 @@ async fn placement_policy_roundtrips_without_status() {
     assert_eq!(created.metadata.name, "host-direct-01HXYZ");
     assert_eq!(created.status, None);
     assert_eq!(fetched.spec.pool, "cleat");
+    assert_eq!(fetched.spec.priority, 100);
     assert!(fetched.spec.host_direct.is_some());
 }
 

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -203,6 +203,7 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
         policy_name: "docker-on-01HXYZ".to_string(),
         target_host: PlacementTargetHost { reference: "01HXYZ".to_string(), display_name: "kiwi".to_string() },
         refused_candidates: Vec::new(),
+        viable_not_selected: Vec::new(),
     };
 
     VesselStatusPatch::MarkProvisioning {
@@ -222,6 +223,7 @@ fn vessel_status_patch_marks_provisioning_ready_and_failed() {
             policy_name: "replacement-must-not-win".to_string(),
             target_host: PlacementTargetHost { reference: "other".to_string(), display_name: "feta".to_string() },
             refused_candidates: Vec::new(),
+            viable_not_selected: Vec::new(),
         }),
         observed_policy_ref: "docker-on-01HXYZ".to_string(),
         observed_policy_version: "13".to_string(),

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -436,7 +436,12 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
                         } else {
                             format!("; {} refused", decision.refused_candidates.len())
                         };
-                        format!("{} on {}{refusals}", decision.policy_name, decision.target_host.display_name)
+                        let viable = if decision.viable_not_selected.is_empty() {
+                            String::new()
+                        } else {
+                            format!("; {} viable not selected", decision.viable_not_selected.len())
+                        };
+                        format!("{} on {}{refusals}{viable}", decision.policy_name, decision.target_host.display_name)
                     },
                 )),
                 Cell::new(format_fleet_staleness(&row.staleness)),

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -1139,6 +1139,17 @@ fn convoy_description(row: &ConvoySummary) -> Vec<DetailField> {
                     .join("\n"),
             });
         }
+        if !decision.viable_not_selected.is_empty() {
+            fields.push(DetailField {
+                label: "Viable placements not selected",
+                value: decision
+                    .viable_not_selected
+                    .iter()
+                    .map(|candidate| format!("{} on {}: {}", candidate.policy_name, candidate.target_host.display_name, candidate.reason))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            });
+        }
     }
     if let Some(change_request) = &row.change_request {
         fields.push(DetailField { label: "Pull request", value: format!("#{} · {}", change_request.id, change_request.status) });
@@ -1291,6 +1302,17 @@ fn vessel_description(row: &VesselProjection) -> Vec<DetailField> {
                     .refused_candidates
                     .iter()
                     .map(|refusal| format!("{} on {}: {}", refusal.policy_name, refusal.target_host.display_name, refusal.reason))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            });
+        }
+        if !decision.viable_not_selected.is_empty() {
+            fields.push(DetailField {
+                label: "Viable placements not selected",
+                value: decision
+                    .viable_not_selected
+                    .iter()
+                    .map(|candidate| format!("{} on {}: {}", candidate.policy_name, candidate.target_host.display_name, candidate.reason))
                     .collect::<Vec<_>>()
                     .join("\n"),
             });
@@ -1450,6 +1472,11 @@ mod tests {
                 target_host: flotilla_protocol::PlacementTargetHost { reference: "02HXYZ".into(), display_name: "feta".into() },
                 reason: "disk below admission floor".into(),
             }],
+            viable_not_selected: vec![flotilla_protocol::PlacementViableCandidate {
+                policy_name: "host-direct-gouda".into(),
+                target_host: flotilla_protocol::PlacementTargetHost { reference: "03HXYZ".into(), display_name: "gouda".into() },
+                reason: "priority 0 is lower than selected policy `host-direct-kiwi` priority 100".into(),
+            }],
         };
         let mut vessel = vessel("implement", &[], WorkPhase::Running);
         vessel.placement_decision = Some(decision.clone());
@@ -1461,9 +1488,17 @@ mod tests {
         assert!(convoy_view.rows[0]
             .describe
             .contains(&DetailField { label: "Placement refusals", value: "host-direct-feta on feta: disk below admission floor".into() }));
+        assert!(convoy_view.rows[0].describe.contains(&DetailField {
+            label: "Viable placements not selected",
+            value: "host-direct-gouda on gouda: priority 0 is lower than selected policy `host-direct-kiwi` priority 100".into(),
+        }));
 
         let vessel_view = project_convoys("vessel/dev/tables/implement", &[&convoy]).expect("vessel table");
         assert!(vessel_view.rows[0].describe.contains(&DetailField { label: "Placement", value: "host-direct-kiwi on kiwi".into() }));
+        assert!(vessel_view.rows[0].describe.contains(&DetailField {
+            label: "Viable placements not selected",
+            value: "host-direct-gouda on gouda: priority 0 is lower than selected policy `host-direct-kiwi` priority 100".into(),
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add integer `priority` to `PlacementPolicy` and order viable candidates by descending priority before the existing local/kind/name fallback
- record every viable loser in `placement_decision.viable_not_selected` with the ordering reason
- expose viable alternatives in fleet CLI summaries and convoy/vessel TUI details
- cover manifest/resource round trips and an in-process dispatch with selected, refused, and viable-not-selected candidates

## Root cause

Candidate enumeration was working: feta passed admission and entered the viable set. The resolver sorted viable policies, selected the first with `into_iter().next()`, and discarded every remaining viable policy. The sort also unconditionally preferred the admitting daemon's local host, so kiwi consistently outcompeted feta without leaving evidence in the decision.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1224