### PR TITLE
fix: bound peer connection resource usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "flotilla-transport",
  "futures",
  "indexmap",
+ "libc",
  "rusqlite",
  "serde",
  "serde_json",

--- a/crates/flotilla-daemon/Cargo.toml
+++ b/crates/flotilla-daemon/Cargo.toml
@@ -31,6 +31,9 @@ uuid = { version = "1", features = ["v4"] }
 futures = "0.3"
 visibility = "0.1.1"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 flotilla-test-support = { path = "../flotilla-test-support" }
 indexmap = { workspace = true }

--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -9,7 +9,7 @@ use flotilla_core::{
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::{runtime::DaemonRuntime, server::DaemonServer};
+use crate::{resource_limits::raise_file_descriptor_limit, runtime::DaemonRuntime, server::DaemonServer};
 
 pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeout_secs: u64) -> Result<(), String> {
     let config = Arc::new(ConfigStore::new(DaemonHostPath::new(config_dir), DaemonHostPath::new(state_dir)));
@@ -35,6 +35,7 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
     let stderr_layer = std::io::stderr().is_terminal().then(|| tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
     let file_layer = tracing_subscriber::fmt::layer().json().with_ansi(false).with_writer(file_appender);
     tracing_subscriber::registry().with(filter).with(stderr_layer).with(file_layer).try_init().ok();
+    raise_file_descriptor_limit();
 
     let timeout = if timeout_secs == 0 { Duration::from_secs(u64::MAX) } else { Duration::from_secs(timeout_secs) };
 

--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -1,6 +1,7 @@
 mod aggregator;
 mod credential;
 mod issue_materializer;
+mod resource_limits;
 pub mod resource_manifest;
 mod sleep_inhibitor;
 pub use aggregator::{Aggregator, AggregatorResolvers};

--- a/crates/flotilla-daemon/src/resource_limits.rs
+++ b/crates/flotilla-daemon/src/resource_limits.rs
@@ -1,0 +1,129 @@
+use chrono::{DateTime, Utc};
+use flotilla_resources::{ConditionValue, HostCondition};
+use tracing::{info, warn};
+
+const TARGET_NOFILE_SOFT_LIMIT: u64 = 8_192;
+const FILE_DESCRIPTOR_PRESSURE_PERCENT: u64 = 80;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileDescriptorUsage {
+    open: u64,
+    soft_limit: u64,
+}
+
+pub(crate) fn raise_file_descriptor_limit() {
+    #[cfg(unix)]
+    if let Err(error) = raise_file_descriptor_limit_unix() {
+        warn!(%error, "failed to raise daemon file descriptor limit");
+    }
+}
+
+pub(crate) fn file_descriptor_pressure_condition() -> Option<HostCondition> {
+    let usage = current_file_descriptor_usage()?;
+    file_descriptor_pressure_condition_for(usage, Utc::now())
+}
+
+fn file_descriptor_pressure_condition_for(usage: FileDescriptorUsage, observed_at: DateTime<Utc>) -> Option<HostCondition> {
+    if usage.soft_limit == 0 || usage.open.saturating_mul(100) < usage.soft_limit.saturating_mul(FILE_DESCRIPTOR_PRESSURE_PERCENT) {
+        return None;
+    }
+
+    let percent = usage.open.saturating_mul(100) / usage.soft_limit;
+    Some(
+        HostCondition::builder()
+            .condition_type("FileDescriptors")
+            .value(ConditionValue::False)
+            .reason("FileDescriptorPressure")
+            .message(format!(
+                "{} of {} file descriptors are open ({percent}%); connection acceptance is at risk",
+                usage.open, usage.soft_limit
+            ))
+            .observed_at(observed_at)
+            .build(),
+    )
+}
+
+fn current_file_descriptor_usage() -> Option<FileDescriptorUsage> {
+    #[cfg(unix)]
+    {
+        let soft_limit = nofile_limits().ok()?.0;
+        let open = open_file_descriptor_count()?;
+        Some(FileDescriptorUsage { open, soft_limit })
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+pub(crate) fn open_file_descriptor_count() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        ["/proc/self/fd", "/dev/fd"]
+            .into_iter()
+            .find_map(|path| std::fs::read_dir(path).ok().map(|entries| entries.filter_map(Result::ok).count() as u64))
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+#[cfg(unix)]
+fn nofile_limits() -> Result<(u64, u64), String> {
+    let mut limits = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+    // SAFETY: `limits` points to a valid `rlimit` value for the duration of the call.
+    let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    Ok((limits.rlim_cur, limits.rlim_max))
+}
+
+#[cfg(unix)]
+fn raise_file_descriptor_limit_unix() -> Result<(), String> {
+    let (current, hard) = nofile_limits()?;
+    let desired = desired_nofile_soft_limit(current, hard);
+    if desired <= current {
+        info!(soft_limit = current, hard_limit = hard, "daemon file descriptor limit");
+        return Ok(());
+    }
+
+    let limits = libc::rlimit { rlim_cur: desired, rlim_max: hard };
+    // SAFETY: `limits` is initialized, and changing only this process's soft
+    // RLIMIT_NOFILE to a value no greater than its hard limit is valid.
+    let result = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &limits) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    info!(previous_soft_limit = current, soft_limit = desired, hard_limit = hard, "raised daemon file descriptor limit");
+    Ok(())
+}
+
+fn desired_nofile_soft_limit(current: u64, hard: u64) -> u64 {
+    current.max(TARGET_NOFILE_SOFT_LIMIT.min(hard))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desired_limit_raises_stock_soft_limit_without_exceeding_hard_limit() {
+        assert_eq!(desired_nofile_soft_limit(1_024, 1_048_576), 8_192);
+        assert_eq!(desired_nofile_soft_limit(1_024, 4_096), 4_096);
+        assert_eq!(desired_nofile_soft_limit(16_384, 1_048_576), 16_384);
+    }
+
+    #[test]
+    fn file_descriptor_pressure_is_reported_at_eighty_percent() {
+        let below = file_descriptor_pressure_condition_for(FileDescriptorUsage { open: 818, soft_limit: 1_024 }, Utc::now());
+        assert!(below.is_none());
+
+        let condition = file_descriptor_pressure_condition_for(FileDescriptorUsage { open: 820, soft_limit: 1_024 }, Utc::now())
+            .expect("80% usage should be diagnosed");
+        assert_eq!(condition.condition_type, "FileDescriptors");
+        assert_eq!(condition.reason, "FileDescriptorPressure");
+        assert!(condition.message.contains("820 of 1024"));
+    }
+}

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -47,6 +47,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     credential::CredentialStore,
+    resource_limits::file_descriptor_pressure_condition,
     resource_manifest::ResourceManifestReconciler,
     sleep_inhibitor,
     supervisor::{supervise, ControllerSupervision, RestartBudgetExhausted},
@@ -1059,7 +1060,8 @@ async fn apply_host_heartbeat_with_credentials(
     let disk_free_bytes = tokio::task::spawn_blocking(move || measure_available_space(&repo_default_dir))
         .await
         .map_err(|error| format!("measure available disk space: {error}"))?;
-    let conditions = runtime_health.conditions();
+    let mut conditions = runtime_health.conditions();
+    conditions.extend(file_descriptor_pressure_condition());
     let status = HostStatus {
         capabilities: host_capabilities(&summary, profile, &held_credentials),
         heartbeat_at: Some(Utc::now()),

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -383,9 +383,10 @@ impl DaemonServer {
 
         // Accept loop
         let mut accept_error_backoff = AcceptErrorBackoff::default();
+        let mut accept_retry_at = None;
         loop {
             tokio::select! {
-                accept_result = listener.accept() => {
+                accept_result = listener.accept(), if accept_retry_at.is_none() => {
                     match accept_result {
                         Ok((stream, _addr)) => {
                             accept_error_backoff.reset();
@@ -424,9 +425,17 @@ impl DaemonServer {
                                 fd_exhausted = e.raw_os_error().is_some_and(|code| code == libc::EMFILE || code == libc::ENFILE),
                                 "failed to accept connection; backing off"
                             );
-                            tokio::time::sleep(delay).await;
+                            accept_retry_at = Some(tokio::time::Instant::now() + delay);
                         }
                     }
+                }
+                () = async {
+                    match accept_retry_at {
+                        Some(retry_at) => tokio::time::sleep_until(retry_at).await,
+                        None => std::future::pending().await,
+                    }
+                } => {
+                    accept_retry_at = None;
                 }
                 _ = shutdown_rx.changed() => {
                     if *shutdown_rx.borrow() {

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -42,6 +42,34 @@ use self::{
 };
 use crate::peer::{ConnectionDirection, ConnectionMeta, InboundPeerEnvelope, PeerManager, SshTransport};
 
+const CONNECTION_PREFACE_TIMEOUT: Duration = Duration::from_secs(10);
+const HELLO_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+const ACCEPT_ERROR_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const ACCEPT_ERROR_MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+struct AcceptErrorBackoff {
+    next: Duration,
+}
+
+impl Default for AcceptErrorBackoff {
+    fn default() -> Self {
+        Self { next: ACCEPT_ERROR_INITIAL_BACKOFF }
+    }
+}
+
+impl AcceptErrorBackoff {
+    fn reset(&mut self) {
+        self.next = ACCEPT_ERROR_INITIAL_BACKOFF;
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        let delay = self.next;
+        self.next = self.next.saturating_mul(2).min(ACCEPT_ERROR_MAX_BACKOFF);
+        delay
+    }
+}
+
 /// Notification sent from connection sites to the outbound task when a
 /// peer connects or reconnects. The outbound task responds by sending
 /// current local state for all repos to the specific peer.
@@ -354,11 +382,13 @@ impl DaemonServer {
             tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).expect("failed to register SIGTERM handler");
 
         // Accept loop
+        let mut accept_error_backoff = AcceptErrorBackoff::default();
         loop {
             tokio::select! {
                 accept_result = listener.accept() => {
                     match accept_result {
                         Ok((stream, _addr)) => {
+                            accept_error_backoff.reset();
                             let daemon = Arc::clone(&daemon);
                             let client_count = Arc::clone(&client_count);
                             let client_notify = Arc::clone(&client_notify);
@@ -387,7 +417,14 @@ impl DaemonServer {
                             });
                         }
                         Err(e) => {
-                            error!(err = %e, "failed to accept connection");
+                            let delay = accept_error_backoff.next_delay();
+                            error!(
+                                err = %e,
+                                delay_ms = delay.as_millis() as u64,
+                                fd_exhausted = e.raw_os_error().is_some_and(|code| code == libc::EMFILE || code == libc::ENFILE),
+                                "failed to accept connection; backing off"
+                            );
+                            tokio::time::sleep(delay).await;
                         }
                     }
                 }
@@ -450,15 +487,19 @@ async fn handle_client(
     environment_context: Option<EnvironmentId>,
 ) {
     let mut first_byte = [0_u8; 1];
-    match tokio::io::AsyncReadExt::read_exact(&mut stream, &mut first_byte).await {
-        Ok(_) if first_byte[0].is_ascii_uppercase() => {
+    match tokio::time::timeout(CONNECTION_PREFACE_TIMEOUT, tokio::io::AsyncReadExt::read_exact(&mut stream, &mut first_byte)).await {
+        Err(_) => {
+            warn!(timeout_secs = CONNECTION_PREFACE_TIMEOUT.as_secs(), "connection timed out before sending a preface");
+            return;
+        }
+        Ok(Ok(_)) if first_byte[0].is_ascii_uppercase() => {
             if let Err(error) = resource_http::serve_resource_http(stream, first_byte[0], daemon.resource_backend().clone()).await {
                 warn!(%error, "resource HTTP connection failed");
             }
             return;
         }
-        Ok(_) => {}
-        Err(error) => {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => {
             warn!(%error, "failed to read connection preface");
             return;
         }
@@ -495,16 +536,20 @@ async fn handle_client_session(
 ) {
     let session = Arc::new(session);
     let first_msg = tokio::select! {
-            message_result = session.read() => {
-                match message_result {
-                    Ok(msg) => msg,
-                    Err(e) => {
-                        error!(err = %e, "error reading first message from client");
-                        None
-                    }
+        message_result = tokio::time::timeout(HELLO_HANDSHAKE_TIMEOUT, session.read()) => {
+            match message_result {
+                Ok(Ok(msg)) => msg,
+                Ok(Err(e)) => {
+                    error!(err = %e, "error reading first message from client");
+                    None
+                }
+                Err(_) => {
+                    warn!(timeout_secs = HELLO_HANDSHAKE_TIMEOUT.as_secs(), "connection timed out before completing Hello handshake");
+                    None
                 }
             }
-            _ = shutdown_rx.changed() => None,
+        }
+        _ = shutdown_rx.changed() => None,
     };
 
     const BUILD_ID: &str = env!("FLOTILLA_BUILD_ID");

--- a/crates/flotilla-daemon/src/server/peer_connection.rs
+++ b/crates/flotilla-daemon/src/server/peer_connection.rs
@@ -15,6 +15,8 @@ use super::{
 };
 use crate::peer::{ActivationResult, InboundPeerEnvelope, PeerManager};
 
+pub(super) const PEER_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 pub(super) struct PeerConnection {
     daemon: Arc<InProcessDaemon>,
     shutdown_rx: watch::Receiver<bool>,
@@ -121,11 +123,14 @@ impl PeerConnection {
             resource_socket_path: None,
         }));
 
+        let idle_deadline = tokio::time::sleep(PEER_IDLE_TIMEOUT);
+        tokio::pin!(idle_deadline);
         loop {
             tokio::select! {
                 message_result = session.read() => {
                     match message_result {
                         Ok(Some(msg)) => {
+                            idle_deadline.as_mut().reset(tokio::time::Instant::now() + PEER_IDLE_TIMEOUT);
                             match msg {
                                 Message::Peer(peer_msg) => {
                                     if let Err(e) = self.peer_data_tx.send(InboundPeerEnvelope {
@@ -149,6 +154,10 @@ impl PeerConnection {
                         }
                         Ok(None) => break,
                     }
+                }
+                () = &mut idle_deadline => {
+                    warn!(peer = %node_id, timeout_secs = PEER_IDLE_TIMEOUT.as_secs(), "peer connection idle timeout");
+                    break;
                 }
                 _ = self.shutdown_rx.changed() => {
                     if *self.shutdown_rx.borrow() {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -35,10 +35,11 @@ use flotilla_resources::{
     ResourceProvenance, Stance, StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec,
     TerminalSessionStatus, TerminalSessionStatusPatch, WatchEvent, WatchStart, WorkflowTemplate,
 };
+use flotilla_test_support::TestSocketDir;
 use flotilla_transport::message::{message_session_pair, MessageSession};
 use indexmap::IndexMap;
 use tokio::{
-    io::{AsyncBufReadExt, BufReader, BufWriter},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter},
     sync::{mpsc, oneshot, watch, Mutex, Notify},
     time::Duration,
 };
@@ -47,6 +48,7 @@ use tokio_util::sync::CancellationToken;
 use super::{
     client_connection::QuerySubscriptions,
     handle_client, handle_client_session,
+    peer_connection::PEER_IDLE_TIMEOUT,
     peer_runtime::{
         disconnect_peer_and_rebuild, forward_with_keepalive_for_test, handle_remote_restart_if_needed, relay_peer_data, send_local_to_peer,
         should_send_local_version, ForwardResult,
@@ -60,7 +62,8 @@ use super::{
     resource_http::serve_resource_http,
     shared::{sync_peer_query_state, write_message, SocketPeerSender},
     test_support::{apply_convoy_replica_feed, seed_trusted_remote_convoy_project},
-    DaemonServer, PeerConnectionEvent,
+    AcceptErrorBackoff, DaemonServer, PeerConnectionEvent, ACCEPT_ERROR_INITIAL_BACKOFF, ACCEPT_ERROR_MAX_BACKOFF,
+    CONNECTION_PREFACE_TIMEOUT, HELLO_HANDSHAKE_TIMEOUT,
 };
 
 #[tokio::test]
@@ -448,6 +451,40 @@ async fn complete_client_hello(session: &MessageSession) {
 
 async fn empty_daemon() -> (tempfile::TempDir, Arc<InProcessDaemon>) {
     empty_daemon_named("local").await
+}
+
+async fn spawn_test_client_handler(
+) -> (tempfile::TempDir, tokio::net::UnixStream, tokio::task::JoinHandle<()>, Arc<AtomicUsize>, watch::Sender<bool>) {
+    let (tmp, daemon) = empty_daemon().await;
+    let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
+    let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let client_count = Arc::new(AtomicUsize::new(0));
+    let client_notify = Arc::new(Notify::new());
+    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
+    let (client_stream, server_stream) = tokio::net::UnixStream::pair().expect("pair");
+
+    let daemon_for_task = Arc::clone(&daemon);
+    let pm = Arc::clone(&peer_manager);
+    let count_ref = Arc::clone(&client_count);
+    let handle = tokio::spawn(async move {
+        let remote_command_router = empty_remote_command_router(&daemon_for_task, &pm);
+        handle_client(
+            server_stream,
+            daemon_for_task,
+            shutdown_rx,
+            peer_data_tx,
+            pm,
+            remote_command_router,
+            count_ref,
+            client_notify,
+            peer_connected_tx,
+            flotilla_core::agents::shared_in_memory_agent_state_store(),
+            None,
+        )
+        .await;
+    });
+    (tmp, client_stream, handle, client_count, shutdown_tx)
 }
 
 async fn empty_daemon_named(host_name: &str) -> (tempfile::TempDir, Arc<InProcessDaemon>) {
@@ -3037,6 +3074,36 @@ async fn handle_client_forwards_peer_data_and_registers_peer() {
 }
 
 #[tokio::test]
+async fn silent_peer_session_is_reaped_at_idle_deadline() {
+    let (_tmp, client, handle, client_count, _shutdown_tx) = spawn_test_client_handler().await;
+    let (read_half, write_half) = client.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+    let mut writer = BufWriter::new(write_half);
+    let hello = Message::Hello {
+        protocol_version: PROTOCOL_VERSION,
+        node_id: NodeId::new("silent-peer"),
+        display_name: "silent-peer".into(),
+        session_id: uuid::Uuid::nil(),
+        connection_role: None,
+        surface: None,
+    };
+    flotilla_protocol::framing::write_message_line(&mut writer, &hello).await.expect("write peer hello");
+    assert!(matches!(
+        serde_json::from_str::<Message>(&reader.next_line().await.expect("read hello").expect("hello line")).expect("parse hello"),
+        Message::Hello { .. }
+    ));
+    assert_eq!(client_count.load(Ordering::SeqCst), 1);
+
+    tokio::time::pause();
+    tokio::time::advance(PEER_IDLE_TIMEOUT).await;
+    tokio::task::yield_now().await;
+
+    assert!(reader.next_line().await.expect("read peer EOF").is_none());
+    handle.await.expect("join idle peer handler");
+    assert_eq!(client_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn handle_client_does_not_advance_host_cursor_for_duplicate_host_summary() {
     let (_tmp, daemon) = empty_daemon().await;
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
@@ -3348,7 +3415,10 @@ async fn assert_client_hello_rejected(protocol_version: u32, display_name: Strin
         .expect("server should close the mismatched connection promptly")
         .expect("read after hello");
     assert!(eof.is_none(), "expected EOF after {mismatch}-mismatch hello, got {eof:?}");
-    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    tokio::time::timeout(Duration::from_secs(2), handle)
+        .await
+        .expect("rejected connection handler should exit")
+        .expect("join rejected connection handler");
 }
 
 #[tokio::test]
@@ -3364,6 +3434,95 @@ async fn handle_client_rejects_client_hello_with_wire_generation_mismatch() {
         "wire generation",
     )
     .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn connection_without_preface_is_closed_at_handshake_deadline() {
+    let (_tmp, mut client, handle, client_count, _shutdown_tx) = spawn_test_client_handler().await;
+    tokio::task::yield_now().await;
+
+    tokio::time::advance(CONNECTION_PREFACE_TIMEOUT).await;
+    tokio::task::yield_now().await;
+
+    let mut byte = [0_u8; 1];
+    assert_eq!(client.read(&mut byte).await.expect("read closed connection"), 0);
+    handle.await.expect("join timed-out connection handler");
+    assert_eq!(client_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn partial_hello_is_closed_at_handshake_deadline() {
+    let (_tmp, mut client, handle, client_count, _shutdown_tx) = spawn_test_client_handler().await;
+    client.write_all(b"{").await.expect("write partial hello");
+    tokio::task::yield_now().await;
+
+    tokio::time::advance(HELLO_HANDSHAKE_TIMEOUT).await;
+    tokio::task::yield_now().await;
+
+    let mut byte = [0_u8; 1];
+    assert_eq!(client.read(&mut byte).await.expect("read closed connection"), 0);
+    handle.await.expect("join timed-out connection handler");
+    assert_eq!(client_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn live_daemon_reaps_partial_peer_dial_churn() {
+    const DIAL_COUNT: u64 = 32;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket_dir = TestSocketDir::new();
+    let socket_path = socket_dir.socket_path("churn.sock");
+    let config = test_config_store(tmp.path().join("config"));
+    let server = DaemonServer::new(Vec::new(), config, fake_discovery(false), socket_path.clone(), StdDuration::from_secs(60))
+        .await
+        .expect("create daemon server");
+    let shutdown_tx = server.shutdown_tx.clone();
+    let server_task = tokio::spawn(server.run());
+    while !socket_path.exists() {
+        tokio::task::yield_now().await;
+    }
+    let baseline = crate::resource_limits::open_file_descriptor_count().expect("count process file descriptors");
+
+    let mut stalled_dials = Vec::new();
+    for _ in 0..DIAL_COUNT {
+        let mut stream = tokio::net::UnixStream::connect(&socket_path).await.expect("dial live daemon");
+        stream.write_all(b"{").await.expect("write partial peer hello");
+        stalled_dials.push(stream);
+    }
+    tokio::task::yield_now().await;
+    let during_churn = crate::resource_limits::open_file_descriptor_count().expect("count descriptors during churn");
+    assert!(during_churn >= baseline + DIAL_COUNT * 2, "each stalled dial should initially hold both ends of a socket");
+
+    tokio::time::pause();
+    tokio::time::advance(HELLO_HANDSHAKE_TIMEOUT).await;
+    tokio::task::yield_now().await;
+    for stream in &mut stalled_dials {
+        let mut byte = [0_u8; 1];
+        assert_eq!(stream.read(&mut byte).await.expect("read closed stalled dial"), 0);
+    }
+    let after_deadline = crate::resource_limits::open_file_descriptor_count().expect("count descriptors after handshake deadlines");
+    assert!(
+        after_deadline <= baseline + DIAL_COUNT + 2,
+        "daemon-side descriptors should be reaped while dialer descriptors remain: baseline={baseline}, after={after_deadline}"
+    );
+
+    drop(stalled_dials);
+    shutdown_tx.send(true).expect("request daemon shutdown");
+    server_task.await.expect("join daemon server").expect("daemon server should stop cleanly");
+}
+
+#[test]
+fn accept_errors_back_off_exponentially_and_reset_after_success() {
+    let mut backoff = AcceptErrorBackoff::default();
+    assert_eq!(backoff.next_delay(), ACCEPT_ERROR_INITIAL_BACKOFF);
+    assert_eq!(backoff.next_delay(), ACCEPT_ERROR_INITIAL_BACKOFF * 2);
+    for _ in 0..10 {
+        backoff.next_delay();
+    }
+    assert_eq!(backoff.next_delay(), ACCEPT_ERROR_MAX_BACKOFF);
+
+    backoff.reset();
+    assert_eq!(backoff.next_delay(), ACCEPT_ERROR_INITIAL_BACKOFF);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1239

## What changed

- Bound accepted connections with 10-second preface and `Hello` handshake deadlines.
- Reap silent inbound peer sessions after 120 seconds; healthy peers remain active through the existing ping/pong traffic.
- Back off accept failures exponentially from 100 ms to 5 seconds, including `EMFILE`/`ENFILE`, instead of spinning.
- Raise the daemon's soft `RLIMIT_NOFILE` to 8192 where the hard limit permits.
- Publish a `FileDescriptors` degraded host condition once usage reaches 80%, so `fleet health` diagnoses pressure before exhaustion.
- Add focused lifecycle, generation-rejection, backoff, resource-pressure, and live-daemon fd-count regressions.

## Root cause

Accepted sockets could wait indefinitely before a complete peer handshake, and inbound peer sessions had no victim-side silence deadline. Repeated aborted SSH-forwarded dials therefore retained descriptors. Separately, the accept loop retried resource-exhaustion errors immediately.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- Live-daemon churn regression holds 32 partial dials open and verifies all daemon-side socket descriptors are released at the handshake deadline while the client ends remain open.