### PR TITLE
Expose resumable resource reads through client and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,6 +1164,7 @@ dependencies = [
 name = "flotilla-protocol"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "bon",
  "chrono",
  "gethostname",

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -19,6 +19,7 @@ use tokio::sync::{broadcast, oneshot, Mutex};
 use tracing::{debug, error, warn};
 
 pub mod reconnect;
+pub mod resource;
 pub const BUILD_ID: &str = env!("FLOTILLA_BUILD_ID");
 
 /// Std RwLock for local seq tracking — the critical sections are single HashMap

--- a/crates/flotilla-client/src/resource.rs
+++ b/crates/flotilla-client/src/resource.rs
@@ -1,0 +1,276 @@
+use std::sync::Arc;
+
+use flotilla_core::daemon::DaemonHandle;
+use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, NodeId, ResourceCursor, ResourceReadEnvelope, StepStatus};
+use tokio::sync::broadcast;
+
+#[derive(Debug, Clone, bon::Builder)]
+pub struct ResourceListRequest {
+    pub kind: String,
+    #[builder(default = "flotilla".to_string())]
+    pub namespace: String,
+    pub node_id: Option<NodeId>,
+    #[builder(default)]
+    pub include_replicas: bool,
+}
+
+#[derive(Debug, Clone, bon::Builder)]
+pub struct ResourceGetRequest {
+    pub kind: String,
+    pub name: String,
+    #[builder(default = "flotilla".to_string())]
+    pub namespace: String,
+    pub node_id: Option<NodeId>,
+}
+
+#[derive(Debug, Clone, bon::Builder)]
+pub struct ResourceWatchRequest {
+    pub kind: String,
+    #[builder(default = "flotilla".to_string())]
+    pub namespace: String,
+    pub name: Option<String>,
+    pub node_id: Option<NodeId>,
+    #[builder(default)]
+    pub include_replicas: bool,
+    pub cursor: Option<ResourceCursor>,
+}
+
+#[derive(Clone)]
+pub struct ResourceClient {
+    daemon: Arc<dyn DaemonHandle>,
+}
+
+impl ResourceClient {
+    pub fn new(daemon: Arc<dyn DaemonHandle>) -> Self {
+        Self { daemon }
+    }
+
+    pub async fn list(&self, request: ResourceListRequest) -> Result<ResourceReadEnvelope, String> {
+        let result = self
+            .daemon
+            .execute_query(
+                Command {
+                    node_id: request.node_id,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::QueryResourceList {
+                        namespace: request.namespace,
+                        kind: request.kind,
+                        include_replicas: request.include_replicas,
+                    },
+                },
+                uuid::Uuid::new_v4(),
+            )
+            .await?;
+        resource_read_result(result)
+    }
+
+    pub async fn get(&self, request: ResourceGetRequest) -> Result<ResourceReadEnvelope, String> {
+        let result = self
+            .daemon
+            .execute_query(
+                Command {
+                    node_id: request.node_id,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::QueryResourceGet { namespace: request.namespace, kind: request.kind, name: request.name },
+                },
+                uuid::Uuid::new_v4(),
+            )
+            .await?;
+        resource_read_result(result)
+    }
+
+    pub async fn watch(&self, request: ResourceWatchRequest) -> Result<ResourceWatch, String> {
+        let events = self.daemon.subscribe();
+        let command_id = self
+            .daemon
+            .execute(Command {
+                node_id: request.node_id,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::ResourceWatch {
+                    namespace: request.namespace,
+                    kind: request.kind,
+                    name: request.name,
+                    include_replicas: request.include_replicas,
+                    replica_sources: false,
+                    cursor: request.cursor,
+                },
+            })
+            .await?;
+        Ok(ResourceWatch { daemon: Arc::clone(&self.daemon), events, command_id, finished: false })
+    }
+}
+
+fn resource_read_result(result: CommandValue) -> Result<ResourceReadEnvelope, String> {
+    match result {
+        CommandValue::ResourceRead(envelope) => Ok(*envelope),
+        CommandValue::Error { message } => Err(message),
+        other => Err(format!("unexpected resource read response: {other:?}")),
+    }
+}
+
+pub struct ResourceWatch {
+    daemon: Arc<dyn DaemonHandle>,
+    events: broadcast::Receiver<DaemonEvent>,
+    command_id: u64,
+    finished: bool,
+}
+
+impl ResourceWatch {
+    pub async fn next(&mut self) -> Result<Option<ResourceReadEnvelope>, String> {
+        if self.finished {
+            return Ok(None);
+        }
+        loop {
+            match self.events.recv().await {
+                Ok(DaemonEvent::CommandStepUpdate { command_id, status: StepStatus::Produced { value }, .. })
+                    if command_id == self.command_id =>
+                {
+                    if let CommandValue::ResourceWatchEvent(envelope) = *value {
+                        return Ok(Some(*envelope));
+                    }
+                }
+                Ok(DaemonEvent::CommandFinished { command_id, result, .. }) if command_id == self.command_id => {
+                    self.finished = true;
+                    return match result {
+                        CommandValue::Ok | CommandValue::Cancelled => Ok(None),
+                        CommandValue::Error { message } => Err(message),
+                        other => Err(format!("unexpected resource watch result: {other:?}")),
+                    };
+                }
+                Ok(_) => {}
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    return Err(format!("resource watch fell behind by {skipped} events; resume from the last emitted cursor"));
+                }
+                Err(broadcast::error::RecvError::Closed) => return Err("daemon disconnected during resource watch".to_string()),
+            }
+        }
+    }
+
+    pub async fn cancel(mut self) -> Result<(), String> {
+        if !self.finished {
+            self.daemon.cancel(self.command_id).await?;
+            self.finished = true;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ResourceWatch {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let daemon = Arc::clone(&self.daemon);
+        let command_id = self.command_id;
+        runtime.spawn(async move {
+            let _ = daemon.cancel(command_id).await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flotilla_protocol::{Message, RepoIdentity, Request, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, Response};
+    use flotilla_transport::message::message_session_pair;
+
+    use super::*;
+    use crate::SocketDaemon;
+
+    fn envelope(record_type: ResourceRecordType, version: &str) -> ResourceReadEnvelope {
+        ResourceReadEnvelope {
+            api_version: "flotilla.work/v1".to_string(),
+            resource_kind: "Convoy".to_string(),
+            plural: "convoys".to_string(),
+            namespace: "flotilla".to_string(),
+            cursor: ResourceCursor::from_position(version, None),
+            records: vec![ResourceReadRecord {
+                record_type,
+                provenance: ResourceRecordProvenance::Local { node_id: NodeId::new("feta") },
+                object: Some(serde_json::json!({"metadata": {"name": "demo", "resourceVersion": version}})),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn client_lists_and_watches_through_the_shared_resource_surface() {
+        let (client_session, server_session) = message_session_pair();
+        let daemon = SocketDaemon::from_session(client_session).expect("create socket daemon");
+        let client = ResourceClient::new(daemon);
+        let server = tokio::spawn(async move {
+            let Some(Message::Request { id, request: Request::Execute { command } }) =
+                server_session.read().await.expect("read list request")
+            else {
+                panic!("expected list request");
+            };
+            assert!(matches!(command.action, CommandAction::QueryResourceList { ref kind, .. } if kind == "convoys"));
+            server_session
+                .write(Message::ok_response(id, Response::QueryResult {
+                    command_id: 1,
+                    value: CommandValue::ResourceRead(Box::new(envelope(ResourceRecordType::Current, "1"))),
+                }))
+                .await
+                .expect("write list response");
+
+            let Some(Message::Request { id, request: Request::Execute { command } }) =
+                server_session.read().await.expect("read watch request")
+            else {
+                panic!("expected watch request");
+            };
+            assert!(matches!(
+                command.action,
+                CommandAction::ResourceWatch { ref name, ref cursor, .. }
+                    if name.as_deref() == Some("demo") && cursor.as_ref().is_some_and(|cursor| cursor.position().is_ok())
+            ));
+            server_session.write(Message::ok_response(id, Response::Execute { command_id: 2 })).await.expect("write watch start");
+            server_session
+                .write(Message::Event {
+                    event: Box::new(DaemonEvent::CommandStepUpdate {
+                        command_id: 2,
+                        node_id: NodeId::new("feta"),
+                        repo_identity: RepoIdentity { authority: "local".to_string(), path: "resource".to_string() },
+                        repo: None,
+                        step_index: 0,
+                        step_count: 1,
+                        description: "modified Convoy".to_string(),
+                        status: StepStatus::Produced {
+                            value: Box::new(CommandValue::ResourceWatchEvent(Box::new(envelope(ResourceRecordType::Modified, "2")))),
+                        },
+                    }),
+                })
+                .await
+                .expect("write watch event");
+            server_session
+                .write(Message::Event {
+                    event: Box::new(DaemonEvent::CommandFinished {
+                        command_id: 2,
+                        node_id: NodeId::new("feta"),
+                        repo_identity: RepoIdentity { authority: "local".to_string(), path: "resource".to_string() },
+                        repo: None,
+                        result: CommandValue::Ok,
+                    }),
+                })
+                .await
+                .expect("write watch finish");
+        });
+
+        let listed = client.list(ResourceListRequest::builder().kind("convoys".to_string()).build()).await.expect("list resources");
+        assert_eq!(listed.records[0].record_type, ResourceRecordType::Current);
+
+        let mut watch = client
+            .watch(ResourceWatchRequest::builder().kind("convoys".to_string()).name("demo".to_string()).cursor(listed.cursor).build())
+            .await
+            .expect("watch resources");
+        assert_eq!(
+            watch.next().await.expect("next watch record").expect("watch envelope").records[0].record_type,
+            ResourceRecordType::Modified
+        );
+        assert!(watch.next().await.expect("watch end").is_none());
+        server.await.expect("server task");
+    }
+}

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -28,9 +28,10 @@ use flotilla_protocol::{
     HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PlacementDecision,
     PlacementRefusal, PlacementTargetHost, PlacementViableCandidate, PrincipalRef, ProjectListEntry, ProjectListRepository,
     ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo,
-    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceJsonResponse,
-    ResourceRef, ResourceWatchResponse, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory,
-    TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceCursor,
+    ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, ResourceRef,
+    StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
+    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
@@ -152,9 +153,10 @@ struct ResourceWatchCommandContext {
     backend: ResourceBackend,
     namespace: String,
     kind: String,
+    name: Option<String>,
     include_replicas: bool,
     replica_sources: bool,
-    cursor: Option<flotilla_protocol::ResourceWatchCursor>,
+    cursor: Option<ResourceCursor>,
     command_id: u64,
     node_id: NodeId,
     repo_identity: RepoIdentity,
@@ -163,14 +165,18 @@ struct ResourceWatchCommandContext {
 }
 
 async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> CommandValue {
-    let start = context.cursor.map(|cursor| match cursor.generation {
-        Some(generation) => WatchStart::FromVersionInGeneration { generation, resource_version: cursor.resource_version },
-        None => WatchStart::FromVersion(cursor.resource_version),
-    });
+    let resuming = context.cursor.is_some();
+    let start = match context.cursor.as_ref().map(ResourceCursor::position).transpose() {
+        Ok(position) => position.map(|(resource_version, generation)| match generation {
+            Some(generation) => WatchStart::FromVersionInGeneration { generation, resource_version },
+            None => WatchStart::FromVersion(resource_version),
+        }),
+        Err(message) => return CommandValue::Error { message },
+    };
     let result = match (context.replica_sources, context.include_replicas, start) {
-        (true, _, Some(_)) => Err(ResourceError::invalid("replica-source watches cannot resume from an origin resourceVersion")),
+        (true, _, Some(_)) => Err(ResourceError::invalid("replica-source watches do not support cursor resume")),
         (true, _, None) => watch_resource_kind_replica_sources(&context.backend, &context.namespace, &context.kind).await,
-        (false, true, Some(_)) => Err(ResourceError::invalid("include-replicas watches cannot resume from an origin resourceVersion")),
+        (false, true, Some(_)) => Err(ResourceError::invalid("include-replicas watches do not support cursor resume")),
         (false, true, None) => watch_resource_kind_including_replicas(&context.backend, &context.namespace, &context.kind).await,
         (false, false, Some(start)) => watch_resource_kind_from(&context.backend, &context.namespace, &context.kind, start).await,
         (false, false, None) => watch_resource_kind(&context.backend, &context.namespace, &context.kind).await,
@@ -180,32 +186,44 @@ async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> Com
         Err(error) => return CommandValue::Error { message: error.to_string() },
     };
 
-    let kind = watch.kind;
+    let resource_kind = watch.kind;
     let plural = watch.plural;
     let namespace = watch.namespace;
     let initial_resource_version = watch.resource_version;
     let generation = watch.generation;
-    for event in watch.initial {
+    let initial_cursor = ResourceCursor::from_position(initial_resource_version.clone(), generation.clone());
+    if !resuming {
+        let initial = watch
+            .initial
+            .into_iter()
+            .filter_map(|event| resource_watch_record(event, &context.node_id).transpose())
+            .collect::<Result<Vec<_>, _>>();
+        let initial = match initial {
+            Ok(initial) => initial.into_iter().filter(|record| resource_record_matches_name(record, context.name.as_deref())).collect(),
+            Err(message) => return CommandValue::Error { message },
+        };
         if context.token.is_cancelled() {
             return CommandValue::Cancelled;
         }
-        send_resource_watch_event(&context.event_tx, context.command_id, &context.node_id, &context.repo_identity, ResourceWatchResponse {
-            kind: kind.clone(),
-            plural: plural.clone(),
-            namespace: namespace.clone(),
-            resource_version: initial_resource_version.clone(),
-            generation: generation.clone(),
-            event,
-        });
+        send_resource_watch_event(
+            &context.event_tx,
+            context.command_id,
+            &context.node_id,
+            &context.repo_identity,
+            resource_read_envelope(resource_kind.clone(), plural.clone(), namespace.clone(), initial_cursor.clone(), initial),
+        );
     }
-    send_resource_watch_event(&context.event_tx, context.command_id, &context.node_id, &context.repo_identity, ResourceWatchResponse {
-        kind: kind.clone(),
-        plural: plural.clone(),
-        namespace: namespace.clone(),
-        resource_version: initial_resource_version.clone(),
-        generation: generation.clone(),
-        event: serde_json::json!({"type": "BOOKMARK"}),
-    });
+    send_resource_watch_event(
+        &context.event_tx,
+        context.command_id,
+        &context.node_id,
+        &context.repo_identity,
+        resource_read_envelope(resource_kind.clone(), plural.clone(), namespace.clone(), initial_cursor, vec![ResourceReadRecord {
+            record_type: ResourceRecordType::Bookmark,
+            provenance: ResourceRecordProvenance::Local { node_id: context.node_id.clone() },
+            object: None,
+        }]),
+    );
 
     let mut stream = watch.stream;
     loop {
@@ -218,20 +236,26 @@ async fn run_resource_watch_command(context: ResourceWatchCommandContext) -> Com
                             .as_str()
                             .unwrap_or(&initial_resource_version)
                             .to_string();
-                        send_resource_watch_event(
-                            &context.event_tx,
-                            context.command_id,
-                            &context.node_id,
-                            &context.repo_identity,
-                            ResourceWatchResponse {
-                                kind: kind.clone(),
-                                plural: plural.clone(),
-                                namespace: namespace.clone(),
-                                resource_version,
-                                generation: generation.clone(),
-                                event,
-                            },
-                        );
+                        let record = match resource_watch_record(event, &context.node_id) {
+                            Ok(Some(record)) => record,
+                            Ok(None) => continue,
+                            Err(message) => return CommandValue::Error { message },
+                        };
+                        if resource_record_matches_name(&record, context.name.as_deref()) {
+                            send_resource_watch_event(
+                                &context.event_tx,
+                                context.command_id,
+                                &context.node_id,
+                                &context.repo_identity,
+                                resource_read_envelope(
+                                    resource_kind.clone(),
+                                    plural.clone(),
+                                    namespace.clone(),
+                                    ResourceCursor::from_position(resource_version, generation.clone()),
+                                    vec![record],
+                                ),
+                            );
+                        }
                     }
                     Some(Err(error)) => return CommandValue::Error { message: error.to_string() },
                     None => return CommandValue::Ok,
@@ -246,9 +270,13 @@ fn send_resource_watch_event(
     command_id: u64,
     node_id: &NodeId,
     repo_identity: &RepoIdentity,
-    response: ResourceWatchResponse,
+    response: ResourceReadEnvelope,
 ) {
-    let description = format!("{} {}", response.event["type"].as_str().unwrap_or("EVENT"), response.kind);
+    let description = format!(
+        "{} {}",
+        response.records.first().map(|record| format!("{:?}", record.record_type)).unwrap_or_else(|| "CURRENT".to_string()),
+        response.resource_kind
+    );
     let _ = event_tx.send(DaemonEvent::CommandStepUpdate {
         command_id,
         node_id: node_id.clone(),
@@ -259,6 +287,59 @@ fn send_resource_watch_event(
         description,
         status: StepStatus::Produced { value: Box::new(CommandValue::ResourceWatchEvent(Box::new(response))) },
     });
+}
+
+fn resource_read_envelope(
+    resource_kind: String,
+    plural: String,
+    namespace: String,
+    cursor: ResourceCursor,
+    records: Vec<ResourceReadRecord>,
+) -> ResourceReadEnvelope {
+    ResourceReadEnvelope { api_version: "flotilla.work/v1".to_string(), resource_kind, plural, namespace, cursor, records }
+}
+
+fn resource_record(record_type: ResourceRecordType, object: serde_json::Value, local_node_id: &NodeId) -> ResourceReadRecord {
+    let annotations = object.get("metadata").and_then(|metadata| metadata.get("annotations"));
+    let origin_root = annotations.and_then(|annotations| annotations.get("flotilla.work/origin-root")).and_then(|value| value.as_str());
+    let last_synced_at =
+        annotations.and_then(|annotations| annotations.get("flotilla.work/last-synced-at")).and_then(|value| value.as_str());
+    let provenance = match (origin_root, last_synced_at) {
+        (Some(origin_root), Some(last_synced_at)) => {
+            ResourceRecordProvenance::Replica { origin_root: NodeId::new(origin_root), last_synced_at: last_synced_at.to_string() }
+        }
+        _ => ResourceRecordProvenance::Local { node_id: local_node_id.clone() },
+    };
+    ResourceReadRecord { record_type, provenance, object: Some(object) }
+}
+
+fn resource_watch_record(event: serde_json::Value, local_node_id: &NodeId) -> Result<Option<ResourceReadRecord>, String> {
+    let Some(event_type) = event.get("type").and_then(|value| value.as_str()) else {
+        return Err("resource watch event is missing type".to_string());
+    };
+    if event_type == "BOOKMARK" {
+        return Ok(None);
+    }
+    let record_type = match event_type {
+        "ADDED" => ResourceRecordType::Added,
+        "MODIFIED" => ResourceRecordType::Modified,
+        "DELETED" => ResourceRecordType::Deleted,
+        other => return Err(format!("unknown resource watch event type '{other}'")),
+    };
+    let object = event.get("object").cloned().ok_or_else(|| "resource watch event is missing object".to_string())?;
+    Ok(Some(resource_record(record_type, object, local_node_id)))
+}
+
+fn resource_record_matches_name(record: &ResourceReadRecord, name: Option<&str>) -> bool {
+    name.is_none_or(|name| {
+        record
+            .object
+            .as_ref()
+            .and_then(|object| object.get("metadata"))
+            .and_then(|metadata| metadata.get("name"))
+            .and_then(|value| value.as_str())
+            == Some(name)
+    })
 }
 
 #[derive(Default)]
@@ -7133,7 +7214,7 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ResourceWatch { namespace, kind, include_replicas, replica_sources, cursor } =
+        if let flotilla_protocol::CommandAction::ResourceWatch { namespace, kind, name, include_replicas, replica_sources, cursor } =
             command.action
         {
             let repo_identity = empty_repo_identity();
@@ -7160,6 +7241,7 @@ impl InProcessDaemon {
                         .backend(backend)
                         .namespace(namespace)
                         .kind(kind)
+                        .maybe_name(name)
                         .include_replicas(include_replicas)
                         .replica_sources(replica_sources)
                         .maybe_cursor(cursor)
@@ -8229,27 +8311,57 @@ impl DaemonHandle for InProcessDaemon {
                     Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
                 }
             }
-            CommandAction::QueryResourceList { namespace, kind, include_replicas } => match if *include_replicas {
-                list_resource_kind_including_replicas(&self.resource_backend, namespace, kind).await
-            } else {
-                list_resource_kind(&self.resource_backend, namespace, kind).await
-            } {
-                Ok(v) => Ok(flotilla_protocol::CommandValue::ResourceList(Box::new(ResourceJsonResponse {
-                    kind: v.kind,
-                    plural: v.plural,
-                    namespace: v.namespace,
-                    value: v.value,
-                }))),
-                Err(error) => Ok(flotilla_protocol::CommandValue::Error { message: error.to_string() }),
-            },
+            CommandAction::QueryResourceList { namespace, kind, include_replicas } => {
+                let listed = if *include_replicas {
+                    list_resource_kind_including_replicas(&self.resource_backend, namespace, kind).await
+                } else {
+                    list_resource_kind(&self.resource_backend, namespace, kind).await
+                };
+                match listed {
+                    Ok(v) => {
+                        let resource_version = v.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string();
+                        let generation = v.value["metadata"]["generation"].as_str().map(ToOwned::to_owned);
+                        let records = v.value["items"]
+                            .as_array()
+                            .into_iter()
+                            .flatten()
+                            .cloned()
+                            .map(|object| resource_record(ResourceRecordType::Current, object, &self.node_id))
+                            .collect();
+                        Ok(CommandValue::ResourceRead(Box::new(resource_read_envelope(
+                            v.kind,
+                            v.plural,
+                            v.namespace,
+                            ResourceCursor::from_position(resource_version, generation),
+                            records,
+                        ))))
+                    }
+                    Err(error) => Ok(CommandValue::Error { message: error.to_string() }),
+                }
+            }
             CommandAction::QueryResourceGet { namespace, kind, name } => {
+                // Take the collection cursor before reading the object. A
+                // concurrent mutation can then be replayed (at worst as a
+                // duplicate) instead of being hidden behind a newer cursor.
+                let listed = list_resource_kind(&self.resource_backend, namespace, kind).await;
                 match get_resource_kind(&self.resource_backend, namespace, kind, name).await {
-                    Ok(v) => Ok(flotilla_protocol::CommandValue::ResourceObject(Box::new(ResourceJsonResponse {
-                        kind: v.kind,
-                        plural: v.plural,
-                        namespace: v.namespace,
-                        value: v.value,
-                    }))),
+                    Ok(v) => {
+                        let (resource_version, generation) = match listed {
+                            Ok(listed) => (
+                                listed.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string(),
+                                listed.value["metadata"]["generation"].as_str().map(ToOwned::to_owned),
+                            ),
+                            Err(_) => (v.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string(), None),
+                        };
+                        let record = resource_record(ResourceRecordType::Current, v.value, &self.node_id);
+                        Ok(CommandValue::ResourceRead(Box::new(resource_read_envelope(
+                            v.kind,
+                            v.plural,
+                            v.namespace,
+                            ResourceCursor::from_position(resource_version, generation),
+                            vec![record],
+                        ))))
+                    }
                     Err(error) => Ok(flotilla_protocol::CommandValue::Error { message: error.to_string() }),
                 }
             }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -8343,16 +8343,14 @@ impl DaemonHandle for InProcessDaemon {
                 // Take the collection cursor before reading the object. A
                 // concurrent mutation can then be replayed (at worst as a
                 // duplicate) instead of being hidden behind a newer cursor.
-                let listed = list_resource_kind(&self.resource_backend, namespace, kind).await;
+                let listed = match list_resource_kind(&self.resource_backend, namespace, kind).await {
+                    Ok(listed) => listed,
+                    Err(error) => return Ok(CommandValue::Error { message: error.to_string() }),
+                };
                 match get_resource_kind(&self.resource_backend, namespace, kind, name).await {
                     Ok(v) => {
-                        let (resource_version, generation) = match listed {
-                            Ok(listed) => (
-                                listed.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string(),
-                                listed.value["metadata"]["generation"].as_str().map(ToOwned::to_owned),
-                            ),
-                            Err(_) => (v.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string(), None),
-                        };
+                        let resource_version = listed.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string();
+                        let generation = listed.value["metadata"]["generation"].as_str().map(ToOwned::to_owned);
                         let record = resource_record(ResourceRecordType::Current, v.value, &self.node_id);
                         Ok(CommandValue::ResourceRead(Box::new(resource_read_envelope(
                             v.kind,

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -742,10 +742,13 @@ async fn resource_list_and_get_queries_return_wire_json() {
         )
         .await
         .expect("list query");
-    let CommandValue::ResourceList(listed) = listed else { panic!("expected resource list") };
-    assert_eq!(listed.value["items"][0]["apiVersion"], "flotilla.work/v1");
-    assert_eq!(listed.value["items"][0]["kind"], "Convoy");
-    assert_eq!(listed.value["items"][0]["metadata"]["name"], "resource-demo");
+    let CommandValue::ResourceRead(listed) = listed else { panic!("expected resource read") };
+    assert_eq!(listed.resource_kind, "Convoy");
+    assert_eq!(listed.records[0].record_type, flotilla_protocol::ResourceRecordType::Current);
+    let listed_object = listed.records[0].object.as_ref().expect("listed object");
+    assert_eq!(listed_object["apiVersion"], "flotilla.work/v1");
+    assert_eq!(listed_object["kind"], "Convoy");
+    assert_eq!(listed_object["metadata"]["name"], "resource-demo");
 
     let fetched = daemon
         .execute_query(
@@ -763,19 +766,20 @@ async fn resource_list_and_get_queries_return_wire_json() {
         )
         .await
         .expect("get query");
-    let CommandValue::ResourceObject(fetched) = fetched else { panic!("expected resource object") };
-    assert_eq!(fetched.value["metadata"]["name"], "resource-demo");
-    assert_eq!(fetched.value["spec"]["workflow_ref"], "wf");
+    let CommandValue::ResourceRead(fetched) = fetched else { panic!("expected resource read") };
+    let fetched_object = fetched.records[0].object.as_ref().expect("fetched object");
+    assert_eq!(fetched_object["metadata"]["name"], "resource-demo");
+    assert_eq!(fetched_object["spec"]["workflow_ref"], "wf");
+    assert_eq!(fetched.cursor.position().expect("decode cursor").0, listed.cursor.position().expect("decode cursor").0);
 }
 
 #[tokio::test]
-async fn resource_watch_emits_initial_resources_as_wire_events() {
+async fn resource_watch_streams_current_update_and_resumed_delete_without_loss() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let daemon =
         InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
-    daemon
-        .resource_backend()
-        .using::<ResourceConvoy>("flotilla")
+    let convoys = daemon.resource_backend().using::<ResourceConvoy>("flotilla");
+    let created = convoys
         .create(
             &InputMeta::builder().name("watched-convoy".to_string()).build(),
             &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
@@ -792,6 +796,7 @@ async fn resource_watch_emits_initial_resources_as_wire_events() {
             action: CommandAction::ResourceWatch {
                 namespace: "flotilla".to_string(),
                 kind: "convoys".to_string(),
+                name: Some("watched-convoy".to_string()),
                 include_replicas: false,
                 replica_sources: false,
                 cursor: None,
@@ -810,30 +815,50 @@ async fn resource_watch_emits_initial_resources_as_wire_events() {
             _ => {}
         }
     };
-    assert_eq!(watched.event["type"], "ADDED");
-    assert_eq!(watched.event["object"]["metadata"]["name"], "watched-convoy");
+    assert_eq!(watched.records.len(), 1);
+    assert_eq!(watched.records[0].record_type, flotilla_protocol::ResourceRecordType::Added);
+    assert_eq!(watched.records[0].object.as_ref().expect("current object")["metadata"]["name"], "watched-convoy");
+    assert!(matches!(watched.records[0].provenance, flotilla_protocol::ResourceRecordProvenance::Local { .. }));
 
-    daemon.cancel(command_id).await.expect("cancel watch");
-    assert!(matches!(recv_command_finished(&mut rx, command_id).await, CommandValue::Cancelled));
-}
+    let _bookmark = loop {
+        match recv_event(&mut rx).await {
+            DaemonEvent::CommandStepUpdate { command_id: id, status, .. } if id == command_id => {
+                let StepStatus::Produced { value } = status else { continue };
+                let CommandValue::ResourceWatchEvent(event) = *value else { continue };
+                if event.records[0].record_type == flotilla_protocol::ResourceRecordType::Bookmark {
+                    break event;
+                }
+            }
+            _ => {}
+        }
+    };
 
-#[tokio::test]
-async fn resource_watch_resumes_after_a_stored_cursor_without_relisting() {
-    let temp = tempfile::tempdir().expect("create tempdir");
-    let daemon =
-        InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
-    let convoys = daemon.resource_backend().using::<ResourceConvoy>("flotilla");
+    let updated_spec = flotilla_resources::ConvoySpec::builder().workflow_ref("wf-v2".to_string()).build();
     convoys
-        .create(
-            &InputMeta::builder().name("before-cursor".to_string()).build(),
-            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
-        )
+        .update(&InputMeta::from(&created.metadata), &created.metadata.resource_version, &updated_spec)
         .await
-        .expect("create initial convoy");
-    let cursor = convoys.list().await.expect("list cursor").resource_version;
+        .expect("update watched convoy");
+    let modified = loop {
+        match recv_event(&mut rx).await {
+            DaemonEvent::CommandStepUpdate { command_id: id, status, .. } if id == command_id => {
+                let StepStatus::Produced { value } = status else { continue };
+                let CommandValue::ResourceWatchEvent(event) = *value else { continue };
+                if event.records[0].record_type == flotilla_protocol::ResourceRecordType::Modified {
+                    break event;
+                }
+            }
+            _ => {}
+        }
+    };
+    let resume_cursor = modified.cursor.clone();
+    assert_eq!(modified.records[0].object.as_ref().expect("modified object")["spec"]["workflow_ref"], "wf-v2");
 
-    let mut rx = daemon.subscribe();
-    let command_id = daemon
+    daemon.cancel(command_id).await.expect("cancel initial watch");
+    assert!(matches!(recv_command_finished(&mut rx, command_id).await, CommandValue::Cancelled));
+    convoys.delete("watched-convoy").await.expect("delete watched convoy");
+
+    let mut resumed_events = daemon.subscribe();
+    let resumed_command_id = daemon
         .execute(Command {
             node_id: None,
             provisioning_target: None,
@@ -841,47 +866,28 @@ async fn resource_watch_resumes_after_a_stored_cursor_without_relisting() {
             action: CommandAction::ResourceWatch {
                 namespace: "flotilla".to_string(),
                 kind: "convoys".to_string(),
+                name: Some("watched-convoy".to_string()),
                 include_replicas: false,
                 replica_sources: false,
-                cursor: Some(flotilla_protocol::ResourceWatchCursor { resource_version: cursor, generation: None }),
+                cursor: Some(resume_cursor),
             },
         })
         .await
         .expect("resume watch command");
-
-    let bookmark = loop {
-        match recv_event(&mut rx).await {
-            DaemonEvent::CommandStepUpdate { command_id: id, status, .. } if id == command_id => {
+    let deleted = loop {
+        match recv_event(&mut resumed_events).await {
+            DaemonEvent::CommandStepUpdate { command_id: id, status, .. } if id == resumed_command_id => {
                 let StepStatus::Produced { value } = status else { continue };
                 let CommandValue::ResourceWatchEvent(event) = *value else { continue };
-                break event;
-            }
-            _ => {}
-        }
-    };
-    assert_eq!(bookmark.event["type"], "BOOKMARK");
-
-    convoys
-        .create(
-            &InputMeta::builder().name("after-cursor".to_string()).build(),
-            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
-        )
-        .await
-        .expect("create convoy after cursor");
-    let added = loop {
-        match recv_event(&mut rx).await {
-            DaemonEvent::CommandStepUpdate { command_id: id, status, .. } if id == command_id => {
-                let StepStatus::Produced { value } = status else { continue };
-                let CommandValue::ResourceWatchEvent(event) = *value else { continue };
-                if event.event["type"] == "ADDED" {
+                if event.records[0].record_type == flotilla_protocol::ResourceRecordType::Deleted {
                     break event;
                 }
             }
             _ => {}
         }
     };
-    assert_eq!(added.event["object"]["metadata"]["name"], "after-cursor");
-    daemon.cancel(command_id).await.expect("cancel resumed watch");
+    assert_eq!(deleted.records[0].object.as_ref().expect("deleted object")["metadata"]["name"], "watched-convoy");
+    daemon.cancel(resumed_command_id).await.expect("cancel resumed watch");
 }
 
 async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBackend, image: &str, agent_adapters: BTreeSet<String>) {

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -786,6 +786,13 @@ async fn resource_watch_streams_current_update_and_resumed_delete_without_loss()
         )
         .await
         .expect("create convoy");
+    let ignored = convoys
+        .create(
+            &InputMeta::builder().name("ignored-convoy".to_string()).build(),
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("ignored-wf".to_string()).build(),
+        )
+        .await
+        .expect("create ignored convoy");
 
     let mut rx = daemon.subscribe();
     let command_id = daemon
@@ -834,6 +841,14 @@ async fn resource_watch_streams_current_update_and_resumed_delete_without_loss()
     };
 
     let updated_spec = flotilla_resources::ConvoySpec::builder().workflow_ref("wf-v2".to_string()).build();
+    convoys
+        .update(
+            &InputMeta::from(&ignored.metadata),
+            &ignored.metadata.resource_version,
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("ignored-wf-v2".to_string()).build(),
+        )
+        .await
+        .expect("update ignored convoy");
     convoys
         .update(&InputMeta::from(&created.metadata), &created.metadata.resource_version, &updated_spec)
         .await

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -1,12 +1,19 @@
 use std::{collections::HashMap, future::Future, path::PathBuf, sync::Arc, time::Duration};
 
 use chrono::Utc;
-use flotilla_core::{daemon::DaemonHandle, in_process::InProcessDaemon};
-use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, NodeId, ResourceWatchCursor, ResourceWatchResponse};
-use flotilla_resources::{
-    HttpBackend, K8sWatchEvent, ReadWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceList, ResourceObject,
-    ResourceProvenance, WatchEvent, WatchStart,
+#[cfg(feature = "test-support")]
+use flotilla_core::daemon::DaemonHandle;
+use flotilla_core::in_process::InProcessDaemon;
+use flotilla_protocol::NodeId;
+#[cfg(feature = "test-support")]
+use flotilla_protocol::{
+    Command, CommandAction, CommandValue, DaemonEvent, ResourceCursor, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordType,
 };
+use flotilla_resources::{
+    HttpBackend, ReadWatchEvent, ReplicationClass, Resource, ResourceBackend, ResourceProvenance, WatchEvent, WatchStart,
+};
+#[cfg(feature = "test-support")]
+use flotilla_resources::{K8sWatchEvent, ResourceList, ResourceObject};
 use futures::StreamExt;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -74,7 +81,7 @@ impl SocketPathSource {
 impl PeerReplicatorSupervisors {
     pub(super) async fn peer_connected(
         &mut self,
-        router: RemoteCommandRouter,
+        _router: RemoteCommandRouter,
         daemon: Arc<InProcessDaemon>,
         peer: NodeId,
         generation: u64,
@@ -87,7 +94,7 @@ impl PeerReplicatorSupervisors {
         let transport = match resource_socket_path {
             Some(_) => ReplicationTransport::Http(socket_path_source),
             #[cfg(feature = "test-support")]
-            None => ReplicationTransport::Routed(router),
+            None => ReplicationTransport::Routed(_router),
             #[cfg(not(feature = "test-support"))]
             None => {
                 debug!(%peer, generation, "peer has no forwarded resource socket; replication waits for an outbound SSH connection");
@@ -459,8 +466,7 @@ async fn run_routed_watch<T: Resource>(
     cursor: Option<flotilla_resources::ReplicaCursor>,
 ) -> Result<(), String> {
     let resuming = cursor.is_some();
-    let protocol_cursor =
-        cursor.map(|cursor| ResourceWatchCursor { resource_version: cursor.resource_version, generation: cursor.generation });
+    let protocol_cursor = cursor.map(|cursor| ResourceCursor::from_position(cursor.resource_version, cursor.generation));
     let mut events = daemon.subscribe();
     let command_id = router
         .dispatch_execute_for_principal(
@@ -471,6 +477,7 @@ async fn run_routed_watch<T: Resource>(
                 action: CommandAction::ResourceWatch {
                     namespace: REPLICATION_NAMESPACE.to_string(),
                     kind: T::API_PATHS.plural.to_string(),
+                    name: None,
                     include_replicas: false,
                     replica_sources: false,
                     cursor: protocol_cursor,
@@ -494,7 +501,7 @@ async fn run_routed_watch<T: Resource>(
                 let CommandValue::ResourceWatchEvent(response) = *value else {
                     continue;
                 };
-                if response.kind != T::API_PATHS.kind {
+                if response.resource_kind != T::API_PATHS.kind {
                     continue;
                 }
                 apply_response(&writer, &mut initial, &mut initializing, *response).await?;
@@ -532,6 +539,7 @@ async fn replicate_relay_over_routed_watch<T: Resource>(
                 action: CommandAction::ResourceWatch {
                     namespace: REPLICATION_NAMESPACE.to_string(),
                     kind: T::API_PATHS.plural.to_string(),
+                    name: None,
                     include_replicas: false,
                     replica_sources: true,
                     cursor: None,
@@ -550,7 +558,7 @@ async fn replicate_relay_over_routed_watch<T: Resource>(
                 let CommandValue::ResourceWatchEvent(response) = *value else {
                     continue;
                 };
-                if response.kind == T::API_PATHS.kind && response.event["type"] != "BOOKMARK" {
+                if response.resource_kind == T::API_PATHS.kind {
                     apply_relay_response::<T>(daemon, peer, *response).await?;
                 }
             }
@@ -575,47 +583,50 @@ async fn replicate_relay_over_routed_watch<T: Resource>(
 async fn apply_relay_response<T: Resource>(
     daemon: &Arc<InProcessDaemon>,
     peer: &NodeId,
-    response: ResourceWatchResponse,
+    response: ResourceReadEnvelope,
 ) -> Result<(), String> {
-    let event: K8sWatchEvent<T> =
-        serde_json::from_value(response.event).map_err(|error| format!("decode relayed {} event: {error}", T::API_PATHS.kind))?;
-    let event = event.into_watch_event().map_err(|error| error.to_string())?;
-    let object = match &event {
-        WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => object,
-    };
-    let Some(origin) = object.metadata.annotations.get("flotilla.work/origin-root") else {
-        return Ok(());
-    };
-    let origin = NodeId::new(origin.clone());
-    if &origin == daemon.node_id() || &origin == peer {
-        return Ok(());
+    for record in response.records {
+        let Some(event) = record_watch_event::<T>(record)? else {
+            continue;
+        };
+        let object = match &event {
+            WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => object,
+        };
+        let Some(origin) = object.metadata.annotations.get("flotilla.work/origin-root") else {
+            continue;
+        };
+        let origin = NodeId::new(origin.clone());
+        if &origin == daemon.node_id() || &origin == peer {
+            continue;
+        }
+        let synced_at = object
+            .metadata
+            .annotations
+            .get("flotilla.work/last-synced-at")
+            .ok_or_else(|| "relayed resource is missing last-synced-at".to_string())
+            .and_then(|value| {
+                chrono::DateTime::parse_from_rfc3339(value)
+                    .map(|value| value.with_timezone(&Utc))
+                    .map_err(|error| format!("decode relayed sync timestamp: {error}"))
+            })?;
+        let strip = |mut object: ResourceObject<T>| {
+            object.metadata.annotations.remove("flotilla.work/origin-root");
+            object.metadata.annotations.remove("flotilla.work/last-synced-at");
+            object
+        };
+        let event = match event {
+            WatchEvent::Added(object) => WatchEvent::Added(strip(object)),
+            WatchEvent::Modified(object) => WatchEvent::Modified(strip(object)),
+            WatchEvent::Deleted(object) => WatchEvent::Deleted(strip(object)),
+        };
+        daemon
+            .resource_backend()
+            .replica_writer::<T>(origin, REPLICATION_NAMESPACE)
+            .apply(event, synced_at)
+            .await
+            .map_err(|error| error.to_string())?;
     }
-    let synced_at = object
-        .metadata
-        .annotations
-        .get("flotilla.work/last-synced-at")
-        .ok_or_else(|| "relayed resource is missing last-synced-at".to_string())
-        .and_then(|value| {
-            chrono::DateTime::parse_from_rfc3339(value)
-                .map(|value| value.with_timezone(&Utc))
-                .map_err(|error| format!("decode relayed sync timestamp: {error}"))
-        })?;
-    let strip = |mut object: ResourceObject<T>| {
-        object.metadata.annotations.remove("flotilla.work/origin-root");
-        object.metadata.annotations.remove("flotilla.work/last-synced-at");
-        object
-    };
-    let event = match event {
-        WatchEvent::Added(object) => WatchEvent::Added(strip(object)),
-        WatchEvent::Modified(object) => WatchEvent::Modified(strip(object)),
-        WatchEvent::Deleted(object) => WatchEvent::Deleted(strip(object)),
-    };
-    daemon
-        .resource_backend()
-        .replica_writer::<T>(origin, REPLICATION_NAMESPACE)
-        .apply(event, synced_at)
-        .await
-        .map_err(|error| error.to_string())
+    Ok(())
 }
 
 #[cfg(feature = "test-support")]
@@ -623,38 +634,52 @@ async fn apply_response<T: Resource>(
     writer: &flotilla_resources::ReplicaWriter<T>,
     initial: &mut Vec<ResourceObject<T>>,
     initializing: &mut bool,
-    response: ResourceWatchResponse,
+    response: ResourceReadEnvelope,
 ) -> Result<(), String> {
-    if response.event["type"] == "BOOKMARK" {
-        if *initializing {
-            writer
-                .replace(
-                    &ResourceList {
-                        items: std::mem::take(initial),
-                        resource_version: response.resource_version,
-                        generation: response.generation,
-                    },
-                    Utc::now(),
-                )
-                .await
-                .map_err(|error| error.to_string())?;
-            *initializing = false;
+    let (resource_version, generation) = response.cursor.position()?;
+    for record in response.records {
+        if record.record_type == ResourceRecordType::Bookmark {
+            if *initializing {
+                writer
+                    .replace(
+                        &ResourceList {
+                            items: std::mem::take(initial),
+                            resource_version: resource_version.clone(),
+                            generation: generation.clone(),
+                        },
+                        Utc::now(),
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?;
+                *initializing = false;
+            }
+            continue;
         }
-        return Ok(());
-    }
-
-    let event: K8sWatchEvent<T> =
-        serde_json::from_value(response.event).map_err(|error| format!("decode replicated {} event: {error}", T::API_PATHS.kind))?;
-    let event = event.into_watch_event().map_err(|error| error.to_string())?;
-    if *initializing && matches!(event, flotilla_resources::WatchEvent::Added(_)) {
-        let object = match event {
-            flotilla_resources::WatchEvent::Added(object) => object,
-            _ => unreachable!("matched added event"),
+        let Some(event) = record_watch_event::<T>(record)? else {
+            continue;
         };
-        initial.push(object);
-        return Ok(());
+        if *initializing && matches!(event, WatchEvent::Added(_)) {
+            let WatchEvent::Added(object) = event else { unreachable!("matched added event") };
+            initial.push(object);
+        } else {
+            writer.apply(event, Utc::now()).await.map_err(|error| error.to_string())?;
+        }
     }
-    writer.apply(event, Utc::now()).await.map_err(|error| error.to_string())
+    Ok(())
+}
+
+#[cfg(feature = "test-support")]
+fn record_watch_event<T: Resource>(record: ResourceReadRecord) -> Result<Option<WatchEvent<T>>, String> {
+    let event_type = match record.record_type {
+        ResourceRecordType::Current | ResourceRecordType::Added => "ADDED",
+        ResourceRecordType::Modified => "MODIFIED",
+        ResourceRecordType::Deleted => "DELETED",
+        ResourceRecordType::Bookmark => return Ok(None),
+    };
+    let object = record.object.ok_or_else(|| format!("{event_type} resource record is missing object"))?;
+    let event: K8sWatchEvent<T> = serde_json::from_value(serde_json::json!({ "type": event_type, "object": object }))
+        .map_err(|error| format!("decode replicated {} event: {error}", T::API_PATHS.kind))?;
+    event.into_watch_event().map(Some).map_err(|error| error.to_string())
 }
 
 #[cfg(test)]

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -25,9 +25,9 @@ use flotilla_protocol::{
     AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachBinding, AttachableId, Checkout, CheckoutTarget, Command,
     CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, DaemonEvent, EnvironmentId, HostName, HostPath,
     HostProviderStatus, HostSummary, Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage,
-    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, Response, ResponseResult, RoutedPeerMessage,
-    StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY, PROTOCOL_VERSION,
-    TERMINAL_POOL_PROVIDER_CATEGORY,
+    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, ResourceCursor, Response, ResponseResult,
+    RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY,
+    PROTOCOL_VERSION, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     list_resource_kind, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, HttpBackend,
@@ -1193,6 +1193,7 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
         &pending_remote_cancels,
         &next_remote_command_id,
     );
+    let cursor = ResourceCursor::from_position("42", Some("generation-a".to_string()));
 
     let command_id = remote_command_router
         .dispatch_execute(Command {
@@ -1202,9 +1203,10 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
             action: CommandAction::ResourceWatch {
                 namespace: "flotilla".into(),
                 kind: "convoys".into(),
+                name: Some("demo".into()),
                 include_replicas: false,
                 replica_sources: false,
-                cursor: None,
+                cursor: Some(cursor.clone()),
             },
         })
         .await
@@ -1226,9 +1228,10 @@ async fn dispatch_execute_remote_resource_watch_routes_through_peer_manager() {
                 action: CommandAction::ResourceWatch {
                     namespace: "flotilla".into(),
                     kind: "convoys".into(),
+                    name: Some("demo".into()),
                     include_replicas: false,
                     replica_sources: false,
-                    cursor: None,
+                    cursor: Some(cursor),
                 }
             });
         }

--- a/crates/flotilla-protocol/Cargo.toml
+++ b/crates/flotilla-protocol/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 test-support = []
 
 [dependencies]
+base64 = "0.22"
 bon = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 serde = { workspace = true }

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -53,23 +54,101 @@ pub struct ResourceJsonResponse {
     pub value: serde_json::Value,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
-pub struct ResourceWatchResponse {
-    #[serde(rename = "resourceKind")]
-    pub kind: String,
-    pub plural: String,
-    pub namespace: String,
-    pub resource_version: String,
+/// Opaque position in one resource kind's ordered mutation stream.
+///
+/// The encoded form is stable for scripts but deliberately hides backend
+/// resource versions and generations from the client surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ResourceCursor(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ResourceCursorPayload {
+    version: u8,
+    resource_version: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub generation: Option<String>,
-    pub event: serde_json::Value,
+    generation: Option<String>,
+}
+
+impl ResourceCursor {
+    pub fn from_position(resource_version: impl Into<String>, generation: Option<String>) -> Self {
+        let payload = ResourceCursorPayload { version: 1, resource_version: resource_version.into(), generation };
+        let encoded = serde_json::to_vec(&payload).expect("resource cursor payload is serializable");
+        Self(URL_SAFE_NO_PAD.encode(encoded))
+    }
+
+    pub fn position(&self) -> Result<(String, Option<String>), String> {
+        let decoded = URL_SAFE_NO_PAD.decode(&self.0).map_err(|error| format!("invalid resource cursor encoding: {error}"))?;
+        let payload: ResourceCursorPayload =
+            serde_json::from_slice(&decoded).map_err(|error| format!("invalid resource cursor payload: {error}"))?;
+        if payload.version != 1 {
+            return Err(format!("unsupported resource cursor version {}", payload.version));
+        }
+        Ok((payload.resource_version, payload.generation))
+    }
+}
+
+impl std::fmt::Display for ResourceCursor {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for ResourceCursor {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let cursor = Self(value.to_string());
+        cursor.position()?;
+        Ok(cursor)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ResourceRecordType {
+    Current,
+    Added,
+    Modified,
+    Deleted,
+    Bookmark,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ResourceWatchCursor {
-    pub resource_version: String,
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum ResourceRecordProvenance {
+    Local {
+        #[serde(rename = "nodeId")]
+        node_id: crate::NodeId,
+    },
+    Replica {
+        #[serde(rename = "originRoot")]
+        origin_root: crate::NodeId,
+        #[serde(rename = "lastSyncedAt")]
+        last_synced_at: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceReadRecord {
+    #[serde(rename = "type")]
+    pub record_type: ResourceRecordType,
+    pub provenance: ResourceRecordProvenance,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub generation: Option<String>,
+    pub object: Option<serde_json::Value>,
+}
+
+/// Stable envelope returned by resource get/list/watch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct ResourceReadEnvelope {
+    #[serde(rename = "apiVersion")]
+    pub api_version: String,
+    #[serde(rename = "resourceKind")]
+    pub resource_kind: String,
+    pub plural: String,
+    pub namespace: String,
+    pub cursor: ResourceCursor,
+    pub records: Vec<ResourceReadRecord>,
 }
 
 /// Filters for reading a daemon's host-local structured log.
@@ -476,12 +555,14 @@ pub enum CommandAction {
     ResourceWatch {
         namespace: String,
         kind: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
         #[serde(default, skip_serializing_if = "is_false")]
         include_replicas: bool,
         #[serde(default, skip_serializing_if = "is_false")]
         replica_sources: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        cursor: Option<ResourceWatchCursor>,
+        cursor: Option<ResourceCursor>,
     },
 }
 
@@ -683,10 +764,10 @@ pub enum CommandValue {
         /// Complete JSON-lines records, oldest first.
         lines: Vec<String>,
     },
-    ResourceList(Box<ResourceJsonResponse>),
+    ResourceRead(Box<ResourceReadEnvelope>),
     ResourceObject(Box<ResourceJsonResponse>),
     ResourceDeleted(Box<ResourceJsonResponse>),
-    ResourceWatchEvent(Box<ResourceWatchResponse>),
+    ResourceWatchEvent(Box<ResourceReadEnvelope>),
     EnvironmentSpecRead {
         spec: crate::EnvironmentSpec,
     },
@@ -1068,6 +1149,7 @@ mod tests {
                 action: CommandAction::ResourceWatch {
                     namespace: "flotilla".into(),
                     kind: "convoys".into(),
+                    name: None,
                     include_replicas: false,
                     replica_sources: false,
                     cursor: None,
@@ -1318,14 +1400,22 @@ mod tests {
                     .build()],
                 result_sets: vec![],
             })),
-            CommandValue::ResourceList(Box::new(ResourceJsonResponse {
-                kind: "Convoy".into(),
+            CommandValue::ResourceRead(Box::new(ResourceReadEnvelope {
+                api_version: "flotilla.work/v1".into(),
+                resource_kind: "Convoy".into(),
                 plural: "convoys".into(),
                 namespace: "flotilla".into(),
-                value: serde_json::json!({
-                    "metadata": { "resourceVersion": "1" },
-                    "items": [{ "apiVersion": "flotilla.work/v1", "kind": "Convoy", "metadata": { "name": "demo" }, "spec": {} }]
-                }),
+                cursor: ResourceCursor::from_position("1", None),
+                records: vec![ResourceReadRecord {
+                    record_type: ResourceRecordType::Current,
+                    provenance: ResourceRecordProvenance::Local { node_id: crate::NodeId::new("desktop") },
+                    object: Some(serde_json::json!({
+                        "apiVersion": "flotilla.work/v1",
+                        "kind": "Convoy",
+                        "metadata": { "name": "demo" },
+                        "spec": {}
+                    })),
+                }],
             })),
             CommandValue::ResourceObject(Box::new(ResourceJsonResponse {
                 kind: "Convoy".into(),
@@ -1338,16 +1428,22 @@ mod tests {
                     "spec": {}
                 }),
             })),
-            CommandValue::ResourceWatchEvent(Box::new(ResourceWatchResponse {
-                kind: "Convoy".into(),
+            CommandValue::ResourceWatchEvent(Box::new(ResourceReadEnvelope {
+                api_version: "flotilla.work/v1".into(),
+                resource_kind: "Convoy".into(),
                 plural: "convoys".into(),
                 namespace: "flotilla".into(),
-                resource_version: "7".into(),
-                generation: None,
-                event: serde_json::json!({
-                    "type": "ADDED",
-                    "object": { "apiVersion": "flotilla.work/v1", "kind": "Convoy", "metadata": { "name": "demo" }, "spec": {} }
-                }),
+                cursor: ResourceCursor::from_position("7", None),
+                records: vec![ResourceReadRecord {
+                    record_type: ResourceRecordType::Added,
+                    provenance: ResourceRecordProvenance::Local { node_id: crate::NodeId::new("desktop") },
+                    object: Some(serde_json::json!({
+                        "apiVersion": "flotilla.work/v1",
+                        "kind": "Convoy",
+                        "metadata": { "name": "demo" },
+                        "spec": {}
+                    })),
+                }],
             })),
             CommandValue::EnvironmentSpecRead {
                 spec: crate::EnvironmentSpec {
@@ -1664,6 +1760,39 @@ mod tests {
     fn issue_page_value_roundtrip() {
         let val = CommandValue::IssuePage(crate::issue_query::IssueResultPage { items: vec![], total: Some(10), has_more: true });
         assert_json_roundtrip(&val);
+    }
+
+    #[test]
+    fn resource_cursor_is_opaque_and_roundtrips_its_position() {
+        let cursor = ResourceCursor::from_position("42", Some("observed-generation".to_string()));
+
+        assert!(!cursor.to_string().contains("42"));
+        assert_eq!(cursor.position().expect("decode cursor"), ("42".to_string(), Some("observed-generation".to_string())));
+        assert_eq!(cursor.to_string().parse::<ResourceCursor>().expect("parse cursor"), cursor);
+    }
+
+    #[test]
+    fn resource_read_envelope_uses_the_stable_script_shape() {
+        let envelope = ResourceReadEnvelope {
+            api_version: "flotilla.work/v1".into(),
+            resource_kind: "Convoy".into(),
+            plural: "convoys".into(),
+            namespace: "flotilla".into(),
+            cursor: ResourceCursor::from_position("1", None),
+            records: vec![ResourceReadRecord {
+                record_type: ResourceRecordType::Current,
+                provenance: ResourceRecordProvenance::Local { node_id: crate::NodeId::new("feta") },
+                object: Some(serde_json::json!({"metadata": {"name": "demo"}})),
+            }],
+        };
+
+        let value = serde_json::to_value(&envelope).expect("serialize resource envelope");
+        assert_eq!(value["apiVersion"], "flotilla.work/v1");
+        assert_eq!(value["resourceKind"], "Convoy");
+        assert!(value["cursor"].is_string());
+        assert_eq!(value["records"][0]["type"], "CURRENT");
+        assert_eq!(value["records"][0]["provenance"]["source"], "local");
+        assert_json_roundtrip(&envelope);
     }
 
     #[test]

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -113,7 +113,8 @@ pub(crate) mod test_helpers {
 pub use commands::{
     AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyAutoAttach,
     ConvoyDispatchRegard, ConvoyStartIntent, IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector,
-    ResolvedPaneCommand, ResourceJsonResponse, ResourceWatchCursor, ResourceWatchResponse, StepStatus,
+    ResolvedPaneCommand, ResourceCursor, ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance,
+    ResourceRecordType, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -269,7 +269,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         | CommandValue::CrewList(_)
         | CommandValue::FleetReplicaSnapshot(_)
         | CommandValue::DaemonLogs { .. }
-        | CommandValue::ResourceList(_)
+        | CommandValue::ResourceRead(_)
         | CommandValue::ResourceObject(_)
         | CommandValue::ResourceDeleted(_)
         | CommandValue::ResourceWatchEvent(_) => {

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -586,15 +586,14 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::CrewList(crew) => format_crew_list_human(crew),
         CommandValue::FleetReplicaSnapshot(_) => "fleet replica snapshot".to_string(),
         CommandValue::DaemonLogs { lines } => lines.join("\n"),
-        CommandValue::ResourceList(response) | CommandValue::ResourceObject(response) => {
-            flotilla_protocol::output::json_pretty(&response.value)
-        }
+        CommandValue::ResourceRead(response) => flotilla_protocol::output::json_pretty(response),
+        CommandValue::ResourceObject(response) => flotilla_protocol::output::json_pretty(&response.value),
         CommandValue::ResourceDeleted(response) => {
             let name = response.value["metadata"]["name"].as_str().unwrap_or("<unknown>");
             let api_version = response.value["apiVersion"].as_str().unwrap_or("<unknown>");
             format!("deleted {api_version}/{}/{}/{name}\nControllers may recreate code-owned objects.", response.kind, response.namespace,)
         }
-        CommandValue::ResourceWatchEvent(response) => flotilla_protocol::output::json_pretty(&response.event),
+        CommandValue::ResourceWatchEvent(response) => flotilla_protocol::output::json_pretty(response),
         CommandValue::EnvironmentSpecRead { .. } => "environment spec read".to_string(),
         CommandValue::IssuePage(page) => format!("issue page: {} items, has_more={}", page.items.len(), page.has_more),
         CommandValue::IssuesByIds { items } => format!("issues by ids: {} items", items.len()),

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,8 @@
 # Architecture
 
+Script-facing resource get/list/watch semantics are documented in
+[Resource reads for scripts](../resource-reads.md).
+
 This directory is the canonical architecture reference for the current
 codebase.
 

--- a/docs/resource-reads.md
+++ b/docs/resource-reads.md
@@ -1,0 +1,89 @@
+# Resource reads for scripts
+
+`flotilla resource get`, `list`, and `watch` expose the same versioned
+resource-read envelope. Use `--json` when consuming these commands from a
+script.
+
+```bash
+flotilla resource get convoy implement-1286 --json
+flotilla resource list convoy --json
+flotilla resource watch convoy --json
+flotilla resource watch convoy implement-1286 --json
+flotilla resource watch convoy --host feta --json
+```
+
+The envelope is stable at `flotilla.work/v1`:
+
+```json
+{
+  "apiVersion": "flotilla.work/v1",
+  "resourceKind": "Convoy",
+  "plural": "convoys",
+  "namespace": "flotilla",
+  "cursor": "eyJ2ZXJzaW9uIjoxLC4uLn0",
+  "records": [
+    {
+      "type": "CURRENT",
+      "provenance": { "source": "local", "nodeId": "01J..." },
+      "object": {
+        "apiVersion": "flotilla.work/v1",
+        "kind": "Convoy",
+        "metadata": { "name": "implement-1286" },
+        "spec": {}
+      }
+    }
+  ]
+}
+```
+
+`cursor` is an opaque position in the kind's ordered mutation stream. Do not
+decode or construct it. A local record has `source: "local"` and the node that
+served it. A replicated record has `source: "replica"`, `originRoot`, and
+`lastSyncedAt`.
+
+`get` returns one `CURRENT` record. `list` returns the complete current slice
+in `records` and a cursor immediately after that slice. An empty list still
+returns an envelope and cursor with an empty `records` array.
+
+## Watching and resuming
+
+JSON watch output is JSON Lines: each line is one complete resource-read
+envelope. A fresh watch is level-triggered:
+
+1. one envelope contains the complete current slice as `ADDED` records;
+2. a `BOOKMARK` record confirms the slice cursor;
+3. later envelopes contain `ADDED`, `MODIFIED`, or `DELETED` records.
+
+The current slice is kept in one envelope so recording its cursor cannot skip
+part of bootstrap state. Persist the cursor only after processing the whole
+line, then pass it back unchanged:
+
+```bash
+cursor_file=.flotilla-resource-cursor
+
+flotilla resource watch convoy --json |
+while IFS= read -r line; do
+  # Process the complete envelope before advancing the durable cursor.
+  jq -c '.records[] | select(.type != "BOOKMARK")' <<<"$line"
+  jq -r '.cursor' <<<"$line" >"$cursor_file.tmp"
+  mv "$cursor_file.tmp" "$cursor_file"
+done
+
+flotilla resource watch convoy \
+  --from-cursor "$(cat "$cursor_file")" \
+  --json
+```
+
+Resume delivers mutations strictly after the supplied cursor without sending
+the current slice again. The stream may first emit a `BOOKMARK` at the accepted
+cursor. A resource name filter applies to both the initial slice and later
+mutations.
+
+A watch that ends normally, or is stopped with Ctrl-C, exits with status 0.
+Connection failures, expired/invalid cursors, lag, and daemon-reported errors
+exit non-zero and write the diagnostic to stderr. Scripts should preserve the
+last successfully processed cursor and resume after an error.
+
+`--host <name>` routes all three reads to that peer. The same wire-generation
+handshake used by every CLI connection rejects an incompatible daemon before
+the read starts.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use flotilla_core::{
 };
 use flotilla_protocol::{
     commands::CommandValue, output::OutputFormat, AgentHookEvent, AttachableId, Command, CommandAction, EnvironmentId, HostName,
-    ProjectListResponse, RepoIdentity, RepoInfo, RepoSelector, StepStatus, ViewAddress,
+    ProjectListResponse, RepoIdentity, RepoInfo, RepoSelector, ViewAddress,
 };
 use flotilla_tui::{app, event_log, theme};
 use tracing::info;
@@ -258,7 +258,7 @@ enum ResourceSubCommand {
     /// Delete exactly one raw resource object, bypassing lifecycle gates
     Delete(ResourceDeleteArgs),
     /// Watch resources of a kind
-    Watch(ResourceListArgs),
+    Watch(ResourceWatchArgs),
 }
 
 #[derive(clap::Args, bon::Builder)]
@@ -288,6 +288,26 @@ struct ResourceGetArgs {
     /// Route the query to a peer host
     #[arg(long)]
     host: Option<String>,
+}
+
+#[derive(clap::Args, bon::Builder)]
+struct ResourceWatchArgs {
+    /// Resource kind or plural name, e.g. convoys or WorkflowTemplate
+    kind: String,
+    /// Restrict the stream to one resource name
+    name: Option<String>,
+    /// Resource namespace
+    #[arg(long, default_value = "flotilla")]
+    namespace: String,
+    /// Route the watch to a peer host
+    #[arg(long)]
+    host: Option<String>,
+    /// Include read-only replicas from peer roots
+    #[arg(long)]
+    include_replicas: bool,
+    /// Resume strictly after a cursor emitted by an earlier read or watch
+    #[arg(long)]
+    from_cursor: Option<flotilla_protocol::ResourceCursor>,
 }
 
 #[derive(clap::Args)]
@@ -913,40 +933,34 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
         ResourceSubCommand::List(args) => {
             let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
             let daemon = connect_daemon(cli).await?;
-            let result = daemon
-                .execute_query(
-                    Command {
-                        node_id: node_id.clone(),
-                        provisioning_target: None,
-                        context_repo: None,
-                        action: CommandAction::QueryResourceList {
-                            namespace: args.namespace,
-                            kind: args.kind,
-                            include_replicas: args.include_replicas,
-                        },
-                    },
-                    uuid::Uuid::new_v4(),
+            let response = flotilla_client::resource::ResourceClient::new(Arc::clone(&daemon))
+                .list(
+                    flotilla_client::resource::ResourceListRequest::builder()
+                        .kind(args.kind)
+                        .namespace(args.namespace)
+                        .maybe_node_id(node_id.clone())
+                        .include_replicas(args.include_replicas)
+                        .build(),
                 )
                 .await
                 .map_err(|e| color_eyre::eyre::eyre!(e))?;
-            print_resource_query_result(daemon.as_ref(), node_id, result, format).await
+            print_resource_read(daemon.as_ref(), node_id, response, format).await
         }
         ResourceSubCommand::Get(args) => {
             let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
             let daemon = connect_daemon(cli).await?;
-            let result = daemon
-                .execute_query(
-                    Command {
-                        node_id: node_id.clone(),
-                        provisioning_target: None,
-                        context_repo: None,
-                        action: CommandAction::QueryResourceGet { namespace: args.namespace, kind: args.kind, name: args.name },
-                    },
-                    uuid::Uuid::new_v4(),
+            let response = flotilla_client::resource::ResourceClient::new(Arc::clone(&daemon))
+                .get(
+                    flotilla_client::resource::ResourceGetRequest::builder()
+                        .kind(args.kind)
+                        .name(args.name)
+                        .namespace(args.namespace)
+                        .maybe_node_id(node_id.clone())
+                        .build(),
                 )
                 .await
                 .map_err(|e| color_eyre::eyre::eyre!(e))?;
-            print_resource_query_result(daemon.as_ref(), node_id, result, format).await
+            print_resource_read(daemon.as_ref(), node_id, response, format).await
         }
         ResourceSubCommand::Apply(args) => {
             let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
@@ -993,30 +1007,15 @@ async fn resolve_optional_host_node(cli: &Cli, host: Option<&str>) -> Result<Opt
     }
 }
 
-async fn print_resource_query_result(
+async fn print_resource_read(
     daemon: &dyn DaemonHandle,
     node_id: Option<flotilla_protocol::NodeId>,
-    result: CommandValue,
+    response: flotilla_protocol::ResourceReadEnvelope,
     format: OutputFormat,
 ) -> Result<()> {
-    match result {
-        CommandValue::ResourceList(response) => {
-            println!("{}", format_resource_value(daemon, node_id, response.value, format).await?);
-            Ok(())
-        }
-        CommandValue::ResourceObject(response) => {
-            println!("{}", format_resource_value(daemon, node_id, response.value, format).await?);
-            Ok(())
-        }
-        CommandValue::Error { message } => match format {
-            OutputFormat::Json => {
-                println!("{}", flotilla_protocol::output::json_pretty(&CommandValue::Error { message: message.clone() }));
-                Err(color_eyre::eyre::eyre!(message))
-            }
-            OutputFormat::Human => Err(color_eyre::eyre::eyre!(message)),
-        },
-        other => Err(color_eyre::eyre::eyre!("unexpected resource response: {other:?}")),
-    }
+    let value = serde_json::to_value(response).map_err(|error| color_eyre::eyre::eyre!("encode resource read: {error}"))?;
+    println!("{}", format_resource_value(daemon, node_id, value, format).await?);
+    Ok(())
 }
 
 async fn format_resource_value(
@@ -1075,62 +1074,46 @@ fn replace_host_ids(value: &mut serde_json::Value, names: &std::collections::Has
     }
 }
 
-async fn run_resource_watch(cli: &Cli, args: ResourceListArgs, format: OutputFormat) -> Result<()> {
+async fn run_resource_watch(cli: &Cli, args: ResourceWatchArgs, format: OutputFormat) -> Result<()> {
+    reset_sigpipe();
     let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
     let daemon = connect_daemon(cli).await?;
-    let mut rx = daemon.subscribe();
-    let command_id = daemon
-        .execute(Command {
-            node_id,
-            provisioning_target: None,
-            context_repo: None,
-            action: CommandAction::ResourceWatch {
-                namespace: args.namespace,
-                kind: args.kind,
-                include_replicas: args.include_replicas,
-                replica_sources: false,
-                cursor: None,
-            },
-        })
+    let client = flotilla_client::resource::ResourceClient::new(daemon);
+    let mut watch = client
+        .watch(
+            flotilla_client::resource::ResourceWatchRequest::builder()
+                .kind(args.kind)
+                .namespace(args.namespace)
+                .maybe_name(args.name)
+                .maybe_node_id(node_id)
+                .include_replicas(args.include_replicas)
+                .maybe_cursor(args.from_cursor)
+                .build(),
+        )
         .await
         .map_err(|e| color_eyre::eyre::eyre!(e))?;
 
     loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                let _ = daemon.cancel(command_id).await;
+                watch.cancel().await.map_err(|e| color_eyre::eyre::eyre!(e))?;
                 return Ok(());
             }
-            event = rx.recv() => {
-                match event {
-                    Ok(flotilla_protocol::DaemonEvent::CommandStepUpdate { command_id: id, status, .. }) if id == command_id => {
-                        if let StepStatus::Produced { value } = status {
-                            if let CommandValue::ResourceWatchEvent(response) = *value {
-                                print_resource_watch_event(&response, format);
-                            }
-                        }
-                    }
-                    Ok(flotilla_protocol::DaemonEvent::CommandFinished { command_id: id, result, .. }) if id == command_id => {
-                        return match result {
-                            CommandValue::Ok | CommandValue::Cancelled => Ok(()),
-                            CommandValue::Error { message } => Err(color_eyre::eyre::eyre!(message)),
-                            other => Err(color_eyre::eyre::eyre!("unexpected resource watch result: {other:?}")),
-                        };
-                    }
-                    Ok(_) => {}
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => eprintln!("warning: skipped {n} events"),
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return Err(color_eyre::eyre::eyre!("daemon disconnected")),
+            event = watch.next() => {
+                match event.map_err(|e| color_eyre::eyre::eyre!(e))? {
+                    Some(response) => print_resource_watch_event(&response, format),
+                    None => return Ok(()),
                 }
             }
         }
     }
 }
 
-fn print_resource_watch_event(response: &flotilla_protocol::ResourceWatchResponse, format: OutputFormat) {
+fn print_resource_watch_event(response: &flotilla_protocol::ResourceReadEnvelope, format: OutputFormat) {
     match format {
-        OutputFormat::Json => println!("{}", flotilla_protocol::output::json_line(&response.event)),
+        OutputFormat::Json => println!("{}", flotilla_protocol::output::json_line(response)),
         OutputFormat::Human => {
-            println!("{}", flotilla_protocol::output::json_pretty(&response.event));
+            println!("{}", flotilla_protocol::output::json_pretty(response));
         }
     }
 }
@@ -1720,7 +1703,7 @@ mod tests {
         attach_exit_disposition, confirm_command, default_project_landing, format_human_resource_value,
         provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target, select_startup_repo_roots,
         should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from, AttachExitDisposition, Cli, CommandValue,
-        ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, SubCommand,
+        ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, ResourceWatchArgs, SubCommand,
     };
 
     fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
@@ -1959,14 +1942,30 @@ mod tests {
             }) if file.as_path() == Path::new("demand.yaml") && namespace == "ops"
         ));
 
-        let watch =
-            Cli::try_parse_from(["flotilla", "--json", "resource", "watch", "terminalsessions"]).expect("resource watch should parse");
+        let watch = Cli::try_parse_from([
+            "flotilla",
+            "resource",
+            "watch",
+            "terminalsessions",
+            "session-a",
+            "--from-cursor",
+            &flotilla_protocol::ResourceCursor::from_position("7", None).to_string(),
+            "--json",
+        ])
+        .expect("resource watch should parse");
         assert!(watch.json);
         assert!(matches!(
             watch.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::Watch(ResourceListArgs { kind, namespace, host: None, include_replicas: false })
-            }) if kind == "terminalsessions" && namespace == "flotilla"
+                command: ResourceSubCommand::Watch(ResourceWatchArgs {
+                    kind,
+                    name: Some(name),
+                    namespace,
+                    host: None,
+                    include_replicas: false,
+                    from_cursor: Some(_),
+                })
+            }) if kind == "terminalsessions" && name == "session-a" && namespace == "flotilla"
         ));
     }
 


### PR DESCRIPTION
## Summary

- add a typed `flotilla-client` resource get/list/watch API with opaque resumable cursors
- expose cursor-addressed `resource watch <kind> [name] --json` locally and through `--host`
- unify get/list/watch output into a documented envelope with ordered records and per-record provenance
- route watch requests across peers and update replica consumers for the unified stream shape
- cover current-state bootstrap, create/update/delete deltas, cancellation, and resume with `InProcessDaemon`

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-protocol --locked`
- `cargo test -p flotilla-client --locked`
- focused core, daemon routing, and CLI parser tests

`cargo test --workspace --locked` passes all affected suites locally, but this macOS runner cannot resolve a machine identity for two pre-existing daemon runtime tests whose fixtures omit `machine_id`; both reproduce in isolation before exercising this change. CI's Linux runner provides `/etc/machine-id`.

Closes #1286
