### PR TITLE
fix: bound terminal session reconcile failures

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -100,6 +100,22 @@ impl<R> TerminalSessionReconciler<R> {
             .map(|source| source.object)
             .ok_or_else(|| ResourceError::not_found(convoy_ref))
     }
+
+    async fn session_owner_missing(&self, session: &ResourceObject<TerminalSession>) -> Result<bool, ResourceError> {
+        let convoy_ref = match &session.spec.source {
+            TerminalSessionSource::Agent { context, .. } => Some(context.convoy.as_str()),
+            TerminalSessionSource::Tool { .. } => session.metadata.labels.get(CONVOY_LABEL).map(String::as_str),
+        };
+        let Some(convoy_ref) = convoy_ref else {
+            return Ok(false);
+        };
+        match self.convoy_for_session(session, convoy_ref).await {
+            Ok(convoy) => Ok(convoy.metadata.deletion_timestamp.is_some()
+                || convoy.status.as_ref().is_some_and(|status| status.phase == ConvoyPhase::Abandoned)),
+            Err(ResourceError::NotFound { .. }) => Ok(true),
+            Err(err) => Err(err),
+        }
+    }
 }
 
 pub enum TerminalDeps {
@@ -122,18 +138,8 @@ where
     type Dependencies = TerminalDeps;
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
-        let convoy_ref = match &obj.spec.source {
-            TerminalSessionSource::Agent { context, .. } => Some(context.convoy.as_str()),
-            TerminalSessionSource::Tool { .. } => obj.metadata.labels.get(CONVOY_LABEL).map(String::as_str),
-        };
-        if let Some(convoy_ref) = convoy_ref {
-            match self.convoy_for_session(obj, convoy_ref).await {
-                Ok(convoy)
-                    if convoy.metadata.deletion_timestamp.is_none()
-                        && !convoy.status.as_ref().is_some_and(|status| status.phase == ConvoyPhase::Abandoned) => {}
-                Ok(_) | Err(ResourceError::NotFound { .. }) => return Ok(TerminalDeps::OwnerMissing),
-                Err(err) => return Err(err),
-            }
+        if self.session_owner_missing(obj).await? {
+            return Ok(TerminalDeps::OwnerMissing);
         }
 
         let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(TerminalSessionPhase::Starting);
@@ -310,5 +316,9 @@ where
 
     fn is_reconcile_degraded(&self, obj: &ResourceObject<Self::Resource>) -> bool {
         obj.status.as_ref().is_some_and(|status| status.degraded.is_some())
+    }
+
+    async fn degraded_object_needs_reconcile(&self, obj: &ResourceObject<Self::Resource>) -> Result<bool, ResourceError> {
+        self.session_owner_missing(obj).await
     }
 }

--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -1,12 +1,12 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use flotilla_resources::{
-    controller::{Actuation, ReconcileOutcome, Reconciler},
-    Convoy, Environment, EnvironmentPhase, ReplicaReadResolver, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
-    TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession, TerminalSessionPhase, TerminalSessionSource,
-    TerminalSessionStatusPatch, TerminalSessionTag, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
+    controller::{Actuation, ReconcileErrorPolicy, ReconcileFailure, ReconcileOutcome, Reconciler},
+    Convoy, ConvoyPhase, Environment, EnvironmentPhase, ReplicaReadResolver, ResourceBackend, ResourceError, ResourceObject,
+    ResourceProvenance, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession, TerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionStatusPatch, TerminalSessionTag, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
     CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REF_SESSION_TAG, VESSEL_REF_LABEL,
 };
 
@@ -128,7 +128,9 @@ where
         };
         if let Some(convoy_ref) = convoy_ref {
             match self.convoy_for_session(obj, convoy_ref).await {
-                Ok(convoy) if convoy.metadata.deletion_timestamp.is_none() => {}
+                Ok(convoy)
+                    if convoy.metadata.deletion_timestamp.is_none()
+                        && !convoy.status.as_ref().is_some_and(|status| status.phase == ConvoyPhase::Abandoned) => {}
                 Ok(_) | Err(ResourceError::NotFound { .. }) => return Ok(TerminalDeps::OwnerMissing),
                 Err(err) => return Err(err),
             }
@@ -284,5 +286,29 @@ where
 
     fn finalizer_name(&self) -> Option<&'static str> {
         Some("flotilla.work/terminal-teardown")
+    }
+
+    fn reconcile_error_policy(&self) -> Option<ReconcileErrorPolicy> {
+        Some(ReconcileErrorPolicy {
+            max_consecutive_failures: 5,
+            initial_backoff: Duration::from_secs(60),
+            max_backoff: Duration::from_secs(15 * 60),
+        })
+    }
+
+    fn reconcile_degraded_patch(
+        &self,
+        _obj: &ResourceObject<Self::Resource>,
+        failure: &ReconcileFailure,
+    ) -> Option<TerminalSessionStatusPatch> {
+        Some(TerminalSessionStatusPatch::MarkReconcileDegraded {
+            message: failure.message.clone(),
+            consecutive_failures: failure.consecutive_failures,
+            observed_at: Utc::now(),
+        })
+    }
+
+    fn is_reconcile_degraded(&self, obj: &ResourceObject<Self::Resource>) -> bool {
+        obj.status.as_ref().is_some_and(|status| status.degraded.is_some())
     }
 }

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -358,6 +358,7 @@ pub async fn create_stopped_terminal(
             launch_command: Some(fixture.command),
             delivered_message_id: None,
             attention: None,
+            degraded: None,
         })
         .await
         .expect("terminal status update should succeed");

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -4,20 +4,22 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex,
     },
+    time::Duration,
 };
 
 use async_trait::async_trait;
 use chrono::Utc;
 use flotilla_controllers::reconcilers::{TerminalRuntime, TerminalRuntimeState, TerminalSessionReconciler};
 use flotilla_resources::{
-    controller::{Actuation, Reconciler},
+    controller::{Actuation, ControllerLoop, Reconciler},
     test_support::{
         run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, Transition,
         TransitionDriver, TransitionSequence, WorldBuilder,
     },
-    EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta, ResourceBackend, ResourceError,
-    ResourceObject, StatusPatch, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession, TerminalSessionPhase,
-    TerminalSessionSpec, TerminalSessionStatusPatch, VirtualClock, CONVOY_LABEL, VESSEL_REF_LABEL,
+    Convoy, ConvoyPhase, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta, ResourceBackend,
+    ResourceError, ResourceObject, StatusPatch, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession,
+    TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, VirtualClock, CONVOY_LABEL,
+    VESSEL_REF_LABEL,
 };
 
 mod common;
@@ -85,6 +87,155 @@ impl TerminalRuntime for FailingTerminalRuntime {
     async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
         Ok(())
     }
+}
+
+#[tokio::test]
+async fn abandoned_convoy_reaps_terminal_without_calling_its_runtime() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let convoy = create_convoy_with_single_task(
+        &backend,
+        "flotilla",
+        "abandoned-convoy",
+        "work",
+        "https://github.com/flotilla-org/flotilla",
+        "main",
+    )
+    .await;
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    let mut status = convoy.status.expect("convoy should have status");
+    status.phase = ConvoyPhase::Abandoned;
+    convoys.update_status("abandoned-convoy", &convoy.metadata.resource_version, &status).await.expect("convoy should be abandoned");
+
+    let session = backend
+        .clone()
+        .using::<TerminalSession>("flotilla")
+        .create(
+            &InputMeta::builder()
+                .name("terminal-abandoned-convoy-work-coder".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "abandoned-convoy".to_string())]))
+                .build(),
+            &TerminalSessionSpec {
+                env_ref: "missing-environment".to_string(),
+                role: "coder".to_string(),
+                source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
+                cwd: "/workspace".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("terminal should exist");
+    let reconciler = TerminalSessionReconciler::new(Arc::new(RecordingTerminalRuntime::default()), backend, "flotilla");
+
+    let deps = reconciler.fetch_dependencies(&session).await.expect("abandoned owner should be handled as lifecycle state");
+    let outcome = reconciler.reconcile(&session, &deps, Utc::now());
+
+    assert!(matches!(
+        outcome.actuations.as_slice(),
+        [Actuation::DeleteTerminalSession { name }] if name == "terminal-abandoned-convoy-work-coder"
+    ));
+}
+
+#[derive(Default)]
+struct UnavailableRunningRuntime {
+    probes: AtomicUsize,
+}
+
+#[async_trait]
+impl TerminalRuntime for UnavailableRunningRuntime {
+    async fn ensure_session(
+        &self,
+        _name: &str,
+        _spec: &TerminalSessionSpec,
+        _tags: &[flotilla_resources::TerminalSessionTag],
+    ) -> Result<TerminalRuntimeState, String> {
+        panic!("a running session must be probed, not ensured")
+    }
+
+    async fn session_is_running(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<bool, String> {
+        self.probes.fetch_add(1, Ordering::SeqCst);
+        Err("provider registry unavailable for environment env-a".to_string())
+    }
+
+    async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn repeated_runtime_probe_failure_becomes_visible_and_stops_retrying() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    create_convoy_with_single_task(&backend, "flotilla", "demo", "work", "https://github.com/flotilla-org/flotilla", "main").await;
+    let sessions = backend.clone().using::<TerminalSession>("flotilla");
+    let created = sessions
+        .create(
+            &InputMeta::builder()
+                .name("terminal-demo-work-coder".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "demo".to_string())]))
+                .build(),
+            &TerminalSessionSpec {
+                env_ref: "env-a".to_string(),
+                role: "coder".to_string(),
+                source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
+                cwd: "/workspace".to_string(),
+                pool: "cleat".to_string(),
+            },
+        )
+        .await
+        .expect("terminal should be created");
+    let mut running = TerminalSessionStatus::default();
+    TerminalSessionStatusPatch::MarkRunning {
+        session_id: "cleat-demo-work-coder".to_string(),
+        pid: None,
+        started_at: Utc::now(),
+        crew: None,
+        launch_command: "cargo test".to_string(),
+        delivered_message_id: None,
+    }
+    .apply(&mut running);
+    sessions.update_status(&created.metadata.name, &created.metadata.resource_version, &running).await.expect("terminal should be running");
+
+    let runtime = Arc::new(UnavailableRunningRuntime::default());
+    let loop_task = tokio::spawn(
+        ControllerLoop {
+            primary: sessions.clone(),
+            secondaries: Vec::new(),
+            reconciler: TerminalSessionReconciler::new(Arc::clone(&runtime), backend.clone(), "flotilla"),
+            resync_interval: Duration::from_secs(3600),
+            backend,
+        }
+        .run(),
+    );
+
+    for delay in [0, 60, 120, 240, 480] {
+        if delay > 0 {
+            tokio::time::advance(Duration::from_secs(delay)).await;
+        }
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    let status = sessions
+        .get("terminal-demo-work-coder")
+        .await
+        .expect("terminal should remain inspectable")
+        .status
+        .expect("terminal should retain status");
+    let degraded = status.degraded.expect("retry budget should produce a degraded condition");
+    assert_eq!(status.phase, TerminalSessionPhase::Failed);
+    assert_eq!(degraded.reason, "ReconcileErrorBudgetExhausted");
+    assert_eq!(degraded.consecutive_failures, 5);
+    assert!(degraded.message.contains("provider registry unavailable"));
+    assert_eq!(runtime.probes.load(Ordering::SeqCst), 5);
+
+    tokio::time::advance(Duration::from_secs(7200)).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(runtime.probes.load(Ordering::SeqCst), 5, "degraded terminal must stay parked across resyncs");
+
+    loop_task.abort();
+    let _ = loop_task.await;
 }
 
 const GHOST_SESSION_NAME: &str = "terminal-deleted-convoy-work-coder";

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -165,6 +165,7 @@ impl TerminalRuntime for UnavailableRunningRuntime {
 async fn repeated_runtime_probe_failure_becomes_visible_and_stops_retrying() {
     let backend = ResourceBackend::InMemory(Default::default());
     create_convoy_with_single_task(&backend, "flotilla", "demo", "work", "https://github.com/flotilla-org/flotilla", "main").await;
+    let convoys = backend.clone().using::<Convoy>("flotilla");
     let sessions = backend.clone().using::<TerminalSession>("flotilla");
     let created = sessions
         .create(
@@ -233,6 +234,22 @@ async fn repeated_runtime_probe_failure_becomes_visible_and_stops_retrying() {
         tokio::task::yield_now().await;
     }
     assert_eq!(runtime.probes.load(Ordering::SeqCst), 5, "degraded terminal must stay parked across resyncs");
+
+    let convoy = convoys.get("demo").await.expect("owning convoy should remain");
+    let mut convoy_status = convoy.status.expect("owning convoy should have status");
+    convoy_status.phase = ConvoyPhase::Abandoned;
+    convoys.update_status("demo", &convoy.metadata.resource_version, &convoy_status).await.expect("owning convoy should be abandoned");
+    tokio::time::advance(Duration::from_secs(3600)).await;
+    for _ in 0..40 {
+        tokio::task::yield_now().await;
+        if matches!(sessions.get("terminal-demo-work-coder").await, Err(ResourceError::NotFound { .. })) {
+            break;
+        }
+    }
+    assert!(
+        matches!(sessions.get("terminal-demo-work-coder").await, Err(ResourceError::NotFound { .. })),
+        "abandonment must wake and reap a previously degraded terminal"
+    );
 
     loop_task.abort();
     let _ = loop_task.await;

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -2204,6 +2204,7 @@ async fn create_running_terminal(
             launch_command: Some(command.to_string()),
             delivered_message_id: None,
             attention: None,
+            degraded: None,
         })
         .await
         .expect("terminal status update should succeed");

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -78,6 +78,11 @@ pub trait Reconciler: Send + Sync + 'static {
         false
     }
 
+    /// Allow a lifecycle change to wake an otherwise parked degraded object.
+    async fn degraded_object_needs_reconcile(&self, _obj: &ResourceObject<Self::Resource>) -> Result<bool, ResourceError> {
+        Ok(false)
+    }
+
     /// Map a finalizer failure to a status update.
     ///
     /// Other object-scoped errors remain isolated and are retried on a later
@@ -107,12 +112,15 @@ impl ReconcileErrorPolicy {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReconcileFailure {
+    /// Stable error identity for one object and failure cause. Reconcilers
+    /// opting into a budget should avoid errors containing volatile data.
     pub message: String,
     pub consecutive_failures: u32,
 }
 
 struct ObjectFailure {
     failure: ReconcileFailure,
+    creation_timestamp: DateTime<Utc>,
     retry_at: Instant,
     terminal: bool,
 }
@@ -570,7 +578,10 @@ impl<R: Reconciler> ControllerLoop<R> {
             if let Some(name) = pending.pop_front() {
                 let object = match primary.get(&name).await {
                     Ok(object) => object,
-                    Err(ResourceError::NotFound { .. }) => continue,
+                    Err(ResourceError::NotFound { .. }) => {
+                        object_failures.remove(&name);
+                        continue;
+                    }
                     Err(err) => {
                         warn!(
                             resource_kind = R::Resource::API_PATHS.kind,
@@ -626,11 +637,16 @@ impl<R: Reconciler> ControllerLoop<R> {
                     if !lifecycle_owned {
                         return Ok(());
                     }
-                    if reconciler.is_reconcile_degraded(&object) {
+                    let degraded_needs_reconcile =
+                        reconciler.is_reconcile_degraded(&object) && reconciler.degraded_object_needs_reconcile(&object).await?;
+                    if reconciler.is_reconcile_degraded(&object) && !degraded_needs_reconcile {
                         return Ok(());
                     }
+                    if object_failures.get(&name).is_some_and(|failure| failure.creation_timestamp != object.metadata.creation_timestamp) {
+                        object_failures.remove(&name);
+                    }
                     if let Some(failure) = object_failures.get(&name) {
-                        if failure.terminal || Instant::now() < failure.retry_at {
+                        if !degraded_needs_reconcile && (failure.terminal || Instant::now() < failure.retry_at) {
                             return Ok(());
                         }
                     }
@@ -677,27 +693,38 @@ impl<R: Reconciler> ControllerLoop<R> {
                                 let failure = ReconcileFailure { message, consecutive_failures };
                                 terminal = consecutive_failures >= policy.max_consecutive_failures;
                                 let delay = policy.backoff(consecutive_failures);
-                                object_failures.insert(name.clone(), ObjectFailure {
-                                    failure: failure.clone(),
-                                    retry_at: Instant::now() + delay,
-                                    terminal,
-                                });
                                 if terminal {
                                     if let Some(patch) = reconciler.reconcile_degraded_patch(&object, &failure) {
-                                        if let Err(patch_error) =
-                                            Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await
-                                        {
-                                            warn!(
-                                                resource_kind = R::Resource::API_PATHS.kind,
-                                                resource = %name,
-                                                %patch_error,
-                                                "controller failed to record degraded reconcile condition",
-                                            );
+                                        match apply_status_patch(&primary, &name, &patch).await {
+                                            Ok(_) => {}
+                                            Err(ResourceError::NotFound { .. }) => {
+                                                object_failures.remove(&name);
+                                                continue;
+                                            }
+                                            Err(patch_error) => {
+                                                terminal = false;
+                                                retry_after = Some(delay);
+                                                warn!(
+                                                    resource_kind = R::Resource::API_PATHS.kind,
+                                                    resource = %name,
+                                                    %patch_error,
+                                                    "controller failed to record degraded reconcile condition; retrying",
+                                                );
+                                            }
                                         }
+                                    } else {
+                                        terminal = false;
+                                        retry_after = Some(delay);
                                     }
                                 } else {
                                     retry_after = Some(delay);
                                 }
+                                object_failures.insert(name.clone(), ObjectFailure {
+                                    failure,
+                                    creation_timestamp: object.metadata.creation_timestamp,
+                                    retry_at: Instant::now() + delay,
+                                    terminal,
+                                });
                             }
                         }
                         warn!(

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -12,6 +12,7 @@ use futures::StreamExt;
 use tokio::{
     sync::{mpsc, Mutex},
     task::JoinHandle,
+    time::Instant,
 };
 use tracing::warn;
 
@@ -54,6 +55,29 @@ pub trait Reconciler: Send + Sync + 'static {
 
     fn finalizer_name(&self) -> Option<&'static str>;
 
+    /// Opt an object reconciler into bounded retries for repeated identical
+    /// errors. Controllers without a policy retain the ordinary resync retry
+    /// behaviour.
+    fn reconcile_error_policy(&self) -> Option<ReconcileErrorPolicy> {
+        None
+    }
+
+    /// Persist a resource-specific degraded condition once the reconcile
+    /// error budget is exhausted.
+    fn reconcile_degraded_patch(
+        &self,
+        _obj: &ResourceObject<Self::Resource>,
+        _failure: &ReconcileFailure,
+    ) -> Option<<Self::Resource as Resource>::StatusPatch> {
+        None
+    }
+
+    /// A persisted degraded condition survives controller restarts and parks
+    /// the object until an explicit resource transition clears it.
+    fn is_reconcile_degraded(&self, _obj: &ResourceObject<Self::Resource>) -> bool {
+        false
+    }
+
     /// Map a finalizer failure to a status update.
     ///
     /// Other object-scoped errors remain isolated and are retried on a later
@@ -65,6 +89,32 @@ pub trait Reconciler: Send + Sync + 'static {
     ) -> Option<<Self::Resource as Resource>::StatusPatch> {
         None
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReconcileErrorPolicy {
+    pub max_consecutive_failures: u32,
+    pub initial_backoff: Duration,
+    pub max_backoff: Duration,
+}
+
+impl ReconcileErrorPolicy {
+    fn backoff(&self, consecutive_failures: u32) -> Duration {
+        let exponent = consecutive_failures.saturating_sub(1).min(31);
+        self.initial_backoff.saturating_mul(1_u32 << exponent).min(self.max_backoff)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconcileFailure {
+    pub message: String,
+    pub consecutive_failures: u32,
+}
+
+struct ObjectFailure {
+    failure: ReconcileFailure,
+    retry_at: Instant,
+    terminal: bool,
 }
 
 pub struct ReconcileOutcome<T: Resource> {
@@ -514,6 +564,7 @@ impl<R: Reconciler> ControllerLoop<R> {
         resync.tick().await;
         let mut pending: VecDeque<String> = VecDeque::new();
         let scheduled_requeues = Arc::new(Mutex::new(HashSet::new()));
+        let mut object_failures = BTreeMap::<String, ObjectFailure>::new();
 
         loop {
             if let Some(name) = pending.pop_front() {
@@ -530,6 +581,7 @@ impl<R: Reconciler> ControllerLoop<R> {
                         continue;
                     }
                 };
+                let mut attempted_reconcile = false;
                 let result = async {
                     let lifecycle_owned = is_lifecycle_owned(object.metadata.lifecycle_authority()?);
                     if let Some(finalizer_name) = reconciler.finalizer_name() {
@@ -574,6 +626,15 @@ impl<R: Reconciler> ControllerLoop<R> {
                     if !lifecycle_owned {
                         return Ok(());
                     }
+                    if reconciler.is_reconcile_degraded(&object) {
+                        return Ok(());
+                    }
+                    if let Some(failure) = object_failures.get(&name) {
+                        if failure.terminal || Instant::now() < failure.retry_at {
+                            return Ok(());
+                        }
+                    }
+                    attempted_reconcile = true;
                     let deps = reconciler.fetch_dependencies(&object).await?;
                     let outcome = reconciler.reconcile(&object, &deps, Utc::now());
                     for actuation in outcome.actuations {
@@ -598,13 +659,68 @@ impl<R: Reconciler> ControllerLoop<R> {
                     Ok(())
                 }
                 .await;
-                if let Err(err) = result {
-                    warn!(
-                        resource_kind = R::Resource::API_PATHS.kind,
-                        resource = %name,
-                        %err,
-                        "controller failed to reconcile object; other objects will continue",
-                    );
+                match result {
+                    Ok(()) if attempted_reconcile => {
+                        object_failures.remove(&name);
+                    }
+                    Ok(()) => {}
+                    Err(err) => {
+                        let mut terminal = false;
+                        let mut retry_after = None;
+                        if attempted_reconcile {
+                            if let Some(policy) = reconciler.reconcile_error_policy() {
+                                let message = err.to_string();
+                                let previous = object_failures.get(&name);
+                                let consecutive_failures = previous
+                                    .filter(|previous| previous.failure.message == message)
+                                    .map_or(1, |previous| previous.failure.consecutive_failures.saturating_add(1));
+                                let failure = ReconcileFailure { message, consecutive_failures };
+                                terminal = consecutive_failures >= policy.max_consecutive_failures;
+                                let delay = policy.backoff(consecutive_failures);
+                                object_failures.insert(name.clone(), ObjectFailure {
+                                    failure: failure.clone(),
+                                    retry_at: Instant::now() + delay,
+                                    terminal,
+                                });
+                                if terminal {
+                                    if let Some(patch) = reconciler.reconcile_degraded_patch(&object, &failure) {
+                                        if let Err(patch_error) =
+                                            Self::write_tolerating_not_found(apply_status_patch(&primary, &name, &patch)).await
+                                        {
+                                            warn!(
+                                                resource_kind = R::Resource::API_PATHS.kind,
+                                                resource = %name,
+                                                %patch_error,
+                                                "controller failed to record degraded reconcile condition",
+                                            );
+                                        }
+                                    }
+                                } else {
+                                    retry_after = Some(delay);
+                                }
+                            }
+                        }
+                        warn!(
+                            resource_kind = R::Resource::API_PATHS.kind,
+                            resource = %name,
+                            %err,
+                            terminal,
+                            "controller failed to reconcile object; other objects will continue",
+                        );
+                        if let Some(delay) = retry_after {
+                            let mut scheduled = scheduled_requeues.lock().await;
+                            if scheduled.insert(name.clone()) {
+                                let scheduled_requeues = Arc::clone(&scheduled_requeues);
+                                let sender = sender.clone();
+                                let name = name.clone();
+                                tokio::spawn(async move {
+                                    tokio::time::sleep(delay).await;
+                                    scheduled_requeues.lock().await.remove(&name);
+                                    let _ = sender.send(name).await;
+                                });
+                            }
+                        }
+                    }
                 }
                 continue;
             }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -119,8 +119,8 @@ pub use status_patch::{apply_status_patch, apply_status_patch_checked, NoStatusP
 pub use terminal_session::{
     terminal_session_attach_target, CrewSessionStatus, InnerCommandStatus, TerminalAttention, TerminalAttentionSource,
     TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession, TerminalSessionAttachTarget,
-    TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
-    TerminalSessionStatusPatch, TerminalSessionTag,
+    TerminalSessionDegradedCondition, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, TerminalSessionStatusPatch, TerminalSessionTag,
 };
 pub use vessel::{
     Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch, ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -172,6 +172,18 @@ pub struct TerminalSessionStatus {
     /// This deliberately does not participate in the session lifecycle phase.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention: Option<TerminalAttention>,
+    /// Set when the controller exhausts its budget for one repeated reconcile
+    /// error. The session remains parked until an explicit restart clears it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub degraded: Option<TerminalSessionDegradedCondition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalSessionDegradedCondition {
+    pub reason: String,
+    pub message: String,
+    pub consecutive_failures: u32,
+    pub observed_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -271,6 +283,11 @@ pub enum TerminalSessionStatusPatch {
         message: String,
         stopped_at: Option<DateTime<Utc>>,
     },
+    MarkReconcileDegraded {
+        message: String,
+        consecutive_failures: u32,
+        observed_at: DateTime<Utc>,
+    },
     ObserveAttention {
         attention: TerminalAttention,
     },
@@ -316,6 +333,20 @@ impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
                     if let Some(stopped_at) = stopped_at {
                         attention.as_of = *stopped_at;
                     }
+                }
+            }
+            Self::MarkReconcileDegraded { message, consecutive_failures, observed_at } => {
+                status.phase = TerminalSessionPhase::Failed;
+                status.message = Some(format!("reconcile stopped after {consecutive_failures} consecutive failures: {message}"));
+                status.degraded = Some(TerminalSessionDegradedCondition {
+                    reason: "ReconcileErrorBudgetExhausted".to_string(),
+                    message: message.clone(),
+                    consecutive_failures: *consecutive_failures,
+                    observed_at: *observed_at,
+                });
+                if let Some(attention) = &mut status.attention {
+                    attention.state = TerminalAttentionState::Unobservable;
+                    attention.as_of = *observed_at;
                 }
             }
             Self::ObserveAttention { attention } => {

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -10,7 +10,10 @@ use std::{
 
 use common::{resource_meta, TestLoopHarness};
 use flotilla_resources::{
-    controller::{Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, ResolverLabelMappedWatch},
+    controller::{
+        Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileErrorPolicy, ReconcileFailure, ReconcileOutcome, Reconciler,
+        ResolverLabelMappedWatch,
+    },
     ApiPaths, InMemoryBackend, InputMeta, LifecycleAuthority, NoStatusPatch, Presentation, PresentationSpec, Resource, ResourceBackend,
     ResourceError, ResourceObject, StatusPatch, TypedResolver, Vessel, VesselSpec,
 };
@@ -50,6 +53,83 @@ impl Resource for SecondaryResource {
     type StatusPatch = NoStatusPatch;
 
     const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "test-secondaries", kind: "TestSecondary" };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FailureResource;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct FailureStatus {
+    degraded: bool,
+    message: Option<String>,
+    consecutive_failures: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MarkDegraded(ReconcileFailure);
+
+impl StatusPatch<FailureStatus> for MarkDegraded {
+    fn apply(&self, status: &mut FailureStatus) {
+        status.degraded = true;
+        status.message = Some(self.0.message.clone());
+        status.consecutive_failures = self.0.consecutive_failures;
+    }
+}
+
+impl Resource for FailureResource {
+    type Spec = PrimarySpec;
+    type Status = FailureStatus;
+    type StatusPatch = MarkDegraded;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "test-failures", kind: "TestFailure" };
+}
+
+#[derive(Clone)]
+struct BudgetedFailureReconciler {
+    attempts: Arc<AtomicUsize>,
+}
+
+impl Reconciler for BudgetedFailureReconciler {
+    type Resource = FailureResource;
+    type Dependencies = ();
+
+    async fn fetch_dependencies(&self, _obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        Err(ResourceError::other("provider registry unavailable"))
+    }
+
+    fn reconcile(
+        &self,
+        _obj: &ResourceObject<Self::Resource>,
+        _deps: &Self::Dependencies,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> ReconcileOutcome<Self::Resource> {
+        unreachable!("dependency failure should prevent reconcile")
+    }
+
+    async fn run_finalizer(&self, _obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
+        Ok(())
+    }
+
+    fn finalizer_name(&self) -> Option<&'static str> {
+        None
+    }
+
+    fn reconcile_error_policy(&self) -> Option<ReconcileErrorPolicy> {
+        Some(ReconcileErrorPolicy {
+            max_consecutive_failures: 3,
+            initial_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(40),
+        })
+    }
+
+    fn reconcile_degraded_patch(&self, _obj: &ResourceObject<Self::Resource>, failure: &ReconcileFailure) -> Option<MarkDegraded> {
+        Some(MarkDegraded(failure.clone()))
+    }
+
+    fn is_reconcile_degraded(&self, obj: &ResourceObject<Self::Resource>) -> bool {
+        obj.status.as_ref().is_some_and(|status| status.degraded)
+    }
 }
 
 #[derive(Clone)]
@@ -1187,6 +1267,73 @@ async fn controller_loop_removes_existing_adopted_finalizer_without_running_tear
     .expect("adopted primary should be unblocked without teardown");
 
     assert!(finalized.lock().expect("finalized lock").is_empty());
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn repeated_identical_reconcile_errors_back_off_and_park_as_degraded() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let failures = backend.clone().using::<FailureResource>("flotilla");
+    failures
+        .create(&primary_meta("terminal-a"), &PrimarySpec { value: "one".to_string() })
+        .await
+        .expect("failure resource should be created");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: failures.clone(),
+            secondaries: Vec::new(),
+            reconciler: BudgetedFailureReconciler { attempts: Arc::clone(&attempts) },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+        if attempts.load(Ordering::SeqCst) == 1 {
+            break;
+        }
+    }
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+    tokio::time::advance(Duration::from_millis(9)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(attempts.load(Ordering::SeqCst), 1, "first retry must respect its backoff");
+    tokio::time::advance(Duration::from_millis(1)).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+        if attempts.load(Ordering::SeqCst) == 2 {
+            break;
+        }
+    }
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+    tokio::time::advance(Duration::from_millis(19)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(attempts.load(Ordering::SeqCst), 2, "second retry must use an increased backoff");
+    tokio::time::advance(Duration::from_millis(1)).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+        if failures.get("terminal-a").await.expect("failure resource should remain").status.as_ref().is_some_and(|status| status.degraded) {
+            break;
+        }
+    }
+
+    let status = failures.get("terminal-a").await.expect("failure resource should remain").status.expect("degraded status");
+    assert!(status.degraded);
+    assert_eq!(status.consecutive_failures, 3);
+    assert_eq!(status.message.as_deref(), Some("provider registry unavailable"));
+    assert_eq!(attempts.load(Ordering::SeqCst), 3);
+
+    tokio::time::advance(Duration::from_secs(120)).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(attempts.load(Ordering::SeqCst), 3, "degraded object must remain parked across resyncs");
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -87,6 +87,7 @@ impl Resource for FailureResource {
 #[derive(Clone)]
 struct BudgetedFailureReconciler {
     attempts: Arc<AtomicUsize>,
+    persist_degraded: bool,
 }
 
 impl Reconciler for BudgetedFailureReconciler {
@@ -124,7 +125,7 @@ impl Reconciler for BudgetedFailureReconciler {
     }
 
     fn reconcile_degraded_patch(&self, _obj: &ResourceObject<Self::Resource>, failure: &ReconcileFailure) -> Option<MarkDegraded> {
-        Some(MarkDegraded(failure.clone()))
+        self.persist_degraded.then(|| MarkDegraded(failure.clone()))
     }
 
     fn is_reconcile_degraded(&self, obj: &ResourceObject<Self::Resource>) -> bool {
@@ -1285,7 +1286,7 @@ async fn repeated_identical_reconcile_errors_back_off_and_park_as_degraded() {
         ControllerLoop {
             primary: failures.clone(),
             secondaries: Vec::new(),
-            reconciler: BudgetedFailureReconciler { attempts: Arc::clone(&attempts) },
+            reconciler: BudgetedFailureReconciler { attempts: Arc::clone(&attempts), persist_degraded: true },
             resync_interval: Duration::from_secs(60),
             backend,
         }
@@ -1334,6 +1335,56 @@ async fn repeated_identical_reconcile_errors_back_off_and_park_as_degraded() {
         tokio::task::yield_now().await;
     }
     assert_eq!(attempts.load(Ordering::SeqCst), 3, "degraded object must remain parked across resyncs");
+
+    failures.delete("terminal-a").await.expect("degraded resource should be deleted");
+    failures
+        .create(&primary_meta("terminal-a"), &PrimarySpec { value: "replacement".to_string() })
+        .await
+        .expect("same-name replacement should be created");
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+        if attempts.load(Ordering::SeqCst) == 4 {
+            break;
+        }
+    }
+    assert_eq!(attempts.load(Ordering::SeqCst), 4, "same-name replacement must not inherit the deleted object's failure budget");
+
+    harness.shutdown().await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn exhausted_budget_keeps_retrying_until_degraded_status_is_persistable() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let failures = backend.clone().using::<FailureResource>("flotilla");
+    failures
+        .create(&primary_meta("terminal-a"), &PrimarySpec { value: "one".to_string() })
+        .await
+        .expect("failure resource should be created");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: failures.clone(),
+            secondaries: Vec::new(),
+            reconciler: BudgetedFailureReconciler { attempts: Arc::clone(&attempts), persist_degraded: false },
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+    }
+    for delay in [10, 20, 40] {
+        tokio::time::advance(Duration::from_millis(delay)).await;
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 4, "missing degraded persistence must not silently park the object");
+    assert!(failures.get("terminal-a").await.expect("failure resource should remain").status.is_none());
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -74,6 +74,7 @@ define_patch_kinds! {
     TerminalObserveAttention => NONE,
     TerminalMarkStopped => DUPLICATE,
     TerminalMarkFailed => DUPLICATE,
+    TerminalMarkReconcileDegraded => NONE,
     VesselMarkProvisioning => DUPLICATE,
     VesselMarkReady => DUPLICATE,
     VesselMarkInterrupted => NONE,
@@ -116,6 +117,7 @@ fn terminal_session_patch_kind(patch: &TerminalSessionStatusPatch) -> PatchKind 
         TerminalSessionStatusPatch::MarkMessageDelivered { .. } => PatchKind::TerminalMarkMessageDelivered,
         TerminalSessionStatusPatch::MarkStopped { .. } => PatchKind::TerminalMarkStopped,
         TerminalSessionStatusPatch::MarkFailed { .. } => PatchKind::TerminalMarkFailed,
+        TerminalSessionStatusPatch::MarkReconcileDegraded { .. } => PatchKind::TerminalMarkReconcileDegraded,
         TerminalSessionStatusPatch::ObserveAttention { .. } => PatchKind::TerminalObserveAttention,
     }
 }
@@ -545,6 +547,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                     launch_command: Some("bash".to_string()),
                     delivered_message_id: None,
                     attention: None,
+                    degraded: None,
                 };
                 let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
                 let patch = TerminalSessionStatusPatch::MarkRunning {


### PR DESCRIPTION
Closes #1297

## Summary

- reap TerminalSessions as soon as their owning convoy is abandoned, before provider lookup
- add opt-in per-object reconcile failure budgets with exponential backoff and terminal parking
- persist a visible TerminalSession degraded condition after five identical failures

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`