### PR TITLE
test: add liveness harness transition vocabulary

### DIFF
--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::BTreeMap,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
 };
 
 use async_trait::async_trait;
@@ -8,9 +11,13 @@ use chrono::Utc;
 use flotilla_controllers::reconcilers::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
 use flotilla_resources::{
     controller::{Actuation, Reconciler},
-    EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta, ResourceBackend, StatusPatch,
-    TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSessionPhase, TerminalSessionSpec, CONVOY_LABEL,
-    VESSEL_REF_LABEL,
+    test_support::{
+        run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, Transition,
+        TransitionDriver, TransitionSequence, WorldBuilder,
+    },
+    EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta, ResourceBackend, ResourceError,
+    ResourceObject, StatusPatch, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession, TerminalSessionPhase,
+    TerminalSessionSpec, TerminalSessionStatusPatch, VirtualClock, CONVOY_LABEL, VESSEL_REF_LABEL,
 };
 
 mod common;
@@ -80,47 +87,205 @@ impl TerminalRuntime for FailingTerminalRuntime {
     }
 }
 
-#[tokio::test]
-async fn orphaned_convoy_session_is_deleted_without_relaunching() {
-    let backend = ResourceBackend::InMemory(Default::default());
-    let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
-    let session = sessions
-        .create(
-            &InputMeta::builder()
-                .name("terminal-deleted-convoy-work-coder".to_string())
-                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "deleted-convoy".to_string())]))
-                .build(),
-            &TerminalSessionSpec {
-                env_ref: "host-direct-feta".to_string(),
-                role: "coder".to_string(),
-                source: flotilla_resources::TerminalSessionSource::Agent {
-                    selector: flotilla_resources::Selector { capability: "coding".to_string() },
-                    brief: flotilla_resources::TerminalBrief {
-                        path: ".flotilla/briefs/coder.md".to_string(),
-                        content: "brief".to_string(),
-                        copies: Vec::new(),
+const GHOST_SESSION_NAME: &str = "terminal-deleted-convoy-work-coder";
+
+struct GhostRecoveryWorld {
+    backend: ResourceBackend,
+    stale_session: ResourceObject<TerminalSession>,
+    runtime: Arc<GhostRecoveryRuntime>,
+    reconciler: TerminalSessionReconciler<GhostRecoveryRuntime>,
+    durable_record_deleted: bool,
+    ownerless_recovery_rejected: bool,
+}
+
+struct GhostRecoveryWorldBuilder;
+
+#[async_trait]
+impl WorldBuilder for GhostRecoveryWorldBuilder {
+    type World = GhostRecoveryWorld;
+
+    async fn build(&self, _scenario: LivenessScenario) -> Result<Self::World, String> {
+        let backend = ResourceBackend::InMemory(Default::default());
+        let environments = backend.clone().using::<flotilla_resources::Environment>("flotilla");
+        let env = environments
+            .create(&meta("host-direct-feta"), &EnvironmentSpec {
+                host_direct: Some(HostDirectEnvironmentSpec { host_ref: "feta".to_string(), repo_default_dir: "/worktrees".to_string() }),
+                docker: None,
+            })
+            .await
+            .map_err(|error| error.to_string())?;
+        let mut env_status = EnvironmentStatus::default();
+        EnvironmentStatusPatch::MarkReady { docker_container_id: None, image_ref: None, image_digest: None }.apply(&mut env_status);
+        environments
+            .update_status("host-direct-feta", &env.metadata.resource_version, &env_status)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        let stale_session = backend
+            .clone()
+            .using::<TerminalSession>("flotilla")
+            .create(
+                &InputMeta::builder()
+                    .name(GHOST_SESSION_NAME.to_string())
+                    .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "deleted-convoy".to_string())]))
+                    .build(),
+                &TerminalSessionSpec {
+                    env_ref: "host-direct-feta".to_string(),
+                    role: "coder".to_string(),
+                    source: flotilla_resources::TerminalSessionSource::Agent {
+                        selector: flotilla_resources::Selector { capability: "coding".to_string() },
+                        brief: flotilla_resources::TerminalBrief {
+                            path: ".flotilla/briefs/coder.md".to_string(),
+                            content: "brief".to_string(),
+                            copies: Vec::new(),
+                        },
+                        context: flotilla_resources::TerminalCrewContext {
+                            namespace: "flotilla".to_string(),
+                            convoy: "deleted-convoy".to_string(),
+                            vessel_ref: "deleted-convoy-work".to_string(),
+                        },
+                        message: None,
                     },
-                    context: flotilla_resources::TerminalCrewContext {
-                        namespace: "flotilla".to_string(),
-                        convoy: "deleted-convoy".to_string(),
-                        vessel_ref: "deleted-convoy-work".to_string(),
-                    },
-                    message: None,
+                    cwd: "/workspace".to_string(),
+                    pool: "cleat".to_string(),
                 },
-                cwd: "/workspace".to_string(),
-                pool: "cleat".to_string(),
-            },
-        )
-        .await
-        .expect("session create should succeed");
-    let reconciler = TerminalSessionReconciler::new(Arc::new(MissingTerminalRuntime), backend, "flotilla");
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        let runtime = Arc::new(GhostRecoveryRuntime::default());
+        let reconciler = TerminalSessionReconciler::new(Arc::clone(&runtime), backend.clone(), "flotilla");
+        Ok(GhostRecoveryWorld {
+            backend,
+            stale_session,
+            runtime,
+            reconciler,
+            durable_record_deleted: false,
+            ownerless_recovery_rejected: false,
+        })
+    }
+}
 
-    let deps = reconciler.fetch_dependencies(&session).await.expect("orphan dependencies should load");
-    let outcome = reconciler.reconcile(&session, &deps, Utc::now());
+#[derive(Default)]
+struct GhostRecoveryRuntime {
+    ensure_calls: AtomicUsize,
+}
 
+#[async_trait]
+impl TerminalRuntime for GhostRecoveryRuntime {
+    async fn ensure_session(
+        &self,
+        name: &str,
+        _spec: &TerminalSessionSpec,
+        _tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
+        self.ensure_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(TerminalRuntimeState {
+            session_id: name.to_string(),
+            pid: None,
+            started_at: Utc::now(),
+            crew: None,
+            launch_command: "codex".to_string(),
+            delivered_message_id: None,
+        })
+    }
+
+    async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+struct GhostRecoveryStep;
+
+#[async_trait]
+impl ReconcileStep<GhostRecoveryWorld> for GhostRecoveryStep {
+    type Patch = TerminalSessionStatusPatch;
+    type Actuation = Actuation;
+
+    async fn reconcile_step(&self, world: &mut GhostRecoveryWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
+        let deps = world.reconciler.fetch_dependencies(&world.stale_session).await.map_err(|error| error.to_string())?;
+        let outcome = world.reconciler.reconcile(&world.stale_session, &deps, Utc::now());
+        world.ownerless_recovery_rejected = outcome.patch.is_none()
+            && matches!(
+                outcome.actuations.as_slice(),
+                [Actuation::DeleteTerminalSession { name }] if name == GHOST_SESSION_NAME
+            );
+        Ok(LivenessStep::new(outcome.patch, outcome.actuations))
+    }
+
+    async fn apply_patch(&self, world: &mut GhostRecoveryWorld, patch: Self::Patch) -> Result<(), String> {
+        flotilla_resources::apply_status_patch(&world.backend.clone().using::<TerminalSession>("flotilla"), GHOST_SESSION_NAME, &patch)
+            .await
+            .map(|_| ())
+            .map_err(|error| error.to_string())
+    }
+
+    async fn apply_actuation(&self, world: &mut GhostRecoveryWorld, actuation: Self::Actuation) -> Result<(), String> {
+        match actuation {
+            Actuation::DeleteTerminalSession { name } => {
+                match world.backend.clone().using::<TerminalSession>("flotilla").delete(&name).await {
+                    Ok(()) | Err(ResourceError::NotFound { .. }) => Ok(()),
+                    Err(error) => Err(error.to_string()),
+                }
+            }
+            other => Err(format!("ghost recovery unexpectedly emitted {other:?}")),
+        }
+    }
+}
+
+#[async_trait]
+impl TransitionDriver<GhostRecoveryWorld> for GhostRecoveryStep {
+    type Field = ();
+    type Value = ();
+    type OriginRoot = String;
+
+    async fn external_spec_write(&self, _world: &mut GhostRecoveryWorld, _field: &Self::Field, _value: &Self::Value) -> Result<(), String> {
+        Err("external spec writes are not part of the ghost recovery property".to_string())
+    }
+
+    async fn delete(&self, world: &mut GhostRecoveryWorld) -> Result<(), String> {
+        let sessions = world.backend.clone().using::<TerminalSession>("flotilla");
+        sessions.delete(GHOST_SESSION_NAME).await.map_err(|error| error.to_string())?;
+        world.durable_record_deleted = matches!(sessions.get(GHOST_SESSION_NAME).await, Err(ResourceError::NotFound { .. }));
+        Ok(())
+    }
+
+    async fn restart_controller(&self, world: &mut GhostRecoveryWorld) -> Result<(), String> {
+        world.reconciler = TerminalSessionReconciler::new(Arc::clone(&world.runtime), world.backend.clone(), "flotilla");
+        Ok(())
+    }
+
+    async fn partition_store(&self, _world: &mut GhostRecoveryWorld, _origin_root: &Self::OriginRoot) -> Result<(), String> {
+        Err("store partition is not part of the ghost recovery property".to_string())
+    }
+}
+
+struct GhostRecoveryFixpoint;
+
+impl FixpointPredicate<GhostRecoveryWorld> for GhostRecoveryFixpoint {
+    fn at_fixpoint(&self, _world: &GhostRecoveryWorld) -> bool {
+        false
+    }
+}
+
+/// Regression property for #1202: a stale TerminalSession snapshot surviving
+/// teardown and controller restart must not recreate the external session once
+/// its owning convoy and durable record are gone.
+#[tokio::test]
+async fn deleted_terminal_session_is_not_resurrected_from_stale_state_after_restart() {
+    let clock = Arc::new(VirtualClock::new(Utc::now()));
+    let enrollment = LivenessEnrollment::new(GhostRecoveryWorldBuilder, GhostRecoveryStep, GhostRecoveryFixpoint, clock);
+    let sequence: TransitionSequence<GhostRecoveryWorld, (), (), String> =
+        TransitionSequence::new([Transition::Delete, Transition::RestartController, Transition::Reconcile, Transition::DeliverActuation])
+            .sometimes("terminal record was absent before recovery", |world: &GhostRecoveryWorld| world.durable_record_deleted)
+            .sometimes("ownerless stale recovery was rejected", |world: &GhostRecoveryWorld| world.ownerless_recovery_rejected);
+
+    let world =
+        run_transition_sequence(&enrollment, LivenessScenario::Normal, &sequence).await.expect("terminal-session ghost recovery sequence");
+
+    assert_eq!(world.runtime.ensure_calls.load(Ordering::SeqCst), 0, "recovery resurrected an ownerless external terminal session");
     assert!(matches!(
-        outcome.actuations.as_slice(),
-        [Actuation::DeleteTerminalSession { name }] if name == "terminal-deleted-convoy-work-coder"
+        world.backend.clone().using::<TerminalSession>("flotilla").get(GHOST_SESSION_NAME).await,
+        Err(ResourceError::NotFound { .. })
     ));
 }
 

--- a/crates/flotilla-core/Cargo.toml
+++ b/crates/flotilla-core/Cargo.toml
@@ -46,6 +46,7 @@ libc = "0.2"
 
 [dev-dependencies]
 flotilla-protocol = { path = "../flotilla-protocol", features = ["test-support"] }
+flotilla-resources = { path = "../flotilla-resources", features = ["test-support"] }
 tempfile = "3"
 insta = "1"
 

--- a/crates/flotilla-core/src/placement_policy.rs
+++ b/crates/flotilla-core/src/placement_policy.rs
@@ -70,11 +70,20 @@ fn merge_registered_policy_spec(existing: &PlacementPolicySpec, desired: &Placem
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+    };
 
+    use async_trait::async_trait;
+    use chrono::{TimeZone, Utc};
     use flotilla_resources::{
+        test_support::{
+            run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, Transition,
+            TransitionDriver, TransitionSequence, WorldBuilder,
+        },
         DockerCheckoutStrategy, DockerImagePullPolicy, DockerPerVesselPlacementPolicySpec, HostDirectPlacementPolicyCheckout,
-        HostDirectPlacementPolicySpec, InMemoryBackend,
+        HostDirectPlacementPolicySpec, InMemoryBackend, ResourceObject, VirtualClock,
     };
 
     use super::*;
@@ -177,5 +186,173 @@ mod tests {
         assert_eq!(runtime.env, BTreeMap::from([("OPERATOR".to_string(), "true".to_string())]));
         let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
         assert!(diagnostics.field_ownership_violations.is_empty(), "registration must not synthesize runtime write attempts");
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum RegistrationRole {
+        Local,
+        Remote,
+    }
+
+    impl RegistrationRole {
+        fn policy_name(self) -> &'static str {
+            match self {
+                Self::Local => "host-direct-local",
+                Self::Remote => "host-direct-remote",
+            }
+        }
+
+        fn host_ref(self) -> &'static str {
+            match self {
+                Self::Local => "local",
+                Self::Remote => "remote",
+            }
+        }
+
+        fn pool(self) -> &'static str {
+            match self {
+                Self::Local => "passthrough",
+                Self::Remote => "zellij",
+            }
+        }
+    }
+
+    struct PolicyWorld {
+        backend: ResourceBackend,
+        role: RegistrationRole,
+        desired: PlacementPolicySpec,
+        current: Option<ResourceObject<PlacementPolicy>>,
+        external_write_observed: bool,
+        reconciles_after_external_write: usize,
+    }
+
+    struct PolicyWorldBuilder {
+        role: RegistrationRole,
+    }
+
+    #[async_trait]
+    impl WorldBuilder for PolicyWorldBuilder {
+        type World = PolicyWorld;
+
+        async fn build(&self, _scenario: LivenessScenario) -> Result<Self::World, String> {
+            Ok(PolicyWorld {
+                backend: ResourceBackend::InMemory(InMemoryBackend::default()),
+                role: self.role,
+                desired: host_direct(self.role.pool(), self.role.host_ref()),
+                current: None,
+                external_write_observed: false,
+                reconciles_after_external_write: 0,
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    enum PolicyField {
+        Priority,
+    }
+
+    struct PolicyStep;
+
+    #[async_trait]
+    impl ReconcileStep<PolicyWorld> for PolicyStep {
+        type Patch = ();
+        type Actuation = ();
+
+        async fn reconcile_step(&self, world: &mut PolicyWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
+            reconcile_registered_policy(&world.backend, NAMESPACE, world.role.policy_name(), &world.desired).await?;
+            world.current = Some(
+                world
+                    .backend
+                    .clone()
+                    .using::<PlacementPolicy>(NAMESPACE)
+                    .get(world.role.policy_name())
+                    .await
+                    .map_err(|error| error.to_string())?,
+            );
+            if world.external_write_observed {
+                world.reconciles_after_external_write += 1;
+            }
+            Ok(LivenessStep::new(None, Vec::new()))
+        }
+
+        async fn apply_patch(&self, _world: &mut PolicyWorld, _patch: Self::Patch) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn apply_actuation(&self, _world: &mut PolicyWorld, _actuation: Self::Actuation) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl TransitionDriver<PolicyWorld> for PolicyStep {
+        type Field = PolicyField;
+        type Value = i32;
+        type OriginRoot = String;
+
+        async fn external_spec_write(&self, world: &mut PolicyWorld, field: &Self::Field, value: &Self::Value) -> Result<(), String> {
+            let current = world.current.as_ref().ok_or_else(|| "registration has not created the policy".to_string())?;
+            let mut spec = current.spec.clone();
+            match field {
+                PolicyField::Priority => spec.priority = *value,
+            }
+            let updated = world
+                .backend
+                .clone()
+                .using::<PlacementPolicy>(NAMESPACE)
+                .write_spec(&WriterIdentity::operator(), &InputMeta::from(&current.metadata), &current.metadata.resource_version, &spec)
+                .await
+                .map_err(|error| error.to_string())?;
+            world.current = Some(updated);
+            world.external_write_observed = true;
+            Ok(())
+        }
+
+        async fn delete(&self, _world: &mut PolicyWorld) -> Result<(), String> {
+            Err("delete is not part of the placement registration property".to_string())
+        }
+
+        async fn restart_controller(&self, _world: &mut PolicyWorld) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn partition_store(&self, _world: &mut PolicyWorld, _origin_root: &Self::OriginRoot) -> Result<(), String> {
+            Err("store partition is not part of the placement registration property".to_string())
+        }
+    }
+
+    struct PolicyFixpoint;
+
+    impl FixpointPredicate<PolicyWorld> for PolicyFixpoint {
+        fn at_fixpoint(&self, _world: &PolicyWorld) -> bool {
+            false
+        }
+    }
+
+    /// Regression property for #1236/#1248: registration owns topology, while
+    /// an operator's priority write must survive subsequent local and remote
+    /// registration reconciles.
+    #[tokio::test]
+    async fn operator_priority_survives_local_and_remote_registration_sequences() {
+        for role in [RegistrationRole::Local, RegistrationRole::Remote] {
+            let clock = Arc::new(VirtualClock::new(Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).single().expect("valid test timestamp")));
+            let enrollment = LivenessEnrollment::new(PolicyWorldBuilder { role }, PolicyStep, PolicyFixpoint, clock);
+            let sequence: TransitionSequence<PolicyWorld, PolicyField, i32, String> = TransitionSequence::new([
+                Transition::Reconcile,
+                Transition::ExternalSpecWrite(PolicyField::Priority, 17),
+                Transition::Reconcile,
+                Transition::Reconcile,
+            ])
+            .sometimes("operator priority survived a registration reconcile", |world: &PolicyWorld| {
+                world.reconciles_after_external_write > 0 && world.current.as_ref().is_some_and(|policy| policy.spec.priority == 17)
+            });
+
+            let world = run_transition_sequence(&enrollment, LivenessScenario::Normal, &sequence)
+                .await
+                .unwrap_or_else(|error| panic!("{role:?} registration sequence failed: {error}"));
+            assert_eq!(world.current.expect("registered policy").spec.priority, 17, "{role:?} registration stomped operator priority");
+            let diagnostics = world.backend.diagnostics().await.expect("diagnostics").expect("embedded diagnostics");
+            assert!(diagnostics.field_ownership_violations.is_empty(), "{role:?} sequence recorded false ownership violations");
+        }
     }
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2811,13 +2811,18 @@ mod tests {
         PlacementDecision, PlacementTargetHost, ResourceRef,
     };
     use flotilla_resources::{
-        api_version, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+        api_version,
+        test_support::{
+            run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, Transition,
+            TransitionDriver, TransitionSequence, WorldBuilder,
+        },
+        Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
         CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CredentialConsumer,
         CredentialGrant, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec,
         CrewSource, CrewSpec, LifecycleAuthority, MaterialPoolSpec, MaterialPoolUnitSpec,
         ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, RepositorySpec, Resource, Selector, SqliteBackend,
-        TerminalAttentionState, TerminalSession, TerminalSessionPhase, VesselRequirement, VesselStatus, WorkPhase, WorkflowTemplate,
-        WorkflowTemplateSpec, ACTUATOR_HOST_REF_ANNOTATION,
+        TerminalAttentionState, TerminalSession, TerminalSessionPhase, VesselRequirement, VesselStatus, VirtualClock, WorkPhase,
+        WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_HOST_REF_ANNOTATION,
     };
     use futures::StreamExt;
     use tempfile::TempDir;
@@ -5045,64 +5050,168 @@ mod tests {
         daemon_with_backend(tracked_repos, config, backend).await
     }
 
+    struct LeaseRecoveryWorld {
+        _temp: TempDir,
+        config: Arc<ConfigStore>,
+        daemon: Arc<InProcessDaemon>,
+        backend: ResourceBackend,
+        pools: MaterialPoolManager,
+        second_holder: ResourceRef,
+        runtime: Option<DaemonRuntime>,
+        pending_finalization: bool,
+        second_outcome: Option<MaterialLeaseOutcome>,
+    }
+
+    struct LeaseRecoveryWorldBuilder;
+
+    #[async_trait]
+    impl WorldBuilder for LeaseRecoveryWorldBuilder {
+        type World = LeaseRecoveryWorld;
+
+        async fn build(&self, _scenario: LivenessScenario) -> Result<Self::World, String> {
+            let temp = TempDir::new().map_err(|error| error.to_string())?;
+            let config = Arc::new(ConfigStore::with_base(temp.path()));
+            let daemon = in_memory_daemon(Vec::new(), Arc::clone(&config)).await;
+            let backend = daemon.resource_backend();
+            backend
+                .clone()
+                .using::<Environment>(NAMESPACE)
+                .create(
+                    &InputMeta::builder()
+                        .name("deleting-environment".to_string())
+                        .finalizers(vec!["flotilla.work/test-environment-finalizer".to_string()])
+                        .build(),
+                    &EnvironmentSpec {
+                        host_direct: Some(HostDirectEnvironmentSpec {
+                            host_ref: "host-test".to_string(),
+                            repo_default_dir: "/tmp/worktrees".to_string(),
+                        }),
+                        docker: None,
+                    },
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+
+            let pools = MaterialPoolManager::new(backend.clone(), NAMESPACE);
+            pools
+                .reconcile_pool("codex-login", &MaterialPoolSpec {
+                    units: BTreeMap::from([("unit-0".to_string(), MaterialPoolUnitSpec {
+                        directory: "/var/lib/flotilla/material/unit-0".to_string(),
+                    })]),
+                })
+                .await?;
+            let deleting_holder =
+                ResourceRef::new(api_version(Environment::API_PATHS), Environment::API_PATHS.kind, NAMESPACE, "deleting-environment");
+            pools.acquire("codex-login", &deleting_holder).await?;
+            let second_holder =
+                ResourceRef::new(api_version(Environment::API_PATHS), Environment::API_PATHS.kind, NAMESPACE, "second-environment");
+
+            Ok(LeaseRecoveryWorld {
+                _temp: temp,
+                config,
+                daemon,
+                backend,
+                pools,
+                second_holder,
+                runtime: None,
+                pending_finalization: false,
+                second_outcome: None,
+            })
+        }
+    }
+
+    struct LeaseRecoveryStep;
+
+    #[async_trait]
+    impl ReconcileStep<LeaseRecoveryWorld> for LeaseRecoveryStep {
+        type Patch = ();
+        type Actuation = ();
+
+        async fn reconcile_step(&self, world: &mut LeaseRecoveryWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
+            world.second_outcome = Some(world.pools.acquire("codex-login", &world.second_holder).await?);
+            Ok(LivenessStep::new(None, Vec::new()))
+        }
+
+        async fn apply_patch(&self, _world: &mut LeaseRecoveryWorld, _patch: Self::Patch) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn apply_actuation(&self, _world: &mut LeaseRecoveryWorld, _actuation: Self::Actuation) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl TransitionDriver<LeaseRecoveryWorld> for LeaseRecoveryStep {
+        type Field = ();
+        type Value = ();
+        type OriginRoot = String;
+
+        async fn external_spec_write(
+            &self,
+            _world: &mut LeaseRecoveryWorld,
+            _field: &Self::Field,
+            _value: &Self::Value,
+        ) -> Result<(), String> {
+            Err("external spec writes are not part of the lease recovery property".to_string())
+        }
+
+        async fn delete(&self, world: &mut LeaseRecoveryWorld) -> Result<(), String> {
+            let environments = world.backend.clone().using::<Environment>(NAMESPACE);
+            environments.delete("deleting-environment").await.map_err(|error| error.to_string())?;
+            world.pending_finalization =
+                environments.get("deleting-environment").await.map_err(|error| error.to_string())?.metadata.deletion_timestamp.is_some();
+            Ok(())
+        }
+
+        async fn restart_controller(&self, world: &mut LeaseRecoveryWorld) -> Result<(), String> {
+            let runtime = DaemonRuntime::start_with_options(Arc::clone(&world.daemon), Arc::clone(&world.config), None, RuntimeOptions {
+                heartbeat_interval: Duration::from_secs(300),
+                controller_resync_interval: Duration::from_secs(300),
+                start_controllers: false,
+                ..RuntimeOptions::default()
+            })
+            .await?;
+            world.runtime = Some(runtime);
+            Ok(())
+        }
+
+        async fn partition_store(&self, _world: &mut LeaseRecoveryWorld, _origin_root: &Self::OriginRoot) -> Result<(), String> {
+            Err("store partition is not part of the lease recovery property".to_string())
+        }
+    }
+
+    struct LeaseRecoveryFixpoint;
+
+    impl FixpointPredicate<LeaseRecoveryWorld> for LeaseRecoveryFixpoint {
+        fn at_fixpoint(&self, _world: &LeaseRecoveryWorld) -> bool {
+            false
+        }
+    }
+
+    /// Regression property from the #1242 review: deletion only timestamps a
+    /// holder while its finalizer is pending, so restart recovery must retain
+    /// its lease and refuse a second holder.
     #[tokio::test]
     async fn startup_recovery_retains_material_lease_for_environment_pending_finalization() {
-        let temp = TempDir::new().expect("tempdir");
-        let config = Arc::new(ConfigStore::with_base(temp.path()));
-        let daemon = in_memory_daemon(Vec::new(), Arc::clone(&config)).await;
-        let backend = daemon.resource_backend();
-        let environments = backend.clone().using::<Environment>(NAMESPACE);
-        environments
-            .create(
-                &InputMeta::builder()
-                    .name("deleting-environment".to_string())
-                    .finalizers(vec!["flotilla.work/test-environment-finalizer".to_string()])
-                    .build(),
-                &EnvironmentSpec {
-                    host_direct: Some(HostDirectEnvironmentSpec {
-                        host_ref: "host-test".to_string(),
-                        repo_default_dir: "/tmp/worktrees".to_string(),
-                    }),
-                    docker: None,
-                },
-            )
+        let clock = Arc::new(VirtualClock::new(Utc::now()));
+        let enrollment = LivenessEnrollment::new(LeaseRecoveryWorldBuilder, LeaseRecoveryStep, LeaseRecoveryFixpoint, clock);
+        let sequence: TransitionSequence<LeaseRecoveryWorld, (), (), String> =
+            TransitionSequence::new([Transition::Delete, Transition::RestartController, Transition::Reconcile])
+                .sometimes("holder reached pending finalization before restart", |world: &LeaseRecoveryWorld| world.pending_finalization)
+                .sometimes("second holder was refused after restart", |world: &LeaseRecoveryWorld| {
+                    world.runtime.is_some() && matches!(world.second_outcome, Some(MaterialLeaseOutcome::Waiting { unit_count: 1 }))
+                });
+
+        let mut world = run_transition_sequence(&enrollment, LivenessScenario::Normal, &sequence)
             .await
-            .expect("create environment with pending finalizer");
-        environments.delete("deleting-environment").await.expect("mark environment for deletion");
-        let deleting = environments.get("deleting-environment").await.expect("pending finalizer should retain environment");
-        assert!(deleting.metadata.deletion_timestamp.is_some(), "environment should be pending finalization");
-
-        let pools = MaterialPoolManager::new(backend, NAMESPACE);
-        pools
-            .reconcile_pool("codex-login", &MaterialPoolSpec {
-                units: BTreeMap::from([("unit-0".to_string(), MaterialPoolUnitSpec {
-                    directory: "/var/lib/flotilla/material/unit-0".to_string(),
-                })]),
-            })
-            .await
-            .expect("create material pool");
-        let deleting_holder =
-            ResourceRef::new(api_version(Environment::API_PATHS), Environment::API_PATHS.kind, NAMESPACE, "deleting-environment");
-        pools.acquire("codex-login", &deleting_holder).await.expect("lease material to deleting environment");
-
-        let runtime = DaemonRuntime::start_with_options(Arc::clone(&daemon), config, None, RuntimeOptions {
-            heartbeat_interval: Duration::from_secs(300),
-            controller_resync_interval: Duration::from_secs(300),
-            start_controllers: false,
-            ..RuntimeOptions::default()
-        })
-        .await
-        .expect("daemon should start");
-
-        let second_holder =
-            ResourceRef::new(api_version(Environment::API_PATHS), Environment::API_PATHS.kind, NAMESPACE, "second-environment");
+            .expect("deleting-holder lease recovery sequence");
         assert_eq!(
-            pools.acquire("codex-login", &second_holder).await.expect("second holder should wait"),
-            MaterialLeaseOutcome::Waiting { unit_count: 1 },
+            world.second_outcome,
+            Some(MaterialLeaseOutcome::Waiting { unit_count: 1 }),
             "startup recovery must retain leases until an environment's finalizer removes it from the store"
         );
-
-        runtime.shutdown();
+        world.runtime.take().expect("sequence restarted daemon runtime").shutdown();
     }
 
     fn insert_undecodable_resource<T: Resource>(connection: &rusqlite::Connection, name: &str) {

--- a/crates/flotilla-resources/src/test_support/liveness.rs
+++ b/crates/flotilla-resources/src/test_support/liveness.rs
@@ -61,6 +61,66 @@ pub trait FixpointPredicate<W>: Send + Sync {
     }
 }
 
+/// A disturbance or controller action in a hand-written liveness trace.
+///
+/// Field and value types are fixture-defined so the same vocabulary can drive
+/// every enrolled reconciler without teaching the harness about resource
+/// schemas. Actuations emitted by [`Transition::Reconcile`] remain pending
+/// until a later [`Transition::DeliverActuation`] or
+/// [`Transition::DropActuation`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Transition<F, V, O> {
+    Reconcile,
+    ExternalSpecWrite(F, V),
+    Delete,
+    RestartController,
+    AdvanceClock(Duration),
+    DropActuation,
+    DeliverActuation,
+    PartitionStore(O),
+}
+
+/// Fixture-specific interpretation of disturbances in a transition trace.
+///
+/// This is an adapter at the liveness harness seam: the generic runner owns
+/// sequencing and actuation control while each enrolled reconciler owns the
+/// meaning of fields, deletion, restart, and store origins.
+#[async_trait]
+pub trait TransitionDriver<W>: ReconcileStep<W> {
+    type Field: Debug + Send + Sync;
+    type Value: Debug + Send + Sync;
+    type OriginRoot: Debug + Send + Sync;
+
+    async fn external_spec_write(&self, world: &mut W, field: &Self::Field, value: &Self::Value) -> Result<(), String>;
+    async fn delete(&self, world: &mut W) -> Result<(), String>;
+    async fn restart_controller(&self, world: &mut W) -> Result<(), String>;
+    async fn partition_store(&self, world: &mut W, origin_root: &Self::OriginRoot) -> Result<(), String>;
+}
+
+struct CoverageAssertion<W> {
+    description: String,
+    predicate: Box<dyn Fn(&W) -> bool + Send + Sync>,
+}
+
+/// A hand-written transition trace with non-vacuity assertions.
+pub struct TransitionSequence<W, F, V, O> {
+    transitions: Vec<Transition<F, V, O>>,
+    coverage: Vec<CoverageAssertion<W>>,
+}
+
+impl<W, F, V, O> TransitionSequence<W, F, V, O> {
+    pub fn new(transitions: impl IntoIterator<Item = Transition<F, V, O>>) -> Self {
+        Self { transitions: transitions.into_iter().collect(), coverage: Vec::new() }
+    }
+
+    /// Require the predicate to hold after at least one point in the trace,
+    /// including the initial fixture state.
+    pub fn sometimes(mut self, description: impl Into<String>, predicate: impl Fn(&W) -> bool + Send + Sync + 'static) -> Self {
+        self.coverage.push(CoverageAssertion { description: description.into(), predicate: Box::new(predicate) });
+        self
+    }
+}
+
 /// The world-builder, direct-step, and fixpoint-predicate fixture triple used
 /// by every enrolled reconciler.
 pub struct LivenessEnrollment<B, S, P> {
@@ -135,6 +195,80 @@ where
     Err(format!("did not reach a fixpoint within {} passes", enrollment.pass_bound))
 }
 
+/// Drive a hand-written disturbance trace and return its final world.
+///
+/// This sits alongside, rather than replaces, the bounded convergence and
+/// quiescence checks. A trace fails if it drops no pending actuation or if any
+/// `sometimes` assertion is never observed.
+pub async fn run_transition_sequence<B, S, P>(
+    enrollment: &LivenessEnrollment<B, S, P>,
+    scenario: LivenessScenario,
+    sequence: &TransitionSequence<B::World, S::Field, S::Value, S::OriginRoot>,
+) -> Result<B::World, String>
+where
+    B: WorldBuilder,
+    S: TransitionDriver<B::World>,
+{
+    let mut world = enrollment.world_builder.build(scenario).await?;
+    let mut pending_actuations = Vec::new();
+    let mut coverage = sequence.coverage.iter().map(|assertion| (assertion.predicate)(&world)).collect::<Vec<_>>();
+
+    for (index, transition) in sequence.transitions.iter().enumerate() {
+        let result = match transition {
+            Transition::Reconcile => {
+                let outcome = enrollment.reconciler_step.reconcile_step(&mut world).await?;
+                if let Some(patch) = outcome.patch {
+                    enrollment.reconciler_step.apply_patch(&mut world, patch).await?;
+                }
+                pending_actuations.extend(outcome.actuations);
+                Ok(())
+            }
+            Transition::ExternalSpecWrite(field, value) => enrollment.reconciler_step.external_spec_write(&mut world, field, value).await,
+            Transition::Delete => enrollment.reconciler_step.delete(&mut world).await,
+            Transition::RestartController => enrollment.reconciler_step.restart_controller(&mut world).await,
+            Transition::AdvanceClock(delta) => {
+                enrollment.clock.advance(*delta);
+                Ok(())
+            }
+            Transition::DropActuation => {
+                if pending_actuations.is_empty() {
+                    Err("no pending actuation to drop".to_string())
+                } else {
+                    pending_actuations.clear();
+                    Ok(())
+                }
+            }
+            Transition::DeliverActuation => {
+                for actuation in pending_actuations.drain(..) {
+                    enrollment.reconciler_step.apply_actuation(&mut world, actuation).await?;
+                }
+                Ok(())
+            }
+            Transition::PartitionStore(origin_root) => enrollment.reconciler_step.partition_store(&mut world, origin_root).await,
+        };
+        result.map_err(|error| format!("transition {index} ({transition:?}) failed: {error}"))?;
+        for (observed, assertion) in coverage.iter_mut().zip(&sequence.coverage) {
+            *observed |= (assertion.predicate)(&world);
+        }
+    }
+
+    if let Some((_, assertion)) = coverage.iter().zip(&sequence.coverage).find(|(observed, _)| !**observed) {
+        return Err(format!("coverage assertion `{}` was never observed", assertion.description));
+    }
+    Ok(world)
+}
+
+pub async fn assert_transition_sequence<B, S, P>(
+    enrollment: &LivenessEnrollment<B, S, P>,
+    scenario: LivenessScenario,
+    sequence: &TransitionSequence<B::World, S::Field, S::Value, S::OriginRoot>,
+) where
+    B: WorldBuilder,
+    S: TransitionDriver<B::World>,
+{
+    run_transition_sequence(enrollment, scenario, sequence).await.expect("transition sequence");
+}
+
 pub async fn assert_bounded_convergence<B, S, P>(enrollment: &LivenessEnrollment<B, S, P>)
 where
     B: WorldBuilder,
@@ -206,4 +340,125 @@ where
         assert!(!enrollment.fixpoint.at_fixpoint(&world), "contradictory world silently reached a successful fixpoint");
     }
     panic!("contradictory world did not become held within {} passes", enrollment.pass_bound);
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::Clock;
+
+    #[derive(Default)]
+    struct TestWorld {
+        interesting: bool,
+        events: Vec<&'static str>,
+    }
+
+    struct TestWorldBuilder;
+
+    #[async_trait]
+    impl WorldBuilder for TestWorldBuilder {
+        type World = TestWorld;
+
+        async fn build(&self, _scenario: LivenessScenario) -> Result<Self::World, String> {
+            Ok(TestWorld::default())
+        }
+    }
+
+    struct TestStep;
+
+    #[async_trait]
+    impl ReconcileStep<TestWorld> for TestStep {
+        type Patch = &'static str;
+        type Actuation = &'static str;
+
+        async fn reconcile_step(&self, _world: &mut TestWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
+            Ok(LivenessStep::new(Some("patch"), vec!["actuation"]))
+        }
+
+        async fn apply_patch(&self, world: &mut TestWorld, patch: Self::Patch) -> Result<(), String> {
+            world.events.push(patch);
+            Ok(())
+        }
+
+        async fn apply_actuation(&self, world: &mut TestWorld, actuation: Self::Actuation) -> Result<(), String> {
+            world.events.push(actuation);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl TransitionDriver<TestWorld> for TestStep {
+        type Field = &'static str;
+        type Value = i32;
+        type OriginRoot = &'static str;
+
+        async fn external_spec_write(&self, world: &mut TestWorld, field: &Self::Field, _value: &Self::Value) -> Result<(), String> {
+            world.events.push(field);
+            Ok(())
+        }
+
+        async fn delete(&self, world: &mut TestWorld) -> Result<(), String> {
+            world.events.push("delete");
+            Ok(())
+        }
+
+        async fn restart_controller(&self, world: &mut TestWorld) -> Result<(), String> {
+            world.events.push("restart");
+            Ok(())
+        }
+
+        async fn partition_store(&self, world: &mut TestWorld, origin_root: &Self::OriginRoot) -> Result<(), String> {
+            world.events.push(origin_root);
+            Ok(())
+        }
+    }
+
+    struct TestFixpoint;
+
+    impl FixpointPredicate<TestWorld> for TestFixpoint {
+        fn at_fixpoint(&self, _world: &TestWorld) -> bool {
+            false
+        }
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "coverage assertion `interesting state` was never observed")]
+    async fn transition_sequence_rejects_vacuous_coverage() {
+        let clock = Arc::new(VirtualClock::new(Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).single().expect("valid test timestamp")));
+        let enrollment = LivenessEnrollment::new(TestWorldBuilder, TestStep, TestFixpoint, clock);
+        let sequence = TransitionSequence::new([Transition::AdvanceClock(Duration::seconds(1))])
+            .sometimes("interesting state", |world: &TestWorld| world.interesting);
+
+        assert_transition_sequence(&enrollment, LivenessScenario::Normal, &sequence).await;
+    }
+
+    #[tokio::test]
+    async fn transition_sequence_drives_the_complete_vocabulary_and_controls_actuation_delivery() {
+        let clock = Arc::new(VirtualClock::new(Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).single().expect("valid test timestamp")));
+        let enrollment = LivenessEnrollment::new(TestWorldBuilder, TestStep, TestFixpoint, Arc::clone(&clock));
+        let sequence = TransitionSequence::new([
+            Transition::Reconcile,
+            Transition::DropActuation,
+            Transition::ExternalSpecWrite("priority", 10),
+            Transition::Delete,
+            Transition::RestartController,
+            Transition::PartitionStore("root-b"),
+            Transition::AdvanceClock(Duration::seconds(5)),
+            Transition::Reconcile,
+            Transition::DeliverActuation,
+        ])
+        .sometimes("external write", |world: &TestWorld| world.events.contains(&"priority"))
+        .sometimes("delivered actuation", |world: &TestWorld| world.events.contains(&"actuation"));
+
+        let world = run_transition_sequence(&enrollment, LivenessScenario::Normal, &sequence).await.expect("complete transition sequence");
+
+        assert_eq!(
+            world.events,
+            vec!["patch", "priority", "delete", "restart", "root-b", "patch", "actuation"],
+            "the first actuation must be dropped and the second delivered"
+        );
+        assert_eq!(clock.now(), Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 5).single().expect("valid advanced timestamp"));
+    }
 }

--- a/crates/flotilla-resources/src/test_support/liveness.rs
+++ b/crates/flotilla-resources/src/test_support/liveness.rs
@@ -216,12 +216,15 @@ where
     for (index, transition) in sequence.transitions.iter().enumerate() {
         let result = match transition {
             Transition::Reconcile => {
-                let outcome = enrollment.reconciler_step.reconcile_step(&mut world).await?;
-                if let Some(patch) = outcome.patch {
-                    enrollment.reconciler_step.apply_patch(&mut world, patch).await?;
+                async {
+                    let outcome = enrollment.reconciler_step.reconcile_step(&mut world).await?;
+                    if let Some(patch) = outcome.patch {
+                        enrollment.reconciler_step.apply_patch(&mut world, patch).await?;
+                    }
+                    pending_actuations.extend(outcome.actuations);
+                    Ok(())
                 }
-                pending_actuations.extend(outcome.actuations);
-                Ok(())
+                .await
             }
             Transition::ExternalSpecWrite(field, value) => enrollment.reconciler_step.external_spec_write(&mut world, field, value).await,
             Transition::Delete => enrollment.reconciler_step.delete(&mut world).await,
@@ -239,10 +242,13 @@ where
                 }
             }
             Transition::DeliverActuation => {
-                for actuation in pending_actuations.drain(..) {
-                    enrollment.reconciler_step.apply_actuation(&mut world, actuation).await?;
+                async {
+                    for actuation in pending_actuations.drain(..) {
+                        enrollment.reconciler_step.apply_actuation(&mut world, actuation).await?;
+                    }
+                    Ok(())
                 }
-                Ok(())
+                .await
             }
             Transition::PartitionStore(origin_root) => enrollment.reconciler_step.partition_store(&mut world, origin_root).await,
         };
@@ -349,7 +355,7 @@ mod tests {
     use super::*;
     use crate::Clock;
 
-    #[derive(Default)]
+    #[derive(Debug, Default)]
     struct TestWorld {
         interesting: bool,
         events: Vec<&'static str>,
@@ -423,10 +429,65 @@ mod tests {
         }
     }
 
+    enum FailurePoint {
+        Reconcile,
+        DeliverActuation,
+    }
+
+    struct FailingStep(FailurePoint);
+
+    #[async_trait]
+    impl ReconcileStep<TestWorld> for FailingStep {
+        type Patch = ();
+        type Actuation = ();
+
+        async fn reconcile_step(&self, _world: &mut TestWorld) -> Result<LivenessStep<Self::Patch, Self::Actuation>, String> {
+            match self.0 {
+                FailurePoint::Reconcile => Err("reconcile failed".to_string()),
+                FailurePoint::DeliverActuation => Ok(LivenessStep::new(None, vec![()])),
+            }
+        }
+
+        async fn apply_patch(&self, _world: &mut TestWorld, _patch: Self::Patch) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn apply_actuation(&self, _world: &mut TestWorld, _actuation: Self::Actuation) -> Result<(), String> {
+            Err("actuation failed".to_string())
+        }
+    }
+
+    #[async_trait]
+    impl TransitionDriver<TestWorld> for FailingStep {
+        type Field = ();
+        type Value = ();
+        type OriginRoot = ();
+
+        async fn external_spec_write(&self, _world: &mut TestWorld, _field: &Self::Field, _value: &Self::Value) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn delete(&self, _world: &mut TestWorld) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn restart_controller(&self, _world: &mut TestWorld) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn partition_store(&self, _world: &mut TestWorld, _origin_root: &Self::OriginRoot) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    fn test_clock() -> Arc<VirtualClock> {
+        Arc::new(VirtualClock::new(Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).single().expect("valid test timestamp")))
+    }
+
     #[tokio::test]
     #[should_panic(expected = "coverage assertion `interesting state` was never observed")]
     async fn transition_sequence_rejects_vacuous_coverage() {
-        let clock = Arc::new(VirtualClock::new(Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).single().expect("valid test timestamp")));
+        let clock = test_clock();
         let enrollment = LivenessEnrollment::new(TestWorldBuilder, TestStep, TestFixpoint, clock);
         let sequence = TransitionSequence::new([Transition::AdvanceClock(Duration::seconds(1))])
             .sometimes("interesting state", |world: &TestWorld| world.interesting);
@@ -436,7 +497,7 @@ mod tests {
 
     #[tokio::test]
     async fn transition_sequence_drives_the_complete_vocabulary_and_controls_actuation_delivery() {
-        let clock = Arc::new(VirtualClock::new(Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).single().expect("valid test timestamp")));
+        let clock = test_clock();
         let enrollment = LivenessEnrollment::new(TestWorldBuilder, TestStep, TestFixpoint, Arc::clone(&clock));
         let sequence = TransitionSequence::new([
             Transition::Reconcile,
@@ -460,5 +521,27 @@ mod tests {
             "the first actuation must be dropped and the second delivered"
         );
         assert_eq!(clock.now(), Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 5).single().expect("valid advanced timestamp"));
+    }
+
+    #[tokio::test]
+    async fn transition_sequence_errors_name_the_failing_transition() {
+        let reconcile_enrollment =
+            LivenessEnrollment::new(TestWorldBuilder, FailingStep(FailurePoint::Reconcile), TestFixpoint, test_clock());
+        let reconcile_error =
+            run_transition_sequence(&reconcile_enrollment, LivenessScenario::Normal, &TransitionSequence::new([Transition::Reconcile]))
+                .await
+                .expect_err("reconcile failure");
+        assert_eq!(reconcile_error, "transition 0 (Reconcile) failed: reconcile failed");
+
+        let actuation_enrollment =
+            LivenessEnrollment::new(TestWorldBuilder, FailingStep(FailurePoint::DeliverActuation), TestFixpoint, test_clock());
+        let actuation_error = run_transition_sequence(
+            &actuation_enrollment,
+            LivenessScenario::Normal,
+            &TransitionSequence::new([Transition::Reconcile, Transition::DeliverActuation]),
+        )
+        .await
+        .expect_err("actuation failure");
+        assert_eq!(actuation_error, "transition 1 (DeliverActuation) failed: actuation failed");
     }
 }

--- a/crates/flotilla-resources/src/test_support/mod.rs
+++ b/crates/flotilla-resources/src/test_support/mod.rs
@@ -5,7 +5,7 @@ mod write_counting;
 
 pub use liveness::{
     assert_actuation_drop_recovery, assert_bounded_convergence, assert_degradation_not_wedging, assert_quiescence_at_fixpoint,
-    assert_staleness_edges, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, WorldBuilder,
-    DEFAULT_PASS_BOUND,
+    assert_staleness_edges, assert_transition_sequence, run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario,
+    LivenessStep, ReconcileStep, Transition, TransitionDriver, TransitionSequence, WorldBuilder, DEFAULT_PASS_BOUND,
 };
 pub use write_counting::{WriteCountingBackend, WriteCountingResolver};


### PR DESCRIPTION
## What changed

- extend the reusable reconciler liveness harness with the ADR 0024 transition vocabulary: `Reconcile`, `ExternalSpecWrite`, `Delete`, `RestartController`, `AdvanceClock`, `DropActuation`, `DeliverActuation`, and `PartitionStore`
- add a generic transition driver that controls pending actuation delivery and composes with the existing bounded-convergence and quiescence enrollment
- add `sometimes` coverage assertions, including a harness self-test proving vacuous traces fail
- encode the three dogfooding regressions as hand-written transition properties:
  - local and remote placement-policy registration preserve an interleaved operator priority write (#1236/#1248)
  - daemon restart retains a material lease whose holder is pending finalization (PR #1242 review)
  - stale TerminalSession recovery after deletion/restart cannot resurrect an ownerless external session (#1202)

## Why

The straight-line liveness battery could verify convergence and quiescence, but it could not reach the interleavings that caused this week's field-stomp and restart/recovery bugs. This adds the disturbance vocabulary from ADR 0024 while keeping resource-specific operations behind fixture adapters.

## Re-break experiments

Each property was run against a temporary local removal of its shipped fix, then the production code was restored:

- changing placement registration to start from `desired` instead of the live spec failed with `coverage assertion \`operator priority survived a registration reconcile\` was never observed`
- filtering deletion-timestamped environments out of startup lease recovery failed with `coverage assertion \`second holder was refused after restart\` was never observed`
- removing the TerminalSession owner lookup caused the ghost sequence to call `ensure_session` and then fail its write with `resource not found: terminal-deleted-convoy-work-coder`

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`

The first full workspace run hit the existing transient fake-zellij `Text file busy (os error 26)` race; the isolated test passed immediately and the complete workspace rerun passed.

Closes #1252