### PR TITLE
feat: enforce declared resource field ownership

### DIFF
--- a/crates/flotilla-core/src/placement_policy.rs
+++ b/crates/flotilla-core/src/placement_policy.rs
@@ -1,4 +1,6 @@
-use flotilla_resources::{InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend, ResourceError, MANAGED_BY_LABEL};
+use flotilla_resources::{
+    InputMeta, PlacementPolicy, PlacementPolicySpec, ResourceBackend, ResourceError, WriterIdentity, MANAGED_BY_LABEL,
+};
 use tracing::warn;
 
 /// Reconcile a daemon-discovered placement policy without claiming
@@ -20,10 +22,14 @@ pub async fn reconcile_registered_policy(
                 return Ok(());
             }
 
-            let merged = merge_registered_policy_spec(&existing.spec, desired)?;
-            if merged != existing.spec {
+            if desired != &existing.spec {
                 policies
-                    .update(&InputMeta::from(&existing.metadata), &existing.metadata.resource_version, &merged)
+                    .write_spec(
+                        &WriterIdentity::reconcile_loop(),
+                        &InputMeta::from(&existing.metadata),
+                        &existing.metadata.resource_version,
+                        desired,
+                    )
                     .await
                     .map_err(|error| format!("reconcile registered placement policy {name}: {error}"))?;
             }
@@ -36,27 +42,4 @@ pub async fn reconcile_registered_policy(
             .map_err(|error| format!("register placement policy {name}: {error}")),
         Err(error) => Err(format!("check registered placement policy {name}: {error}")),
     }
-}
-
-fn merge_registered_policy_spec(existing: &PlacementPolicySpec, desired: &PlacementPolicySpec) -> Result<PlacementPolicySpec, String> {
-    // Registration owns placement topology, not operator scheduling or runtime
-    // configuration. Starting from the live spec also preserves future fields
-    // until their ownership is explicitly assigned here.
-    let mut merged = existing.clone();
-    merged.pool.clone_from(&desired.pool);
-    match (&desired.host_direct, &desired.docker_per_vessel) {
-        (Some(host_direct), None) => {
-            merged.host_direct = Some(host_direct.clone());
-            merged.docker_per_vessel = None;
-        }
-        (None, Some(desired_docker)) => {
-            let mut docker = existing.docker_per_vessel.clone().unwrap_or_else(|| desired_docker.clone());
-            docker.host_ref.clone_from(&desired_docker.host_ref);
-            docker.checkout.clone_from(&desired_docker.checkout);
-            merged.host_direct = None;
-            merged.docker_per_vessel = Some(docker);
-        }
-        _ => return Err("registered placement policy must define exactly one strategy".to_string()),
-    }
-    Ok(merged)
 }

--- a/crates/flotilla-core/src/placement_policy.rs
+++ b/crates/flotilla-core/src/placement_policy.rs
@@ -22,13 +22,14 @@ pub async fn reconcile_registered_policy(
                 return Ok(());
             }
 
-            if desired != &existing.spec {
+            let merged = merge_registered_policy_spec(&existing.spec, desired)?;
+            if merged != existing.spec {
                 policies
                     .write_spec(
                         &WriterIdentity::reconcile_loop(),
                         &InputMeta::from(&existing.metadata),
                         &existing.metadata.resource_version,
-                        desired,
+                        &merged,
                     )
                     .await
                     .map_err(|error| format!("reconcile registered placement policy {name}: {error}"))?;
@@ -41,5 +42,140 @@ pub async fn reconcile_registered_policy(
             .map(|_| ())
             .map_err(|error| format!("register placement policy {name}: {error}")),
         Err(error) => Err(format!("check registered placement policy {name}: {error}")),
+    }
+}
+
+fn merge_registered_policy_spec(existing: &PlacementPolicySpec, desired: &PlacementPolicySpec) -> Result<PlacementPolicySpec, String> {
+    // Registration owns placement topology, not operator scheduling or runtime
+    // configuration. Starting from the live spec means the ownership-aware
+    // write only expresses intent for fields the registration loop controls.
+    let mut merged = existing.clone();
+    merged.pool.clone_from(&desired.pool);
+    match (&desired.host_direct, &desired.docker_per_vessel) {
+        (Some(host_direct), None) => {
+            merged.host_direct = Some(host_direct.clone());
+            merged.docker_per_vessel = None;
+        }
+        (None, Some(desired_docker)) => {
+            let mut docker = existing.docker_per_vessel.clone().unwrap_or_else(|| desired_docker.clone());
+            docker.host_ref.clone_from(&desired_docker.host_ref);
+            docker.checkout.clone_from(&desired_docker.checkout);
+            merged.host_direct = None;
+            merged.docker_per_vessel = Some(docker);
+        }
+        _ => return Err("registered placement policy must define exactly one strategy".to_string()),
+    }
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use flotilla_resources::{
+        DockerCheckoutStrategy, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, HostDirectPlacementPolicyCheckout,
+        HostDirectPlacementPolicySpec, InMemoryBackend,
+    };
+
+    use super::*;
+
+    const NAMESPACE: &str = "flotilla";
+
+    fn host_direct(pool: &str, host: &str) -> PlacementPolicySpec {
+        PlacementPolicySpec::builder()
+            .pool(pool.to_string())
+            .host_direct(HostDirectPlacementPolicySpec {
+                host_ref: host.to_string(),
+                checkout: HostDirectPlacementPolicyCheckout::Worktree,
+            })
+            .build()
+    }
+
+    fn docker(pool: &str, host: &str) -> PlacementPolicySpec {
+        PlacementPolicySpec::builder()
+            .pool(pool.to_string())
+            .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
+                host_ref: host.to_string(),
+                image: "registration-default:latest".to_string(),
+                pull_policy: DockerImagePullPolicy::IfNotPresent,
+                agent_adapters: BTreeSet::new(),
+                default_cwd: Some("/workspace".to_string()),
+                env: BTreeMap::new(),
+                checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".to_string() },
+            })
+            .build()
+    }
+
+    #[tokio::test]
+    async fn repeated_registration_preserves_operator_priority_without_false_violations() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let policies = backend.using::<PlacementPolicy>(NAMESPACE);
+        reconcile_registered_policy(&backend, NAMESPACE, "host-direct-shared", &host_direct("local", "local"))
+            .await
+            .expect("initial registration");
+        let created = policies.get("host-direct-shared").await.expect("registered policy");
+        let mut operator_spec = created.spec.clone();
+        operator_spec.priority = 73;
+        policies
+            .write_spec(
+                &WriterIdentity::operator(),
+                &InputMeta::from(&created.metadata),
+                &created.metadata.resource_version,
+                &operator_spec,
+            )
+            .await
+            .expect("operator applies priority");
+
+        for cycle in 0..256 {
+            let (pool, host) = if cycle % 2 == 0 { ("local", "local") } else { ("remote", "remote") };
+            reconcile_registered_policy(&backend, NAMESPACE, "host-direct-shared", &host_direct(pool, host))
+                .await
+                .expect("registration cycle");
+            assert_eq!(
+                policies.get("host-direct-shared").await.expect("registered policy").spec.priority,
+                73,
+                "priority changed during registration cycle {cycle}"
+            );
+        }
+
+        let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
+        assert!(diagnostics.field_ownership_violations.is_empty(), "registration must not claim intent for operator fields");
+    }
+
+    #[tokio::test]
+    async fn docker_registration_preserves_operator_runtime_configuration_without_false_violations() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let policies = backend.using::<PlacementPolicy>(NAMESPACE);
+        reconcile_registered_policy(&backend, NAMESPACE, "docker-shared", &docker("local", "local")).await.expect("initial registration");
+        let created = policies.get("docker-shared").await.expect("registered policy");
+        let mut operator_spec = created.spec.clone();
+        let runtime = operator_spec.docker_per_vessel.as_mut().expect("docker strategy");
+        runtime.image = "operator/custom:latest".to_string();
+        runtime.pull_policy = DockerImagePullPolicy::Never;
+        runtime.agent_adapters = BTreeSet::from(["codex".to_string()]);
+        runtime.default_cwd = Some("/operator-workspace".to_string());
+        runtime.env = BTreeMap::from([("OPERATOR".to_string(), "true".to_string())]);
+        policies
+            .write_spec(
+                &WriterIdentity::operator(),
+                &InputMeta::from(&created.metadata),
+                &created.metadata.resource_version,
+                &operator_spec,
+            )
+            .await
+            .expect("operator configures runtime");
+
+        reconcile_registered_policy(&backend, NAMESPACE, "docker-shared", &docker("remote", "remote")).await.expect("registration refresh");
+        let refreshed = policies.get("docker-shared").await.expect("refreshed policy");
+        let runtime = refreshed.spec.docker_per_vessel.expect("docker strategy");
+
+        assert_eq!(runtime.host_ref, "remote");
+        assert_eq!(runtime.image, "operator/custom:latest");
+        assert_eq!(runtime.pull_policy, DockerImagePullPolicy::Never);
+        assert_eq!(runtime.agent_adapters, BTreeSet::from(["codex".to_string()]));
+        assert_eq!(runtime.default_cwd.as_deref(), Some("/operator-workspace"));
+        assert_eq!(runtime.env, BTreeMap::from([("OPERATOR".to_string(), "true".to_string())]));
+        let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
+        assert!(diagnostics.field_ownership_violations.is_empty(), "registration must not synthesize runtime write attempts");
     }
 }

--- a/crates/flotilla-daemon/src/resource_manifest.rs
+++ b/crates/flotilla-daemon/src/resource_manifest.rs
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fast_forwards_only_when_live_spec_matches_last_applied_hash() {
+    async fn manifest_change_to_loop_owned_field_is_preserved_and_diagnosed() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("policy.yaml");
         write(&path, &manifest("moving", "one"));
@@ -417,8 +417,16 @@ mod tests {
         let object = resolver.get("moving").await.expect("policy");
 
         assert_eq!(report.updated, 1);
-        assert_eq!(object.spec.pool, "two");
+        assert_eq!(object.spec.pool, "one", "operator manifest must not replace a loop-owned field");
         assert_eq!(object.metadata.labels.get("another-controller/observation").map(String::as_str), Some("kept"));
+        let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
+        assert!(
+            diagnostics
+                .field_ownership_violations
+                .iter()
+                .any(|violation| violation.field == "spec.pool" && violation.writer.role == flotilla_resources::WriterRole::Operator),
+            "the rejected manifest field must remain fleet-visible"
+        );
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/resource_manifest.rs
+++ b/crates/flotilla-daemon/src/resource_manifest.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use flotilla_resources::{
-    apply_resource_document, get_resource_kind, resource_document_spec_hash, ResourceBackend, ResourceError, MANAGED_BY_LABEL,
+    apply_manifest_resource_document, get_resource_kind, resource_document_spec_hash, ResourceBackend, ResourceError, MANAGED_BY_LABEL,
 };
 use serde::Deserialize;
 use serde_json::{Map, Value};
@@ -197,7 +197,8 @@ impl ResourceManifestReconciler {
     }
 
     async fn apply_manifest_document(&self, document: Value) -> Result<(), String> {
-        let applied = apply_resource_document(&self.backend, &self.default_namespace, document).await.map_err(|error| error.to_string())?;
+        let applied =
+            apply_manifest_resource_document(&self.backend, &self.default_namespace, document).await.map_err(|error| error.to_string())?;
         let persisted_hash = resource_document_spec_hash(&applied.value).map_err(|error| error.to_string())?;
         let recorded_hash = string_map(&applied.value, "annotations")?.get(LAST_APPLIED_HASH_ANNOTATION).cloned();
         if recorded_hash.as_deref() == Some(persisted_hash.as_str()) {
@@ -212,7 +213,7 @@ impl ResourceManifestReconciler {
         let metadata =
             persisted.get_mut("metadata").and_then(Value::as_object_mut).ok_or_else(|| "stored object has invalid metadata".to_string())?;
         insert_metadata_value(metadata, "annotations", LAST_APPLIED_HASH_ANNOTATION, &persisted_hash)?;
-        apply_resource_document(&self.backend, &self.default_namespace, persisted).await.map_err(|error| error.to_string())?;
+        apply_manifest_resource_document(&self.backend, &self.default_namespace, persisted).await.map_err(|error| error.to_string())?;
         Ok(())
     }
 }
@@ -423,7 +424,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn manifest_change_to_loop_owned_field_is_preserved_and_diagnosed() {
+    async fn manifest_updates_all_declared_fields_and_then_settles() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("policy.yaml");
         write(&path, &manifest("moving", "one"));
@@ -436,12 +437,13 @@ mod tests {
         live_meta.labels.insert("another-controller/observation".to_string(), "kept".to_string());
         resolver.update(&live_meta, &applied.metadata.resource_version, &applied.spec).await.expect("add external metadata");
 
-        write(&path, &manifest("moving", "two"));
+        write(&path, &manifest_with_priority("moving", "two", 100));
         let report = reconciler.reconcile_once().await.expect("fast-forward pass");
         let object = resolver.get("moving").await.expect("policy");
 
         assert_eq!(report.updated, 1);
-        assert_eq!(object.spec.pool, "one", "operator manifest must not replace a loop-owned field");
+        assert_eq!(object.spec.pool, "two");
+        assert_eq!(object.spec.priority, 100);
         assert_eq!(object.metadata.labels.get("another-controller/observation").map(String::as_str), Some("kept"));
         assert_eq!(
             object.metadata.annotations.get(LAST_APPLIED_HASH_ANNOTATION),
@@ -452,22 +454,16 @@ mod tests {
             "last-applied must describe the ownership-filtered spec"
         );
 
-        write(&path, &manifest_with_priority("moving", "two", 100));
-        let follow_up = reconciler.reconcile_once().await.expect("follow-up pass");
-        let object = resolver.get("moving").await.expect("updated policy");
+        let settled_version = object.metadata.resource_version;
+        let settled = reconciler.reconcile_once().await.expect("settled pass");
+        let object = resolver.get("moving").await.expect("settled policy");
 
-        assert_eq!(follow_up.drifted, 0, "ownership preservation must not be mistaken for external drift");
-        assert_eq!(follow_up.updated, 1);
-        assert_eq!(object.spec.pool, "one");
-        assert_eq!(object.spec.priority, 100, "later operator-owned changes must still apply");
+        assert_eq!(settled.unchanged, 1);
+        assert_eq!(settled.updated, 0);
+        assert_eq!(settled.drifted, 0);
+        assert_eq!(object.metadata.resource_version, settled_version, "settled manifests must not keep writing");
         let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
-        assert!(
-            diagnostics
-                .field_ownership_violations
-                .iter()
-                .any(|violation| violation.field == "spec.pool" && violation.writer.role == flotilla_resources::WriterRole::Operator),
-            "the rejected manifest field must remain fleet-visible"
-        );
+        assert!(diagnostics.field_ownership_violations.is_empty(), "manifest projection must not synthesize ownership violations");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/resource_manifest.rs
+++ b/crates/flotilla-daemon/src/resource_manifest.rs
@@ -151,9 +151,7 @@ impl ResourceManifestReconciler {
             Err(error) => return Err(format!("{identity}: {error}")),
         };
         let Some(existing) = existing else {
-            apply_resource_document(&self.backend, &self.default_namespace, document)
-                .await
-                .map_err(|error| format!("{identity}: {error}"))?;
+            self.apply_manifest_document(document).await.map_err(|error| format!("{identity}: {error}"))?;
             report.created += 1;
             return Ok(());
         };
@@ -192,9 +190,29 @@ impl ResourceManifestReconciler {
         }
 
         preserve_external_metadata(&mut document, &existing)?;
-        apply_resource_document(&self.backend, &self.default_namespace, document).await.map_err(|error| format!("{identity}: {error}"))?;
+        self.apply_manifest_document(document).await.map_err(|error| format!("{identity}: {error}"))?;
         self.warned_drift.retain(|(warned, _, _)| warned != &identity);
         report.updated += 1;
+        Ok(())
+    }
+
+    async fn apply_manifest_document(&self, document: Value) -> Result<(), String> {
+        let applied = apply_resource_document(&self.backend, &self.default_namespace, document).await.map_err(|error| error.to_string())?;
+        let persisted_hash = resource_document_spec_hash(&applied.value).map_err(|error| error.to_string())?;
+        let recorded_hash = string_map(&applied.value, "annotations")?.get(LAST_APPLIED_HASH_ANNOTATION).cloned();
+        if recorded_hash.as_deref() == Some(persisted_hash.as_str()) {
+            return Ok(());
+        }
+
+        // Ownership enforcement can preserve protected fields, so the stored
+        // spec may differ from the requested manifest. Record the hash of what
+        // was actually persisted or the next pass will misclassify that
+        // preservation as external drift.
+        let mut persisted = applied.value;
+        let metadata =
+            persisted.get_mut("metadata").and_then(Value::as_object_mut).ok_or_else(|| "stored object has invalid metadata".to_string())?;
+        insert_metadata_value(metadata, "annotations", LAST_APPLIED_HASH_ANNOTATION, &persisted_hash)?;
+        apply_resource_document(&self.backend, &self.default_namespace, persisted).await.map_err(|error| error.to_string())?;
         Ok(())
     }
 }
@@ -324,6 +342,12 @@ mod tests {
         format!("apiVersion: flotilla.work/v1\nkind: PlacementPolicy\nmetadata:\n  name: {name}\nspec:\n  pool: {pool}\n")
     }
 
+    fn manifest_with_priority(name: &str, pool: &str, priority: i32) -> String {
+        format!(
+            "apiVersion: flotilla.work/v1\nkind: PlacementPolicy\nmetadata:\n  name: {name}\nspec:\n  pool: {pool}\n  priority: {priority}\n"
+        )
+    }
+
     #[tokio::test]
     async fn fresh_directory_applies_all_documents_with_ownership_and_source() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -419,6 +443,23 @@ mod tests {
         assert_eq!(report.updated, 1);
         assert_eq!(object.spec.pool, "one", "operator manifest must not replace a loop-owned field");
         assert_eq!(object.metadata.labels.get("another-controller/observation").map(String::as_str), Some("kept"));
+        assert_eq!(
+            object.metadata.annotations.get(LAST_APPLIED_HASH_ANNOTATION),
+            Some(
+                &resource_document_spec_hash(&serde_json::to_value(object.to_k8s_object()).expect("resource document"))
+                    .expect("persisted spec digest")
+            ),
+            "last-applied must describe the ownership-filtered spec"
+        );
+
+        write(&path, &manifest_with_priority("moving", "two", 100));
+        let follow_up = reconciler.reconcile_once().await.expect("follow-up pass");
+        let object = resolver.get("moving").await.expect("updated policy");
+
+        assert_eq!(follow_up.drifted, 0, "ownership preservation must not be mistaken for external drift");
+        assert_eq!(follow_up.updated, 1);
+        assert_eq!(object.spec.pool, "one");
+        assert_eq!(object.spec.priority, 100, "later operator-owned changes must still apply");
         let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
         assert!(
             diagnostics

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1187,6 +1187,9 @@ async fn apply_host_heartbeat_with_credentials(
     if let Some(condition) = resource_decode_quarantine_condition(resource_store.as_ref()) {
         conditions.push(condition);
     }
+    if let Some(condition) = resource_field_ownership_condition(resource_store.as_ref()) {
+        conditions.push(condition);
+    }
     if let Some(condition) = resource_replication_content_condition(daemon, namespace).await? {
         conditions.push(condition);
     }
@@ -1274,6 +1277,42 @@ fn resource_decode_quarantine_condition(diagnostics: Option<&flotilla_resources:
                 quarantines.len(),
                 if quarantines.len() == 1 { "" } else { "s" },
                 if quarantines.len() == 1 { "" } else { "s" },
+            ))
+            .observed_at(Utc::now())
+            .build(),
+    )
+}
+
+fn resource_field_ownership_condition(diagnostics: Option<&flotilla_resources::ResourceStoreDiagnostics>) -> Option<HostCondition> {
+    let violations = &diagnostics?.field_ownership_violations;
+    if violations.is_empty() {
+        return None;
+    }
+    let details = violations
+        .iter()
+        .map(|violation| {
+            format!(
+                "{}/{}/{} {:?} attempted {}={} ({})",
+                violation.kind,
+                violation.namespace,
+                violation.name,
+                violation.writer.role,
+                violation.field,
+                violation.attempted_value,
+                violation.rule
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    Some(
+        HostCondition::builder()
+            .condition_type("ResourceStore/FieldOwnership")
+            .value(ConditionValue::False)
+            .reason("FieldOwnershipViolation")
+            .message(format!(
+                "{} field ownership violation{} recorded: {details}",
+                violations.len(),
+                if violations.len() == 1 { "" } else { "s" }
             ))
             .observed_at(Utc::now())
             .build(),
@@ -2876,6 +2915,39 @@ mod tests {
             "fleet diagnosis must clear after bootstrap: {:?}",
             feta_row.degraded_conditions
         );
+    }
+
+    #[tokio::test]
+    async fn field_ownership_violation_is_exposed_in_fleet_diagnosis() {
+        let temp = TempDir::new().expect("tempdir");
+        let daemon = in_memory_daemon(Vec::new(), Arc::new(ConfigStore::with_base(temp.path()))).await;
+        let host_id = daemon.local_host_id().expect("local host id").to_string();
+        let profile = manual_profile(&host_id, false);
+        register_startup_resources(&daemon, NAMESPACE, &profile).await.expect("register resources");
+
+        let policies = daemon.resource_backend().using::<PlacementPolicy>(NAMESPACE);
+        let policy = policies.get(&profile.host_direct_policy_name()).await.expect("registered policy");
+        policies
+            .write_spec(
+                &flotilla_resources::WriterIdentity::operator(),
+                &InputMeta::from(&policy.metadata),
+                &policy.metadata.resource_version,
+                &PlacementPolicySpec::builder()
+                    .pool("operator-attempt".to_string())
+                    .priority(8)
+                    .host_direct(policy.spec.host_direct.clone().expect("host-direct policy"))
+                    .build(),
+            )
+            .await
+            .expect("observe-mode operator write");
+
+        apply_host_heartbeat(&daemon, NAMESPACE, &profile, &test_health_identity()).await.expect("publish heartbeat");
+        let fleet = daemon.fleet_health_internal().await.expect("fleet diagnosis");
+        let local = fleet.hosts.iter().find(|host| host.is_local).expect("local host");
+        let diagnosis = local.degraded_conditions.join("; ");
+        assert!(diagnosis.contains("ResourceStore/FieldOwnership"), "{diagnosis}");
+        assert!(diagnosis.contains("spec.pool"), "{diagnosis}");
+        assert!(diagnosis.contains("Operator"), "{diagnosis}");
     }
 
     #[cfg(unix)]

--- a/crates/flotilla-daemon/src/server/resource_http.rs
+++ b/crates/flotilla-daemon/src/server/resource_http.rs
@@ -141,6 +141,7 @@ async fn write_resource_error(stream: &mut UnixStream, error: ResourceError) -> 
         ResourceError::Invalid { .. } => 400,
         ResourceError::NotFound { .. } => 404,
         ResourceError::Conflict { .. } => 409,
+        ResourceError::FieldOwnership { .. } => 409,
         ResourceError::Unauthorized { .. } => 403,
         ResourceError::Other { .. } => 500,
     };

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -7,6 +7,7 @@ use futures::{stream, StreamExt};
 use crate::{
     definition::DefinitionResolver,
     error::ResourceError,
+    field_ownership::merge_owned_spec,
     http::HttpBackend,
     in_memory::InMemoryBackend,
     replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEventKind},
@@ -14,6 +15,7 @@ use crate::{
     retention::ResourceStoreDiagnostics,
     sqlite::SqliteBackend,
     watch::{ResourceList, WatchStart, WatchStream},
+    FieldOwnedResource, FieldOwnershipViolation, OwnershipEnforcement, WriterIdentity,
 };
 
 macro_rules! dispatch_backend {
@@ -75,6 +77,17 @@ impl ResourceBackend {
             Self::InMemory(backend) => backend.diagnostics().await.map(Some),
             Self::Http(_) => Ok(None),
             Self::Sqlite(backend) => backend.diagnostics().await.map(Some),
+        }
+    }
+
+    async fn record_field_ownership_violation(&self, violation: FieldOwnershipViolation) -> Result<(), ResourceError> {
+        match self {
+            Self::InMemory(backend) => {
+                backend.record_field_ownership_violation(violation).await;
+                Ok(())
+            }
+            Self::Sqlite(backend) => backend.record_field_ownership_violation(violation).await,
+            Self::Http(_) => Ok(()),
         }
     }
 }
@@ -304,5 +317,40 @@ impl<T: Resource> TypedResolver<T> {
 
     pub async fn watch(&self, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {
         dispatch_backend!(self, watch_typed, start)
+    }
+}
+
+impl<T: FieldOwnedResource> TypedResolver<T> {
+    /// The only update path for an enrolled resource kind.
+    ///
+    /// Observe mode records attempted ownership violations and applies the
+    /// writer's owned fields while preserving protected stored values. Enforce
+    /// mode records the same event and refuses the complete write.
+    pub async fn write_spec(
+        &self,
+        writer: &WriterIdentity,
+        meta: &InputMeta,
+        resource_version: &str,
+        requested: &T::Spec,
+    ) -> Result<ResourceObject<T>, ResourceError> {
+        let current = self.get(&meta.name).await?;
+        let (merged, violations) = merge_owned_spec::<T>(&current.spec, requested, writer, &self.namespace, &meta.name)?;
+        for violation in &violations {
+            tracing::warn!(
+                kind = %violation.kind,
+                namespace = %violation.namespace,
+                name = %violation.name,
+                writer_role = ?violation.writer.role,
+                field = %violation.field,
+                attempted_value = %violation.attempted_value,
+                rule = %violation.rule,
+                "resource field ownership violation"
+            );
+            self.backend.record_field_ownership_violation(violation.clone()).await?;
+        }
+        if !violations.is_empty() && T::OWNERSHIP_ENFORCEMENT == OwnershipEnforcement::Enforce {
+            return Err(ResourceError::FieldOwnership { violations });
+        }
+        self.update(meta, resource_version, &merged).await
     }
 }

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -87,6 +87,8 @@ impl ResourceBackend {
                 Ok(())
             }
             Self::Sqlite(backend) => backend.record_field_ownership_violation(violation).await,
+            // HTTP clients cannot publish authoritative host diagnostics. The
+            // enrolled write paths currently execute against embedded stores.
             Self::Http(_) => Ok(()),
         }
     }

--- a/crates/flotilla-resources/src/error.rs
+++ b/crates/flotilla-resources/src/error.rs
@@ -1,5 +1,7 @@
 use std::{error::Error, fmt};
 
+use crate::FieldOwnershipViolation;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResourceError {
     NotFound { name: String },
@@ -7,6 +9,7 @@ pub enum ResourceError {
     Invalid { message: String },
     WatchExpired { requested_version: String, compacted_through: Option<String> },
     Unauthorized { message: String },
+    FieldOwnership { violations: Vec<FieldOwnershipViolation> },
     Other { message: String },
 }
 
@@ -34,6 +37,12 @@ impl ResourceError {
     pub fn decode(message: impl Into<String>) -> Self {
         Self::other(message)
     }
+
+    /// Reconcilers requeue both optimistic concurrency conflicts and ownership
+    /// enforcement failures from a fresh read.
+    pub fn is_stale_view(&self) -> bool {
+        matches!(self, Self::Conflict { .. } | Self::FieldOwnership { .. })
+    }
 }
 
 impl fmt::Display for ResourceError {
@@ -49,6 +58,9 @@ impl fmt::Display for ResourceError {
                 write!(f, "watch resourceVersion {requested_version} expired")
             }
             Self::Unauthorized { message } => write!(f, "unauthorized: {message}"),
+            Self::FieldOwnership { violations } => {
+                write!(f, "field ownership refused {} violation(s)", violations.len())
+            }
             Self::Other { message } => f.write_str(message),
         }
     }

--- a/crates/flotilla-resources/src/field_ownership.rs
+++ b/crates/flotilla-resources/src/field_ownership.rs
@@ -1,0 +1,167 @@
+use chrono::{DateTime, Utc};
+use flotilla_protocol::NodeId;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{Resource, ResourceError};
+
+/// The closed set of roles which may author resource fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriterRole {
+    Operator,
+    ReconcileLoop,
+    Actuator,
+}
+
+/// Identity supplied at the single resource write path.
+///
+/// `store_authority` is deliberately part of the identity rather than a separate
+/// write argument. ADR 0025 can make it mandatory without changing call sites.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct WriterIdentity {
+    pub role: WriterRole,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_authority: Option<NodeId>,
+}
+
+impl WriterIdentity {
+    pub fn new(role: WriterRole) -> Self {
+        Self { role, store_authority: None }
+    }
+
+    pub fn operator() -> Self {
+        Self::new(WriterRole::Operator)
+    }
+
+    pub fn reconcile_loop() -> Self {
+        Self::new(WriterRole::ReconcileLoop)
+    }
+
+    pub fn actuator() -> Self {
+        Self::new(WriterRole::Actuator)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OwnershipEnforcement {
+    Observe,
+    Enforce,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FieldOwnership {
+    /// Dot-separated path rooted at `spec` or `status`.
+    pub field: &'static str,
+    pub owner: WriterRole,
+}
+
+impl FieldOwnership {
+    pub const fn new(field: &'static str, owner: WriterRole) -> Self {
+        Self { field, owner }
+    }
+}
+
+/// A resource enrolled in static field ownership.
+///
+/// Tables live beside the resource type and enumerate every spec/status leaf.
+/// Nested objects may be declared as one field when they have one indivisible
+/// owner. New enrollees start in `Observe` and flip this associated constant
+/// only after their adversarial scenarios pass.
+pub trait FieldOwnedResource: Resource {
+    const FIELD_OWNERSHIP: &'static [FieldOwnership];
+    const OWNERSHIP_ENFORCEMENT: OwnershipEnforcement = OwnershipEnforcement::Observe;
+
+    fn spec_field_value(spec: &Self::Spec, field: &str) -> Result<Option<Value>, ResourceError>
+    where
+        Self: Sized,
+    {
+        serialized_spec_field_value::<Self>(spec, field)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct FieldOwnershipViolation {
+    pub kind: String,
+    pub namespace: String,
+    pub name: String,
+    pub writer: WriterIdentity,
+    pub field: String,
+    pub attempted_value: Value,
+    pub rule: String,
+    pub observed_at: DateTime<Utc>,
+}
+
+pub(crate) fn merge_owned_spec<T: FieldOwnedResource>(
+    current: &T::Spec,
+    requested: &T::Spec,
+    writer: &WriterIdentity,
+    namespace: &str,
+    name: &str,
+) -> Result<(T::Spec, Vec<FieldOwnershipViolation>), ResourceError> {
+    let mut merged =
+        serde_json::to_value(requested).map_err(|error| ResourceError::decode(format!("serialize requested spec: {error}")))?;
+    let mut violations = Vec::new();
+
+    for ownership in T::FIELD_OWNERSHIP {
+        let relative = ownership.field.strip_prefix("spec.").ok_or_else(|| {
+            ResourceError::invalid(format!("{} ownership table field '{}' is not rooted at spec", T::API_PATHS.kind, ownership.field))
+        })?;
+        let current_field = T::spec_field_value(current, ownership.field)?;
+        let requested_field = T::spec_field_value(requested, ownership.field)?;
+        if current_field == requested_field || ownership.owner == writer.role {
+            continue;
+        }
+        // A role which creates a newly-applicable strategy must initialize its
+        // complete shape. Ownership protects stored values, not absent values.
+        if current_field.as_ref().is_none_or(Value::is_null) {
+            continue;
+        }
+        let attempted_value = requested_field.unwrap_or(Value::Null);
+        violations.push(
+            FieldOwnershipViolation::builder()
+                .kind(T::API_PATHS.kind.to_string())
+                .namespace(namespace.to_string())
+                .name(name.to_string())
+                .writer(writer.clone())
+                .field(ownership.field.to_string())
+                .attempted_value(attempted_value)
+                .rule(format!("{} is owned by {:?}", ownership.field, ownership.owner))
+                .observed_at(Utc::now())
+                .build(),
+        );
+        set_value_at_path(&mut merged, relative, current_field.unwrap_or(Value::Null))?;
+    }
+
+    let merged = serde_json::from_value(merged).map_err(|error| ResourceError::decode(format!("decode ownership-merged spec: {error}")))?;
+    Ok((merged, violations))
+}
+
+pub(crate) fn serialized_spec_field_value<T: Resource>(spec: &T::Spec, field: &str) -> Result<Option<Value>, ResourceError> {
+    let relative = field
+        .strip_prefix("spec.")
+        .ok_or_else(|| ResourceError::invalid(format!("{} ownership field '{field}' is not rooted at spec", T::API_PATHS.kind)))?;
+    let value = serde_json::to_value(spec).map_err(|error| ResourceError::decode(format!("serialize spec field: {error}")))?;
+    Ok(value_at_path(&value, relative).cloned())
+}
+
+fn value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    path.split('.').try_fold(value, |cursor, segment| cursor.get(segment))
+}
+
+fn set_value_at_path(value: &mut Value, path: &str, replacement: Value) -> Result<(), ResourceError> {
+    let mut segments = path.split('.').peekable();
+    let mut cursor = value;
+    while let Some(segment) = segments.next() {
+        if segments.peek().is_none() {
+            let object = cursor
+                .as_object_mut()
+                .ok_or_else(|| ResourceError::invalid(format!("ownership field parent for '{path}' is not an object")))?;
+            object.insert(segment.to_string(), replacement);
+            return Ok(());
+        }
+        cursor = cursor.get_mut(segment).ok_or_else(|| ResourceError::invalid(format!("ownership field parent for '{path}' is absent")))?;
+    }
+    Err(ResourceError::invalid("ownership field path must not be empty"))
+}

--- a/crates/flotilla-resources/src/field_ownership.rs
+++ b/crates/flotilla-resources/src/field_ownership.rs
@@ -52,7 +52,9 @@ pub enum OwnershipEnforcement {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FieldOwnership {
-    /// Dot-separated path rooted at `spec` or `status`.
+    /// Dot-separated path rooted at `spec`.
+    ///
+    /// Status ownership joins this format when the status write path enrolls.
     pub field: &'static str,
     pub owner: WriterRole,
 }
@@ -79,6 +81,13 @@ pub trait FieldOwnedResource: Resource {
     {
         serialized_spec_field_value::<Self>(spec, field)
     }
+
+    fn spec_field_restore_value(spec: &Self::Spec, field: &str) -> Result<Value, ResourceError>
+    where
+        Self: Sized,
+    {
+        Ok(serialized_spec_field_value::<Self>(spec, field)?.unwrap_or(Value::Null))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
@@ -103,19 +112,22 @@ pub(crate) fn merge_owned_spec<T: FieldOwnedResource>(
     let mut merged =
         serde_json::to_value(requested).map_err(|error| ResourceError::decode(format!("serialize requested spec: {error}")))?;
     let mut violations = Vec::new();
+    let mut resolved_subtrees = Vec::<&str>::new();
 
     for ownership in T::FIELD_OWNERSHIP {
+        if resolved_subtrees.iter().any(|parent| ownership.field.strip_prefix(parent).is_some_and(|suffix| suffix.starts_with('.'))) {
+            continue;
+        }
         let relative = ownership.field.strip_prefix("spec.").ok_or_else(|| {
             ResourceError::invalid(format!("{} ownership table field '{}' is not rooted at spec", T::API_PATHS.kind, ownership.field))
         })?;
         let current_field = T::spec_field_value(current, ownership.field)?;
         let requested_field = T::spec_field_value(requested, ownership.field)?;
-        if current_field == requested_field || ownership.owner == writer.role {
+        if current_field == requested_field {
             continue;
         }
-        // A role which creates a newly-applicable strategy must initialize its
-        // complete shape. Ownership protects stored values, not absent values.
-        if current_field.as_ref().is_none_or(Value::is_null) {
+        if ownership.owner == writer.role {
+            resolved_subtrees.push(ownership.field);
             continue;
         }
         let attempted_value = requested_field.unwrap_or(Value::Null);
@@ -131,7 +143,8 @@ pub(crate) fn merge_owned_spec<T: FieldOwnedResource>(
                 .observed_at(Utc::now())
                 .build(),
         );
-        set_value_at_path(&mut merged, relative, current_field.unwrap_or(Value::Null))?;
+        set_value_at_path(&mut merged, relative, T::spec_field_restore_value(current, ownership.field)?)?;
+        resolved_subtrees.push(ownership.field);
     }
 
     let merged = serde_json::from_value(merged).map_err(|error| ResourceError::decode(format!("decode ownership-merged spec: {error}")))?;

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -14,7 +14,7 @@ use crate::{
     field_ownership::FieldOwnershipViolation,
     replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
     resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
-    retention::{EventRetention, ResourceStoreDiagnostics},
+    retention::{EventRetention, ResourceStoreDiagnostics, MAX_FIELD_OWNERSHIP_VIOLATIONS},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
 };
 
@@ -155,7 +155,12 @@ impl InMemoryBackend {
     }
 
     pub(crate) async fn record_field_ownership_violation(&self, violation: FieldOwnershipViolation) {
-        self.ownership_violations.lock().await.push(violation);
+        let mut violations = self.ownership_violations.lock().await;
+        violations.push(violation);
+        let excess = violations.len().saturating_sub(MAX_FIELD_OWNERSHIP_VIOLATIONS);
+        if excess > 0 {
+            violations.drain(..excess);
+        }
     }
 
     fn store_key<T: Resource>(namespace: &str) -> StoreKey {

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -11,6 +11,7 @@ use tokio::sync::{mpsc, Mutex};
 
 use crate::{
     error::ResourceError,
+    field_ownership::FieldOwnershipViolation,
     replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
     resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
     retention::{EventRetention, ResourceStoreDiagnostics},
@@ -27,6 +28,7 @@ pub struct InMemoryBackend {
     generation: Option<String>,
     event_retention: EventRetention,
     local_root: Option<NodeId>,
+    ownership_violations: Arc<Mutex<Vec<FieldOwnershipViolation>>>,
 }
 
 type ReplicaKey = (NodeId, StoreKey);
@@ -107,11 +109,19 @@ impl InMemoryBackend {
             generation: Some(uuid::Uuid::new_v4().to_string()),
             event_retention: EventRetention::default(),
             local_root: None,
+            ownership_violations: Arc::default(),
         }
     }
 
     pub fn with_event_retention(event_retention: EventRetention) -> Self {
-        Self { stores: Arc::default(), replicas: Arc::default(), generation: None, event_retention, local_root: None }
+        Self {
+            stores: Arc::default(),
+            replicas: Arc::default(),
+            generation: None,
+            event_retention,
+            local_root: None,
+            ownership_violations: Arc::default(),
+        }
     }
 
     pub fn observed_with_event_retention(event_retention: EventRetention) -> Self {
@@ -121,6 +131,7 @@ impl InMemoryBackend {
             generation: Some(uuid::Uuid::new_v4().to_string()),
             event_retention,
             local_root: None,
+            ownership_violations: Arc::default(),
         }
     }
 
@@ -138,7 +149,13 @@ impl InMemoryBackend {
         let object_count = stores.values().map(|store| store.objects.len() as u64).sum();
         let event_count = stores.values().map(|store| store.event_log.len() as u64).sum();
         let resource_stream_count = stores.values().filter(|store| store.current_version() > 0).count() as u64;
-        Ok(ResourceStoreDiagnostics::new(object_count, event_count, resource_stream_count, self.event_retention))
+        let mut diagnostics = ResourceStoreDiagnostics::new(object_count, event_count, resource_stream_count, self.event_retention);
+        diagnostics.field_ownership_violations = self.ownership_violations.lock().await.clone();
+        Ok(diagnostics)
+    }
+
+    pub(crate) async fn record_field_ownership_violation(&self, violation: FieldOwnershipViolation) {
+        self.ownership_violations.lock().await.push(violation);
     }
 
     fn store_key<T: Resource>(namespace: &str) -> StoreKey {

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -8,6 +8,7 @@ mod credential;
 mod definition;
 mod environment;
 mod error;
+mod field_ownership;
 mod host;
 mod http;
 mod in_memory;
@@ -62,6 +63,7 @@ pub use environment::{
     EnvironmentStatusPatch, EnvironmentWaitReason, HostDirectEnvironmentSpec,
 };
 pub use error::ResourceError;
+pub use field_ownership::{FieldOwnedResource, FieldOwnership, FieldOwnershipViolation, OwnershipEnforcement, WriterIdentity, WriterRole};
 pub use flotilla_protocol::{PrincipalRef, ResourceRef};
 pub use host::{
     Host, HostCondition, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY, HEARTBEAT_READY_TTL_SECS,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -97,11 +97,11 @@ pub use project::{
 };
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
-    apply_resource_document, delete_resource_kind, get_resource_kind, list_resource_kind, list_resource_kind_including_replicas,
-    list_resource_kind_replica_sources, quarantine_undecodable_stored_objects, replica_cursor_for_resource_kind,
-    resource_document_spec_hash, resource_list_api_version, watch_resource_kind, watch_resource_kind_from,
-    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList, DynamicResourceObject,
-    DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
+    apply_manifest_resource_document, apply_resource_document, delete_resource_kind, get_resource_kind, list_resource_kind,
+    list_resource_kind_including_replicas, list_resource_kind_replica_sources, quarantine_undecodable_stored_objects,
+    replica_cursor_for_resource_kind, resource_document_spec_hash, resource_list_api_version, watch_resource_kind,
+    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList,
+    DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{

--- a/crates/flotilla-resources/src/placement_policy.rs
+++ b/crates/flotilla-resources/src/placement_policy.rs
@@ -2,7 +2,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{resource::define_resource, status_patch::NoStatusPatch, ReplicationClass};
+use crate::{
+    field_ownership::serialized_spec_field_value, resource::define_resource, status_patch::NoStatusPatch, FieldOwnedResource,
+    FieldOwnership, OwnershipEnforcement, ReplicationClass, ResourceError, WriterRole,
+};
 
 define_resource!(
     PlacementPolicy,
@@ -12,6 +15,34 @@ define_resource!(
     NoStatusPatch,
     replication = ReplicationClass::HomeBoundRuntime
 );
+
+/// Complete PlacementPolicy ownership declaration.
+///
+/// Strategy topology discovered by registration loops is loop-derived.
+/// Scheduling priority and runtime/container configuration are operator-authored.
+/// PlacementPolicy has no status fields.
+impl FieldOwnedResource for PlacementPolicy {
+    const FIELD_OWNERSHIP: &'static [FieldOwnership] = &[
+        FieldOwnership::new("spec.pool", WriterRole::ReconcileLoop),
+        FieldOwnership::new("spec.priority", WriterRole::Operator),
+        FieldOwnership::new("spec.host_direct", WriterRole::ReconcileLoop),
+        FieldOwnership::new("spec.docker_per_vessel.host_ref", WriterRole::ReconcileLoop),
+        FieldOwnership::new("spec.docker_per_vessel.image", WriterRole::Operator),
+        FieldOwnership::new("spec.docker_per_vessel.pull_policy", WriterRole::Operator),
+        FieldOwnership::new("spec.docker_per_vessel.agent_adapters", WriterRole::Operator),
+        FieldOwnership::new("spec.docker_per_vessel.default_cwd", WriterRole::Operator),
+        FieldOwnership::new("spec.docker_per_vessel.env", WriterRole::Operator),
+        FieldOwnership::new("spec.docker_per_vessel.checkout", WriterRole::ReconcileLoop),
+    ];
+    const OWNERSHIP_ENFORCEMENT: OwnershipEnforcement = OwnershipEnforcement::Observe;
+
+    fn spec_field_value(spec: &Self::Spec, field: &str) -> Result<Option<serde_json::Value>, ResourceError> {
+        match field {
+            "spec.priority" => Ok(Some(serde_json::json!(spec.priority))),
+            _ => serialized_spec_field_value::<Self>(spec, field),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct PlacementPolicySpec {

--- a/crates/flotilla-resources/src/placement_policy.rs
+++ b/crates/flotilla-resources/src/placement_policy.rs
@@ -26,6 +26,7 @@ impl FieldOwnedResource for PlacementPolicy {
         FieldOwnership::new("spec.pool", WriterRole::ReconcileLoop),
         FieldOwnership::new("spec.priority", WriterRole::Operator),
         FieldOwnership::new("spec.host_direct", WriterRole::ReconcileLoop),
+        FieldOwnership::new("spec.docker_per_vessel", WriterRole::ReconcileLoop),
         FieldOwnership::new("spec.docker_per_vessel.host_ref", WriterRole::ReconcileLoop),
         FieldOwnership::new("spec.docker_per_vessel.image", WriterRole::Operator),
         FieldOwnership::new("spec.docker_per_vessel.pull_policy", WriterRole::Operator),
@@ -39,7 +40,16 @@ impl FieldOwnedResource for PlacementPolicy {
     fn spec_field_value(spec: &Self::Spec, field: &str) -> Result<Option<serde_json::Value>, ResourceError> {
         match field {
             "spec.priority" => Ok(Some(serde_json::json!(spec.priority))),
+            "spec.docker_per_vessel" => Ok(Some(serde_json::json!(spec.docker_per_vessel.is_some()))),
             _ => serialized_spec_field_value::<Self>(spec, field),
+        }
+    }
+
+    fn spec_field_restore_value(spec: &Self::Spec, field: &str) -> Result<serde_json::Value, ResourceError> {
+        match field {
+            "spec.docker_per_vessel" => Ok(serde_json::to_value(&spec.docker_per_vessel)
+                .map_err(|error| ResourceError::decode(format!("serialize docker_per_vessel: {error}")))?),
+            _ => Ok(serialized_spec_field_value::<Self>(spec, field)?.unwrap_or(serde_json::Value::Null)),
         }
     }
 }

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 
 use crate::{
     api_version,
+    field_ownership::merge_owned_spec,
     host::HostStatus,
     replica::{LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION},
     Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, Environment, FieldOwnedResource, Host, InputMeta,
@@ -216,6 +217,20 @@ macro_rules! dispatch_apply_resource_kind {
     };
 }
 
+/// Manifest reconciliation is authoritative for both operator-authored input
+/// and loop-derived topology. Enrolled resources project the same desired spec
+/// through each role instead of bypassing the single ownership-aware write path.
+macro_rules! dispatch_manifest_apply_resource_kind {
+    ($resource:expr, $backend:expr, $namespace:expr, $metadata:expr, $spec:expr) => {
+        match $resource {
+            RegisteredResource::PlacementPolicy => {
+                apply_manifest_owned_typed::<PlacementPolicy>($backend, $namespace, $metadata, $spec).await
+            }
+            resource => dispatch_resource_kind!(resource, apply_typed($backend, $namespace, $metadata, $spec).await),
+        }
+    };
+}
+
 /// Drives a typed read of every kind in the embedded durable store.
 ///
 /// Embedded stores use this startup pass to isolate rows whose persisted
@@ -332,6 +347,23 @@ pub async fn apply_resource_document(
         serde_json::from_value(document).map_err(|error| ResourceError::decode(format!("decode resource document: {error}")))?;
     let namespace = document.metadata.namespace.clone().unwrap_or_else(|| default_namespace.to_string());
     dispatch_apply_resource_kind!(lookup_resource_kind(&document.kind)?.resource, backend, &namespace, document.metadata, document.spec)
+}
+
+pub async fn apply_manifest_resource_document(
+    backend: &ResourceBackend,
+    default_namespace: &str,
+    document: Value,
+) -> Result<DynamicResourceObject, ResourceError> {
+    let document: DynamicApplyDocument =
+        serde_json::from_value(document).map_err(|error| ResourceError::decode(format!("decode resource document: {error}")))?;
+    let namespace = document.metadata.namespace.clone().unwrap_or_else(|| default_namespace.to_string());
+    dispatch_manifest_apply_resource_kind!(
+        lookup_resource_kind(&document.kind)?.resource,
+        backend,
+        &namespace,
+        document.metadata,
+        document.spec
+    )
 }
 
 /// Hash a resource document's spec after its registered typed representation
@@ -632,6 +664,46 @@ async fn apply_owned_typed<T: FieldOwnedResource>(
             resolver.write_spec(&WriterIdentity::operator(), &meta, &existing.metadata.resource_version, &spec).await?
         }
         Err(ResourceError::NotFound { .. }) => resolver.create(&metadata.input_meta_for_create(), &spec).await?,
+        Err(error) => return Err(error),
+    };
+    Ok(DynamicResourceObject {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value: object_value(&object)?,
+    })
+}
+
+async fn apply_manifest_owned_typed<T: FieldOwnedResource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+    metadata: DynamicApplyMetadata,
+    spec: Value,
+) -> Result<DynamicResourceObject, ResourceError> {
+    let desired =
+        serde_json::from_value(spec).map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", T::API_PATHS.kind)))?;
+    let resolver = backend.using::<T>(namespace);
+    let object = match resolver.get(&metadata.name).await {
+        Ok(existing) => {
+            let operator = WriterIdentity::operator();
+            let (operator_spec, _) = merge_owned_spec::<T>(&existing.spec, &desired, &operator, namespace, &metadata.name)?;
+            let meta = metadata.input_meta_for_update(&existing.metadata);
+            let operator_written = resolver.write_spec(&operator, &meta, &existing.metadata.resource_version, &operator_spec).await?;
+
+            let reconcile_loop = WriterIdentity::reconcile_loop();
+            let (loop_spec, _) = merge_owned_spec::<T>(&operator_written.spec, &desired, &reconcile_loop, namespace, &metadata.name)?;
+            let current_value = serde_json::to_value(&operator_written.spec)
+                .map_err(|error| ResourceError::decode(format!("encode current {} spec: {error}", T::API_PATHS.kind)))?;
+            let loop_value = serde_json::to_value(&loop_spec)
+                .map_err(|error| ResourceError::decode(format!("encode projected {} spec: {error}", T::API_PATHS.kind)))?;
+            if current_value == loop_value {
+                operator_written
+            } else {
+                let meta = metadata.input_meta_for_update(&operator_written.metadata);
+                resolver.write_spec(&reconcile_loop, &meta, &operator_written.metadata.resource_version, &loop_spec).await?
+            }
+        }
+        Err(ResourceError::NotFound { .. }) => resolver.create(&metadata.input_meta_for_create(), &desired).await?,
         Err(error) => return Err(error),
     };
     Ok(DynamicResourceObject {

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -12,7 +12,7 @@ use crate::{
     Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, Environment, Host, InputMeta, MaterialPool,
     ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project, ReadResourceList, ReadWatchEvent, Regard, ReplicaCursor,
     ReplicationClass, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, ResourceProvenance,
-    TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
+    TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate, WriterIdentity,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -319,10 +319,11 @@ pub async fn apply_resource_document(
     let document: DynamicApplyDocument =
         serde_json::from_value(document).map_err(|error| ResourceError::decode(format!("decode resource document: {error}")))?;
     let namespace = document.metadata.namespace.clone().unwrap_or_else(|| default_namespace.to_string());
-    dispatch_resource_kind!(
-        lookup_resource_kind(&document.kind)?.resource,
-        apply_typed(backend, &namespace, document.metadata, document.spec).await
-    )
+    let registered = lookup_resource_kind(&document.kind)?.resource;
+    if registered == RegisteredResource::PlacementPolicy {
+        return apply_placement_policy(backend, &namespace, document.metadata, document.spec).await;
+    }
+    dispatch_resource_kind!(registered, apply_typed(backend, &namespace, document.metadata, document.spec).await)
 }
 
 /// Hash a resource document's spec after its registered typed representation
@@ -603,6 +604,31 @@ async fn apply_typed<T: Resource>(
     Ok(DynamicResourceObject {
         kind: T::API_PATHS.kind.to_string(),
         plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value: object_value(&object)?,
+    })
+}
+
+async fn apply_placement_policy(
+    backend: &ResourceBackend,
+    namespace: &str,
+    metadata: DynamicApplyMetadata,
+    spec: Value,
+) -> Result<DynamicResourceObject, ResourceError> {
+    let spec = serde_json::from_value(spec)
+        .map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", PlacementPolicy::API_PATHS.kind)))?;
+    let resolver = backend.using::<PlacementPolicy>(namespace);
+    let object = match resolver.get(&metadata.name).await {
+        Ok(existing) => {
+            let meta = metadata.input_meta_for_update(&existing.metadata);
+            resolver.write_spec(&WriterIdentity::operator(), &meta, &existing.metadata.resource_version, &spec).await?
+        }
+        Err(ResourceError::NotFound { .. }) => resolver.create(&metadata.input_meta_for_create(), &spec).await?,
+        Err(error) => return Err(error),
+    };
+    Ok(DynamicResourceObject {
+        kind: PlacementPolicy::API_PATHS.kind.to_string(),
+        plural: PlacementPolicy::API_PATHS.plural.to_string(),
         namespace: namespace.to_string(),
         value: object_value(&object)?,
     })

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -9,10 +9,10 @@ use crate::{
     api_version,
     host::HostStatus,
     replica::{LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION},
-    Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, Environment, Host, InputMeta, MaterialPool,
-    ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project, ReadResourceList, ReadWatchEvent, Regard, ReplicaCursor,
-    ReplicationClass, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject, ResourceProvenance,
-    TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate, WriterIdentity,
+    Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, Environment, FieldOwnedResource, Host, InputMeta,
+    MaterialPool, ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project, ReadResourceList, ReadWatchEvent, Regard,
+    ReplicaCursor, ReplicationClass, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject,
+    ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate, WriterIdentity,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -204,6 +204,18 @@ macro_rules! dispatch_resource_kind {
     };
 }
 
+/// Dynamic apply uses the ownership-aware path for enrolled kinds. Enrolling
+/// another resource changes one dispatch arm rather than adding a one-off
+/// apply function or branch.
+macro_rules! dispatch_apply_resource_kind {
+    ($resource:expr, $backend:expr, $namespace:expr, $metadata:expr, $spec:expr) => {
+        match $resource {
+            RegisteredResource::PlacementPolicy => apply_owned_typed::<PlacementPolicy>($backend, $namespace, $metadata, $spec).await,
+            resource => dispatch_resource_kind!(resource, apply_typed($backend, $namespace, $metadata, $spec).await),
+        }
+    };
+}
+
 /// Drives a typed read of every kind in the embedded durable store.
 ///
 /// Embedded stores use this startup pass to isolate rows whose persisted
@@ -319,11 +331,7 @@ pub async fn apply_resource_document(
     let document: DynamicApplyDocument =
         serde_json::from_value(document).map_err(|error| ResourceError::decode(format!("decode resource document: {error}")))?;
     let namespace = document.metadata.namespace.clone().unwrap_or_else(|| default_namespace.to_string());
-    let registered = lookup_resource_kind(&document.kind)?.resource;
-    if registered == RegisteredResource::PlacementPolicy {
-        return apply_placement_policy(backend, &namespace, document.metadata, document.spec).await;
-    }
-    dispatch_resource_kind!(registered, apply_typed(backend, &namespace, document.metadata, document.spec).await)
+    dispatch_apply_resource_kind!(lookup_resource_kind(&document.kind)?.resource, backend, &namespace, document.metadata, document.spec)
 }
 
 /// Hash a resource document's spec after its registered typed representation
@@ -609,15 +617,15 @@ async fn apply_typed<T: Resource>(
     })
 }
 
-async fn apply_placement_policy(
+async fn apply_owned_typed<T: FieldOwnedResource>(
     backend: &ResourceBackend,
     namespace: &str,
     metadata: DynamicApplyMetadata,
     spec: Value,
 ) -> Result<DynamicResourceObject, ResourceError> {
-    let spec = serde_json::from_value(spec)
-        .map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", PlacementPolicy::API_PATHS.kind)))?;
-    let resolver = backend.using::<PlacementPolicy>(namespace);
+    let spec =
+        serde_json::from_value(spec).map_err(|error| ResourceError::decode(format!("decode {} spec: {error}", T::API_PATHS.kind)))?;
+    let resolver = backend.using::<T>(namespace);
     let object = match resolver.get(&metadata.name).await {
         Ok(existing) => {
             let meta = metadata.input_meta_for_update(&existing.metadata);
@@ -627,8 +635,8 @@ async fn apply_placement_policy(
         Err(error) => return Err(error),
     };
     Ok(DynamicResourceObject {
-        kind: PlacementPolicy::API_PATHS.kind.to_string(),
-        plural: PlacementPolicy::API_PATHS.plural.to_string(),
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
         namespace: namespace.to_string(),
         value: object_value(&object)?,
     })

--- a/crates/flotilla-resources/src/retention.rs
+++ b/crates/flotilla-resources/src/retention.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::ResourceError;
+use crate::{FieldOwnershipViolation, ResourceError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventRetention {
@@ -55,6 +55,8 @@ pub struct ResourceStoreDiagnostics {
     pub warnings: Vec<ResourceStoreWarning>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub decode_quarantines: Vec<ResourceDecodeQuarantine>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub field_ownership_violations: Vec<FieldOwnershipViolation>,
 }
 
 impl ResourceStoreDiagnostics {
@@ -70,7 +72,15 @@ impl ResourceStoreDiagnostics {
         if event_count > ratio_baseline.saturating_mul(Self::EVENT_TO_OBJECT_WARNING_MULTIPLIER) {
             warnings.push(ResourceStoreWarning::ExcessiveEventToObjectRatio);
         }
-        Self { object_count, event_count, resource_stream_count, max_retained_events, warnings, decode_quarantines: Vec::new() }
+        Self {
+            object_count,
+            event_count,
+            resource_stream_count,
+            max_retained_events,
+            warnings,
+            decode_quarantines: Vec::new(),
+            field_ownership_violations: Vec::new(),
+        }
     }
 
     pub fn event_log_within_retention(&self) -> bool {

--- a/crates/flotilla-resources/src/retention.rs
+++ b/crates/flotilla-resources/src/retention.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{FieldOwnershipViolation, ResourceError};
 
+pub(crate) const MAX_FIELD_OWNERSHIP_VIOLATIONS: usize = 1_024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventRetention {
     max_events_per_resource_stream: usize,

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -17,7 +17,7 @@ use crate::{
     error::ResourceError,
     replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
     resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
-    retention::{EventRetention, ResourceDecodeQuarantine, ResourceStoreDiagnostics},
+    retention::{EventRetention, ResourceDecodeQuarantine, ResourceStoreDiagnostics, MAX_FIELD_OWNERSHIP_VIOLATIONS},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
     FieldOwnershipViolation,
 };
@@ -383,6 +383,15 @@ impl SqliteBackend {
                     observed_at
                 ])
                 .map_err(|error| Self::map_sqlite(error, "record field ownership violation"))?;
+            connection
+                .execute(
+                    "DELETE FROM field_ownership_violations
+                     WHERE id NOT IN (
+                         SELECT id FROM field_ownership_violations ORDER BY id DESC LIMIT ?1
+                     )",
+                    rusqlite::params![MAX_FIELD_OWNERSHIP_VIOLATIONS],
+                )
+                .map_err(|error| Self::map_sqlite(error, "compact field ownership violations"))?;
             Ok(())
         })
         .await

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -19,6 +19,7 @@ use crate::{
     resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
     retention::{EventRetention, ResourceDecodeQuarantine, ResourceStoreDiagnostics},
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
+    FieldOwnershipViolation,
 };
 
 type StoreKey = (String, String, String, String);
@@ -193,6 +194,12 @@ impl SqliteBackend {
                     PRIMARY KEY (group_name, version, kind, namespace)
                 );
 
+                CREATE TABLE IF NOT EXISTS field_ownership_violations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    body_json TEXT NOT NULL,
+                    observed_at TEXT NOT NULL
+                );
+
                 CREATE TABLE IF NOT EXISTS replica_objects (
                     origin_root TEXT NOT NULL,
                     group_name TEXT NOT NULL,
@@ -350,7 +357,35 @@ impl SqliteBackend {
             .collect::<Result<Vec<_>, ResourceError>>()?;
         let mut diagnostics = ResourceStoreDiagnostics::new(object_count, event_count, resource_stream_count, event_retention);
         diagnostics.decode_quarantines = decode_quarantines;
+        let mut statement = connection
+            .prepare("SELECT body_json FROM field_ownership_violations ORDER BY id")
+            .map_err(|err| Self::map_sqlite(err, "prepare field ownership violation diagnostics"))?;
+        diagnostics.field_ownership_violations = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|err| Self::map_sqlite(err, "query field ownership violation diagnostics"))?
+            .map(|row| {
+                let body = row.map_err(|err| Self::map_sqlite(err, "read field ownership violation diagnostic"))?;
+                serde_json::from_str(&body)
+                    .map_err(|err| ResourceError::decode(format!("decode field ownership violation diagnostic: {err}")))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(diagnostics)
+    }
+
+    pub(crate) async fn record_field_ownership_violation(&self, violation: FieldOwnershipViolation) -> Result<(), ResourceError> {
+        let body = serde_json::to_string(&violation)
+            .map_err(|error| ResourceError::decode(format!("encode field ownership violation: {error}")))?;
+        let observed_at = violation.observed_at.to_rfc3339();
+        self.call(move |connection| {
+            connection
+                .execute("INSERT INTO field_ownership_violations (body_json, observed_at) VALUES (?1, ?2)", rusqlite::params![
+                    body,
+                    observed_at
+                ])
+                .map_err(|error| Self::map_sqlite(error, "record field ownership violation"))?;
+            Ok(())
+        })
+        .await
     }
 
     fn clone_through_serde<T>(value: &T) -> Result<T, ResourceError>

--- a/crates/flotilla-resources/tests/field_ownership.rs
+++ b/crates/flotilla-resources/tests/field_ownership.rs
@@ -1,7 +1,9 @@
+use std::collections::{BTreeMap, BTreeSet};
+
 use flotilla_resources::{
-    ApiPaths, FieldOwnedResource, FieldOwnership, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InMemoryBackend,
-    InputMeta, NoStatusPatch, OwnershipEnforcement, PlacementPolicy, PlacementPolicySpec, ReplicationClass, Resource, ResourceBackend,
-    ResourceError, WriterIdentity, WriterRole,
+    ApiPaths, DockerCheckoutStrategy, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, FieldOwnedResource, FieldOwnership,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InMemoryBackend, InputMeta, NoStatusPatch, OwnershipEnforcement,
+    PlacementPolicy, PlacementPolicySpec, ReplicationClass, Resource, ResourceBackend, ResourceError, WriterIdentity, WriterRole,
 };
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +12,22 @@ fn host_direct(pool: &str, priority: i32, host: &str) -> PlacementPolicySpec {
         .pool(pool.to_string())
         .priority(priority)
         .host_direct(HostDirectPlacementPolicySpec { host_ref: host.to_string(), checkout: HostDirectPlacementPolicyCheckout::Worktree })
+        .build()
+}
+
+fn docker(pool: &str, priority: i32, host: &str, image: &str) -> PlacementPolicySpec {
+    PlacementPolicySpec::builder()
+        .pool(pool.to_string())
+        .priority(priority)
+        .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
+            host_ref: host.to_string(),
+            image: image.to_string(),
+            pull_policy: DockerImagePullPolicy::IfNotPresent,
+            agent_adapters: BTreeSet::from(["codex".to_string()]),
+            default_cwd: Some("/workspace".to_string()),
+            env: BTreeMap::new(),
+            checkout: DockerCheckoutStrategy::WorktreeOnHostAndMount { mount_path: "/workspace".to_string() },
+        })
         .build()
 }
 
@@ -23,6 +41,7 @@ fn placement_policy_declares_every_spec_leaf_and_no_status_fields() {
         ("spec.pool", WriterRole::ReconcileLoop),
         ("spec.priority", WriterRole::Operator),
         ("spec.host_direct", WriterRole::ReconcileLoop),
+        ("spec.docker_per_vessel", WriterRole::ReconcileLoop),
         ("spec.docker_per_vessel.host_ref", WriterRole::ReconcileLoop),
         ("spec.docker_per_vessel.image", WriterRole::Operator),
         ("spec.docker_per_vessel.pull_policy", WriterRole::Operator),
@@ -88,6 +107,59 @@ async fn operator_apply_preserves_loop_fields_while_updating_priority() {
     assert_eq!(updated.spec.priority, 99);
     assert_eq!(updated.spec.pool, "owned-pool");
     assert_eq!(updated.spec.host_direct.expect("host-direct").host_ref, "owned-host");
+}
+
+#[tokio::test]
+async fn operator_cannot_clear_loop_owned_docker_strategy_and_violation_remains_visible() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let policies = backend.using::<PlacementPolicy>("flotilla");
+    let created = policies
+        .create(&InputMeta::builder().name("docker-local".to_string()).build(), &docker("docker", 4, "local", "operator/image:latest"))
+        .await
+        .expect("create docker policy");
+
+    let updated = policies
+        .write_spec(
+            &WriterIdentity::operator(),
+            &InputMeta::from(&created.metadata),
+            &created.metadata.resource_version,
+            &host_direct("docker", 9, "local"),
+        )
+        .await
+        .expect("observe-mode structural violation must not become Invalid");
+
+    assert_eq!(updated.spec.priority, 9);
+    assert!(updated.spec.host_direct.is_none());
+    assert_eq!(updated.spec.docker_per_vessel.expect("preserved docker strategy").image, "operator/image:latest");
+    let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
+    assert!(
+        diagnostics.field_ownership_violations.iter().any(|violation| violation.field == "spec.docker_per_vessel"),
+        "the structural violation must be recorded"
+    );
+}
+
+#[tokio::test]
+async fn loop_can_switch_from_docker_to_host_direct_without_descendant_ownership_conflicts() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let policies = backend.using::<PlacementPolicy>("flotilla");
+    let created = policies
+        .create(&InputMeta::builder().name("switching".to_string()).build(), &docker("docker", 44, "local", "operator/image:latest"))
+        .await
+        .expect("create docker policy");
+
+    let updated = policies
+        .write_spec(
+            &WriterIdentity::reconcile_loop(),
+            &InputMeta::from(&created.metadata),
+            &created.metadata.resource_version,
+            &host_direct("direct", 0, "local"),
+        )
+        .await
+        .expect("loop-owned strategy switch");
+
+    assert_eq!(updated.spec.priority, 44);
+    assert!(updated.spec.docker_per_vessel.is_none());
+    assert_eq!(updated.spec.host_direct.expect("host-direct strategy").host_ref, "local");
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/tests/field_ownership.rs
+++ b/crates/flotilla-resources/tests/field_ownership.rs
@@ -208,36 +208,3 @@ async fn enforce_mode_records_and_refuses_with_typed_error() {
     assert_eq!(resources.get("only").await.expect("stored resource").spec.operator_value, "stored");
     assert_eq!(backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics").field_ownership_violations.len(), 1);
 }
-
-#[tokio::test]
-async fn operator_priority_survives_unbounded_local_and_remote_registration_cycles() {
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    let policies = backend.using::<PlacementPolicy>("flotilla");
-    let created = policies
-        .create(&InputMeta::builder().name("host-direct-shared".to_string()).build(), &host_direct("local", 0, "local"))
-        .await
-        .expect("create policy");
-    let mut current = policies
-        .write_spec(
-            &WriterIdentity::operator(),
-            &InputMeta::from(&created.metadata),
-            &created.metadata.resource_version,
-            &host_direct("local", 73, "local"),
-        )
-        .await
-        .expect("operator applies priority");
-
-    for cycle in 0..256 {
-        let (pool, host) = if cycle % 2 == 0 { ("local", "local") } else { ("remote", "remote") };
-        current = policies
-            .write_spec(
-                &WriterIdentity::reconcile_loop(),
-                &InputMeta::from(&current.metadata),
-                &current.metadata.resource_version,
-                &host_direct(pool, 0, host),
-            )
-            .await
-            .expect("registration cycle");
-        assert_eq!(current.spec.priority, 73, "priority changed during registration cycle {cycle}");
-    }
-}

--- a/crates/flotilla-resources/tests/field_ownership.rs
+++ b/crates/flotilla-resources/tests/field_ownership.rs
@@ -1,0 +1,171 @@
+use flotilla_resources::{
+    ApiPaths, FieldOwnedResource, FieldOwnership, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InMemoryBackend,
+    InputMeta, NoStatusPatch, OwnershipEnforcement, PlacementPolicy, PlacementPolicySpec, ReplicationClass, Resource, ResourceBackend,
+    ResourceError, WriterIdentity, WriterRole,
+};
+use serde::{Deserialize, Serialize};
+
+fn host_direct(pool: &str, priority: i32, host: &str) -> PlacementPolicySpec {
+    PlacementPolicySpec::builder()
+        .pool(pool.to_string())
+        .priority(priority)
+        .host_direct(HostDirectPlacementPolicySpec { host_ref: host.to_string(), checkout: HostDirectPlacementPolicyCheckout::Worktree })
+        .build()
+}
+
+#[test]
+fn placement_policy_declares_every_spec_leaf_and_no_status_fields() {
+    let declared = <PlacementPolicy as FieldOwnedResource>::FIELD_OWNERSHIP
+        .iter()
+        .map(|ownership| (ownership.field, ownership.owner))
+        .collect::<Vec<_>>();
+    assert_eq!(declared, vec![
+        ("spec.pool", WriterRole::ReconcileLoop),
+        ("spec.priority", WriterRole::Operator),
+        ("spec.host_direct", WriterRole::ReconcileLoop),
+        ("spec.docker_per_vessel.host_ref", WriterRole::ReconcileLoop),
+        ("spec.docker_per_vessel.image", WriterRole::Operator),
+        ("spec.docker_per_vessel.pull_policy", WriterRole::Operator),
+        ("spec.docker_per_vessel.agent_adapters", WriterRole::Operator),
+        ("spec.docker_per_vessel.default_cwd", WriterRole::Operator),
+        ("spec.docker_per_vessel.env", WriterRole::Operator),
+        ("spec.docker_per_vessel.checkout", WriterRole::ReconcileLoop),
+    ]);
+    assert!(declared.iter().all(|(field, _)| !field.starts_with("status.")), "PlacementPolicy has no status fields");
+}
+
+#[tokio::test]
+async fn observe_mode_preserves_operator_fields_and_surfaces_loop_violation() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let policies = backend.using::<PlacementPolicy>("flotilla");
+    let created = policies
+        .create(&InputMeta::builder().name("host-direct-local".to_string()).build(), &host_direct("old", 42, "old-host"))
+        .await
+        .expect("create policy");
+
+    let updated = policies
+        .write_spec(
+            &WriterIdentity::reconcile_loop(),
+            &InputMeta::from(&created.metadata),
+            &created.metadata.resource_version,
+            &host_direct("new", 0, "new-host"),
+        )
+        .await
+        .expect("observe-mode owned update");
+
+    assert_eq!(updated.spec.priority, 42, "the stored operator field must be preserved");
+    assert_eq!(updated.spec.pool, "new");
+    assert_eq!(updated.spec.host_direct.expect("host-direct").host_ref, "new-host");
+
+    let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
+    assert_eq!(diagnostics.field_ownership_violations.len(), 1);
+    let violation = &diagnostics.field_ownership_violations[0];
+    assert_eq!(violation.writer.role, WriterRole::ReconcileLoop);
+    assert_eq!(violation.field, "spec.priority");
+    assert_eq!(violation.attempted_value, serde_json::json!(0));
+    assert!(violation.rule.contains("Operator"));
+}
+
+#[tokio::test]
+async fn operator_apply_preserves_loop_fields_while_updating_priority() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let policies = backend.using::<PlacementPolicy>("flotilla");
+    let created = policies
+        .create(&InputMeta::builder().name("host-direct-local".to_string()).build(), &host_direct("owned-pool", 1, "owned-host"))
+        .await
+        .expect("create policy");
+
+    let updated = policies
+        .write_spec(
+            &WriterIdentity::operator(),
+            &InputMeta::from(&created.metadata),
+            &created.metadata.resource_version,
+            &host_direct("attempted-pool", 99, "attempted-host"),
+        )
+        .await
+        .expect("operator write");
+
+    assert_eq!(updated.spec.priority, 99);
+    assert_eq!(updated.spec.pool, "owned-pool");
+    assert_eq!(updated.spec.host_direct.expect("host-direct").host_ref, "owned-host");
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct EnforcedSpec {
+    operator_value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EnforcedResource;
+
+impl Resource for EnforcedResource {
+    type Spec = EnforcedSpec;
+    type Status = ();
+    type StatusPatch = NoStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "enforcedresources", kind: "EnforcedResource" };
+    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::None;
+}
+
+impl FieldOwnedResource for EnforcedResource {
+    const FIELD_OWNERSHIP: &'static [FieldOwnership] = &[FieldOwnership::new("spec.operator_value", WriterRole::Operator)];
+    const OWNERSHIP_ENFORCEMENT: OwnershipEnforcement = OwnershipEnforcement::Enforce;
+}
+
+#[tokio::test]
+async fn enforce_mode_records_and_refuses_with_typed_error() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let resources = backend.using::<EnforcedResource>("flotilla");
+    let created = resources
+        .create(&InputMeta::builder().name("only".to_string()).build(), &EnforcedSpec { operator_value: "stored".to_string() })
+        .await
+        .expect("create");
+
+    let error = resources
+        .write_spec(
+            &WriterIdentity::reconcile_loop(),
+            &InputMeta::from(&created.metadata),
+            &created.metadata.resource_version,
+            &EnforcedSpec { operator_value: "attempted".to_string() },
+        )
+        .await
+        .expect_err("enforcement must refuse");
+
+    assert!(matches!(error, ResourceError::FieldOwnership { ref violations } if violations.len() == 1));
+    assert!(error.is_stale_view(), "callers must classify ownership refusal as a stale-view requeue");
+    assert_eq!(resources.get("only").await.expect("stored resource").spec.operator_value, "stored");
+    assert_eq!(backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics").field_ownership_violations.len(), 1);
+}
+
+#[tokio::test]
+async fn operator_priority_survives_unbounded_local_and_remote_registration_cycles() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let policies = backend.using::<PlacementPolicy>("flotilla");
+    let created = policies
+        .create(&InputMeta::builder().name("host-direct-shared".to_string()).build(), &host_direct("local", 0, "local"))
+        .await
+        .expect("create policy");
+    let mut current = policies
+        .write_spec(
+            &WriterIdentity::operator(),
+            &InputMeta::from(&created.metadata),
+            &created.metadata.resource_version,
+            &host_direct("local", 73, "local"),
+        )
+        .await
+        .expect("operator applies priority");
+
+    for cycle in 0..256 {
+        let (pool, host) = if cycle % 2 == 0 { ("local", "local") } else { ("remote", "remote") };
+        current = policies
+            .write_spec(
+                &WriterIdentity::reconcile_loop(),
+                &InputMeta::from(&current.metadata),
+                &current.metadata.resource_version,
+                &host_direct(pool, 0, host),
+            )
+            .await
+            .expect("registration cycle");
+        assert_eq!(current.spec.priority, 73, "priority changed during registration cycle {cycle}");
+    }
+}


### PR DESCRIPTION
Closes #1251

## Summary

- add reusable static field-ownership declarations and a single role-aware spec write path
- enroll PlacementPolicy in observe mode, preserving operator priority across local and remote registration
- persist/log ownership violations and surface them through fleet health diagnosis
- provide enforce-mode typed stale-view errors without a force/override API

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`