### PR TITLE
fix: inject machine identity in interior cleat runtime tests

### DIFF
--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2815,7 +2815,10 @@ mod tests {
         use flotilla_core::providers::discovery::{ProviderCategory, ProviderDescriptor};
 
         let temp = TempDir::new().expect("tempdir");
-        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let config_base = temp.path().join("config");
+        fs::create_dir_all(&config_base).expect("config directory");
+        fs::write(config_base.join("daemon.toml"), "machine_id = \"local-profile-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_base));
         let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
         let daemon = InProcessDaemon::new(Vec::new(), config, discovery, flotilla_protocol::HostName::new("dinghy")).await;
         let mut registry = ProviderRegistry::new();
@@ -4673,7 +4676,10 @@ mod tests {
     #[tokio::test]
     async fn contained_terminal_session_never_falls_back_from_the_requested_interior_pool() {
         let temp = TempDir::new().expect("tempdir");
-        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let config_base = temp.path().join("config");
+        fs::create_dir_all(&config_base).expect("config directory");
+        fs::write(config_base.join("daemon.toml"), "machine_id = \"interior-pool-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_base));
         let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
         let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
         let env_id = EnvironmentId::new("contained-work");


### PR DESCRIPTION
Closes #1290.

Two #1281 runtime tests construct `InProcessDaemon::new` without writing `machine_id` into the temp `daemon.toml`, so identity resolution falls through to `/etc/machine-id` (absent on macOS) and then `ioreg` via the mock runner (which only answers `git --version`) — failing on every macOS checkout while passing on Linux CI only by silently reading the host's real `/etc/machine-id`.

This applies the pattern every other `InProcessDaemon` test in the module already uses: write `machine_id` into the temp config before constructing the daemon, so step 1 of resolution wins deterministically on all platforms and the tests never touch real host state.

The broader consideration from #1290 — whether `read_etc_machine_id` should go through an injected collaborator so no test can accidentally depend on the real file — is left for a follow-up if it recurs; with `machine_id` injected these two tests no longer exercise that path.

Verified: both tests pass on macOS (previously both panicked with "Cannot determine machine identity").

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp