### PR TITLE
fix: bind flotilla-default template in daily-driver layout

### DIFF
--- a/layouts/daily-driver.kdl
+++ b/layouts/daily-driver.kdl
@@ -19,8 +19,8 @@ plugins {
         rail_sizing "active-large"
         rail_grouping "directory"
         rail_segment_between_color "#282c34"
-        template_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
-        grouping_config_path "file:$ANDAMENTO_ROOT/templates/andamento-git.kdl"
+        template_config_path "file:$ANDAMENTO_ROOT/templates/flotilla-default.kdl"
+        grouping_config_path "file:$ANDAMENTO_ROOT/templates/flotilla-default.kdl"
     }
     andamento-rail location="native:andamento-rail" {
         controller_plugin_url "andamento-controller"


### PR DESCRIPTION
Flotilla-side counterpart to andamento#57 (a#56): the daily-driver layout bound templates/andamento-git.kdl — no flotilla grouping rules, no flotilla detail templates — which starved both the project-level grouping and the hover detail panel in the daily driver. Points both config paths at flotilla-default.kdl. Was running as a local edit since 2026-07-29; committing so the binding survives checkouts.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp