### PR TITLE
fix: make crew completion resilient to partitions

### DIFF
--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -358,6 +358,7 @@ pub async fn create_stopped_terminal(
             launch_command: Some(fixture.command),
             delivered_message_id: None,
             attention: None,
+            completion_pending: None,
         })
         .await
         .expect("terminal status update should succeed");

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -2204,6 +2204,7 @@ async fn create_running_terminal(
             launch_command: Some(command.to_string()),
             delivered_message_id: None,
             attention: None,
+            completion_pending: None,
         })
         .await
         .expect("terminal status update should succeed");

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6073,10 +6073,16 @@ impl InProcessDaemon {
     }
 
     pub async fn crew_complete_internal(&self, requested: &CrewCommandContext, message: Option<String>) -> Result<(), String> {
+        let routing = self.resolve_crew_routing_context(requested).await?;
         self.apply_crew_work_patch(requested, |context| {
             convoy_external_patches::mark_crew_completed(context.vessel.clone(), context.caller_role.clone(), chrono::Utc::now(), message)
         })
-        .await
+        .await?;
+        if let Some(session_name) = routing.session_name {
+            let namespace = routing.command_context.namespace.as_deref().expect("resolved crew routing context has a namespace");
+            self.clear_crew_completion_pending(namespace, &session_name).await?;
+        }
+        Ok(())
     }
 
     pub async fn crew_fail_internal(&self, requested: &CrewCommandContext, message: String) -> Result<(), String> {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -41,11 +41,11 @@ use flotilla_resources::{
     watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
     CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
-    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewSource, Environment as ResourceEnvironment, EnvironmentPhase,
-    Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
-    InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
-    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
-    ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
+    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment,
+    EnvironmentPhase, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,
+    HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution,
+    IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec,
+    Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
     ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
     TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
@@ -1441,6 +1441,13 @@ struct ResolvedCrewContext {
     caller_session: Option<flotilla_resources::ResourceObject<ResourceTerminalSession>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrewRoutingContext {
+    pub command_context: CrewCommandContext,
+    pub session_name: Option<String>,
+    pub convoy: String,
+}
+
 fn input_meta_from_resource<T: Resource>(resource: &flotilla_resources::ResourceObject<T>) -> InputMeta {
     InputMeta::builder()
         .name(resource.metadata.name.clone())
@@ -2632,6 +2639,14 @@ impl InProcessDaemon {
             flotilla_protocol::CommandAction::ConvoyWorkForceComplete { convoy, .. } => {
                 (self.provisioning_namespace().await, convoy.as_str())
             }
+            flotilla_protocol::CommandAction::CrewComplete { context, .. }
+            | flotilla_protocol::CommandAction::CrewFail { context, .. }
+            | flotilla_protocol::CommandAction::CrewHandoff { context, .. }
+            | flotilla_protocol::CommandAction::QueryCrewList { context } => {
+                let namespace = context.namespace.clone().unwrap_or(self.provisioning_namespace().await);
+                let name = context.convoy.as_deref().ok_or_else(|| "crew command was not resolved to a convoy".to_string())?;
+                (namespace, name)
+            }
             _ => return Ok(None),
         };
 
@@ -2665,6 +2680,14 @@ impl InProcessDaemon {
             .await?
             .ok_or_else(|| format!("connect to {home} for convoy {name}: no routed node address found for host"))?;
         Ok(Some(ExistingConvoyTarget { home, node_id }))
+    }
+
+    pub async fn has_authoritative_convoy(&self, namespace: &str, name: &str) -> Result<bool, String> {
+        match self.resource_backend.clone().using::<ResourceConvoy>(namespace).get(name).await {
+            Ok(_) => Ok(true),
+            Err(ResourceError::NotFound { .. }) => Ok(false),
+            Err(error) => Err(error.to_string()),
+        }
     }
 
     /// Admit a convoy against this daemon's authoritative project resources,
@@ -5844,7 +5867,10 @@ impl InProcessDaemon {
         Ok(FleetListResponse { rows, replicas })
     }
 
-    async fn resolve_crew_context(&self, requested: &CrewCommandContext) -> Result<ResolvedCrewContext, String> {
+    /// Resolve enough crew identity locally to route a verb to the convoy
+    /// authority. Unlike `resolve_crew_context`, this does not read the
+    /// authority-owned Convoy or Vessel.
+    pub async fn resolve_crew_routing_context(&self, requested: &CrewCommandContext) -> Result<CrewRoutingContext, String> {
         let provisioning_namespace = self.provisioning_namespace().await;
         let namespace = requested.namespace.clone().unwrap_or_else(|| provisioning_namespace.clone());
         if namespace != provisioning_namespace {
@@ -5855,7 +5881,7 @@ impl InProcessDaemon {
 
         if let Some(crew_id) = requested.crew_id.as_deref() {
             let session = session_list
-                .into_iter()
+                .iter()
                 .find(|session| session.status.as_ref().and_then(|status| status.crew.as_ref()).is_some_and(|crew| crew.id == crew_id))
                 .ok_or_else(|| format!("unknown FLOTILLA_CREW_ID `{crew_id}`"))?;
             let role = session.spec.role.clone();
@@ -5865,7 +5891,17 @@ impl InProcessDaemon {
                     return Err(format!("crew identity `{crew_id}` belongs to a non-agent process"));
                 }
             };
-            return self.resolved_crew_context(namespace, convoy, vessel_ref, role, Some(session)).await;
+            return Ok(CrewRoutingContext {
+                command_context: CrewCommandContext {
+                    crew_id: None,
+                    namespace: Some(namespace),
+                    convoy: Some(convoy.clone()),
+                    vessel_ref: Some(vessel_ref),
+                    role: Some(role),
+                },
+                session_name: Some(session.metadata.name.clone()),
+                convoy,
+            });
         }
 
         let convoy = requested
@@ -5880,10 +5916,87 @@ impl InProcessDaemon {
             .role
             .clone()
             .ok_or_else(|| "crew context requires FLOTILLA_CREW_ID or --convoy, --vessel-ref, and --role".to_string())?;
-        let caller = session_list.into_iter().find(|session| {
-            session.spec.role == role && session.metadata.labels.get(VESSEL_REF_LABEL).map(String::as_str) == Some(vessel_ref.as_str())
+        let caller = session_list.iter().find(|session| {
+            session.spec.role == role
+                && (session.metadata.labels.get(VESSEL_REF_LABEL).map(String::as_str) == Some(vessel_ref.as_str())
+                    || matches!(
+                        &session.spec.source,
+                        TerminalSessionSource::Agent { context, .. } if context.vessel_ref == vessel_ref && context.convoy == convoy
+                    ))
         });
+        Ok(CrewRoutingContext {
+            command_context: CrewCommandContext {
+                crew_id: None,
+                namespace: Some(namespace),
+                convoy: Some(convoy.clone()),
+                vessel_ref: Some(vessel_ref),
+                role: Some(role),
+            },
+            session_name: caller.map(|session| session.metadata.name.clone()),
+            convoy,
+        })
+    }
+
+    async fn resolve_crew_context(&self, requested: &CrewCommandContext) -> Result<ResolvedCrewContext, String> {
+        let routing = self.resolve_crew_routing_context(requested).await?;
+        let CrewCommandContext { namespace, convoy, vessel_ref, role, .. } = routing.command_context;
+        let namespace = namespace.expect("routing context always has namespace");
+        let convoy = convoy.expect("routing context always has convoy");
+        let vessel_ref = vessel_ref.expect("routing context always has vessel ref");
+        let role = role.expect("routing context always has role");
+        let caller = match routing.session_name {
+            Some(name) => self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace).get(&name).await.ok(),
+            None => None,
+        };
         self.resolved_crew_context(namespace, convoy, vessel_ref, role, caller).await
+    }
+
+    pub async fn mark_crew_completion_pending(
+        &self,
+        namespace: &str,
+        session_name: &str,
+        pending: CrewCompletionPending,
+    ) -> Result<(), String> {
+        apply_resource_status_patch(
+            &self.resource_backend.clone().using::<ResourceTerminalSession>(namespace),
+            session_name,
+            &TerminalSessionStatusPatch::MarkCompletionPending { pending },
+        )
+        .await
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+    }
+
+    pub async fn clear_crew_completion_pending(&self, namespace: &str, session_name: &str) -> Result<(), String> {
+        apply_resource_status_patch(
+            &self.resource_backend.clone().using::<ResourceTerminalSession>(namespace),
+            session_name,
+            &TerminalSessionStatusPatch::ClearCompletionPending,
+        )
+        .await
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+    }
+
+    pub async fn pending_crew_completions(&self) -> Result<Vec<(String, CrewCompletionPending, CrewCommandContext)>, String> {
+        let namespace = self.provisioning_namespace().await;
+        let sessions =
+            self.resource_backend.clone().using::<ResourceTerminalSession>(&namespace).list().await.map_err(|error| error.to_string())?;
+        Ok(sessions
+            .items
+            .into_iter()
+            .filter_map(|session| {
+                let pending = session.status.as_ref()?.completion_pending.clone()?;
+                let TerminalSessionSource::Agent { context, .. } = &session.spec.source else { return None };
+                Some((session.metadata.name, pending, CrewCommandContext {
+                    crew_id: None,
+                    namespace: Some(context.namespace.clone()),
+                    convoy: Some(context.convoy.clone()),
+                    vessel_ref: Some(context.vessel_ref.clone()),
+                    role: Some(session.spec.role),
+                }))
+            })
+            .collect())
     }
 
     async fn resolved_crew_context(

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1437,6 +1437,16 @@ async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
     let env_ref = create_local_attach_environment(&daemon).await;
     create_two_agent_crew(&daemon, &env_ref).await;
 
+    daemon
+        .mark_crew_completion_pending("flotilla", "terminal-demo-implement-coder", CrewCompletionPending {
+            message: Some("ready for review".into()),
+            attempted_at: chrono::Utc::now(),
+            authority: "remote-before-failover".into(),
+            last_error: "authority unreachable".into(),
+        })
+        .await
+        .expect("mark completion pending before authority failover");
+
     let mut events = daemon.subscribe();
     let command_id = daemon
         .execute(Command {
@@ -1456,6 +1466,19 @@ async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
     let coder = &convoy.status.expect("convoy status").crew_work["implement"]["coder"];
     assert_eq!(coder.phase, CrewWorkPhase::Done);
     assert_eq!(coder.message.as_deref(), Some("ready for review"));
+    assert!(
+        daemon
+            .resource_backend()
+            .using::<ResourceTerminalSession>("flotilla")
+            .get("terminal-demo-implement-coder")
+            .await
+            .expect("coder terminal")
+            .status
+            .expect("coder terminal status")
+            .completion_pending
+            .is_none(),
+        "successful local completion should acknowledge the durable intent"
+    );
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1819,19 +1819,28 @@ impl Aggregator {
             .collect();
         let work_unsettled = !state.is_some_and(|state| state.phase.is_terminal());
         let now = chrono::Utc::now();
-        let needs_attention = self.terminal_sessions.values().any(|session| {
-            session.object.metadata.namespace == convoy_ref.namespace
-                && session.object.metadata.labels.get(CONVOY_LABEL) == Some(&convoy_ref.name)
-                && session.object.metadata.labels.get(VESSEL_LABEL) == Some(&definition.name)
-                && self.read_host(&session.provenance).as_ref() == Some(&vessel_host)
-                && session.object.status.as_ref().is_some_and(|status| {
+        let matching_sessions = || {
+            self.terminal_sessions.values().filter(|session| {
+                session.object.metadata.namespace == convoy_ref.namespace
+                    && session.object.metadata.labels.get(CONVOY_LABEL) == Some(&convoy_ref.name)
+                    && session.object.metadata.labels.get(VESSEL_LABEL) == Some(&definition.name)
+                    && self.read_host(&session.provenance).as_ref() == Some(&vessel_host)
+            })
+        };
+        let completion_pending = matching_sessions()
+            .filter_map(|session| session.object.status.as_ref()?.completion_pending.as_ref())
+            .min_by_key(|pending| pending.attempted_at)
+            .cloned();
+        let needs_attention = completion_pending.is_some()
+            || matching_sessions().any(|session| {
+                session.object.status.as_ref().is_some_and(|status| {
                     status.phase == TerminalSessionPhase::Running
                         && status
                             .attention
                             .as_ref()
                             .is_some_and(|attention| !attention.is_stale_at(now) && attention_needs_human(attention.state, work_unsettled))
                 })
-        });
+            });
         VesselRow::builder()
             .resource(convoy_ref.subresource(format!("vessels/{}", definition.name)))
             .maybe_vessel_resource(vessel_resource)
@@ -1842,7 +1851,11 @@ impl Aggregator {
             .maybe_ready_at(state.and_then(|state| state.ready_at))
             .maybe_started_at(state.and_then(|state| state.started_at))
             .maybe_finished_at(state.and_then(|state| state.finished_at))
-            .maybe_message(state.and_then(|state| state.message.clone()))
+            .maybe_message(
+                completion_pending
+                    .map(|pending| format!("completion pending: {}", pending.last_error))
+                    .or_else(|| state.and_then(|state| state.message.clone())),
+            )
             .requested_stance(requested_stance)
             .maybe_effective_stance(effective_stance)
             .maybe_image_ref(image_ref)
@@ -2079,6 +2092,33 @@ mod tests {
         let convoy = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
         assert!(convoy.vessels.first().expect("vessel row").needs_attention);
         assert!(convoy.needs_attention);
+    }
+
+    #[tokio::test]
+    async fn pending_crew_completion_is_visible_on_the_convoy() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(4);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy_with_vessel("convoy-a").await)).await;
+
+        let mut session = session_object("terminal-convoy-a-implement").await;
+        session.metadata.labels =
+            BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
+        session.status.as_mut().expect("running status").completion_pending = Some(flotilla_resources::CrewCompletionPending {
+            message: Some("https://github.com/flotilla-org/flotilla/pull/1300".into()),
+            attempted_at: Utc::now(),
+            authority: "kiwi".into(),
+            last_error: "authority unreachable for convoy-a".into(),
+        });
+
+        aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Added(session)).await;
+
+        let result_set = state.result_set().await;
+        let convoy = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
+        assert!(convoy.needs_attention);
+        let vessel = convoy.vessels.first().expect("vessel row");
+        assert!(vessel.needs_attention);
+        assert_eq!(vessel.message.as_deref(), Some("completion pending: authority unreachable for convoy-a"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -176,6 +176,10 @@ pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &Con
     }
     let (peer_data_tx, peer_data_rx) = mpsc::channel(256);
     let remote_command_router = build_remote_command_router(&daemon, &peer_manager);
+    {
+        let router = remote_command_router.clone();
+        tokio::spawn(async move { router.resume_pending_crew_completions().await });
+    }
     let (handle, _peer_connected_tx) = spawn_peer_networking_runtime(
         daemon,
         peer_manager,
@@ -333,6 +337,8 @@ impl DaemonServer {
         let agent_state_store = self.agent_state_store;
         let remote_command_router = self.remote_command_router;
         let peer_resource_socket_dir = self.peer_resource_socket_dir;
+
+        remote_command_router.resume_pending_crew_completions().await;
 
         // Spawn idle timeout watcher (disabled for follower-mode daemons
         // which serve peer connections and should stay up indefinitely)

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex as StdMutex,
     },
     time::Duration,
 };
@@ -15,9 +15,10 @@ use flotilla_core::{
     step::{RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, RemoteStepProgressUpdate, StepOutcome},
 };
 use flotilla_protocol::{
-    Command, CommandAction, CommandPeerEvent, CommandValue, DaemonEvent, EnvironmentId, HostName, NodeId, PeerWireMessage, RepoIdentity,
-    RepoSelector, RoutedPeerMessage, Step, StepStatus,
+    Command, CommandAction, CommandPeerEvent, CommandValue, CrewCommandContext, DaemonEvent, EnvironmentId, HostName, NodeId,
+    PeerWireMessage, RepoIdentity, RepoSelector, RoutedPeerMessage, Step, StepStatus,
 };
+use flotilla_resources::CrewCompletionPending;
 use tokio::sync::{oneshot, Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -35,6 +36,17 @@ pub(super) struct PendingRemoteCommand {
     /// than a broadcast `CommandFinished` event.  `complete_remote_command`
     /// resolves this instead of broadcasting.
     pub(super) query_completion: Option<oneshot::Sender<CommandValue>>,
+    pub(super) crew_completion: Option<PendingCrewCompletionRoute>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PendingCrewCompletionRoute {
+    namespace: String,
+    convoy: String,
+    session_name: String,
+    context: CrewCommandContext,
+    message: Option<String>,
+    authority: Option<HostName>,
 }
 
 #[derive(Debug, Clone)]
@@ -101,6 +113,9 @@ pub(super) struct RemoteCommandRouter {
     pending_remote_step_cancels: PendingRemoteStepCancelMap,
     forwarded_remote_step_batches: ForwardedRemoteStepBatchMap,
     next_remote_command_id: Arc<AtomicU64>,
+    /// Session name -> whether another retry was requested while its retry
+    /// task was dispatching.
+    retrying_crew_completions: Arc<StdMutex<HashMap<String, bool>>>,
 }
 
 #[derive(bon::Builder)]
@@ -130,6 +145,7 @@ impl RemoteCommandRouter {
             pending_remote_step_cancels: Arc::new(Mutex::new(HashMap::new())),
             forwarded_remote_step_batches: Arc::new(Mutex::new(HashMap::new())),
             next_remote_command_id,
+            retrying_crew_completions: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -146,7 +162,20 @@ impl RemoteCommandRouter {
         if matches!(command.action, CommandAction::ConvoyStartPrepared { .. }) {
             return Err("prepared convoy starts are reserved for authenticated peer forwarding".to_string());
         }
+        let mut crew_completion = self.resolve_crew_command_routing(&mut command.action).await?;
         let existing_convoy_target = self.daemon.resolve_existing_convoy_target(&command.action).await?;
+        if let (Some(completion), Some(target)) = (&mut crew_completion, &existing_convoy_target) {
+            completion.authority = Some(target.home.clone());
+        }
+        if let (Some(completion), None) = (&crew_completion, &existing_convoy_target) {
+            if !self.daemon.has_authoritative_convoy(&completion.namespace, &completion.convoy).await? {
+                let authority = HostName::new("unknown");
+                let message = format!("authority unreachable for {}: no authority route is available", completion.convoy);
+                self.persist_crew_completion(completion, &authority, &message).await;
+                self.spawn_crew_completion_retry(completion.clone());
+                return Err(format!("completion pending: {message}"));
+            }
+        }
         if let Some(target) = existing_convoy_target.as_ref() {
             command.node_id = Some(target.node_id.clone());
         }
@@ -182,9 +211,20 @@ impl RemoteCommandRouter {
                         | CommandAction::ConvoyAbandon { .. }
                         | CommandAction::ConvoyResume { .. }
                         | CommandAction::ConvoyWorkForceComplete { .. }
+                        | CommandAction::CrewComplete { .. }
+                        | CommandAction::CrewFail { .. }
+                        | CommandAction::CrewHandoff { .. }
                         | CommandAction::ResourceWatch { .. }
                 )
             {
+                if let (Some(completion), Some(target)) = (&crew_completion, &existing_convoy_target) {
+                    self.persist_crew_completion(
+                        completion,
+                        &target.home,
+                        &format!("authority acknowledgement pending for {}", completion.convoy),
+                    )
+                    .await;
+                }
                 let request_id = {
                     let mut pm = self.peer_manager.lock().await;
                     pm.next_request_id()
@@ -197,6 +237,7 @@ impl RemoteCommandRouter {
                         .target_node_id(target_node_id.clone())
                         .maybe_repo_identity(extract_command_repo_identity(&command))
                         .finished_via_event(false)
+                        .maybe_crew_completion(crew_completion.clone())
                         .build(),
                 );
 
@@ -224,7 +265,14 @@ impl RemoteCommandRouter {
                     Ok(()) => Ok(command_id),
                     Err(err) => {
                         self.pending_remote_commands.lock().await.remove(&request_id);
-                        Err(err)
+                        if let (Some(completion), Some(target)) = (crew_completion, existing_convoy_target) {
+                            let message = self.authority_unreachable_message(&completion.convoy, &target.home, &err);
+                            self.persist_crew_completion(&completion, &target.home, &message).await;
+                            self.spawn_crew_completion_retry(completion);
+                            Err(format!("completion pending: {message}"))
+                        } else {
+                            Err(err)
+                        }
                     }
                 }
             } else {
@@ -242,7 +290,16 @@ impl RemoteCommandRouter {
     /// targets the command is forwarded via the peer manager and we wait on a
     /// oneshot for the `CommandResponse` to arrive — no `CommandFinished`
     /// broadcast is synthesised.
-    pub(super) async fn dispatch_query(&self, command: Command, session_id: uuid::Uuid) -> Result<CommandValue, String> {
+    pub(super) async fn dispatch_query(&self, mut command: Command, session_id: uuid::Uuid) -> Result<CommandValue, String> {
+        self.resolve_crew_command_routing(&mut command.action).await?;
+        let existing_convoy_target = self.daemon.resolve_existing_convoy_target(&command.action).await?;
+        let crew_convoy = match &command.action {
+            CommandAction::QueryCrewList { context } => context.convoy.clone(),
+            _ => None,
+        };
+        if let Some(target) = &existing_convoy_target {
+            command.node_id = Some(target.node_id.clone());
+        }
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
 
         if target_node_id == *self.daemon.node_id() {
@@ -278,7 +335,12 @@ impl RemoteCommandRouter {
         };
         if let Err(err) = self.send_routed_to(&target_node_id, routed).await {
             self.pending_remote_commands.lock().await.remove(&request_id);
-            return Err(err);
+            return Err(match existing_convoy_target {
+                Some(target) => {
+                    format!("authority unreachable for {} at {}: {err}", crew_convoy.as_deref().unwrap_or("convoy"), target.home)
+                }
+                None => err,
+            });
         }
 
         const REMOTE_QUERY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -459,6 +521,11 @@ impl RemoteCommandRouter {
         let Some(entry) = pending.remove(&request_id) else {
             return;
         };
+        drop(pending);
+
+        if let Some(completion) = entry.crew_completion.clone() {
+            self.finish_crew_completion(completion, &result).await;
+        }
 
         // Query commands: resolve the oneshot directly without broadcasting
         // a CommandFinished event.
@@ -599,7 +666,16 @@ impl RemoteCommandRouter {
             pending.extract_if(|_, entry| entry.target_node_id == *node_id).map(|(_, entry)| entry).collect::<Vec<_>>()
         };
         for entry in failed {
-            let message = format!("remote command peer disconnected: {node_id}");
+            let transport_error = format!("remote command peer disconnected: {node_id}");
+            let message = if let Some(completion) = entry.crew_completion.clone() {
+                let authority = HostName::new(node_id.to_string());
+                let pending_message = self.authority_unreachable_message(&completion.convoy, &authority, &transport_error);
+                self.persist_crew_completion(&completion, &authority, &pending_message).await;
+                self.spawn_crew_completion_retry(completion);
+                format!("completion pending: {pending_message}")
+            } else {
+                transport_error
+            };
             if let Some(completion) = entry.query_completion {
                 let _ = completion.send(CommandValue::Error { message });
                 continue;
@@ -886,6 +962,118 @@ impl RemoteStepExecutor for RemoteCommandRouter {
 }
 
 impl RemoteCommandRouter {
+    async fn resolve_crew_command_routing(&self, action: &mut CommandAction) -> Result<Option<PendingCrewCompletionRoute>, String> {
+        let (context, completion_message) = match action {
+            CommandAction::CrewComplete { context, message } => (context, Some(message.clone())),
+            CommandAction::CrewFail { context, .. }
+            | CommandAction::CrewHandoff { context, .. }
+            | CommandAction::QueryCrewList { context } => (context, None),
+            _ => return Ok(None),
+        };
+        let routing = self.daemon.resolve_crew_routing_context(context).await?;
+        *context = routing.command_context.clone();
+        let Some(message) = completion_message else { return Ok(None) };
+        let Some(session_name) = routing.session_name else { return Ok(None) };
+        Ok(Some(PendingCrewCompletionRoute {
+            namespace: context.namespace.clone().expect("resolved crew context has namespace"),
+            convoy: routing.convoy,
+            session_name,
+            context: context.clone(),
+            message,
+            authority: None,
+        }))
+    }
+
+    fn authority_unreachable_message(&self, convoy: &str, authority: &HostName, cause: &str) -> String {
+        format!("authority unreachable for {convoy} at {authority}: {cause}")
+    }
+
+    async fn persist_crew_completion(&self, completion: &PendingCrewCompletionRoute, authority: &HostName, last_error: &str) {
+        let pending = CrewCompletionPending {
+            message: completion.message.clone(),
+            attempted_at: chrono::Utc::now(),
+            authority: authority.to_string(),
+            last_error: last_error.to_string(),
+        };
+        if let Err(error) = self.daemon.mark_crew_completion_pending(&completion.namespace, &completion.session_name, pending).await {
+            tracing::warn!(session = %completion.session_name, %error, "failed to persist pending crew completion");
+        }
+    }
+
+    async fn finish_crew_completion(&self, completion: PendingCrewCompletionRoute, result: &CommandValue) {
+        match result {
+            CommandValue::Ok => {
+                if let Err(error) = self.daemon.clear_crew_completion_pending(&completion.namespace, &completion.session_name).await {
+                    tracing::warn!(session = %completion.session_name, %error, "failed to clear acknowledged crew completion");
+                }
+            }
+            CommandValue::Error { message } => {
+                let authority = completion.authority.clone().unwrap_or_else(|| HostName::new("unknown"));
+                self.persist_crew_completion(&completion, &authority, message).await;
+                self.spawn_crew_completion_retry(completion);
+            }
+            _ => {}
+        }
+    }
+
+    fn spawn_crew_completion_retry(&self, completion: PendingCrewCompletionRoute) {
+        {
+            let mut retrying = self.retrying_crew_completions.lock().expect("crew completion retry lock");
+            if let Some(retry_requested) = retrying.get_mut(&completion.session_name) {
+                *retry_requested = true;
+                return;
+            }
+            retrying.insert(completion.session_name.clone(), false);
+        }
+        let router = self.clone();
+        tokio::spawn(async move {
+            let mut delay = Duration::from_secs(1);
+            loop {
+                tokio::time::sleep(delay).await;
+                if let Some(retry_requested) =
+                    router.retrying_crew_completions.lock().expect("crew completion retry lock").get_mut(&completion.session_name)
+                {
+                    *retry_requested = false;
+                }
+                let command = Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::CrewComplete { context: completion.context.clone(), message: completion.message.clone() },
+                };
+                if router.dispatch_execute_for_principal(command, None).await.is_ok() {
+                    let mut retrying = router.retrying_crew_completions.lock().expect("crew completion retry lock");
+                    if !retrying.get(&completion.session_name).copied().unwrap_or(false) {
+                        retrying.remove(&completion.session_name);
+                        return;
+                    }
+                }
+                delay = (delay * 2).min(Duration::from_secs(30));
+            }
+        });
+    }
+
+    pub(super) async fn resume_pending_crew_completions(&self) {
+        let completions = match self.daemon.pending_crew_completions().await {
+            Ok(completions) => completions,
+            Err(error) => {
+                tracing::warn!(%error, "failed to load pending crew completions");
+                return;
+            }
+        };
+        for (session_name, pending, context) in completions {
+            let convoy = context.convoy.clone().unwrap_or_else(|| "unknown-convoy".to_string());
+            self.spawn_crew_completion_retry(PendingCrewCompletionRoute {
+                namespace: context.namespace.clone().unwrap_or_else(|| "flotilla".to_string()),
+                convoy,
+                session_name,
+                context,
+                message: pending.message,
+                authority: Some(HostName::new(pending.authority)),
+            });
+        }
+    }
+
     async fn resolve_placement_route(&self, target: ConvoyStartTarget) -> Result<PlacementRoute, String> {
         let environment_id = EnvironmentId::host(target.host_id.clone());
         let (host_name, node_id, sender) = {

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -49,6 +49,12 @@ pub(super) struct PendingCrewCompletionRoute {
     authority: Option<HostName>,
 }
 
+#[derive(Clone)]
+struct CrewCompletionRetryState {
+    completion: PendingCrewCompletionRoute,
+    generation: u64,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct ForwardedCommand {
     pub(super) state: ForwardedCommandState,
@@ -113,9 +119,8 @@ pub(super) struct RemoteCommandRouter {
     pending_remote_step_cancels: PendingRemoteStepCancelMap,
     forwarded_remote_step_batches: ForwardedRemoteStepBatchMap,
     next_remote_command_id: Arc<AtomicU64>,
-    /// Session name -> whether another retry was requested while its retry
-    /// task was dispatching.
-    retrying_crew_completions: Arc<StdMutex<HashMap<String, bool>>>,
+    /// Session name -> latest completion intent and its update generation.
+    retrying_crew_completions: Arc<StdMutex<HashMap<String, CrewCompletionRetryState>>>,
 }
 
 #[derive(bon::Builder)]
@@ -1017,34 +1022,38 @@ impl RemoteCommandRouter {
     }
 
     fn spawn_crew_completion_retry(&self, completion: PendingCrewCompletionRoute) {
+        let session_name = completion.session_name.clone();
         {
             let mut retrying = self.retrying_crew_completions.lock().expect("crew completion retry lock");
-            if let Some(retry_requested) = retrying.get_mut(&completion.session_name) {
-                *retry_requested = true;
+            if let Some(state) = retrying.get_mut(&session_name) {
+                state.completion = completion;
+                state.generation = state.generation.wrapping_add(1);
                 return;
             }
-            retrying.insert(completion.session_name.clone(), false);
+            retrying.insert(session_name.clone(), CrewCompletionRetryState { completion, generation: 0 });
         }
         let router = self.clone();
         tokio::spawn(async move {
             let mut delay = Duration::from_secs(1);
             loop {
                 tokio::time::sleep(delay).await;
-                if let Some(retry_requested) =
-                    router.retrying_crew_completions.lock().expect("crew completion retry lock").get_mut(&completion.session_name)
-                {
-                    *retry_requested = false;
-                }
+                let Some(state) = router.retrying_crew_completions.lock().expect("crew completion retry lock").get(&session_name).cloned()
+                else {
+                    return;
+                };
                 let command = Command {
                     node_id: None,
                     provisioning_target: None,
                     context_repo: None,
-                    action: CommandAction::CrewComplete { context: completion.context.clone(), message: completion.message.clone() },
+                    action: CommandAction::CrewComplete {
+                        context: state.completion.context.clone(),
+                        message: state.completion.message.clone(),
+                    },
                 };
                 if router.dispatch_execute_for_principal(command, None).await.is_ok() {
                     let mut retrying = router.retrying_crew_completions.lock().expect("crew completion retry lock");
-                    if !retrying.get(&completion.session_name).copied().unwrap_or(false) {
-                        retrying.remove(&completion.session_name);
+                    if retrying.get(&session_name).is_some_and(|current| current.generation == state.generation) {
+                        retrying.remove(&session_name);
                         return;
                     }
                 }

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -1007,15 +1007,10 @@ impl RemoteCommandRouter {
 
     async fn finish_crew_completion(&self, completion: PendingCrewCompletionRoute, result: &CommandValue) {
         match result {
-            CommandValue::Ok => {
+            CommandValue::Ok | CommandValue::Error { .. } => {
                 if let Err(error) = self.daemon.clear_crew_completion_pending(&completion.namespace, &completion.session_name).await {
                     tracing::warn!(session = %completion.session_name, %error, "failed to clear acknowledged crew completion");
                 }
-            }
-            CommandValue::Error { message } => {
-                let authority = completion.authority.clone().unwrap_or_else(|| HostName::new("unknown"));
-                self.persist_crew_completion(&completion, &authority, message).await;
-                self.spawn_crew_completion_retry(completion);
             }
             _ => {}
         }

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1373,6 +1373,28 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
     assert_eq!(pending.authority, "feta");
     assert!(pending.last_error.contains("authority unreachable for stranded"));
 
+    router
+        .dispatch_execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::CrewComplete {
+                context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
+                message: Some("https://github.com/flotilla-org/flotilla/pull/1301".into()),
+            },
+        })
+        .await
+        .expect_err("corrected completion should remain queued during the partition");
+    let pending = sessions
+        .get("terminal-stranded-work-coder")
+        .await
+        .expect("terminal after corrected completion")
+        .status
+        .expect("terminal status")
+        .completion_pending
+        .expect("corrected durable completion intent");
+    assert_eq!(pending.message.as_deref(), Some("https://github.com/flotilla-org/flotilla/pull/1301"));
+
     let delivered = Arc::new(StdMutex::new(Vec::new()));
     peer_manager.lock().await.register_sender(node("feta"), Arc::new(CapturePeerSender(Arc::clone(&delivered))));
     tokio::time::timeout(Duration::from_secs(3), async {
@@ -1388,7 +1410,11 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
 
     let request_id = match delivered.lock().expect("delivered lock").first().expect("retried command") {
         PeerWireMessage::Routed(RoutedPeerMessage::CommandRequest { request_id, command, .. }) => {
-            assert!(matches!(command.action, CommandAction::CrewComplete { .. }));
+            assert!(matches!(
+                &command.action,
+                CommandAction::CrewComplete { message: Some(message), .. }
+                    if message == "https://github.com/flotilla-org/flotilla/pull/1301"
+            ));
             *request_id
         }
         other => panic!("expected retried crew completion, got {other:?}"),

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1419,7 +1419,7 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
         }
         other => panic!("expected retried crew completion, got {other:?}"),
     };
-    router.complete_remote_command(request_id, node("feta"), CommandValue::Ok).await;
+    router.complete_remote_command(request_id, node("feta"), CommandValue::Error { message: "crew work no longer exists".into() }).await;
     assert!(
         sessions
             .get("terminal-stranded-work-coder")
@@ -1429,7 +1429,38 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
             .expect("terminal status")
             .completion_pending
             .is_none(),
-        "authority acknowledgement should retire the durable completion intent"
+        "authority rejection should retire the acknowledged durable intent"
+    );
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert_eq!(delivered.lock().expect("delivered lock").len(), 1, "permanent authority rejection must not retry");
+
+    router
+        .dispatch_execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::CrewComplete {
+                context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
+                message: Some("https://github.com/flotilla-org/flotilla/pull/1302".into()),
+            },
+        })
+        .await
+        .expect("reachable authority should accept a fresh completion");
+    let request_id = match delivered.lock().expect("delivered lock").get(1).expect("fresh completion") {
+        PeerWireMessage::Routed(RoutedPeerMessage::CommandRequest { request_id, .. }) => *request_id,
+        other => panic!("expected fresh crew completion, got {other:?}"),
+    };
+    router.complete_remote_command(request_id, node("feta"), CommandValue::Ok).await;
+    assert!(
+        sessions
+            .get("terminal-stranded-work-coder")
+            .await
+            .expect("terminal after successful acknowledgement")
+            .status
+            .expect("terminal status")
+            .completion_pending
+            .is_none(),
+        "successful authority acknowledgement should retire the durable completion intent"
     );
 
     peer_manager.lock().await.register_sender(node("feta"), Arc::new(FailingPeerSender));

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -23,17 +23,18 @@ use flotilla_protocol::{
     qualified_path::QualifiedPath,
     result_set::{QueryChanges, QueryId, ResultDelta},
     AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachBinding, AttachableId, Checkout, CheckoutTarget, Command,
-    CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, DaemonEvent, EnvironmentId, HostName, HostPath,
-    HostProviderStatus, HostSummary, Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage,
-    PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, ResourceCursor, Response, ResponseResult,
-    RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY,
-    PROTOCOL_VERSION, TERMINAL_POOL_PROVIDER_CATEGORY,
+    CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, CrewCommandContext, DaemonEvent, EnvironmentId,
+    HostName, HostPath, HostProviderStatus, HostSummary, Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage,
+    PeerWireMessage, PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, ResourceCursor, Response,
+    ResponseResult, RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock,
+    AGENT_ADAPTER_PROVIDER_CATEGORY, PROTOCOL_VERSION, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    list_resource_kind, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, HttpBackend,
-    InMemoryBackend, InputMeta, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend, ResourceError,
-    ResourceProvenance, Stance, StatusPatch, TerminalAttentionState, TerminalSession, TerminalSessionSource, TerminalSessionSpec,
-    TerminalSessionStatus, TerminalSessionStatusPatch, WatchEvent, WatchStart, WorkflowTemplate,
+    list_resource_kind, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, CrewSessionStatus,
+    HttpBackend, InMemoryBackend, InputMeta, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend,
+    ResourceError, ResourceProvenance, Selector, Stance, StatusPatch, TerminalAttentionState, TerminalBrief, TerminalCrewContext,
+    TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, WatchEvent, WatchStart,
+    WorkflowTemplate,
 };
 use flotilla_test_support::TestSocketDir;
 use flotilla_transport::message::{message_session_pair, MessageSession};
@@ -548,6 +549,20 @@ struct FailingPeerSender;
 impl PeerSender for FailingPeerSender {
     async fn send(&self, _msg: PeerWireMessage) -> Result<(), String> {
         Err("outbound channel closed".to_string())
+    }
+
+    async fn retire(&self, _reason: flotilla_protocol::GoodbyeReason) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+struct CapturePeerSender(Arc<StdMutex<Vec<PeerWireMessage>>>);
+
+#[async_trait::async_trait]
+impl PeerSender for CapturePeerSender {
+    async fn send(&self, message: PeerWireMessage) -> Result<(), String> {
+        self.0.lock().expect("capture sender lock").push(message);
+        Ok(())
     }
 
     async fn retire(&self, _reason: flotilla_protocol::GoodbyeReason) -> Result<(), String> {
@@ -1275,6 +1290,138 @@ async fn dispatch_execute_remote_convoy_failure_names_transport_target_and_cause
         .expect_err("failed peer send should reject dispatch");
 
     assert_eq!(message, "connect to feta at ssh://feta.example: outbound channel closed");
+}
+
+#[tokio::test]
+async fn crew_completion_partition_is_persisted_and_names_the_unreachable_authority() {
+    let (_tmp, daemon) = empty_daemon().await;
+    let home = HostName::new("feta");
+    apply_convoy_replica_feed(&daemon, "flotilla", "stranded", home.clone()).await;
+    daemon
+        .publish_peer_summary(
+            HostSummary::builder()
+                .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new("feta-host")))
+                .host_name(home.clone())
+                .node(node_info("feta"))
+                .system(flotilla_protocol::SystemInfo::default())
+                .providers(vec![])
+                .build(),
+        )
+        .await;
+
+    let sessions = daemon.resource_backend().using::<TerminalSession>("flotilla");
+    let created = sessions
+        .create(&InputMeta::builder().name("terminal-stranded-work-coder".to_string()).build(), &TerminalSessionSpec {
+            env_ref: "local".into(),
+            role: "coder".into(),
+            source: TerminalSessionSource::Agent {
+                selector: Selector { capability: "code".into() },
+                brief: TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: String::new(), copies: vec![] },
+                context: TerminalCrewContext {
+                    namespace: "flotilla".into(),
+                    convoy: "stranded".into(),
+                    vessel_ref: "stranded-work".into(),
+                },
+                message: None,
+            },
+            cwd: "/repo".into(),
+            pool: "cleat".into(),
+        })
+        .await
+        .expect("terminal create");
+    let mut status = TerminalSessionStatus::default();
+    TerminalSessionStatusPatch::MarkRunning {
+        session_id: "terminal-stranded-work-coder".into(),
+        pid: None,
+        started_at: chrono::Utc::now(),
+        crew: Some(
+            CrewSessionStatus::builder().id("crew-coder".to_string()).adapter("codex".to_string()).stance("trusted".to_string()).build(),
+        ),
+        launch_command: "codex".into(),
+        delivered_message_id: None,
+    }
+    .apply(&mut status);
+    sessions.update_status(&created.metadata.name, &created.metadata.resource_version, &status).await.expect("running terminal");
+
+    let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
+    {
+        let mut manager = peer_manager.lock().await;
+        manager.add_configured_target(ConfigLabel("feta".to_string()), home, Some(node("feta")), Box::new(FailingPeerTransport));
+        manager.register_sender(node("feta"), Arc::new(FailingPeerSender));
+    }
+    let router = empty_remote_command_router(&daemon, &peer_manager);
+
+    let error = router
+        .dispatch_execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::CrewComplete {
+                context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
+                message: Some("https://github.com/flotilla-org/flotilla/pull/1300".into()),
+            },
+        })
+        .await
+        .expect_err("partitioned completion should report that it was queued");
+
+    assert_eq!(
+        error,
+        "completion pending: authority unreachable for stranded at feta: connect to feta at ssh://feta.example: outbound channel closed"
+    );
+    let terminal = sessions.get("terminal-stranded-work-coder").await.expect("terminal");
+    let pending = terminal.status.expect("terminal status").completion_pending.expect("durable completion intent");
+    assert_eq!(pending.authority, "feta");
+    assert!(pending.last_error.contains("authority unreachable for stranded"));
+
+    let delivered = Arc::new(StdMutex::new(Vec::new()));
+    peer_manager.lock().await.register_sender(node("feta"), Arc::new(CapturePeerSender(Arc::clone(&delivered))));
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            if !delivered.lock().expect("delivered lock").is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("queued completion should retry when the authority route heals");
+
+    let request_id = match delivered.lock().expect("delivered lock").first().expect("retried command") {
+        PeerWireMessage::Routed(RoutedPeerMessage::CommandRequest { request_id, command, .. }) => {
+            assert!(matches!(command.action, CommandAction::CrewComplete { .. }));
+            *request_id
+        }
+        other => panic!("expected retried crew completion, got {other:?}"),
+    };
+    router.complete_remote_command(request_id, node("feta"), CommandValue::Ok).await;
+    assert!(
+        sessions
+            .get("terminal-stranded-work-coder")
+            .await
+            .expect("terminal after acknowledgement")
+            .status
+            .expect("terminal status")
+            .completion_pending
+            .is_none(),
+        "authority acknowledgement should retire the durable completion intent"
+    );
+
+    peer_manager.lock().await.register_sender(node("feta"), Arc::new(FailingPeerSender));
+    let query_error = router
+        .dispatch_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryCrewList {
+                    context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
+                },
+            },
+            uuid::Uuid::nil(),
+        )
+        .await
+        .expect_err("partitioned follower query should name the authority");
+    assert_eq!(query_error, "authority unreachable for stranded at feta: outbound channel closed");
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -117,10 +117,10 @@ pub use retention::{EventRetention, ResourceDecodeQuarantine, ResourceStoreDiagn
 pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, apply_status_patch_checked, NoStatusPatch, StatusPatch};
 pub use terminal_session::{
-    terminal_session_attach_target, CrewSessionStatus, InnerCommandStatus, TerminalAttention, TerminalAttentionSource,
-    TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession, TerminalSessionAttachTarget,
-    TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
-    TerminalSessionStatusPatch, TerminalSessionTag,
+    terminal_session_attach_target, CrewCompletionPending, CrewSessionStatus, InnerCommandStatus, TerminalAttention,
+    TerminalAttentionSource, TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession,
+    TerminalSessionAttachTarget, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec,
+    TerminalSessionStatus, TerminalSessionStatusPatch, TerminalSessionTag,
 };
 pub use vessel::{
     Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch, ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -172,6 +172,19 @@ pub struct TerminalSessionStatus {
     /// This deliberately does not participate in the session lifecycle phase.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attention: Option<TerminalAttention>,
+    /// A crew completion accepted by this host but not yet acknowledged by
+    /// the convoy authority. The local terminal session owns this durable
+    /// intent so a daemon restart or mesh partition cannot lose the final act.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_pending: Option<CrewCompletionPending>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrewCompletionPending {
+    pub message: Option<String>,
+    pub attempted_at: DateTime<Utc>,
+    pub authority: String,
+    pub last_error: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -274,13 +287,18 @@ pub enum TerminalSessionStatusPatch {
     ObserveAttention {
         attention: TerminalAttention,
     },
+    MarkCompletionPending {
+        pending: CrewCompletionPending,
+    },
+    ClearCompletionPending,
 }
 
 impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
     fn apply(&self, status: &mut TerminalSessionStatus) {
         match self {
             Self::MarkStarting => {
-                *status = TerminalSessionStatus::default();
+                let completion_pending = status.completion_pending.take();
+                *status = TerminalSessionStatus { completion_pending, ..Default::default() };
             }
             Self::MarkRunning { session_id, pid, started_at, crew, launch_command, delivered_message_id } => {
                 status.phase = TerminalSessionPhase::Running;
@@ -324,6 +342,8 @@ impl StatusPatch<TerminalSessionStatus> for TerminalSessionStatusPatch {
                     status.attention = Some(attention.clone());
                 }
             }
+            Self::MarkCompletionPending { pending } => status.completion_pending = Some(pending.clone()),
+            Self::ClearCompletionPending => status.completion_pending = None,
         }
     }
 }
@@ -401,5 +421,23 @@ mod tests {
             .apply(&mut status);
 
         assert_eq!(status.attention.expect("attention").state, TerminalAttentionState::Unobservable);
+    }
+
+    #[test]
+    fn pending_completion_survives_terminal_restart_until_acknowledged() {
+        let pending = CrewCompletionPending {
+            message: Some("https://github.com/flotilla-org/flotilla/pull/1300".into()),
+            attempted_at: Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).single().expect("valid timestamp"),
+            authority: "kiwi".into(),
+            last_error: "authority unreachable for convoy-a".into(),
+        };
+        let mut status =
+            TerminalSessionStatus { phase: TerminalSessionPhase::Running, completion_pending: Some(pending.clone()), ..Default::default() };
+
+        TerminalSessionStatusPatch::MarkStarting.apply(&mut status);
+        assert_eq!(status.completion_pending, Some(pending));
+
+        TerminalSessionStatusPatch::ClearCompletionPending.apply(&mut status);
+        assert_eq!(status.completion_pending, None);
     }
 }

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -72,6 +72,8 @@ define_patch_kinds! {
     TerminalMarkRunning => DUPLICATE,
     TerminalMarkMessageDelivered => NONE,
     TerminalObserveAttention => NONE,
+    TerminalMarkCompletionPending => NONE,
+    TerminalClearCompletionPending => NONE,
     TerminalMarkStopped => DUPLICATE,
     TerminalMarkFailed => DUPLICATE,
     VesselMarkProvisioning => DUPLICATE,
@@ -117,6 +119,8 @@ fn terminal_session_patch_kind(patch: &TerminalSessionStatusPatch) -> PatchKind 
         TerminalSessionStatusPatch::MarkStopped { .. } => PatchKind::TerminalMarkStopped,
         TerminalSessionStatusPatch::MarkFailed { .. } => PatchKind::TerminalMarkFailed,
         TerminalSessionStatusPatch::ObserveAttention { .. } => PatchKind::TerminalObserveAttention,
+        TerminalSessionStatusPatch::MarkCompletionPending { .. } => PatchKind::TerminalMarkCompletionPending,
+        TerminalSessionStatusPatch::ClearCompletionPending => PatchKind::TerminalClearCompletionPending,
     }
 }
 
@@ -545,6 +549,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                     launch_command: Some("bash".to_string()),
                     delivered_message_id: None,
                     attention: None,
+                    completion_pending: None,
                 };
                 let before = LifecycleTimestamps { started_at: status.started_at, finished_at: status.stopped_at };
                 let patch = TerminalSessionStatusPatch::MarkRunning {


### PR DESCRIPTION
Closes #1296

## Summary
- persist crew-completion intent on the local terminal session before routing to the convoy authority
- retry pending completion automatically after authority reachability returns and clear it only after acknowledgement
- surface completion-pending state in convoy/vessel health and report authority-unreachable routing errors
- route ambient crew commands through locally resolvable terminal-session context

## Validation
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`