### PR TITLE
fix: reap abandoned checkout worktrees

### DIFF
--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -3839,6 +3839,7 @@ mod tests {
         let temp = TempDir::new().expect("tempdir");
         let clone = TestGitRepo::init(temp.path().join("clone")).with_initial_commit();
         let target = temp.path().join("checkout-root/convoy-a/flotilla.feature-prune");
+        let stale_target = temp.path().join("checkout-root/stale-convoy/flotilla.feature-stale");
         let commands = Arc::new(StdMutex::new(Vec::new()));
         let runtime = CheckoutControllerRuntime { runner: Arc::new(RecordingProcessRunner { commands: Arc::clone(&commands) }) };
 
@@ -3851,6 +3852,23 @@ mod tests {
             )
             .await
             .expect("worktree should create");
+        runtime
+            .create_worktree(
+                clone.path().to_str().expect("utf-8 clone path"),
+                "feature/stale",
+                Some("main"),
+                stale_target.to_str().expect("utf-8 stale target path"),
+            )
+            .await
+            .expect("stale worktree should create");
+        fs::remove_dir_all(&stale_target).expect("simulate checkout directory disappearing without git cleanup");
+        let stale_worktrees = ProcessCommand::new("git")
+            .args(["-C", clone.path().to_str().expect("utf-8 clone path"), "worktree", "list", "--porcelain"])
+            .output()
+            .expect("git should list stale worktree metadata");
+        assert!(String::from_utf8(stale_worktrees.stdout)
+            .expect("utf-8 stale worktree list")
+            .contains(stale_target.to_str().expect("utf-8 stale target path")));
         let removal = CheckoutRemoval::Worktree {
             clone_path: clone.path().to_str().expect("utf-8 clone path").to_string(),
             branch: "feature/prune".to_string(),
@@ -3864,7 +3882,12 @@ mod tests {
             .output()
             .expect("git should list worktrees");
         assert!(worktrees.status.success());
-        assert!(!String::from_utf8(worktrees.stdout).expect("utf-8 worktree list").contains(target.to_str().expect("utf-8 target path")));
+        let worktrees = String::from_utf8(worktrees.stdout).expect("utf-8 worktree list");
+        assert!(!worktrees.contains(target.to_str().expect("utf-8 target path")));
+        assert!(
+            !worktrees.contains(stale_target.to_str().expect("utf-8 stale target path")),
+            "base-clone prune must remove stale metadata"
+        );
         assert!(!target.exists(), "checkout resource cleanup must not retain its directory");
         assert!(commands
             .lock()

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2295,6 +2295,7 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
                     return Err(remove.stderr);
                 }
                 remove_checkout_path(&*runner, target_path).await?;
+                runner.run("git", &["-C", clone_path, "worktree", "prune"], Path::new("/"), &ChannelLabel::Noop).await?;
                 remove_empty_checkout_parents(clone_path, target_path).await?;
 
                 let branch_ref = format!("refs/heads/{branch}");
@@ -3804,6 +3805,72 @@ mod tests {
             .status()
             .expect("git should inspect the branch");
         assert!(!branch.success(), "zero-commit convoy branch should be deleted");
+    }
+
+    #[tokio::test]
+    async fn checkout_runtime_prunes_base_clone_after_removing_worktree() {
+        struct RecordingProcessRunner {
+            commands: Arc<StdMutex<Vec<Vec<String>>>>,
+        }
+
+        #[async_trait]
+        impl CommandRunner for RecordingProcessRunner {
+            async fn run(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<String, String> {
+                self.commands
+                    .lock()
+                    .expect("command lock")
+                    .push(std::iter::once(cmd.to_string()).chain(args.iter().map(|arg| (*arg).to_string())).collect());
+                ProcessCommandRunner.run(cmd, args, cwd, label).await
+            }
+
+            async fn run_output(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<CommandOutput, String> {
+                self.commands
+                    .lock()
+                    .expect("command lock")
+                    .push(std::iter::once(cmd.to_string()).chain(args.iter().map(|arg| (*arg).to_string())).collect());
+                ProcessCommandRunner.run_output(cmd, args, cwd, label).await
+            }
+
+            async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
+                ProcessCommandRunner.exists(cmd, args).await
+            }
+        }
+
+        let temp = TempDir::new().expect("tempdir");
+        let clone = TestGitRepo::init(temp.path().join("clone")).with_initial_commit();
+        let target = temp.path().join("checkout-root/convoy-a/flotilla.feature-prune");
+        let commands = Arc::new(StdMutex::new(Vec::new()));
+        let runtime = CheckoutControllerRuntime { runner: Arc::new(RecordingProcessRunner { commands: Arc::clone(&commands) }) };
+
+        runtime
+            .create_worktree(
+                clone.path().to_str().expect("utf-8 clone path"),
+                "feature/prune",
+                Some("main"),
+                target.to_str().expect("utf-8 target path"),
+            )
+            .await
+            .expect("worktree should create");
+        let removal = CheckoutRemoval::Worktree {
+            clone_path: clone.path().to_str().expect("utf-8 clone path").to_string(),
+            branch: "feature/prune".to_string(),
+            target_path: target.to_str().expect("utf-8 target path").to_string(),
+        };
+
+        runtime.remove_checkout(&removal).await.expect("worktree cleanup should prune its base clone");
+
+        let worktrees = ProcessCommand::new("git")
+            .args(["-C", clone.path().to_str().expect("utf-8 clone path"), "worktree", "list", "--porcelain"])
+            .output()
+            .expect("git should list worktrees");
+        assert!(worktrees.status.success());
+        assert!(!String::from_utf8(worktrees.stdout).expect("utf-8 worktree list").contains(target.to_str().expect("utf-8 target path")));
+        assert!(!target.exists(), "checkout resource cleanup must not retain its directory");
+        assert!(commands
+            .lock()
+            .expect("command lock")
+            .iter()
+            .any(|command| { command == &["git", "-C", clone.path().to_str().expect("utf-8 clone path"), "worktree", "prune"] }));
     }
 
     #[tokio::test]

--- a/crates/flotilla-resources/tests/controller_loop.rs
+++ b/crates/flotilla-resources/tests/controller_loop.rs
@@ -14,8 +14,9 @@ use flotilla_resources::{
         Actuation, ControllerLoop, LabelJoinWatch, LabelMappedWatch, ReconcileErrorPolicy, ReconcileFailure, ReconcileOutcome, Reconciler,
         ResolverLabelMappedWatch,
     },
-    ApiPaths, InMemoryBackend, InputMeta, LifecycleAuthority, NoStatusPatch, Presentation, PresentationSpec, Resource, ResourceBackend,
-    ResourceError, ResourceObject, StatusPatch, TypedResolver, Vessel, VesselSpec,
+    ApiPaths, Checkout, CheckoutSpec, CheckoutWorktreeSpec, InMemoryBackend, InputMeta, LifecycleAuthority, NoStatusPatch, Presentation,
+    PresentationSpec, RepositoryKey, Resource, ResourceBackend, ResourceError, ResourceObject, StatusPatch, TypedResolver, Vessel,
+    VesselSpec,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -1633,6 +1634,7 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
     let primaries = backend.clone().using::<PrimaryResource>("flotilla");
     let presentations = backend.clone().using::<Presentation>("flotilla");
     let vessels = backend.clone().using::<Vessel>("flotilla");
+    let checkouts = backend.clone().using::<Checkout>("flotilla");
     primaries.create(&primary_meta("alpha"), &PrimarySpec { value: "one".to_string() }).await.expect("primary create should succeed");
     presentations
         .create(
@@ -1655,6 +1657,20 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
         })
         .await
         .expect("task workspace create should succeed");
+    checkouts
+        .create(
+            &resource_meta().name("adopted-checkout").call().with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: RepositoryKey("repo-a".to_string()),
+                env_ref: "host-direct-a".to_string(),
+                r#ref: "feature/adopted".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/adopted".to_string(),
+                clone_ref: "clone-a".to_string(),
+            }),
+        )
+        .await
+        .expect("adopted checkout create should succeed");
 
     let reconciled = Arc::new(Mutex::new(Vec::new()));
     let mut harness = TestLoopHarness::new();
@@ -1691,10 +1707,41 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
     let mut harness = TestLoopHarness::new();
     harness.spawn(
         ControllerLoop {
-            primary: primaries,
+            primary: primaries.clone(),
             secondaries: Vec::new(),
             reconciler: ActuatingReconciler {
                 actuation: Actuation::DeleteVessel { name: "observed-task".to_string() },
+                reconciled: Some(Arc::clone(&reconciled)),
+            },
+            resync_interval: Duration::from_secs(60),
+            backend: backend.clone(),
+        }
+        .run(),
+    );
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if reconciled.lock().expect("reconciled lock").iter().any(|name| name == "alpha") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("delete task workspace actuation should run");
+    let vessel = vessels.get("observed-task").await.expect("observed task workspace should remain");
+    assert_eq!(vessel.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
+
+    harness.shutdown().await;
+
+    let reconciled = Arc::new(Mutex::new(Vec::new()));
+    let mut harness = TestLoopHarness::new();
+    harness.spawn(
+        ControllerLoop {
+            primary: primaries,
+            secondaries: Vec::new(),
+            reconciler: ActuatingReconciler {
+                actuation: Actuation::DeleteCheckout { name: "adopted-checkout".to_string() },
                 reconciled: Some(Arc::clone(&reconciled)),
             },
             resync_interval: Duration::from_secs(60),
@@ -1712,9 +1759,9 @@ async fn controller_loop_delete_actuations_preserve_observed_and_adopted_resourc
         }
     })
     .await
-    .expect("delete task workspace actuation should run");
-    let vessel = vessels.get("observed-task").await.expect("observed task workspace should remain");
-    assert_eq!(vessel.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Observed));
+    .expect("delete checkout actuation should run");
+    let checkout = checkouts.get("adopted-checkout").await.expect("adopted checkout owner record should remain");
+    assert_eq!(checkout.metadata.lifecycle_authority().expect("authority label should parse"), Some(LifecycleAuthority::Adopted));
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -11,11 +11,12 @@ use common::{
 use flotilla_resources::{
     controller::{Actuation, Reconciler},
     controller_patches, interactive_single_workflow_spec, reconcile, Checkout, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec,
-    CheckoutStatus, ConditionValue, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatus, ConvoyStatusPatch,
-    ConvoyTeardownRuntime, CrewSource, CrewWorkPhase, InMemoryBackend, InputMeta, InputValue, IntegrationCondition, LandedEvidence,
-    ObservedCheckoutSpec, OwnerReference, Presentation, PresentationSpec, RepositoryKey, ResourceBackend, StatusPatch, TargetMismatch,
-    TerminalSession, TerminalSessionSource, TerminalSessionSpec, ValidationError, Vessel, VesselPhase, VesselSpec, VesselStatus,
-    WorkCompletionAuthority, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL, VESSEL_LABEL,
+    CheckoutStatus, CheckoutWorktreeSpec, ConditionValue, Convoy, ConvoyEvent, ConvoyPhase, ConvoyReconciler, ConvoyStatus,
+    ConvoyStatusPatch, ConvoyTeardownRuntime, CrewSource, CrewWorkPhase, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
+    LandedEvidence, LifecycleAuthority, ObservedCheckoutSpec, OwnerReference, Presentation, PresentationSpec, RepositoryKey,
+    ResourceBackend, StatusPatch, TargetMismatch, TerminalSession, TerminalSessionSource, TerminalSessionSpec, ValidationError, Vessel,
+    VesselPhase, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkflowSnapshot, WorkflowTemplate, CONVOY_LABEL,
+    VESSEL_LABEL,
 };
 
 struct AlwaysEligible;
@@ -1319,6 +1320,59 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
         .actuations
         .iter()
         .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-a-implement")));
+}
+
+#[tokio::test]
+async fn abandoned_convoy_reclaims_managed_checkout_but_retains_adopted_owner_record() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    let checkouts = backend.clone().using::<Checkout>("flotilla");
+    let mut status = bootstrapped_tool_only_convoy_status();
+    status.phase = ConvoyPhase::Abandoned;
+    status.finished_at = Some(timestamp(20));
+    let source = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+    let created = convoys.create(&convoy_meta("convoy-a"), &source.spec).await.expect("convoy create");
+    convoys
+        .update_status("convoy-a", &created.metadata.resource_version, source.status.as_ref().expect("convoy status"))
+        .await
+        .expect("convoy status update");
+
+    let checkout_spec = CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+        repo_ref: RepositoryKey("repo-a".to_string()),
+        env_ref: "host-direct-a".to_string(),
+        r#ref: "feature/abandon".to_string(),
+        base_ref: Some("main".to_string()),
+        target_path: "/checkouts/convoy-a/repo-a".to_string(),
+        clone_ref: "clone-a".to_string(),
+    });
+    for (name, authority) in [("managed-checkout", LifecycleAuthority::Managed), ("adopted-checkout", LifecycleAuthority::Adopted)] {
+        checkouts
+            .create(
+                &InputMeta::builder()
+                    .name(name.to_string())
+                    .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string())]))
+                    .build()
+                    .with_lifecycle_authority(authority),
+                &checkout_spec,
+            )
+            .await
+            .expect("checkout create");
+    }
+
+    let convoy = convoys.get("convoy-a").await.expect("convoy get");
+    let reconciler = ConvoyReconciler::new(templates).with_checkouts(checkouts).with_teardown_runtime(Arc::new(AlwaysEligible));
+    let deps = reconciler.fetch_dependencies(&convoy).await.expect("dependencies");
+    let outcome = reconciler.reconcile(&convoy, &deps, timestamp(21));
+
+    assert!(outcome
+        .actuations
+        .iter()
+        .any(|actuation| matches!(actuation, Actuation::DeleteCheckout { name } if name == "managed-checkout")));
+    assert!(!outcome
+        .actuations
+        .iter()
+        .any(|actuation| matches!(actuation, Actuation::DeleteCheckout { name } if name == "adopted-checkout")));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Follow-up to #1300 for the checkout leak added to #1297 after the original PR merged.

## Summary

- prune the base clone after removing every managed checkout worktree
- keep checkout finalization pending if directory removal or worktree pruning fails
- verify abandoned convoys reclaim managed checkouts while adopted checkout resources remain as owner records

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
