### PR TITLE
fix: replicate resources over inbound peer connections

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2374,6 +2374,14 @@ impl InProcessDaemon {
         self.host_registry.peer_connection_status(node_id).await
     }
 
+    pub async fn connected_peer_node_ids(&self) -> Vec<NodeId> {
+        let mut peers =
+            self.host_registry.connected_peer_summaries().await.into_iter().map(|summary| summary.node.node_id).collect::<Vec<_>>();
+        peers.sort();
+        peers.dedup();
+        peers
+    }
+
     pub async fn set_configured_peers(&self, peers: Vec<NodeInfo>) {
         let remote_counts = self.remote_host_counts().await;
         self.host_registry

--- a/crates/flotilla-daemon/src/peer/mod.rs
+++ b/crates/flotilla-daemon/src/peer/mod.rs
@@ -13,8 +13,8 @@ pub use manager::{
     ReversePathKey, RouteHop, RouteState,
 };
 pub use merge::merge_provider_data;
-pub(crate) use ssh_transport::peer_resource_socket_path;
-pub use ssh_transport::SshTransport;
+pub(crate) use ssh_transport::{peer_resource_socket_path, reverse_peer_resource_socket_path};
+pub use ssh_transport::{SshTransport, SshTransportPaths};
 pub use transport::{PeerConnectionStatus, PeerSender, PeerTransport};
 
 #[cfg(test)]

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -41,6 +41,27 @@ pub(crate) fn peer_resource_socket_path(peer_resource_socket_dir: &Path, config_
     Ok(peer_resource_socket_dir.join(format!("{}.sock", config_label.0)))
 }
 
+/// Path bound on the accepting peer by the reverse half of an SSH resource
+/// tunnel. Both ends derive it from the accepting daemon socket and the
+/// dialing node identity, so no follower-side peer configuration is needed.
+pub(crate) fn reverse_peer_resource_socket_path(daemon_socket: &Path, dialing_node: &NodeId) -> Result<PathBuf, String> {
+    let parent = daemon_socket
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| format!("daemon socket has no parent directory: {}", daemon_socket.display()))?;
+    let node_hash = dialing_node
+        .as_str()
+        .bytes()
+        .fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| (hash ^ u64::from(byte)).wrapping_mul(0x0000_0100_0000_01b3));
+    Ok(parent.join(format!(".peer-{node_hash:016x}")))
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SshTransportPaths<'a> {
+    pub state_dir: &'a Path,
+    pub daemon_socket: &'a Path,
+}
+
 struct ChannelPeerSender {
     tx: tokio::sync::Mutex<Option<mpsc::Sender<PeerWireMessage>>>,
 }
@@ -61,13 +82,15 @@ impl PeerSender for ChannelPeerSender {
     }
 }
 
-/// SSH-based transport that forwards a remote daemon's Unix socket locally
-/// and exchanges peer wire messages over it.
+/// SSH-based transport that forwards both daemons' Unix sockets over one SSH
+/// connection and exchanges peer wire messages over the local forward.
 ///
-/// The transport spawns `ssh -N -L <local>:<remote> [user@]host` as a child
-/// process, then connects to the locally-forwarded socket to read/write
-/// JSON-line `Message` values. Only `Message::Peer` payloads are forwarded;
-/// other message types on the wire are silently discarded.
+/// The transport spawns
+/// `ssh -N -L <local-resource>:<remote-daemon>
+///          -R <remote-resource>:<local-daemon> [user@]host`
+/// as a child process, then connects to the locally-forwarded socket to
+/// read/write JSON-line `Message` values. Only `Message::Peer` payloads are
+/// forwarded; other message types on the wire are silently discarded.
 pub struct SshTransport {
     local_node_id: NodeId,
     local_display_name: String,
@@ -76,6 +99,8 @@ pub struct SshTransport {
     expected_host_name: HostName,
     expected_node_id: Option<NodeId>,
     local_socket_path: PathBuf,
+    local_daemon_socket_path: PathBuf,
+    remote_resource_socket_path: PathBuf,
     ssh_process: Option<tokio::process::Child>,
     status: PeerConnectionStatus,
     /// Receiver for inbound peer data, produced by `connect_socket()` and
@@ -105,9 +130,10 @@ impl SshTransport {
         config: RemoteHostConfig,
         expected_node_id: Option<NodeId>,
         local_session_id: uuid::Uuid,
-        state_dir: &Path,
+        paths: SshTransportPaths<'_>,
     ) -> Result<Self, String> {
-        let local_socket_path = peer_resource_socket_path(&state_dir.join("peers"), &config_label)?;
+        let local_socket_path = peer_resource_socket_path(&paths.state_dir.join("peers"), &config_label)?;
+        let remote_resource_socket_path = reverse_peer_resource_socket_path(Path::new(&config.daemon_socket), &local_node_id)?;
         let expected_host_name = HostName::new(&config.expected_host_name);
 
         Ok(Self {
@@ -118,6 +144,8 @@ impl SshTransport {
             expected_host_name,
             expected_node_id,
             local_socket_path,
+            local_daemon_socket_path: paths.daemon_socket.to_path_buf(),
+            remote_resource_socket_path,
             ssh_process: None,
             status: PeerConnectionStatus::Disconnected,
             inbound_rx: None,
@@ -139,7 +167,7 @@ impl SshTransport {
             std::fs::create_dir_all(parent).map_err(|e| format!("failed to create peers directory: {e}"))?;
         }
 
-        let forward_spec = format!("{}:{}", self.local_socket_path.display(), self.config.daemon_socket);
+        let (forward_spec, reverse_forward_spec) = self.resource_forward_specs();
 
         let destination = match &self.config.user {
             Some(user) => format!("{user}@{}", self.config.hostname),
@@ -150,7 +178,8 @@ impl SshTransport {
             expected_host = %self.expected_host_name,
             label = %self.config_label.0,
             %destination,
-            forward = %forward_spec,
+            local_forward = %forward_spec,
+            reverse_forward = %reverse_forward_spec,
             "spawning SSH tunnel"
         );
 
@@ -158,8 +187,12 @@ impl SshTransport {
             .arg("-N") // no remote command
             .arg("-L")
             .arg(&forward_spec)
+            .arg("-R")
+            .arg(&reverse_forward_spec)
             .arg("-o")
             .arg("ExitOnForwardFailure=yes")
+            .arg("-o")
+            .arg("StreamLocalBindUnlink=yes")
             .arg("-o")
             .arg("ServerAliveInterval=15")
             .arg("-o")
@@ -174,6 +207,13 @@ impl SshTransport {
 
         self.ssh_process = Some(child);
         Ok(())
+    }
+
+    fn resource_forward_specs(&self) -> (String, String) {
+        (
+            format!("{}:{}", self.local_socket_path.display(), self.config.daemon_socket),
+            format!("{}:{}", self.remote_resource_socket_path.display(), self.local_daemon_socket_path.display()),
+        )
     }
 
     /// Wait for the forwarded local socket file to appear on disk.
@@ -513,10 +553,49 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
-            Path::new("/tmp/flotilla-test"),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
         assert!(transport.local_socket_path.to_string_lossy().ends_with("peers/my-server.sock"));
+    }
+
+    #[test]
+    fn resource_socket_forward_specs_are_bidirectional() {
+        let config = RemoteHostConfig {
+            hostname: "feta.local".to_string(),
+            expected_host_name: "feta".to_string(),
+            expected_node_id: None,
+            user: Some("flotilla".to_string()),
+            daemon_socket: "/home/flotilla/.config/flotilla/flotilla.sock".to_string(),
+            ssh_multiplex: None,
+        };
+        let local_node = NodeId::new("kiwi-root");
+        let transport = SshTransport::new(
+            local_node.clone(),
+            "kiwi".into(),
+            ConfigLabel("feta".to_string()),
+            config,
+            None,
+            uuid::Uuid::nil(),
+            SshTransportPaths {
+                state_dir: Path::new("/home/kiwi/.local/state/flotilla"),
+                daemon_socket: Path::new("/home/kiwi/.config/flotilla/flotilla.sock"),
+            },
+        )
+        .expect("valid transport");
+
+        let (local_forward, reverse_forward) = transport.resource_forward_specs();
+
+        assert_eq!(local_forward, "/home/kiwi/.local/state/flotilla/peers/feta.sock:/home/flotilla/.config/flotilla/flotilla.sock");
+        assert_eq!(
+            reverse_forward,
+            format!(
+                "{}:/home/kiwi/.config/flotilla/flotilla.sock",
+                reverse_peer_resource_socket_path(Path::new("/home/flotilla/.config/flotilla/flotilla.sock"), &local_node)
+                    .expect("reverse path")
+                    .display()
+            )
+        );
     }
 
     #[test]
@@ -536,7 +615,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
-            Path::new("/tmp/flotilla-test"),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         ) {
             Err(e) => assert!(e.contains("path separators"), "unexpected error: {e}"),
             Ok(_) => panic!("should reject host name with path separators"),
@@ -560,7 +639,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
-            Path::new("/tmp/flotilla-test"),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
         assert_eq!(transport.status(), PeerConnectionStatus::Disconnected);
@@ -664,7 +743,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
-            Path::new("/tmp/flotilla-test"),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
         assert!(transport.sender().is_none(), "disconnected transport should not expose a sender");
@@ -687,7 +766,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
-            Path::new("/tmp/flotilla-test"),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
 
@@ -718,7 +797,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
-            Path::new("/tmp/flotilla-test"),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
         transport.local_socket_path = socket_path.clone();
@@ -790,7 +869,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
-            Path::new("/tmp/flotilla-test"),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -32,15 +32,16 @@ use flotilla_core::{
         ChannelLabel, CommandRunner,
     },
 };
-use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, Rows, TerminalStatus};
+use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, NodeId, Rows, TerminalStatus};
 use flotilla_resources::{
     canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, Checkout, CheckoutBranchProvenance,
     CheckoutIntegrationStatus, Clone, CloneSpec, ConditionValue, Convoy, ConvoyReconciler, ConvoyTeardownRuntime, CrewSource, CrewSpec,
     Demand, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment, EnvironmentSpec, EnvironmentWaitReason, ForgeIdentity,
     Host, HostCondition, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus,
-    InputDefinition, InputMeta, PlacementPolicySpec, Presentation, Project, Regard, Repository, ResourceBackend, ResourceError,
-    ResourceObject, Stance, TerminalSession, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
-    AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY, MANAGED_BY_LABEL,
+    InputDefinition, InputMeta, PlacementPolicySpec, Presentation, Project, Regard, ReplicationClass, Repository, ResourceBackend,
+    ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate,
+    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY,
+    MANAGED_BY_LABEL, REGISTERED_RESOURCE_KINDS,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -1186,6 +1187,9 @@ async fn apply_host_heartbeat_with_credentials(
     if let Some(condition) = resource_decode_quarantine_condition(resource_store.as_ref()) {
         conditions.push(condition);
     }
+    if let Some(condition) = resource_replication_content_condition(daemon, namespace).await? {
+        conditions.push(condition);
+    }
     let status = HostStatus {
         capabilities: host_capabilities(&summary, profile, &held_credentials),
         agent_adapter_baseline: Some(adapter_assessment.baseline),
@@ -1202,6 +1206,52 @@ async fn apply_host_heartbeat_with_credentials(
     hosts.update_status(&profile.host_id, &host.metadata.resource_version, &status).await.map_err(|err| err.to_string())?;
     daemon.refresh_connected_peer_host_heartbeats().await;
     Ok(())
+}
+
+async fn resource_replication_content_condition(daemon: &Arc<InProcessDaemon>, namespace: &str) -> Result<Option<HostCondition>, String> {
+    let connected_peers = daemon.connected_peer_node_ids().await;
+    if connected_peers.is_empty() {
+        return Ok(None);
+    }
+
+    let backend = daemon.resource_backend();
+    let mut peers_without_cursors = Vec::new();
+    for peer in connected_peers {
+        let mut cursor_count = 0;
+        for kind in REGISTERED_RESOURCE_KINDS {
+            if kind.replication_class == ReplicationClass::None {
+                continue;
+            }
+            if flotilla_resources::replica_cursor_for_resource_kind(&backend, namespace, kind.kind, &peer)
+                .await
+                .map_err(|error| error.to_string())?
+                .is_some()
+            {
+                cursor_count += 1;
+            }
+        }
+        if cursor_count == 0 {
+            peers_without_cursors.push(peer);
+        }
+    }
+    if peers_without_cursors.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(
+        HostCondition::builder()
+            .condition_type("ResourceReplication")
+            .value(ConditionValue::False)
+            .reason("ReplicaCursorsMissing")
+            .message(format!(
+                "connected peer{} {} {} zero replica cursors; resource replication has not bootstrapped",
+                if peers_without_cursors.len() == 1 { "" } else { "s" },
+                peers_without_cursors.iter().map(NodeId::as_str).collect::<Vec<_>>().join(", "),
+                if peers_without_cursors.len() == 1 { "has" } else { "have" },
+            ))
+            .observed_at(Utc::now())
+            .build(),
+    ))
 }
 
 fn resource_decode_quarantine_condition(diagnostics: Option<&flotilla_resources::ResourceStoreDiagnostics>) -> Option<HostCondition> {
@@ -2718,8 +2768,8 @@ mod tests {
         },
     };
     use flotilla_protocol::{
-        Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent, ImageId, ImageSource, PlacementDecision,
-        PlacementTargetHost, ResourceRef,
+        Command, CommandAction, CommandValue, CrewCommandContext, DaemonEvent, ImageId, ImageSource, NodeInfo, PeerConnectionState,
+        PlacementDecision, PlacementTargetHost, ResourceRef,
     };
     use flotilla_resources::{
         api_version, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
@@ -2759,6 +2809,73 @@ mod tests {
         }
 
         assert_eq!(adjacent_flotilla_binary(&daemon_binary).expect("adjacent flotilla binary"), DaemonHostPath::new(flotilla_binary),);
+    }
+
+    #[tokio::test]
+    async fn connected_peer_with_replicable_resources_and_zero_cursors_is_degraded() {
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("feta")));
+        let feta = in_memory_daemon(Vec::new(), config).await;
+        let kiwi_node = NodeId::new("kiwi-root");
+        let kiwi = NodeInfo::new(kiwi_node.clone(), "kiwi");
+        feta.set_configured_peers(vec![kiwi.clone()]).await;
+        feta.publish_peer_summary(
+            HostSummary::builder()
+                .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new("kiwi-host")))
+                .host_name(flotilla_protocol::HostName::new("kiwi"))
+                .node(kiwi.clone())
+                .system(flotilla_protocol::SystemInfo::default())
+                .providers(Vec::new())
+                .build(),
+        )
+        .await;
+        feta.publish_peer_connection_status(&kiwi, PeerConnectionState::Connected).await;
+
+        let kiwi_store = ResourceBackend::InMemory(Default::default());
+        let kiwi_hosts = kiwi_store.using::<Host>(NAMESPACE);
+        kiwi_hosts
+            .create(&empty_meta("kiwi-host"), &HostSpec { display_name: "kiwi".to_string() })
+            .await
+            .expect("kiwi holds a replicable Host");
+
+        let degraded = resource_replication_content_condition(&feta, NAMESPACE)
+            .await
+            .expect("diagnose empty follower replica store")
+            .expect("zero cursors must be degraded");
+        assert_eq!(degraded.condition_type, "ResourceReplication");
+        assert_eq!(degraded.reason, "ReplicaCursorsMissing");
+        assert!(degraded.message.contains("zero replica cursors"));
+
+        let feta_host_id = feta.local_host_id().expect("feta Host identity").to_string();
+        let profile = manual_profile(&feta_host_id, false);
+        ensure_host_exists(&feta.resource_backend(), NAMESPACE, &feta_host_id, "feta").await.expect("register feta Host");
+        apply_host_heartbeat(&feta, NAMESPACE, &profile, &test_health_identity()).await.expect("publish degraded heartbeat");
+        let fleet = feta.fleet_health_internal().await.expect("feta fleet health");
+        let feta_row = fleet.hosts.iter().find(|host| host.is_local).expect("local feta fleet row");
+        assert!(
+            feta_row.degraded_conditions.iter().any(|condition| condition.contains("zero replica cursors")),
+            "fleet diagnosis must expose the empty replica store: {:?}",
+            feta_row.degraded_conditions
+        );
+
+        feta.resource_backend()
+            .replica_writer::<Host>(kiwi_node, NAMESPACE)
+            .replace(&kiwi_hosts.list().await.expect("list kiwi Hosts"), Utc::now())
+            .await
+            .expect("bootstrap one replica cursor");
+
+        assert!(
+            resource_replication_content_condition(&feta, NAMESPACE).await.expect("diagnose bootstrapped follower").is_none(),
+            "the zero-cursor diagnosis must clear once resource replication bootstraps"
+        );
+        apply_host_heartbeat(&feta, NAMESPACE, &profile, &test_health_identity()).await.expect("publish healthy heartbeat");
+        let fleet = feta.fleet_health_internal().await.expect("healthy feta fleet");
+        let feta_row = fleet.hosts.iter().find(|host| host.is_local).expect("local feta fleet row");
+        assert!(
+            feta_row.degraded_conditions.iter().all(|condition| !condition.contains("replica cursors")),
+            "fleet diagnosis must clear after bootstrap: {:?}",
+            feta_row.degraded_conditions
+        );
     }
 
     #[cfg(unix)]
@@ -4149,6 +4266,24 @@ mod tests {
         fs::create_dir_all(&feta_profile.repo_default_dir).expect("feta repo root");
         register_startup_resources(&kiwi, NAMESPACE, &kiwi_profile).await.expect("register kiwi resources");
         register_startup_resources(&feta, NAMESPACE, &feta_profile).await.expect("register feta resources");
+        assert!(
+            feta.resource_backend()
+                .replica_writer::<Convoy>(kiwi.node_id().clone(), NAMESPACE)
+                .cursor()
+                .await
+                .expect("read initial Convoy replica cursor")
+                .is_none(),
+            "the placement host must begin with an empty replica store"
+        );
+        assert!(
+            feta.resource_backend()
+                .replica_writer::<Vessel>(kiwi.node_id().clone(), NAMESPACE)
+                .cursor()
+                .await
+                .expect("read initial Vessel replica cursor")
+                .is_none(),
+            "the placement host must begin with an empty replica store"
+        );
 
         let kiwi_state = Arc::new(ControllerRuntimeState::new(
             Arc::clone(&kiwi),

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -12,7 +12,7 @@ pub mod test_support;
 
 use std::{
     collections::HashMap,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
@@ -40,7 +40,7 @@ use self::{
     remote_commands::{ForwardedCommandMap, PendingRemoteCancelMap, PendingRemoteCommandMap, RemoteCommandRouter},
     shared::{sync_peer_query_state, SocketPeerSender},
 };
-use crate::peer::{ConnectionDirection, ConnectionMeta, InboundPeerEnvelope, PeerManager, SshTransport};
+use crate::peer::{ConnectionDirection, ConnectionMeta, InboundPeerEnvelope, PeerManager, SshTransport, SshTransportPaths};
 
 const CONNECTION_PREFACE_TIMEOUT: Duration = Duration::from_secs(10);
 const HELLO_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -114,7 +114,11 @@ fn build_remote_command_router(daemon: &Arc<InProcessDaemon>, peer_manager: &Arc
     )
 }
 
-fn build_peer_manager(daemon: &Arc<InProcessDaemon>, config: &ConfigStore) -> Result<Arc<Mutex<PeerManager>>, String> {
+fn build_peer_manager(
+    daemon: &Arc<InProcessDaemon>,
+    config: &ConfigStore,
+    local_daemon_socket_path: &Path,
+) -> Result<Arc<Mutex<PeerManager>>, String> {
     let host_name = daemon.host_name().clone();
     let local_node_id = daemon.node_id().clone();
     let hosts_config = config.load_hosts()?;
@@ -131,7 +135,7 @@ fn build_peer_manager(daemon: &Arc<InProcessDaemon>, config: &ConfigStore) -> Re
             host_config,
             expected_node_id.clone(),
             daemon.session_id(),
-            config.state_dir().as_path(),
+            SshTransportPaths { state_dir: config.state_dir().as_path(), daemon_socket: local_daemon_socket_path },
         ) {
             Ok(transport) => {
                 peer_manager.add_configured_target(ConfigLabel(name), expected_host_name, expected_node_id, Box::new(transport));
@@ -161,7 +165,8 @@ async fn build_embedded_resource_backend(config: &ConfigStore) -> Result<Resourc
 }
 
 pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &ConfigStore) -> Result<tokio::task::JoinHandle<()>, String> {
-    let peer_manager = build_peer_manager(&daemon, config)?;
+    let local_daemon_socket_path = config.base_path().join("flotilla.sock");
+    let peer_manager = build_peer_manager(&daemon, config, local_daemon_socket_path.as_path())?;
     {
         let daemon = Arc::clone(&daemon);
         let peer_manager = Arc::clone(&peer_manager);
@@ -254,7 +259,7 @@ impl DaemonServer {
         let daemon =
             InProcessDaemon::new_with_resource_backend(repo_paths, Arc::clone(&config), discovery, host_name.clone(), resource_backend)
                 .await;
-        let peer_manager = build_peer_manager(&daemon, &config)?;
+        let peer_manager = build_peer_manager(&daemon, &config, &socket_path)?;
         sync_peer_query_state(&peer_manager, &daemon).await;
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let (peer_data_tx, peer_data_rx) = mpsc::channel(256);

--- a/crates/flotilla-daemon/src/server/peer_connection.rs
+++ b/crates/flotilla-daemon/src/server/peer_connection.rs
@@ -13,7 +13,7 @@ use super::{
     peer_runtime::disconnect_peer_and_rebuild, sync_peer_query_state, ConnectionDirection, ConnectionMeta, PeerConnectedNotice,
     PeerConnectionEvent, SocketPeerSender,
 };
-use crate::peer::{ActivationResult, InboundPeerEnvelope, PeerManager};
+use crate::peer::{reverse_peer_resource_socket_path, ActivationResult, InboundPeerEnvelope, PeerManager};
 
 pub(super) const PEER_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
@@ -117,10 +117,16 @@ impl PeerConnection {
 
         sync_peer_query_state(&self.peer_manager, &self.daemon).await;
         self.daemon.publish_peer_connection_status(&peer_node, PeerConnectionState::Connected).await;
+        let resource_socket_path = match self.daemon.daemon_socket_path().await {
+            Some(daemon_socket_path) => reverse_peer_resource_socket_path(&daemon_socket_path, &node_id)
+                .inspect_err(|error| warn!(peer = %node_id, %error, "cannot derive reverse-forwarded resource socket"))
+                .ok(),
+            None => None,
+        };
         let _ = self.peer_connected_tx.send(PeerConnectionEvent::Connected(PeerConnectedNotice {
             peer: node_id.clone(),
             generation,
-            resource_socket_path: None,
+            resource_socket_path,
         }));
 
         let idle_deadline = tokio::time::sleep(PEER_IDLE_TIMEOUT);

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -2982,13 +2982,15 @@ fn host_seq_for(events: &[DaemonEvent], host_name: &NodeId) -> Option<u64> {
 #[tokio::test]
 async fn handle_client_forwards_peer_data_and_registers_peer() {
     let (_tmp, daemon) = empty_daemon().await;
+    let daemon_socket_path = PathBuf::from("/tmp/flotilla-follower.sock");
+    daemon.set_daemon_socket_path(daemon_socket_path.clone()).await;
     let expected_local_host = daemon.node_id().clone();
     let (peer_data_tx, mut peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
-    let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
+    let (peer_connected_tx, mut peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
 
     let (client_stream, server_stream) = tokio::net::UnixStream::pair().expect("pair");
 
@@ -3038,6 +3040,17 @@ async fn handle_client_forwards_peer_data_and_registers_peer() {
         }
         other => panic!("expected hello response, got {other:?}"),
     }
+    let connected = peer_connected_rx.recv().await.expect("peer connected notice");
+    let PeerConnectionEvent::Connected(notice) = connected else {
+        panic!("expected peer connected notice");
+    };
+    assert_eq!(
+        notice.resource_socket_path,
+        Some(
+            crate::peer::reverse_peer_resource_socket_path(&daemon_socket_path, &NodeId::new("remote-host")).expect("reverse socket path")
+        ),
+        "an inbound peer connection must expose the reverse-forwarded resource socket so follower replication can bootstrap",
+    );
 
     // Send a peer message from the client side
     let peer_msg = test_peer_msg("remote-host");

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -96,9 +96,10 @@ pub use project::{
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
     apply_resource_document, delete_resource_kind, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas,
-    list_resource_kind_replica_sources, quarantine_undecodable_stored_objects, resource_document_spec_hash, resource_list_api_version,
-    watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources,
-    DynamicResourceList, DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
+    list_resource_kind_replica_sources, quarantine_undecodable_stored_objects, replica_cursor_for_resource_kind,
+    resource_document_spec_hash, resource_list_api_version, watch_resource_kind, watch_resource_kind_from,
+    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList, DynamicResourceObject,
+    DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use flotilla_protocol::NodeId;
 use futures::{stream::BoxStream, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -9,15 +10,16 @@ use crate::{
     host::HostStatus,
     replica::{LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION},
     Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, Environment, Host, InputMeta, MaterialPool,
-    ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project, ReadResourceList, ReadWatchEvent, Regard, Repository, Resource,
-    ResourceBackend, ResourceError, ResourceList, ResourceObject, ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart,
-    WorkflowTemplate,
+    ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project, ReadResourceList, ReadWatchEvent, Regard, ReplicaCursor,
+    ReplicationClass, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, ResourceProvenance,
+    TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RegisteredResourceKind {
     pub kind: &'static str,
     pub plural: &'static str,
+    pub replication_class: ReplicationClass,
     aliases: &'static [&'static str],
     resource: RegisteredResource,
 }
@@ -127,7 +129,13 @@ pub const REGISTERED_RESOURCE_KINDS: &[RegisteredResourceKind] = &[
 ];
 
 const fn kind<T: Resource>(resource: RegisteredResource, aliases: &'static [&'static str]) -> RegisteredResourceKind {
-    RegisteredResourceKind { kind: T::API_PATHS.kind, plural: T::API_PATHS.plural, aliases, resource }
+    RegisteredResourceKind {
+        kind: T::API_PATHS.kind,
+        plural: T::API_PATHS.plural,
+        replication_class: T::REPLICATION_CLASS,
+        aliases,
+        resource,
+    }
 }
 
 macro_rules! dispatch_resource_kind {
@@ -225,6 +233,23 @@ pub async fn list_resource_kind_including_replicas(
     requested_kind: &str,
 ) -> Result<DynamicResourceList, ResourceError> {
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, list_typed_including_replicas(backend, namespace).await)
+}
+
+pub async fn replica_cursor_for_resource_kind(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+    origin_root: &NodeId,
+) -> Result<Option<ReplicaCursor>, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, replica_cursor_typed(backend, namespace, origin_root).await)
+}
+
+async fn replica_cursor_typed<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+    origin_root: &NodeId,
+) -> Result<Option<ReplicaCursor>, ResourceError> {
+    backend.replica_writer::<T>(origin_root.clone(), namespace).cursor().await
 }
 
 pub async fn get_resource_kind(


### PR DESCRIPTION
Closes #1257

## Summary

- forward both daemon resource sockets over the existing leader-initiated SSH session
- mark connected peers with zero replica cursors as DEGRADED until replication bootstraps
- strengthen the two-store remote-placement regression so the follower begins with empty Convoy and Vessel replica cursors

## Cause

Resource replication only gave the outbound SSH owner a forwarded HTTP-over-UDS path. An inbound follower connection emitted no resource socket, so its replicators waited forever. The test-support transport routed watches in memory, which masked that production-only gap.

## Connection topology

This implements the #1257 ruling: the same leader-owned SSH process carries a local and reverse Unix-socket forward. Followers do not dial, gain a peer address book, or create a second SSH connection. Both sides derive the reverse socket path from the accepting daemon socket and dialing node identity during the existing handshake.

## Verification

- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked

The live feta convoy recovery remains a post-deployment acceptance check; this PR does not merge or deploy itself.