### PR TITLE
fix: preserve attach refusal visibility

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -91,6 +91,7 @@ use crate::{
         },
         issue_tracker::{forge_issue_source, IssueProvider},
         ssh_runner::SshCommandRunner,
+        terminal::AttachSeat,
         ChannelLabel, CommandRunner,
     },
     refresh::RefreshSnapshot,
@@ -530,10 +531,16 @@ enum AttachTarget {
 }
 
 impl AttachTarget {
-    async fn resolve(&self, daemon: &InProcessDaemon, reference: &str, transient: bool) -> Result<ResolvedAttach, String> {
+    async fn resolve(
+        &self,
+        daemon: &InProcessDaemon,
+        reference: &str,
+        transient: bool,
+        seat: AttachSeat,
+    ) -> Result<ResolvedAttach, String> {
         match self {
             Self::Local(session) => {
-                let (plan, host) = daemon.attach_plan_for_session(reference, session).await?;
+                let (plan, host) = daemon.attach_plan_for_session(reference, session, seat).await?;
                 let labels = &session.metadata.labels;
                 let binding = AttachBinding::builder()
                     .host(host)
@@ -546,7 +553,7 @@ impl AttachTarget {
                 Ok(ResolvedAttach { plan, binding: Some(binding) })
             }
             Self::Replica { row } => {
-                let plan = daemon.recursive_attach_plan_for_remote(&row.host, reference).await?;
+                let plan = daemon.recursive_attach_plan_for_remote(&row.host, reference, seat).await?;
                 // Replica rows carry crew as "vessel/role" (or a bare role)
                 // and the owning host's namespace + session name, so
                 // cross-host panes stamp the full join key.
@@ -569,9 +576,9 @@ impl AttachTarget {
                     return Err(format!("checkout '{}' is only available as a transient attach target", row.path));
                 }
                 let plan = if row.host == daemon.host_name {
-                    daemon.local_checkout_terminal_plan(row).await?
+                    daemon.local_checkout_terminal_plan(row, seat).await?
                 } else {
-                    daemon.recursive_attach_plan_for_remote(&row.host, reference).await?
+                    daemon.recursive_attach_plan_for_remote(&row.host, reference, seat).await?
                 };
                 Ok(ResolvedAttach { plan, binding: None })
             }
@@ -608,6 +615,7 @@ impl AttachCandidateIndex {
         reference: &str,
         host: Option<&HostName>,
         transient: bool,
+        seat: AttachSeat,
     ) -> Result<ResolvedAttach, String> {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
@@ -629,7 +637,7 @@ impl AttachCandidateIndex {
                 Some(host) => Err(format!("no attach target matching '{reference}' on host '{host}'")),
                 None => Err(format!("no attach target matching '{reference}'")),
             },
-            [index] => self.candidates[*index].target.resolve(daemon, reference, transient).await,
+            [index] => self.candidates[*index].target.resolve(daemon, reference, transient, seat).await,
             _ => {
                 let mut labels: Vec<_> = matches.iter().map(|index| self.candidates[*index].label.clone()).collect();
                 labels.sort();
@@ -6650,12 +6658,22 @@ impl InProcessDaemon {
         reference: &str,
         host: Option<&HostName>,
     ) -> Result<ResolvedAttach, String> {
+        self.resolve_attach_for_seat_internal(reference, host, false, AttachSeat::Control).await
+    }
+
+    async fn resolve_attach_for_seat_internal(
+        &self,
+        reference: &str,
+        host: Option<&HostName>,
+        transient: bool,
+        seat: AttachSeat,
+    ) -> Result<ResolvedAttach, String> {
         // Preserve validation precedence without paying to build the candidate index.
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }
         let index = self.attach_candidate_index().await?;
-        index.resolve(self, reference, host, false).await
+        index.resolve(self, reference, host, transient, seat).await
     }
 
     pub async fn resolve_transient_attach_command_internal(
@@ -6666,8 +6684,7 @@ impl InProcessDaemon {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }
-        let index = self.attach_candidate_index().await?;
-        index.resolve(self, reference, host, true).await
+        self.resolve_attach_for_seat_internal(reference, host, true, AttachSeat::Control).await
     }
 
     pub async fn resolvable_attach_references_internal(&self, references: &[String]) -> Result<HashSet<String>, String> {
@@ -6677,7 +6694,7 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = HashSet::new();
         for reference in references {
-            if index.resolve(self, reference, None, false).await.is_ok() {
+            if index.resolve(self, reference, None, false, AttachSeat::Control).await.is_ok() {
                 resolved.insert(reference.clone());
             }
         }
@@ -6688,7 +6705,7 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = Vec::with_capacity(targets.len());
         for (reference, host) in targets {
-            resolved.push(index.resolve(self, reference, Some(host), false).await.is_ok());
+            resolved.push(index.resolve(self, reference, Some(host), false, AttachSeat::Control).await.is_ok());
         }
         Ok(resolved)
     }
@@ -6861,7 +6878,7 @@ impl InProcessDaemon {
         Ok(AttachCandidateIndex::new(candidates))
     }
 
-    async fn local_checkout_terminal_plan(&self, checkout: &CheckoutRow) -> Result<ResolvedAttachPlan, String> {
+    async fn local_checkout_terminal_plan(&self, checkout: &CheckoutRow, seat: AttachSeat) -> Result<ResolvedAttachPlan, String> {
         let cwd = ExecutionEnvironmentPath::new(&checkout.path);
         let discovery = discover_repo_for_environment(
             &self.environment_manager,
@@ -6882,7 +6899,7 @@ impl InProcessDaemon {
         let session_name = transient_checkout_session_name(checkout);
         let command = "${SHELL:-/bin/sh}";
         pool.ensure_session(&session_name, command, &cwd, &Vec::new(), &[]).await?;
-        let args = pool.attach_args(&session_name, command, &cwd, &Vec::new())?;
+        let args = pool.attach_args_for_seat(&session_name, command, &cwd, &Vec::new(), seat)?;
         Ok(ResolvedAttachPlan(vec![ResolvedAttachAction::Command(args)]))
     }
 
@@ -6892,6 +6909,7 @@ impl InProcessDaemon {
         &self,
         reference: &str,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
+        seat: AttachSeat,
     ) -> Result<(ResolvedAttachPlan, HostName), String> {
         let namespace = self.provisioning_namespace().await;
         let environments = self.resource_backend.clone().using::<ResourceEnvironment>(&namespace);
@@ -6908,15 +6926,20 @@ impl InProcessDaemon {
             .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
         let target_host = self.target_host_for_resource_ref(host_ref);
         if target_host != self.host_name {
-            let plan = self.recursive_attach_plan_for_remote(&target_host, reference).await?;
+            let plan = self.recursive_attach_plan_for_remote(&target_host, reference, seat).await?;
             return Ok((plan, target_host));
         }
 
-        let plan = self.local_attach_plan_for_session(session, &environment).await?;
+        let plan = self.local_attach_plan_for_session(session, &environment, seat).await?;
         Ok((plan, self.host_name.clone()))
     }
 
-    async fn recursive_attach_plan_for_remote(&self, target_host: &HostName, reference: &str) -> Result<ResolvedAttachPlan, String> {
+    async fn recursive_attach_plan_for_remote(
+        &self,
+        target_host: &HostName,
+        reference: &str,
+        seat: AttachSeat,
+    ) -> Result<ResolvedAttachPlan, String> {
         let next_hop = self.host_registry.next_hop_host_for_target_host(target_host).await?.unwrap_or_else(|| target_host.clone());
         if next_hop == self.host_name {
             return Err(format!("unreachable next hop for host '{target_host}': route points back to local host"));
@@ -6930,6 +6953,9 @@ impl InProcessDaemon {
         // Recursive attaches only traverse transport boundaries; Presentation
         // Manager identity belongs to the original foreground attach.
         command.push(flotilla_protocol::arg::Arg::Literal("--transient".to_string()));
+        if seat == AttachSeat::Watch {
+            command.push(flotilla_protocol::arg::Arg::Literal("--watch".to_string()));
+        }
         command.push(flotilla_protocol::arg::Arg::Quoted(reference.to_string()));
         let hop_resolver = HopResolver::new(
             Arc::new(resolver),
@@ -6957,13 +6983,14 @@ impl InProcessDaemon {
             .as_deref()
             .or(binding.convoy.as_deref())
             .ok_or_else(|| "remote attach binding has neither a session nor convoy reference".to_string())?;
-        self.recursive_attach_plan_for_remote(&binding.host, reference).await
+        self.recursive_attach_plan_for_remote(&binding.host, reference, AttachSeat::Control).await
     }
 
     async fn local_attach_plan_for_session(
         &self,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
         environment: &flotilla_resources::ResourceObject<ResourceEnvironment>,
+        seat: AttachSeat,
     ) -> Result<ResolvedAttachPlan, String> {
         let cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
         let registry = self.registry_for_resource_environment(environment, cwd.as_path()).await?;
@@ -6973,7 +7000,7 @@ impl InProcessDaemon {
             .map(|(_, pool)| Arc::clone(pool))
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
         let attach_target = terminal_session_attach_target(session)?;
-        let attach_args = pool.attach_args(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new())?;
+        let attach_args = pool.attach_args_for_seat(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new(), seat)?;
         if environment.spec.docker.is_some() {
             let environment_id = EnvironmentId::new(session.spec.env_ref.clone());
             let container_name = environment.status.as_ref().and_then(|status| status.docker_container_id.as_deref());
@@ -8363,7 +8390,14 @@ impl DaemonHandle for InProcessDaemon {
                     Err(error) => Ok(flotilla_protocol::CommandValue::Error { message: error.to_string() }),
                 }
             }
-            CommandAction::Attach { reference, host } => match self.resolve_attach_command_on_host_internal(reference, host.as_ref()).await
+            CommandAction::Attach { reference, host, watch } => match self
+                .resolve_attach_for_seat_internal(
+                    reference,
+                    host.as_ref(),
+                    false,
+                    if *watch { AttachSeat::Watch } else { AttachSeat::Control },
+                )
+                .await
             {
                 Ok(resolved) => {
                     if let Some(binding) = &resolved.binding {
@@ -8375,8 +8409,16 @@ impl DaemonHandle for InProcessDaemon {
                 }
                 Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
             },
-            CommandAction::AttachTransient { reference, host } => {
-                match self.resolve_transient_attach_command_internal(reference, host.as_ref()).await {
+            CommandAction::AttachTransient { reference, host, watch } => {
+                match self
+                    .resolve_attach_for_seat_internal(
+                        reference,
+                        host.as_ref(),
+                        true,
+                        if *watch { AttachSeat::Watch } else { AttachSeat::Control },
+                    )
+                    .await
+                {
                     Ok(resolved) => {
                         Ok(flotilla_protocol::CommandValue::AttachCommandResolved { plan: resolved.plan, binding: resolved.binding })
                     }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use flotilla_protocol::{
     arg::{flatten, Arg},
-    commands::RepositoryIdentityChange,
+    commands::{AttachMode, RepositoryIdentityChange},
     qualified_path::{HostId, QualifiedPath},
     result_set::{CheckoutRow, ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
     AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, CorrelationKey, CrewCommandContext, CrewListMember,
@@ -91,7 +91,6 @@ use crate::{
         },
         issue_tracker::{forge_issue_source, IssueProvider},
         ssh_runner::SshCommandRunner,
-        terminal::AttachSeat,
         ChannelLabel, CommandRunner,
     },
     refresh::RefreshSnapshot,
@@ -536,7 +535,7 @@ impl AttachTarget {
         daemon: &InProcessDaemon,
         reference: &str,
         transient: bool,
-        seat: AttachSeat,
+        seat: AttachMode,
     ) -> Result<ResolvedAttach, String> {
         match self {
             Self::Local(session) => {
@@ -615,7 +614,7 @@ impl AttachCandidateIndex {
         reference: &str,
         host: Option<&HostName>,
         transient: bool,
-        seat: AttachSeat,
+        seat: AttachMode,
     ) -> Result<ResolvedAttach, String> {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
@@ -6658,22 +6657,22 @@ impl InProcessDaemon {
         reference: &str,
         host: Option<&HostName>,
     ) -> Result<ResolvedAttach, String> {
-        self.resolve_attach_for_seat_internal(reference, host, false, AttachSeat::Control).await
+        self.resolve_attach_with_mode_internal(reference, host, false, AttachMode::Default).await
     }
 
-    async fn resolve_attach_for_seat_internal(
+    async fn resolve_attach_with_mode_internal(
         &self,
         reference: &str,
         host: Option<&HostName>,
         transient: bool,
-        seat: AttachSeat,
+        mode: AttachMode,
     ) -> Result<ResolvedAttach, String> {
         // Preserve validation precedence without paying to build the candidate index.
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }
         let index = self.attach_candidate_index().await?;
-        index.resolve(self, reference, host, transient, seat).await
+        index.resolve(self, reference, host, transient, mode).await
     }
 
     pub async fn resolve_transient_attach_command_internal(
@@ -6684,7 +6683,7 @@ impl InProcessDaemon {
         if reference.trim().is_empty() {
             return Err("attach reference is required".to_string());
         }
-        self.resolve_attach_for_seat_internal(reference, host, true, AttachSeat::Control).await
+        self.resolve_attach_with_mode_internal(reference, host, true, AttachMode::Default).await
     }
 
     pub async fn resolvable_attach_references_internal(&self, references: &[String]) -> Result<HashSet<String>, String> {
@@ -6694,7 +6693,7 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = HashSet::new();
         for reference in references {
-            if index.resolve(self, reference, None, false, AttachSeat::Control).await.is_ok() {
+            if index.resolve(self, reference, None, false, AttachMode::Default).await.is_ok() {
                 resolved.insert(reference.clone());
             }
         }
@@ -6705,7 +6704,7 @@ impl InProcessDaemon {
         let index = self.attach_candidate_index().await?;
         let mut resolved = Vec::with_capacity(targets.len());
         for (reference, host) in targets {
-            resolved.push(index.resolve(self, reference, Some(host), false, AttachSeat::Control).await.is_ok());
+            resolved.push(index.resolve(self, reference, Some(host), false, AttachMode::Default).await.is_ok());
         }
         Ok(resolved)
     }
@@ -6878,7 +6877,7 @@ impl InProcessDaemon {
         Ok(AttachCandidateIndex::new(candidates))
     }
 
-    async fn local_checkout_terminal_plan(&self, checkout: &CheckoutRow, seat: AttachSeat) -> Result<ResolvedAttachPlan, String> {
+    async fn local_checkout_terminal_plan(&self, checkout: &CheckoutRow, seat: AttachMode) -> Result<ResolvedAttachPlan, String> {
         let cwd = ExecutionEnvironmentPath::new(&checkout.path);
         let discovery = discover_repo_for_environment(
             &self.environment_manager,
@@ -6899,7 +6898,8 @@ impl InProcessDaemon {
         let session_name = transient_checkout_session_name(checkout);
         let command = "${SHELL:-/bin/sh}";
         pool.ensure_session(&session_name, command, &cwd, &Vec::new(), &[]).await?;
-        let args = pool.attach_args_for_seat(&session_name, command, &cwd, &Vec::new(), seat)?;
+        pool.preflight_attach(seat).await?;
+        let args = pool.attach_args_for_mode(&session_name, command, &cwd, &Vec::new(), seat)?;
         Ok(ResolvedAttachPlan(vec![ResolvedAttachAction::Command(args)]))
     }
 
@@ -6909,7 +6909,7 @@ impl InProcessDaemon {
         &self,
         reference: &str,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
-        seat: AttachSeat,
+        seat: AttachMode,
     ) -> Result<(ResolvedAttachPlan, HostName), String> {
         let namespace = self.provisioning_namespace().await;
         let environments = self.resource_backend.clone().using::<ResourceEnvironment>(&namespace);
@@ -6938,7 +6938,7 @@ impl InProcessDaemon {
         &self,
         target_host: &HostName,
         reference: &str,
-        seat: AttachSeat,
+        seat: AttachMode,
     ) -> Result<ResolvedAttachPlan, String> {
         let next_hop = self.host_registry.next_hop_host_for_target_host(target_host).await?.unwrap_or_else(|| target_host.clone());
         if next_hop == self.host_name {
@@ -6953,8 +6953,10 @@ impl InProcessDaemon {
         // Recursive attaches only traverse transport boundaries; Presentation
         // Manager identity belongs to the original foreground attach.
         command.push(flotilla_protocol::arg::Arg::Literal("--transient".to_string()));
-        if seat == AttachSeat::Watch {
-            command.push(flotilla_protocol::arg::Arg::Literal("--watch".to_string()));
+        match seat {
+            AttachMode::Default => {}
+            AttachMode::Strict => command.push(flotilla_protocol::arg::Arg::Literal("--strict".to_string())),
+            AttachMode::Take => command.push(flotilla_protocol::arg::Arg::Literal("--take".to_string())),
         }
         command.push(flotilla_protocol::arg::Arg::Quoted(reference.to_string()));
         let hop_resolver = HopResolver::new(
@@ -6983,14 +6985,14 @@ impl InProcessDaemon {
             .as_deref()
             .or(binding.convoy.as_deref())
             .ok_or_else(|| "remote attach binding has neither a session nor convoy reference".to_string())?;
-        self.recursive_attach_plan_for_remote(&binding.host, reference, AttachSeat::Control).await
+        self.recursive_attach_plan_for_remote(&binding.host, reference, AttachMode::Default).await
     }
 
     async fn local_attach_plan_for_session(
         &self,
         session: &flotilla_resources::ResourceObject<ResourceTerminalSession>,
         environment: &flotilla_resources::ResourceObject<ResourceEnvironment>,
-        seat: AttachSeat,
+        seat: AttachMode,
     ) -> Result<ResolvedAttachPlan, String> {
         let cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
         let registry = self.registry_for_resource_environment(environment, cwd.as_path()).await?;
@@ -7000,7 +7002,8 @@ impl InProcessDaemon {
             .map(|(_, pool)| Arc::clone(pool))
             .ok_or_else(|| format!("terminal pool {} unavailable for environment {}", session.spec.pool, session.spec.env_ref))?;
         let attach_target = terminal_session_attach_target(session)?;
-        let attach_args = pool.attach_args_for_seat(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new(), seat)?;
+        pool.preflight_attach(seat).await?;
+        let attach_args = pool.attach_args_for_mode(attach_target.session_id, attach_target.launch_command, &cwd, &Vec::new(), seat)?;
         if environment.spec.docker.is_some() {
             let environment_id = EnvironmentId::new(session.spec.env_ref.clone());
             let container_name = environment.status.as_ref().and_then(|status| status.docker_container_id.as_deref());
@@ -8390,35 +8393,21 @@ impl DaemonHandle for InProcessDaemon {
                     Err(error) => Ok(flotilla_protocol::CommandValue::Error { message: error.to_string() }),
                 }
             }
-            CommandAction::Attach { reference, host, watch } => match self
-                .resolve_attach_for_seat_internal(
-                    reference,
-                    host.as_ref(),
-                    false,
-                    if *watch { AttachSeat::Watch } else { AttachSeat::Control },
-                )
-                .await
-            {
-                Ok(resolved) => {
-                    if let Some(binding) = &resolved.binding {
-                        if let Err(error) = self.emit_attach_regard(binding, session_id).await {
-                            warn!(%error, "failed to emit attach regard");
+            CommandAction::Attach { reference, host, mode } => {
+                match self.resolve_attach_with_mode_internal(reference, host.as_ref(), false, *mode).await {
+                    Ok(resolved) => {
+                        if let Some(binding) = &resolved.binding {
+                            if let Err(error) = self.emit_attach_regard(binding, session_id).await {
+                                warn!(%error, "failed to emit attach regard");
+                            }
                         }
+                        Ok(flotilla_protocol::CommandValue::AttachCommandResolved { plan: resolved.plan, binding: resolved.binding })
                     }
-                    Ok(flotilla_protocol::CommandValue::AttachCommandResolved { plan: resolved.plan, binding: resolved.binding })
+                    Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
                 }
-                Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
-            },
-            CommandAction::AttachTransient { reference, host, watch } => {
-                match self
-                    .resolve_attach_for_seat_internal(
-                        reference,
-                        host.as_ref(),
-                        true,
-                        if *watch { AttachSeat::Watch } else { AttachSeat::Control },
-                    )
-                    .await
-                {
+            }
+            CommandAction::AttachTransient { reference, host, mode } => {
+                match self.resolve_attach_with_mode_internal(reference, host.as_ref(), true, *mode).await {
                     Ok(resolved) => {
                         Ok(flotilla_protocol::CommandValue::AttachCommandResolved { plan: resolved.plan, binding: resolved.binding })
                     }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6897,8 +6897,8 @@ impl InProcessDaemon {
             .ok_or_else(|| format!("no terminal pool available for checkout {}", checkout.path))?;
         let session_name = transient_checkout_session_name(checkout);
         let command = "${SHELL:-/bin/sh}";
-        pool.ensure_session(&session_name, command, &cwd, &Vec::new(), &[]).await?;
         pool.preflight_attach(seat).await?;
+        pool.ensure_session(&session_name, command, &cwd, &Vec::new(), &[]).await?;
         let args = pool.attach_args_for_mode(&session_name, command, &cwd, &Vec::new(), seat)?;
         Ok(ResolvedAttachPlan(vec![ResolvedAttachAction::Command(args)]))
     }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2605,7 +2605,7 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2632,7 +2632,7 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
 }
 
 #[tokio::test]
-async fn watch_attach_query_resolves_a_read_only_terminal_seat() {
+async fn strict_attach_query_passes_through_controller_seat_policy() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -2657,17 +2657,17 @@ async fn watch_attach_query_resolves_a_read_only_terminal_seat() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: true },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Strict },
             },
             uuid::Uuid::new_v4(),
         )
         .await
-        .expect("watch attach query should execute");
+        .expect("strict attach query should execute");
 
     let CommandValue::AttachCommandResolved { plan, .. } = result else {
         panic!("expected attach command, got {result:?}");
     };
-    assert_eq!(single_attach_command(&plan), "attach --watch cleat-session-1");
+    assert_eq!(single_attach_command(&plan), "attach --strict cleat-session-1");
 }
 
 #[tokio::test]
@@ -2725,7 +2725,7 @@ async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command(
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2766,7 +2766,7 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3009,7 +3009,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3038,7 +3038,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "coder".to_string(), host: None, watch: true },
+                action: CommandAction::Attach { reference: "coder".to_string(), host: None, mode: AttachMode::Strict },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3051,7 +3051,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
     let command = attach_plan_text(&plan);
     assert!(command.contains(&format!("ssh -t 'alice@{remote_hostname}'")), "bare role should resolve through the replica host: {command}");
     assert!(command.contains("flotilla attach"), "bare role should recursively invoke flotilla attach: {command}");
-    assert!(command.contains("--watch"), "watcher mode should survive the recursive hop: {command}");
+    assert!(command.contains("--strict"), "strict mode should survive the recursive hop: {command}");
     assert!(command.contains("coder"), "command should preserve the original bare role reference: {command}");
 
     let result = daemon
@@ -3060,7 +3060,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "terminal-remote-coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "terminal-remote-coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3134,7 +3134,7 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
                 action: CommandAction::AttachTransient {
                     reference: "terminal-scratch".to_string(),
                     host: Some(HostName::new(selected_host)),
-                    watch: false,
+                    mode: AttachMode::Default,
                 },
             },
             uuid::Uuid::new_v4(),
@@ -3191,7 +3191,7 @@ async fn transient_attach_resolves_standing_checkout_paths_locally_and_determini
                     action: CommandAction::AttachTransient {
                         reference: checkout_path.display().to_string(),
                         host: Some(HostName::new(TEST_LOCAL_ATTACH_HOST)),
-                        watch: false,
+                        mode: AttachMode::Default,
                     },
                 },
                 uuid::Uuid::new_v4(),
@@ -3245,7 +3245,7 @@ async fn transient_attach_routes_standing_checkout_paths_to_the_displayed_remote
                 action: CommandAction::AttachTransient {
                     reference: "/work/standing".to_owned(),
                     host: Some(HostName::new(remote_host)),
-                    watch: false,
+                    mode: AttachMode::Default,
                 },
             },
             uuid::Uuid::new_v4(),
@@ -3295,7 +3295,7 @@ async fn attach_query_ignores_fleet_replica_hosts_that_are_not_configured() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "removed-env".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "removed-env".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3352,7 +3352,7 @@ async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3406,7 +3406,7 @@ async fn attach_query_prefers_exact_reference_over_prefix_matches() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3482,7 +3482,7 @@ async fn attach_query_rejects_ambiguous_prefix() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3515,7 +3515,7 @@ async fn attach_query_reports_no_matching_reference() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "missing".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "missing".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3543,7 +3543,7 @@ async fn attach_query_reports_unreachable_next_hop_for_remote_session_without_ho
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3591,7 +3591,7 @@ async fn attach_query_reports_route_that_points_back_to_local_host() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3625,7 +3625,7 @@ async fn attach_query_reports_ambiguous_routed_host_name() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3649,7 +3649,7 @@ async fn attach_query_rejects_empty_reference() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3686,7 +3686,7 @@ async fn attach_query_errors_when_recorded_terminal_pool_is_unavailable() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, mode: AttachMode::Default },
             },
             uuid::Uuid::new_v4(),
         )

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -3212,6 +3212,51 @@ async fn transient_attach_resolves_standing_checkout_paths_locally_and_determini
 }
 
 #[tokio::test]
+async fn transient_checkout_attach_preflights_before_creating_a_session() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let checkout_path = temp.path().join("standing-checkout");
+    std::fs::create_dir_all(&checkout_path).expect("create checkout");
+    let (daemon, terminal_pool) = new_attach_test_daemon_with_pool(&config_base).await;
+    terminal_pool.set_attach_preflight_error("stale pool cleat").await;
+    let row = CheckoutRow::builder()
+        .resource(ResourceRef::new("flotilla.work/v1", "Checkout", "dev", "standing").on_host(HostName::new(TEST_LOCAL_ATTACH_HOST)))
+        .repo(RepositoryKey("repo-standing".to_owned()))
+        .repo_label("standing")
+        .path(checkout_path.display().to_string())
+        .branch("main")
+        .host(HostName::new(TEST_LOCAL_ATTACH_HOST))
+        .authority(LifecycleAuthority::Observed)
+        .build();
+    daemon.aggregator_projection_state().await.replace_local_checkout_rows(vec![row]).await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::AttachTransient {
+                    reference: checkout_path.display().to_string(),
+                    host: Some(HostName::new(TEST_LOCAL_ATTACH_HOST)),
+                    mode: AttachMode::Default,
+                },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("attach query should return its preflight error");
+
+    let CommandValue::Error { message } = result else {
+        panic!("expected preflight error, got {result:?}");
+    };
+    assert!(message.contains("stale pool cleat"), "{message}");
+    assert!(terminal_pool.ensured.lock().await.is_empty(), "preflight failure must not create a terminal session");
+}
+
+#[tokio::test]
 async fn transient_attach_routes_standing_checkout_paths_to_the_displayed_remote_host() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -2605,7 +2605,7 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2629,6 +2629,45 @@ async fn attach_query_resolves_running_terminal_session_by_convoy_task_role() {
         regards.items[0].spec.target,
         ResourceRef::new("flotilla.work/v1", "Convoy", "flotilla", "convoy-a").subresource("vessels/implement")
     );
+}
+
+#[tokio::test]
+async fn watch_attach_query_resolves_a_read_only_terminal_seat() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let env_ref = create_local_attach_environment(&daemon).await;
+    create_running_attach_session(
+        &daemon,
+        &env_ref,
+        "terminal-convoy-a-implement-coder",
+        "cleat-session-1",
+        "convoy-a",
+        "implement",
+        "coder",
+    )
+    .await;
+
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: true },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("watch attach query should execute");
+
+    let CommandValue::AttachCommandResolved { plan, .. } = result else {
+        panic!("expected attach command, got {result:?}");
+    };
+    assert_eq!(single_attach_command(&plan), "attach --watch cleat-session-1");
 }
 
 #[tokio::test]
@@ -2686,7 +2725,7 @@ async fn attach_query_rejects_a_running_agent_without_a_recorded_launch_command(
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2727,7 +2766,7 @@ async fn attach_query_resolves_remote_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2970,7 +3009,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -2999,7 +3038,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "coder".to_string(), host: None, watch: true },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3012,6 +3051,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
     let command = attach_plan_text(&plan);
     assert!(command.contains(&format!("ssh -t 'alice@{remote_hostname}'")), "bare role should resolve through the replica host: {command}");
     assert!(command.contains("flotilla attach"), "bare role should recursively invoke flotilla attach: {command}");
+    assert!(command.contains("--watch"), "watcher mode should survive the recursive hop: {command}");
     assert!(command.contains("coder"), "command should preserve the original bare role reference: {command}");
 
     let result = daemon
@@ -3020,7 +3060,7 @@ async fn attach_query_resolves_fleet_replica_session_as_one_recursive_hop() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "terminal-remote-coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "terminal-remote-coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3094,6 +3134,7 @@ async fn transient_attach_selects_the_displayed_host_for_result_set_only_indepen
                 action: CommandAction::AttachTransient {
                     reference: "terminal-scratch".to_string(),
                     host: Some(HostName::new(selected_host)),
+                    watch: false,
                 },
             },
             uuid::Uuid::new_v4(),
@@ -3150,6 +3191,7 @@ async fn transient_attach_resolves_standing_checkout_paths_locally_and_determini
                     action: CommandAction::AttachTransient {
                         reference: checkout_path.display().to_string(),
                         host: Some(HostName::new(TEST_LOCAL_ATTACH_HOST)),
+                        watch: false,
                     },
                 },
                 uuid::Uuid::new_v4(),
@@ -3200,7 +3242,11 @@ async fn transient_attach_routes_standing_checkout_paths_to_the_displayed_remote
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::AttachTransient { reference: "/work/standing".to_owned(), host: Some(HostName::new(remote_host)) },
+                action: CommandAction::AttachTransient {
+                    reference: "/work/standing".to_owned(),
+                    host: Some(HostName::new(remote_host)),
+                    watch: false,
+                },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3249,7 +3295,7 @@ async fn attach_query_ignores_fleet_replica_hosts_that_are_not_configured() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "removed-env".to_string(), host: None },
+                action: CommandAction::Attach { reference: "removed-env".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3306,7 +3352,7 @@ async fn attach_query_uses_topology_next_hop_for_multi_hop_route_shape() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3360,7 +3406,7 @@ async fn attach_query_prefers_exact_reference_over_prefix_matches() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3436,7 +3482,7 @@ async fn attach_query_rejects_ambiguous_prefix() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3469,7 +3515,7 @@ async fn attach_query_reports_no_matching_reference() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "missing".to_string(), host: None },
+                action: CommandAction::Attach { reference: "missing".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3497,7 +3543,7 @@ async fn attach_query_reports_unreachable_next_hop_for_remote_session_without_ho
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3545,7 +3591,7 @@ async fn attach_query_reports_route_that_points_back_to_local_host() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3579,7 +3625,7 @@ async fn attach_query_reports_ambiguous_routed_host_name() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3603,7 +3649,7 @@ async fn attach_query_rejects_empty_reference() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "".to_string(), host: None },
+                action: CommandAction::Attach { reference: "".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )
@@ -3640,7 +3686,7 @@ async fn attach_query_errors_when_recorded_terminal_pool_is_unavailable() {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a/implement/coder".to_string(), host: None, watch: false },
             },
             uuid::Uuid::new_v4(),
         )

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -896,6 +896,18 @@ impl TerminalPool for FakeTerminalPool {
         Ok(vec![flotilla_protocol::arg::Arg::Literal(format!("attach {session_name}"))])
     }
 
+    fn attach_args_for_seat(
+        &self,
+        session_name: &str,
+        _command: &str,
+        _cwd: &ExecutionEnvironmentPath,
+        _env_vars: &super::super::terminal::TerminalEnvVars,
+        seat: super::super::terminal::AttachSeat,
+    ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
+        let watch = if seat == super::super::terminal::AttachSeat::Watch { " --watch" } else { "" };
+        Ok(vec![flotilla_protocol::arg::Arg::Literal(format!("attach{watch} {session_name}"))])
+    }
+
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {
         self.killed.lock().await.push(session_name.to_string());
         self.sessions.lock().await.retain(|session| session.session_name != session_name);

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -809,6 +809,7 @@ pub struct FakeTerminalPool {
     pub delivered: Arc<TokioMutex<Vec<(String, String, bool)>>>,
     pub ensured: Arc<TokioMutex<Vec<EnsuredTerminalSession>>>,
     pub captured_screens: Arc<TokioMutex<HashMap<String, String>>>,
+    attach_preflight_error: Arc<TokioMutex<Option<String>>>,
 }
 
 pub struct EnsuredTerminalSession {
@@ -832,6 +833,7 @@ impl FakeTerminalPool {
             delivered: Arc::new(TokioMutex::new(Vec::new())),
             ensured: Arc::new(TokioMutex::new(Vec::new())),
             captured_screens: Arc::new(TokioMutex::new(HashMap::new())),
+            attach_preflight_error: Arc::new(TokioMutex::new(None)),
         }
     }
 
@@ -845,6 +847,10 @@ impl FakeTerminalPool {
 
     pub async fn set_captured_screen(&self, session_name: &str, screen: &str) {
         self.captured_screens.lock().await.insert(session_name.to_string(), screen.to_string());
+    }
+
+    pub async fn set_attach_preflight_error(&self, error: impl Into<String>) {
+        *self.attach_preflight_error.lock().await = Some(error.into());
     }
 }
 
@@ -897,7 +903,10 @@ impl TerminalPool for FakeTerminalPool {
     }
 
     async fn preflight_attach(&self, _mode: flotilla_protocol::commands::AttachMode) -> Result<(), String> {
-        Ok(())
+        match self.attach_preflight_error.lock().await.clone() {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 
     fn attach_args_for_mode(

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -896,16 +896,24 @@ impl TerminalPool for FakeTerminalPool {
         Ok(vec![flotilla_protocol::arg::Arg::Literal(format!("attach {session_name}"))])
     }
 
-    fn attach_args_for_seat(
+    async fn preflight_attach(&self, _mode: flotilla_protocol::commands::AttachMode) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn attach_args_for_mode(
         &self,
         session_name: &str,
         _command: &str,
         _cwd: &ExecutionEnvironmentPath,
         _env_vars: &super::super::terminal::TerminalEnvVars,
-        seat: super::super::terminal::AttachSeat,
+        mode: flotilla_protocol::commands::AttachMode,
     ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
-        let watch = if seat == super::super::terminal::AttachSeat::Watch { " --watch" } else { "" };
-        Ok(vec![flotilla_protocol::arg::Arg::Literal(format!("attach{watch} {session_name}"))])
+        let flag = match mode {
+            flotilla_protocol::commands::AttachMode::Default => "",
+            flotilla_protocol::commands::AttachMode::Strict => " --strict",
+            flotilla_protocol::commands::AttachMode::Take => " --take",
+        };
+        Ok(vec![flotilla_protocol::arg::Arg::Literal(format!("attach{flag} {session_name}"))])
     }
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {

--- a/crates/flotilla-core/src/providers/scan_cache.rs
+++ b/crates/flotilla-core/src/providers/scan_cache.rs
@@ -5,13 +5,14 @@ use std::{
 };
 
 use async_trait::async_trait;
+use flotilla_protocol::commands::AttachMode;
 use tokio::{sync::Mutex as AsyncMutex, time::Instant};
 
 use crate::{
     path_context::ExecutionEnvironmentPath,
     providers::{
         presentation::PresentationManager,
-        terminal::{AttachSeat, ManagedSessionMetadata, TerminalEnvVars, TerminalPool, TerminalSession},
+        terminal::{ManagedSessionMetadata, TerminalEnvVars, TerminalPool, TerminalSession},
         types::{Workspace, WorkspaceAttachRequest},
     },
 };
@@ -174,15 +175,19 @@ impl TerminalPool for SharedTerminalPool {
         self.inner.attach_args(session_name, command, cwd, env_vars)
     }
 
-    fn attach_args_for_seat(
+    async fn preflight_attach(&self, mode: AttachMode) -> Result<(), String> {
+        self.inner.preflight_attach(mode).await
+    }
+
+    fn attach_args_for_mode(
         &self,
         session_name: &str,
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
-        seat: AttachSeat,
+        mode: AttachMode,
     ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
-        self.inner.attach_args_for_seat(session_name, command, cwd, env_vars, seat)
+        self.inner.attach_args_for_mode(session_name, command, cwd, env_vars, mode)
     }
 
     async fn attach_command(

--- a/crates/flotilla-core/src/providers/scan_cache.rs
+++ b/crates/flotilla-core/src/providers/scan_cache.rs
@@ -11,7 +11,7 @@ use crate::{
     path_context::ExecutionEnvironmentPath,
     providers::{
         presentation::PresentationManager,
-        terminal::{ManagedSessionMetadata, TerminalEnvVars, TerminalPool, TerminalSession},
+        terminal::{AttachSeat, ManagedSessionMetadata, TerminalEnvVars, TerminalPool, TerminalSession},
         types::{Workspace, WorkspaceAttachRequest},
     },
 };
@@ -172,6 +172,17 @@ impl TerminalPool for SharedTerminalPool {
         env_vars: &TerminalEnvVars,
     ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
         self.inner.attach_args(session_name, command, cwd, env_vars)
+    }
+
+    fn attach_args_for_seat(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+        seat: AttachSeat,
+    ) -> Result<Vec<flotilla_protocol::arg::Arg>, String> {
+        self.inner.attach_args_for_seat(session_name, command, cwd, env_vars, seat)
     }
 
     async fn attach_command(

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -37,7 +37,7 @@ pub struct CleatTerminalPool {
     runner: Arc<dyn CommandRunner>,
     binary: String,
     terminal_env_defaults: TerminalEnvVars,
-    attach_capability: tokio::sync::OnceCell<Result<(), String>>,
+    attach_capability: tokio::sync::OnceCell<()>,
 }
 
 impl CleatTerminalPool {
@@ -147,7 +147,7 @@ impl TerminalPool for CleatTerminalPool {
         // degrade-to-watch behavior, and watcher banner. Check before starting
         // the interactive attach so a stale selected pool fails on the primary screen.
         self.attach_capability
-            .get_or_init(|| async {
+            .get_or_try_init(|| async {
                 let help = run!(self.runner, &self.binary, &["attach", "--help"], Path::new("/"));
                 if help.as_ref().is_ok_and(|help| help.contains("--strict") && help.contains("--take")) {
                     return Ok(());
@@ -161,7 +161,7 @@ impl TerminalPool for CleatTerminalPool {
                 ))
             })
             .await
-            .clone()
+            .copied()
     }
 
     fn attach_args_for_mode(
@@ -417,6 +417,21 @@ mod tests {
         assert!(error.contains("/pool/bin/cleat"), "{error}");
         assert!(error.contains("cleat 0.5.0"), "{error}");
         assert!(error.contains("--strict/--take"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn attach_preflight_retries_after_a_stale_binary_is_upgraded() {
+        let runner = Arc::new(MockRunner::new(vec![
+            Ok("Options:\n  --no-create\n".into()),
+            Ok("cleat 0.5.0".into()),
+            Ok("Options:\n  --strict\n  --take\n".into()),
+        ]));
+        let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "/pool/bin/cleat");
+
+        pool.preflight_attach(AttachMode::Default).await.expect_err("stale cleat should fail preflight");
+        pool.preflight_attach(AttachMode::Default).await.expect("upgraded cleat should pass without restarting the daemon");
+
+        assert_eq!(runner.calls().len(), 3, "failed capability probes must not be cached");
     }
 
     #[test]

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use flotilla_protocol::arg::Arg;
 use serde::Deserialize;
 
-use super::{ScreenActivity, TerminalEnvVars, TerminalPool, TerminalSession, TerminalSessionTag};
+use super::{AttachSeat, ScreenActivity, TerminalEnvVars, TerminalPool, TerminalSession, TerminalSessionTag};
 use crate::{
     path_context::ExecutionEnvironmentPath,
     providers::{run, CommandRunner},
@@ -133,6 +133,21 @@ impl TerminalPool for CleatTerminalPool {
             // Session names are UUIDs (attachable IDs) — always shell-safe, no quoting needed.
             Arg::Literal(session_name.into()),
         ])
+    }
+
+    fn attach_args_for_seat(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+        seat: AttachSeat,
+    ) -> Result<Vec<Arg>, String> {
+        let mut args = self.attach_args(session_name, command, cwd, env_vars)?;
+        if seat == AttachSeat::Watch {
+            args.insert(3, Arg::Literal("--watch".into()));
+        }
+        Ok(args)
     }
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {
@@ -340,6 +355,16 @@ mod tests {
         let flat = flotilla_protocol::arg::flatten(&args, 0);
 
         assert_eq!(flat, "cleat attach --no-create my-session");
+    }
+
+    #[test]
+    fn watch_attach_args_request_a_read_only_seat() {
+        let pool = CleatTerminalPool::new(Arc::new(MockRunner::new(vec![])), "cleat");
+        let args = pool
+            .attach_args_for_seat("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![], AttachSeat::Watch)
+            .expect("watch attach args");
+
+        assert_eq!(flotilla_protocol::arg::flatten(&args, 0), "cleat attach --no-create --watch my-session");
     }
 
     #[test]

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -37,11 +37,12 @@ pub struct CleatTerminalPool {
     runner: Arc<dyn CommandRunner>,
     binary: String,
     terminal_env_defaults: TerminalEnvVars,
+    attach_capability: tokio::sync::OnceCell<Result<(), String>>,
 }
 
 impl CleatTerminalPool {
     pub fn new(runner: Arc<dyn CommandRunner>, binary: impl Into<String>) -> Self {
-        Self { runner, binary: binary.into(), terminal_env_defaults: vec![] }
+        Self { runner, binary: binary.into(), terminal_env_defaults: vec![], attach_capability: tokio::sync::OnceCell::new() }
     }
 
     pub fn with_terminal_env_defaults(mut self, defaults: TerminalEnvVars) -> Self {
@@ -51,6 +52,18 @@ impl CleatTerminalPool {
 
     fn parse_list_output(json: &str) -> Result<Vec<SessionInfo>, String> {
         serde_json::from_str(json).map_err(|err| format!("parse session list: {err}"))
+    }
+
+    fn build_attach_args(&self, session_name: &str, mode: AttachMode) -> Vec<Arg> {
+        let mut args = vec![Arg::Literal(self.binary.clone()), Arg::Literal("attach".into()), Arg::Literal("--no-create".into())];
+        match mode {
+            AttachMode::Default => {}
+            AttachMode::Strict => args.push(Arg::Literal("--strict".into())),
+            AttachMode::Take => args.push(Arg::Literal("--take".into())),
+        }
+        // Session names are UUIDs (attachable IDs) — always shell-safe, no quoting needed.
+        args.push(Arg::Literal(session_name.into()));
+        args
     }
 }
 
@@ -126,50 +139,40 @@ impl TerminalPool for CleatTerminalPool {
         _cwd: &ExecutionEnvironmentPath,
         _env_vars: &TerminalEnvVars,
     ) -> Result<Vec<Arg>, String> {
-        Ok(vec![
-            Arg::Literal(self.binary.clone()),
-            Arg::Literal("attach".into()),
-            Arg::Literal("--no-create".into()),
-            // Session names are UUIDs (attachable IDs) — always shell-safe, no quoting needed.
-            Arg::Literal(session_name.into()),
-        ])
+        Ok(self.build_attach_args(session_name, AttachMode::Default))
     }
 
     async fn preflight_attach(&self, _mode: AttachMode) -> Result<(), String> {
         // These flags arrived with cleat's controller-seat handshake, default
         // degrade-to-watch behavior, and watcher banner. Check before starting
         // the interactive attach so a stale selected pool fails on the primary screen.
-        let help = run!(self.runner, &self.binary, &["attach", "--help"], Path::new("/"));
-        if help.as_ref().is_ok_and(|help| help.contains("--strict") && help.contains("--take")) {
-            return Ok(());
-        }
-        let version =
-            run!(self.runner, &self.binary, &["--version"], Path::new("/")).unwrap_or_else(|error| format!("version unavailable: {error}"));
-        Err(format!(
-            "cleat terminal pool binary '{}' lacks controller-seat attach support (--strict/--take); detected {}",
-            self.binary,
-            version.trim()
-        ))
+        self.attach_capability
+            .get_or_init(|| async {
+                let help = run!(self.runner, &self.binary, &["attach", "--help"], Path::new("/"));
+                if help.as_ref().is_ok_and(|help| help.contains("--strict") && help.contains("--take")) {
+                    return Ok(());
+                }
+                let version = run!(self.runner, &self.binary, &["--version"], Path::new("/"))
+                    .unwrap_or_else(|error| format!("version unavailable: {error}"));
+                Err(format!(
+                    "cleat terminal pool binary '{}' lacks controller-seat attach support (--strict/--take); detected {}",
+                    self.binary,
+                    version.trim()
+                ))
+            })
+            .await
+            .clone()
     }
 
     fn attach_args_for_mode(
         &self,
         session_name: &str,
-        command: &str,
-        cwd: &ExecutionEnvironmentPath,
-        env_vars: &TerminalEnvVars,
+        _command: &str,
+        _cwd: &ExecutionEnvironmentPath,
+        _env_vars: &TerminalEnvVars,
         mode: AttachMode,
     ) -> Result<Vec<Arg>, String> {
-        let mut args = self.attach_args(session_name, command, cwd, env_vars)?;
-        let flag = match mode {
-            AttachMode::Default => None,
-            AttachMode::Strict => Some("--strict"),
-            AttachMode::Take => Some("--take"),
-        };
-        if let Some(flag) = flag {
-            args.insert(3, Arg::Literal(flag.into()));
-        }
-        Ok(args)
+        Ok(self.build_attach_args(session_name, mode))
     }
 
     async fn kill_session(&self, session_name: &str) -> Result<(), String> {
@@ -399,6 +402,7 @@ mod tests {
         let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "/pool/bin/cleat");
 
         pool.preflight_attach(AttachMode::Default).await.expect("modern cleat should pass preflight");
+        pool.preflight_attach(AttachMode::Take).await.expect("capability result should be cached");
 
         assert_eq!(runner.calls(), [("/pool/bin/cleat".to_string(), vec!["attach".to_string(), "--help".to_string()])]);
     }

--- a/crates/flotilla-core/src/providers/terminal/cleat.rs
+++ b/crates/flotilla-core/src/providers/terminal/cleat.rs
@@ -1,10 +1,10 @@
 use std::{path::Path, sync::Arc};
 
 use async_trait::async_trait;
-use flotilla_protocol::arg::Arg;
+use flotilla_protocol::{arg::Arg, commands::AttachMode};
 use serde::Deserialize;
 
-use super::{AttachSeat, ScreenActivity, TerminalEnvVars, TerminalPool, TerminalSession, TerminalSessionTag};
+use super::{ScreenActivity, TerminalEnvVars, TerminalPool, TerminalSession, TerminalSessionTag};
 use crate::{
     path_context::ExecutionEnvironmentPath,
     providers::{run, CommandRunner},
@@ -135,17 +135,39 @@ impl TerminalPool for CleatTerminalPool {
         ])
     }
 
-    fn attach_args_for_seat(
+    async fn preflight_attach(&self, _mode: AttachMode) -> Result<(), String> {
+        // These flags arrived with cleat's controller-seat handshake, default
+        // degrade-to-watch behavior, and watcher banner. Check before starting
+        // the interactive attach so a stale selected pool fails on the primary screen.
+        let help = run!(self.runner, &self.binary, &["attach", "--help"], Path::new("/"));
+        if help.as_ref().is_ok_and(|help| help.contains("--strict") && help.contains("--take")) {
+            return Ok(());
+        }
+        let version =
+            run!(self.runner, &self.binary, &["--version"], Path::new("/")).unwrap_or_else(|error| format!("version unavailable: {error}"));
+        Err(format!(
+            "cleat terminal pool binary '{}' lacks controller-seat attach support (--strict/--take); detected {}",
+            self.binary,
+            version.trim()
+        ))
+    }
+
+    fn attach_args_for_mode(
         &self,
         session_name: &str,
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
-        seat: AttachSeat,
+        mode: AttachMode,
     ) -> Result<Vec<Arg>, String> {
         let mut args = self.attach_args(session_name, command, cwd, env_vars)?;
-        if seat == AttachSeat::Watch {
-            args.insert(3, Arg::Literal("--watch".into()));
+        let flag = match mode {
+            AttachMode::Default => None,
+            AttachMode::Strict => Some("--strict"),
+            AttachMode::Take => Some("--take"),
+        };
+        if let Some(flag) = flag {
+            args.insert(3, Arg::Literal(flag.into()));
         }
         Ok(args)
     }
@@ -358,13 +380,39 @@ mod tests {
     }
 
     #[test]
-    fn watch_attach_args_request_a_read_only_seat() {
+    fn attach_args_pass_through_controller_seat_flags() {
         let pool = CleatTerminalPool::new(Arc::new(MockRunner::new(vec![])), "cleat");
-        let args = pool
-            .attach_args_for_seat("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![], AttachSeat::Watch)
-            .expect("watch attach args");
+        let strict = pool
+            .attach_args_for_mode("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![], AttachMode::Strict)
+            .expect("strict attach args");
+        let take = pool
+            .attach_args_for_mode("my-session", "bash", &ExecutionEnvironmentPath::new("/repo"), &vec![], AttachMode::Take)
+            .expect("take attach args");
 
-        assert_eq!(flotilla_protocol::arg::flatten(&args, 0), "cleat attach --no-create --watch my-session");
+        assert_eq!(flotilla_protocol::arg::flatten(&strict, 0), "cleat attach --no-create --strict my-session");
+        assert_eq!(flotilla_protocol::arg::flatten(&take, 0), "cleat attach --no-create --take my-session");
+    }
+
+    #[tokio::test]
+    async fn attach_preflight_accepts_controller_seat_capabilities() {
+        let runner = Arc::new(MockRunner::new(vec![Ok("Options:\n  --strict\n  --take\n".into())]));
+        let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "/pool/bin/cleat");
+
+        pool.preflight_attach(AttachMode::Default).await.expect("modern cleat should pass preflight");
+
+        assert_eq!(runner.calls(), [("/pool/bin/cleat".to_string(), vec!["attach".to_string(), "--help".to_string()])]);
+    }
+
+    #[tokio::test]
+    async fn attach_preflight_names_a_stale_pool_binary_and_version() {
+        let runner = Arc::new(MockRunner::new(vec![Ok("Options:\n  --no-create\n".into()), Ok("cleat 0.5.0".into())]));
+        let pool = CleatTerminalPool::new(Arc::clone(&runner) as Arc<dyn CommandRunner>, "/pool/bin/cleat");
+
+        let error = pool.preflight_attach(AttachMode::Default).await.expect_err("stale cleat should fail preflight");
+
+        assert!(error.contains("/pool/bin/cleat"), "{error}");
+        assert!(error.contains("cleat 0.5.0"), "{error}");
+        assert!(error.contains("--strict/--take"), "{error}");
     }
 
     #[test]

--- a/crates/flotilla-core/src/providers/terminal/mod.rs
+++ b/crates/flotilla-core/src/providers/terminal/mod.rs
@@ -28,6 +28,12 @@ pub enum ScreenActivity {
     Stable,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachSeat {
+    Control,
+    Watch,
+}
+
 pub(crate) const MANAGED_SESSION_PREFIX: &str = "flotilla-v2:";
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
@@ -109,6 +115,22 @@ pub trait TerminalPool: Send + Sync {
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
     ) -> Result<Vec<Arg>, String>;
+
+    /// Returns attach arguments for the requested seat. Pools without watcher
+    /// support reject read-only attaches explicitly.
+    fn attach_args_for_seat(
+        &self,
+        session_name: &str,
+        command: &str,
+        cwd: &ExecutionEnvironmentPath,
+        env_vars: &TerminalEnvVars,
+        seat: AttachSeat,
+    ) -> Result<Vec<Arg>, String> {
+        match seat {
+            AttachSeat::Control => self.attach_args(session_name, command, cwd, env_vars),
+            AttachSeat::Watch => Err("terminal pool does not support read-only watcher attachments".to_string()),
+        }
+    }
 
     /// Returns the attach command as a flat shell string.
     /// Default implementation calls `attach_args()` + `flatten()`.

--- a/crates/flotilla-core/src/providers/terminal/mod.rs
+++ b/crates/flotilla-core/src/providers/terminal/mod.rs
@@ -3,7 +3,7 @@ pub mod passthrough;
 pub mod shpool;
 
 use async_trait::async_trait;
-use flotilla_protocol::{arg::Arg, AttachableId, AttachableSetId, TerminalStatus};
+use flotilla_protocol::{arg::Arg, commands::AttachMode, AttachableId, AttachableSetId, TerminalStatus};
 pub use flotilla_resources::TerminalSessionTag;
 
 use crate::path_context::ExecutionEnvironmentPath;
@@ -26,12 +26,6 @@ pub struct TerminalSession {
 pub enum ScreenActivity {
     Active,
     Stable,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AttachSeat {
-    Control,
-    Watch,
 }
 
 pub(crate) const MANAGED_SESSION_PREFIX: &str = "flotilla-v2:";
@@ -116,19 +110,26 @@ pub trait TerminalPool: Send + Sync {
         env_vars: &TerminalEnvVars,
     ) -> Result<Vec<Arg>, String>;
 
-    /// Returns attach arguments for the requested seat. Pools without watcher
-    /// support reject read-only attaches explicitly.
-    fn attach_args_for_seat(
+    /// Verify that the resolved pool supports the requested seat semantics.
+    async fn preflight_attach(&self, mode: AttachMode) -> Result<(), String> {
+        match mode {
+            AttachMode::Default => Ok(()),
+            AttachMode::Strict | AttachMode::Take => Err("terminal pool does not support controller-seat attach options".to_string()),
+        }
+    }
+
+    /// Returns attach arguments for the requested controller-seat behavior.
+    fn attach_args_for_mode(
         &self,
         session_name: &str,
         command: &str,
         cwd: &ExecutionEnvironmentPath,
         env_vars: &TerminalEnvVars,
-        seat: AttachSeat,
+        mode: AttachMode,
     ) -> Result<Vec<Arg>, String> {
-        match seat {
-            AttachSeat::Control => self.attach_args(session_name, command, cwd, env_vars),
-            AttachSeat::Watch => Err("terminal pool does not support read-only watcher attachments".to_string()),
+        match mode {
+            AttachMode::Default => self.attach_args(session_name, command, cwd, env_vars),
+            AttachMode::Strict | AttachMode::Take => Err("terminal pool does not support controller-seat attach options".to_string()),
         }
     }
 

--- a/crates/flotilla-core/src/terminal_manager.rs
+++ b/crates/flotilla-core/src/terminal_manager.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use flotilla_protocol::{arg, qualified_path::QualifiedPath, AttachableId, AttachableSet, AttachableSetId, HostName, TerminalStatus};
+use flotilla_protocol::{
+    arg, commands::AttachMode, qualified_path::QualifiedPath, AttachableId, AttachableSet, AttachableSetId, HostName, TerminalStatus,
+};
 use tracing::warn;
 
 use crate::{
@@ -168,6 +170,7 @@ impl TerminalManager {
     /// resolves it for interactive attach and flattens the sole local command to a string.
     /// For local attach (same-host), the plan is just `[AttachTerminal(id)]` with no remote hop.
     pub async fn attach_command(&self, attachable_id: &AttachableId, daemon_socket_path: Option<&str>) -> Result<String, String> {
+        self.pool.preflight_attach(AttachMode::Default).await?;
         let plan = {
             let store = self.store.lock().map_err(|e| format!("failed to lock store: {e}"))?;
             let builder = HopPlanBuilder::new(&self.local_host);

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -243,6 +243,18 @@ pub enum ConvoyAutoAttach {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum AttachMode {
+    /// Request control, degrading to a read-only watcher when control is held.
+    #[default]
+    Default,
+    /// Refuse when another attachment holds control.
+    Strict,
+    /// Take control and demote the current controller to watcher.
+    Take,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ConvoyDispatchRegard {
     #[default]
     Emit,
@@ -339,9 +351,8 @@ pub enum CommandAction {
         /// Restrict resolution to the host that advertised the recipe.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         host: Option<crate::HostName>,
-        /// Request a read-only watcher seat instead of foreground control.
-        #[serde(default, skip_serializing_if = "is_false")]
-        watch: bool,
+        #[serde(default)]
+        mode: AttachMode,
     },
     /// Resolve an attach for a temporary foreground excursion. Unlike the
     /// human-facing CLI attach, recursive hops must not stamp PM metadata.
@@ -349,9 +360,8 @@ pub enum CommandAction {
         reference: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         host: Option<crate::HostName>,
-        /// Preserve watcher mode while traversing a transport boundary.
-        #[serde(default, skip_serializing_if = "is_false")]
-        watch: bool,
+        #[serde(default)]
+        mode: AttachMode,
     },
     PrepareTerminalForCheckout {
         checkout_path: PathBuf,
@@ -933,7 +943,7 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".into(), host: None, watch: false },
+                action: CommandAction::Attach { reference: "convoy-a".into(), host: None, mode: AttachMode::Default },
             },
             Command {
                 node_id: None,
@@ -942,7 +952,7 @@ mod tests {
                 action: CommandAction::AttachTransient {
                     reference: "terminal-scratch".into(),
                     host: Some(crate::HostName::new("feta")),
-                    watch: false,
+                    mode: AttachMode::Default,
                 },
             },
             Command {

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -339,6 +339,9 @@ pub enum CommandAction {
         /// Restrict resolution to the host that advertised the recipe.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         host: Option<crate::HostName>,
+        /// Request a read-only watcher seat instead of foreground control.
+        #[serde(default, skip_serializing_if = "is_false")]
+        watch: bool,
     },
     /// Resolve an attach for a temporary foreground excursion. Unlike the
     /// human-facing CLI attach, recursive hops must not stamp PM metadata.
@@ -346,6 +349,9 @@ pub enum CommandAction {
         reference: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         host: Option<crate::HostName>,
+        /// Preserve watcher mode while traversing a transport boundary.
+        #[serde(default, skip_serializing_if = "is_false")]
+        watch: bool,
     },
     PrepareTerminalForCheckout {
         checkout_path: PathBuf,
@@ -927,13 +933,17 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::Attach { reference: "convoy-a".into(), host: None },
+                action: CommandAction::Attach { reference: "convoy-a".into(), host: None, watch: false },
             },
             Command {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::AttachTransient { reference: "terminal-scratch".into(), host: Some(crate::HostName::new("feta")) },
+                action: CommandAction::AttachTransient {
+                    reference: "terminal-scratch".into(),
+                    host: Some(crate::HostName::new("feta")),
+                    watch: false,
+                },
             },
             Command {
                 node_id: None,

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -608,6 +608,7 @@ mod tests {
         let command = app.command(CommandAction::AttachTransient {
             reference: "terminal-scratch".to_string(),
             host: Some(flotilla_protocol::HostName::new("kiwi")),
+            watch: false,
         });
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
 

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -608,7 +608,7 @@ mod tests {
         let command = app.command(CommandAction::AttachTransient {
             reference: "terminal-scratch".to_string(),
             host: Some(flotilla_protocol::HostName::new("kiwi")),
-            watch: false,
+            mode: flotilla_protocol::commands::AttachMode::Default,
         });
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
 

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -426,7 +426,11 @@ impl App {
                 (self.repo_command_for_identity(repo_identity, CommandAction::SelectWorkspace { ws_ref: workspace_ref }), host)
             }
             TableIntent::AttachPane { reference, host } => {
-                self.proto_commands.push(self.command(CommandAction::AttachTransient { reference, host: Some(host), watch: false }));
+                self.proto_commands.push(self.command(CommandAction::AttachTransient {
+                    reference,
+                    host: Some(host),
+                    mode: flotilla_protocol::commands::AttachMode::Default,
+                }));
                 return;
             }
             TableIntent::DeleteConvoy { row_id, namespace, name, host } => {

--- a/crates/flotilla-tui/src/app/key_handlers.rs
+++ b/crates/flotilla-tui/src/app/key_handlers.rs
@@ -426,7 +426,7 @@ impl App {
                 (self.repo_command_for_identity(repo_identity, CommandAction::SelectWorkspace { ws_ref: workspace_ref }), host)
             }
             TableIntent::AttachPane { reference, host } => {
-                self.proto_commands.push(self.command(CommandAction::AttachTransient { reference, host: Some(host) }));
+                self.proto_commands.push(self.command(CommandAction::AttachTransient { reference, host: Some(host), watch: false }));
                 return;
             }
             TableIntent::DeleteConvoy { row_id, namespace, name, host } => {

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2502,7 +2502,7 @@ fn independent_view_subscribes_and_generates_a_pane_attach_query() {
     let command = app.proto_commands.take_next().expect("attach query").0;
     assert!(matches!(
         command.action,
-        CommandAction::AttachTransient { ref reference, host: Some(ref host) }
+        CommandAction::AttachTransient { ref reference, host: Some(ref host), watch: false }
             if reference == "terminal-scratch" && host == &HostName::local()
     ));
 }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -2502,7 +2502,7 @@ fn independent_view_subscribes_and_generates_a_pane_attach_query() {
     let command = app.proto_commands.take_next().expect("attach query").0;
     assert!(matches!(
         command.action,
-        CommandAction::AttachTransient { ref reference, host: Some(ref host), watch: false }
+        CommandAction::AttachTransient { ref reference, host: Some(ref host), mode: flotilla_protocol::commands::AttachMode::Default }
             if reference == "terminal-scratch" && host == &HostName::local()
     ));
 }

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     io::{stderr, stdout, Read, Write},
     process::{ExitStatus, Stdio},
     sync::{LazyLock, Mutex, MutexGuard, Once},
@@ -39,6 +39,8 @@ struct AttachCommandOutput {
 
 struct SystemAttachCommandRunner;
 
+const ATTACH_STDERR_TAIL_LIMIT: usize = 64 * 1024;
+
 static ACTIVE_ATTACH_BRIDGES: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 static ATTACH_PANIC_HOOK: Once = Once::new();
 #[cfg(unix)]
@@ -52,10 +54,7 @@ impl AttachCommandRunner for SystemAttachCommandRunner {
             .spawn()
             .map_err(|error| format!("could not start {program}: {error}"))?;
         let mut child_stderr = child.stderr.take().expect("piped child stderr should be available");
-        let stderr_reader = std::thread::spawn(move || {
-            let mut captured = Vec::new();
-            child_stderr.read_to_end(&mut captured).map(|_| captured)
-        });
+        let stderr_reader = std::thread::spawn(move || tee_stderr_tail(&mut child_stderr, stderr(), ATTACH_STDERR_TAIL_LIMIT));
         let status = child.wait().map_err(|error| format!("could not wait for {program}: {error}"))?;
         let stderr = stderr_reader
             .join()
@@ -63,6 +62,28 @@ impl AttachCommandRunner for SystemAttachCommandRunner {
             .map_err(|error| format!("could not read stderr from {program}: {error}"))?;
         Ok(AttachCommandOutput { status, stderr })
     }
+}
+
+fn tee_stderr_tail(mut reader: impl Read, mut live: impl Write, limit: usize) -> std::io::Result<Vec<u8>> {
+    let mut tail = VecDeque::with_capacity(limit);
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        live.write_all(&chunk[..read])?;
+        live.flush()?;
+        for byte in &chunk[..read] {
+            if tail.len() == limit {
+                tail.pop_front();
+            }
+            if limit > 0 {
+                tail.push_back(*byte);
+            }
+        }
+    }
+    Ok(tail.into_iter().collect())
 }
 
 fn active_attach_bridges() -> MutexGuard<'static, HashSet<String>> {
@@ -171,7 +192,8 @@ fn replay_attach_stderr(captured: &[u8], mut writer: impl Write) -> Result<(), S
 }
 
 /// Execute an interactive attach plan and return the attached process status.
-/// Child stderr is replayed only after the primary screen has been restored.
+/// Child stderr remains live during the attach. On failure, its bounded tail is
+/// replayed after the primary screen has been restored.
 pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<ExitStatus, String> {
     // Standalone CLI and convoy auto-attach paths do not pass through TUI
     // startup, so install the idempotent bridge cleanup hooks here too.
@@ -181,7 +203,9 @@ pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<ExitStatus, String> 
 
     let output = execute_attach_plan(plan, &mut SystemAttachCommandRunner)?;
     restore_terminal();
-    replay_attach_stderr(&output.stderr, stderr())?;
+    if !output.status.success() {
+        replay_attach_stderr(&output.stderr, stderr())?;
+    }
     Ok(output.status)
 }
 
@@ -257,7 +281,7 @@ mod tests {
 
     use flotilla_protocol::{arg::Arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
 
-    use super::{replay_attach_stderr, run_send_keys_attach, AttachCommandOutput, AttachCommandRunner};
+    use super::{replay_attach_stderr, run_send_keys_attach, tee_stderr_tail, AttachCommandOutput, AttachCommandRunner};
 
     #[derive(Default)]
     struct FakeRunner {
@@ -355,6 +379,16 @@ mod tests {
 
         let replayed = String::from_utf8(replayed).expect("replayed stderr should be UTF-8");
         assert_eq!(replayed, "session held by host feta pid 4242: already has a foreground client\n");
+    }
+
+    #[test]
+    fn attach_stderr_is_live_and_retains_only_a_bounded_tail() {
+        let mut live = Vec::new();
+
+        let tail = tee_stderr_tail(&b"warning then refusal"[..], &mut live, 7).expect("stderr should be teed");
+
+        assert_eq!(live, b"warning then refusal");
+        assert_eq!(tail, b"refusal");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -167,15 +167,6 @@ fn execute_attach_plan(plan: &ResolvedAttachPlan, runner: &mut dyn AttachCommand
 
 fn replay_attach_stderr(captured: &[u8], mut writer: impl Write) -> Result<(), String> {
     writer.write_all(captured).map_err(|error| format!("could not replay attach error: {error}"))?;
-    let message = String::from_utf8_lossy(captured);
-    if message.contains("foreground client") && !message.contains("--watch") {
-        if !captured.ends_with(b"\n") {
-            writer.write_all(b"\n").map_err(|error| format!("could not replay attach error: {error}"))?;
-        }
-        writer
-            .write_all(b"hint: use `flotilla attach --watch <ref>` for a read-only view\n")
-            .map_err(|error| format!("could not replay attach error: {error}"))?;
-    }
     writer.flush().map_err(|error| format!("could not replay attach error: {error}"))
 }
 
@@ -213,9 +204,6 @@ pub fn run_temporary_attach(plan: &ResolvedAttachPlan) -> (ratatui::DefaultTermi
             if !captured.trim().is_empty() {
                 message.push_str(": ");
                 message.push_str(captured.trim());
-            }
-            if captured.contains("foreground client") && !captured.contains("--watch") {
-                message.push_str("; use `flotilla attach --watch <ref>` for a read-only view");
             }
             Err(message)
         }
@@ -359,15 +347,14 @@ mod tests {
     }
 
     #[test]
-    fn foreground_refusal_replay_preserves_holder_and_suggests_watch() {
+    fn attach_failure_replay_preserves_the_original_error() {
         let mut replayed = Vec::new();
 
         replay_attach_stderr(b"session held by host feta pid 4242: already has a foreground client\n", &mut replayed)
             .expect("refusal should replay");
 
         let replayed = String::from_utf8(replayed).expect("replayed stderr should be UTF-8");
-        assert!(replayed.contains("host feta pid 4242"), "{replayed}");
-        assert!(replayed.contains("flotilla attach --watch <ref>"), "{replayed}");
+        assert_eq!(replayed, "session held by host feta pid 4242: already has a foreground client\n");
     }
 
     #[test]

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
-    io::stdout,
+    io::{stderr, stdout, Read, Write},
+    process::{ExitStatus, Stdio},
     sync::{LazyLock, Mutex, MutexGuard, Once},
 };
 
@@ -27,7 +28,13 @@ fn reinitialize_terminal() -> ratatui::DefaultTerminal {
 }
 
 trait AttachCommandRunner {
-    fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String>;
+    fn run(&mut self, program: &str, args: &[String]) -> Result<AttachCommandOutput, String>;
+}
+
+#[derive(Debug)]
+struct AttachCommandOutput {
+    status: ExitStatus,
+    stderr: Vec<u8>,
 }
 
 struct SystemAttachCommandRunner;
@@ -38,8 +45,23 @@ static ATTACH_PANIC_HOOK: Once = Once::new();
 static ATTACH_SIGNAL_HANDLER: Once = Once::new();
 
 impl AttachCommandRunner for SystemAttachCommandRunner {
-    fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String> {
-        std::process::Command::new(program).args(args).status().map_err(|error| format!("could not start {program}: {error}"))
+    fn run(&mut self, program: &str, args: &[String]) -> Result<AttachCommandOutput, String> {
+        let mut child = std::process::Command::new(program)
+            .args(args)
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| format!("could not start {program}: {error}"))?;
+        let mut child_stderr = child.stderr.take().expect("piped child stderr should be available");
+        let stderr_reader = std::thread::spawn(move || {
+            let mut captured = Vec::new();
+            child_stderr.read_to_end(&mut captured).map(|_| captured)
+        });
+        let status = child.wait().map_err(|error| format!("could not wait for {program}: {error}"))?;
+        let stderr = stderr_reader
+            .join()
+            .map_err(|_| format!("stderr reader for {program} panicked"))?
+            .map_err(|error| format!("could not read stderr from {program}: {error}"))?;
+        Ok(AttachCommandOutput { status, stderr })
     }
 }
 
@@ -56,7 +78,7 @@ fn register_attach_bridge(bridge: &str) {
 
 fn kill_attach_bridge(bridge: &str, runner: &mut dyn AttachCommandRunner) {
     if active_attach_bridges().remove(bridge) {
-        let _ = runner.status("cleat", &["kill".to_string(), bridge.to_string()]);
+        let _ = runner.run("cleat", &["kill".to_string(), bridge.to_string()]);
     }
 }
 
@@ -64,23 +86,20 @@ fn kill_all_attach_bridges() {
     let bridges: Vec<_> = active_attach_bridges().drain().collect();
     let mut runner = SystemAttachCommandRunner;
     for bridge in bridges {
-        let _ = runner.status("cleat", &["kill".to_string(), bridge]);
+        let _ = runner.run("cleat", &["kill".to_string(), bridge]);
     }
 }
 
-fn run_direct_attach(
-    args: &[flotilla_protocol::arg::Arg],
-    runner: &mut dyn AttachCommandRunner,
-) -> Result<std::process::ExitStatus, String> {
+fn run_direct_attach(args: &[flotilla_protocol::arg::Arg], runner: &mut dyn AttachCommandRunner) -> Result<AttachCommandOutput, String> {
     let command = arg::flatten(args, 0);
-    runner.status("sh", &["-lc".to_string(), command])
+    runner.run("sh", &["-lc".to_string(), command])
 }
 
 fn run_send_keys_attach(
     plan: &ResolvedAttachPlan,
     bridge: &str,
     runner: &mut dyn AttachCommandRunner,
-) -> Result<std::process::ExitStatus, String> {
+) -> Result<AttachCommandOutput, String> {
     let mut actions = plan.0.clone();
     let Some(ResolvedAttachAction::Command(args)) = actions.pop() else {
         return Err("attach plan must end with an outer command".to_string());
@@ -88,16 +107,16 @@ fn run_send_keys_attach(
     let command = arg::flatten(&args, 0);
     register_attach_bridge(bridge);
     let launch =
-        match runner.status("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command]) {
+        match runner.run("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command]) {
             Ok(status) => status,
             Err(error) => {
                 kill_attach_bridge(bridge, runner);
                 return Err(error);
             }
         };
-    if !launch.success() {
+    if !launch.status.success() {
         kill_attach_bridge(bridge, runner);
-        return Err(format!("could not launch attach bridge for outer command (status {launch})"));
+        return Err(format!("could not launch attach bridge for outer command (status {})", launch.status));
     }
 
     let result = (|| {
@@ -108,7 +127,7 @@ fn run_send_keys_attach(
             while let Some(step) = steps.pop() {
                 match step {
                     SendKeyStep::WaitForReady => {
-                        let status = runner.status("cleat", &[
+                        let status = runner.run("cleat", &[
                             "wait".to_string(),
                             bridge.to_string(),
                             "--screen-stable".to_string(),
@@ -116,42 +135,63 @@ fn run_send_keys_attach(
                             "--timeout".to_string(),
                             "30".to_string(),
                         ])?;
-                        if !status.success() {
-                            return Err(format!("attach hop {hop} did not become ready (cleat wait status {status})"));
+                        if !status.status.success() {
+                            return Err(format!("attach hop {hop} did not become ready (cleat wait status {})", status.status));
                         }
                     }
                     SendKeyStep::Type { text } => {
-                        let status = runner.status("cleat", &["send".to_string(), bridge.to_string(), text])?;
-                        if !status.success() {
-                            return Err(format!("could not send keys for attach hop {hop} (cleat send status {status})"));
+                        let status = runner.run("cleat", &["send".to_string(), bridge.to_string(), text])?;
+                        if !status.status.success() {
+                            return Err(format!("could not send keys for attach hop {hop} (cleat send status {})", status.status));
                         }
                     }
                 }
             }
         }
-        runner.status("cleat", &["attach".to_string(), bridge.to_string()])
+        runner.run("cleat", &["attach".to_string(), bridge.to_string()])
     })();
 
     kill_attach_bridge(bridge, runner);
     result
 }
 
+fn execute_attach_plan(plan: &ResolvedAttachPlan, runner: &mut dyn AttachCommandRunner) -> Result<AttachCommandOutput, String> {
+    match plan.0.as_slice() {
+        [ResolvedAttachAction::Command(args)] => run_direct_attach(args, runner),
+        _ => {
+            let bridge = format!("flotilla-attach-{}", uuid::Uuid::new_v4());
+            run_send_keys_attach(plan, &bridge, runner)
+        }
+    }
+}
+
+fn replay_attach_stderr(captured: &[u8], mut writer: impl Write) -> Result<(), String> {
+    writer.write_all(captured).map_err(|error| format!("could not replay attach error: {error}"))?;
+    let message = String::from_utf8_lossy(captured);
+    if message.contains("foreground client") && !message.contains("--watch") {
+        if !captured.ends_with(b"\n") {
+            writer.write_all(b"\n").map_err(|error| format!("could not replay attach error: {error}"))?;
+        }
+        writer
+            .write_all(b"hint: use `flotilla attach --watch <ref>` for a read-only view\n")
+            .map_err(|error| format!("could not replay attach error: {error}"))?;
+    }
+    writer.flush().map_err(|error| format!("could not replay attach error: {error}"))
+}
+
 /// Execute an interactive attach plan and return the attached process status.
-pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<std::process::ExitStatus, String> {
+/// Child stderr is replayed only after the primary screen has been restored.
+pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<ExitStatus, String> {
     // Standalone CLI and convoy auto-attach paths do not pass through TUI
     // startup, so install the idempotent bridge cleanup hooks here too.
     install_panic_hook();
     #[cfg(unix)]
     install_sigterm_handler();
 
-    let mut runner = SystemAttachCommandRunner;
-    match plan.0.as_slice() {
-        [ResolvedAttachAction::Command(args)] => run_direct_attach(args, &mut runner),
-        _ => {
-            let bridge = format!("flotilla-attach-{}", uuid::Uuid::new_v4());
-            run_send_keys_attach(plan, &bridge, &mut runner)
-        }
-    }
+    let output = execute_attach_plan(plan, &mut SystemAttachCommandRunner)?;
+    restore_terminal();
+    replay_attach_stderr(&output.stderr, stderr())?;
+    Ok(output.status)
 }
 
 /// Temporarily leave the TUI to inspect a terminal session, then restore it.
@@ -161,14 +201,23 @@ pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<std::process::ExitSt
 /// is only a transient foreground excursion.
 pub fn run_temporary_attach(plan: &ResolvedAttachPlan) -> (ratatui::DefaultTerminal, Result<(), String>) {
     restore_terminal();
-    let result = run_attach_plan(plan).and_then(|status| {
-        if status.success() {
+    let result = execute_attach_plan(plan, &mut SystemAttachCommandRunner).and_then(|output| {
+        if output.status.success() {
             Ok(())
         } else {
-            Err(format!(
+            let mut message = format!(
                 "attach command exited with status {}",
-                status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
-            ))
+                output.status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
+            );
+            let captured = String::from_utf8_lossy(&output.stderr);
+            if !captured.trim().is_empty() {
+                message.push_str(": ");
+                message.push_str(captured.trim());
+            }
+            if captured.contains("foreground client") && !captured.contains("--watch") {
+                message.push_str("; use `flotilla attach --watch <ref>` for a read-only view");
+            }
+            Err(message)
         }
     });
     (reinitialize_terminal(), result)
@@ -220,7 +269,7 @@ mod tests {
 
     use flotilla_protocol::{arg::Arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
 
-    use super::{run_send_keys_attach, AttachCommandRunner};
+    use super::{replay_attach_stderr, run_send_keys_attach, AttachCommandOutput, AttachCommandRunner};
 
     #[derive(Default)]
     struct FakeRunner {
@@ -235,10 +284,10 @@ mod tests {
     }
 
     impl AttachCommandRunner for FakeRunner {
-        fn status(&mut self, program: &str, args: &[String]) -> Result<ExitStatus, String> {
+        fn run(&mut self, program: &str, args: &[String]) -> Result<AttachCommandOutput, String> {
             self.calls.push((program.to_string(), args.to_vec()));
             let code = self.statuses.pop_front().unwrap_or(0);
-            Ok(ExitStatus::from_raw(code << 8))
+            Ok(AttachCommandOutput { status: ExitStatus::from_raw(code << 8), stderr: Vec::new() })
         }
     }
 
@@ -248,9 +297,9 @@ mod tests {
     }
 
     impl AttachCommandRunner for DockerProbeRunner {
-        fn status(&mut self, program: &str, args: &[String]) -> Result<ExitStatus, String> {
+        fn run(&mut self, program: &str, args: &[String]) -> Result<AttachCommandOutput, String> {
             if program == "cleat" && args.first().is_some_and(|command| command == "attach") {
-                return self.inner.status("cleat", &[
+                return self.inner.run("cleat", &[
                     "expect".to_string(),
                     args[1].clone(),
                     "--since-marker".to_string(),
@@ -261,11 +310,11 @@ mod tests {
                     "10".to_string(),
                 ]);
             }
-            let status = self.inner.status(program, args)?;
-            if status.success() && program == "cleat" && args.first().is_some_and(|command| command == "wait") {
-                return self.inner.status("cleat", &["mark".to_string(), args[1].clone(), "before-inner-attach".to_string()]);
+            let output = self.inner.run(program, args)?;
+            if output.status.success() && program == "cleat" && args.first().is_some_and(|command| command == "wait") {
+                return self.inner.run("cleat", &["mark".to_string(), args[1].clone(), "before-inner-attach".to_string()]);
             }
-            Ok(status)
+            Ok(output)
         }
     }
 
@@ -310,6 +359,18 @@ mod tests {
     }
 
     #[test]
+    fn foreground_refusal_replay_preserves_holder_and_suggests_watch() {
+        let mut replayed = Vec::new();
+
+        replay_attach_stderr(b"session held by host feta pid 4242: already has a foreground client\n", &mut replayed)
+            .expect("refusal should replay");
+
+        let replayed = String::from_utf8(replayed).expect("replayed stderr should be UTF-8");
+        assert!(replayed.contains("host feta pid 4242"), "{replayed}");
+        assert!(replayed.contains("flotilla attach --watch <ref>"), "{replayed}");
+    }
+
+    #[test]
     #[ignore = "requires Docker, cleat, and the debian:trixie-slim image"]
     fn real_docker_hop_types_the_inner_attach_into_the_container_shell() {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
@@ -340,11 +401,11 @@ mod tests {
 
         let result = (|| {
             let mut runner = DockerProbeRunner { marker, inner: super::SystemAttachCommandRunner };
-            let status = run_send_keys_attach(&plan, &bridge, &mut runner)?;
-            if status.success() {
+            let output = run_send_keys_attach(&plan, &bridge, &mut runner)?;
+            if output.status.success() {
                 Ok(())
             } else {
-                Err(format!("container crew marker was not observed (status {status})"))
+                Err(format!("container crew marker was not observed (status {})", output.status))
             }
         })();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,9 +108,12 @@ enum SubCommand {
     Ls,
     /// Attach to a running convoy crew session
     Attach {
-        /// Attach read-only without taking the controller seat
-        #[arg(long)]
-        watch: bool,
+        /// Refuse when another attachment holds the controller seat
+        #[arg(long, conflicts_with = "take")]
+        strict: bool,
+        /// Take control and demote the current controller to watcher
+        #[arg(long, conflicts_with = "strict")]
+        take: bool,
         /// Convoy, vessel, role, terminal session, or unique prefix
         reference: String,
         /// Internal attach mode used by temporary TUI excursions.
@@ -379,8 +382,8 @@ async fn main() -> Result<()> {
         Some(SubCommand::Logs { host, since, level, target }) => run_logs(&cli, host.as_deref(), since, level, target).await,
         Some(SubCommand::Fleet) => run_fleet_health(&cli, format).await,
         Some(SubCommand::Ls) => run_fleet_list(&cli, format).await,
-        Some(SubCommand::Attach { reference, watch, transient, host }) => {
-            run_attach(&cli, &reference, watch, transient, host.as_deref(), format).await
+        Some(SubCommand::Attach { reference, strict, take, transient, host }) => {
+            run_attach(&cli, &reference, attach_mode(strict, take), transient, host.as_deref(), format).await
         }
         Some(SubCommand::ReplicaSnapshot) => run_replica_snapshot(&cli).await,
         Some(SubCommand::Hook { harness, event_type }) => run_hook(&cli, &harness, &event_type).await,
@@ -827,7 +830,23 @@ fn exit_command_error(message: String, format: OutputFormat) -> ! {
     std::process::exit(1);
 }
 
-async fn run_attach(cli: &Cli, reference: &str, watch: bool, transient: bool, host: Option<&str>, format: OutputFormat) -> Result<()> {
+fn attach_mode(strict: bool, take: bool) -> flotilla_protocol::commands::AttachMode {
+    match (strict, take) {
+        (true, false) => flotilla_protocol::commands::AttachMode::Strict,
+        (false, true) => flotilla_protocol::commands::AttachMode::Take,
+        (false, false) => flotilla_protocol::commands::AttachMode::Default,
+        (true, true) => unreachable!("clap rejects --strict with --take"),
+    }
+}
+
+async fn run_attach(
+    cli: &Cli,
+    reference: &str,
+    mode: flotilla_protocol::commands::AttachMode,
+    transient: bool,
+    host: Option<&str>,
+    format: OutputFormat,
+) -> Result<()> {
     reset_sigpipe();
     let daemon = connect_daemon(cli).await?;
     let result = daemon
@@ -840,10 +859,10 @@ async fn run_attach(cli: &Cli, reference: &str, watch: bool, transient: bool, ho
                     CommandAction::AttachTransient {
                         reference: reference.to_string(),
                         host: host.map(flotilla_protocol::HostName::new),
-                        watch,
+                        mode,
                     }
                 } else {
-                    CommandAction::Attach { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new), watch }
+                    CommandAction::Attach { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new), mode }
                 },
             },
             uuid::Uuid::new_v4(),
@@ -2034,20 +2053,27 @@ mod tests {
         let cli = Cli::try_parse_from(["flotilla", "attach", "convoy-a/implement/coder"]).expect("attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, watch: false, transient: false, host: None })
+            Some(SubCommand::Attach { reference, strict: false, take: false, transient: false, host: None })
                 if reference == "convoy-a/implement/coder"
         ));
     }
 
     #[test]
-    fn cli_parses_watch_attach_subcommand() {
-        let cli =
-            Cli::try_parse_from(["flotilla", "attach", "--watch", "convoy-a/implement/coder"]).expect("watch attach cli should parse");
+    fn cli_parses_controller_seat_flags() {
+        let strict =
+            Cli::try_parse_from(["flotilla", "attach", "--strict", "convoy-a/implement/coder"]).expect("strict attach cli should parse");
         assert!(matches!(
-            cli.command,
-            Some(SubCommand::Attach { reference, watch: true, transient: false, host: None })
+            strict.command,
+            Some(SubCommand::Attach { reference, strict: true, take: false, transient: false, host: None })
                 if reference == "convoy-a/implement/coder"
         ));
+        let take = Cli::try_parse_from(["flotilla", "attach", "--take", "convoy-a/implement/coder"]).expect("take attach cli should parse");
+        assert!(matches!(
+            take.command,
+            Some(SubCommand::Attach { reference, strict: false, take: true, transient: false, host: None })
+                if reference == "convoy-a/implement/coder"
+        ));
+        assert!(Cli::try_parse_from(["flotilla", "attach", "--strict", "--take", "convoy-a/implement/coder"]).is_err());
     }
 
     #[test]
@@ -2068,7 +2094,7 @@ mod tests {
             .expect("transient attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, watch: false, transient: true, host: Some(host) })
+            Some(SubCommand::Attach { reference, strict: false, take: false, transient: true, host: Some(host) })
                 if reference == "terminal-scratch" && host == "feta"
         ));
     }
@@ -2079,7 +2105,7 @@ mod tests {
             .expect("host-qualified attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, watch: false, transient: false, host: Some(host) })
+            Some(SubCommand::Attach { reference, strict: false, take: false, transient: false, host: Some(host) })
                 if reference == "terminal-scratch" && host == "feta"
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,9 @@ enum SubCommand {
     Ls,
     /// Attach to a running convoy crew session
     Attach {
+        /// Attach read-only without taking the controller seat
+        #[arg(long)]
+        watch: bool,
         /// Convoy, vessel, role, terminal session, or unique prefix
         reference: String,
         /// Internal attach mode used by temporary TUI excursions.
@@ -376,7 +379,9 @@ async fn main() -> Result<()> {
         Some(SubCommand::Logs { host, since, level, target }) => run_logs(&cli, host.as_deref(), since, level, target).await,
         Some(SubCommand::Fleet) => run_fleet_health(&cli, format).await,
         Some(SubCommand::Ls) => run_fleet_list(&cli, format).await,
-        Some(SubCommand::Attach { reference, transient, host }) => run_attach(&cli, &reference, transient, host.as_deref(), format).await,
+        Some(SubCommand::Attach { reference, watch, transient, host }) => {
+            run_attach(&cli, &reference, watch, transient, host.as_deref(), format).await
+        }
         Some(SubCommand::ReplicaSnapshot) => run_replica_snapshot(&cli).await,
         Some(SubCommand::Hook { harness, event_type }) => run_hook(&cli, &harness, &event_type).await,
         Some(SubCommand::Hooks { command }) => run_hooks_command(&command).await,
@@ -822,7 +827,7 @@ fn exit_command_error(message: String, format: OutputFormat) -> ! {
     std::process::exit(1);
 }
 
-async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&str>, format: OutputFormat) -> Result<()> {
+async fn run_attach(cli: &Cli, reference: &str, watch: bool, transient: bool, host: Option<&str>, format: OutputFormat) -> Result<()> {
     reset_sigpipe();
     let daemon = connect_daemon(cli).await?;
     let result = daemon
@@ -832,9 +837,13 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
                 provisioning_target: None,
                 context_repo: None,
                 action: if transient {
-                    CommandAction::AttachTransient { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
+                    CommandAction::AttachTransient {
+                        reference: reference.to_string(),
+                        host: host.map(flotilla_protocol::HostName::new),
+                        watch,
+                    }
                 } else {
-                    CommandAction::Attach { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new) }
+                    CommandAction::Attach { reference: reference.to_string(), host: host.map(flotilla_protocol::HostName::new), watch }
                 },
             },
             uuid::Uuid::new_v4(),
@@ -2025,7 +2034,19 @@ mod tests {
         let cli = Cli::try_parse_from(["flotilla", "attach", "convoy-a/implement/coder"]).expect("attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, transient: false, host: None }) if reference == "convoy-a/implement/coder"
+            Some(SubCommand::Attach { reference, watch: false, transient: false, host: None })
+                if reference == "convoy-a/implement/coder"
+        ));
+    }
+
+    #[test]
+    fn cli_parses_watch_attach_subcommand() {
+        let cli =
+            Cli::try_parse_from(["flotilla", "attach", "--watch", "convoy-a/implement/coder"]).expect("watch attach cli should parse");
+        assert!(matches!(
+            cli.command,
+            Some(SubCommand::Attach { reference, watch: true, transient: false, host: None })
+                if reference == "convoy-a/implement/coder"
         ));
     }
 
@@ -2047,7 +2068,7 @@ mod tests {
             .expect("transient attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, transient: true, host: Some(host) })
+            Some(SubCommand::Attach { reference, watch: false, transient: true, host: Some(host) })
                 if reference == "terminal-scratch" && host == "feta"
         ));
     }
@@ -2058,7 +2079,7 @@ mod tests {
             .expect("host-qualified attach cli should parse");
         assert!(matches!(
             cli.command,
-            Some(SubCommand::Attach { reference, transient: false, host: Some(host) })
+            Some(SubCommand::Attach { reference, watch: false, transient: false, host: Some(host) })
                 if reference == "terminal-scratch" && host == "feta"
         ));
     }


### PR DESCRIPTION
Closes #1299.

- buffer attach stderr and replay it only after restoring the primary screen
- pass cleat's default, --strict, and --take controller-seat policy through local, container, and remote attach plans
- preflight the selected cleat pool for the #178 capability surface and name stale binaries and versions
- rely on modern cleat's native watcher banner to announce a degraded watcher seat and identify the controller

Checks:
- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
