### PR TITLE
fix: clean stale reverse peer sockets

### DIFF
--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -616,36 +616,39 @@ mod tests {
     #[test]
     fn resource_socket_forward_specs_are_bidirectional() {
         let config = RemoteHostConfig {
-            hostname: "feta.local".to_string(),
-            expected_host_name: "feta".to_string(),
+            hostname: "peer-a.example.invalid".to_string(),
+            expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
-            user: Some("flotilla".to_string()),
-            daemon_socket: "/home/flotilla/.config/flotilla/flotilla.sock".to_string(),
+            user: Some("test-user".to_string()),
+            daemon_socket: "/home/test-remote/.config/flotilla/flotilla.sock".to_string(),
             ssh_multiplex: None,
         };
-        let local_node = NodeId::new("kiwi-root");
+        let local_node = NodeId::new("local-node");
         let transport = SshTransport::new(
             local_node.clone(),
-            "kiwi".into(),
-            ConfigLabel("feta".to_string()),
+            "local-host".into(),
+            ConfigLabel("peer-a".to_string()),
             config,
             None,
             uuid::Uuid::nil(),
             SshTransportPaths {
-                state_dir: Path::new("/home/kiwi/.local/state/flotilla"),
-                daemon_socket: Path::new("/home/kiwi/.config/flotilla/flotilla.sock"),
+                state_dir: Path::new("/home/test-local/.local/state/flotilla"),
+                daemon_socket: Path::new("/home/test-local/.config/flotilla/flotilla.sock"),
             },
         )
         .expect("valid transport");
 
         let (local_forward, reverse_forward) = transport.resource_forward_specs();
 
-        assert_eq!(local_forward, "/home/kiwi/.local/state/flotilla/peers/feta.sock:/home/flotilla/.config/flotilla/flotilla.sock");
+        assert_eq!(
+            local_forward,
+            "/home/test-local/.local/state/flotilla/peers/peer-a.sock:/home/test-remote/.config/flotilla/flotilla.sock"
+        );
         assert_eq!(
             reverse_forward,
             format!(
-                "{}:/home/kiwi/.config/flotilla/flotilla.sock",
-                reverse_peer_resource_socket_path(Path::new("/home/flotilla/.config/flotilla/flotilla.sock"), &local_node)
+                "{}:/home/test-local/.config/flotilla/flotilla.sock",
+                reverse_peer_resource_socket_path(Path::new("/home/test-remote/.config/flotilla/flotilla.sock"), &local_node)
                     .expect("reverse path")
                     .display()
             )
@@ -655,17 +658,17 @@ mod tests {
     #[test]
     fn remote_socket_cleanup_command_quotes_the_derived_path() {
         let config = RemoteHostConfig {
-            hostname: "feta.local".to_string(),
-            expected_host_name: "feta".to_string(),
+            hostname: "peer-a.example.invalid".to_string(),
+            expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
-            user: Some("flotilla".to_string()),
+            user: Some("test-user".to_string()),
             daemon_socket: "/home/O'Brien/.config/flotilla/flotilla.sock".to_string(),
             ssh_multiplex: None,
         };
         let transport = SshTransport::new(
-            NodeId::new("kiwi"),
-            "kiwi".into(),
-            ConfigLabel("feta".into()),
+            NodeId::new("local-node"),
+            "local-host".into(),
+            ConfigLabel("peer-a".into()),
             config,
             None,
             uuid::Uuid::nil(),
@@ -687,17 +690,17 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let daemon_socket = tmp.path().join("flotilla.sock");
         let config = RemoteHostConfig {
-            hostname: "feta.local".to_string(),
-            expected_host_name: "feta".to_string(),
+            hostname: "peer-a.example.invalid".to_string(),
+            expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
             user: None,
             daemon_socket: daemon_socket.to_string_lossy().into_owned(),
             ssh_multiplex: None,
         };
         let mut transport = SshTransport::new(
-            NodeId::new("kiwi"),
-            "kiwi".into(),
-            ConfigLabel("feta".into()),
+            NodeId::new("local-node"),
+            "local-host".into(),
+            ConfigLabel("peer-a".into()),
             config,
             None,
             uuid::Uuid::nil(),
@@ -725,17 +728,17 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let daemon_socket = tmp.path().join("flotilla.sock");
         let config = RemoteHostConfig {
-            hostname: "feta.local".to_string(),
-            expected_host_name: "feta".to_string(),
+            hostname: "peer-a.example.invalid".to_string(),
+            expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
             user: None,
             daemon_socket: daemon_socket.to_string_lossy().into_owned(),
             ssh_multiplex: None,
         };
         let mut transport = SshTransport::new(
-            NodeId::new("kiwi"),
-            "kiwi".into(),
-            ConfigLabel("feta".into()),
+            NodeId::new("local-node"),
+            "local-host".into(),
+            ConfigLabel("peer-a".into()),
             config,
             None,
             uuid::Uuid::nil(),

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -101,6 +101,7 @@ pub struct SshTransport {
     local_socket_path: PathBuf,
     local_daemon_socket_path: PathBuf,
     remote_resource_socket_path: PathBuf,
+    ssh_binary: PathBuf,
     ssh_process: Option<tokio::process::Child>,
     status: PeerConnectionStatus,
     /// Receiver for inbound peer data, produced by `connect_socket()` and
@@ -146,6 +147,7 @@ impl SshTransport {
             local_socket_path,
             local_daemon_socket_path: paths.daemon_socket.to_path_buf(),
             remote_resource_socket_path,
+            ssh_binary: PathBuf::from("ssh"),
             ssh_process: None,
             status: PeerConnectionStatus::Disconnected,
             inbound_rx: None,
@@ -162,6 +164,13 @@ impl SshTransport {
         // Clean up any stale local socket before spawning
         self.cleanup_socket();
 
+        // OpenSSH's client-side StreamLocalBindUnlink option only applies to
+        // the local (-L) socket. The reverse (-R) socket is bound by sshd and
+        // survives a dead tunnel unless the server is configured to unlink
+        // it. Remove our deterministic reverse socket explicitly so a stale
+        // file cannot make every subsequent tunnel attempt fail.
+        self.cleanup_remote_socket().await?;
+
         // Ensure peers directory exists
         if let Some(parent) = self.local_socket_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| format!("failed to create peers directory: {e}"))?;
@@ -169,10 +178,7 @@ impl SshTransport {
 
         let (forward_spec, reverse_forward_spec) = self.resource_forward_specs();
 
-        let destination = match &self.config.user {
-            Some(user) => format!("{user}@{}", self.config.hostname),
-            None => self.config.hostname.clone(),
-        };
+        let destination = self.destination();
 
         info!(
             expected_host = %self.expected_host_name,
@@ -183,7 +189,7 @@ impl SshTransport {
             "spawning SSH tunnel"
         );
 
-        let child = tokio::process::Command::new("ssh")
+        let child = tokio::process::Command::new(&self.ssh_binary)
             .arg("-N") // no remote command
             .arg("-L")
             .arg(&forward_spec)
@@ -207,6 +213,48 @@ impl SshTransport {
 
         self.ssh_process = Some(child);
         Ok(())
+    }
+
+    fn destination(&self) -> String {
+        match &self.config.user {
+            Some(user) => format!("{user}@{}", self.config.hostname),
+            None => self.config.hostname.clone(),
+        }
+    }
+
+    async fn cleanup_remote_socket(&self) -> Result<(), String> {
+        let destination = self.destination();
+        let path = self.remote_resource_socket_path.to_string_lossy();
+        let command = self.remote_cleanup_command();
+        debug!(%destination, remote_socket = %path, "removing stale reverse peer socket before SSH tunnel dial");
+
+        let output = tokio::process::Command::new(&self.ssh_binary)
+            .arg(&destination)
+            .arg(&command)
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .output();
+        let output = tokio::time::timeout(SOCKET_POLL_TIMEOUT, output)
+            .await
+            .map_err(|_| format!("timed out removing stale reverse peer socket at {path} on {destination}"))?
+            .map_err(|e| format!("failed to run remote stale peer socket cleanup at {path} on {destination}: {e}"))?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!(
+            "failed to remove stale reverse peer socket at {path} on {destination}: ssh exited with {}{}",
+            output.status,
+            if stderr.trim().is_empty() { String::new() } else { format!(": {}", stderr.trim()) }
+        ))
+    }
+
+    fn remote_cleanup_command(&self) -> String {
+        format!("rm -f -- {}", shell_quote(&self.remote_resource_socket_path.to_string_lossy()))
     }
 
     fn resource_forward_specs(&self) -> (String, String) {
@@ -425,6 +473,10 @@ impl SshTransport {
     }
 }
 
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
 #[async_trait]
 impl PeerTransport for SshTransport {
     async fn connect(&mut self) -> Result<(), String> {
@@ -518,6 +570,8 @@ impl Drop for SshTransport {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
     use flotilla_protocol::PeerDataMessage;
     use tokio::io::AsyncWriteExt;
 
@@ -596,6 +650,111 @@ mod tests {
                     .display()
             )
         );
+    }
+
+    #[test]
+    fn remote_socket_cleanup_command_quotes_the_derived_path() {
+        let config = RemoteHostConfig {
+            hostname: "feta.local".to_string(),
+            expected_host_name: "feta".to_string(),
+            expected_node_id: None,
+            user: Some("flotilla".to_string()),
+            daemon_socket: "/home/O'Brien/.config/flotilla/flotilla.sock".to_string(),
+            ssh_multiplex: None,
+        };
+        let transport = SshTransport::new(
+            NodeId::new("kiwi"),
+            "kiwi".into(),
+            ConfigLabel("feta".into()),
+            config,
+            None,
+            uuid::Uuid::nil(),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
+        )
+        .expect("valid transport");
+
+        assert_eq!(
+            transport.remote_cleanup_command(),
+            format!(
+                "rm -f -- '/home/O'\"'\"'Brien/.config/flotilla/{}'",
+                transport.remote_resource_socket_path.file_name().expect("socket file name").to_string_lossy()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn spawning_tunnel_removes_stale_reverse_socket_first() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let daemon_socket = tmp.path().join("flotilla.sock");
+        let config = RemoteHostConfig {
+            hostname: "feta.local".to_string(),
+            expected_host_name: "feta".to_string(),
+            expected_node_id: None,
+            user: None,
+            daemon_socket: daemon_socket.to_string_lossy().into_owned(),
+            ssh_multiplex: None,
+        };
+        let mut transport = SshTransport::new(
+            NodeId::new("kiwi"),
+            "kiwi".into(),
+            ConfigLabel("feta".into()),
+            config,
+            None,
+            uuid::Uuid::nil(),
+            SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
+        )
+        .expect("valid transport");
+        std::fs::write(&transport.remote_resource_socket_path, []).expect("create stale reverse socket stand-in");
+
+        let fake_ssh = tmp.path().join("ssh");
+        std::fs::write(&fake_ssh, "#!/bin/sh\nif [ \"$#\" -eq 2 ]; then exec /bin/sh -c \"$2\"; fi\nexit 0\n").expect("write fake ssh");
+        let mut permissions = std::fs::metadata(&fake_ssh).expect("fake ssh metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
+        transport.ssh_binary = fake_ssh;
+
+        transport.spawn_ssh().await.expect("stale cleanup and tunnel spawn should succeed");
+
+        assert!(!transport.remote_resource_socket_path.exists(), "stale reverse socket must be removed before the tunnel is spawned");
+        let status = transport.ssh_process.as_mut().expect("tunnel child").wait().await.expect("wait for fake tunnel");
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn remote_socket_cleanup_failure_names_the_stale_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let daemon_socket = tmp.path().join("flotilla.sock");
+        let config = RemoteHostConfig {
+            hostname: "feta.local".to_string(),
+            expected_host_name: "feta".to_string(),
+            expected_node_id: None,
+            user: None,
+            daemon_socket: daemon_socket.to_string_lossy().into_owned(),
+            ssh_multiplex: None,
+        };
+        let mut transport = SshTransport::new(
+            NodeId::new("kiwi"),
+            "kiwi".into(),
+            ConfigLabel("feta".into()),
+            config,
+            None,
+            uuid::Uuid::nil(),
+            SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
+        )
+        .expect("valid transport");
+        let fake_ssh = tmp.path().join("ssh");
+        std::fs::write(&fake_ssh, "#!/bin/sh\necho cleanup-denied >&2\nexit 23\n").expect("write failing fake ssh");
+        let mut permissions = std::fs::metadata(&fake_ssh).expect("fake ssh metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
+        transport.ssh_binary = fake_ssh;
+
+        let error = transport.spawn_ssh().await.expect_err("cleanup failure must stop the tunnel dial");
+
+        assert!(error.contains("failed to remove stale reverse peer socket"), "unexpected error: {error}");
+        assert!(error.contains(&transport.remote_resource_socket_path.to_string_lossy().into_owned()), "unexpected error: {error}");
+        assert!(error.contains("cleanup-denied"), "unexpected error: {error}");
+        assert!(transport.ssh_process.is_none(), "tunnel must not spawn after cleanup failure");
     }
 
     #[test]

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -47,6 +47,38 @@ const HELLO_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 const ACCEPT_ERROR_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 const ACCEPT_ERROR_MAX_BACKOFF: Duration = Duration::from_secs(5);
 
+fn is_reverse_peer_resource_socket_name(name: &str) -> bool {
+    name.strip_prefix(".peer-").is_some_and(|hash| hash.len() == 16 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}
+
+fn cleanup_reverse_peer_resource_sockets(socket_dir: &Path) -> Result<usize, String> {
+    let entries = match std::fs::read_dir(socket_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(format!("failed to inspect daemon socket directory {}: {error}", socket_dir.display())),
+    };
+
+    let mut removed = 0;
+    for entry in entries {
+        let entry =
+            entry.map_err(|error| format!("failed to inspect entry in daemon socket directory {}: {error}", socket_dir.display()))?;
+        if !is_reverse_peer_resource_socket_name(&entry.file_name().to_string_lossy()) {
+            continue;
+        }
+        let file_type =
+            entry.file_type().map_err(|error| format!("failed to inspect stale peer socket {}: {error}", entry.path().display()))?;
+        if file_type.is_dir() {
+            continue;
+        }
+        match std::fs::remove_file(entry.path()) {
+            Ok(()) => removed += 1,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(format!("failed to remove stale reverse peer socket {}: {error}", entry.path().display())),
+        }
+    }
+    Ok(removed)
+}
+
 #[derive(Debug)]
 struct AcceptErrorBackoff {
     next: Duration,
@@ -309,6 +341,10 @@ impl DaemonServer {
         // Ensure parent directory exists
         if let Some(parent) = self.socket_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| format!("failed to create socket directory: {e}"))?;
+            let removed = cleanup_reverse_peer_resource_sockets(parent)?;
+            if removed > 0 {
+                info!(socket_dir = %parent.display(), removed, "removed stale reverse peer sockets");
+            }
         }
 
         let listener = UnixListener::bind(&self.socket_path).map_err(|e| format!("failed to bind socket: {e}"))?;

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -51,32 +51,47 @@ fn is_reverse_peer_resource_socket_name(name: &str) -> bool {
     name.strip_prefix(".peer-").is_some_and(|hash| hash.len() == 16 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 
-fn cleanup_reverse_peer_resource_sockets(socket_dir: &Path) -> Result<usize, String> {
+fn cleanup_reverse_peer_resource_sockets(socket_dir: &Path) -> usize {
     let entries = match std::fs::read_dir(socket_dir) {
         Ok(entries) => entries,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(error) => return Err(format!("failed to inspect daemon socket directory {}: {error}", socket_dir.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return 0,
+        Err(error) => {
+            warn!(socket_dir = %socket_dir.display(), %error, "failed to inspect daemon socket directory for stale reverse peer sockets");
+            return 0;
+        }
     };
 
     let mut removed = 0;
     for entry in entries {
-        let entry =
-            entry.map_err(|error| format!("failed to inspect entry in daemon socket directory {}: {error}", socket_dir.display()))?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                warn!(socket_dir = %socket_dir.display(), %error, "failed to inspect daemon socket directory entry during stale reverse peer socket cleanup");
+                continue;
+            }
+        };
         if !is_reverse_peer_resource_socket_name(&entry.file_name().to_string_lossy()) {
             continue;
         }
-        let file_type =
-            entry.file_type().map_err(|error| format!("failed to inspect stale peer socket {}: {error}", entry.path().display()))?;
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                warn!(path = %entry.path().display(), %error, "failed to inspect stale reverse peer socket during startup cleanup");
+                continue;
+            }
+        };
         if file_type.is_dir() {
             continue;
         }
         match std::fs::remove_file(entry.path()) {
             Ok(()) => removed += 1,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(format!("failed to remove stale reverse peer socket {}: {error}", entry.path().display())),
+            Err(error) => {
+                warn!(path = %entry.path().display(), %error, "failed to remove stale reverse peer socket during startup cleanup");
+            }
         }
     }
-    Ok(removed)
+    removed
 }
 
 #[derive(Debug)]
@@ -341,7 +356,7 @@ impl DaemonServer {
         // Ensure parent directory exists
         if let Some(parent) = self.socket_path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| format!("failed to create socket directory: {e}"))?;
-            let removed = cleanup_reverse_peer_resource_sockets(parent)?;
+            let removed = cleanup_reverse_peer_resource_sockets(parent);
             if removed > 0 {
                 info!(socket_dir = %parent.display(), removed, "removed stale reverse peer sockets");
             }

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -46,6 +46,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 
 use super::{
+    cleanup_reverse_peer_resource_sockets,
     client_connection::QuerySubscriptions,
     handle_client, handle_client_session,
     peer_connection::PEER_IDLE_TIMEOUT,
@@ -776,6 +777,30 @@ async fn daemon_server_uses_sqlite_resource_backend_in_state_dir() {
         restarted.daemon().resource_backend().using::<Convoy>("flotilla").get("persisted").await.expect("convoy should survive restart");
 
     assert_eq!(fetched.spec.workflow_ref, "scratch");
+}
+
+#[test]
+fn daemon_startup_cleanup_removes_only_reverse_peer_socket_files() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stale_a = tmp.path().join(".peer-0123456789abcdef");
+    let stale_b = tmp.path().join(".peer-fedcba9876543210");
+    let daemon_socket = tmp.path().join("flotilla.sock");
+    let similarly_named_file = tmp.path().join(".peer-not-a-node-hash");
+    let peer_directory = tmp.path().join(".peer-preserve-directory");
+    std::fs::write(&stale_a, []).expect("create first stale socket stand-in");
+    std::fs::write(&stale_b, []).expect("create second stale socket stand-in");
+    std::fs::write(&daemon_socket, []).expect("create unrelated daemon socket stand-in");
+    std::fs::write(&similarly_named_file, []).expect("create similarly named file");
+    std::fs::create_dir(&peer_directory).expect("create similarly named directory");
+
+    let removed = cleanup_reverse_peer_resource_sockets(tmp.path()).expect("clean stale reverse peer sockets");
+
+    assert_eq!(removed, 2);
+    assert!(!stale_a.exists());
+    assert!(!stale_b.exists());
+    assert!(daemon_socket.exists());
+    assert!(similarly_named_file.exists());
+    assert!(peer_directory.exists());
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -793,7 +793,7 @@ fn daemon_startup_cleanup_removes_only_reverse_peer_socket_files() {
     std::fs::write(&similarly_named_file, []).expect("create similarly named file");
     std::fs::create_dir(&peer_directory).expect("create similarly named directory");
 
-    let removed = cleanup_reverse_peer_resource_sockets(tmp.path()).expect("clean stale reverse peer sockets");
+    let removed = cleanup_reverse_peer_resource_sockets(tmp.path());
 
     assert_eq!(removed, 2);
     assert!(!stale_a.exists());


### PR DESCRIPTION
## Summary

- remove the deterministic reverse peer socket over SSH before each tunnel dial
- clean orphaned `.peer-<node-hash>` socket entries when the accepting daemon starts
- surface cleanup failures with the remote host and stale path instead of an ambiguous hello EOF
- cover successful pre-clean ordering, failure diagnostics, shell quoting, and startup cleanup

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1295
