### PR TITLE
fix: reconcile remote vessel placements locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "flotilla-manifest",
  "flotilla-protocol",
  "flotilla-resources",
+ "futures",
  "rstest",
  "serde_json",
  "sha2",

--- a/crates/flotilla-controllers/Cargo.toml
+++ b/crates/flotilla-controllers/Cargo.toml
@@ -23,3 +23,4 @@ flotilla-resources = { path = "../flotilla-resources", features = ["test-support
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 rstest = { workspace = true }
 tempfile = "3"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/crates/flotilla-controllers/Cargo.toml
+++ b/crates/flotilla-controllers/Cargo.toml
@@ -15,6 +15,7 @@ bon = { workspace = true }
 tracing = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 dirs = "6"
+futures = "0.3"
 sha2 = "0.10"
 serde_json = { workspace = true }
 

--- a/crates/flotilla-controllers/src/reconcilers/mod.rs
+++ b/crates/flotilla-controllers/src/reconcilers/mod.rs
@@ -5,6 +5,7 @@ pub mod presentation;
 pub mod repository;
 pub mod terminal_session;
 pub mod vessel;
+pub mod vessel_placement;
 
 pub use checkout::{
     BranchPreservationReason, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout,
@@ -19,3 +20,4 @@ pub use presentation::{
 pub use repository::{ForgeDefaultBranchResolver, RepositoryReconciler};
 pub use terminal_session::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
 pub use vessel::{VesselDeps, VesselReconciler};
+pub use vessel_placement::{VesselPlacementProjector, VesselPlacementSync};

--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -4,9 +4,10 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
     controller::{Actuation, ReconcileOutcome, Reconciler},
-    Convoy, Environment, EnvironmentPhase, ResourceBackend, ResourceError, ResourceObject, TerminalAttention, TerminalAttentionSource,
-    TerminalAttentionState, TerminalSession, TerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, TerminalSessionTag,
-    TypedResolver, CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REF_SESSION_TAG, VESSEL_REF_LABEL,
+    Convoy, Environment, EnvironmentPhase, ReplicaReadResolver, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
+    TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession, TerminalSessionPhase, TerminalSessionSource,
+    TerminalSessionStatusPatch, TerminalSessionTag, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
+    CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REF_SESSION_TAG, VESSEL_REF_LABEL,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
@@ -54,12 +55,50 @@ pub trait TerminalRuntime: Send + Sync {
 pub struct TerminalSessionReconciler<R> {
     runtime: Arc<R>,
     convoys: TypedResolver<Convoy>,
+    federated_convoys: Option<ReplicaReadResolver<Convoy>>,
     environments: TypedResolver<Environment>,
 }
 
 impl<R> TerminalSessionReconciler<R> {
     pub fn new(runtime: Arc<R>, backend: ResourceBackend, namespace: &str) -> Self {
-        Self { runtime, convoys: backend.clone().using::<Convoy>(namespace), environments: backend.using::<Environment>(namespace) }
+        Self {
+            runtime,
+            convoys: backend.clone().using::<Convoy>(namespace),
+            federated_convoys: None,
+            environments: backend.using::<Environment>(namespace),
+        }
+    }
+
+    pub fn with_federated_convoys(mut self, backend: &ResourceBackend, namespace: &str) -> Self {
+        self.federated_convoys = Some(backend.including_replicas::<Convoy>(namespace));
+        self
+    }
+
+    async fn convoy_for_session(
+        &self,
+        session: &ResourceObject<TerminalSession>,
+        convoy_ref: &str,
+    ) -> Result<ResourceObject<Convoy>, ResourceError> {
+        let Some(origin) = session.metadata.annotations.get(ACTUATOR_SOURCE_ROOT_ANNOTATION) else {
+            return self.convoys.get(convoy_ref).await;
+        };
+        let Some(federated) = self.federated_convoys.as_ref() else {
+            return Err(ResourceError::not_found(convoy_ref));
+        };
+        federated
+            .list()
+            .await?
+            .items
+            .into_iter()
+            .find(|source| {
+                source.object.metadata.name == convoy_ref
+                    && matches!(
+                        &source.provenance,
+                        ResourceProvenance::Replica { origin_root, .. } if origin_root.as_str() == origin
+                    )
+            })
+            .map(|source| source.object)
+            .ok_or_else(|| ResourceError::not_found(convoy_ref))
     }
 }
 
@@ -88,7 +127,7 @@ where
             TerminalSessionSource::Tool { .. } => obj.metadata.labels.get(CONVOY_LABEL).map(String::as_str),
         };
         if let Some(convoy_ref) = convoy_ref {
-            match self.convoys.get(convoy_ref).await {
+            match self.convoy_for_session(obj, convoy_ref).await {
                 Ok(convoy) if convoy.metadata.deletion_timestamp.is_none() => {}
                 Ok(_) | Err(ResourceError::NotFound { .. }) => return Ok(TerminalDeps::OwnerMissing),
                 Err(err) => return Err(err),

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -19,11 +19,13 @@ use flotilla_resources::{
     CrewSource, CrewWorkPhase, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, Environment, EnvironmentMount,
     EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, EnvironmentWaitReason, FreshCloneCheckoutSpec,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy,
-    PlacementPolicySpec, Repository, RepositoryIdentity, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSpec, TypedResolver, Vessel,
-    VesselPhase, VesselStatusPatch, WorkPhase, CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REFS_ENV,
+    PlacementPolicySpec, ReplicaReadResolver, Repository, RepositoryIdentity, RepositoryKey, RepositorySpec, Resource, ResourceBackend,
+    ResourceError, ResourceObject, ResourceProvenance, Stance, TerminalSession, TerminalSessionIdentity, TerminalSessionPhase,
+    TerminalSessionSpec, TypedResolver, Vessel, VesselPhase, VesselStatusPatch, WorkPhase, ACTUATOR_HOST_REF_ANNOTATION,
+    ACTUATOR_SOURCE_ROOT_ANNOTATION, CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REFS_ENV,
     VESSEL_REF_LABEL,
 };
+use tracing::warn;
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
 const REPO_LABEL: &str = "flotilla.work/repo";
@@ -41,6 +43,9 @@ pub struct VesselReconciler {
     clones: TypedResolver<Clone>,
     checkouts: TypedResolver<Checkout>,
     terminal_sessions: TypedResolver<TerminalSession>,
+    federated_convoys: Option<ReplicaReadResolver<Convoy>>,
+    federated_placement_policies: Option<ReplicaReadResolver<PlacementPolicy>>,
+    local_host_ref: Option<String>,
     namespace: String,
     brief_templates: CrewBriefTemplateResolver,
 }
@@ -55,6 +60,9 @@ impl VesselReconciler {
             clones: backend.clone().using::<Clone>(namespace),
             checkouts: backend.clone().using::<Checkout>(namespace),
             terminal_sessions: backend.using::<TerminalSession>(namespace),
+            federated_convoys: None,
+            federated_placement_policies: None,
+            local_host_ref: None,
             namespace: namespace.to_string(),
             brief_templates: CrewBriefTemplateResolver::default(),
         }
@@ -64,6 +72,13 @@ impl VesselReconciler {
         Self { brief_templates: CrewBriefTemplateResolver::with_config_dir(config_dir), ..Self::new(backend, namespace) }
     }
 
+    pub fn with_federated_dependencies(mut self, backend: &ResourceBackend, local_host_ref: impl Into<String>) -> Self {
+        self.federated_convoys = Some(backend.including_replicas::<Convoy>(&self.namespace));
+        self.federated_placement_policies = Some(backend.including_replicas::<PlacementPolicy>(&self.namespace));
+        self.local_host_ref = Some(local_host_ref.into());
+        self
+    }
+
     pub fn secondary_watches() -> Vec<Box<dyn SecondaryWatch<Primary = Vessel>>> {
         vec![
             Box::new(LabelMappedWatch::<Environment, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
@@ -71,6 +86,48 @@ impl VesselReconciler {
             Box::new(LabelJoinWatch::<Checkout, Vessel> { label_key: CONVOY_LABEL, _marker: PhantomData }),
             Box::new(LabelMappedWatch::<TerminalSession, Vessel> { label_key: VESSEL_REF_LABEL, _marker: PhantomData }),
         ]
+    }
+
+    async fn dependency<T: Resource>(
+        local: &TypedResolver<T>,
+        federated: Option<&ReplicaReadResolver<T>>,
+        vessel: &ResourceObject<Vessel>,
+        name: &str,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        let Some(origin) = vessel.metadata.annotations.get(ACTUATOR_SOURCE_ROOT_ANNOTATION) else {
+            return local.get(name).await;
+        };
+        let Some(federated) = federated else {
+            return Err(ResourceError::not_found(name));
+        };
+        federated
+            .list()
+            .await?
+            .items
+            .into_iter()
+            .find(|source| {
+                source.object.metadata.name == name
+                    && matches!(
+                        &source.provenance,
+                        ResourceProvenance::Replica { origin_root, .. } if origin_root.as_str() == origin
+                    )
+            })
+            .map(|source| source.object)
+            .ok_or_else(|| ResourceError::not_found(name))
+    }
+
+    fn missing_host_local_environment(&self, environment_ref: &str, placement_host_ref: &str) -> String {
+        let reconciler_host_ref = self.local_host_ref.as_deref().unwrap_or("unknown");
+        let message = format!(
+            "host-local Environment {environment_ref} for placement host {placement_host_ref} was not found in the resource store for reconciler host {reconciler_host_ref}"
+        );
+        warn!(
+            %environment_ref,
+            %placement_host_ref,
+            %reconciler_host_ref,
+            "host-local Environment lookup failed in Vessel reconciliation"
+        );
+        message
     }
 }
 
@@ -199,19 +256,34 @@ impl Reconciler for VesselReconciler {
             return Ok(VesselDeps::none());
         }
 
-        let convoy = match self.convoys.get(&obj.spec.convoy_ref).await {
+        let convoy = match Self::dependency(&self.convoys, self.federated_convoys.as_ref(), obj, &obj.spec.convoy_ref).await {
             Ok(convoy) => convoy,
             Err(ResourceError::NotFound { .. }) => return Ok(VesselDeps::failed(format!("convoy {} not found", obj.spec.convoy_ref))),
             Err(err) => return Err(err),
         };
-        let placement_policy = match self.placement_policies.get(&obj.spec.placement_policy_ref).await {
+        let placement_decision = convoy.status.as_ref().and_then(|status| status.placement_decision.clone());
+        if self
+            .local_host_ref
+            .as_ref()
+            .zip(placement_decision.as_ref())
+            .is_some_and(|(local_host_ref, decision)| decision.target_host.reference != *local_host_ref)
+        {
+            return Ok(VesselDeps::none());
+        }
+        let placement_policy = match Self::dependency(
+            &self.placement_policies,
+            self.federated_placement_policies.as_ref(),
+            obj,
+            &obj.spec.placement_policy_ref,
+        )
+        .await
+        {
             Ok(policy) => policy,
             Err(ResourceError::NotFound { .. }) => {
                 return Ok(VesselDeps::failed(format!("placement policy {} not found", obj.spec.placement_policy_ref)))
             }
             Err(err) => return Err(err),
         };
-        let placement_decision = convoy.status.as_ref().and_then(|status| status.placement_decision.clone());
         let strategy = match placement_strategy(&placement_policy.spec) {
             Ok(strategy) => strategy,
             Err(message) => return Ok(VesselDeps::failed(message)),
@@ -297,7 +369,7 @@ impl Reconciler for VesselReconciler {
             let clone_env = match self.environments.get(&clone_env_ref).await {
                 Ok(environment) => environment,
                 Err(ResourceError::NotFound { .. }) => {
-                    return Ok(VesselDeps::failed(format!("host-direct environment {clone_env_ref} not found")))
+                    return Ok(VesselDeps::failed(self.missing_host_local_environment(&clone_env_ref, strategy.host_ref())))
                 }
                 Err(err) => return Err(err),
             };
@@ -585,7 +657,7 @@ impl Reconciler for VesselReconciler {
                     }
                     let meta = match &strategy {
                         PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
-                            convoy_owned_child_meta(&checkout_name, &convoy, labels)
+                            convoy_owned_child_meta(&checkout_name, &convoy, obj, labels)
                         }
                         PlacementStrategy::DockerFreshCloneInContainer { .. } => owned_child_meta(&checkout_name, obj, labels),
                     };
@@ -619,7 +691,7 @@ impl Reconciler for VesselReconciler {
                 let environment = match self.environments.get(&env_name).await {
                     Ok(environment) => environment,
                     Err(ResourceError::NotFound { .. }) => {
-                        return Ok(VesselDeps::failed(format!("host-direct environment {env_name} not found")))
+                        return Ok(VesselDeps::failed(self.missing_host_local_environment(&env_name, host_ref)))
                     }
                     Err(err) => return Err(err),
                 };
@@ -844,6 +916,7 @@ impl Reconciler for VesselReconciler {
                         }
                     };
                     let mut terminal_meta = identity.input_meta();
+                    terminal_meta.annotations.extend(actuator_annotations(obj));
                     if !requirement.credential_refs.is_empty() {
                         terminal_meta.annotations.insert(
                             CREDENTIAL_REFS_ANNOTATION.to_string(),
@@ -1121,6 +1194,7 @@ fn owned_child_meta(name: &str, workspace: &ResourceObject<Vessel>, mut extra_la
     InputMeta::builder()
         .name(name.to_string())
         .labels(extra_labels)
+        .annotations(actuator_annotations(workspace))
         .owner_references(vec![OwnerReference {
             api_version: format!("{}/{}", Vessel::API_PATHS.group, Vessel::API_PATHS.version),
             kind: Vessel::API_PATHS.kind.to_string(),
@@ -1130,11 +1204,24 @@ fn owned_child_meta(name: &str, workspace: &ResourceObject<Vessel>, mut extra_la
         .build()
 }
 
-fn convoy_owned_child_meta(name: &str, convoy: &ResourceObject<Convoy>, mut extra_labels: BTreeMap<String, String>) -> InputMeta {
+fn actuator_annotations(workspace: &ResourceObject<Vessel>) -> BTreeMap<String, String> {
+    [ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION]
+        .into_iter()
+        .filter_map(|key| workspace.metadata.annotations.get(key).map(|value| (key.to_string(), value.clone())))
+        .collect()
+}
+
+fn convoy_owned_child_meta(
+    name: &str,
+    convoy: &ResourceObject<Convoy>,
+    workspace: &ResourceObject<Vessel>,
+    mut extra_labels: BTreeMap<String, String>,
+) -> InputMeta {
     extra_labels.insert(CONVOY_LABEL.to_string(), convoy.metadata.name.clone());
     InputMeta::builder()
         .name(name.to_string())
         .labels(extra_labels)
+        .annotations(actuator_annotations(workspace))
         .owner_references(vec![OwnerReference {
             api_version: format!("{}/{}", Convoy::API_PATHS.group, Convoy::API_PATHS.version),
             kind: Convoy::API_PATHS.kind.to_string(),
@@ -1207,9 +1294,26 @@ impl PlacementStrategy {
 
 #[cfg(test)]
 mod tests {
-    use flotilla_protocol::{PlacementDecision, PlacementTargetHost};
+    use std::sync::{Arc, Mutex};
 
-    use super::legible_waiting_for;
+    use flotilla_protocol::{PlacementDecision, PlacementTargetHost};
+    use flotilla_resources::ResourceBackend;
+
+    use super::{legible_waiting_for, VesselReconciler};
+
+    #[derive(Clone)]
+    struct LogCaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for LogCaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log output lock should be healthy").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn waiting_message_replaces_the_structured_host_direct_environment_name() {
@@ -1229,5 +1333,33 @@ mod tests {
             "checkout checkout-01HXYZ to become ready",
             "unrelated names containing the host ref must not be rewritten"
         );
+    }
+
+    #[test]
+    fn missing_host_local_environment_warns_with_store_and_host_context() {
+        let backend = ResourceBackend::InMemory(Default::default());
+        let reconciler = VesselReconciler::new(backend.clone(), "flotilla").with_federated_dependencies(&backend, "feta-host");
+        let log_output = Arc::new(Mutex::new(Vec::new()));
+        let message;
+        {
+            let writer = LogCaptureWriter(Arc::clone(&log_output));
+            let subscriber = tracing_subscriber::fmt()
+                .without_time()
+                .with_ansi(false)
+                .with_target(false)
+                .with_max_level(tracing::Level::WARN)
+                .with_writer(move || writer.clone())
+                .finish();
+            let _guard = tracing::subscriber::set_default(subscriber);
+            message = reconciler.missing_host_local_environment("host-direct-kiwi", "kiwi-host");
+        }
+
+        let logs =
+            String::from_utf8(log_output.lock().expect("log output lock should be healthy").clone()).expect("logs should be valid UTF-8");
+        assert!(logs.contains(" WARN "), "missing warning level: {logs}");
+        assert!(logs.contains("environment_ref=host-direct-kiwi"), "missing Environment context: {logs}");
+        assert!(logs.contains("placement_host_ref=kiwi-host"), "missing placement-host context: {logs}");
+        assert!(logs.contains("reconciler_host_ref=feta-host"), "missing store-host context: {logs}");
+        assert!(message.contains("resource store for reconciler host feta-host"));
     }
 }

--- a/crates/flotilla-controllers/src/reconcilers/vessel_placement.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel_placement.rs
@@ -1,0 +1,163 @@
+use std::collections::{btree_map::Entry, BTreeMap, HashMap};
+
+use flotilla_resources::{
+    Convoy, InputMeta, LifecycleAuthority, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, Vessel,
+    ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,
+};
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct VesselPlacementSync {
+    pub created: usize,
+    pub updated: usize,
+    pub deleted: usize,
+}
+
+/// Projects remotely-authored Vessels placed on this host into this host's
+/// local resource log. The ordinary Vessel controller then owns all local
+/// actuation and records its status on the projected object; replication
+/// carries that actuator-authored fact back to the admitting store.
+#[derive(Clone)]
+pub struct VesselPlacementProjector {
+    backend: ResourceBackend,
+    namespace: String,
+    local_host_ref: String,
+}
+
+impl VesselPlacementProjector {
+    pub fn new(backend: ResourceBackend, namespace: impl Into<String>, local_host_ref: impl Into<String>) -> Self {
+        Self { backend, namespace: namespace.into(), local_host_ref: local_host_ref.into() }
+    }
+
+    pub async fn sync_once(&self) -> Result<VesselPlacementSync, ResourceError> {
+        let convoy_sources = self.backend.including_replicas::<Convoy>(&self.namespace).list().await?;
+        let convoys_by_origin = convoy_sources
+            .items
+            .into_iter()
+            .filter_map(|source| match source.provenance {
+                ResourceProvenance::Replica { origin_root, .. } => {
+                    Some(((origin_root.to_string(), source.object.metadata.name.clone()), source.object))
+                }
+                ResourceProvenance::Local => None,
+            })
+            .collect::<HashMap<_, _>>();
+
+        let vessel_sources = self.backend.including_replicas::<Vessel>(&self.namespace).list().await?;
+        let mut desired = BTreeMap::<String, (String, ResourceObject<Vessel>)>::new();
+        for source in vessel_sources.items {
+            let ResourceProvenance::Replica { origin_root, .. } = source.provenance else {
+                continue;
+            };
+            if source.object.metadata.annotations.contains_key(ACTUATOR_SOURCE_ROOT_ANNOTATION)
+                || source.object.metadata.deletion_timestamp.is_some()
+            {
+                continue;
+            }
+            let origin_root = origin_root.to_string();
+            let Some(convoy) = convoys_by_origin.get(&(origin_root.clone(), source.object.spec.convoy_ref.clone())) else {
+                continue;
+            };
+            let placed_here = convoy
+                .status
+                .as_ref()
+                .and_then(|status| status.placement_decision.as_ref())
+                .is_some_and(|decision| decision.target_host.reference == self.local_host_ref);
+            if !placed_here {
+                continue;
+            }
+
+            match desired.entry(source.object.metadata.name.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert((origin_root, source.object));
+                }
+                Entry::Occupied(entry) => {
+                    warn!(
+                        vessel = %entry.key(),
+                        first_origin = %entry.get().0,
+                        second_origin = %origin_root,
+                        host_ref = %self.local_host_ref,
+                        "multiple admitting stores projected the same Vessel name; leaving the existing local actuator untouched"
+                    );
+                }
+            }
+        }
+
+        let vessels = self.backend.using::<Vessel>(&self.namespace);
+        let existing = vessels.list().await?;
+        let mut local_actuators = existing
+            .items
+            .into_iter()
+            .filter(|vessel| {
+                vessel.metadata.annotations.get(ACTUATOR_HOST_REF_ANNOTATION).is_some_and(|host_ref| host_ref == &self.local_host_ref)
+            })
+            .map(|vessel| (vessel.metadata.name.clone(), vessel))
+            .collect::<BTreeMap<_, _>>();
+
+        let mut result = VesselPlacementSync::default();
+        for (name, (origin_root, source)) in desired {
+            let current = match vessels.get(&name).await {
+                Ok(current) => Some(current),
+                Err(ResourceError::NotFound { .. }) => None,
+                Err(error) => return Err(error),
+            };
+            if let Some(current) = current.as_ref() {
+                let projected_origin = current.metadata.annotations.get(ACTUATOR_SOURCE_ROOT_ANNOTATION);
+                if projected_origin.is_none_or(|projected_origin| projected_origin != &origin_root) {
+                    warn!(
+                        vessel = %name,
+                        source_origin = %origin_root,
+                        host_ref = %self.local_host_ref,
+                        "cannot project remotely placed Vessel because the local store already owns that name"
+                    );
+                    continue;
+                }
+            }
+
+            let mut labels = source.metadata.labels.clone();
+            labels.insert(flotilla_resources::AUTHORITY_LABEL.to_string(), LifecycleAuthority::Managed.as_label_value().to_string());
+            let mut annotations = source.metadata.annotations.clone();
+            annotations.insert(ACTUATOR_HOST_REF_ANNOTATION.to_string(), self.local_host_ref.clone());
+            annotations.insert(ACTUATOR_SOURCE_ROOT_ANNOTATION.to_string(), origin_root);
+            let mut meta = InputMeta::builder()
+                .name(name.clone())
+                .labels(labels)
+                .annotations(annotations)
+                .owner_references(source.metadata.owner_references.clone())
+                .build();
+            if let Some(current) = current {
+                local_actuators.remove(&name);
+                if current.spec == source.spec
+                    && current.metadata.labels == meta.labels
+                    && current.metadata.annotations == meta.annotations
+                    && current.metadata.owner_references == meta.owner_references
+                {
+                    continue;
+                }
+                meta.finalizers = current.metadata.finalizers.clone();
+                meta.deletion_timestamp = current.metadata.deletion_timestamp;
+                vessels.update(&meta, &current.metadata.resource_version, &source.spec).await?;
+                result.updated += 1;
+            } else {
+                vessels.create(&meta, &source.spec).await?;
+                result.created += 1;
+            }
+        }
+
+        for (name, actuator) in local_actuators {
+            if actuator.metadata.deletion_timestamp.is_some() {
+                continue;
+            }
+            vessels.delete(&name).await?;
+            result.deleted += 1;
+        }
+
+        debug!(
+            host_ref = %self.local_host_ref,
+            created = result.created,
+            updated = result.updated,
+            deleted = result.deleted,
+            "synchronized placed Vessel actuators"
+        );
+        Ok(result)
+    }
+}

--- a/crates/flotilla-controllers/src/reconcilers/vessel_placement.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel_placement.rs
@@ -1,9 +1,10 @@
 use std::collections::{btree_map::Entry, BTreeMap, HashMap};
 
 use flotilla_resources::{
-    Convoy, InputMeta, LifecycleAuthority, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, Vessel,
-    ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,
+    Convoy, InputMeta, LifecycleAuthority, ReadWatchEvent, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
+    Vessel, ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,
 };
+use futures::StreamExt;
 use tracing::{debug, warn};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -27,6 +28,22 @@ pub struct VesselPlacementProjector {
 impl VesselPlacementProjector {
     pub fn new(backend: ResourceBackend, namespace: impl Into<String>, local_host_ref: impl Into<String>) -> Self {
         Self { backend, namespace: namespace.into(), local_host_ref: local_host_ref.into() }
+    }
+
+    pub async fn run(&self) -> Result<(), ResourceError> {
+        let mut convoy_watch = self.backend.including_replicas::<Convoy>(&self.namespace).watch().await?;
+        let mut vessel_watch = self.backend.including_replicas::<Vessel>(&self.namespace).watch().await?;
+        self.sync_once().await?;
+
+        loop {
+            let replica_changed = tokio::select! {
+                event = convoy_watch.next() => replica_changed(event, Convoy::API_PATHS.kind)?,
+                event = vessel_watch.next() => replica_changed(event, Vessel::API_PATHS.kind)?,
+            };
+            if replica_changed {
+                self.sync_once().await?;
+            }
+        }
     }
 
     pub async fn sync_once(&self) -> Result<VesselPlacementSync, ResourceError> {
@@ -160,4 +177,12 @@ impl VesselPlacementProjector {
         );
         Ok(result)
     }
+}
+
+fn replica_changed<T: Resource>(event: Option<Result<ReadWatchEvent<T>, ResourceError>>, kind: &str) -> Result<bool, ResourceError> {
+    let event = event.ok_or_else(|| ResourceError::invalid(format!("{kind} replica watch ended")))?;
+    let source = match event? {
+        ReadWatchEvent::Added(source) | ReadWatchEvent::Modified(source) | ReadWatchEvent::Deleted(source) => source,
+    };
+    Ok(matches!(source.provenance, ResourceProvenance::Replica { .. }))
 }

--- a/crates/flotilla-controllers/tests/vessel_placement.rs
+++ b/crates/flotilla-controllers/tests/vessel_placement.rs
@@ -1,0 +1,85 @@
+use std::collections::BTreeMap;
+
+use chrono::Utc;
+use flotilla_controllers::reconcilers::VesselPlacementProjector;
+use flotilla_protocol::{NodeId, PlacementDecision, PlacementTargetHost};
+use flotilla_resources::{
+    Convoy, ConvoySpec, ConvoyStatus, InMemoryBackend, InputMeta, ResourceBackend, Vessel, VesselSpec, ACTUATOR_HOST_REF_ANNOTATION,
+    ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
+};
+
+const NAMESPACE: &str = "flotilla";
+
+#[tokio::test]
+async fn placed_replica_is_projected_into_the_actuation_hosts_local_store() {
+    let kiwi_root = NodeId::new("kiwi-root");
+    let feta_root = NodeId::new("feta-root");
+    let kiwi = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(kiwi_root.clone());
+    let feta = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(feta_root);
+
+    let convoys = kiwi.using::<Convoy>(NAMESPACE);
+    let convoy = convoys
+        .create(
+            &InputMeta::builder().name("remote-placement".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+        )
+        .await
+        .expect("create admitting Convoy");
+    convoys
+        .update_status("remote-placement", &convoy.metadata.resource_version, &ConvoyStatus {
+            placement_decision: Some(PlacementDecision {
+                policy_name: "host-direct-feta".to_string(),
+                target_host: PlacementTargetHost { reference: "feta-host".to_string(), display_name: "feta".to_string() },
+                refused_candidates: Vec::new(),
+                viable_not_selected: Vec::new(),
+            }),
+            ..ConvoyStatus::default()
+        })
+        .await
+        .expect("record placement");
+    kiwi.using::<Vessel>(NAMESPACE)
+        .create(
+            &InputMeta::builder()
+                .name("remote-placement-work".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "remote-placement".to_string())]))
+                .build(),
+            &VesselSpec {
+                convoy_ref: "remote-placement".to_string(),
+                vessel_name: "work".to_string(),
+                placement_policy_ref: "host-direct-feta".to_string(),
+                adopted_checkout_refs: BTreeMap::new(),
+            },
+        )
+        .await
+        .expect("create admitting Vessel");
+
+    feta.replica_writer::<Convoy>(kiwi_root.clone(), NAMESPACE)
+        .replace(&convoys.list().await.expect("list Convoys"), Utc::now())
+        .await
+        .expect("replicate Convoy");
+    feta.replica_writer::<Vessel>(kiwi_root, NAMESPACE)
+        .replace(&kiwi.using::<Vessel>(NAMESPACE).list().await.expect("list Vessels"), Utc::now())
+        .await
+        .expect("replicate Vessel");
+
+    let projector = VesselPlacementProjector::new(feta.clone(), NAMESPACE, "feta-host");
+    let sync = projector.sync_once().await.expect("project placed Vessel");
+    assert_eq!(sync.created, 1);
+    assert_eq!(projector.sync_once().await.expect("repeat projection"), Default::default());
+
+    let actuator =
+        feta.using::<Vessel>(NAMESPACE).get("remote-placement-work").await.expect("placement host should author an actuator Vessel");
+    assert_eq!(actuator.metadata.annotations.get(ACTUATOR_HOST_REF_ANNOTATION).map(String::as_str), Some("feta-host"));
+    assert_eq!(actuator.metadata.annotations.get(ACTUATOR_SOURCE_ROOT_ANNOTATION).map(String::as_str), Some("kiwi-root"));
+    assert!(
+        !kiwi
+            .using::<Vessel>(NAMESPACE)
+            .get("remote-placement-work")
+            .await
+            .expect("admitting Vessel remains")
+            .metadata
+            .annotations
+            .contains_key(ACTUATOR_SOURCE_ROOT_ANNOTATION),
+        "projection must not transfer ownership of the admitting object"
+    );
+}

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -12,7 +12,7 @@ use flotilla_controllers::reconcilers::{
     BranchPreservationReason, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, CloneReconciler, CloneRuntime,
     DockerEnvironmentRuntime, DockerProvisioning, DockerProvisioningError, EnvironmentReconciler, ForgeDefaultBranchResolver,
     HopChainContext, PreparedCheckout, PresentationPolicyRegistry, PresentationReconciler, ProviderPresentationRuntime,
-    RepositoryReconciler, TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler, VesselReconciler,
+    RepositoryReconciler, TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler, VesselPlacementProjector, VesselReconciler,
 };
 use flotilla_core::{
     agent_adapter::{AgentLaunchRequest, CapabilityTable},
@@ -61,6 +61,7 @@ use crate::{
 /// wedge can hide in.
 const LIVENESS_WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
 const MANIFEST_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
+const VESSEL_PLACEMENT_SYNC_INTERVAL: Duration = Duration::from_millis(250);
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 const BUILTIN_MANAGED_BY_VALUE: &str = "builtin";
@@ -1316,6 +1317,26 @@ fn spawn_controller_loops(
     vec![
         tokio::spawn({
             let backend = backend.clone();
+            let namespace_string = namespace_string.clone();
+            let local_host_ref = state.local_host_ref.clone();
+            let supervision = supervision.clone();
+            let runtime_health = runtime_health.clone();
+            async move {
+                supervise_controller("vessel_placement", supervision, runtime_health, move || {
+                    let projector = VesselPlacementProjector::new(backend.clone(), namespace_string.clone(), local_host_ref.clone());
+                    async move {
+                        let mut interval = tokio::time::interval(VESSEL_PLACEMENT_SYNC_INTERVAL);
+                        loop {
+                            interval.tick().await;
+                            projector.sync_once().await?;
+                        }
+                    }
+                })
+                .await;
+            }
+        }),
+        tokio::spawn({
+            let backend = backend.clone();
             let observed_backend = observed_backend.clone();
             let namespace_string = namespace_string.clone();
             let forge_default_branch_resolver = forge_default_branch_resolver.clone();
@@ -1452,7 +1473,8 @@ fn spawn_controller_loops(
                                 Arc::new(TerminalControllerRuntime { state }),
                                 backend.clone(),
                                 &namespace_string,
-                            ),
+                            )
+                            .with_federated_convoys(&backend, &namespace_string),
                             resync_interval: controller_resync_interval,
                             backend,
                         }
@@ -1467,6 +1489,7 @@ fn spawn_controller_loops(
             let backend = backend.clone();
             let namespace_string = namespace_string.clone();
             let config_dir = state.config.base_path().as_path().to_path_buf();
+            let local_host_ref = state.local_host_ref.clone();
             let supervision = supervision.clone();
             let runtime_health = runtime_health.clone();
             async move {
@@ -1474,11 +1497,13 @@ fn spawn_controller_loops(
                     let backend = backend.clone();
                     let namespace_string = namespace_string.clone();
                     let config_dir = config_dir.clone();
+                    let local_host_ref = local_host_ref.clone();
                     async move {
                         ControllerLoop {
                             primary: backend.clone().using::<Vessel>(&namespace_string),
                             secondaries: VesselReconciler::secondary_watches(),
-                            reconciler: VesselReconciler::new_with_config_dir(backend.clone(), &namespace_string, config_dir),
+                            reconciler: VesselReconciler::new_with_config_dir(backend.clone(), &namespace_string, config_dir)
+                                .with_federated_dependencies(&backend, local_host_ref),
                             resync_interval: controller_resync_interval,
                             backend,
                         }
@@ -1552,12 +1577,14 @@ fn spawn_controller_loops(
                     async move {
                         ControllerLoop {
                             primary: backend.clone().using::<Convoy>(&namespace_string),
-                            secondaries: ConvoyReconciler::secondary_watches(),
+                            secondaries: ConvoyReconciler::federated_secondary_watches(&backend, &namespace_string),
                             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(&namespace_string))
                                 .with_vessels(backend.clone().using::<Vessel>(&namespace_string))
+                                .with_federated_vessels(backend.including_replicas::<Vessel>(&namespace_string))
                                 .with_terminal_sessions(backend.clone().using::<TerminalSession>(&namespace_string))
                                 .with_presentations(backend.clone().using::<Presentation>(&namespace_string))
                                 .with_checkouts(backend.clone().using::<Checkout>(&namespace_string))
+                                .with_federated_checkouts(backend.including_replicas::<Checkout>(&namespace_string))
                                 .with_teardown_runtime(Arc::new(DaemonConvoyTeardownRuntime::new(daemon)))
                                 .with_prepared_snapshot_gc(flotilla_resources::PreparedSnapshotGarbageCollector::new(
                                     backend.clone(),
@@ -2753,14 +2780,18 @@ mod tests {
             ChannelLabel, CommandOutput, CommandRunner, ProcessCommandRunner,
         },
     };
-    use flotilla_protocol::{Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent, ImageId, ImageSource, ResourceRef};
+    use flotilla_protocol::{
+        Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent, ImageId, ImageSource, PlacementDecision,
+        PlacementTargetHost, ResourceRef,
+    };
     use flotilla_resources::{
         api_version, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-        CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, CredentialConsumer, CredentialGrant,
-        CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec,
-        LifecycleAuthority, MaterialPoolSpec, MaterialPoolUnitSpec, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy,
-        RepositorySpec, Resource, Selector, SqliteBackend, TerminalAttentionState, TerminalSession, TerminalSessionPhase,
-        VesselRequirement, WorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+        CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CredentialConsumer,
+        CredentialGrant, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec,
+        CrewSource, CrewSpec, LifecycleAuthority, MaterialPoolSpec, MaterialPoolUnitSpec,
+        ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, RepositorySpec, Resource, Selector, SqliteBackend,
+        TerminalAttentionState, TerminalSession, TerminalSessionPhase, VesselRequirement, VesselStatus, WorkPhase, WorkflowTemplate,
+        WorkflowTemplateSpec, ACTUATOR_HOST_REF_ANNOTATION,
     };
     use futures::StreamExt;
     use tempfile::TempDir;
@@ -4101,6 +4132,300 @@ mod tests {
             Arc::new(PassthroughTerminalPool),
         );
         Arc::new(registry)
+    }
+
+    fn passthrough_registry_with_environment(handle: EnvironmentHandle) -> Arc<ProviderRegistry> {
+        use flotilla_core::providers::{
+            discovery::{ProviderCategory, ProviderDescriptor},
+            registry::ProviderRegistry,
+            terminal::passthrough::PassthroughTerminalPool,
+        };
+
+        let mut registry = ProviderRegistry::new();
+        registry.terminal_pools.insert(
+            "passthrough",
+            ProviderDescriptor::named(ProviderCategory::TerminalPool, "passthrough"),
+            Arc::new(PassthroughTerminalPool),
+        );
+        registry.environment_providers.insert(
+            "docker",
+            ProviderDescriptor::named(ProviderCategory::EnvironmentProvider, "docker"),
+            Arc::new(TestInteriorEnvironmentProvider { handle: Mutex::new(Some(handle)) }),
+        );
+        Arc::new(registry)
+    }
+
+    async fn replicate_local_kind<T: Resource>(source: &InProcessDaemon, target: &InProcessDaemon) {
+        let listed = source
+            .resource_backend()
+            .using::<T>(NAMESPACE)
+            .list()
+            .await
+            .unwrap_or_else(|error| panic!("list {} for test replication: {error}", T::API_PATHS.kind));
+        target
+            .resource_backend()
+            .replica_writer::<T>(source.node_id().clone(), NAMESPACE)
+            .replace(&listed, Utc::now())
+            .await
+            .unwrap_or_else(|error| panic!("replicate {} in test: {error}", T::API_PATHS.kind));
+    }
+
+    async fn bridge_runtime_resource_stores(first: &InProcessDaemon, second: &InProcessDaemon) {
+        replicate_local_kind::<Convoy>(first, second).await;
+        replicate_local_kind::<Vessel>(first, second).await;
+        replicate_local_kind::<PlacementPolicy>(first, second).await;
+        replicate_local_kind::<ResourceCheckout>(first, second).await;
+        replicate_local_kind::<TerminalSession>(first, second).await;
+
+        replicate_local_kind::<Convoy>(second, first).await;
+        replicate_local_kind::<Vessel>(second, first).await;
+        replicate_local_kind::<PlacementPolicy>(second, first).await;
+        replicate_local_kind::<ResourceCheckout>(second, first).await;
+        replicate_local_kind::<TerminalSession>(second, first).await;
+    }
+
+    async fn remote_shared_clone_placement_reaches_running(docker: bool) {
+        let temp = TempDir::new().expect("tempdir");
+        let kiwi_config_path = temp.path().join("kiwi-config");
+        let feta_config_path = temp.path().join("feta-config");
+        fs::create_dir_all(&kiwi_config_path).expect("kiwi config");
+        fs::create_dir_all(&feta_config_path).expect("feta config");
+        fs::write(kiwi_config_path.join("daemon.toml"), "machine_id = \"kiwi-root\"\n").expect("kiwi daemon config");
+        fs::write(feta_config_path.join("daemon.toml"), "machine_id = \"feta-root\"\n").expect("feta daemon config");
+        let kiwi_config = Arc::new(ConfigStore::with_base(kiwi_config_path));
+        let feta_config = Arc::new(ConfigStore::with_base(feta_config_path));
+        let kiwi = in_memory_daemon(Vec::new(), Arc::clone(&kiwi_config)).await;
+        let feta = in_memory_daemon(Vec::new(), Arc::clone(&feta_config)).await;
+        let kiwi_host_ref = kiwi.local_host_id().expect("kiwi Host identity").to_string();
+        let feta_host_ref = feta.local_host_id().expect("feta Host identity").to_string();
+        assert_ne!(kiwi_host_ref, feta_host_ref);
+
+        let kiwi_profile = LocalProvisioningProfile {
+            repo_default_dir: temp.path().join("kiwi-repos").display().to_string(),
+            ..manual_profile(&kiwi_host_ref, false)
+        };
+        let feta_profile = LocalProvisioningProfile {
+            repo_default_dir: temp.path().join("feta-repos").display().to_string(),
+            ..manual_profile(&feta_host_ref, docker)
+        };
+        fs::create_dir_all(&kiwi_profile.repo_default_dir).expect("kiwi repo root");
+        fs::create_dir_all(&feta_profile.repo_default_dir).expect("feta repo root");
+        register_startup_resources(&kiwi, NAMESPACE, &kiwi_profile).await.expect("register kiwi resources");
+        register_startup_resources(&feta, NAMESPACE, &feta_profile).await.expect("register feta resources");
+
+        let kiwi_state = Arc::new(ControllerRuntimeState::new(
+            Arc::clone(&kiwi),
+            Arc::clone(&kiwi_config),
+            passthrough_registry(),
+            None,
+            kiwi_host_ref.clone(),
+            None,
+            kiwi_profile.host_direct_environment_name(),
+        ));
+        let feta_registry = if docker {
+            let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {
+                id: EnvironmentId::new("env-remote-placement-work"),
+                image: ImageId::new("test-image"),
+                runner: Arc::new(ProcessCommandRunner),
+                env_vars: HashMap::from([("HOME".to_string(), temp.path().join("container-home").display().to_string())]),
+                destroyed: Arc::new(AtomicBool::new(false)),
+            });
+            passthrough_registry_with_environment(handle)
+        } else {
+            passthrough_registry()
+        };
+        let feta_state = Arc::new(
+            ControllerRuntimeState::new(
+                Arc::clone(&feta),
+                Arc::clone(&feta_config),
+                feta_registry,
+                docker.then(|| DaemonHostPath::new(temp.path().join("flotilla.sock"))),
+                feta_host_ref.clone(),
+                None,
+                feta_profile.host_direct_environment_name(),
+            )
+            .with_flotilla_binary_path(DaemonHostPath::new("/usr/local/bin/flotilla")),
+        );
+        let mut controller_handles = spawn_controller_loops(
+            kiwi_state,
+            NAMESPACE,
+            Duration::from_millis(25),
+            ControllerSupervision::default(),
+            RuntimeHealth::default(),
+        );
+        controller_handles.extend(spawn_controller_loops(
+            feta_state,
+            NAMESPACE,
+            Duration::from_millis(25),
+            ControllerSupervision::default(),
+            RuntimeHealth::default(),
+        ));
+        let bridge = tokio::spawn({
+            let kiwi = Arc::clone(&kiwi);
+            let feta = Arc::clone(&feta);
+            async move {
+                loop {
+                    bridge_runtime_resource_stores(&kiwi, &feta).await;
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        });
+
+        let source = TestGitRepo::init(temp.path().join("source")).with_initial_commit();
+        let repo_url = format!("file://{}", source.path().display());
+        let repository_spec = RepositorySpec::remote(&repo_url).expect("test repository spec");
+        let repository_key = repository_spec.key();
+        let workflow_name = if docker { "remote-docker" } else { "remote-host-direct" };
+        kiwi.resource_backend()
+            .using::<WorkflowTemplate>(NAMESPACE)
+            .create(
+                &empty_meta(workflow_name),
+                &WorkflowTemplateSpec::builder()
+                    .inputs(Vec::new())
+                    .vessels(vec![VesselRequirement::builder()
+                        .name("work".to_string())
+                        .stance(if docker { Stance::Contained } else { Stance::Trusted })
+                        .crew(vec![CrewSpec::builder()
+                            .role("coder".to_string())
+                            .source(CrewSource::Tool { command: "true".to_string() })
+                            .build()])
+                        .build()])
+                    .build(),
+            )
+            .await
+            .expect("create workflow");
+        let policy_name = if docker { "remote-docker-feta" } else { "remote-host-direct-feta" };
+        let policy = if docker {
+            PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
+                    host_ref: feta_host_ref.clone(),
+                    image: "test-image".to_string(),
+                    pull_policy: Default::default(),
+                    agent_adapters: BTreeSet::new(),
+                    default_cwd: Some("/workspace".to_string()),
+                    env: BTreeMap::new(),
+                    checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".to_string() },
+                })
+                .build()
+        } else {
+            PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: feta_host_ref.clone(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build()
+        };
+        kiwi.resource_backend()
+            .using::<PlacementPolicy>(NAMESPACE)
+            .create(&empty_meta(policy_name), &policy)
+            .await
+            .expect("create remote placement policy");
+        let convoys = kiwi.resource_backend().using::<Convoy>(NAMESPACE);
+        let convoy = convoys
+            .create(&empty_meta("remote-placement"), &ConvoySpec {
+                workflow_ref: workflow_name.to_string(),
+                dispatching_principal_ref: Default::default(),
+                inputs: BTreeMap::new(),
+                placement_policy: Some(policy_name.to_string()),
+                repositories: vec![ConvoyRepositorySpec {
+                    url: repo_url,
+                    repo_ref: repository_key,
+                    source_ref: "main".to_string(),
+                    target_ref: "main".to_string(),
+                    workspace_slug: repository_spec.leaf_slug(),
+                    subpaths: Vec::new(),
+                }],
+                r#ref: Some("remote-placement".to_string()),
+                project_ref: None,
+                adopted_checkout_refs: BTreeMap::new(),
+                issues: Vec::new(),
+                change_request: None,
+                instruction: None,
+            })
+            .await
+            .expect("create admitting Convoy");
+        convoys
+            .update_status("remote-placement", &convoy.metadata.resource_version, &ConvoyStatus {
+                placement_decision: Some(PlacementDecision {
+                    policy_name: policy_name.to_string(),
+                    target_host: PlacementTargetHost { reference: feta_host_ref.clone(), display_name: "feta".to_string() },
+                    refused_candidates: Vec::new(),
+                    viable_not_selected: Vec::new(),
+                }),
+                ..ConvoyStatus::default()
+            })
+            .await
+            .expect("record remote placement");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let running = convoys.get("remote-placement").await.ok().and_then(|convoy| convoy.status).is_some_and(|status| {
+                status.phase == ConvoyPhase::Active && status.work.get("work").is_some_and(|work| work.phase == WorkPhase::Running)
+            });
+            if running {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                let kiwi_convoy = convoys.get("remote-placement").await.expect("kiwi Convoy");
+                let kiwi_vessels = kiwi.resource_backend().using::<Vessel>(NAMESPACE).list().await.expect("kiwi Vessels");
+                let feta_vessels = feta.resource_backend().using::<Vessel>(NAMESPACE).list().await.expect("feta Vessels");
+                let feta_clones = feta.resource_backend().using::<Clone>(NAMESPACE).list().await.expect("feta Clones");
+                let feta_checkouts = feta.resource_backend().using::<ResourceCheckout>(NAMESPACE).list().await.expect("feta Checkouts");
+                let feta_terminals =
+                    feta.resource_backend().using::<TerminalSession>(NAMESPACE).list().await.expect("feta TerminalSessions");
+                let feta_environments = feta.resource_backend().using::<Environment>(NAMESPACE).list().await.expect("feta Environments");
+                panic!(
+                    "remote placement did not reach Running: convoy={kiwi_convoy:?} kiwi_vessels={kiwi_vessels:?} \
+                     feta_vessels={feta_vessels:?} feta_clones={feta_clones:?} feta_checkouts={feta_checkouts:?} \
+                     feta_terminals={feta_terminals:?} feta_environments={feta_environments:?}"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let actuator = feta.resource_backend().using::<Vessel>(NAMESPACE).get("remote-placement-work").await.expect("feta actuator Vessel");
+        assert_eq!(actuator.status.as_ref().map(|status| status.phase), Some(flotilla_resources::VesselPhase::Ready));
+        assert_eq!(actuator.metadata.annotations.get(ACTUATOR_HOST_REF_ANNOTATION).map(String::as_str), Some(feta_host_ref.as_str()));
+        let owner = kiwi.resource_backend().using::<Vessel>(NAMESPACE).get("remote-placement-work").await.expect("kiwi owner Vessel");
+        assert!(
+            owner.status.as_ref().is_none_or(|status: &VesselStatus| status.phase != flotilla_resources::VesselPhase::Failed),
+            "the admitting-side Vessel must not attempt remote actuation"
+        );
+        assert!(
+            matches!(
+                kiwi.resource_backend().using::<Environment>(NAMESPACE).get(&feta_profile.host_direct_environment_name()).await,
+                Err(ResourceError::NotFound { .. })
+            ),
+            "the placement host's Environment must remain host-local"
+        );
+        let ready_checkouts = feta
+            .resource_backend()
+            .using::<ResourceCheckout>(NAMESPACE)
+            .list()
+            .await
+            .expect("feta Checkouts")
+            .items
+            .into_iter()
+            .filter(|checkout| checkout.status.as_ref().map(|status| status.phase) == Some(ResourceCheckoutPhase::Ready))
+            .count();
+        assert_eq!(ready_checkouts, 1);
+
+        bridge.abort();
+        for handle in controller_handles {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn remotely_placed_host_direct_shared_clone_provisions_across_two_stores() {
+        remote_shared_clone_placement_reaches_running(false).await;
+    }
+
+    #[tokio::test]
+    async fn remotely_placed_docker_shared_clone_provisions_across_two_stores() {
+        remote_shared_clone_placement_reaches_running(true).await;
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -61,7 +61,6 @@ use crate::{
 /// wedge can hide in.
 const LIVENESS_WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
 const MANIFEST_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
-const VESSEL_PLACEMENT_SYNC_INTERVAL: Duration = Duration::from_millis(250);
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 const BUILTIN_MANAGED_BY_VALUE: &str = "builtin";
@@ -1324,13 +1323,7 @@ fn spawn_controller_loops(
             async move {
                 supervise_controller("vessel_placement", supervision, runtime_health, move || {
                     let projector = VesselPlacementProjector::new(backend.clone(), namespace_string.clone(), local_host_ref.clone());
-                    async move {
-                        let mut interval = tokio::time::interval(VESSEL_PLACEMENT_SYNC_INTERVAL);
-                        loop {
-                            interval.tick().await;
-                            projector.sync_once().await?;
-                        }
-                    }
+                    async move { projector.run().await }
                 })
                 .await;
             }

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -79,11 +79,17 @@ impl ResourceBackend {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ReplicaReadResolver<T: Resource> {
     backend: ResourceBackend,
     namespace: String,
     _marker: PhantomData<T>,
+}
+
+impl<T: Resource> Clone for ReplicaReadResolver<T> {
+    fn clone(&self) -> Self {
+        Self { backend: self.backend.clone(), namespace: self.namespace.clone(), _marker: PhantomData }
+    }
 }
 
 impl<T: Resource> ReplicaReadResolver<T> {

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -1,8 +1,15 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryCheckoutKind, RepositoryKey};
+use crate::{resource::define_resource, status_patch::StatusPatch, ReplicationClass, RepositoryCheckoutKind, RepositoryKey};
 
-define_resource!(Checkout, "checkouts", CheckoutSpec, CheckoutStatus, CheckoutStatusPatch);
+define_resource!(
+    Checkout,
+    "checkouts",
+    CheckoutSpec,
+    CheckoutStatus,
+    CheckoutStatusPatch,
+    replication = ReplicationClass::HomeBoundRuntime
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -17,7 +17,7 @@ use tracing::warn;
 
 use crate::{
     apply_status_patch,
-    backend::{ResourceBackend, TypedResolver},
+    backend::{ReplicaReadResolver, ResourceBackend, TypedResolver},
     checkout::CheckoutSpec,
     clone::CloneSpec,
     environment::EnvironmentSpec,
@@ -206,6 +206,45 @@ impl<W: Resource, P: Resource> SecondaryWatch for ResolverLabelMappedWatch<W, P>
                         LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, &object).await?;
                     }
                 }
+            }
+            Ok(())
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct ReplicaLabelMappedWatch<W: Resource, P: Resource> {
+    pub label_key: &'static str,
+    pub resolver: ReplicaReadResolver<W>,
+    pub _marker: PhantomData<P>,
+}
+
+impl<W: Resource, P: Resource> SecondaryWatch for ReplicaLabelMappedWatch<W, P> {
+    type Primary = P;
+
+    fn clone_box(&self) -> Box<dyn SecondaryWatch<Primary = Self::Primary>> {
+        Box::new(Self { label_key: self.label_key, resolver: self.resolver.clone(), _marker: PhantomData })
+    }
+
+    fn spawn(
+        self: Box<Self>,
+        _backend: ResourceBackend,
+        _namespace: String,
+        sender: mpsc::Sender<String>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ResourceError>> + Send>> {
+        Box::pin(async move {
+            let listed = self.resolver.list().await?;
+            for source in &listed.items {
+                LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, &source.object).await?;
+            }
+            let mut watch = self.resolver.watch().await?;
+            while let Some(event) = watch.next().await {
+                let source = match event? {
+                    crate::ReadWatchEvent::Added(source)
+                    | crate::ReadWatchEvent::Modified(source)
+                    | crate::ReadWatchEvent::Deleted(source) => source,
+                };
+                LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, &source.object).await?;
             }
             Ok(())
         })

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -233,11 +233,11 @@ impl<W: Resource, P: Resource> SecondaryWatch for ReplicaLabelMappedWatch<W, P> 
         sender: mpsc::Sender<String>,
     ) -> Pin<Box<dyn Future<Output = Result<(), ResourceError>> + Send>> {
         Box::pin(async move {
+            let mut watch = self.resolver.watch().await?;
             let listed = self.resolver.list().await?;
             for source in &listed.items {
                 LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, &source.object).await?;
             }
-            let mut watch = self.resolver.watch().await?;
             while let Some(event) = watch.next().await {
                 let source = match event? {
                     crate::ReadWatchEvent::Added(source)

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -16,7 +16,7 @@ use crate::{
     checkout::Checkout,
     controller::{
         delete_lifecycle_owned_matching, Actuation, LabelMappedWatch, ReconcileOutcome as ControllerReconcileOutcome, Reconciler,
-        SecondaryWatch,
+        ReplicaLabelMappedWatch, SecondaryWatch,
     },
     labels::{LifecycleAuthority, CONVOY_LABEL, VESSEL_LABEL},
     pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending,
@@ -24,9 +24,10 @@ use crate::{
     resource::ResourceObject,
     status_patch::StatusPatch,
     terminal_session::TerminalSession,
-    vessel::{Vessel, VesselPhase},
+    vessel::{Vessel, VesselPhase, ACTUATOR_HOST_REF_ANNOTATION},
     workflow_template::{validate, visit_template_tokens, CrewSource, CrewSpec, ValidationError, WorkflowTemplate},
-    InputMeta, InputValue, OwnerReference, PlacementStatus, PreparedSnapshotGarbageCollector, Resource, ResourceError, TypedResolver,
+    InputMeta, InputValue, OwnerReference, PlacementStatus, PreparedSnapshotGarbageCollector, ReplicaReadResolver, Resource, ResourceError,
+    ResourceProvenance, TypedResolver,
 };
 
 #[async_trait]
@@ -81,9 +82,11 @@ pub enum ConvoyEvent {
 pub struct ConvoyReconciler {
     templates: TypedResolver<WorkflowTemplate>,
     vessels: Option<TypedResolver<Vessel>>,
+    federated_vessels: Option<ReplicaReadResolver<Vessel>>,
     terminal_sessions: Option<TypedResolver<TerminalSession>>,
     presentations: Option<TypedResolver<Presentation>>,
     checkouts: Option<TypedResolver<Checkout>>,
+    federated_checkouts: Option<ReplicaReadResolver<Checkout>>,
     prepared_snapshot_gc: Option<PreparedSnapshotGarbageCollector>,
     teardown_runtime: Option<Arc<dyn ConvoyTeardownRuntime>>,
 }
@@ -103,9 +106,11 @@ impl ConvoyReconciler {
         Self {
             templates,
             vessels: None,
+            federated_vessels: None,
             terminal_sessions: None,
             presentations: None,
             checkouts: None,
+            federated_checkouts: None,
             prepared_snapshot_gc: None,
             teardown_runtime: None,
         }
@@ -113,6 +118,11 @@ impl ConvoyReconciler {
 
     pub fn with_vessels(mut self, vessels: TypedResolver<Vessel>) -> Self {
         self.vessels = Some(vessels);
+        self
+    }
+
+    pub fn with_federated_vessels(mut self, vessels: ReplicaReadResolver<Vessel>) -> Self {
+        self.federated_vessels = Some(vessels);
         self
     }
 
@@ -128,6 +138,11 @@ impl ConvoyReconciler {
 
     pub fn with_checkouts(mut self, checkouts: TypedResolver<Checkout>) -> Self {
         self.checkouts = Some(checkouts);
+        self
+    }
+
+    pub fn with_federated_checkouts(mut self, checkouts: ReplicaReadResolver<Checkout>) -> Self {
+        self.federated_checkouts = Some(checkouts);
         self
     }
 
@@ -148,6 +163,56 @@ impl ConvoyReconciler {
             Box::new(LabelMappedWatch::<Checkout, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
         ]
     }
+
+    pub fn federated_secondary_watches(
+        backend: &crate::ResourceBackend,
+        namespace: &str,
+    ) -> Vec<Box<dyn SecondaryWatch<Primary = Convoy>>> {
+        vec![
+            Box::new(ReplicaLabelMappedWatch::<Vessel, Convoy> {
+                label_key: CONVOY_LABEL,
+                resolver: backend.including_replicas::<Vessel>(namespace),
+                _marker: PhantomData,
+            }),
+            Box::new(LabelMappedWatch::<Presentation, Convoy> { label_key: CONVOY_LABEL, _marker: PhantomData }),
+            Box::new(ReplicaLabelMappedWatch::<Checkout, Convoy> {
+                label_key: CONVOY_LABEL,
+                resolver: backend.including_replicas::<Checkout>(namespace),
+                _marker: PhantomData,
+            }),
+        ]
+    }
+}
+
+async fn federated_children<T: Resource>(
+    resolver: &ReplicaReadResolver<T>,
+    convoy: &ResourceObject<Convoy>,
+) -> Result<BTreeMap<String, ResourceObject<T>>, ResourceError> {
+    let target_host_ref = convoy
+        .status
+        .as_ref()
+        .and_then(|status| status.placement_decision.as_ref())
+        .map(|decision| decision.target_host.reference.as_str());
+    let mut selected = BTreeMap::<String, (u8, ResourceObject<T>)>::new();
+    for source in resolver.list().await?.items {
+        if source.object.metadata.labels.get(CONVOY_LABEL) != Some(&convoy.metadata.name) {
+            continue;
+        }
+        let actuator_matches = target_host_ref
+            .is_some_and(|target| source.object.metadata.annotations.get(ACTUATOR_HOST_REF_ANNOTATION).is_some_and(|host| host == target));
+        let priority = if actuator_matches {
+            2
+        } else if matches!(source.provenance, ResourceProvenance::Local) {
+            1
+        } else {
+            0
+        };
+        let name = source.object.metadata.name.clone();
+        if selected.get(&name).is_none_or(|(current_priority, _)| priority > *current_priority) {
+            selected.insert(name, (priority, source.object));
+        }
+    }
+    Ok(selected.into_iter().map(|(name, (_, object))| (name, object)).collect())
 }
 
 impl Reconciler for ConvoyReconciler {
@@ -164,8 +229,11 @@ impl Reconciler for ConvoyReconciler {
                 Err(err) => return Err(err),
             }
         };
-        let vessels = match &self.vessels {
-            Some(vessels) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => vessels
+        let vessels = match (&self.federated_vessels, &self.vessels) {
+            (Some(vessels), _) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => {
+                federated_children(vessels, obj).await?
+            }
+            (None, Some(vessels)) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => vessels
                 .list_matching_labels(&BTreeMap::from([(CONVOY_LABEL.to_string(), obj.metadata.name.clone())]))
                 .await?
                 .items
@@ -184,8 +252,11 @@ impl Reconciler for ConvoyReconciler {
                 .collect(),
             _ => BTreeMap::new(),
         };
-        let checkouts = match &self.checkouts {
-            Some(checkouts) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => checkouts
+        let checkouts = match (&self.federated_checkouts, &self.checkouts) {
+            (Some(checkouts), _) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => {
+                federated_children(checkouts, obj).await?
+            }
+            (None, Some(checkouts)) if obj.status.as_ref().and_then(|status| status.observed_workflow_ref.as_ref()).is_some() => checkouts
                 .list_matching_labels(&BTreeMap::from([(CONVOY_LABEL.to_string(), obj.metadata.name.clone())]))
                 .await?
                 .items

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -119,7 +119,9 @@ pub use terminal_session::{
     TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
     TerminalSessionStatusPatch, TerminalSessionTag,
 };
-pub use vessel::{Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch};
+pub use vessel::{
+    Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch, ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,
+};
 pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
 
 #[doc(hidden)]

--- a/crates/flotilla-resources/src/placement_policy.rs
+++ b/crates/flotilla-resources/src/placement_policy.rs
@@ -2,9 +2,16 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::NoStatusPatch};
+use crate::{resource::define_resource, status_patch::NoStatusPatch, ReplicationClass};
 
-define_resource!(PlacementPolicy, "placementpolicies", PlacementPolicySpec, (), NoStatusPatch);
+define_resource!(
+    PlacementPolicy,
+    "placementpolicies",
+    PlacementPolicySpec,
+    (),
+    NoStatusPatch,
+    replication = ReplicationClass::HomeBoundRuntime
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct PlacementPolicySpec {

--- a/crates/flotilla-resources/src/vessel.rs
+++ b/crates/flotilla-resources/src/vessel.rs
@@ -8,6 +8,9 @@ use crate::{resource::define_resource, status_patch::StatusPatch, ReplicationCla
 
 define_resource!(Vessel, "vessels", VesselSpec, VesselStatus, VesselStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
 
+pub const ACTUATOR_HOST_REF_ANNOTATION: &str = "flotilla.work/actuator-host-ref";
+pub const ACTUATOR_SOURCE_ROOT_ANNOTATION: &str = "flotilla.work/actuator-source-root";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VesselSpec {
     pub convoy_ref: String,


### PR DESCRIPTION
## Summary

- project replicated-in Vessels whose placement decision targets the local host into locally authored actuator records, so the placement host performs shared-clone and vessel provisioning against its own resource store
- carry actuator provenance through Checkout and TerminalSession resources, and fold the placement host's replicated Vessel/Checkout facts back into the admitting Convoy's status
- replicate the control-plane PlacementPolicy dependency and Checkout fact needed by that flow while keeping Environment strictly host-local
- WARN when a host-local Environment is absent, with the Environment reference, placement host, and reconciler-store host in both logs and status

## Architecture

This follows the #1188 / ADR 0016 direction: replicated-in placement intent is filtered by `placed-on-me`, then actuation is authored and reconciled on the placement host. The admitting-side Vessel reconciler stands down for remote decisions. Environment replication is deliberately unchanged; the actuator reads only the placement host's local Environment.

The projected actuator record is an incremental bridge toward placement-authored Vessels: it preserves the admitting record as coordination input while giving the placement daemon a local-only primary that its existing controller can reconcile. Origin annotations make dependency lookup and returned facts source-qualified.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- two-store InProcessDaemon regressions for remote host-direct and Docker worktree-on-host-and-mount placement
- focused projection idempotence and structured WARN-context coverage

Closes #1247
