### PR TITLE
fix: reap cross-host attaches on client disconnect

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -995,6 +995,24 @@ impl DaemonHandle for SocketDaemon {
         }
     }
 
+    async fn begin_attach_excursion(
+        &self,
+        excursion_id: flotilla_protocol::AttachExcursionId,
+        cleanup_actions: Vec<Vec<flotilla_protocol::arg::Arg>>,
+    ) -> Result<(), String> {
+        match into_success_response(self.request(Request::BeginAttachExcursion { excursion_id, cleanup_actions }).await?)? {
+            Response::BeginAttachExcursion => Ok(()),
+            other => Err(format!("unexpected response for begin attach excursion: {other:?}")),
+        }
+    }
+
+    async fn finish_attach_excursion(&self, excursion_id: flotilla_protocol::AttachExcursionId) -> Result<(), String> {
+        match into_success_response(self.request(Request::FinishAttachExcursion { excursion_id }).await?)? {
+            Response::FinishAttachExcursion => Ok(()),
+            other => Err(format!("unexpected response for finish attach excursion: {other:?}")),
+        }
+    }
+
     /// Execute a query command and return the result directly.
     ///
     /// The `session_id` parameter is ignored by `SocketDaemon` because cursor

--- a/crates/flotilla-core/src/daemon.rs
+++ b/crates/flotilla-core/src/daemon.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use flotilla_protocol::{
-    commands::CommandValue, Command, DaemonEvent, QueryCursor, RepoInfo, RepoSelector, RepoSnapshot, StatusResponse, StreamKey,
-    TopologyResponse,
+    arg::Arg, commands::CommandValue, AttachExcursionId, Command, DaemonEvent, QueryCursor, RepoInfo, RepoSelector, RepoSnapshot,
+    StatusResponse, StreamKey, TopologyResponse,
 };
 use tokio::sync::broadcast;
 use uuid::Uuid;
@@ -100,6 +100,17 @@ pub trait DaemonHandle: Send + Sync {
     /// Replace the calling surface's current focal resource set.
     async fn observe_focus(&self, _surface_id: Uuid, _targets: Vec<flotilla_protocol::ResourceRef>) -> Result<(), String> {
         Ok(())
+    }
+
+    /// Give the daemon ownership of an attach excursion's compensating
+    /// actions. Socket daemons bind that ownership to the calling connection.
+    async fn begin_attach_excursion(&self, _excursion_id: AttachExcursionId, _cleanup_actions: Vec<Vec<Arg>>) -> Result<(), String> {
+        Err("attach excursions are unsupported by this daemon".to_string())
+    }
+
+    /// Complete an excursion and run its teardown innermost-to-outermost.
+    async fn finish_attach_excursion(&self, _excursion_id: AttachExcursionId) -> Result<(), String> {
+        Err("attach excursions are unsupported by this daemon".to_string())
     }
 
     /// Execute a query command synchronously. Returns the result directly

--- a/crates/flotilla-core/src/hop_chain/environment.rs
+++ b/crates/flotilla-core/src/hop_chain/environment.rs
@@ -75,7 +75,10 @@ impl EnvironmentHopResolver for DockerEnvironmentHopResolver {
                     Arg::Literal("exec".into()),
                     Arg::Literal("sh".into()),
                     Arg::Literal("-c".into()),
-                    Arg::Quoted(format!("echo $$ > {pid_file}; exec {inner_command}")),
+                    Arg::Quoted(format!(
+                        "export FLOTILLA_ATTACH_LEASE={}; echo $$ > {pid_file}; exec {inner_command}",
+                        flotilla_protocol::ATTACH_LEASE_PLACEHOLDER
+                    )),
                 ],
                 0,
             );
@@ -90,7 +93,10 @@ impl EnvironmentHopResolver for DockerEnvironmentHopResolver {
                 Arg::Literal("sh".into()),
                 Arg::Literal("-c".into()),
                 Arg::Quoted(format!(
-                    "pid=$(cat {pid_file} 2>/dev/null) || exit 0; kill -KILL \"$pid\" 2>/dev/null || true; rm -f {pid_file}"
+                    "pid=$(cat {pid_file} 2>/dev/null) || exit 0; \
+                     if [ -r \"/proc/$pid/environ\" ] && tr '\\000' '\\n' < \"/proc/$pid/environ\" | \
+                     grep -Fqx 'FLOTILLA_ATTACH_LEASE={}' ; then kill -KILL \"$pid\" 2>/dev/null || true; fi; rm -f {pid_file}",
+                    flotilla_protocol::ATTACH_LEASE_PLACEHOLDER
                 )),
             ]));
         }

--- a/crates/flotilla-core/src/hop_chain/environment.rs
+++ b/crates/flotilla-core/src/hop_chain/environment.rs
@@ -68,11 +68,31 @@ impl EnvironmentHopResolver for DockerEnvironmentHopResolver {
 
         // Convert inner command to SendKeys (if non-empty)
         if !inner_args.is_empty() {
-            let text = format!("exec {}", flotilla_protocol::arg::flatten(&inner_args, 0));
+            let pid_file = format!("/tmp/flotilla-attach-{}.pid", flotilla_protocol::ATTACH_LEASE_PLACEHOLDER);
+            let inner_command = flotilla_protocol::arg::flatten(&inner_args, 0);
+            let supervised_command = flotilla_protocol::arg::flatten(
+                &[
+                    Arg::Literal("exec".into()),
+                    Arg::Literal("sh".into()),
+                    Arg::Literal("-c".into()),
+                    Arg::Quoted(format!("echo $$ > {pid_file}; exec {inner_command}")),
+                ],
+                0,
+            );
             context.actions.push(ResolvedAction::SendKeys {
                 hop: format!("docker environment '{env_id}'"),
-                steps: vec![SendKeyStep::Type { text }, SendKeyStep::WaitForReady],
+                steps: vec![SendKeyStep::Type { text: supervised_command }, SendKeyStep::WaitForReady],
             });
+            context.actions.push(ResolvedAction::Cleanup(vec![
+                Arg::Literal("docker".into()),
+                Arg::Literal("exec".into()),
+                Arg::Quoted(container.to_string()),
+                Arg::Literal("sh".into()),
+                Arg::Literal("-c".into()),
+                Arg::Quoted(format!(
+                    "pid=$(cat {pid_file} 2>/dev/null) || exit 0; kill -KILL \"$pid\" 2>/dev/null || true; rm -f {pid_file}"
+                )),
+            ]));
         }
 
         // Push docker exec enter command

--- a/crates/flotilla-core/src/hop_chain/remote.rs
+++ b/crates/flotilla-core/src/hop_chain/remote.rs
@@ -60,9 +60,12 @@ impl SshRemoteHopResolver {
         Ok(SshInfo { target, multiplex })
     }
 
-    /// Build the SSH prefix args: `ssh -t [-o ControlMaster=auto ...] <target>`
-    fn ssh_prefix_args(&self, info: &SshInfo) -> Vec<Arg> {
-        let mut args = vec![Arg::Literal("ssh".into()), Arg::Literal("-t".into())];
+    /// Build the SSH prefix args: `ssh [-t] [-o ControlMaster=auto ...] <target>`
+    fn ssh_prefix_args(&self, info: &SshInfo, allocate_tty: bool) -> Vec<Arg> {
+        let mut args = vec![Arg::Literal("ssh".into())];
+        if allocate_tty {
+            args.push(Arg::Literal("-t".into()));
+        }
 
         if info.multiplex {
             if let Some(ref ctrl_path) = self.multiplex_ctrl_path {
@@ -91,7 +94,7 @@ impl SshRemoteHopResolver {
     /// user-installed tools such as `flotilla` under `~/.cargo/bin` are found.
     pub fn one_hop_command_args(&self, host: &HostName, command: Vec<Arg>) -> Result<Vec<Arg>, String> {
         let info = self.ssh_info(host)?;
-        let mut ssh_args = self.ssh_prefix_args(&info);
+        let mut ssh_args = self.ssh_prefix_args(&info, true);
         ssh_args.push(Arg::NestedCommand(vec![
             Arg::Literal("${SHELL:-/bin/sh}".into()),
             Arg::Literal("-l".into()),
@@ -99,6 +102,20 @@ impl SshRemoteHopResolver {
             Arg::NestedCommand(command),
         ]));
         Ok(ssh_args)
+    }
+
+    fn route_cleanup_actions(&self, info: &SshInfo, context: &mut ResolutionContext) {
+        for action in &mut context.actions {
+            let ResolvedAction::Cleanup(command) = action else { continue };
+            let mut ssh_args = self.ssh_prefix_args(info, false);
+            ssh_args.push(Arg::NestedCommand(vec![
+                Arg::Literal("${SHELL:-/bin/sh}".into()),
+                Arg::Literal("-l".into()),
+                Arg::Literal("-c".into()),
+                Arg::NestedCommand(std::mem::take(command)),
+            ]));
+            *command = ssh_args;
+        }
     }
 }
 
@@ -114,6 +131,7 @@ impl RemoteHopResolver for SshRemoteHopResolver {
     ///       NestedCommand([Literal("cd"), Quoted("/dir"), Literal("&&"), ...inner...])])]
     fn resolve_wrap(&self, host: &HostName, context: &mut ResolutionContext) -> Result<(), String> {
         let info = self.ssh_info(host)?;
+        self.route_cleanup_actions(&info, context);
 
         // Pop the inner action — must be a Command
         let inner_action = context.actions.pop().ok_or("resolve_wrap: no inner action on stack")?;
@@ -150,7 +168,7 @@ impl RemoteHopResolver for SshRemoteHopResolver {
         ];
 
         // Build: ssh -t [multiplex] target <NestedCommand(login_wrapper)>
-        let mut ssh_args = self.ssh_prefix_args(&info);
+        let mut ssh_args = self.ssh_prefix_args(&info, true);
         ssh_args.push(Arg::NestedCommand(login_wrapper));
 
         context.actions.push(ResolvedAction::Command(ssh_args));
@@ -166,6 +184,7 @@ impl RemoteHopResolver for SshRemoteHopResolver {
     ///   2. SendKeys: Type(flattened inner command) + WaitForReady (top)
     fn resolve_enter(&self, host: &HostName, context: &mut ResolutionContext) -> Result<(), String> {
         let info = self.ssh_info(host)?;
+        self.route_cleanup_actions(&info, context);
 
         // Pop the inner action — must be a Command
         let inner_action = context.actions.pop().ok_or("resolve_enter: no inner action on stack")?;
@@ -197,7 +216,7 @@ impl RemoteHopResolver for SshRemoteHopResolver {
         }
 
         // Push SSH enter command (no remote command — just open the session)
-        let ssh_args = self.ssh_prefix_args(&info);
+        let ssh_args = self.ssh_prefix_args(&info, true);
         context.actions.push(ResolvedAction::Command(ssh_args));
 
         // Working directory consumed

--- a/crates/flotilla-core/src/hop_chain/tests.rs
+++ b/crates/flotilla-core/src/hop_chain/tests.rs
@@ -52,6 +52,14 @@ fn expect_send_keys(action: &ResolvedAction) -> &[SendKeyStep] {
 }
 
 #[track_caller]
+fn expect_cleanup(action: &ResolvedAction) -> &[Arg] {
+    match action {
+        ResolvedAction::Cleanup(args) => args,
+        other => panic!("expected Cleanup, got {other:?}"),
+    }
+}
+
+#[track_caller]
 fn expect_type_step(step: &SendKeyStep) -> &str {
     match step {
         SendKeyStep::Type { text } => text,
@@ -72,6 +80,7 @@ fn flatten_actions(actions: &[ResolvedAction]) -> Vec<String> {
         .iter()
         .map(|action| match action {
             ResolvedAction::Command(args) => format!("Command: {}", flatten(args, 0)),
+            ResolvedAction::Cleanup(args) => format!("Cleanup: {}", flatten(args, 0)),
             ResolvedAction::SendKeys { hop, steps } => format!("SendKeys({hop}): {steps:?}"),
         })
         .collect()
@@ -1323,17 +1332,26 @@ fn enter_environment_enter_produces_docker_exec_shell_and_sendkeys() {
 
     // Terminal pushes Command(mock-attach, sess-1)
     // Environment enter pops it, converts to SendKeys, pushes docker exec -it container /bin/sh
-    assert_eq!(resolved.0.len(), 2);
+    assert_eq!(resolved.0.len(), 3);
 
     // First action: SendKeys with the terminal attach command
     let steps = expect_send_keys(&resolved.0[0]);
     assert_eq!(steps.len(), 2);
     let text = expect_type_step(&steps[0]);
     assert!(text.contains("mock-attach"), "SendKeys should contain terminal command: {text}");
+    assert!(text.contains("echo $$ > /tmp/flotilla-attach-"), "SendKeys should publish the interior PID lease: {text}");
     assert_eq!(steps[1], SendKeyStep::WaitForReady);
 
-    // Second action: docker exec enter command
-    let args = expect_command(&resolved.0[1]);
+    let pid_file_start = text.find("/tmp/flotilla-attach-").expect("PID lease path in typed command");
+    let pid_file_end = text[pid_file_start..].find(".pid").expect("PID lease suffix") + pid_file_start + 4;
+    let pid_file = &text[pid_file_start..pid_file_end];
+    let cleanup = flatten(expect_cleanup(&resolved.0[1]), 0);
+    assert!(cleanup.contains("docker exec 'my-container'"), "cleanup should run in the owning Docker environment: {cleanup}");
+    assert!(cleanup.contains(pid_file), "cleanup should consume the same PID lease: {cleanup}");
+    assert!(cleanup.contains("kill -KILL"), "cleanup should explicitly reap the interior attach: {cleanup}");
+
+    // Final action: docker exec enter command
+    let args = expect_command(&resolved.0[2]);
     assert_eq!(args[0], Arg::Literal("docker".into()));
     assert_eq!(args[1], Arg::Literal("exec".into()));
     assert_eq!(args[2], Arg::Literal("-it".into()));
@@ -1356,8 +1374,18 @@ fn send_keys_quotes_hostile_attach_names_exactly_once() {
     resolver.resolve_enter(&env_id, &mut context).expect("hostile names should resolve");
 
     let steps = expect_send_keys(&context.actions[0]);
-    assert_eq!(expect_type_step(&steps[0]), "exec flotilla attach 'crew with '\\''quote'\\'' 雪'");
-    let command = expect_command(&context.actions[1]);
+    let inner = "flotilla attach 'crew with '\\''quote'\\'' 雪'";
+    let expected = flatten(
+        &[
+            Arg::Literal("exec".into()),
+            Arg::Literal("sh".into()),
+            Arg::Literal("-c".into()),
+            Arg::Quoted(format!("echo $$ > /tmp/flotilla-attach-{}.pid; exec {inner}", flotilla_protocol::ATTACH_LEASE_PLACEHOLDER)),
+        ],
+        0,
+    );
+    assert_eq!(expect_type_step(&steps[0]), expected);
+    let command = expect_command(&context.actions[2]);
     assert_eq!(
         flatten(command, 0),
         "docker exec -it 'container with '\\''quote'\\'' 雪' /bin/sh",

--- a/crates/flotilla-core/src/hop_chain/tests.rs
+++ b/crates/flotilla-core/src/hop_chain/tests.rs
@@ -1318,6 +1318,37 @@ fn remote_then_environment_then_terminal() {
 }
 
 #[test]
+fn remote_then_environment_attach_routes_cleanup_back_through_ssh() {
+    let env_id = EnvironmentId::new("abc");
+    let terminal = Arc::new(MockTerminalHopResolver::new());
+    let resolver = HopResolver {
+        remote: Arc::new(test_resolver_no_multiplex()),
+        environment: Arc::new(docker_env_resolver(&[("abc", "container-abc")])),
+        terminal,
+        strategy: Arc::new(AlwaysSendKeys),
+    };
+    let plan = HopPlan(vec![
+        Hop::RemoteToHost { host: HostName::new("feta") },
+        Hop::EnterEnvironment { env_id, provider: "docker".into() },
+        Hop::AttachTerminal { attachable_id: AttachableId::new("sess-1") },
+    ]);
+    let mut context = minimal_context();
+
+    let resolved = resolver.resolve(&plan, &mut context).expect("cross-host Docker attach should resolve");
+
+    assert_eq!(resolved.0.len(), 4);
+    let cleanup = expect_cleanup(&resolved.0[1]);
+    assert_eq!(cleanup[0], Arg::Literal("ssh".into()));
+    assert_eq!(cleanup[1], Arg::Quoted("alice@feta.local".into()));
+    assert!(!cleanup.contains(&Arg::Literal("-t".into())), "background cleanup must not require a local TTY");
+    let remote_shell = expect_nested(&cleanup[2]);
+    let docker_cleanup = expect_nested(&remote_shell[3]);
+    assert_eq!(docker_cleanup[0], Arg::Literal("docker".into()));
+    assert_eq!(docker_cleanup[1], Arg::Literal("exec".into()));
+    assert_eq!(docker_cleanup[2], Arg::Quoted("container-abc".into()));
+}
+
+#[test]
 fn enter_environment_enter_produces_docker_exec_shell_and_sendkeys() {
     let env_id = EnvironmentId::new("my-env");
     let att_id = AttachableId::new("sess-1");
@@ -1339,6 +1370,7 @@ fn enter_environment_enter_produces_docker_exec_shell_and_sendkeys() {
     assert_eq!(steps.len(), 2);
     let text = expect_type_step(&steps[0]);
     assert!(text.contains("mock-attach"), "SendKeys should contain terminal command: {text}");
+    assert!(text.contains("export FLOTILLA_ATTACH_LEASE="), "SendKeys should stamp the interior process identity: {text}");
     assert!(text.contains("echo $$ > /tmp/flotilla-attach-"), "SendKeys should publish the interior PID lease: {text}");
     assert_eq!(steps[1], SendKeyStep::WaitForReady);
 
@@ -1348,6 +1380,11 @@ fn enter_environment_enter_produces_docker_exec_shell_and_sendkeys() {
     let cleanup = flatten(expect_cleanup(&resolved.0[1]), 0);
     assert!(cleanup.contains("docker exec 'my-container'"), "cleanup should run in the owning Docker environment: {cleanup}");
     assert!(cleanup.contains(pid_file), "cleanup should consume the same PID lease: {cleanup}");
+    assert!(cleanup.contains("/proc/$pid/environ"), "cleanup should verify the leased process identity: {cleanup}");
+    assert!(
+        cleanup.contains(&format!("FLOTILLA_ATTACH_LEASE={}", flotilla_protocol::ATTACH_LEASE_PLACEHOLDER)),
+        "cleanup should require the same attach lease: {cleanup}"
+    );
     assert!(cleanup.contains("kill -KILL"), "cleanup should explicitly reap the interior attach: {cleanup}");
 
     // Final action: docker exec enter command
@@ -1380,7 +1417,11 @@ fn send_keys_quotes_hostile_attach_names_exactly_once() {
             Arg::Literal("exec".into()),
             Arg::Literal("sh".into()),
             Arg::Literal("-c".into()),
-            Arg::Quoted(format!("echo $$ > /tmp/flotilla-attach-{}.pid; exec {inner}", flotilla_protocol::ATTACH_LEASE_PLACEHOLDER)),
+            Arg::Quoted(format!(
+                "export FLOTILLA_ATTACH_LEASE={}; echo $$ > /tmp/flotilla-attach-{}.pid; exec {inner}",
+                flotilla_protocol::ATTACH_LEASE_PLACEHOLDER,
+                flotilla_protocol::ATTACH_LEASE_PLACEHOLDER,
+            )),
         ],
         0,
     );

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -62,6 +62,7 @@ fn attach_plan_text(plan: &flotilla_protocol::ResolvedAttachPlan) -> String {
         .iter()
         .map(|action| match action {
             flotilla_protocol::ResolvedAttachAction::Command(args) => flotilla_protocol::arg::flatten(args, 0),
+            flotilla_protocol::ResolvedAttachAction::Cleanup(args) => flotilla_protocol::arg::flatten(args, 0),
             flotilla_protocol::ResolvedAttachAction::SendKeys { steps, .. } => steps
                 .iter()
                 .filter_map(|step| match step {

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -1,3 +1,4 @@
+mod attach_excursions;
 mod client_connection;
 pub mod environment_sockets;
 mod peer_connection;

--- a/crates/flotilla-daemon/src/server/attach_excursions.rs
+++ b/crates/flotilla-daemon/src/server/attach_excursions.rs
@@ -1,0 +1,62 @@
+use std::{collections::HashMap, time::Duration};
+
+use flotilla_protocol::{arg, arg::Arg, AttachExcursionId};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+/// Connection-scoped ownership of interactive attach side effects.
+#[derive(Default)]
+pub(super) struct AttachExcursions {
+    pending: Mutex<HashMap<AttachExcursionId, Vec<Vec<Arg>>>>,
+}
+
+impl AttachExcursions {
+    pub(super) async fn begin(&self, excursion_id: AttachExcursionId, cleanup_actions: Vec<Vec<Arg>>) -> Result<(), String> {
+        if cleanup_actions.is_empty() {
+            return Err("attach excursion must have at least one cleanup action".to_string());
+        }
+        let mut pending = self.pending.lock().await;
+        if pending.contains_key(&excursion_id) {
+            return Err("attach excursion is already registered".to_string());
+        }
+        pending.insert(excursion_id, cleanup_actions);
+        Ok(())
+    }
+
+    pub(super) async fn finish(&self, excursion_id: AttachExcursionId) -> Result<(), String> {
+        let actions = self.pending.lock().await.remove(&excursion_id).ok_or_else(|| "attach excursion is not registered".to_string())?;
+        run_cleanup_actions(actions).await
+    }
+
+    pub(super) async fn finish_all(&self) {
+        let excursions = {
+            let mut pending = self.pending.lock().await;
+            pending.drain().collect::<Vec<_>>()
+        };
+        for (excursion_id, actions) in excursions {
+            if let Err(error) = run_cleanup_actions(actions).await {
+                warn!(?excursion_id, %error, "attach excursion cleanup failed after client disconnect");
+            }
+        }
+    }
+}
+
+async fn run_cleanup_actions(actions: Vec<Vec<Arg>>) -> Result<(), String> {
+    let mut failures = Vec::new();
+    for action in actions {
+        let command = arg::flatten(&action, 0);
+        let mut process = tokio::process::Command::new("sh");
+        process.arg("-lc").arg(&command).kill_on_drop(true);
+        match tokio::time::timeout(Duration::from_secs(5), process.status()).await {
+            Ok(Ok(status)) if status.success() => {}
+            Ok(Ok(status)) => failures.push(format!("`{command}` exited with {status}")),
+            Ok(Err(error)) => failures.push(format!("could not start attach cleanup `{command}`: {error}")),
+            Err(_) => failures.push(format!("attach cleanup `{command}` timed out after 5s")),
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("; "))
+    }
+}

--- a/crates/flotilla-daemon/src/server/client_connection.rs
+++ b/crates/flotilla-daemon/src/server/client_connection.rs
@@ -12,7 +12,7 @@ use flotilla_transport::message::MessageSession;
 use tokio::sync::{watch, Notify};
 use tracing::{error, info, warn};
 
-use super::{remote_commands::RemoteCommandRouter, request_dispatch::RequestDispatcher};
+use super::{attach_excursions::AttachExcursions, remote_commands::RemoteCommandRouter, request_dispatch::RequestDispatcher};
 
 /// Named queries a client connection has subscribed to. Result-set events
 /// for other queries are not relayed to the connection.
@@ -34,6 +34,7 @@ pub(super) struct ClientConnection {
     client_count: Arc<AtomicUsize>,
     client_notify: Arc<Notify>,
     agent_state_store: SharedAgentStateStore,
+    attach_excursions: Arc<AttachExcursions>,
 }
 
 impl ClientConnection {
@@ -45,7 +46,15 @@ impl ClientConnection {
         client_notify: Arc<Notify>,
         agent_state_store: SharedAgentStateStore,
     ) -> Self {
-        Self { daemon, shutdown_rx, remote_command_router, client_count, client_notify, agent_state_store }
+        Self {
+            daemon,
+            shutdown_rx,
+            remote_command_router,
+            client_count,
+            client_notify,
+            agent_state_store,
+            attach_excursions: Default::default(),
+        }
     }
 
     /// Run a stateful client session that began with a Hello handshake.
@@ -98,14 +107,21 @@ impl ClientConnection {
             }
         });
 
-        let request_dispatcher =
-            RequestDispatcher::new(&self.daemon, &self.remote_command_router, &self.agent_state_store, session_id, subscriptions);
+        let request_dispatcher = RequestDispatcher::with_attach_excursions(
+            &self.daemon,
+            &self.remote_command_router,
+            &self.agent_state_store,
+            Arc::clone(&self.attach_excursions),
+            session_id,
+            subscriptions,
+        );
         (event_task, request_dispatcher, self.shutdown_rx.clone())
     }
 
     /// Common teardown: abort event relay, decrement client count.
     async fn finish_session(&self, event_task: tokio::task::JoinHandle<()>, session_id: uuid::Uuid) {
         event_task.abort();
+        self.attach_excursions.finish_all().await;
         self.daemon.unsubscribe_queries(session_id).await;
         if let Err(error) = self.daemon.disconnect_surface(session_id).await {
             warn!(%error, "failed to disconnect client surface");

--- a/crates/flotilla-daemon/src/server/request_dispatch.rs
+++ b/crates/flotilla-daemon/src/server/request_dispatch.rs
@@ -8,17 +8,19 @@ use flotilla_core::{
 use flotilla_protocol::{AgentHookEvent, Command, CommandAction, Message, RepoSelector, Request, Response};
 use tracing::warn;
 
-use super::{client_connection::QuerySubscriptions, remote_commands::RemoteCommandRouter};
+use super::{attach_excursions::AttachExcursions, client_connection::QuerySubscriptions, remote_commands::RemoteCommandRouter};
 
 pub(super) struct RequestDispatcher<'a> {
     daemon: &'a Arc<InProcessDaemon>,
     remote_command_router: &'a RemoteCommandRouter,
     agent_state_store: &'a SharedAgentStateStore,
+    attach_excursions: Arc<AttachExcursions>,
     session_id: uuid::Uuid,
     query_subscriptions: QuerySubscriptions,
 }
 
 impl<'a> RequestDispatcher<'a> {
+    #[cfg(test)]
     pub(super) fn new(
         daemon: &'a Arc<InProcessDaemon>,
         remote_command_router: &'a RemoteCommandRouter,
@@ -26,7 +28,25 @@ impl<'a> RequestDispatcher<'a> {
         session_id: uuid::Uuid,
         query_subscriptions: QuerySubscriptions,
     ) -> Self {
-        Self { daemon, remote_command_router, agent_state_store, session_id, query_subscriptions }
+        Self::with_attach_excursions(
+            daemon,
+            remote_command_router,
+            agent_state_store,
+            Arc::new(AttachExcursions::default()),
+            session_id,
+            query_subscriptions,
+        )
+    }
+
+    pub(super) fn with_attach_excursions(
+        daemon: &'a Arc<InProcessDaemon>,
+        remote_command_router: &'a RemoteCommandRouter,
+        agent_state_store: &'a SharedAgentStateStore,
+        attach_excursions: Arc<AttachExcursions>,
+        session_id: uuid::Uuid,
+        query_subscriptions: QuerySubscriptions,
+    ) -> Self {
+        Self { daemon, remote_command_router, agent_state_store, attach_excursions, session_id, query_subscriptions }
     }
 
     pub(super) async fn dispatch(&self, id: u64, request: Request) -> Message {
@@ -139,6 +159,18 @@ impl<'a> RequestDispatcher<'a> {
 
             Request::ObserveFocus { targets } => match self.daemon.observe_surface_focus(self.session_id, targets).await {
                 Ok(()) => Message::ok_response(id, Response::ObserveFocus),
+                Err(error) => Message::error_response(id, error),
+            },
+
+            Request::BeginAttachExcursion { excursion_id, cleanup_actions } => {
+                match self.attach_excursions.begin(excursion_id, cleanup_actions).await {
+                    Ok(()) => Message::ok_response(id, Response::BeginAttachExcursion),
+                    Err(error) => Message::error_response(id, error),
+                }
+            }
+
+            Request::FinishAttachExcursion { excursion_id } => match self.attach_excursions.finish(excursion_id).await {
+                Ok(()) => Message::ok_response(id, Response::FinishAttachExcursion),
                 Err(error) => Message::error_response(id, error),
             },
 

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -19,11 +19,12 @@ use flotilla_core::{
     },
 };
 use flotilla_protocol::{
+    arg::Arg,
     commands::DaemonLogQuery,
     qualified_path::QualifiedPath,
     result_set::{QueryChanges, QueryId, ResultDelta},
-    AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachBinding, AttachableId, Checkout, CheckoutTarget, Command,
-    CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, DaemonEvent, EnvironmentId, HostName, HostPath,
+    AgentEventType, AgentHarness, AgentHookEvent, AgentStatus, AttachBinding, AttachExcursionId, AttachableId, Checkout, CheckoutTarget,
+    Command, CommandAction, CommandPeerEvent, CommandValue, ConfigLabel, ConvoyStartIntent, DaemonEvent, EnvironmentId, HostName, HostPath,
     HostProviderStatus, HostSummary, Message, NodeId, NodeInfo, PeerConnectionState, PeerDataKind, PeerDataMessage, PeerWireMessage,
     PreparedWorkspace, ProviderData, QueryCursor, RepoIdentity, RepoSelector, Request, ResourceCursor, Response, ResponseResult,
     RoutedPeerMessage, StepAction, StepExecutionContext, StepOutcome, StepStatus, StreamKey, VectorClock, AGENT_ADAPTER_PROVIDER_CATEGORY,
@@ -3254,6 +3255,126 @@ async fn handle_client_streams_daemon_events_to_request_clients() {
     drop(writer);
     let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
     assert_eq!(client_count.load(Ordering::SeqCst), 0, "request client should be removed after disconnect");
+}
+
+#[tokio::test]
+async fn client_disconnect_finishes_attach_excursion_inside_out() {
+    let (tmp, client, handle, client_count, _shutdown_tx) = spawn_test_client_handler().await;
+    let order_path = tmp.path().join("attach-cleanup-order");
+    let (read_half, write_half) = client.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+    let mut writer = BufWriter::new(write_half);
+
+    flotilla_protocol::framing::write_message_line(&mut writer, &current_client_hello()).await.expect("write client hello");
+    let _hello = reader.next_line().await.expect("read hello response").expect("hello response line");
+
+    let inner = format!("printf inner > '{}'", order_path.display());
+    let outer = format!("printf -- '->outer' >> '{}'", order_path.display());
+    let request = Message::Request {
+        id: 1,
+        request: Request::BeginAttachExcursion {
+            excursion_id: AttachExcursionId::new(),
+            cleanup_actions: vec![vec![Arg::Literal("sh".into()), Arg::Literal("-c".into()), Arg::Quoted(inner)], vec![
+                Arg::Literal("sh".into()),
+                Arg::Literal("-c".into()),
+                Arg::Quoted(outer),
+            ]],
+        },
+    };
+    flotilla_protocol::framing::write_message_line(&mut writer, &request).await.expect("register attach excursion");
+    let response = reader.next_line().await.expect("read response").expect("response line");
+    assert!(matches!(ok_response(serde_json::from_str(&response).expect("parse response"), 1), Response::BeginAttachExcursion));
+
+    drop(writer);
+    drop(reader);
+    tokio::time::timeout(Duration::from_secs(2), handle).await.expect("client disconnect cleanup timed out").expect("client handler");
+
+    assert_eq!(std::fs::read_to_string(order_path).expect("cleanup order marker"), "inner->outer");
+    assert_eq!(client_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+#[ignore = "requires Docker and the debian:trixie-slim image"]
+async fn client_disconnect_reaps_docker_exec_and_frees_interior_seat() {
+    struct ContainerCleanup(String);
+    impl Drop for ContainerCleanup {
+        fn drop(&mut self) {
+            let _ = std::process::Command::new("docker").args(["rm", "-f", &self.0]).status();
+        }
+    }
+
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let container = format!("flotilla-attach-liveness-{suffix}");
+    let pid_file = format!("/tmp/flotilla-attach-{suffix}.pid");
+    let seat = format!("/tmp/flotilla-attach-{suffix}.seat");
+    let lease = format!("lease-{suffix}");
+    let started = tokio::process::Command::new("docker")
+        .args(["run", "-d", "--name", &container, "debian:trixie-slim", "sleep", "infinity"])
+        .status()
+        .await
+        .expect("start Docker liveness container");
+    assert!(started.success());
+    let _container_cleanup = ContainerCleanup(container.clone());
+
+    let (_tmp, client, handle, _client_count, _shutdown_tx) = spawn_test_client_handler().await;
+    let session = flotilla_transport::message::unix_message_session(client);
+    complete_client_hello(&session).await;
+    let cleanup = format!(
+        "pid=$(cat {pid_file} 2>/dev/null) || exit 0; \
+         if [ -r \"/proc/$pid/environ\" ] && tr '\\000' '\\n' < \"/proc/$pid/environ\" | \
+         grep -Fqx 'FLOTILLA_ATTACH_LEASE={lease}'; then kill -KILL \"$pid\" 2>/dev/null || true; fi; rm -f {pid_file}"
+    );
+    session
+        .write(Message::Request {
+            id: 1,
+            request: Request::BeginAttachExcursion {
+                excursion_id: AttachExcursionId::new(),
+                cleanup_actions: vec![vec![
+                    Arg::Literal("docker".into()),
+                    Arg::Literal("exec".into()),
+                    Arg::Quoted(container.clone()),
+                    Arg::Literal("sh".into()),
+                    Arg::Literal("-c".into()),
+                    Arg::Quoted(cleanup),
+                ]],
+            },
+        })
+        .await
+        .expect("register Docker cleanup");
+    assert!(matches!(ok_response(read_session_message(&session).await, 1), Response::BeginAttachExcursion));
+
+    let inner = format!("export FLOTILLA_ATTACH_LEASE={lease}; exec 9>{seat}; flock -n 9 || exit 1; echo $$ > {pid_file}; exec sleep 300");
+    let mut docker_exec =
+        tokio::process::Command::new("docker").args(["exec", &container, "sh", "-c", &inner]).spawn().expect("spawn Docker exec attach");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let status = tokio::process::Command::new("docker")
+                .args(["exec", &container, "test", "-s", &pid_file])
+                .status()
+                .await
+                .expect("probe interior PID");
+            if status.success() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("interior attach did not publish its PID");
+
+    drop(session);
+    tokio::time::timeout(Duration::from_secs(5), handle).await.expect("disconnect cleanup timed out").expect("client handler");
+    let exec_status = tokio::time::timeout(Duration::from_secs(2), docker_exec.wait())
+        .await
+        .expect("docker exec client lingered")
+        .expect("wait for Docker exec");
+    assert!(!exec_status.success(), "killed attach should not exit successfully");
+    let second = tokio::process::Command::new("docker")
+        .args(["exec", &container, "flock", "-n", &seat, "true"])
+        .status()
+        .await
+        .expect("attempt second attach");
+    assert!(second.success(), "second attach should acquire the released seat");
 }
 
 #[tokio::test]

--- a/crates/flotilla-protocol/src/attach_plan.rs
+++ b/crates/flotilla-protocol/src/attach_plan.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::arg::Arg;
 
+/// Replaced with a unique value by the attach-plan executor. Keeping the
+/// placeholder in resolved plans makes resolution deterministic and lets all
+/// actions in a plan share one lifecycle lease.
+pub const ATTACH_LEASE_PLACEHOLDER: &str = "__FLOTILLA_ATTACH_LEASE__";
+
 /// An interactive attach plan in execution-stack order.
 ///
 /// Consumers pop actions from the end: run the outer command first, then wait
@@ -23,6 +28,9 @@ impl ResolvedAttachPlan {
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum ResolvedAttachAction {
     Command(Vec<Arg>),
+    /// A command that must run when the attach owner exits, including when it
+    /// dies without an opportunity to unwind.
+    Cleanup(Vec<Arg>),
     /// Steps are also in stack order and are popped from the end.
     SendKeys {
         hop: String,

--- a/crates/flotilla-protocol/src/attach_plan.rs
+++ b/crates/flotilla-protocol/src/attach_plan.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::arg::Arg;
 
@@ -6,6 +7,25 @@ use crate::arg::Arg;
 /// placeholder in resolved plans makes resolution deterministic and lets all
 /// actions in a plan share one lifecycle lease.
 pub const ATTACH_LEASE_PLACEHOLDER: &str = "__FLOTILLA_ATTACH_LEASE__";
+
+/// Identifies one client-owned interactive excursion. The daemon keeps its
+/// cleanup actions until the client explicitly finishes the excursion or the
+/// owning connection disappears.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AttachExcursionId(pub Uuid);
+
+impl AttachExcursionId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for AttachExcursionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// An interactive attach plan in execution-stack order.
 ///

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -28,7 +28,7 @@ pub mod test_support;
 
 use std::fmt;
 
-pub use attach_plan::{ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
+pub use attach_plan::{ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep, ATTACH_LEASE_PLACEHOLDER};
 pub use environment::{EnvironmentId, EnvironmentInfo, EnvironmentKind, EnvironmentSpec, EnvironmentStatus, ImageId, ImageSource};
 pub use host::{HostName, HostPath, RepoIdentity};
 pub use host_summary::{

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -28,7 +28,7 @@ pub mod test_support;
 
 use std::fmt;
 
-pub use attach_plan::{ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep, ATTACH_LEASE_PLACEHOLDER};
+pub use attach_plan::{AttachExcursionId, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep, ATTACH_LEASE_PLACEHOLDER};
 pub use environment::{EnvironmentId, EnvironmentInfo, EnvironmentKind, EnvironmentSpec, EnvironmentStatus, ImageId, ImageSource};
 pub use host::{HostName, HostPath, RepoIdentity};
 pub use host_summary::{
@@ -276,6 +276,17 @@ pub enum Request {
     ObserveFocus {
         targets: Vec<ResourceRef>,
     },
+    /// Register teardown for an interactive attach before launching it. The
+    /// actions are ordered innermost-to-outermost and belong to this socket
+    /// connection until finished.
+    BeginAttachExcursion {
+        excursion_id: AttachExcursionId,
+        cleanup_actions: Vec<Vec<arg::Arg>>,
+    },
+    /// Run and forget a registered attach teardown.
+    FinishAttachExcursion {
+        excursion_id: AttachExcursionId,
+    },
     GetStatus,
     GetTopology,
     AgentHook {
@@ -305,6 +316,8 @@ pub enum Response {
     SubscribeQueries(Vec<DaemonEvent>),
     FetchMore,
     ObserveFocus,
+    BeginAttachExcursion,
+    FinishAttachExcursion,
     GetStatus(StatusResponse),
     GetTopology(TopologyResponse),
     AgentHook,

--- a/crates/flotilla-tui/src/run.rs
+++ b/crates/flotilla-tui/src/run.rs
@@ -181,7 +181,26 @@ pub async fn run_event_loop(mut terminal: ratatui::DefaultTerminal, mut app: App
         }
         if let Some(plan) = app.pending_attach_plan.take() {
             events.pause_terminal_input().await;
-            let (next_terminal, result) = crate::terminal::run_temporary_attach(&plan);
+            let prepared = crate::terminal::prepare_attach_plan(&plan);
+            let registration = match prepared.excursion_id {
+                Some(excursion_id) => app.daemon.begin_attach_excursion(excursion_id, prepared.cleanup_actions.clone()).await,
+                None => Ok(()),
+            };
+            let registered = registration.is_ok();
+            let (next_terminal, mut result) = match registration {
+                Err(error) => (terminal, Err(error)),
+                Ok(()) => crate::terminal::run_temporary_attach(&prepared),
+            };
+            if registered {
+                if let Some(excursion_id) = prepared.excursion_id {
+                    if let Err(error) = app.daemon.finish_attach_excursion(excursion_id).await {
+                        result = Err(match result {
+                            Ok(()) => error,
+                            Err(attach_error) => format!("{attach_error}; attach cleanup also failed: {error}"),
+                        });
+                    }
+                }
+            }
             terminal = next_terminal;
             terminal_title = None;
             events.resume_terminal_input();

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::HashSet,
-    io::stdout,
-    path::PathBuf,
-    process::{Child, Stdio},
-    sync::{LazyLock, Mutex, MutexGuard, Once},
-};
+use std::{io::stdout, sync::Once};
 
 use crossterm::{event::DisableMouseCapture, execute};
 use flotilla_protocol::{arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
@@ -30,15 +24,10 @@ fn reinitialize_terminal() -> ratatui::DefaultTerminal {
 
 trait AttachCommandRunner {
     fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String>;
-
-    fn start_cleanup_watchdog(&mut self, _commands: &[String]) -> Result<Option<CleanupWatchdog>, String> {
-        Ok(None)
-    }
 }
 
 struct SystemAttachCommandRunner;
 
-static ACTIVE_ATTACH_BRIDGES: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 static ATTACH_PANIC_HOOK: Once = Once::new();
 #[cfg(unix)]
 static ATTACH_SIGNAL_HANDLER: Once = Once::new();
@@ -46,88 +35,6 @@ static ATTACH_SIGNAL_HANDLER: Once = Once::new();
 impl AttachCommandRunner for SystemAttachCommandRunner {
     fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String> {
         std::process::Command::new(program).args(args).status().map_err(|error| format!("could not start {program}: {error}"))
-    }
-
-    fn start_cleanup_watchdog(&mut self, commands: &[String]) -> Result<Option<CleanupWatchdog>, String> {
-        CleanupWatchdog::spawn(commands).map(Some)
-    }
-}
-
-struct CleanupWatchdog {
-    lease: PathBuf,
-    child: Child,
-}
-
-impl CleanupWatchdog {
-    fn spawn(commands: &[String]) -> Result<Self, String> {
-        #[cfg(unix)]
-        use std::os::unix::process::CommandExt;
-
-        let lease = std::env::temp_dir().join(format!("flotilla-attach-watchdog-{}", uuid::Uuid::new_v4()));
-        std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&lease)
-            .map_err(|error| format!("could not create attach cleanup lease {}: {error}", lease.display()))?;
-        let mut command = std::process::Command::new("sh");
-        command
-            .arg("-c")
-            .arg(
-                "parent=$1; lease=$2; shift 2; while kill -0 \"$parent\" 2>/dev/null && [ -e \"$lease\" ]; do sleep 0.05; done; \
-                 for command in \"$@\"; do sh -lc \"$command\"; done; rm -f \"$lease\"",
-            )
-            .arg("flotilla-attach-watchdog")
-            .arg(std::process::id().to_string())
-            .arg(&lease)
-            .args(commands)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
-        #[cfg(unix)]
-        unsafe {
-            // The watchdog must survive the attach owner's entire terminal
-            // session disappearing, not merely an individual-process signal.
-            command.pre_exec(|| if libc::setsid() == -1 { Err(std::io::Error::last_os_error()) } else { Ok(()) });
-        }
-        match command.spawn() {
-            Ok(child) => Ok(Self { lease, child }),
-            Err(error) => {
-                let _ = std::fs::remove_file(&lease);
-                Err(format!("could not start attach cleanup watchdog: {error}"))
-            }
-        }
-    }
-}
-
-impl Drop for CleanupWatchdog {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.lease);
-        let _ = self.child.wait();
-    }
-}
-
-fn active_attach_bridges() -> MutexGuard<'static, HashSet<String>> {
-    match ACTIVE_ATTACH_BRIDGES.lock() {
-        Ok(bridges) => bridges,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-fn register_attach_bridge(bridge: &str) {
-    active_attach_bridges().insert(bridge.to_string());
-}
-
-fn kill_attach_bridge(bridge: &str, runner: &mut dyn AttachCommandRunner) {
-    if active_attach_bridges().remove(bridge) {
-        let _ = runner.status("cleat", &["kill".to_string(), bridge.to_string()]);
-    }
-}
-
-fn kill_all_attach_bridges() {
-    let bridges: Vec<_> = active_attach_bridges().drain().collect();
-    let mut runner = SystemAttachCommandRunner;
-    for bridge in bridges {
-        let _ = runner.status("cleat", &["kill".to_string(), bridge]);
     }
 }
 
@@ -144,41 +51,14 @@ fn run_send_keys_attach(
     bridge: &str,
     runner: &mut dyn AttachCommandRunner,
 ) -> Result<std::process::ExitStatus, String> {
-    let plan = instantiate_attach_plan(plan);
-    let cleanup_commands = std::iter::once(vec![
-        flotilla_protocol::arg::Arg::Literal("cleat".into()),
-        flotilla_protocol::arg::Arg::Literal("kill".into()),
-        flotilla_protocol::arg::Arg::Quoted(bridge.to_string()),
-    ])
-    .chain(plan.0.iter().filter_map(|action| match action {
-        ResolvedAttachAction::Cleanup(args) => Some(args.clone()),
-        _ => None,
-    }))
-    .map(|args| arg::flatten(&args, 0))
-    .collect::<Vec<_>>();
-    let mut actions = plan.0.iter().filter(|action| !matches!(action, ResolvedAttachAction::Cleanup(_))).cloned().collect::<Vec<_>>();
+    let mut actions = plan.0.clone();
     let Some(ResolvedAttachAction::Command(args)) = actions.pop() else {
         return Err("attach plan must end with an outer command".to_string());
     };
     let command = arg::flatten(&args, 0);
-    register_attach_bridge(bridge);
-    let _watchdog = match runner.start_cleanup_watchdog(&cleanup_commands) {
-        Ok(watchdog) => watchdog,
-        Err(error) => {
-            kill_attach_bridge(bridge, runner);
-            return Err(error);
-        }
-    };
     let launch =
-        match runner.status("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command]) {
-            Ok(status) => status,
-            Err(error) => {
-                kill_attach_bridge(bridge, runner);
-                return Err(error);
-            }
-        };
+        runner.status("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command])?;
     if !launch.success() {
-        kill_attach_bridge(bridge, runner);
         return Err(format!("could not launch attach bridge for outer command (status {launch})"));
     }
 
@@ -214,19 +94,23 @@ fn run_send_keys_attach(
         runner.status("cleat", &["attach".to_string(), bridge.to_string()])
     })();
 
-    kill_attach_bridge(bridge, runner);
     result
 }
 
+#[cfg(test)]
 fn instantiate_attach_plan(plan: &ResolvedAttachPlan) -> ResolvedAttachPlan {
     let lease = uuid::Uuid::new_v4().simple().to_string();
+    instantiate_attach_plan_with_lease(plan, &lease)
+}
+
+fn instantiate_attach_plan_with_lease(plan: &ResolvedAttachPlan, lease: &str) -> ResolvedAttachPlan {
     ResolvedAttachPlan(
         plan.0
             .iter()
             .cloned()
             .map(|action| match action {
-                ResolvedAttachAction::Command(args) => ResolvedAttachAction::Command(instantiate_args(args, &lease)),
-                ResolvedAttachAction::Cleanup(args) => ResolvedAttachAction::Cleanup(instantiate_args(args, &lease)),
+                ResolvedAttachAction::Command(args) => ResolvedAttachAction::Command(instantiate_args(args, lease)),
+                ResolvedAttachAction::Cleanup(args) => ResolvedAttachAction::Cleanup(instantiate_args(args, lease)),
                 ResolvedAttachAction::SendKeys { hop, steps } => ResolvedAttachAction::SendKeys {
                     hop,
                     steps: steps
@@ -234,7 +118,7 @@ fn instantiate_attach_plan(plan: &ResolvedAttachPlan) -> ResolvedAttachPlan {
                         .map(|step| match step {
                             SendKeyStep::WaitForReady => SendKeyStep::WaitForReady,
                             SendKeyStep::Type { text } => {
-                                SendKeyStep::Type { text: text.replace(flotilla_protocol::ATTACH_LEASE_PLACEHOLDER, &lease) }
+                                SendKeyStep::Type { text: text.replace(flotilla_protocol::ATTACH_LEASE_PLACEHOLDER, lease) }
                             }
                         })
                         .collect(),
@@ -258,21 +142,57 @@ fn instantiate_args(args: Vec<flotilla_protocol::arg::Arg>, lease: &str) -> Vec<
         .collect()
 }
 
+/// An attach execution whose side effects have been split from their
+/// compensating teardown. Callers register `cleanup_actions` with the daemon
+/// before running the plan.
+pub struct PreparedAttachPlan {
+    executable: ResolvedAttachPlan,
+    bridge: Option<String>,
+    pub excursion_id: Option<flotilla_protocol::AttachExcursionId>,
+    pub cleanup_actions: Vec<Vec<flotilla_protocol::arg::Arg>>,
+}
+
+pub fn prepare_attach_plan(plan: &ResolvedAttachPlan) -> PreparedAttachPlan {
+    if matches!(plan.0.as_slice(), [ResolvedAttachAction::Command(_)]) {
+        return PreparedAttachPlan { executable: plan.clone(), bridge: None, excursion_id: None, cleanup_actions: Vec::new() };
+    }
+
+    let excursion_id = flotilla_protocol::AttachExcursionId::new();
+    let lease = excursion_id.0.simple().to_string();
+    let bridge = format!("flotilla-attach-{}", uuid::Uuid::new_v4());
+    let instantiated = instantiate_attach_plan_with_lease(plan, &lease);
+    let mut cleanup_actions = instantiated
+        .0
+        .iter()
+        .filter_map(|action| match action {
+            ResolvedAttachAction::Cleanup(args) => Some(args.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    // The bridge is the outermost acquired resource, so it is released last.
+    cleanup_actions.push(vec![
+        flotilla_protocol::arg::Arg::Literal("cleat".into()),
+        flotilla_protocol::arg::Arg::Literal("kill".into()),
+        flotilla_protocol::arg::Arg::Quoted(bridge.clone()),
+    ]);
+    let executable =
+        ResolvedAttachPlan(instantiated.0.into_iter().filter(|action| !matches!(action, ResolvedAttachAction::Cleanup(_))).collect());
+    PreparedAttachPlan { executable, bridge: Some(bridge), excursion_id: Some(excursion_id), cleanup_actions }
+}
+
 /// Execute an interactive attach plan and return the attached process status.
-pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<std::process::ExitStatus, String> {
+pub fn run_attach_plan(plan: &PreparedAttachPlan) -> Result<std::process::ExitStatus, String> {
     // Standalone CLI and convoy auto-attach paths do not pass through TUI
-    // startup, so install the idempotent bridge cleanup hooks here too.
+    // startup, so install the terminal restoration hooks here too.
     install_panic_hook();
     #[cfg(unix)]
     install_sigterm_handler();
 
     let mut runner = SystemAttachCommandRunner;
-    match plan.0.as_slice() {
-        [ResolvedAttachAction::Command(args)] => run_direct_attach(args, &mut runner),
-        _ => {
-            let bridge = format!("flotilla-attach-{}", uuid::Uuid::new_v4());
-            run_send_keys_attach(plan, &bridge, &mut runner)
-        }
+    match (plan.executable.0.as_slice(), plan.bridge.as_deref()) {
+        ([ResolvedAttachAction::Command(args)], None) => run_direct_attach(args, &mut runner),
+        (_, Some(bridge)) => run_send_keys_attach(&plan.executable, bridge, &mut runner),
+        _ => Err("attach plan is missing its bridge".to_string()),
     }
 }
 
@@ -281,7 +201,7 @@ pub fn run_attach_plan(plan: &ResolvedAttachPlan) -> Result<std::process::ExitSt
 /// This deliberately does not stamp Presentation Manager metadata: the pane
 /// remains owned by its existing project/archipelago context while the attach
 /// is only a transient foreground excursion.
-pub fn run_temporary_attach(plan: &ResolvedAttachPlan) -> (ratatui::DefaultTerminal, Result<(), String>) {
+pub fn run_temporary_attach(plan: &PreparedAttachPlan) -> (ratatui::DefaultTerminal, Result<(), String>) {
     restore_terminal();
     let result = run_attach_plan(plan).and_then(|status| {
         if status.success() {
@@ -306,7 +226,6 @@ pub fn install_panic_hook() {
         let hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             restore_terminal();
-            kill_all_attach_bridges();
             hook(info);
         }));
     });
@@ -330,7 +249,6 @@ pub fn install_sigterm_handler() {
                 _ = sigterm.recv() => 0,
             };
             restore_terminal();
-            kill_all_attach_bridges();
             std::process::exit(exit_code);
         });
     });
@@ -338,20 +256,11 @@ pub fn install_sigterm_handler() {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use std::{
-        collections::VecDeque,
-        os::unix::process::ExitStatusExt,
-        path::Path,
-        process::ExitStatus,
-        time::{Duration, Instant},
-    };
+    use std::{collections::VecDeque, os::unix::process::ExitStatusExt, process::ExitStatus};
 
-    use flotilla_protocol::{
-        arg::{self, Arg},
-        ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep,
-    };
+    use flotilla_protocol::{arg::Arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
 
-    use super::{instantiate_attach_plan, run_send_keys_attach, AttachCommandRunner};
+    use super::{instantiate_attach_plan, prepare_attach_plan, run_send_keys_attach, AttachCommandRunner};
 
     #[derive(Default)]
     struct FakeRunner {
@@ -376,39 +285,6 @@ mod tests {
     struct DockerProbeRunner {
         marker: String,
         inner: super::SystemAttachCommandRunner,
-    }
-
-    struct SigkillProbeRunner {
-        ready: String,
-        inner: super::SystemAttachCommandRunner,
-    }
-
-    struct DockerLivenessCleanup {
-        bridge: String,
-        container: String,
-    }
-
-    impl Drop for DockerLivenessCleanup {
-        fn drop(&mut self) {
-            let _ = std::process::Command::new("cleat").args(["kill", &self.bridge]).status();
-            let _ = std::process::Command::new("docker").args(["rm", "-f", &self.container]).status();
-        }
-    }
-
-    impl AttachCommandRunner for SigkillProbeRunner {
-        fn status(&mut self, program: &str, args: &[String]) -> Result<ExitStatus, String> {
-            if program == "cleat" && args.first().is_some_and(|command| command == "attach") {
-                std::fs::write(&self.ready, b"ready").map_err(|error| format!("write SIGKILL probe marker: {error}"))?;
-                loop {
-                    std::thread::sleep(Duration::from_secs(60));
-                }
-            }
-            self.inner.status(program, args)
-        }
-
-        fn start_cleanup_watchdog(&mut self, commands: &[String]) -> Result<Option<super::CleanupWatchdog>, String> {
-            self.inner.start_cleanup_watchdog(commands)
-        }
     }
 
     impl AttachCommandRunner for DockerProbeRunner {
@@ -457,7 +333,7 @@ mod tests {
 
         assert!(error.contains("docker environment 'crew-box'"), "{error}");
         assert!(error.contains("did not become ready"), "{error}");
-        assert_eq!(runner.calls.last().expect("cleanup call").1[0], "kill");
+        assert_eq!(runner.calls.last().expect("failed wait call").1[0], "wait");
     }
 
     #[test]
@@ -467,7 +343,7 @@ mod tests {
         run_send_keys_attach(&two_hop_plan(), "ready-bridge", &mut runner).expect("attach plan should run");
 
         let commands: Vec<_> = runner.calls.iter().map(|(_, args)| args[0].as_str()).collect();
-        assert_eq!(commands, ["launch", "wait", "send", "attach", "kill"]);
+        assert_eq!(commands, ["launch", "wait", "send", "attach"]);
         let wait = &runner.calls[1].1;
         assert!(wait.windows(2).any(|pair| pair == ["--screen-stable", "100ms"]));
         assert!(!runner.calls.iter().any(|(_, args)| args.iter().any(|arg| arg == "expect")));
@@ -491,198 +367,19 @@ mod tests {
     }
 
     #[test]
-    fn attach_sigkill_helper() {
-        let Ok(bridge) = std::env::var("FLOTILLA_ATTACH_SIGKILL_BRIDGE") else { return };
-        let ready = std::env::var("FLOTILLA_ATTACH_SIGKILL_READY").expect("SIGKILL helper ready path");
-        let cleaned = std::env::var("FLOTILLA_ATTACH_SIGKILL_CLEANED").expect("SIGKILL helper cleanup path");
-        let plan = if let Ok(container) = std::env::var("FLOTILLA_ATTACH_SIGKILL_CONTAINER") {
-            let pid_file = std::env::var("FLOTILLA_ATTACH_SIGKILL_PID_FILE").expect("SIGKILL helper PID file");
-            let seat = std::env::var("FLOTILLA_ATTACH_SIGKILL_SEAT").expect("SIGKILL helper seat path");
-            ResolvedAttachPlan(vec![
-                ResolvedAttachAction::SendKeys {
-                    hop: "Docker SIGKILL probe".into(),
-                    steps: vec![
-                        SendKeyStep::Type {
-                            text: arg::flatten(
-                                &[
-                                    Arg::Literal("exec".into()),
-                                    Arg::Literal("sh".into()),
-                                    Arg::Literal("-c".into()),
-                                    Arg::Quoted(format!("echo $$ > {pid_file}; exec flock -n {seat} sleep 300")),
-                                ],
-                                0,
-                            ),
-                        },
-                        SendKeyStep::WaitForReady,
-                    ],
-                },
-                ResolvedAttachAction::Cleanup(vec![
-                    Arg::Literal("docker".into()),
-                    Arg::Literal("exec".into()),
-                    Arg::Quoted(container.clone()),
-                    Arg::Literal("sh".into()),
-                    Arg::Literal("-c".into()),
-                    Arg::Quoted(format!(
-                        "pid=$(cat {pid_file} 2>/dev/null) || exit 0; kill -KILL \"$pid\" 2>/dev/null || true; rm -f {pid_file}"
-                    )),
-                ]),
-                ResolvedAttachAction::Cleanup(vec![Arg::Literal("touch".into()), Arg::Quoted(cleaned)]),
-                ResolvedAttachAction::Command(vec![
-                    Arg::Literal("docker".into()),
-                    Arg::Literal("exec".into()),
-                    Arg::Literal("-it".into()),
-                    Arg::Quoted(container),
-                    Arg::Literal("/bin/sh".into()),
-                ]),
-            ])
-        } else {
-            ResolvedAttachPlan(vec![
-                ResolvedAttachAction::SendKeys {
-                    hop: "SIGKILL probe".into(),
-                    steps: vec![SendKeyStep::Type { text: "exec sleep 300".into() }, SendKeyStep::WaitForReady],
-                },
-                ResolvedAttachAction::Cleanup(vec![Arg::Literal("touch".into()), Arg::Quoted(cleaned)]),
-                ResolvedAttachAction::Command(vec![Arg::Literal("sh".into())]),
-            ])
-        };
-        let mut runner = SigkillProbeRunner { ready, inner: super::SystemAttachCommandRunner };
+    fn preparation_orders_cleanup_inside_out_and_bridge_last() {
+        let plan = ResolvedAttachPlan(vec![
+            ResolvedAttachAction::SendKeys { hop: "inner".into(), steps: vec![] },
+            ResolvedAttachAction::Cleanup(vec![Arg::Literal("kill-inner".into())]),
+            ResolvedAttachAction::Command(vec![Arg::Literal("outer".into())]),
+        ]);
 
-        run_send_keys_attach(&plan, &bridge, &mut runner).expect("SIGKILL helper attach");
-    }
+        let prepared = prepare_attach_plan(&plan);
 
-    #[test]
-    #[ignore = "requires the cleat binary"]
-    fn killing_attach_owner_reaps_the_bridge() {
-        let temp = tempfile::tempdir().expect("SIGKILL probe tempdir");
-        let ready = temp.path().join("ready");
-        let cleaned = temp.path().join("cleaned");
-        let bridge = format!("flotilla-attach-sigkill-{}", uuid::Uuid::new_v4());
-        let mut helper = std::process::Command::new(std::env::current_exe().expect("current test executable"))
-            .args(["attach_sigkill_helper", "--nocapture"])
-            .env("FLOTILLA_ATTACH_SIGKILL_BRIDGE", &bridge)
-            .env("FLOTILLA_ATTACH_SIGKILL_READY", &ready)
-            .env("FLOTILLA_ATTACH_SIGKILL_CLEANED", &cleaned)
-            .spawn()
-            .expect("spawn SIGKILL attach helper");
-
-        wait_for_path(&ready, Duration::from_secs(10));
-        unsafe {
-            libc::kill(helper.id() as libc::pid_t, libc::SIGKILL);
-        }
-        let _ = helper.wait();
-
-        wait_for_path(&cleaned, Duration::from_secs(3));
-        let deadline = Instant::now() + Duration::from_secs(3);
-        let reaped = loop {
-            let output = std::process::Command::new("cleat").args(["list", "--json"]).output().expect("list cleat sessions");
-            if !String::from_utf8_lossy(&output.stdout).contains(&bridge) {
-                break true;
-            }
-            if Instant::now() >= deadline {
-                break false;
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        };
-        let _ = std::process::Command::new("cleat").args(["kill", &bridge]).status();
-        assert!(reaped, "attach bridge {bridge} survived its SIGKILLed owner");
-    }
-
-    #[test]
-    #[ignore = "requires Docker, cleat, and the debian:trixie-slim image"]
-    fn killing_attach_owner_reaps_docker_exec_and_frees_the_interior_seat() {
-        let suffix = uuid::Uuid::new_v4().simple().to_string();
-        let container = format!("flotilla-attach-liveness-{suffix}");
-        let bridge = format!("flotilla-attach-liveness-{suffix}");
-        let pid_file = format!("/tmp/flotilla-attach-{suffix}.pid");
-        let seat = format!("/tmp/flotilla-attach-{suffix}.seat");
-        let temp = tempfile::tempdir().expect("Docker liveness tempdir");
-        let ready = temp.path().join("ready");
-        let cleaned = temp.path().join("cleaned");
-
-        let started = std::process::Command::new("docker")
-            .args(["run", "-d", "--name", &container, "debian:trixie-slim", "sleep", "infinity"])
-            .status()
-            .expect("start Docker liveness container");
-        assert!(started.success(), "Docker liveness container should start");
-        let _cleanup = DockerLivenessCleanup { bridge: bridge.clone(), container: container.clone() };
-
-        let mut helper = std::process::Command::new(std::env::current_exe().expect("current test executable"))
-            .args(["attach_sigkill_helper", "--nocapture"])
-            .env("FLOTILLA_ATTACH_SIGKILL_BRIDGE", &bridge)
-            .env("FLOTILLA_ATTACH_SIGKILL_READY", &ready)
-            .env("FLOTILLA_ATTACH_SIGKILL_CLEANED", &cleaned)
-            .env("FLOTILLA_ATTACH_SIGKILL_CONTAINER", &container)
-            .env("FLOTILLA_ATTACH_SIGKILL_PID_FILE", &pid_file)
-            .env("FLOTILLA_ATTACH_SIGKILL_SEAT", &seat)
-            .spawn()
-            .expect("spawn Docker attach helper");
-        wait_for_path(&ready, Duration::from_secs(10));
-
-        let pid = wait_for_docker_pid(&container, &pid_file, Duration::from_secs(5));
-        unsafe {
-            libc::kill(helper.id() as libc::pid_t, libc::SIGKILL);
-        }
-        let _ = helper.wait();
-        wait_for_path(&cleaned, Duration::from_secs(3));
-
-        let deadline = Instant::now() + Duration::from_secs(3);
-        loop {
-            let bridge_gone = !cleat_sessions().contains(&bridge);
-            let interior_gone = !docker_process_exists(&container, &pid);
-            let exec_gone = !host_processes().contains(&format!("docker exec -it {container} /bin/sh"));
-            if bridge_gone && interior_gone && exec_gone {
-                break;
-            }
-            assert!(
-                Instant::now() < deadline,
-                "attach chain survived owner death: bridge={bridge_gone}, interior={interior_gone}, exec={exec_gone}"
-            );
-            std::thread::sleep(Duration::from_millis(50));
-        }
-
-        let second = std::process::Command::new("docker")
-            .args(["exec", &container, "flock", "-n", &seat, "true"])
-            .status()
-            .expect("attempt second interior attach");
-        assert!(second.success(), "the second attach should acquire the freed controller seat");
-    }
-
-    fn wait_for_docker_pid(container: &str, pid_file: &str, timeout: Duration) -> String {
-        let deadline = Instant::now() + timeout;
-        loop {
-            let output =
-                std::process::Command::new("docker").args(["exec", container, "cat", pid_file]).output().expect("read interior PID");
-            if output.status.success() {
-                return String::from_utf8_lossy(&output.stdout).trim().to_string();
-            }
-            assert!(Instant::now() < deadline, "timed out waiting for interior attach PID");
-            std::thread::sleep(Duration::from_millis(50));
-        }
-    }
-
-    fn docker_process_exists(container: &str, pid: &str) -> bool {
-        std::process::Command::new("docker")
-            .args(["exec", container, "test", "-e", &format!("/proc/{pid}")])
-            .status()
-            .is_ok_and(|status| status.success())
-    }
-
-    fn cleat_sessions() -> String {
-        let output = std::process::Command::new("cleat").args(["list", "--json"]).output().expect("list cleat sessions");
-        String::from_utf8_lossy(&output.stdout).into_owned()
-    }
-
-    fn host_processes() -> String {
-        let output = std::process::Command::new("ps").args(["-eo", "args="]).output().expect("list host processes");
-        String::from_utf8_lossy(&output.stdout).into_owned()
-    }
-
-    fn wait_for_path(path: &Path, timeout: Duration) {
-        let deadline = Instant::now() + timeout;
-        while !path.exists() {
-            assert!(Instant::now() < deadline, "timed out waiting for {}", path.display());
-            std::thread::sleep(Duration::from_millis(25));
-        }
+        assert_eq!(prepared.cleanup_actions.len(), 2);
+        assert_eq!(prepared.cleanup_actions[0][0], Arg::Literal("kill-inner".into()));
+        assert_eq!(prepared.cleanup_actions[1][0], Arg::Literal("cleat".into()));
+        assert_eq!(prepared.cleanup_actions[1][1], Arg::Literal("kill".into()));
     }
 
     #[test]

--- a/crates/flotilla-tui/src/terminal.rs
+++ b/crates/flotilla-tui/src/terminal.rs
@@ -1,6 +1,8 @@
 use std::{
     collections::HashSet,
     io::stdout,
+    path::PathBuf,
+    process::{Child, Stdio},
     sync::{LazyLock, Mutex, MutexGuard, Once},
 };
 
@@ -28,6 +30,10 @@ fn reinitialize_terminal() -> ratatui::DefaultTerminal {
 
 trait AttachCommandRunner {
     fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String>;
+
+    fn start_cleanup_watchdog(&mut self, _commands: &[String]) -> Result<Option<CleanupWatchdog>, String> {
+        Ok(None)
+    }
 }
 
 struct SystemAttachCommandRunner;
@@ -40,6 +46,63 @@ static ATTACH_SIGNAL_HANDLER: Once = Once::new();
 impl AttachCommandRunner for SystemAttachCommandRunner {
     fn status(&mut self, program: &str, args: &[String]) -> Result<std::process::ExitStatus, String> {
         std::process::Command::new(program).args(args).status().map_err(|error| format!("could not start {program}: {error}"))
+    }
+
+    fn start_cleanup_watchdog(&mut self, commands: &[String]) -> Result<Option<CleanupWatchdog>, String> {
+        CleanupWatchdog::spawn(commands).map(Some)
+    }
+}
+
+struct CleanupWatchdog {
+    lease: PathBuf,
+    child: Child,
+}
+
+impl CleanupWatchdog {
+    fn spawn(commands: &[String]) -> Result<Self, String> {
+        #[cfg(unix)]
+        use std::os::unix::process::CommandExt;
+
+        let lease = std::env::temp_dir().join(format!("flotilla-attach-watchdog-{}", uuid::Uuid::new_v4()));
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lease)
+            .map_err(|error| format!("could not create attach cleanup lease {}: {error}", lease.display()))?;
+        let mut command = std::process::Command::new("sh");
+        command
+            .arg("-c")
+            .arg(
+                "parent=$1; lease=$2; shift 2; while kill -0 \"$parent\" 2>/dev/null && [ -e \"$lease\" ]; do sleep 0.05; done; \
+                 for command in \"$@\"; do sh -lc \"$command\"; done; rm -f \"$lease\"",
+            )
+            .arg("flotilla-attach-watchdog")
+            .arg(std::process::id().to_string())
+            .arg(&lease)
+            .args(commands)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        #[cfg(unix)]
+        unsafe {
+            // The watchdog must survive the attach owner's entire terminal
+            // session disappearing, not merely an individual-process signal.
+            command.pre_exec(|| if libc::setsid() == -1 { Err(std::io::Error::last_os_error()) } else { Ok(()) });
+        }
+        match command.spawn() {
+            Ok(child) => Ok(Self { lease, child }),
+            Err(error) => {
+                let _ = std::fs::remove_file(&lease);
+                Err(format!("could not start attach cleanup watchdog: {error}"))
+            }
+        }
+    }
+}
+
+impl Drop for CleanupWatchdog {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.lease);
+        let _ = self.child.wait();
     }
 }
 
@@ -81,12 +144,31 @@ fn run_send_keys_attach(
     bridge: &str,
     runner: &mut dyn AttachCommandRunner,
 ) -> Result<std::process::ExitStatus, String> {
-    let mut actions = plan.0.clone();
+    let plan = instantiate_attach_plan(plan);
+    let cleanup_commands = std::iter::once(vec![
+        flotilla_protocol::arg::Arg::Literal("cleat".into()),
+        flotilla_protocol::arg::Arg::Literal("kill".into()),
+        flotilla_protocol::arg::Arg::Quoted(bridge.to_string()),
+    ])
+    .chain(plan.0.iter().filter_map(|action| match action {
+        ResolvedAttachAction::Cleanup(args) => Some(args.clone()),
+        _ => None,
+    }))
+    .map(|args| arg::flatten(&args, 0))
+    .collect::<Vec<_>>();
+    let mut actions = plan.0.iter().filter(|action| !matches!(action, ResolvedAttachAction::Cleanup(_))).cloned().collect::<Vec<_>>();
     let Some(ResolvedAttachAction::Command(args)) = actions.pop() else {
         return Err("attach plan must end with an outer command".to_string());
     };
     let command = arg::flatten(&args, 0);
     register_attach_bridge(bridge);
+    let _watchdog = match runner.start_cleanup_watchdog(&cleanup_commands) {
+        Ok(watchdog) => watchdog,
+        Err(error) => {
+            kill_attach_bridge(bridge, runner);
+            return Err(error);
+        }
+    };
     let launch =
         match runner.status("cleat", &["launch".to_string(), bridge.to_string(), "--record".to_string(), "--cmd".to_string(), command]) {
             Ok(status) => status,
@@ -134,6 +216,46 @@ fn run_send_keys_attach(
 
     kill_attach_bridge(bridge, runner);
     result
+}
+
+fn instantiate_attach_plan(plan: &ResolvedAttachPlan) -> ResolvedAttachPlan {
+    let lease = uuid::Uuid::new_v4().simple().to_string();
+    ResolvedAttachPlan(
+        plan.0
+            .iter()
+            .cloned()
+            .map(|action| match action {
+                ResolvedAttachAction::Command(args) => ResolvedAttachAction::Command(instantiate_args(args, &lease)),
+                ResolvedAttachAction::Cleanup(args) => ResolvedAttachAction::Cleanup(instantiate_args(args, &lease)),
+                ResolvedAttachAction::SendKeys { hop, steps } => ResolvedAttachAction::SendKeys {
+                    hop,
+                    steps: steps
+                        .into_iter()
+                        .map(|step| match step {
+                            SendKeyStep::WaitForReady => SendKeyStep::WaitForReady,
+                            SendKeyStep::Type { text } => {
+                                SendKeyStep::Type { text: text.replace(flotilla_protocol::ATTACH_LEASE_PLACEHOLDER, &lease) }
+                            }
+                        })
+                        .collect(),
+                },
+            })
+            .collect(),
+    )
+}
+
+fn instantiate_args(args: Vec<flotilla_protocol::arg::Arg>, lease: &str) -> Vec<flotilla_protocol::arg::Arg> {
+    args.into_iter()
+        .map(|arg| match arg {
+            flotilla_protocol::arg::Arg::Literal(value) => {
+                flotilla_protocol::arg::Arg::Literal(value.replace(flotilla_protocol::ATTACH_LEASE_PLACEHOLDER, lease))
+            }
+            flotilla_protocol::arg::Arg::Quoted(value) => {
+                flotilla_protocol::arg::Arg::Quoted(value.replace(flotilla_protocol::ATTACH_LEASE_PLACEHOLDER, lease))
+            }
+            flotilla_protocol::arg::Arg::NestedCommand(args) => flotilla_protocol::arg::Arg::NestedCommand(instantiate_args(args, lease)),
+        })
+        .collect()
 }
 
 /// Execute an interactive attach plan and return the attached process status.
@@ -216,11 +338,20 @@ pub fn install_sigterm_handler() {
 
 #[cfg(all(test, unix))]
 mod tests {
-    use std::{collections::VecDeque, os::unix::process::ExitStatusExt, process::ExitStatus};
+    use std::{
+        collections::VecDeque,
+        os::unix::process::ExitStatusExt,
+        path::Path,
+        process::ExitStatus,
+        time::{Duration, Instant},
+    };
 
-    use flotilla_protocol::{arg::Arg, ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep};
+    use flotilla_protocol::{
+        arg::{self, Arg},
+        ResolvedAttachAction, ResolvedAttachPlan, SendKeyStep,
+    };
 
-    use super::{run_send_keys_attach, AttachCommandRunner};
+    use super::{instantiate_attach_plan, run_send_keys_attach, AttachCommandRunner};
 
     #[derive(Default)]
     struct FakeRunner {
@@ -245,6 +376,39 @@ mod tests {
     struct DockerProbeRunner {
         marker: String,
         inner: super::SystemAttachCommandRunner,
+    }
+
+    struct SigkillProbeRunner {
+        ready: String,
+        inner: super::SystemAttachCommandRunner,
+    }
+
+    struct DockerLivenessCleanup {
+        bridge: String,
+        container: String,
+    }
+
+    impl Drop for DockerLivenessCleanup {
+        fn drop(&mut self) {
+            let _ = std::process::Command::new("cleat").args(["kill", &self.bridge]).status();
+            let _ = std::process::Command::new("docker").args(["rm", "-f", &self.container]).status();
+        }
+    }
+
+    impl AttachCommandRunner for SigkillProbeRunner {
+        fn status(&mut self, program: &str, args: &[String]) -> Result<ExitStatus, String> {
+            if program == "cleat" && args.first().is_some_and(|command| command == "attach") {
+                std::fs::write(&self.ready, b"ready").map_err(|error| format!("write SIGKILL probe marker: {error}"))?;
+                loop {
+                    std::thread::sleep(Duration::from_secs(60));
+                }
+            }
+            self.inner.status(program, args)
+        }
+
+        fn start_cleanup_watchdog(&mut self, commands: &[String]) -> Result<Option<super::CleanupWatchdog>, String> {
+            self.inner.start_cleanup_watchdog(commands)
+        }
     }
 
     impl AttachCommandRunner for DockerProbeRunner {
@@ -307,6 +471,218 @@ mod tests {
         let wait = &runner.calls[1].1;
         assert!(wait.windows(2).any(|pair| pair == ["--screen-stable", "100ms"]));
         assert!(!runner.calls.iter().any(|(_, args)| args.iter().any(|arg| arg == "expect")));
+    }
+
+    #[test]
+    fn attach_plan_instantiation_shares_one_fresh_lease() {
+        let placeholder = flotilla_protocol::ATTACH_LEASE_PLACEHOLDER;
+        let plan = ResolvedAttachPlan(vec![
+            ResolvedAttachAction::SendKeys { hop: "Docker".into(), steps: vec![SendKeyStep::Type { text: format!("echo {placeholder}") }] },
+            ResolvedAttachAction::Cleanup(vec![Arg::Quoted(format!("kill {placeholder}"))]),
+            ResolvedAttachAction::Command(vec![Arg::NestedCommand(vec![Arg::Quoted(format!("run {placeholder}"))])]),
+        ]);
+
+        let instantiated = instantiate_attach_plan(&plan);
+        let rendered = format!("{instantiated:?}");
+        assert!(!rendered.contains(placeholder));
+        let lease = rendered.split("echo ").nth(1).and_then(|rest| rest.split('"').next()).expect("instantiated lease");
+        assert_eq!(rendered.matches(lease).count(), 3, "all lifecycle actions should share the lease: {rendered}");
+        assert!(format!("{plan:?}").contains(placeholder), "instantiation must not mutate the deterministic resolved plan");
+    }
+
+    #[test]
+    fn attach_sigkill_helper() {
+        let Ok(bridge) = std::env::var("FLOTILLA_ATTACH_SIGKILL_BRIDGE") else { return };
+        let ready = std::env::var("FLOTILLA_ATTACH_SIGKILL_READY").expect("SIGKILL helper ready path");
+        let cleaned = std::env::var("FLOTILLA_ATTACH_SIGKILL_CLEANED").expect("SIGKILL helper cleanup path");
+        let plan = if let Ok(container) = std::env::var("FLOTILLA_ATTACH_SIGKILL_CONTAINER") {
+            let pid_file = std::env::var("FLOTILLA_ATTACH_SIGKILL_PID_FILE").expect("SIGKILL helper PID file");
+            let seat = std::env::var("FLOTILLA_ATTACH_SIGKILL_SEAT").expect("SIGKILL helper seat path");
+            ResolvedAttachPlan(vec![
+                ResolvedAttachAction::SendKeys {
+                    hop: "Docker SIGKILL probe".into(),
+                    steps: vec![
+                        SendKeyStep::Type {
+                            text: arg::flatten(
+                                &[
+                                    Arg::Literal("exec".into()),
+                                    Arg::Literal("sh".into()),
+                                    Arg::Literal("-c".into()),
+                                    Arg::Quoted(format!("echo $$ > {pid_file}; exec flock -n {seat} sleep 300")),
+                                ],
+                                0,
+                            ),
+                        },
+                        SendKeyStep::WaitForReady,
+                    ],
+                },
+                ResolvedAttachAction::Cleanup(vec![
+                    Arg::Literal("docker".into()),
+                    Arg::Literal("exec".into()),
+                    Arg::Quoted(container.clone()),
+                    Arg::Literal("sh".into()),
+                    Arg::Literal("-c".into()),
+                    Arg::Quoted(format!(
+                        "pid=$(cat {pid_file} 2>/dev/null) || exit 0; kill -KILL \"$pid\" 2>/dev/null || true; rm -f {pid_file}"
+                    )),
+                ]),
+                ResolvedAttachAction::Cleanup(vec![Arg::Literal("touch".into()), Arg::Quoted(cleaned)]),
+                ResolvedAttachAction::Command(vec![
+                    Arg::Literal("docker".into()),
+                    Arg::Literal("exec".into()),
+                    Arg::Literal("-it".into()),
+                    Arg::Quoted(container),
+                    Arg::Literal("/bin/sh".into()),
+                ]),
+            ])
+        } else {
+            ResolvedAttachPlan(vec![
+                ResolvedAttachAction::SendKeys {
+                    hop: "SIGKILL probe".into(),
+                    steps: vec![SendKeyStep::Type { text: "exec sleep 300".into() }, SendKeyStep::WaitForReady],
+                },
+                ResolvedAttachAction::Cleanup(vec![Arg::Literal("touch".into()), Arg::Quoted(cleaned)]),
+                ResolvedAttachAction::Command(vec![Arg::Literal("sh".into())]),
+            ])
+        };
+        let mut runner = SigkillProbeRunner { ready, inner: super::SystemAttachCommandRunner };
+
+        run_send_keys_attach(&plan, &bridge, &mut runner).expect("SIGKILL helper attach");
+    }
+
+    #[test]
+    #[ignore = "requires the cleat binary"]
+    fn killing_attach_owner_reaps_the_bridge() {
+        let temp = tempfile::tempdir().expect("SIGKILL probe tempdir");
+        let ready = temp.path().join("ready");
+        let cleaned = temp.path().join("cleaned");
+        let bridge = format!("flotilla-attach-sigkill-{}", uuid::Uuid::new_v4());
+        let mut helper = std::process::Command::new(std::env::current_exe().expect("current test executable"))
+            .args(["attach_sigkill_helper", "--nocapture"])
+            .env("FLOTILLA_ATTACH_SIGKILL_BRIDGE", &bridge)
+            .env("FLOTILLA_ATTACH_SIGKILL_READY", &ready)
+            .env("FLOTILLA_ATTACH_SIGKILL_CLEANED", &cleaned)
+            .spawn()
+            .expect("spawn SIGKILL attach helper");
+
+        wait_for_path(&ready, Duration::from_secs(10));
+        unsafe {
+            libc::kill(helper.id() as libc::pid_t, libc::SIGKILL);
+        }
+        let _ = helper.wait();
+
+        wait_for_path(&cleaned, Duration::from_secs(3));
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let reaped = loop {
+            let output = std::process::Command::new("cleat").args(["list", "--json"]).output().expect("list cleat sessions");
+            if !String::from_utf8_lossy(&output.stdout).contains(&bridge) {
+                break true;
+            }
+            if Instant::now() >= deadline {
+                break false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        };
+        let _ = std::process::Command::new("cleat").args(["kill", &bridge]).status();
+        assert!(reaped, "attach bridge {bridge} survived its SIGKILLed owner");
+    }
+
+    #[test]
+    #[ignore = "requires Docker, cleat, and the debian:trixie-slim image"]
+    fn killing_attach_owner_reaps_docker_exec_and_frees_the_interior_seat() {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let container = format!("flotilla-attach-liveness-{suffix}");
+        let bridge = format!("flotilla-attach-liveness-{suffix}");
+        let pid_file = format!("/tmp/flotilla-attach-{suffix}.pid");
+        let seat = format!("/tmp/flotilla-attach-{suffix}.seat");
+        let temp = tempfile::tempdir().expect("Docker liveness tempdir");
+        let ready = temp.path().join("ready");
+        let cleaned = temp.path().join("cleaned");
+
+        let started = std::process::Command::new("docker")
+            .args(["run", "-d", "--name", &container, "debian:trixie-slim", "sleep", "infinity"])
+            .status()
+            .expect("start Docker liveness container");
+        assert!(started.success(), "Docker liveness container should start");
+        let _cleanup = DockerLivenessCleanup { bridge: bridge.clone(), container: container.clone() };
+
+        let mut helper = std::process::Command::new(std::env::current_exe().expect("current test executable"))
+            .args(["attach_sigkill_helper", "--nocapture"])
+            .env("FLOTILLA_ATTACH_SIGKILL_BRIDGE", &bridge)
+            .env("FLOTILLA_ATTACH_SIGKILL_READY", &ready)
+            .env("FLOTILLA_ATTACH_SIGKILL_CLEANED", &cleaned)
+            .env("FLOTILLA_ATTACH_SIGKILL_CONTAINER", &container)
+            .env("FLOTILLA_ATTACH_SIGKILL_PID_FILE", &pid_file)
+            .env("FLOTILLA_ATTACH_SIGKILL_SEAT", &seat)
+            .spawn()
+            .expect("spawn Docker attach helper");
+        wait_for_path(&ready, Duration::from_secs(10));
+
+        let pid = wait_for_docker_pid(&container, &pid_file, Duration::from_secs(5));
+        unsafe {
+            libc::kill(helper.id() as libc::pid_t, libc::SIGKILL);
+        }
+        let _ = helper.wait();
+        wait_for_path(&cleaned, Duration::from_secs(3));
+
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            let bridge_gone = !cleat_sessions().contains(&bridge);
+            let interior_gone = !docker_process_exists(&container, &pid);
+            let exec_gone = !host_processes().contains(&format!("docker exec -it {container} /bin/sh"));
+            if bridge_gone && interior_gone && exec_gone {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "attach chain survived owner death: bridge={bridge_gone}, interior={interior_gone}, exec={exec_gone}"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        let second = std::process::Command::new("docker")
+            .args(["exec", &container, "flock", "-n", &seat, "true"])
+            .status()
+            .expect("attempt second interior attach");
+        assert!(second.success(), "the second attach should acquire the freed controller seat");
+    }
+
+    fn wait_for_docker_pid(container: &str, pid_file: &str, timeout: Duration) -> String {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let output =
+                std::process::Command::new("docker").args(["exec", container, "cat", pid_file]).output().expect("read interior PID");
+            if output.status.success() {
+                return String::from_utf8_lossy(&output.stdout).trim().to_string();
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for interior attach PID");
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn docker_process_exists(container: &str, pid: &str) -> bool {
+        std::process::Command::new("docker")
+            .args(["exec", container, "test", "-e", &format!("/proc/{pid}")])
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    fn cleat_sessions() -> String {
+        let output = std::process::Command::new("cleat").args(["list", "--json"]).output().expect("list cleat sessions");
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn host_processes() -> String {
+        let output = std::process::Command::new("ps").args(["-eo", "args="]).output().expect("list host processes");
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn wait_for_path(path: &Path, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while !path.exists() {
+            assert!(Instant::now() < deadline, "timed out waiting for {}", path.display());
+            std::thread::sleep(Duration::from_millis(25));
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -808,7 +808,7 @@ async fn run_control_command(cli: &Cli, command: Command, format: OutputFormat) 
     if let CommandValue::ConvoyStarted { name, attach_plan: Some(plan), binding } = result {
         if matches!(format, OutputFormat::Human) {
             stamp_pane_identity(&name, binding.as_ref()).await;
-            return run_attach_plan(&plan);
+            return run_attach_plan(&*daemon, &plan).await;
         }
     }
     Ok(())
@@ -852,7 +852,7 @@ async fn run_attach(cli: &Cli, reference: &str, transient: bool, host: Option<&s
                 if !transient {
                     stamp_pane_identity(reference, binding.as_ref()).await;
                 }
-                run_attach_plan(&plan)
+                run_attach_plan(&*daemon, &plan).await
             }
         },
         CommandValue::Error { message } => match format {
@@ -1118,8 +1118,26 @@ fn print_resource_watch_event(response: &flotilla_protocol::ResourceReadEnvelope
     }
 }
 
-fn run_attach_plan(plan: &flotilla_protocol::ResolvedAttachPlan) -> Result<()> {
-    let status = flotilla_tui::terminal::run_attach_plan(plan).map_err(|error| color_eyre::eyre::eyre!(error))?;
+async fn run_attach_plan(daemon: &dyn DaemonHandle, plan: &flotilla_protocol::ResolvedAttachPlan) -> Result<()> {
+    let prepared = flotilla_tui::terminal::prepare_attach_plan(plan);
+    if let Some(excursion_id) = prepared.excursion_id {
+        daemon
+            .begin_attach_excursion(excursion_id, prepared.cleanup_actions.clone())
+            .await
+            .map_err(|error| color_eyre::eyre::eyre!(error))?;
+    }
+    let attach_result = flotilla_tui::terminal::run_attach_plan(&prepared).map_err(|error| color_eyre::eyre::eyre!(error));
+    let cleanup_result = match prepared.excursion_id {
+        Some(excursion_id) => daemon.finish_attach_excursion(excursion_id).await.map_err(|error| color_eyre::eyre::eyre!(error)),
+        None => Ok(()),
+    };
+    let status = match (attach_result, cleanup_result) {
+        (Ok(status), Ok(())) => status,
+        (Err(error), Ok(())) | (Ok(_), Err(error)) => return Err(error),
+        (Err(attach_error), Err(cleanup_error)) => {
+            return Err(color_eyre::eyre::eyre!("{attach_error}; attach cleanup also failed: {cleanup_error}"));
+        }
+    };
     terminate_with_attach_status(status)
 }
 


### PR DESCRIPTION
Closes #1298.

## What changed

- Add connection-scoped attach excursions: the daemon registers compensating actions before launch and drains them on explicit completion or client EOF.
- Compose cleanup through every transport boundary, including routing Docker cleanup back through the outer SSH hop.
- Tear down innermost-to-outermost: kill the leased interior process first, then remove the outer cleat bridge.
- Stamp Docker-interior attach processes with a unique lease and verify both PID and lease identity before killing, preventing PID-reuse kills.
- Bound each daemon cleanup action so a failed inner transport cannot indefinitely prevent outer teardown.

## Root cause

Multi-hop attaches launched persistent side effects, but ownership lived in client-local signal and panic hooks. SIGKILL and network loss bypassed those hooks. Docker also deliberately leaves an execd interior process alive when the docker exec client disappears, so the interior cleat attach continued holding its controller seat.

The daemon connection is now the lifetime boundary. When that connection disappears, its remaining attach excursions are reaped without relying on client code running.

## Validation

- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- cargo test -p flotilla-daemon client_disconnect_reaps_docker_exec_and_frees_interior_seat --locked -- --ignored --nocapture

The Docker liveness harness verifies that disconnecting the upstream client reaps the docker exec client and interior PID, then permits an immediate second seat acquisition.