### PR TITLE
docs: prototype workflow scenario definitions

### DIFF
--- a/prototypes/1262-scenarios/GAPS.md
+++ b/prototypes/1262-scenarios/GAPS.md
@@ -22,23 +22,36 @@ names are not yet decided.
 
 ## What the model cannot express yet
 
-1. **An engagement round has no runtime shape.** No resource or status records
-   its identity, target, attempt, admitted brief, report, or result. A rule
-   cannot distinguish "this round completed" from the existing
-   `CrewWorkPhase::Done`, which contributes to completing a vessel and moving a
-   convoy to `Landing`. Re-engaging a warm, completed crew needs an inner-round
-   contract that does not accidentally claim an outer lifecycle edge.
+1. **Outcome-carrying engagement completion has no runtime shape yet.**
+   `builtin-implement-review.yaml` adopts the refined candidate contract:
+   completion is `Done` plus a typed outcome, and pure interpreters derive
+   transitions such as `review.requested-changes` and `review.approved` from
+   that stored fact. No resource or status yet records the engagement identity,
+   attempt, admitted brief, typed outcome schema, report, or result. The
+   producer authority and validation rules for each outcome kind also remain
+   undefined.
 
-2. **Agent-directed handoff has no declaration or typed outcome.** Today's
-   `implement-review` coder chooses when to run `flotilla crew reviewer
+   This exposes a sharper lifecycle gap. Today's bare
+   `CrewWorkPhase::Done` unconditionally contributes to completing the vessel
+   and moving the convoy to `Landing`. In the refined model,
+   Done-with-requested-changes completes the review engagement but is not a
+   settlement claim: the workflow remains active and re-engages the coder.
+   Only Done-with-approved admits the existing `Work → Complete` and
+   `Convoy → Landing` progression. The roll-up must therefore consume the
+   pinned rule's accepted verdict, associate it with the current engagement
+   attempt, and supersede it safely when a rule re-arms.
+
+2. **Agent-directed early handoff still has no declaration.** The typed
+   implementation/review outcomes now express the full normal loop: ready for
+   review, requested changes, revised implementation, re-review, and approval.
+   Today's `implement-review` coder chooses when to run `flotilla crew reviewer
    handoff`, may overlap implementation and review, and supplies a free-form
    message. The `diff-review` brief can hand findings back and re-review. The
    ruled model reserves adaptive engagements that write workflow data, but it
    does not define the declaration an agent writes for "engage reviewer now
-   with this result," nor how a typed review outcome requests the next coder or
-   reviewer round. `builtin-implement-review.yaml` can express the deterministic
-   serial path; it cannot preserve today's discretionary timing and payload
-   exactly without that missing shape.
+   with this partial result." The file preserves the workflow's full settled
+   behavior, but cannot preserve today's optional early/overlapping timing and
+   free-form payload exactly without that declaration shape.
 
 3. **Wake admission, coalescing, and re-arming are unspecified.**
    `rebase-on-conflict.yaml` states the desired cause and outcome but cannot
@@ -100,12 +113,15 @@ These are deliberate translations, not missing expressive power:
    `shepherd` on `engage`, allowing later engagements of one role to use a
    different brief without cloning the role.
 
-3. **The normal implement-review sequence is declared rather than prompted.**
-   Today the coder learns about the latent reviewer from generated brief text
-   and invokes a handoff command. The ruled normal path makes coder completion
-   engage the reviewer with `diff-review`. This removes lifecycle sequencing
-   from prose. Preserving the optional early/overlapping handoff is the true
-   gap described above, not a reason to keep the normal path implicit.
+3. **The full implement-review loop is declared rather than prompted.** Today
+   the coder learns about the latent reviewer from generated brief text and
+   agents drive the loop with handoff commands. The ruled path stores typed
+   Done-with-verdict outcomes: ready-for-review engages the reviewer,
+   requested-changes re-arms review and engages the coder, and approved settles
+   the loop into the declared work-completion and convoy-Landing progression.
+   This removes lifecycle sequencing and settlement from prose. Preserving the
+   optional early/overlapping handoff is the true gap described above, not a
+   reason to keep the normal loop implicit.
 
 4. **Follow-up shepherding becomes event-driven.** Today
    `single-agent-shepherd` runs one eager round, then a human or governor

--- a/prototypes/1262-scenarios/GAPS.md
+++ b/prototypes/1262-scenarios/GAPS.md
@@ -1,0 +1,91 @@
+# Gaps exposed by the #1262 workflow scenarios
+
+These files are candidate `WorkflowTemplate` resources for human reaction, not
+documents accepted by the current `flotilla.work/v1` schema. They preserve the
+resolved model from the workflow-core and subscription grills:
+
+- A workflow extends today's vessel, stance, credential, and crew topology with
+  declared engagement rules.
+- A rule has the form `when state or semantic transition + guards → engage role
+  with brief template → expect completion condition`.
+- Engagement-rule `when` clauses are the only workflow subscription surface.
+  With no explicit widening, each rule sees only its convoy's resources.
+- Rules reference declared convoy phases and derived semantic transitions. They
+  do not add phases, add edges, emit events, or encode an imperative script.
+
+The three fixtures intentionally use one small candidate serialization:
+`engagement_rules`, `when`, `engage`, and `expecting`. Exact Rust/YAML field
+names are not yet decided.
+
+## What the model could not express
+
+1. **An engagement round has no runtime shape.** The model names an engagement
+   as the idempotent unit of crew work, but no resource or status records its
+   identity, target, attempt, admitted brief, report, or result. In particular,
+   `review-round-trip.yaml` cannot distinguish "this round completed" from the
+   existing `CrewWorkPhase::Done`, which currently contributes to completing
+   the vessel and moving the convoy to `Landing`. Re-engaging a warm, completed
+   crew needs a contract that does not confuse an inner round with an outer
+   lifecycle edge.
+
+2. **Wake admission, coalescing, and re-arming are unspecified.**
+   `rebase-on-conflict.yaml` states the desired cause and outcome but cannot
+   express one wake per conflict episode, idempotent retry under one wake ID,
+   suppression while a round is active, or a successor wake when relevant
+   material arrives during that round. It also cannot say that a later
+   mergeable-to-conflicting transition opens a new episode. These are the open
+   questions in the wake-semantics grill, not rebase-specific fields to add to
+   the workflow.
+
+3. **Target policy is absent.** `engage vessel: work, role: coder|shepherd`
+   names the logical target but not what to do when its session is warm, cold,
+   reaped, failed, or gone. Resume, re-provision, hold, escalate, and cancel
+   policies need one general routing contract. Delivery acknowledgement must
+   mean durable admission of the wake, not successful completion of the work.
+
+4. **The review budget and loud hold do not fit.** #1216 requires a maximum
+   number of rounds and a visible held condition when the budget is exhausted.
+   The ruled engagement-rule shape has no counter scope, reset rule, or
+   `Demand`/hold action. Adding `max_turns` directly to this one fixture would
+   hide the larger policy question: whether budgets govern a rule, a workflow,
+   a change request, or a convoy lifecycle interval.
+
+5. **Stable review state is not an engagement.** "Checks green and no
+   unaddressed feedback" should surface merge readiness without waking a crew.
+   Rules-only subscriptions deliberately have one effect—request an
+   engagement—so the model needs a separate derived condition or presentation
+   projection for readiness. It must not smuggle a second workflow-subscription
+   surface into the template.
+
+6. **PR adoption crosses the admission boundary.**
+   `pr-adoption-turn.yaml` can guard on the already-bound change request, but it
+   cannot declare the `--pr` resolver, derive the branch/base/title, adopt or
+   provision the checkout, or atomically write `ConvoySpec.change_request`.
+   Those operations belong to admission rather than the inner workflow. What is
+   missing is the explicit hand-off: whether `convoy.entered-active` creates the
+   first engagement, claims an eagerly started crew turn, or would double-wake
+   the session that vessel bootstrap already launched.
+
+7. **The closed semantic vocabulary is only partly named.**
+   `change-request.went-conflicting` and phase-edge transitions are ruled.
+   `change-request.review-arrived` and
+   `change-request.checks-failed` are candidate dotted, past-tense names for the
+   required review/check interpreters. Their typed payloads still need to
+   define review identity, unresolved-thread state, check roll-up, observation
+   freshness, and the comparison needed for "feedback newer than the last crew
+   activity." The definitions must live beside the ADR 0024 tables and carry
+   the vocabulary generation stamp.
+
+8. **Brief and digest inputs are not declared.** The existing `shepherd`
+   template covers one round, but the rebase brief named here does not yet
+   exist. The workflow model also does not say which typed transition digest,
+   current resource facts, target/base refs, pinned CI gates, and wake identity
+   a brief template may consume. Canonical wake state should remain typed data;
+   rendered prompt prose must not become the event payload.
+
+9. **Pinned definitions currently snapshot only vessels.** The core grill says
+   the resolved builtin/fleet/project/repo source is recorded and definitions
+   are pinned at admission, but `WorkflowSnapshot` currently contains only
+   vessels. Engagement rules, their resolved source, the transition-vocabulary
+   generation, and brief-template identity all need to be part of the pinned,
+   legible definition seen by a running convoy.

--- a/prototypes/1262-scenarios/GAPS.md
+++ b/prototypes/1262-scenarios/GAPS.md
@@ -1,8 +1,11 @@
 # Gaps exposed by the #1262 workflow scenarios
 
 These files are candidate `WorkflowTemplate` resources for human reaction, not
-documents accepted by the current `flotilla.work/v1` schema. They preserve the
-resolved model from the workflow-core and subscription grills:
+documents accepted by the current `flotilla.work/v1` schema. The three proving
+scenarios are joined by ruled-model translations of three code-owned builtins:
+`single-agent-trusted`, `implement-review`, and `single-agent-shepherd`.
+
+All six preserve the workflow-core and subscription-grill decisions:
 
 - A workflow extends today's vessel, stance, credential, and crew topology with
   declared engagement rules.
@@ -13,79 +16,124 @@ resolved model from the workflow-core and subscription grills:
 - Rules reference declared convoy phases and derived semantic transitions. They
   do not add phases, add edges, emit events, or encode an imperative script.
 
-The three fixtures intentionally use one small candidate serialization:
+The fixtures intentionally use one small candidate serialization:
 `engagement_rules`, `when`, `engage`, and `expecting`. Exact Rust/YAML field
 names are not yet decided.
 
-## What the model could not express
+## What the model cannot express yet
 
-1. **An engagement round has no runtime shape.** The model names an engagement
-   as the idempotent unit of crew work, but no resource or status records its
-   identity, target, attempt, admitted brief, report, or result. In particular,
-   `review-round-trip.yaml` cannot distinguish "this round completed" from the
-   existing `CrewWorkPhase::Done`, which currently contributes to completing
-   the vessel and moving the convoy to `Landing`. Re-engaging a warm, completed
-   crew needs a contract that does not confuse an inner round with an outer
-   lifecycle edge.
+1. **An engagement round has no runtime shape.** No resource or status records
+   its identity, target, attempt, admitted brief, report, or result. A rule
+   cannot distinguish "this round completed" from the existing
+   `CrewWorkPhase::Done`, which contributes to completing a vessel and moving a
+   convoy to `Landing`. Re-engaging a warm, completed crew needs an inner-round
+   contract that does not accidentally claim an outer lifecycle edge.
 
-2. **Wake admission, coalescing, and re-arming are unspecified.**
+2. **Agent-directed handoff has no declaration or typed outcome.** Today's
+   `implement-review` coder chooses when to run `flotilla crew reviewer
+   handoff`, may overlap implementation and review, and supplies a free-form
+   message. The `diff-review` brief can hand findings back and re-review. The
+   ruled model reserves adaptive engagements that write workflow data, but it
+   does not define the declaration an agent writes for "engage reviewer now
+   with this result," nor how a typed review outcome requests the next coder or
+   reviewer round. `builtin-implement-review.yaml` can express the deterministic
+   serial path; it cannot preserve today's discretionary timing and payload
+   exactly without that missing shape.
+
+3. **Wake admission, coalescing, and re-arming are unspecified.**
    `rebase-on-conflict.yaml` states the desired cause and outcome but cannot
    express one wake per conflict episode, idempotent retry under one wake ID,
    suppression while a round is active, or a successor wake when relevant
    material arrives during that round. It also cannot say that a later
-   mergeable-to-conflicting transition opens a new episode. These are the open
-   questions in the wake-semantics grill, not rebase-specific fields to add to
-   the workflow.
+   mergeable-to-conflicting transition opens a new episode. These are general
+   wake-semantics questions, not rebase-specific fields to add to the workflow.
 
-3. **Target policy is absent.** `engage vessel: work, role: coder|shepherd`
+4. **Target policy is absent.** `engage vessel: work, role: coder|shepherd`
    names the logical target but not what to do when its session is warm, cold,
    reaped, failed, or gone. Resume, re-provision, hold, escalate, and cancel
    policies need one general routing contract. Delivery acknowledgement must
    mean durable admission of the wake, not successful completion of the work.
 
-4. **The review budget and loud hold do not fit.** #1216 requires a maximum
+5. **The review budget and loud hold do not fit.** #1216 requires a maximum
    number of rounds and a visible held condition when the budget is exhausted.
-   The ruled engagement-rule shape has no counter scope, reset rule, or
-   `Demand`/hold action. Adding `max_turns` directly to this one fixture would
-   hide the larger policy question: whether budgets govern a rule, a workflow,
-   a change request, or a convoy lifecycle interval.
+   The rule shape has no counter scope, reset rule, or `Demand`/hold action.
+   Adding `max_turns` directly to one fixture would hide the larger policy
+   question: whether budgets govern a rule, a workflow, a change request, or a
+   convoy lifecycle interval.
 
-5. **Stable review state is not an engagement.** "Checks green and no
-   unaddressed feedback" should surface merge readiness without waking a crew.
-   Rules-only subscriptions deliberately have one effect—request an
-   engagement—so the model needs a separate derived condition or presentation
-   projection for readiness. It must not smuggle a second workflow-subscription
-   surface into the template.
-
-6. **PR adoption crosses the admission boundary.**
-   `pr-adoption-turn.yaml` can guard on the already-bound change request, but it
-   cannot declare the `--pr` resolver, derive the branch/base/title, adopt or
-   provision the checkout, or atomically write `ConvoySpec.change_request`.
-   Those operations belong to admission rather than the inner workflow. What is
-   missing is the explicit hand-off: whether `convoy.entered-active` creates the
-   first engagement, claims an eagerly started crew turn, or would double-wake
-   the session that vessel bootstrap already launched.
-
-7. **The closed semantic vocabulary is only partly named.**
+6. **The closed semantic vocabulary is only partly named.**
    `change-request.went-conflicting` and phase-edge transitions are ruled.
    `change-request.review-arrived` and
    `change-request.checks-failed` are candidate dotted, past-tense names for the
    required review/check interpreters. Their typed payloads still need to
    define review identity, unresolved-thread state, check roll-up, observation
-   freshness, and the comparison needed for "feedback newer than the last crew
-   activity." The definitions must live beside the ADR 0024 tables and carry
-   the vocabulary generation stamp.
+   freshness, and "feedback newer than the last crew activity." Definitions
+   must live beside the ADR 0024 tables and carry the vocabulary generation.
 
-8. **Brief and digest inputs are not declared.** The existing `shepherd`
-   template covers one round, but the rebase brief named here does not yet
-   exist. The workflow model also does not say which typed transition digest,
-   current resource facts, target/base refs, pinned CI gates, and wake identity
-   a brief template may consume. Canonical wake state should remain typed data;
-   rendered prompt prose must not become the event payload.
+7. **Brief and digest inputs are not declared.** The existing `crew`,
+   `diff-review`, and `shepherd` templates cover the builtin turns, but the
+   rebase brief named here does not yet exist. The model also does not say which
+   typed transition digest, current resource facts, target/base refs, pinned CI
+   gates, handoff result, and wake identity a template may consume. Canonical
+   wake state should remain typed data; prompt prose must not become the event
+   payload.
 
-9. **Pinned definitions currently snapshot only vessels.** The core grill says
+8. **Pinned definitions currently snapshot only vessels.** The core grill says
    the resolved builtin/fleet/project/repo source is recorded and definitions
    are pinned at admission, but `WorkflowSnapshot` currently contains only
    vessels. Engagement rules, their resolved source, the transition-vocabulary
-   generation, and brief-template identity all need to be part of the pinned,
-   legible definition seen by a running convoy.
+   generation, and brief-template identity all need to be pinned and legible.
+
+## What the model expresses differently from today's code
+
+These are deliberate translations, not missing expressive power:
+
+1. **Initial agent start becomes an engagement rule.** Today
+   `VesselRequirement::starts_eagerly` starts the first agent when the vessel
+   launches. The three builtin fixtures instead state
+   `work.entered-running → engage role`. The topology still says who can run;
+   the rule says why this turn exists.
+
+2. **Brief selection moves from crew topology to each engagement.** Today
+   `CrewSource::Agent.brief_template` is fixed per role, with `None` resolving
+   to the default crew brief. The ruled files name `crew`, `diff-review`, or
+   `shepherd` on `engage`, allowing later engagements of one role to use a
+   different brief without cloning the role.
+
+3. **The normal implement-review sequence is declared rather than prompted.**
+   Today the coder learns about the latent reviewer from generated brief text
+   and invokes a handoff command. The ruled normal path makes coder completion
+   engage the reviewer with `diff-review`. This removes lifecycle sequencing
+   from prose. Preserving the optional early/overlapping handoff is the true
+   gap described above, not a reason to keep the normal path implicit.
+
+4. **Follow-up shepherding becomes event-driven.** Today
+   `single-agent-shepherd` runs one eager round, then a human or governor
+   manually resumes it. `review-round-trip.yaml` and
+   `rebase-on-conflict.yaml` make later rounds consequences of semantic
+   transitions while retaining the real one-round `shepherd` brief.
+
+5. **Builtins become ordinary layered data.** Today
+   `builtin_workflow_templates()` constructs specs in Rust and the daemon
+   reconciles them into resources labelled `flotilla.work/managed-by: builtin`.
+   The ruled model treats builtin as the least-specific data source beneath
+   fleet, project, and repo definitions. The three files retain the current
+   names, labels, stances, roles, and capabilities while showing that future
+   home.
+
+## Behavior intentionally outside workflow data
+
+- **PR adoption is admission.** `pr-adoption-turn.yaml` can guard on an
+  already-bound change request, but `--pr` resolution, branch/base/title
+  derivation, checkout adoption, and the atomic `ConvoySpec.change_request`
+  write remain admission responsibilities. The missing contract is only the
+  hand-off between eager bootstrap and the first declared engagement, so the
+  same session is not engaged twice.
+- **Stable review state is a derived condition or projection.** "Checks green
+  and no unaddressed feedback" should surface merge readiness without waking a
+  crew. Rules-only subscriptions deliberately have one effect—request an
+  engagement—so readiness belongs in the condition/presentation substrate, not
+  a second workflow subscription surface.
+- **Transition interpretation stays substrate code.** Workflow data consumes
+  stable dotted names; it does not define the pure `(old, new)` interpreters or
+  alter ADR 0024 phase tables.

--- a/prototypes/1262-scenarios/builtin-implement-review.yaml
+++ b/prototypes/1262-scenarios/builtin-implement-review.yaml
@@ -32,36 +32,61 @@ spec:
         role: coder
         brief_template: crew
       expecting:
-        fact: crew-work.phase
-        subject:
-          vessel: work
-          role: coder
-        equals: Done
+        completion:
+          phase: Done
+          outcome:
+            kind: implementation
+            verdict: ready-for-review
 
-    # This is the ruled model's deterministic normal path: completed
-    # implementation engages the latent reviewer. Today's coder may instead
-    # choose an earlier, overlapping handoff with a free-form message; GAPS.md
-    # records the missing declaration/outcome shape needed to preserve that
-    # choice exactly.
-    - name: review-completed-implementation
+    # An implementation outcome is a stored fact. Its derived transition opens
+    # a review engagement. A requested-changes verdict re-arms this rule while
+    # the next coder round runs; approval leaves it closed.
+    - name: review-ready-implementation
       when:
-        transition: crew-work.entered-done
-        subject:
-          vessel: work
-          role: coder
+        transition: implementation.ready-for-review
         guards:
-          - fact: crew-work.phase
-            subject:
-              vessel: work
-              role: reviewer
-            equals: Pending
+          - fact: convoy.phase
+            equals: Active
       engage:
         vessel: work
         role: reviewer
         brief_template: diff-review
       expecting:
-        fact: crew-work.phase
-        subject:
-          vessel: work
-          role: reviewer
-        equals: Done
+        completion:
+          phase: Done
+          outcome:
+            kind: review
+            verdict:
+              one_of:
+                - requested-changes
+                - approved
+      rearm:
+        on_transition: review.requested-changes
+      settles:
+        on_transition: review.approved
+        through_declared_transitions:
+          - work.entered-complete
+          - convoy.entered-landing
+
+    # Done-with-requested-changes completes only the review engagement; it does
+    # not settle the work. The derived transition requests a fresh coder
+    # engagement. Its ready-for-review outcome both completes this round and
+    # supplies the fact the re-armed reviewer rule consumes.
+    - name: address-requested-changes
+      when:
+        transition: review.requested-changes
+        guards:
+          - fact: convoy.phase
+            equals: Active
+      engage:
+        vessel: work
+        role: coder
+        brief_template: crew
+      expecting:
+        completion:
+          phase: Done
+          outcome:
+            kind: implementation
+            verdict: ready-for-review
+      rearm:
+        on_transition: implementation.ready-for-review

--- a/prototypes/1262-scenarios/builtin-implement-review.yaml
+++ b/prototypes/1262-scenarios/builtin-implement-review.yaml
@@ -1,0 +1,67 @@
+# Ruled-model translation of implement_review_workflow_spec().
+# This is reaction data for #1269, not a document accepted by today's schema.
+apiVersion: flotilla.work/v1
+kind: WorkflowTemplate
+metadata:
+  name: implement-review
+  namespace: flotilla
+  labels:
+    flotilla.work/managed-by: builtin
+spec:
+  vessels:
+    - name: work
+      stance: contained
+      crew:
+        - role: coder
+          selector:
+            capability: code
+        - role: reviewer
+          selector:
+            capability: code-review
+
+  engagement_rules:
+    # Today the first agent starts eagerly with the vessel. This rule states
+    # that initial engagement explicitly.
+    - name: initial-coding-turn
+      when:
+        transition: work.entered-running
+        subject:
+          vessel: work
+      engage:
+        vessel: work
+        role: coder
+        brief_template: crew
+      expecting:
+        fact: crew-work.phase
+        subject:
+          vessel: work
+          role: coder
+        equals: Done
+
+    # This is the ruled model's deterministic normal path: completed
+    # implementation engages the latent reviewer. Today's coder may instead
+    # choose an earlier, overlapping handoff with a free-form message; GAPS.md
+    # records the missing declaration/outcome shape needed to preserve that
+    # choice exactly.
+    - name: review-completed-implementation
+      when:
+        transition: crew-work.entered-done
+        subject:
+          vessel: work
+          role: coder
+        guards:
+          - fact: crew-work.phase
+            subject:
+              vessel: work
+              role: reviewer
+            equals: Pending
+      engage:
+        vessel: work
+        role: reviewer
+        brief_template: diff-review
+      expecting:
+        fact: crew-work.phase
+        subject:
+          vessel: work
+          role: reviewer
+        equals: Done

--- a/prototypes/1262-scenarios/builtin-single-agent-shepherd.yaml
+++ b/prototypes/1262-scenarios/builtin-single-agent-shepherd.yaml
@@ -1,0 +1,37 @@
+# Ruled-model translation of single_agent_shepherd_workflow_spec().
+# This is reaction data for #1269, not a document accepted by today's schema.
+apiVersion: flotilla.work/v1
+kind: WorkflowTemplate
+metadata:
+  name: single-agent-shepherd
+  namespace: flotilla
+  labels:
+    flotilla.work/managed-by: builtin
+spec:
+  vessels:
+    - name: work
+      stance: trusted
+      crew:
+        - role: shepherd
+          selector:
+            capability: code
+
+  # The shepherd brief's real contract is exactly one review and CI round,
+  # followed by crew completion and a return to Landing. Future PR material
+  # belongs to a later engagement, as modeled by review-round-trip.yaml.
+  engagement_rules:
+    - name: initial-shepherd-round
+      when:
+        transition: work.entered-running
+        subject:
+          vessel: work
+      engage:
+        vessel: work
+        role: shepherd
+        brief_template: shepherd
+      expecting:
+        fact: crew-work.phase
+        subject:
+          vessel: work
+          role: shepherd
+        equals: Done

--- a/prototypes/1262-scenarios/builtin-single-agent-trusted.yaml
+++ b/prototypes/1262-scenarios/builtin-single-agent-trusted.yaml
@@ -1,0 +1,37 @@
+# Ruled-model translation of single_agent_trusted_workflow_spec().
+# This is reaction data for #1269, not a document accepted by today's schema.
+apiVersion: flotilla.work/v1
+kind: WorkflowTemplate
+metadata:
+  name: single-agent-trusted
+  namespace: flotilla
+  labels:
+    flotilla.work/managed-by: builtin
+spec:
+  vessels:
+    - name: work
+      stance: trusted
+      crew:
+        - role: coder
+          selector:
+            capability: code
+
+  # Today the first agent starts eagerly with the vessel and an absent
+  # brief_template resolves to the default crew brief. The ruled model makes
+  # both choices explicit on the engagement.
+  engagement_rules:
+    - name: initial-coding-turn
+      when:
+        transition: work.entered-running
+        subject:
+          vessel: work
+      engage:
+        vessel: work
+        role: coder
+        brief_template: crew
+      expecting:
+        fact: crew-work.phase
+        subject:
+          vessel: work
+          role: coder
+        equals: Done

--- a/prototypes/1262-scenarios/pr-adoption-turn.yaml
+++ b/prototypes/1262-scenarios/pr-adoption-turn.yaml
@@ -16,7 +16,6 @@ spec:
         - role: shepherd
           selector:
             capability: code
-          brief_template: shepherd
 
   # PR adoption remains a Convoy admission operation: it writes the explicit
   # change-request binding and provisions or adopts the PR branch. The workflow

--- a/prototypes/1262-scenarios/pr-adoption-turn.yaml
+++ b/prototypes/1262-scenarios/pr-adoption-turn.yaml
@@ -1,0 +1,41 @@
+# Candidate WorkflowTemplate extension for the PR-first adoption turn from
+# flotilla-org/flotilla#1071. This is reaction data for #1269, not a document
+# accepted by today's schema.
+apiVersion: flotilla.work/v1
+kind: WorkflowTemplate
+metadata:
+  name: pr-adoption-turn
+  namespace: flotilla
+spec:
+  vessels:
+    - name: work
+      stance: trusted
+      credential_refs:
+        - forge
+      crew:
+        - role: shepherd
+          selector:
+            capability: code
+          brief_template: shepherd
+
+  # PR adoption remains a Convoy admission operation: it writes the explicit
+  # change-request binding and provisions or adopts the PR branch. The workflow
+  # reacts to the ordinary declared Active phase edge, guarded by that binding;
+  # it does not require an imperative "adopted" event.
+  engagement_rules:
+    - name: first-shepherd-round
+      when:
+        transition: convoy.entered-active
+        guards:
+          - fact: convoy.change-request
+            operator: present
+      engage:
+        vessel: work
+        role: shepherd
+        brief_template: shepherd
+      expecting:
+        fact: crew-work.phase
+        subject:
+          vessel: work
+          role: shepherd
+        equals: Done

--- a/prototypes/1262-scenarios/rebase-on-conflict.yaml
+++ b/prototypes/1262-scenarios/rebase-on-conflict.yaml
@@ -1,0 +1,35 @@
+# Candidate WorkflowTemplate extension for flotilla-org/flotilla#1150.
+# This is reaction data for #1269, not a document accepted by today's schema.
+apiVersion: flotilla.work/v1
+kind: WorkflowTemplate
+metadata:
+  name: rebase-on-conflict
+  namespace: flotilla
+spec:
+  vessels:
+    - name: work
+      stance: contained
+      credential_refs:
+        - forge
+      crew:
+        - role: coder
+          selector:
+            capability: code
+
+  # Engagement rules are the sole subscription surface. Because this rule does
+  # not declare a wider scope, the transition subject is implicitly restricted
+  # to change requests bound to this convoy.
+  engagement_rules:
+    - name: rebase-on-conflict
+      when:
+        transition: change-request.went-conflicting
+        guards:
+          - fact: convoy.phase
+            equals: Landing
+      engage:
+        vessel: work
+        role: coder
+        brief_template: rebase-on-conflict
+      expecting:
+        fact: change-request.mergeability
+        equals: mergeable

--- a/prototypes/1262-scenarios/review-round-trip.yaml
+++ b/prototypes/1262-scenarios/review-round-trip.yaml
@@ -15,7 +15,6 @@ spec:
         - role: shepherd
           selector:
             capability: code
-          brief_template: shepherd
 
   # One rule deliberately groups every kind of actionable PR material. The
   # subscription is implicitly limited to this convoy's bound change request.

--- a/prototypes/1262-scenarios/review-round-trip.yaml
+++ b/prototypes/1262-scenarios/review-round-trip.yaml
@@ -1,0 +1,43 @@
+# Candidate WorkflowTemplate extension for flotilla-org/flotilla#1216.
+# This is reaction data for #1269, not a document accepted by today's schema.
+apiVersion: flotilla.work/v1
+kind: WorkflowTemplate
+metadata:
+  name: review-round-trip
+  namespace: flotilla
+spec:
+  vessels:
+    - name: work
+      stance: trusted
+      credential_refs:
+        - forge
+      crew:
+        - role: shepherd
+          selector:
+            capability: code
+          brief_template: shepherd
+
+  # One rule deliberately groups every kind of actionable PR material. The
+  # subscription is implicitly limited to this convoy's bound change request.
+  # Each match requests one engagement round; it does not create a workflow
+  # phase or an edge outside the ADR 0024 convoy machine.
+  engagement_rules:
+    - name: process-review-round
+      when:
+        any_transition:
+          - change-request.review-arrived
+          - change-request.checks-failed
+          - change-request.went-conflicting
+        guards:
+          - fact: convoy.phase
+            equals: Landing
+      engage:
+        vessel: work
+        role: shepherd
+        brief_template: shepherd
+      expecting:
+        fact: crew-work.phase
+        subject:
+          vessel: work
+          role: shepherd
+        equals: Done


### PR DESCRIPTION
## Summary

- model rebase-on-conflict, review round-trip, and PR adoption as candidate WorkflowTemplate data
- translate the existing single-agent-trusted, implement-review, and single-agent-shepherd builtins into the ruled engagement model
- put subscriptions only in engagement-rule when clauses with implicit own-resource scope
- distinguish true expressibility gaps from deliberate differences with today's code and behavior outside workflow data

## Validation

- parsed all six YAML documents with Ruby YAML
- checked builtin names, managed-by labels, stances, roles, and selector capabilities against their Rust constructors
- checked staged whitespace with git diff --check

Closes #1269
