### PR TITLE
Run contained crews through interior cleat sessions

### DIFF
--- a/.flotilla/placement-policy.crew-image.yaml
+++ b/.flotilla/placement-policy.crew-image.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     flotilla.work/image-recipe: .flotilla/Dockerfile.crew
 spec:
-  pool: passthrough
+  pool: cleat
   docker_per_vessel:
     host_ref: d49f4c59-811f-44aa-a4ca-d4cac66cf2a3
     image: forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1

--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -3,7 +3,10 @@ use std::{path::PathBuf, sync::Arc};
 use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
-        environment::{CreateOpts, EnvironmentProvider, ProvisionedMount, ProvisionedMountMode},
+        environment::{
+            CreateOpts, EnvironmentProvider, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind,
+            EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
+        },
         terminal::TerminalPool,
         vcs::{CloneInspection, CloneProvisioner},
     },
@@ -45,11 +48,19 @@ impl DockerEnvironmentActuator {
     pub fn build_create_opts(&self, spec: &DockerEnvironmentSpec) -> CreateOpts {
         CreateOpts {
             tokens: self.tokens.clone(),
-            daemon_socket_path: self.daemon_socket_path.clone(),
             working_directory: None,
             image_pull_policy: spec.pull_policy.into(),
             docker_config_dir: None,
             provisioned_mounts: spec.mounts.iter().map(provisioned_mount).collect(),
+            tools: vec![EnvironmentTool::new("flotilla-daemon-access", "/usr/local/bin/flotilla")
+                .with_asset(EnvironmentToolAsset::new(
+                    self.daemon_socket_path.as_path().to_path_buf(),
+                    "/run/flotilla.sock",
+                    EnvironmentToolAssetKind::UnixSocket,
+                    EnvironmentToolAssetAccess::SharedWritable,
+                    "the daemon socket",
+                ))
+                .with_environment(EnvironmentVariableUpdate::set("FLOTILLA_DAEMON_SOCKET", "/run/flotilla.sock", "the daemon socket"))],
         }
     }
 }

--- a/crates/flotilla-controllers/src/reconcilers/presentation.rs
+++ b/crates/flotilla-controllers/src/reconcilers/presentation.rs
@@ -252,7 +252,6 @@ impl<R> PresentationReconciler<R> {
             .terminal_pools
             .get(&session.spec.pool)
             .map(|(_, pool)| Arc::clone(pool))
-            .or_else(|| registry.terminal_pools.preferred().cloned())
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
 
         let session_cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);

--- a/crates/flotilla-core/examples/environment_checkout.rs
+++ b/crates/flotilla-core/examples/environment_checkout.rs
@@ -52,19 +52,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n--- Creating environment ---");
     let env_id = EnvironmentId::new("smoke-test");
 
-    // We need git inside the container — install it after creation
-    // Use a temp socket path (we don't need a real daemon socket for this test)
-    let temp = tempfile::tempdir()?;
-    let socket_path = DaemonHostPath::new(temp.path().join("fake.sock"));
-    // Create a dummy socket file so the mount doesn't fail
-    std::fs::write(socket_path.as_path(), "")?;
-
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: socket_path,
         working_directory: None,
         image_pull_policy: Default::default(),
         docker_config_dir: None,
+        tools: Vec::new(),
         provisioned_mounts: vec![flotilla_core::providers::environment::ProvisionedMount::new(
             reference_repo.as_path().to_path_buf(),
             "/ref/repo",

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -17,7 +17,10 @@ use crate::{
             detectors::default_host_detectors, run_host_detectors, run_provisioned_host_detectors, DiscoveryRuntime, EnvironmentBag,
             FactoryRegistry,
         },
-        environment::{CreateOpts, EnvironmentHandle, ProvisionedMount, ProvisionedMountMode},
+        environment::{
+            CreateOpts, EnvironmentHandle, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind,
+            EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
+        },
         registry::ProviderRegistry,
         CommandRunner,
     },
@@ -272,9 +275,17 @@ impl EnvironmentManager {
             .unwrap_or_default();
         let opts = CreateOpts {
             tokens,
-            daemon_socket_path: daemon_socket_path.clone(),
             working_directory: None,
             provisioned_mounts,
+            tools: vec![EnvironmentTool::new("flotilla-daemon-access", "/usr/local/bin/flotilla")
+                .with_asset(EnvironmentToolAsset::new(
+                    daemon_socket_path.as_path().to_path_buf(),
+                    "/run/flotilla.sock",
+                    EnvironmentToolAssetKind::UnixSocket,
+                    EnvironmentToolAssetAccess::SharedWritable,
+                    "the daemon socket",
+                ))
+                .with_environment(EnvironmentVariableUpdate::set("FLOTILLA_DAEMON_SOCKET", "/run/flotilla.sock", "the daemon socket"))],
             image_pull_policy: Default::default(),
             docker_config_dir: None,
         };

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6388,7 +6388,6 @@ impl InProcessDaemon {
             .terminal_pools
             .get(&session.spec.pool)
             .map(|(_, pool)| Arc::clone(pool))
-            .or_else(|| registry.terminal_pools.preferred().cloned())
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
         let session_id = session.status.as_ref().and_then(|status| status.session_id.as_deref()).unwrap_or(session.metadata.name.as_str());
         pool.deliver(session_id, message, true).await

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1501,6 +1501,35 @@ async fn convoy_resume_delivers_follow_up_to_unique_completed_crew_session() {
 }
 
 #[tokio::test]
+async fn convoy_resume_does_not_fall_back_from_the_sessions_named_pool() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(temp.path()).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_two_agent_crew(&daemon, &env_ref).await;
+    daemon
+        .crew_complete_internal(&CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() }, Some("ready".into()))
+        .await
+        .expect("complete coder work");
+    let sessions = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let session = sessions.get("terminal-demo-implement-coder").await.expect("coder session");
+    let mut spec = session.spec.clone();
+    spec.pool = "missing-interior-pool".to_string();
+    sessions
+        .update(&InputMeta::from(&session.metadata), &session.metadata.resource_version, &spec)
+        .await
+        .expect("simulate a named interior pool that is no longer available");
+
+    let error = daemon
+        .convoy_resume_internal("flotilla", "demo", "Continue", Some("implement"), Some("coder"))
+        .await
+        .expect_err("message delivery must not use the preferred fallback pool");
+
+    assert_eq!(error, format!("terminal pool missing-interior-pool unavailable for environment {env_ref}"));
+    assert!(terminal_pool.delivered.lock().await.is_empty());
+}
+
+#[tokio::test]
 async fn convoy_resume_requires_a_selector_when_completed_crew_is_ambiguous() {
     let temp = tempfile::tempdir().expect("tempdir");
     std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("daemon config");

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -10,13 +10,11 @@ use flotilla_protocol::{EnvironmentId, EnvironmentSpec, EnvironmentStatus, Image
 use sha2::{Digest, Sha256};
 
 use super::{
-    runner::DockerEnvironmentRunner, CreateOpts, EnvironmentHandle, EnvironmentProvider, ProvisionedEnvironment, ProvisionedMount,
-    ProvisionedMountMode,
+    runner::DockerEnvironmentRunner, CreateOpts, EnvironmentHandle, EnvironmentProvider, EnvironmentToolAssetAccess,
+    EnvironmentVariableUpdate, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode,
 };
 use crate::providers::{ChannelLabel, CommandRunner};
 
-/// Fixed path inside the container where the daemon socket is mounted.
-const CONTAINER_SOCKET_PATH: &str = "/run/flotilla.sock";
 /// Bump this when the short-term Dockerfile image fingerprint inputs change.
 const DOCKERFILE_IMAGE_TAG_VERSION: &str = "v1";
 
@@ -72,23 +70,48 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
     async fn create(&self, id: EnvironmentId, image: &ImageId, opts: CreateOpts) -> Result<EnvironmentHandle, String> {
         let container_name = format!("flotilla-env-{}", id);
 
-        if opts.provisioned_mounts.iter().any(|mount| mount.environment_path.as_path() == Path::new(CONTAINER_SOCKET_PATH)) {
-            return Err(format!("mount target {CONTAINER_SOCKET_PATH} is reserved for the daemon socket"));
+        let requested_mounts = opts.provisioned_mounts;
+        let mut provisioned_mounts = Vec::new();
+        let mut tokens = opts.tokens;
+        for tool in &opts.tools {
+            for asset in &tool.assets {
+                if requested_mounts.iter().chain(&provisioned_mounts).any(|mount| mount.environment_path == asset.environment_path) {
+                    return Err(format!("mount target {} is reserved for {}", asset.environment_path, asset.purpose));
+                }
+                let mode = match asset.access {
+                    EnvironmentToolAssetAccess::ReadOnly => ProvisionedMountMode::Ro,
+                    EnvironmentToolAssetAccess::SharedWritable => ProvisionedMountMode::Rw,
+                };
+                provisioned_mounts.push(ProvisionedMount::new(
+                    asset.host_path.as_path().to_path_buf(),
+                    asset.environment_path.as_path().to_path_buf(),
+                    mode,
+                ));
+            }
+            for update in &tool.environment {
+                match update {
+                    EnvironmentVariableUpdate::Set { name, value, purpose } => {
+                        if tokens.iter().any(|(existing, _)| existing == name) {
+                            return Err(format!("environment variable {name} is reserved for {purpose}"));
+                        }
+                        tokens.push((name.clone(), value.clone()));
+                    }
+                    EnvironmentVariableUpdate::PrependPath { name, value } => {
+                        match tokens.iter_mut().find(|(existing, _)| existing == name) {
+                            Some((_, existing)) => *existing = format!("{value}:{existing}"),
+                            None => tokens.push((name.clone(), value.clone())),
+                        }
+                    }
+                }
+            }
         }
-        let mut provisioned_mounts = Vec::with_capacity(opts.provisioned_mounts.len() + 1);
-        provisioned_mounts.push(ProvisionedMount::new(
-            opts.daemon_socket_path.as_path().to_path_buf(),
-            CONTAINER_SOCKET_PATH,
-            ProvisionedMountMode::Rw,
-        ));
-        provisioned_mounts.extend(opts.provisioned_mounts);
+        provisioned_mounts.extend(requested_mounts);
         let env_id_str = id.to_string();
         let image_str = image.as_str().to_string();
         let label_val = format!("flotilla.environment={}", id);
         let mounts_label_val =
             format!("flotilla.provisioned_mounts={}", serde_json::to_string(&provisioned_mounts).map_err(|err| err.to_string())?);
         let env_id_env = format!("FLOTILLA_ENVIRONMENT_ID={}", env_id_str);
-        let socket_env = format!("FLOTILLA_DAEMON_SOCKET={CONTAINER_SOCKET_PATH}");
         #[cfg(unix)]
         let user = host_user();
 
@@ -108,8 +131,6 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
             &label_val,
             "--label",
             &mounts_label_val,
-            "-e",
-            &socket_env,
             "-e",
             &env_id_env,
         ]);
@@ -132,7 +153,7 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
         }
 
         // Token env vars
-        let token_env_strs: Vec<String> = opts.tokens.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
+        let token_env_strs: Vec<String> = tokens.iter().map(|(k, v)| format!("{}={}", k, v)).collect();
         for token_env in &token_env_strs {
             args.push("-e");
             args.push(token_env);

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -22,11 +22,103 @@ use super::CommandRunner;
 #[derive(Debug, Clone)]
 pub struct CreateOpts {
     pub tokens: Vec<(String, String)>,
-    pub daemon_socket_path: DaemonHostPath,
     pub working_directory: Option<ExecutionEnvironmentPath>,
     pub provisioned_mounts: Vec<ProvisionedMount>,
+    /// Tools that must be made available inside the environment.
+    ///
+    /// Providers choose how to deliver these assets. Docker currently lowers
+    /// them to bind mounts; remote sandbox providers may upload files or expose
+    /// sockets through their own transport.
+    pub tools: Vec<EnvironmentTool>,
     pub image_pull_policy: ImagePullPolicy,
     pub docker_config_dir: Option<DaemonHostPath>,
+}
+
+/// A host-side tool that an environment provider must make invokable inside a
+/// provisioned environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvironmentTool {
+    pub name: String,
+    pub executable: ExecutionEnvironmentPath,
+    pub assets: Vec<EnvironmentToolAsset>,
+    pub environment: Vec<EnvironmentVariableUpdate>,
+}
+
+impl EnvironmentTool {
+    pub fn new(name: impl Into<String>, executable: impl Into<PathBuf>) -> Self {
+        Self { name: name.into(), executable: ExecutionEnvironmentPath::new(executable), assets: Vec::new(), environment: Vec::new() }
+    }
+
+    pub fn with_asset(mut self, asset: EnvironmentToolAsset) -> Self {
+        self.assets.push(asset);
+        self
+    }
+
+    pub fn with_environment(mut self, update: EnvironmentVariableUpdate) -> Self {
+        self.environment.push(update);
+        self
+    }
+}
+
+/// An asset needed by a tool inside an environment.
+///
+/// The source is deliberately described as a host path rather than as a bind
+/// mount. Bind mounting is one provider's delivery strategy, not the contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvironmentToolAsset {
+    pub host_path: DaemonHostPath,
+    pub environment_path: ExecutionEnvironmentPath,
+    pub kind: EnvironmentToolAssetKind,
+    pub access: EnvironmentToolAssetAccess,
+    pub purpose: String,
+}
+
+impl EnvironmentToolAsset {
+    pub fn new(
+        host_path: impl Into<PathBuf>,
+        environment_path: impl Into<PathBuf>,
+        kind: EnvironmentToolAssetKind,
+        access: EnvironmentToolAssetAccess,
+        purpose: impl Into<String>,
+    ) -> Self {
+        Self {
+            host_path: DaemonHostPath::new(host_path),
+            environment_path: ExecutionEnvironmentPath::new(environment_path),
+            kind,
+            access,
+            purpose: purpose.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvironmentToolAssetKind {
+    File,
+    Directory,
+    UnixSocket,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvironmentToolAssetAccess {
+    ReadOnly,
+    SharedWritable,
+}
+
+/// A tool's requested mutation to the environment it runs in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnvironmentVariableUpdate {
+    Set { name: String, value: String, purpose: String },
+    PrependPath { name: String, value: String },
+}
+
+impl EnvironmentVariableUpdate {
+    pub fn set(name: impl Into<String>, value: impl Into<String>, purpose: impl Into<String>) -> Self {
+        Self::Set { name: name.into(), value: value.into(), purpose: purpose.into() }
+    }
+
+    pub fn prepend_path(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self::PrependPath { name: name.into(), value: value.into() }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -8,10 +8,23 @@ use async_trait::async_trait;
 use flotilla_protocol::{DaemonHostPath, EnvironmentId, EnvironmentSpec, EnvironmentStatus, HostName, ImageSource};
 
 use super::{
-    docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, ImagePullPolicy, ProvisionedMount,
-    ProvisionedMountMode,
+    docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, EnvironmentTool,
+    EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind, EnvironmentVariableUpdate, ImagePullPolicy,
+    ProvisionedMount, ProvisionedMountMode,
 };
 use crate::providers::{ChannelLabel, CommandOutput, CommandRunner};
+
+fn test_daemon_tool(socket_path: impl Into<PathBuf>) -> EnvironmentTool {
+    EnvironmentTool::new("flotilla", "/usr/local/bin/flotilla")
+        .with_asset(EnvironmentToolAsset::new(
+            socket_path,
+            "/run/flotilla.sock",
+            EnvironmentToolAssetKind::UnixSocket,
+            EnvironmentToolAssetAccess::SharedWritable,
+            "the daemon socket",
+        ))
+        .with_environment(EnvironmentVariableUpdate::set("FLOTILLA_DAEMON_SOCKET", "/run/flotilla.sock", "the daemon socket"))
+}
 
 /// A mock CommandRunner that records all (cmd, args, cwd) tuples passed to run/run_output.
 struct RecordingRunner {
@@ -255,7 +268,7 @@ async fn create_returns_handle() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![("GITHUB_TOKEN".into(), "ghp_secret".into())],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -308,7 +321,7 @@ async fn create_runs_container_as_the_host_user() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: Vec::new(),
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: Vec::new(),
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -336,7 +349,7 @@ async fn create_removes_container_when_image_digest_cannot_be_resolved() {
     let image = ImageId::new("registry.example/crew:latest");
     let opts = CreateOpts {
         tokens: Vec::new(),
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: Vec::new(),
         image_pull_policy: ImagePullPolicy::Always,
@@ -367,7 +380,7 @@ async fn create_translates_image_pull_policy_to_docker_run() {
         let image = ImageId::new("flotilla-dev-env:latest");
         let opts = CreateOpts {
             tokens: Vec::new(),
-            daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+            tools: vec![test_daemon_tool("/run/flotilla.sock")],
             working_directory: None,
             provisioned_mounts: Vec::new(),
             image_pull_policy: policy,
@@ -393,7 +406,7 @@ async fn create_uses_the_credential_scoped_docker_config_for_pull_on_run() {
     let image = ImageId::new("registry.example/crew:latest");
     let opts = CreateOpts {
         tokens: Vec::new(),
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: Vec::new(),
         image_pull_policy: ImagePullPolicy::Always,
@@ -419,7 +432,7 @@ async fn create_reports_infrastructure_and_requested_mount_metadata() {
     let reference_repo = DaemonHostPath::new("/host/reference-repo");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo", ProvisionedMountMode::Ro)],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -454,7 +467,7 @@ async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_path() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/host/flotilla.sock"),
+        tools: vec![test_daemon_tool("/host/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new("/host/replacement.sock", "/run/flotilla.sock", ProvisionedMountMode::Rw)],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -472,6 +485,48 @@ async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_path() {
 }
 
 #[tokio::test]
+async fn create_delivers_tool_assets_and_applies_tool_environment() {
+    use flotilla_protocol::ImageId;
+
+    let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
+    let provider = DockerEnvironmentProvider::new(runner.clone());
+    let image = ImageId::new("ubuntu:22.04");
+    let tool = EnvironmentTool::new("terminal", "/usr/local/bin/terminal")
+        .with_asset(EnvironmentToolAsset::new(
+            "/host/bin/terminal",
+            "/usr/local/bin/terminal",
+            EnvironmentToolAssetKind::File,
+            EnvironmentToolAssetAccess::ReadOnly,
+            "the terminal executable",
+        ))
+        .with_asset(EnvironmentToolAsset::new(
+            "/host/state/terminal",
+            "/var/lib/terminal",
+            EnvironmentToolAssetKind::Directory,
+            EnvironmentToolAssetAccess::SharedWritable,
+            "terminal state",
+        ))
+        .with_environment(EnvironmentVariableUpdate::set("TERMINAL_STATE", "/var/lib/terminal", "terminal state"))
+        .with_environment(EnvironmentVariableUpdate::prepend_path("LD_LIBRARY_PATH", "/usr/local/lib/terminal"));
+    let opts = CreateOpts {
+        tokens: vec![("LD_LIBRARY_PATH".to_string(), "/image/lib".to_string())],
+        working_directory: None,
+        provisioned_mounts: Vec::new(),
+        tools: vec![tool],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
+        docker_config_dir: None,
+    };
+
+    provider.create(EnvironmentId::new("tool-delivery"), &image, opts).await.expect("Docker should lower provider-neutral tool assets");
+
+    let args = &runner.calls()[0].1;
+    assert!(args.contains(&"/host/bin/terminal:/usr/local/bin/terminal:ro".to_string()));
+    assert!(args.contains(&"/host/state/terminal:/var/lib/terminal:rw".to_string()));
+    assert!(args.contains(&"TERMINAL_STATE=/var/lib/terminal".to_string()));
+    assert!(args.contains(&"LD_LIBRARY_PATH=/usr/local/lib/terminal:/image/lib".to_string()));
+}
+
+#[tokio::test]
 async fn create_uses_requested_mount_modes_in_docker_arguments() {
     use flotilla_protocol::ImageId;
 
@@ -480,7 +535,7 @@ async fn create_uses_requested_mount_modes_in_docker_arguments() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![
             ProvisionedMount::new("/host/workspace", "/workspace", ProvisionedMountMode::Rw),
@@ -524,7 +579,7 @@ async fn list_preserves_provisioned_mount_metadata() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -558,7 +613,7 @@ async fn list_fails_on_malformed_reference_repo_mount_metadata() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -584,7 +639,7 @@ async fn list_rejects_missing_reference_repo_mount_metadata() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -606,7 +661,7 @@ async fn provisioned_handle_returns_its_initialized_runner() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -632,7 +687,7 @@ async fn status_returns_running() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -664,7 +719,7 @@ async fn env_vars_parses_output() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -698,7 +753,7 @@ async fn destroy_calls_docker_rm() {
     let image = ImageId::new("ubuntu:22.04");
     let opts = CreateOpts {
         tokens: vec![],
-        daemon_socket_path: DaemonHostPath::new("/run/flotilla.sock"),
+        tools: vec![test_daemon_tool("/run/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![],
         image_pull_policy: ImagePullPolicy::IfNotPresent,

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -109,7 +109,7 @@ impl TerminalPool for CleatTerminalPool {
             parts.join(" ")
         };
         let cwd = cwd.as_path().display().to_string();
-        let mut args = vec!["create", "--json", session_name, "--cwd", &cwd, "--cmd", &effective_cmd];
+        let mut args = vec!["launch", "--json", "--record", session_name, "--cwd", &cwd, "--cmd", &effective_cmd];
         let encoded_tags = tags.iter().map(|tag| format!("{}={}", tag.key, tag.value)).collect::<Vec<_>>();
         for tag in &encoded_tags {
             args.push("--tag");
@@ -123,16 +123,15 @@ impl TerminalPool for CleatTerminalPool {
         &self,
         session_name: &str,
         _command: &str,
-        cwd: &ExecutionEnvironmentPath,
+        _cwd: &ExecutionEnvironmentPath,
         _env_vars: &TerminalEnvVars,
     ) -> Result<Vec<Arg>, String> {
         Ok(vec![
             Arg::Literal(self.binary.clone()),
             Arg::Literal("attach".into()),
+            Arg::Literal("--no-create".into()),
             // Session names are UUIDs (attachable IDs) — always shell-safe, no quoting needed.
             Arg::Literal(session_name.into()),
-            Arg::Literal("--cwd".into()),
-            Arg::Quoted(cwd.as_path().display().to_string()),
         ])
     }
 
@@ -201,11 +200,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_creates_session() {
+    async fn ensure_launches_recorded_session() {
         let create_json = r#"{"id":"my-session","cwd":"/repo","cmd":"bash","status":"Detached"}"#;
         let runner = Arc::new(MockRunner::new(vec![
             Ok("[]".into()),        // list_sessions: empty (session doesn't exist)
-            Ok(create_json.into()), // create response
+            Ok(create_json.into()), // launch response
         ]));
         let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
 
@@ -214,7 +213,7 @@ mod tests {
         let calls = runner.calls();
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[1].0, "cleat");
-        assert_eq!(calls[1].1, vec!["create", "--json", "my-session", "--cwd", "/repo", "--cmd", "bash"]);
+        assert_eq!(calls[1].1, vec!["launch", "--json", "--record", "my-session", "--cwd", "/repo", "--cmd", "bash"]);
     }
 
     #[tokio::test]
@@ -222,7 +221,7 @@ mod tests {
         let create_json = r#"{"id":"my-session","cwd":"/repo","cmd":"env FOO='bar' claude","status":"Detached"}"#;
         let runner = Arc::new(MockRunner::new(vec![
             Ok("[]".into()),        // list_sessions: empty
-            Ok(create_json.into()), // create response
+            Ok(create_json.into()), // launch response
         ]));
         let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "cleat");
         let env = vec![("FOO".to_string(), "bar".to_string())];
@@ -252,8 +251,9 @@ mod tests {
         .expect("ensure tagged session");
 
         assert_eq!(runner.calls()[1].1, vec![
-            "create",
+            "launch",
             "--json",
+            "--record",
             "terminal-demo-coder",
             "--cwd",
             "/repo",
@@ -278,7 +278,7 @@ mod tests {
         pool.ensure_session("my-session", "claude", &ExecutionEnvironmentPath::new("/repo"), &env, &[]).await.expect("ensure session");
 
         let calls = runner.calls();
-        assert_eq!(calls.len(), 1, "should only call list, not create: {calls:?}");
+        assert_eq!(calls.len(), 1, "should only call list, not launch: {calls:?}");
         assert!(calls[0].1.contains(&"list".to_string()), "should be a list call: {:?}", calls[0].1);
     }
 
@@ -289,8 +289,7 @@ mod tests {
         let cmd =
             pool.attach_command("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![]).await.expect("attach command");
 
-        assert!(cmd.contains("cleat attach my-session"));
-        assert!(cmd.contains("--cwd '/repo'"));
+        assert_eq!(cmd, "cleat attach --no-create my-session");
         assert!(!cmd.contains("--cmd"), "should NOT have --cmd");
     }
 
@@ -329,9 +328,8 @@ mod tests {
         assert_eq!(args, vec![
             Arg::Literal("cleat".into()),
             Arg::Literal("attach".into()),
+            Arg::Literal("--no-create".into()),
             Arg::Literal("my-session".into()),
-            Arg::Literal("--cwd".into()),
-            Arg::Quoted("/repo".into()),
         ]);
     }
 
@@ -341,7 +339,7 @@ mod tests {
         let args = pool.attach_args("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![]).expect("attach_args");
         let flat = flotilla_protocol::arg::flatten(&args, 0);
 
-        assert_eq!(flat, "cleat attach my-session --cwd '/repo'");
+        assert_eq!(flat, "cleat attach --no-create my-session");
     }
 
     #[test]
@@ -353,9 +351,8 @@ mod tests {
         assert_eq!(args, vec![
             Arg::Literal("cleat".into()),
             Arg::Literal("attach".into()),
+            Arg::Literal("--no-create".into()),
             Arg::Literal("sess-1".into()),
-            Arg::Literal("--cwd".into()),
-            Arg::Quoted("/home/dev".into()),
         ]);
     }
 
@@ -365,13 +362,12 @@ mod tests {
         let env = vec![("FOO".to_string(), "bar".to_string()), ("BAZ".to_string(), "qu'x".to_string())];
         let args = pool.attach_args("sess", "cmd", &ExecutionEnvironmentPath::new("/wd"), &env).expect("attach_args");
 
-        // Env vars are baked in at ensure_session/create time — not in attach_args
+        // Env vars are baked in at ensure_session/launch time — not in attach_args
         assert_eq!(args, vec![
             Arg::Literal("cleat".into()),
             Arg::Literal("attach".into()),
+            Arg::Literal("--no-create".into()),
             Arg::Literal("sess".into()),
-            Arg::Literal("--cwd".into()),
-            Arg::Quoted("/wd".into()),
         ]);
     }
 
@@ -384,9 +380,8 @@ mod tests {
         assert_eq!(args, vec![
             Arg::Literal("cleat".into()),
             Arg::Literal("attach".into()),
+            Arg::Literal("--no-create".into()),
             Arg::Literal("sess".into()),
-            Arg::Literal("--cwd".into()),
-            Arg::Quoted("/wd".into()),
         ]);
     }
 
@@ -398,7 +393,7 @@ mod tests {
         let flat = flotilla_protocol::arg::flatten(&args, 0);
 
         // No --cmd, no NestedCommand
-        assert_eq!(flat, "cleat attach sess --cwd '/wd'");
+        assert_eq!(flat, "cleat attach --no-create sess");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/environment_tools.rs
+++ b/crates/flotilla-daemon/src/environment_tools.rs
@@ -1,0 +1,357 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use flotilla_core::{
+    config::ConfigStore,
+    in_process::InProcessDaemon,
+    path_context::DaemonHostPath,
+    providers::{
+        environment::{
+            EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind, EnvironmentVariableUpdate,
+        },
+        ChannelLabel, CommandRunner,
+    },
+};
+use tokio::sync::OnceCell;
+
+pub(crate) const ENVIRONMENT_FLOTILLA_PATH: &str = "/usr/local/bin/flotilla";
+pub(crate) const ENVIRONMENT_DAEMON_SOCKET_PATH: &str = "/run/flotilla.sock";
+pub(crate) const ENVIRONMENT_CLEAT_PATH: &str = "/usr/local/bin/cleat";
+pub(crate) const ENVIRONMENT_CLEAT_LIBRARY_DIR: &str = "/usr/local/lib/flotilla";
+pub(crate) const ENVIRONMENT_CLEAT_GHOSTTY_LIBRARY_PATH: &str = "/usr/local/lib/flotilla/libghostty-vt.so.0";
+pub(crate) const ENVIRONMENT_CLEAT_RUNTIME_DIR: &str = "/var/lib/flotilla/cleat";
+const CLEAT_GHOSTTY_LIBRARY: &str = "libghostty-vt.so.0";
+
+#[async_trait]
+pub(crate) trait EnvironmentToolFactory: Send + Sync {
+    async fn prepare(&self, environment_name: &str) -> Result<EnvironmentTool, String>;
+}
+
+/// Prepares the provider-neutral set of tools required by a new environment.
+///
+/// Factories resolve host assets and durable state. The resulting
+/// `EnvironmentTool` values are handed to the selected `EnvironmentProvider`,
+/// which owns the delivery strategy.
+pub(crate) struct EnvironmentToolProvisioner {
+    factories: Vec<Arc<dyn EnvironmentToolFactory>>,
+}
+
+impl EnvironmentToolProvisioner {
+    pub(crate) fn for_local_host(
+        daemon: &Arc<InProcessDaemon>,
+        config: &Arc<ConfigStore>,
+        daemon_socket_path: Option<DaemonHostPath>,
+    ) -> Self {
+        let cleat_binary_path = daemon
+            .local_environment_bag()
+            .and_then(|bag| bag.find_binary("cleat").cloned())
+            .map(|path| resolve_host_binary(path.as_path()))
+            .transpose()
+            .and_then(|path| path.ok_or_else(|| "binary unavailable for contained environment delivery".to_string()));
+        let runner = daemon.local_command_runner();
+        Self::new(vec![
+            Arc::new(FlotillaCliTool {
+                binary_path: running_daemon_flotilla_binary(),
+                daemon_socket_path: daemon_socket_path.ok_or_else(|| "daemon socket path unavailable".to_string()),
+            }),
+            Arc::new(CleatTool {
+                binary_path: cleat_binary_path,
+                ghostty_library_path: OnceCell::new(),
+                state_root: config.state_dir().join("contained-cleat").as_path().to_path_buf(),
+                runner,
+            }),
+        ])
+    }
+
+    pub(crate) fn new(factories: Vec<Arc<dyn EnvironmentToolFactory>>) -> Self {
+        Self { factories }
+    }
+
+    pub(crate) async fn prepare(&self, environment_name: &str) -> Result<Vec<EnvironmentTool>, String> {
+        let mut tools = Vec::with_capacity(self.factories.len());
+        for factory in &self.factories {
+            tools.push(factory.prepare(environment_name).await?);
+        }
+        Ok(tools)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fixed(
+        flotilla_binary_path: DaemonHostPath,
+        daemon_socket_path: DaemonHostPath,
+        cleat_binary_path: DaemonHostPath,
+        cleat_ghostty_library_path: DaemonHostPath,
+        state_root: PathBuf,
+    ) -> Self {
+        Self::new(vec![
+            Arc::new(FlotillaCliTool { binary_path: Ok(flotilla_binary_path), daemon_socket_path: Ok(daemon_socket_path) }),
+            Arc::new(CleatTool {
+                binary_path: Ok(cleat_binary_path),
+                ghostty_library_path: OnceCell::new_with(Some(cleat_ghostty_library_path)),
+                state_root,
+                runner: None,
+            }),
+        ])
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_unavailable_cleat(
+        flotilla_binary_path: DaemonHostPath,
+        daemon_socket_path: DaemonHostPath,
+        error: impl Into<String>,
+    ) -> Self {
+        Self::new(vec![
+            Arc::new(FlotillaCliTool { binary_path: Ok(flotilla_binary_path), daemon_socket_path: Ok(daemon_socket_path) }),
+            Arc::new(FailingTool { name: "cleat", error: error.into() }),
+        ])
+    }
+}
+
+struct FlotillaCliTool {
+    binary_path: Result<DaemonHostPath, String>,
+    daemon_socket_path: Result<DaemonHostPath, String>,
+}
+
+#[async_trait]
+impl EnvironmentToolFactory for FlotillaCliTool {
+    async fn prepare(&self, _environment_name: &str) -> Result<EnvironmentTool, String> {
+        let binary_path =
+            self.binary_path.as_ref().map_err(|error| format!("flotilla CLI unavailable for environment provisioning: {error}"))?;
+        let daemon_socket_path =
+            self.daemon_socket_path.as_ref().map_err(|error| format!("flotilla CLI unavailable for environment provisioning: {error}"))?;
+        Ok(EnvironmentTool::new("flotilla", ENVIRONMENT_FLOTILLA_PATH)
+            .with_asset(EnvironmentToolAsset::new(
+                binary_path.as_path().to_path_buf(),
+                ENVIRONMENT_FLOTILLA_PATH,
+                EnvironmentToolAssetKind::File,
+                EnvironmentToolAssetAccess::ReadOnly,
+                "the flotilla CLI",
+            ))
+            .with_asset(EnvironmentToolAsset::new(
+                daemon_socket_path.as_path().to_path_buf(),
+                ENVIRONMENT_DAEMON_SOCKET_PATH,
+                EnvironmentToolAssetKind::UnixSocket,
+                EnvironmentToolAssetAccess::SharedWritable,
+                "the daemon socket",
+            ))
+            .with_environment(EnvironmentVariableUpdate::set(
+                "FLOTILLA_DAEMON_SOCKET",
+                ENVIRONMENT_DAEMON_SOCKET_PATH,
+                "the daemon socket",
+            )))
+    }
+}
+
+struct CleatTool {
+    binary_path: Result<DaemonHostPath, String>,
+    ghostty_library_path: OnceCell<DaemonHostPath>,
+    state_root: PathBuf,
+    runner: Option<Arc<dyn CommandRunner>>,
+}
+
+#[async_trait]
+impl EnvironmentToolFactory for CleatTool {
+    async fn prepare(&self, environment_name: &str) -> Result<EnvironmentTool, String> {
+        let binary_path = self.binary_path.as_ref().map_err(|error| format!("cleat unavailable for environment provisioning: {error}"))?;
+        let ghostty_library_path = self
+            .ghostty_library_path
+            .get_or_try_init(|| async {
+                let runner =
+                    self.runner.as_ref().ok_or_else(|| "local command runner unavailable for cleat asset discovery".to_string())?;
+                resolve_cleat_ghostty_library(&**runner, binary_path).await
+            })
+            .await
+            .map_err(|error| format!("cleat unavailable for environment provisioning: {error}"))?;
+        let state_path = self.state_root.join(environment_name);
+        tokio::fs::create_dir_all(&state_path)
+            .await
+            .map_err(|error| format!("create durable cleat state directory {}: {error}", state_path.display()))?;
+
+        Ok(EnvironmentTool::new("cleat", ENVIRONMENT_CLEAT_PATH)
+            .with_asset(EnvironmentToolAsset::new(
+                binary_path.as_path().to_path_buf(),
+                ENVIRONMENT_CLEAT_PATH,
+                EnvironmentToolAssetKind::File,
+                EnvironmentToolAssetAccess::ReadOnly,
+                "the cleat CLI",
+            ))
+            .with_asset(EnvironmentToolAsset::new(
+                ghostty_library_path.as_path().to_path_buf(),
+                ENVIRONMENT_CLEAT_GHOSTTY_LIBRARY_PATH,
+                EnvironmentToolAssetKind::File,
+                EnvironmentToolAssetAccess::ReadOnly,
+                "the cleat VT library",
+            ))
+            .with_asset(EnvironmentToolAsset::new(
+                state_path,
+                ENVIRONMENT_CLEAT_RUNTIME_DIR,
+                EnvironmentToolAssetKind::Directory,
+                EnvironmentToolAssetAccess::SharedWritable,
+                "durable cleat state",
+            ))
+            .with_environment(EnvironmentVariableUpdate::set("CLEAT_RUNTIME_DIR", ENVIRONMENT_CLEAT_RUNTIME_DIR, "durable cleat state"))
+            .with_environment(EnvironmentVariableUpdate::prepend_path("LD_LIBRARY_PATH", ENVIRONMENT_CLEAT_LIBRARY_DIR)))
+    }
+}
+
+#[cfg(test)]
+struct FailingTool {
+    name: &'static str,
+    error: String,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl EnvironmentToolFactory for FailingTool {
+    async fn prepare(&self, _environment_name: &str) -> Result<EnvironmentTool, String> {
+        Err(format!("{} unavailable for environment provisioning: {}", self.name, self.error))
+    }
+}
+
+fn resolve_host_binary_from(path: &Path, current_dir: &Path, search_path: Option<&std::ffi::OsStr>) -> Result<DaemonHostPath, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else if path.components().count() > 1 {
+        current_dir.join(path)
+    } else {
+        let search_path = search_path.ok_or_else(|| format!("resolve {}: PATH is unavailable", path.display()))?;
+        env::split_paths(search_path)
+            .map(|directory| directory.join(path))
+            .find(|candidate| candidate.is_file())
+            .ok_or_else(|| format!("resolve {}: binary is no longer present on PATH", path.display()))?
+    };
+    let canonical = std::fs::canonicalize(&candidate).map_err(|error| format!("resolve host binary {}: {error}", candidate.display()))?;
+    if !canonical.is_file() {
+        return Err(format!("resolved host binary is not a file: {}", canonical.display()));
+    }
+    Ok(DaemonHostPath::new(canonical))
+}
+
+fn resolve_host_binary(path: &Path) -> Result<DaemonHostPath, String> {
+    let current_dir = env::current_dir().map_err(|error| format!("resolve current directory for {}: {error}", path.display()))?;
+    let search_path = env::var_os("PATH");
+    resolve_host_binary_from(path, &current_dir, search_path.as_deref())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn adjacent_flotilla_binary(daemon_binary: &Path) -> Result<DaemonHostPath, String> {
+    let parent = daemon_binary.parent().ok_or_else(|| format!("daemon binary has no parent directory: {}", daemon_binary.display()))?;
+    let flotilla_binary = parent.join("flotilla");
+    if !flotilla_binary.is_file() {
+        return Err(format!("flotilla binary not found next to daemon at {}", flotilla_binary.display()));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let permissions = std::fs::metadata(&flotilla_binary)
+            .map_err(|error| format!("inspect flotilla binary at {}: {error}", flotilla_binary.display()))?
+            .permissions();
+        if permissions.mode() & 0o111 == 0 {
+            return Err(format!("flotilla binary is not executable: {}", flotilla_binary.display()));
+        }
+    }
+    Ok(DaemonHostPath::new(flotilla_binary))
+}
+
+fn running_daemon_flotilla_binary() -> Result<DaemonHostPath, String> {
+    #[cfg(target_os = "linux")]
+    {
+        let daemon_binary = std::env::current_exe().map_err(|error| format!("resolve running daemon binary: {error}"))?;
+        adjacent_flotilla_binary(&daemon_binary)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err("daemon-adjacent flotilla injection requires a Linux host; generation-addressed environment binaries are not available yet"
+            .to_string())
+    }
+}
+
+async fn resolve_cleat_ghostty_library(runner: &dyn CommandRunner, cleat_binary_path: &DaemonHostPath) -> Result<DaemonHostPath, String> {
+    let binary = cleat_binary_path.as_path().to_string_lossy().into_owned();
+    let output = runner.run_output("ldd", &[&binary], Path::new("/"), &ChannelLabel::Noop).await?;
+    if !output.success {
+        return Err(format!("inspect cleat runtime libraries: {}", output.stderr.trim()));
+    }
+    let path = output.stdout.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        (fields.next() == Some(CLEAT_GHOSTTY_LIBRARY) && fields.next() == Some("=>"))
+            .then(|| fields.next())
+            .flatten()
+            .filter(|path| *path != "not")
+    });
+    let path = path.ok_or_else(|| format!("cleat runtime library {CLEAT_GHOSTTY_LIBRARY} was not resolved by ldd"))?;
+    let path = Path::new(path);
+    if !path.is_absolute() {
+        return Err(format!("cleat runtime library resolved to a non-absolute path: {}", path.display()));
+    }
+    Ok(DaemonHostPath::new(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    use flotilla_core::providers::discovery::test_support::DiscoveryMockRunner;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn resolves_detected_host_binary_names_through_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let binary = temp.path().join("cleat");
+        fs::write(&binary, b"test binary").expect("write binary");
+        let search_path = env::join_paths([temp.path()]).expect("search path");
+
+        let resolved =
+            resolve_host_binary_from(Path::new("cleat"), Path::new("/not-used"), Some(&search_path)).expect("resolve detected binary");
+
+        assert_eq!(resolved.as_path(), binary.canonicalize().expect("canonical binary"));
+    }
+
+    #[test]
+    fn resolves_flotilla_binary_adjacent_to_daemon() {
+        let temp = TempDir::new().expect("tempdir");
+        let daemon_binary = temp.path().join("flotillad");
+        let flotilla_binary = temp.path().join("flotilla");
+        fs::write(&daemon_binary, b"daemon").expect("write daemon");
+        fs::write(&flotilla_binary, b"cli").expect("write cli");
+        fs::set_permissions(&flotilla_binary, fs::Permissions::from_mode(0o755)).expect("make cli executable");
+
+        assert_eq!(adjacent_flotilla_binary(&daemon_binary).expect("adjacent flotilla binary"), DaemonHostPath::new(flotilla_binary),);
+    }
+
+    #[test]
+    fn rejects_non_executable_flotilla_binary_adjacent_to_daemon() {
+        let temp = TempDir::new().expect("tempdir");
+        let daemon_binary = temp.path().join("flotillad");
+        let flotilla_binary = temp.path().join("flotilla");
+        fs::write(&daemon_binary, "").expect("daemon binary");
+        fs::write(&flotilla_binary, "").expect("flotilla binary");
+
+        let error = adjacent_flotilla_binary(&daemon_binary).expect_err("non-executable flotilla binary should be rejected");
+
+        assert_eq!(error, format!("flotilla binary is not executable: {}", flotilla_binary.display()));
+    }
+
+    #[tokio::test]
+    async fn resolves_the_cleat_vt_library_from_the_host_asset_set() {
+        let runner = DiscoveryMockRunner::builder()
+            .on_run(
+                "ldd",
+                &["/opt/flotilla/bin/cleat"],
+                Ok("\tlibghostty-vt.so.0 => /opt/flotilla/lib/libghostty-vt.so.0 (0x00007f)\n".to_string()),
+            )
+            .build();
+
+        let library =
+            resolve_cleat_ghostty_library(&runner, &DaemonHostPath::new("/opt/flotilla/bin/cleat")).await.expect("resolve ghostty library");
+
+        assert_eq!(library, DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0"));
+    }
+}

--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -1,6 +1,7 @@
 mod agent_material;
 mod aggregator;
 mod credential;
+mod environment_tools;
 mod issue_materializer;
 mod material_pool;
 mod resource_limits;

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -45,7 +45,10 @@ use flotilla_resources::{
     MANAGED_BY_LABEL, REGISTERED_RESOURCE_KINDS,
 };
 use serde_json::json;
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::{
+    sync::{Mutex, OnceCell},
+    task::JoinHandle,
+};
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -622,7 +625,7 @@ struct ControllerRuntimeState {
     host_direct_environment_name: String,
     flotilla_binary_path: Result<DaemonHostPath, String>,
     cleat_binary_path: Result<DaemonHostPath, String>,
-    cleat_ghostty_library_path: Option<DaemonHostPath>,
+    cleat_ghostty_library_path: OnceCell<DaemonHostPath>,
     credential_store: Option<Arc<CredentialStore>>,
     agent_material: Option<Arc<AgentMaterialRegistry>>,
     provisioned_environments: Mutex<HashMap<String, ActiveProvisionedEnvironment>>,
@@ -672,7 +675,7 @@ impl ControllerRuntimeState {
             host_direct_environment_name,
             flotilla_binary_path: running_daemon_flotilla_binary(),
             cleat_binary_path,
-            cleat_ghostty_library_path: None,
+            cleat_ghostty_library_path: OnceCell::new(),
             credential_store: None,
             agent_material: None,
             provisioned_environments: Mutex::new(HashMap::new()),
@@ -704,7 +707,7 @@ impl ControllerRuntimeState {
 
     #[cfg(test)]
     fn with_cleat_ghostty_library_path(mut self, cleat_ghostty_library_path: DaemonHostPath) -> Self {
-        self.cleat_ghostty_library_path = Some(cleat_ghostty_library_path);
+        self.cleat_ghostty_library_path = OnceCell::new_with(Some(cleat_ghostty_library_path));
         self
     }
 }
@@ -740,6 +743,8 @@ fn build_local_profile(daemon: &Arc<InProcessDaemon>, local_registry: &ProviderR
 
     let host_direct_pool = local_registry.terminal_pools.preferred_name().unwrap_or("passthrough").to_string();
     let docker_pool = "cleat".to_string();
+    let docker_available =
+        local_registry.environment_providers.contains_key("docker") && local_registry.terminal_pools.contains_key(&docker_pool);
     let available_agent_adapters = local_registry.agent_adapters.ids().map(ToString::to_string).collect();
 
     Ok(LocalProvisioningProfile {
@@ -750,7 +755,7 @@ fn build_local_profile(daemon: &Arc<InProcessDaemon>, local_registry: &ProviderR
         docker_pool,
         available_pools,
         available_agent_adapters,
-        docker_available: local_registry.environment_providers.contains_key("docker"),
+        docker_available,
     })
 }
 
@@ -1833,44 +1838,48 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             CONTAINER_FLOTILLA_PATH,
             ProvisionedMountMode::Ro,
         ));
-        if let Ok(cleat_binary_path) = &self.state.cleat_binary_path {
-            let cleat_ghostty_library_path = match &self.state.cleat_ghostty_library_path {
-                Some(path) => path.clone(),
-                None => {
-                    let runner = self
-                        .state
-                        .daemon
-                        .local_command_runner()
-                        .ok_or_else(|| "local command runner unavailable for cleat asset discovery".to_string())?;
-                    resolve_cleat_ghostty_library(&*runner, cleat_binary_path)
-                        .await
-                        .map_err(|error| format!("cleat unavailable for docker environment provisioning: {error}"))?
-                }
-            };
-            let cleat_state = self.state.config.state_dir().join(format!("contained-cleat/{name}"));
-            tokio::fs::create_dir_all(cleat_state.as_path())
-                .await
-                .map_err(|error| format!("create durable cleat state directory {}: {error}", cleat_state.as_path().display()))?;
-            provisioned_mounts.push(ProvisionedMount::new(
-                cleat_binary_path.as_path().to_path_buf(),
-                CONTAINER_CLEAT_PATH,
-                ProvisionedMountMode::Ro,
-            ));
-            provisioned_mounts.push(ProvisionedMount::new(
-                cleat_ghostty_library_path.as_path().to_path_buf(),
-                CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH,
-                ProvisionedMountMode::Ro,
-            ));
-            provisioned_mounts.push(ProvisionedMount::new(
-                cleat_state.as_path().to_path_buf(),
-                CONTAINER_CLEAT_RUNTIME_DIR,
-                ProvisionedMountMode::Rw,
-            ));
-            environment_variables.push((CLEAT_RUNTIME_DIR_ENV.to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()));
-            match environment_variables.iter_mut().find(|(name, _)| name == "LD_LIBRARY_PATH") {
-                Some((_, value)) => *value = format!("{CONTAINER_CLEAT_LIBRARY_DIR}:{value}"),
-                None => environment_variables.push(("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string())),
-            }
+        let cleat_binary_path = self
+            .state
+            .cleat_binary_path
+            .as_ref()
+            .map_err(|error| format!("cleat unavailable for docker environment provisioning: {error}"))?;
+        let cleat_ghostty_library_path = self
+            .state
+            .cleat_ghostty_library_path
+            .get_or_try_init(|| async {
+                let runner = self
+                    .state
+                    .daemon
+                    .local_command_runner()
+                    .ok_or_else(|| "local command runner unavailable for cleat asset discovery".to_string())?;
+                resolve_cleat_ghostty_library(&*runner, cleat_binary_path)
+                    .await
+                    .map_err(|error| format!("cleat unavailable for docker environment provisioning: {error}"))
+            })
+            .await?;
+        let cleat_state = self.state.config.state_dir().join(format!("contained-cleat/{name}"));
+        tokio::fs::create_dir_all(cleat_state.as_path())
+            .await
+            .map_err(|error| format!("create durable cleat state directory {}: {error}", cleat_state.as_path().display()))?;
+        provisioned_mounts.push(ProvisionedMount::new(
+            cleat_binary_path.as_path().to_path_buf(),
+            CONTAINER_CLEAT_PATH,
+            ProvisionedMountMode::Ro,
+        ));
+        provisioned_mounts.push(ProvisionedMount::new(
+            cleat_ghostty_library_path.as_path().to_path_buf(),
+            CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH,
+            ProvisionedMountMode::Ro,
+        ));
+        provisioned_mounts.push(ProvisionedMount::new(
+            cleat_state.as_path().to_path_buf(),
+            CONTAINER_CLEAT_RUNTIME_DIR,
+            ProvisionedMountMode::Rw,
+        ));
+        environment_variables.push((CLEAT_RUNTIME_DIR_ENV.to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()));
+        match environment_variables.iter_mut().find(|(name, _)| name == "LD_LIBRARY_PATH") {
+            Some((_, value)) => *value = format!("{CONTAINER_CLEAT_LIBRARY_DIR}:{value}"),
+            None => environment_variables.push(("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string())),
         }
         provisioned_mounts.extend(spec.mounts.iter().map(flotilla_controllers::actuators::provisioned_mount));
         for delivery in &material_deliveries {
@@ -2963,6 +2972,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn local_profile_does_not_advertise_docker_without_interior_cleat() {
+        use flotilla_core::providers::discovery::{ProviderCategory, ProviderDescriptor};
+
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
+        let daemon = InProcessDaemon::new(Vec::new(), config, discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        let mut registry = ProviderRegistry::new();
+        registry.environment_providers.insert(
+            "docker",
+            ProviderDescriptor::named(ProviderCategory::EnvironmentProvider, "docker"),
+            Arc::new(CapturingFailingEnvironmentProvider { create_opts: Mutex::new(None) }),
+        );
+        registry.terminal_pools.insert(
+            "passthrough",
+            ProviderDescriptor::named(ProviderCategory::TerminalPool, "passthrough"),
+            Arc::new(flotilla_core::providers::terminal::passthrough::PassthroughTerminalPool),
+        );
+
+        let profile = build_local_profile(&daemon, &registry).expect("local profile");
+
+        assert_eq!(profile.docker_pool, "cleat");
+        assert!(!profile.docker_available, "a host must not advertise contained placement until it can deliver interior cleat");
+    }
+
+    #[tokio::test]
     async fn connected_peer_with_replicable_resources_and_zero_cursors_is_degraded() {
         let temp = TempDir::new().expect("tempdir");
         let config = Arc::new(ConfigStore::with_base(temp.path().join("feta")));
@@ -3447,6 +3482,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn docker_provisioning_fails_loudly_without_interior_cleat_assets() {
+        let temp = TempDir::new().expect("tempdir");
+        let config_base = temp.path().join("config");
+        fs::create_dir_all(&config_base).expect("config directory");
+        fs::write(config_base.join("daemon.toml"), "machine_id = \"missing-cleat-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_base));
+        let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
+        let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        let provider = Arc::new(CapturingFailingEnvironmentProvider { create_opts: Mutex::new(None) });
+        let mut local_registry = ProviderRegistry::new();
+        local_registry.environment_providers.insert(
+            "docker",
+            flotilla_core::providers::discovery::ProviderDescriptor::named(
+                flotilla_core::providers::discovery::ProviderCategory::EnvironmentProvider,
+                "docker",
+            ),
+            Arc::clone(&provider) as Arc<dyn EnvironmentProvider>,
+        );
+        let state = Arc::new(
+            ControllerRuntimeState::new(
+                daemon,
+                config,
+                Arc::new(local_registry),
+                Some(DaemonHostPath::new("/tmp/flotilla.sock")),
+                "host-test".to_string(),
+                None,
+                "host-direct-host-test".to_string(),
+            )
+            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla")),
+        );
+        let spec = flotilla_resources::DockerEnvironmentSpec {
+            host_ref: "host-test".to_string(),
+            image: "contained-image".to_string(),
+            declared_agent_adapters: BTreeSet::new(),
+            required_agent_adapters: BTreeSet::new(),
+            pull_policy: Default::default(),
+            mounts: Vec::new(),
+            env: BTreeMap::new(),
+        };
+
+        let error = DockerControllerRuntime { state }
+            .provision("contained-work", &spec)
+            .await
+            .expect_err("provisioning without cleat must fail before creating a container");
+
+        assert_eq!(
+            error.to_string(),
+            "cleat unavailable for docker environment provisioning: cleat binary unavailable for contained environment injection"
+        );
+        assert!(provider.create_opts.lock().await.is_none(), "the incomplete container must not be created");
+    }
+
+    #[tokio::test]
     async fn codex_adapter_delivers_leased_material_as_a_writable_codex_home() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -3497,6 +3585,8 @@ mod tests {
                 "host-direct-host-test".to_string(),
             )
             .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla"))
+            .with_cleat_binary_path(DaemonHostPath::new("/opt/flotilla/bin/cleat"))
+            .with_cleat_ghostty_library_path(DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0"))
             .with_credential_store(credential_store)
             .with_agent_material(agent_material),
         );
@@ -3518,7 +3608,11 @@ mod tests {
         assert_eq!(error.to_string(), "stop after capturing create options");
         let opts = provider.create_opts.lock().await.take().expect("captured create options");
         assert!(opts.provisioned_mounts.contains(&ProvisionedMount::new(slot, CONTAINER_CODEX_HOME, ProvisionedMountMode::Rw,)));
-        assert_eq!(opts.tokens, vec![("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string())]);
+        assert_eq!(opts.tokens, vec![
+            ("CLEAT_RUNTIME_DIR".to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()),
+            ("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string()),
+            ("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string()),
+        ]);
 
         let mut preconfigured = spec;
         preconfigured.env.insert("CODEX_HOME".to_string(), "/image/codex".to_string());
@@ -3527,7 +3621,11 @@ mod tests {
             .await
             .expect_err("capture provider should stop provision");
         let opts = provider.create_opts.lock().await.take().expect("captured preconfigured create options");
-        assert_eq!(opts.tokens, vec![("CODEX_HOME".to_string(), "/image/codex".to_string())]);
+        assert_eq!(opts.tokens, vec![
+            ("CODEX_HOME".to_string(), "/image/codex".to_string()),
+            ("CLEAT_RUNTIME_DIR".to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()),
+            ("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string()),
+        ]);
         assert!(
             opts.provisioned_mounts.iter().all(|mount| mount.environment_path.as_path() != Path::new(CONTAINER_CODEX_HOME)),
             "a placement-provided CODEX_HOME must not be overwritten with a leased slot"
@@ -4480,7 +4578,9 @@ mod tests {
                 None,
                 feta_profile.host_direct_environment_name(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/usr/local/bin/flotilla")),
+            .with_flotilla_binary_path(DaemonHostPath::new("/usr/local/bin/flotilla"))
+            .with_cleat_binary_path(DaemonHostPath::new("/usr/local/bin/cleat"))
+            .with_cleat_ghostty_library_path(DaemonHostPath::new("/usr/local/lib/libghostty-vt.so.0")),
         );
         let mut controller_handles = spawn_controller_loops(
             kiwi_state,
@@ -4807,7 +4907,9 @@ mod tests {
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/usr/local/bin/flotilla")),
+            .with_flotilla_binary_path(DaemonHostPath::new("/usr/local/bin/flotilla"))
+            .with_cleat_binary_path(DaemonHostPath::new("/usr/local/bin/cleat"))
+            .with_cleat_ghostty_library_path(DaemonHostPath::new("/usr/local/lib/libghostty-vt.so.0")),
         );
         let spec = flotilla_resources::DockerEnvironmentSpec {
             host_ref: "host-test".to_string(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    env,
     future::Future,
     path::{Path, PathBuf},
     sync::{Arc, Mutex as StdMutex, Weak},
@@ -26,7 +25,7 @@ use flotilla_core::{
     placement_policy::reconcile_registered_policy,
     providers::{
         discovery::{run_provisioned_host_detectors, EnvironmentBag},
-        environment::{CreateOpts, EnvironmentHandle, ProvisionedMount, ProvisionedMountMode},
+        environment::{CreateOpts, EnvironmentHandle, EnvironmentVariableUpdate},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
         vcs::{CloneInspection, CloneProvisioner, GitCloneProvisioner},
@@ -45,15 +44,13 @@ use flotilla_resources::{
     MANAGED_BY_LABEL, REGISTERED_RESOURCE_KINDS,
 };
 use serde_json::json;
-use tokio::{
-    sync::{Mutex, OnceCell},
-    task::JoinHandle,
-};
+use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{debug, error, info, warn};
 
 use crate::{
     agent_material::{AgentMaterialPrepareError, AgentMaterialRegistry},
     credential::CredentialStore,
+    environment_tools::EnvironmentToolProvisioner,
     resource_limits::file_descriptor_pressure_condition,
     resource_manifest::ResourceManifestReconciler,
     sleep_inhibitor,
@@ -69,72 +66,6 @@ const MANIFEST_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 const BUILTIN_MANAGED_BY_VALUE: &str = "builtin";
-const CONTAINER_FLOTILLA_PATH: &str = "/usr/local/bin/flotilla";
-const CONTAINER_CLEAT_PATH: &str = "/usr/local/bin/cleat";
-const CONTAINER_CLEAT_LIBRARY_DIR: &str = "/usr/local/lib/flotilla";
-const CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH: &str = "/usr/local/lib/flotilla/libghostty-vt.so.0";
-const CONTAINER_CLEAT_RUNTIME_DIR: &str = "/var/lib/flotilla/cleat";
-const CLEAT_RUNTIME_DIR_ENV: &str = "CLEAT_RUNTIME_DIR";
-const CLEAT_GHOSTTY_LIBRARY: &str = "libghostty-vt.so.0";
-
-fn resolve_host_binary_from(path: &Path, current_dir: &Path, search_path: Option<&std::ffi::OsStr>) -> Result<DaemonHostPath, String> {
-    let candidate = if path.is_absolute() {
-        path.to_path_buf()
-    } else if path.components().count() > 1 {
-        current_dir.join(path)
-    } else {
-        let search_path = search_path.ok_or_else(|| format!("resolve {}: PATH is unavailable", path.display()))?;
-        env::split_paths(search_path)
-            .map(|directory| directory.join(path))
-            .find(|candidate| candidate.is_file())
-            .ok_or_else(|| format!("resolve {}: binary is no longer present on PATH", path.display()))?
-    };
-    let canonical = std::fs::canonicalize(&candidate).map_err(|error| format!("resolve host binary {}: {error}", candidate.display()))?;
-    if !canonical.is_file() {
-        return Err(format!("resolved host binary is not a file: {}", canonical.display()));
-    }
-    Ok(DaemonHostPath::new(canonical))
-}
-
-fn resolve_host_binary(path: &Path) -> Result<DaemonHostPath, String> {
-    let current_dir = env::current_dir().map_err(|error| format!("resolve current directory for {}: {error}", path.display()))?;
-    let search_path = env::var_os("PATH");
-    resolve_host_binary_from(path, &current_dir, search_path.as_deref())
-}
-
-#[cfg(any(target_os = "linux", test))]
-fn adjacent_flotilla_binary(daemon_binary: &Path) -> Result<DaemonHostPath, String> {
-    let parent = daemon_binary.parent().ok_or_else(|| format!("daemon binary has no parent directory: {}", daemon_binary.display()))?;
-    let flotilla_binary = parent.join("flotilla");
-    if !flotilla_binary.is_file() {
-        return Err(format!("flotilla binary not found next to daemon at {}", flotilla_binary.display()));
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-
-        let permissions = std::fs::metadata(&flotilla_binary)
-            .map_err(|error| format!("inspect flotilla binary at {}: {error}", flotilla_binary.display()))?
-            .permissions();
-        if permissions.mode() & 0o111 == 0 {
-            return Err(format!("flotilla binary is not executable: {}", flotilla_binary.display()));
-        }
-    }
-    Ok(DaemonHostPath::new(flotilla_binary))
-}
-
-fn running_daemon_flotilla_binary() -> Result<DaemonHostPath, String> {
-    #[cfg(target_os = "linux")]
-    {
-        let daemon_binary = std::env::current_exe().map_err(|error| format!("resolve running daemon binary: {error}"))?;
-        adjacent_flotilla_binary(&daemon_binary)
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        Err("daemon-adjacent flotilla injection requires a Linux host; generation-addressed container binaries are not available yet"
-            .to_string())
-    }
-}
 
 struct DaemonConvoyTeardownRuntime {
     daemon: Arc<InProcessDaemon>,
@@ -619,13 +550,10 @@ struct ControllerRuntimeState {
     daemon: Arc<InProcessDaemon>,
     config: Arc<ConfigStore>,
     local_registry: Arc<ProviderRegistry>,
-    daemon_socket_path: Option<DaemonHostPath>,
     local_host_ref: String,
     local_repo_root: Option<ExecutionEnvironmentPath>,
     host_direct_environment_name: String,
-    flotilla_binary_path: Result<DaemonHostPath, String>,
-    cleat_binary_path: Result<DaemonHostPath, String>,
-    cleat_ghostty_library_path: OnceCell<DaemonHostPath>,
+    environment_tools: EnvironmentToolProvisioner,
     credential_store: Option<Arc<CredentialStore>>,
     agent_material: Option<Arc<AgentMaterialRegistry>>,
     provisioned_environments: Mutex<HashMap<String, ActiveProvisionedEnvironment>>,
@@ -659,23 +587,15 @@ impl ControllerRuntimeState {
         local_repo_root: Option<ExecutionEnvironmentPath>,
         host_direct_environment_name: String,
     ) -> Self {
-        let cleat_binary_path = daemon
-            .local_environment_bag()
-            .and_then(|bag| bag.find_binary("cleat").cloned())
-            .map(|path| resolve_host_binary(path.as_path()))
-            .transpose()
-            .and_then(|path| path.ok_or_else(|| "cleat binary unavailable for contained environment injection".to_string()));
+        let environment_tools = EnvironmentToolProvisioner::for_local_host(&daemon, &config, daemon_socket_path.clone());
         Self {
             daemon,
             config,
             local_registry,
-            daemon_socket_path,
             local_host_ref,
             local_repo_root,
             host_direct_environment_name,
-            flotilla_binary_path: running_daemon_flotilla_binary(),
-            cleat_binary_path,
-            cleat_ghostty_library_path: OnceCell::new(),
+            environment_tools,
             credential_store: None,
             agent_material: None,
             provisioned_environments: Mutex::new(HashMap::new()),
@@ -694,20 +614,8 @@ impl ControllerRuntimeState {
     }
 
     #[cfg(test)]
-    fn with_flotilla_binary_path(mut self, flotilla_binary_path: DaemonHostPath) -> Self {
-        self.flotilla_binary_path = Ok(flotilla_binary_path);
-        self
-    }
-
-    #[cfg(test)]
-    fn with_cleat_binary_path(mut self, cleat_binary_path: DaemonHostPath) -> Self {
-        self.cleat_binary_path = Ok(cleat_binary_path);
-        self
-    }
-
-    #[cfg(test)]
-    fn with_cleat_ghostty_library_path(mut self, cleat_ghostty_library_path: DaemonHostPath) -> Self {
-        self.cleat_ghostty_library_path = OnceCell::new_with(Some(cleat_ghostty_library_path));
+    fn with_environment_tools(mut self, environment_tools: EnvironmentToolProvisioner) -> Self {
+        self.environment_tools = environment_tools;
         self
     }
 }
@@ -1699,27 +1607,6 @@ struct DockerControllerRuntime {
     state: Arc<ControllerRuntimeState>,
 }
 
-async fn resolve_cleat_ghostty_library(runner: &dyn CommandRunner, cleat_binary_path: &DaemonHostPath) -> Result<DaemonHostPath, String> {
-    let binary = cleat_binary_path.as_path().to_string_lossy().into_owned();
-    let output = runner.run_output("ldd", &[&binary], Path::new("/"), &ChannelLabel::Noop).await?;
-    if !output.success {
-        return Err(format!("inspect cleat runtime libraries: {}", output.stderr.trim()));
-    }
-    let path = output.stdout.lines().find_map(|line| {
-        let mut fields = line.split_whitespace();
-        (fields.next() == Some(CLEAT_GHOSTTY_LIBRARY) && fields.next() == Some("=>"))
-            .then(|| fields.next())
-            .flatten()
-            .filter(|path| *path != "not")
-    });
-    let path = path.ok_or_else(|| format!("cleat runtime library {CLEAT_GHOSTTY_LIBRARY} was not resolved by ldd"))?;
-    let path = Path::new(path);
-    if !path.is_absolute() {
-        return Err(format!("cleat runtime library resolved to a non-absolute path: {}", path.display()));
-    }
-    Ok(DaemonHostPath::new(path))
-}
-
 #[async_trait]
 impl DockerEnvironmentRuntime for DockerControllerRuntime {
     async fn provision(
@@ -1727,32 +1614,25 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
         name: &str,
         spec: &flotilla_resources::DockerEnvironmentSpec,
     ) -> Result<DockerProvisioning, DockerProvisioningError> {
-        for (path, purpose) in [
-            (CONTAINER_FLOTILLA_PATH, "the flotilla CLI"),
-            (CONTAINER_CLEAT_PATH, "the cleat CLI"),
-            (CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH, "the cleat VT library"),
-            (CONTAINER_CLEAT_RUNTIME_DIR, "durable cleat state"),
-        ] {
-            if spec.mounts.iter().any(|mount| Path::new(&mount.target_path) == Path::new(path)) {
-                return Err(DockerProvisioningError::Failed(format!("mount target {path} is reserved for {purpose}")));
+        let tools = self.state.environment_tools.prepare(name).await?;
+        for tool in &tools {
+            for asset in &tool.assets {
+                if spec.mounts.iter().any(|mount| Path::new(&mount.target_path) == asset.environment_path.as_path()) {
+                    return Err(DockerProvisioningError::Failed(format!(
+                        "mount target {} is reserved for {}",
+                        asset.environment_path, asset.purpose
+                    )));
+                }
+            }
+            for update in &tool.environment {
+                if let EnvironmentVariableUpdate::Set { name, purpose, .. } = update {
+                    if spec.env.contains_key(name) {
+                        return Err(DockerProvisioningError::Failed(format!("environment variable {name} is reserved for {purpose}")));
+                    }
+                }
             }
         }
-        if spec.env.contains_key(CLEAT_RUNTIME_DIR_ENV) {
-            return Err(DockerProvisioningError::Failed(format!(
-                "environment variable {CLEAT_RUNTIME_DIR_ENV} is reserved for durable cleat state"
-            )));
-        }
         let credential_refs = credential_refs_from_environment(spec)?;
-        let daemon_socket_path = self
-            .state
-            .daemon_socket_path
-            .clone()
-            .ok_or_else(|| "daemon socket path unavailable for docker environment provisioning".to_string())?;
-        let flotilla_binary_path = self
-            .state
-            .flotilla_binary_path
-            .clone()
-            .map_err(|error| format!("flotilla CLI unavailable for docker environment provisioning: {error}"))?;
         let (_, provider) = self
             .state
             .local_registry
@@ -1832,55 +1712,7 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             None if credential_refs.is_empty() => None,
             None => return Err("host-local credential store unavailable".to_string().into()),
         };
-        let mut provisioned_mounts = Vec::with_capacity(spec.mounts.len() + 4);
-        provisioned_mounts.push(ProvisionedMount::new(
-            flotilla_binary_path.as_path().to_path_buf(),
-            CONTAINER_FLOTILLA_PATH,
-            ProvisionedMountMode::Ro,
-        ));
-        let cleat_binary_path = self
-            .state
-            .cleat_binary_path
-            .as_ref()
-            .map_err(|error| format!("cleat unavailable for docker environment provisioning: {error}"))?;
-        let cleat_ghostty_library_path = self
-            .state
-            .cleat_ghostty_library_path
-            .get_or_try_init(|| async {
-                let runner = self
-                    .state
-                    .daemon
-                    .local_command_runner()
-                    .ok_or_else(|| "local command runner unavailable for cleat asset discovery".to_string())?;
-                resolve_cleat_ghostty_library(&*runner, cleat_binary_path)
-                    .await
-                    .map_err(|error| format!("cleat unavailable for docker environment provisioning: {error}"))
-            })
-            .await?;
-        let cleat_state = self.state.config.state_dir().join(format!("contained-cleat/{name}"));
-        tokio::fs::create_dir_all(cleat_state.as_path())
-            .await
-            .map_err(|error| format!("create durable cleat state directory {}: {error}", cleat_state.as_path().display()))?;
-        provisioned_mounts.push(ProvisionedMount::new(
-            cleat_binary_path.as_path().to_path_buf(),
-            CONTAINER_CLEAT_PATH,
-            ProvisionedMountMode::Ro,
-        ));
-        provisioned_mounts.push(ProvisionedMount::new(
-            cleat_ghostty_library_path.as_path().to_path_buf(),
-            CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH,
-            ProvisionedMountMode::Ro,
-        ));
-        provisioned_mounts.push(ProvisionedMount::new(
-            cleat_state.as_path().to_path_buf(),
-            CONTAINER_CLEAT_RUNTIME_DIR,
-            ProvisionedMountMode::Rw,
-        ));
-        environment_variables.push((CLEAT_RUNTIME_DIR_ENV.to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()));
-        match environment_variables.iter_mut().find(|(name, _)| name == "LD_LIBRARY_PATH") {
-            Some((_, value)) => *value = format!("{CONTAINER_CLEAT_LIBRARY_DIR}:{value}"),
-            None => environment_variables.push(("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string())),
-        }
+        let mut provisioned_mounts = Vec::with_capacity(spec.mounts.len() + material_deliveries.len());
         provisioned_mounts.extend(spec.mounts.iter().map(flotilla_controllers::actuators::provisioned_mount));
         for delivery in &material_deliveries {
             provisioned_mounts.push(delivery.mount.clone());
@@ -1889,10 +1721,10 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
         let handle = match provider
             .create(env_id.clone(), &image, CreateOpts {
                 tokens: environment_variables,
-                daemon_socket_path,
                 working_directory: None,
                 image_pull_policy: spec.pull_policy.into(),
                 provisioned_mounts,
+                tools,
                 docker_config_dir,
             })
             .await
@@ -2917,58 +2749,21 @@ mod tests {
     use super::{test_git_repo::TestGitRepo, *};
     use crate::{
         agent_material::CONTAINER_CODEX_HOME,
+        environment_tools::{
+            ENVIRONMENT_CLEAT_GHOSTTY_LIBRARY_PATH, ENVIRONMENT_CLEAT_LIBRARY_DIR, ENVIRONMENT_CLEAT_PATH, ENVIRONMENT_CLEAT_RUNTIME_DIR,
+            ENVIRONMENT_DAEMON_SOCKET_PATH, ENVIRONMENT_FLOTILLA_PATH,
+        },
         material_pool::{MaterialLeaseOutcome, MaterialPoolManager},
     };
 
-    #[test]
-    fn resolves_flotilla_binary_adjacent_to_daemon() {
-        let temp = TempDir::new().expect("tempdir");
-        let bin_dir = temp.path().join("bin");
-        fs::create_dir(&bin_dir).expect("bin directory");
-        let daemon_binary = bin_dir.join("flotillad");
-        let flotilla_binary = bin_dir.join("flotilla");
-        fs::write(&daemon_binary, "").expect("daemon binary");
-        fs::write(&flotilla_binary, "").expect("flotilla binary");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-
-            let mut permissions = fs::metadata(&flotilla_binary).expect("flotilla metadata").permissions();
-            permissions.set_mode(0o755);
-            fs::set_permissions(&flotilla_binary, permissions).expect("executable flotilla binary");
-        }
-
-        assert_eq!(adjacent_flotilla_binary(&daemon_binary).expect("adjacent flotilla binary"), DaemonHostPath::new(flotilla_binary),);
-    }
-
-    #[test]
-    fn resolves_detected_host_binary_names_through_path() {
-        let temp = TempDir::new().expect("tempdir");
-        let binary = temp.path().join("cleat");
-        fs::write(&binary, b"test binary").expect("write binary");
-        let search_path = env::join_paths([temp.path()]).expect("search path");
-
-        let resolved =
-            resolve_host_binary_from(Path::new("cleat"), Path::new("/not-used"), Some(&search_path)).expect("resolve detected binary");
-
-        assert_eq!(resolved.as_path(), binary.canonicalize().expect("canonical binary"));
-    }
-
-    #[tokio::test]
-    async fn resolves_the_cleat_vt_library_from_the_host_asset_set() {
-        let runner = DiscoveryMockRunner::builder()
-            .on_run(
-                "ldd",
-                &["/opt/flotilla/bin/cleat"],
-                Ok("\tlibghostty-vt.so.0 => /opt/flotilla/lib/libghostty-vt.so.0 (0x00007f)\n".to_string()),
-            )
-            .build();
-
-        let library = resolve_cleat_ghostty_library(&runner, &DaemonHostPath::new("/opt/flotilla/bin/cleat"))
-            .await
-            .expect("resolve cleat VT library");
-
-        assert_eq!(library, DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0"));
+    fn fixed_environment_tools(state_root: impl Into<PathBuf>) -> EnvironmentToolProvisioner {
+        EnvironmentToolProvisioner::fixed(
+            DaemonHostPath::new("/opt/flotilla/bin/flotilla"),
+            DaemonHostPath::new("/tmp/flotilla.sock"),
+            DaemonHostPath::new("/opt/flotilla/bin/cleat"),
+            DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0"),
+            state_root.into(),
+        )
     }
 
     #[tokio::test]
@@ -3062,20 +2857,6 @@ mod tests {
             "fleet diagnosis must clear after bootstrap: {:?}",
             feta_row.degraded_conditions
         );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn rejects_non_executable_flotilla_binary_adjacent_to_daemon() {
-        let temp = TempDir::new().expect("tempdir");
-        let daemon_binary = temp.path().join("flotillad");
-        let flotilla_binary = temp.path().join("flotilla");
-        fs::write(&daemon_binary, "").expect("daemon binary");
-        fs::write(&flotilla_binary, "").expect("flotilla binary");
-
-        let error = adjacent_flotilla_binary(&daemon_binary).expect_err("non-executable flotilla binary should be rejected");
-
-        assert_eq!(error, format!("flotilla binary is not executable: {}", flotilla_binary.display()));
     }
 
     #[derive(Clone, Copy)]
@@ -3436,16 +3217,14 @@ mod tests {
         let state = Arc::new(
             ControllerRuntimeState::new(
                 daemon,
-                config,
+                Arc::clone(&config),
                 Arc::new(local_registry),
                 Some(DaemonHostPath::new("/tmp/flotilla.sock")),
                 "host-test".to_string(),
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla"))
-            .with_cleat_binary_path(DaemonHostPath::new("/opt/flotilla/bin/cleat"))
-            .with_cleat_ghostty_library_path(DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0")),
+            .with_environment_tools(fixed_environment_tools(config.state_dir().join("contained-cleat").as_path().to_path_buf())),
         );
         let spec = flotilla_resources::DockerEnvironmentSpec {
             host_ref: "host-test".to_string(),
@@ -3464,21 +3243,17 @@ mod tests {
 
         assert_eq!(error.to_string(), "stop after capturing create options");
         let opts = provider.create_opts.lock().await.take().expect("captured create options");
-        assert_eq!(opts.provisioned_mounts, vec![
-            ProvisionedMount::new("/opt/flotilla/bin/flotilla", CONTAINER_FLOTILLA_PATH, ProvisionedMountMode::Ro,),
-            ProvisionedMount::new("/opt/flotilla/bin/cleat", CONTAINER_CLEAT_PATH, ProvisionedMountMode::Ro),
-            ProvisionedMount::new("/opt/flotilla/lib/libghostty-vt.so.0", CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH, ProvisionedMountMode::Ro,),
-            ProvisionedMount::new(cleat_state.as_path().to_path_buf(), CONTAINER_CLEAT_RUNTIME_DIR, ProvisionedMountMode::Rw,),
-        ],);
-        assert_eq!(
-            opts.tokens,
-            vec![
-                ("CLEAT_RUNTIME_DIR".to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()),
-                ("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string()),
-            ],
-            "launch and attach must resolve the same interior cleat state root"
-        );
-        assert!(cleat_state.as_path().is_dir(), "the durable recording directory must exist before Docker bind-mounts it");
+        assert!(opts.provisioned_mounts.is_empty(), "tool assets remain provider-neutral until the environment provider delivers them");
+        assert!(opts.tokens.is_empty(), "tool environment belongs to the tool description");
+        assert_eq!(opts.tools.iter().map(|tool| tool.name.as_str()).collect::<Vec<_>>(), vec!["flotilla", "cleat"]);
+        assert_eq!(opts.tools[0].executable.as_path(), Path::new(ENVIRONMENT_FLOTILLA_PATH));
+        assert_eq!(opts.tools[0].assets[1].environment_path.as_path(), Path::new(ENVIRONMENT_DAEMON_SOCKET_PATH));
+        assert_eq!(opts.tools[1].executable.as_path(), Path::new(ENVIRONMENT_CLEAT_PATH));
+        assert_eq!(opts.tools[1].assets[1].environment_path.as_path(), Path::new(ENVIRONMENT_CLEAT_GHOSTTY_LIBRARY_PATH));
+        assert_eq!(opts.tools[1].assets[2].host_path.as_path(), cleat_state.as_path());
+        assert_eq!(opts.tools[1].assets[2].environment_path.as_path(), Path::new(ENVIRONMENT_CLEAT_RUNTIME_DIR));
+        assert_eq!(opts.tools[1].environment[1], EnvironmentVariableUpdate::prepend_path("LD_LIBRARY_PATH", ENVIRONMENT_CLEAT_LIBRARY_DIR),);
+        assert!(cleat_state.as_path().is_dir(), "durable tool state must exist before the provider delivers it");
     }
 
     #[tokio::test]
@@ -3503,14 +3278,18 @@ mod tests {
         let state = Arc::new(
             ControllerRuntimeState::new(
                 daemon,
-                config,
+                Arc::clone(&config),
                 Arc::new(local_registry),
                 Some(DaemonHostPath::new("/tmp/flotilla.sock")),
                 "host-test".to_string(),
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla")),
+            .with_environment_tools(EnvironmentToolProvisioner::with_unavailable_cleat(
+                DaemonHostPath::new("/opt/flotilla/bin/flotilla"),
+                DaemonHostPath::new("/tmp/flotilla.sock"),
+                "binary unavailable for contained environment delivery",
+            )),
         );
         let spec = flotilla_resources::DockerEnvironmentSpec {
             host_ref: "host-test".to_string(),
@@ -3529,7 +3308,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "cleat unavailable for docker environment provisioning: cleat binary unavailable for contained environment injection"
+            "cleat unavailable for environment provisioning: binary unavailable for contained environment delivery"
         );
         assert!(provider.create_opts.lock().await.is_none(), "the incomplete container must not be created");
     }
@@ -3577,16 +3356,14 @@ mod tests {
         let state = Arc::new(
             ControllerRuntimeState::new(
                 daemon,
-                config,
+                Arc::clone(&config),
                 Arc::new(local_registry),
                 Some(DaemonHostPath::new("/tmp/flotilla.sock")),
                 "host-test".to_string(),
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla"))
-            .with_cleat_binary_path(DaemonHostPath::new("/opt/flotilla/bin/cleat"))
-            .with_cleat_ghostty_library_path(DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0"))
+            .with_environment_tools(fixed_environment_tools(config.state_dir().join("contained-cleat").as_path().to_path_buf()))
             .with_credential_store(credential_store)
             .with_agent_material(agent_material),
         );
@@ -3608,11 +3385,7 @@ mod tests {
         assert_eq!(error.to_string(), "stop after capturing create options");
         let opts = provider.create_opts.lock().await.take().expect("captured create options");
         assert!(opts.provisioned_mounts.contains(&ProvisionedMount::new(slot, CONTAINER_CODEX_HOME, ProvisionedMountMode::Rw,)));
-        assert_eq!(opts.tokens, vec![
-            ("CLEAT_RUNTIME_DIR".to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()),
-            ("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string()),
-            ("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string()),
-        ]);
+        assert_eq!(opts.tokens, vec![("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string())]);
 
         let mut preconfigured = spec;
         preconfigured.env.insert("CODEX_HOME".to_string(), "/image/codex".to_string());
@@ -3621,11 +3394,7 @@ mod tests {
             .await
             .expect_err("capture provider should stop provision");
         let opts = provider.create_opts.lock().await.take().expect("captured preconfigured create options");
-        assert_eq!(opts.tokens, vec![
-            ("CODEX_HOME".to_string(), "/image/codex".to_string()),
-            ("CLEAT_RUNTIME_DIR".to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()),
-            ("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string()),
-        ]);
+        assert_eq!(opts.tokens, vec![("CODEX_HOME".to_string(), "/image/codex".to_string())]);
         assert!(
             opts.provisioned_mounts.iter().all(|mount| mount.environment_path.as_path() != Path::new(CONTAINER_CODEX_HOME)),
             "a placement-provided CODEX_HOME must not be overwritten with a leased slot"
@@ -3698,7 +3467,7 @@ mod tests {
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla"))
+            .with_environment_tools(fixed_environment_tools(config.state_dir().join("contained-cleat").as_path().to_path_buf()))
             .with_credential_store(credential_store)
             .with_agent_material(agent_material),
         );
@@ -3803,7 +3572,7 @@ mod tests {
             DockerControllerRuntime { state }.provision("contained-work", &spec).await.expect_err("missing CLI should fail provision");
 
         assert!(
-            error.to_string().starts_with("flotilla CLI unavailable for docker environment provisioning: "),
+            error.to_string().starts_with("flotilla CLI unavailable for environment provisioning: "),
             "unavailable CLI resolution should retain its clear provisioning context: {error}",
         );
     }
@@ -3830,14 +3599,14 @@ mod tests {
         let state = Arc::new(
             ControllerRuntimeState::new(
                 daemon,
-                config,
+                Arc::clone(&config),
                 Arc::new(local_registry),
                 Some(DaemonHostPath::new("/tmp/flotilla.sock")),
                 "host-test".to_string(),
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla")),
+            .with_environment_tools(fixed_environment_tools(config.state_dir().join("contained-cleat").as_path().to_path_buf())),
         );
         let spec = flotilla_resources::DockerEnvironmentSpec {
             host_ref: "host-test".to_string(),
@@ -4578,9 +4347,7 @@ mod tests {
                 None,
                 feta_profile.host_direct_environment_name(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/usr/local/bin/flotilla"))
-            .with_cleat_binary_path(DaemonHostPath::new("/usr/local/bin/cleat"))
-            .with_cleat_ghostty_library_path(DaemonHostPath::new("/usr/local/lib/libghostty-vt.so.0")),
+            .with_environment_tools(fixed_environment_tools(temp.path().join("contained-cleat"))),
         );
         let mut controller_handles = spawn_controller_loops(
             kiwi_state,
@@ -4900,16 +4667,14 @@ mod tests {
         let state = Arc::new(
             ControllerRuntimeState::new(
                 daemon,
-                config,
+                Arc::clone(&config),
                 Arc::new(local_registry),
                 Some(DaemonHostPath::new("/tmp/flotilla.sock")),
                 "host-test".to_string(),
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/usr/local/bin/flotilla"))
-            .with_cleat_binary_path(DaemonHostPath::new("/usr/local/bin/cleat"))
-            .with_cleat_ghostty_library_path(DaemonHostPath::new("/usr/local/lib/libghostty-vt.so.0")),
+            .with_environment_tools(fixed_environment_tools(config.state_dir().join("contained-cleat").as_path().to_path_buf())),
         );
         let spec = flotilla_resources::DockerEnvironmentSpec {
             host_ref: "host-test".to_string(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    env,
     future::Future,
     path::{Path, PathBuf},
     sync::{Arc, Mutex as StdMutex, Weak},
@@ -66,6 +67,37 @@ const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 const BUILTIN_MANAGED_BY_VALUE: &str = "builtin";
 const CONTAINER_FLOTILLA_PATH: &str = "/usr/local/bin/flotilla";
+const CONTAINER_CLEAT_PATH: &str = "/usr/local/bin/cleat";
+const CONTAINER_CLEAT_LIBRARY_DIR: &str = "/usr/local/lib/flotilla";
+const CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH: &str = "/usr/local/lib/flotilla/libghostty-vt.so.0";
+const CONTAINER_CLEAT_RUNTIME_DIR: &str = "/var/lib/flotilla/cleat";
+const CLEAT_RUNTIME_DIR_ENV: &str = "CLEAT_RUNTIME_DIR";
+const CLEAT_GHOSTTY_LIBRARY: &str = "libghostty-vt.so.0";
+
+fn resolve_host_binary_from(path: &Path, current_dir: &Path, search_path: Option<&std::ffi::OsStr>) -> Result<DaemonHostPath, String> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else if path.components().count() > 1 {
+        current_dir.join(path)
+    } else {
+        let search_path = search_path.ok_or_else(|| format!("resolve {}: PATH is unavailable", path.display()))?;
+        env::split_paths(search_path)
+            .map(|directory| directory.join(path))
+            .find(|candidate| candidate.is_file())
+            .ok_or_else(|| format!("resolve {}: binary is no longer present on PATH", path.display()))?
+    };
+    let canonical = std::fs::canonicalize(&candidate).map_err(|error| format!("resolve host binary {}: {error}", candidate.display()))?;
+    if !canonical.is_file() {
+        return Err(format!("resolved host binary is not a file: {}", canonical.display()));
+    }
+    Ok(DaemonHostPath::new(canonical))
+}
+
+fn resolve_host_binary(path: &Path) -> Result<DaemonHostPath, String> {
+    let current_dir = env::current_dir().map_err(|error| format!("resolve current directory for {}: {error}", path.display()))?;
+    let search_path = env::var_os("PATH");
+    resolve_host_binary_from(path, &current_dir, search_path.as_deref())
+}
 
 #[cfg(any(target_os = "linux", test))]
 fn adjacent_flotilla_binary(daemon_binary: &Path) -> Result<DaemonHostPath, String> {
@@ -589,6 +621,8 @@ struct ControllerRuntimeState {
     local_repo_root: Option<ExecutionEnvironmentPath>,
     host_direct_environment_name: String,
     flotilla_binary_path: Result<DaemonHostPath, String>,
+    cleat_binary_path: Result<DaemonHostPath, String>,
+    cleat_ghostty_library_path: Option<DaemonHostPath>,
     credential_store: Option<Arc<CredentialStore>>,
     agent_material: Option<Arc<AgentMaterialRegistry>>,
     provisioned_environments: Mutex<HashMap<String, ActiveProvisionedEnvironment>>,
@@ -622,6 +656,12 @@ impl ControllerRuntimeState {
         local_repo_root: Option<ExecutionEnvironmentPath>,
         host_direct_environment_name: String,
     ) -> Self {
+        let cleat_binary_path = daemon
+            .local_environment_bag()
+            .and_then(|bag| bag.find_binary("cleat").cloned())
+            .map(|path| resolve_host_binary(path.as_path()))
+            .transpose()
+            .and_then(|path| path.ok_or_else(|| "cleat binary unavailable for contained environment injection".to_string()));
         Self {
             daemon,
             config,
@@ -631,6 +671,8 @@ impl ControllerRuntimeState {
             local_repo_root,
             host_direct_environment_name,
             flotilla_binary_path: running_daemon_flotilla_binary(),
+            cleat_binary_path,
+            cleat_ghostty_library_path: None,
             credential_store: None,
             agent_material: None,
             provisioned_environments: Mutex::new(HashMap::new()),
@@ -651,6 +693,18 @@ impl ControllerRuntimeState {
     #[cfg(test)]
     fn with_flotilla_binary_path(mut self, flotilla_binary_path: DaemonHostPath) -> Self {
         self.flotilla_binary_path = Ok(flotilla_binary_path);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_cleat_binary_path(mut self, cleat_binary_path: DaemonHostPath) -> Self {
+        self.cleat_binary_path = Ok(cleat_binary_path);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_cleat_ghostty_library_path(mut self, cleat_ghostty_library_path: DaemonHostPath) -> Self {
+        self.cleat_ghostty_library_path = Some(cleat_ghostty_library_path);
         self
     }
 }
@@ -685,8 +739,7 @@ fn build_local_profile(daemon: &Arc<InProcessDaemon>, local_registry: &ProviderR
     available_pools.dedup();
 
     let host_direct_pool = local_registry.terminal_pools.preferred_name().unwrap_or("passthrough").to_string();
-    let docker_pool =
-        if local_registry.terminal_pools.contains_key("passthrough") { "passthrough".to_string() } else { host_direct_pool.clone() };
+    let docker_pool = "cleat".to_string();
     let available_agent_adapters = local_registry.agent_adapters.ids().map(ToString::to_string).collect();
 
     Ok(LocalProvisioningProfile {
@@ -1641,6 +1694,27 @@ struct DockerControllerRuntime {
     state: Arc<ControllerRuntimeState>,
 }
 
+async fn resolve_cleat_ghostty_library(runner: &dyn CommandRunner, cleat_binary_path: &DaemonHostPath) -> Result<DaemonHostPath, String> {
+    let binary = cleat_binary_path.as_path().to_string_lossy().into_owned();
+    let output = runner.run_output("ldd", &[&binary], Path::new("/"), &ChannelLabel::Noop).await?;
+    if !output.success {
+        return Err(format!("inspect cleat runtime libraries: {}", output.stderr.trim()));
+    }
+    let path = output.stdout.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        (fields.next() == Some(CLEAT_GHOSTTY_LIBRARY) && fields.next() == Some("=>"))
+            .then(|| fields.next())
+            .flatten()
+            .filter(|path| *path != "not")
+    });
+    let path = path.ok_or_else(|| format!("cleat runtime library {CLEAT_GHOSTTY_LIBRARY} was not resolved by ldd"))?;
+    let path = Path::new(path);
+    if !path.is_absolute() {
+        return Err(format!("cleat runtime library resolved to a non-absolute path: {}", path.display()));
+    }
+    Ok(DaemonHostPath::new(path))
+}
+
 #[async_trait]
 impl DockerEnvironmentRuntime for DockerControllerRuntime {
     async fn provision(
@@ -1648,9 +1722,19 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
         name: &str,
         spec: &flotilla_resources::DockerEnvironmentSpec,
     ) -> Result<DockerProvisioning, DockerProvisioningError> {
-        if spec.mounts.iter().any(|mount| Path::new(&mount.target_path) == Path::new(CONTAINER_FLOTILLA_PATH)) {
+        for (path, purpose) in [
+            (CONTAINER_FLOTILLA_PATH, "the flotilla CLI"),
+            (CONTAINER_CLEAT_PATH, "the cleat CLI"),
+            (CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH, "the cleat VT library"),
+            (CONTAINER_CLEAT_RUNTIME_DIR, "durable cleat state"),
+        ] {
+            if spec.mounts.iter().any(|mount| Path::new(&mount.target_path) == Path::new(path)) {
+                return Err(DockerProvisioningError::Failed(format!("mount target {path} is reserved for {purpose}")));
+            }
+        }
+        if spec.env.contains_key(CLEAT_RUNTIME_DIR_ENV) {
             return Err(DockerProvisioningError::Failed(format!(
-                "mount target {CONTAINER_FLOTILLA_PATH} is reserved for the flotilla CLI"
+                "environment variable {CLEAT_RUNTIME_DIR_ENV} is reserved for durable cleat state"
             )));
         }
         let credential_refs = credential_refs_from_environment(spec)?;
@@ -1743,12 +1827,51 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             None if credential_refs.is_empty() => None,
             None => return Err("host-local credential store unavailable".to_string().into()),
         };
-        let mut provisioned_mounts = Vec::with_capacity(spec.mounts.len() + 2);
+        let mut provisioned_mounts = Vec::with_capacity(spec.mounts.len() + 4);
         provisioned_mounts.push(ProvisionedMount::new(
             flotilla_binary_path.as_path().to_path_buf(),
             CONTAINER_FLOTILLA_PATH,
             ProvisionedMountMode::Ro,
         ));
+        if let Ok(cleat_binary_path) = &self.state.cleat_binary_path {
+            let cleat_ghostty_library_path = match &self.state.cleat_ghostty_library_path {
+                Some(path) => path.clone(),
+                None => {
+                    let runner = self
+                        .state
+                        .daemon
+                        .local_command_runner()
+                        .ok_or_else(|| "local command runner unavailable for cleat asset discovery".to_string())?;
+                    resolve_cleat_ghostty_library(&*runner, cleat_binary_path)
+                        .await
+                        .map_err(|error| format!("cleat unavailable for docker environment provisioning: {error}"))?
+                }
+            };
+            let cleat_state = self.state.config.state_dir().join(format!("contained-cleat/{name}"));
+            tokio::fs::create_dir_all(cleat_state.as_path())
+                .await
+                .map_err(|error| format!("create durable cleat state directory {}: {error}", cleat_state.as_path().display()))?;
+            provisioned_mounts.push(ProvisionedMount::new(
+                cleat_binary_path.as_path().to_path_buf(),
+                CONTAINER_CLEAT_PATH,
+                ProvisionedMountMode::Ro,
+            ));
+            provisioned_mounts.push(ProvisionedMount::new(
+                cleat_ghostty_library_path.as_path().to_path_buf(),
+                CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH,
+                ProvisionedMountMode::Ro,
+            ));
+            provisioned_mounts.push(ProvisionedMount::new(
+                cleat_state.as_path().to_path_buf(),
+                CONTAINER_CLEAT_RUNTIME_DIR,
+                ProvisionedMountMode::Rw,
+            ));
+            environment_variables.push((CLEAT_RUNTIME_DIR_ENV.to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()));
+            match environment_variables.iter_mut().find(|(name, _)| name == "LD_LIBRARY_PATH") {
+                Some((_, value)) => *value = format!("{CONTAINER_CLEAT_LIBRARY_DIR}:{value}"),
+                None => environment_variables.push(("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string())),
+            }
+        }
         provisioned_mounts.extend(spec.mounts.iter().map(flotilla_controllers::actuators::provisioned_mount));
         for delivery in &material_deliveries {
             provisioned_mounts.push(delivery.mount.clone());
@@ -2490,7 +2613,6 @@ impl TerminalRuntime for TerminalControllerRuntime {
             .terminal_pools
             .get(&spec.pool)
             .map(|(_, pool)| Arc::clone(pool))
-            .or_else(|| registry.terminal_pools.preferred().cloned())
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", spec.pool, spec.env_ref))?;
 
         let cwd = ExecutionEnvironmentPath::new(&spec.cwd);
@@ -2696,7 +2818,6 @@ impl TerminalControllerRuntime {
             .terminal_pools
             .get(&spec.pool)
             .map(|(_, pool)| Arc::clone(pool))
-            .or_else(|| registry.terminal_pools.preferred().cloned())
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", spec.pool, spec.env_ref))
     }
 }
@@ -2809,6 +2930,36 @@ mod tests {
         }
 
         assert_eq!(adjacent_flotilla_binary(&daemon_binary).expect("adjacent flotilla binary"), DaemonHostPath::new(flotilla_binary),);
+    }
+
+    #[test]
+    fn resolves_detected_host_binary_names_through_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let binary = temp.path().join("cleat");
+        fs::write(&binary, b"test binary").expect("write binary");
+        let search_path = env::join_paths([temp.path()]).expect("search path");
+
+        let resolved =
+            resolve_host_binary_from(Path::new("cleat"), Path::new("/not-used"), Some(&search_path)).expect("resolve detected binary");
+
+        assert_eq!(resolved.as_path(), binary.canonicalize().expect("canonical binary"));
+    }
+
+    #[tokio::test]
+    async fn resolves_the_cleat_vt_library_from_the_host_asset_set() {
+        let runner = DiscoveryMockRunner::builder()
+            .on_run(
+                "ldd",
+                &["/opt/flotilla/bin/cleat"],
+                Ok("\tlibghostty-vt.so.0 => /opt/flotilla/lib/libghostty-vt.so.0 (0x00007f)\n".to_string()),
+            )
+            .build();
+
+        let library = resolve_cleat_ghostty_library(&runner, &DaemonHostPath::new("/opt/flotilla/bin/cleat"))
+            .await
+            .expect("resolve cleat VT library");
+
+        assert_eq!(library, DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0"));
     }
 
     #[tokio::test]
@@ -3228,12 +3379,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_provisioning_mounts_daemon_adjacent_cli_read_only() {
+    async fn docker_provisioning_mounts_interior_control_binaries_and_durable_cleat_state() {
         let temp = TempDir::new().expect("tempdir");
         let config_base = temp.path().join("config");
         fs::create_dir_all(&config_base).expect("config directory");
         fs::write(config_base.join("daemon.toml"), "machine_id = \"cli-mount-test\"\n").expect("daemon config");
         let config = Arc::new(ConfigStore::with_base(config_base));
+        let cleat_state = config.state_dir().join("contained-cleat/contained-work");
         let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
         let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
         let provider = Arc::new(CapturingFailingEnvironmentProvider { create_opts: Mutex::new(None) });
@@ -3256,7 +3408,9 @@ mod tests {
                 None,
                 "host-direct-host-test".to_string(),
             )
-            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla")),
+            .with_flotilla_binary_path(DaemonHostPath::new("/opt/flotilla/bin/flotilla"))
+            .with_cleat_binary_path(DaemonHostPath::new("/opt/flotilla/bin/cleat"))
+            .with_cleat_ghostty_library_path(DaemonHostPath::new("/opt/flotilla/lib/libghostty-vt.so.0")),
         );
         let spec = flotilla_resources::DockerEnvironmentSpec {
             host_ref: "host-test".to_string(),
@@ -3275,11 +3429,21 @@ mod tests {
 
         assert_eq!(error.to_string(), "stop after capturing create options");
         let opts = provider.create_opts.lock().await.take().expect("captured create options");
-        assert_eq!(opts.provisioned_mounts, vec![ProvisionedMount::new(
-            "/opt/flotilla/bin/flotilla",
-            "/usr/local/bin/flotilla",
-            ProvisionedMountMode::Ro,
-        )],);
+        assert_eq!(opts.provisioned_mounts, vec![
+            ProvisionedMount::new("/opt/flotilla/bin/flotilla", CONTAINER_FLOTILLA_PATH, ProvisionedMountMode::Ro,),
+            ProvisionedMount::new("/opt/flotilla/bin/cleat", CONTAINER_CLEAT_PATH, ProvisionedMountMode::Ro),
+            ProvisionedMount::new("/opt/flotilla/lib/libghostty-vt.so.0", CONTAINER_CLEAT_GHOSTTY_LIBRARY_PATH, ProvisionedMountMode::Ro,),
+            ProvisionedMount::new(cleat_state.as_path().to_path_buf(), CONTAINER_CLEAT_RUNTIME_DIR, ProvisionedMountMode::Rw,),
+        ],);
+        assert_eq!(
+            opts.tokens,
+            vec![
+                ("CLEAT_RUNTIME_DIR".to_string(), CONTAINER_CLEAT_RUNTIME_DIR.to_string()),
+                ("LD_LIBRARY_PATH".to_string(), CONTAINER_CLEAT_LIBRARY_DIR.to_string()),
+            ],
+            "launch and attach must resolve the same interior cleat state root"
+        );
+        assert!(cleat_state.as_path().is_dir(), "the durable recording directory must exist before Docker bind-mounts it");
     }
 
     #[tokio::test]
@@ -4560,6 +4724,50 @@ mod tests {
         };
         let error = verify_declared_agent_adapters(&spec, &registry).expect_err("missing declared adapter should fail");
         assert_eq!(error, "image `contained-image` declares agent adapter `missing-adapter`, but interior discovery did not find it");
+    }
+
+    #[tokio::test]
+    async fn contained_terminal_session_never_falls_back_from_the_requested_interior_pool() {
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
+        let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        let env_id = EnvironmentId::new("contained-work");
+        let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {
+            id: env_id.clone(),
+            image: ImageId::new("contained-image"),
+            runner: Arc::new(DiscoveryMockRunner::builder().build()),
+            env_vars: HashMap::new(),
+            destroyed: Arc::new(AtomicBool::new(false)),
+        });
+        daemon
+            .register_provisioned_environment(env_id.clone(), handle, EnvironmentBag::new(), Some(passthrough_registry()))
+            .expect("register contained environment");
+        let runtime = TerminalControllerRuntime {
+            state: Arc::new(ControllerRuntimeState::new(
+                daemon,
+                config,
+                passthrough_registry(),
+                None,
+                "host-test".to_string(),
+                None,
+                "host-direct-host-test".to_string(),
+            )),
+        };
+        let spec = flotilla_resources::TerminalSessionSpec {
+            env_ref: env_id.to_string(),
+            role: "coder".to_string(),
+            source: TerminalSessionSource::Tool { command: "sleep infinity".to_string() },
+            cwd: "/workspace".to_string(),
+            pool: "cleat".to_string(),
+        };
+
+        let error = runtime
+            .ensure_session("terminal-contained-work-coder", &spec, &[])
+            .await
+            .expect_err("a missing interior cleat must fail instead of launching through passthrough");
+
+        assert_eq!(error, "terminal pool cleat unavailable for environment contained-work");
     }
 
     #[tokio::test]

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -9,6 +9,24 @@ forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1
 The explicit release tag is the deployment contract. Do not point placement
 policies at `latest`.
 
+Contained crew terminal sessions run inside the environment. A Docker
+placement therefore names `pool: cleat`, meaning the cleat discovered inside
+that container; it does not name a host-side session that wraps `docker exec`.
+Launch, liveness observation, and attach all resolve that same interior pool.
+
+The current Linux-host interim delivers the cleat executable and its
+`libghostty-vt` runtime library with the same read-only bind-mount mechanism
+used for the Flotilla CLI. Its runtime root is a writable bind mount from
+`<flotilla-state>/contained-cleat/<environment>` to
+`/var/lib/flotilla/cleat`, with `CLEAT_RUNTIME_DIR` set to the latter. Cleat
+records sessions by default, so recordings remain on the host after container
+teardown. A future image release should bake cleat into the image; the mounted
+runtime root remains the durability boundary either way.
+
+The mounted Flotilla CLI connects back to the host daemon through the mounted
+socket named by `FLOTILLA_DAEMON_SOCKET`; normal CLI commands honor that
+variable, not only agent-hook delivery.
+
 This document is curation advice for the Flotilla project. It is not a schema
 or a contract that Flotilla validates. Flotilla's contract stays deliberately
 narrow: a placement names an image and declares the adapters it promises,
@@ -58,7 +76,8 @@ fastest-changing:
 1. Ubuntu, certificates, Git, and curl;
 2. Rust stable, the repository's pinned `nightly-2026-03-12`, and Node.js;
 3. `gh` and general development utilities;
-4. Claude Code and Codex.
+4. the cleat terminal runtime;
+5. Claude Code and Codex.
 
 From the repository root, a builder with amd64 and arm64 workers can publish
 the release with:
@@ -94,8 +113,9 @@ docker run --rm "$IMAGE" claude --version
 docker run --rm "$IMAGE" codex --version
 ```
 
-The Dockerfile also runs these checks while building. A build cannot publish
-successfully if either declared adapter is missing or not executable.
+Until the image bakes cleat, run its version check against a provisioned
+environment, where Flotilla supplies the interim bind mount. The Dockerfile
+currently checks both declared agent adapters while building.
 
 ## Placement policy
 

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -14,13 +14,20 @@ placement therefore names `pool: cleat`, meaning the cleat discovered inside
 that container; it does not name a host-side session that wraps `docker exec`.
 Launch, liveness observation, and attach all resolve that same interior pool.
 
-The current Linux-host interim delivers the cleat executable and its
-`libghostty-vt` runtime library with the same read-only bind-mount mechanism
-used for the Flotilla CLI. Its runtime root is a writable bind mount from
+Provisioning describes required in-environment tools independently of an
+environment provider: executable location, host-sourced files/directories or
+sockets, access mode, and environment mutations. The Flotilla CLI plus daemon
+socket and the cleat terminal runtime are separate consumers of that contract.
+Docker currently delivers their assets as bind mounts; future providers may
+upload files or expose sockets through their own transport without changing
+the tool descriptions.
+
+For cleat, the current Linux-host delivery supplies the executable and
+`libghostty-vt` read-only. Its shared writable runtime root maps
 `<flotilla-state>/contained-cleat/<environment>` to
 `/var/lib/flotilla/cleat`, with `CLEAT_RUNTIME_DIR` set to the latter. Cleat
 records sessions by default, so recordings remain on the host after container
-teardown. A future image release should bake cleat into the image; the mounted
+teardown. A future image release should bake cleat into the image; the shared
 runtime root remains the durability boundary either way.
 
 The mounted Flotilla CLI connects back to the host daemon through the mounted

--- a/src/main.rs
+++ b/src/main.rs
@@ -1496,10 +1496,7 @@ async fn run_hook(cli: &Cli, harness: &str, event_type: &str) -> Result<()> {
 
     // 6. Send to daemon via socket. The daemon owns agent state as a single
     // actor — no file-level races between concurrent hook processes.
-    // Priority: FLOTILLA_DAEMON_SOCKET env > --socket CLI flag > global default.
-    let socket_path = std::env::var("FLOTILLA_DAEMON_SOCKET").map(std::path::PathBuf::from).unwrap_or_else(|_| cli.socket_path());
-
-    send_hook_event(&socket_path, event).await
+    send_hook_event(&cli.socket_path(), event).await
 }
 
 /// One-shot client: connect to daemon, send an AgentHook request, read one response, exit.

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,8 +315,12 @@ impl Cli {
     }
 
     fn socket_path(&self) -> PathBuf {
-        self.socket.clone().unwrap_or_else(|| self.config_dir().join("flotilla.sock"))
+        socket_path_from(self.socket.as_deref(), &self.config_dir(), std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref())
     }
+}
+
+fn socket_path_from(explicit: Option<&Path>, config_dir: &Path, environment: Option<&std::ffi::OsStr>) -> PathBuf {
+    environment.map(PathBuf::from).or_else(|| explicit.map(PathBuf::from)).unwrap_or_else(|| config_dir.join("flotilla.sock"))
 }
 
 #[tokio::main]
@@ -1713,8 +1717,8 @@ mod tests {
     use super::{
         attach_exit_disposition, confirm_command, default_project_landing, format_human_resource_value,
         provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target, select_startup_repo_roots,
-        should_reexec_for_incompatible_daemon, show_startup_splash, AttachExitDisposition, Cli, CommandValue, ResourceApplyArgs,
-        ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
+        should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from, AttachExitDisposition, Cli, CommandValue,
+        ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
     };
 
     fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
@@ -2022,6 +2026,18 @@ mod tests {
             cli.command,
             Some(SubCommand::Attach { reference, transient: false, host: None }) if reference == "convoy-a/implement/coder"
         ));
+    }
+
+    #[test]
+    fn contained_cli_socket_environment_takes_precedence() {
+        assert_eq!(
+            socket_path_from(
+                Some(Path::new("/explicit/flotilla.sock")),
+                Path::new("/config"),
+                Some(std::ffi::OsStr::new("/run/flotilla.sock")),
+            ),
+            PathBuf::from("/run/flotilla.sock"),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- make Docker-contained vessels request the `cleat` terminal pool inside the environment and remove silent fallback to a different pool for launch or presentation
- deliver the host cleat executable and its `libghostty-vt` runtime dependency into Linux containers as read-only mounts
- mount cleat's runtime root at `/var/lib/flotilla/cleat`, backed by host state under `contained-cleat/<environment>`, and launch sessions with recording enabled
- update the cleat adapter to the current `cleat launch` contract and make attach strict with `attach --no-create`
- make ordinary mounted CLI commands honor `FLOTILLA_DAEMON_SOCKET`, allowing contained crews to use the host daemon socket without an in-container `flotillad`
- document the interim bind-mounted delivery model and the preferred future baked-image model

## Root cause

Launch accepted an explicitly requested interior pool but silently fell back to the registry's preferred provider when that pool was absent. Attach resolved the named pool exactly. That split launch and attach across two models and let a host-side process appear `Working` while the container held only its keepalive.

The current cleat adapter also used the removed `create` command. Finally, the mounted Flotilla CLI ignored `FLOTILLA_DAEMON_SOCKET` for normal commands, so a correctly contained agent could not complete work through the mounted socket.

## Impact

Contained crew engagement now has one model: the agent is a child of cleat inside the container, in `/workspace`, with the leased `CODEX_HOME`. Attach tunnels to that same interior session. Missing sessions cannot be recreated by attach, and existing liveness reconciliation turns a disappeared session into stopped/interrupted work instead of a stable phantom `Working` state. Recordings survive container teardown on the host-mounted runtime root.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Focused coverage includes exact-pool/no-fallback behavior, cleat asset resolution and mounts, current cleat launch/attach arguments, disappeared-session stopping, and vessel interruption/restart behavior.

## Contained smoke report

Ran `single-agent-contained` on feta with `forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1` and placement `pool: cleat`.

While live:

- container process tree showed `/usr/local/bin/cleat ... serve` as PID 275, with the Codex node/native processes as its descendants
- the agent's `/proc/<pid>/cwd` resolved to `/workspace`
- agent environment contained `CODEX_HOME=/run/flotilla/codex`
- `CLEAT_RUNTIME_DIR=/var/lib/flotilla/cleat`; the live `.cast` was present there
- MaterialPool `codex-login` showed `slot-00000000000000000000` leased to the contained environment
- from kiwi, `flotilla attach smoke-1278-interior-cleat-3` routed through feta and executed `cleat attach --no-create terminal-smoke-1278-interior-cleat-3-work-coder`, displaying the live interior Codex UI at `/workspace`

The final r4 run landed without intervention in about 11 seconds. Its completion message reported `cwd=/workspace`, `CODEX_HOME=/run/flotilla/codex`, `CLI+socket=ok`, and slot 0. After teardown:

- the Docker container was gone
- MaterialPool leases were empty
- the recording remained at `~/.local/state/flotilla/contained-cleat/env-smoke-1278-interior-cleat-4-work/default/sessions/terminal-smoke-1278-interior-cleat-4-work-coder/session.cast`
- slot-0 `auth.json` mtime/content size were unchanged, so no token refresh occurred during the short run

Closes #1278