### PR TITLE
fix: decouple environment teardown from mount metadata

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/environment.rs
+++ b/crates/flotilla-controllers/src/reconcilers/environment.rs
@@ -122,4 +122,13 @@ where
     fn finalizer_name(&self) -> Option<&'static str> {
         Some("flotilla.work/environment-teardown")
     }
+
+    fn finalizer_error_patch(&self, obj: &ResourceObject<Self::Resource>, error: &ResourceError) -> Option<EnvironmentStatusPatch> {
+        let message = format!("environment teardown failed: {error}");
+        if obj.status.as_ref().is_some_and(|status| status.phase == EnvironmentPhase::Failed && status.message.as_deref() == Some(&message))
+        {
+            return None;
+        }
+        Some(EnvironmentStatusPatch::MarkFailed { message })
+    }
 }

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -47,6 +47,10 @@ impl EnvironmentProvider for FakeEnvironmentProvider {
     async fn list(&self) -> Result<Vec<Arc<dyn ProvisionedEnvironment>>, String> {
         Ok(vec![])
     }
+
+    async fn destroy(&self, _container_id: &str) -> Result<(), String> {
+        Err("unused in test".to_string())
+    }
 }
 
 #[derive(Default)]

--- a/crates/flotilla-controllers/tests/environment_reconciler.rs
+++ b/crates/flotilla-controllers/tests/environment_reconciler.rs
@@ -3,8 +3,8 @@ use std::{collections::BTreeSet, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use flotilla_controllers::reconcilers::{DockerEnvironmentRuntime, DockerProvisioning, DockerProvisioningError, EnvironmentReconciler};
 use flotilla_resources::{
-    controller::Reconciler, DockerEnvironmentSpec, Environment, EnvironmentSpec, EnvironmentStatusPatch, EnvironmentWaitReason, InputMeta,
-    ResourceBackend,
+    controller::Reconciler, DockerEnvironmentSpec, Environment, EnvironmentPhase, EnvironmentSpec, EnvironmentStatus,
+    EnvironmentStatusPatch, EnvironmentWaitReason, InputMeta, ResourceBackend, ResourceError, StatusPatch,
 };
 
 struct WaitingDockerRuntime;
@@ -55,4 +55,28 @@ async fn pool_exhaustion_stays_pending_with_a_legible_requeued_wait() {
             reason: EnvironmentWaitReason::MaterialPoolExhausted { pool_ref },
         }) if message == "waiting for agent login material; 2 in pool, all leased" && pool_ref == "agent-login"
     ));
+}
+
+#[tokio::test]
+async fn finalizer_error_surfaces_as_failed_environment_status() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let environment = backend
+        .using::<Environment>("flotilla")
+        .create(&InputMeta::builder().name("env-corrupt-metadata".to_string()).build(), &EnvironmentSpec {
+            host_direct: None,
+            docker: None,
+        })
+        .await
+        .expect("create environment");
+    let reconciler = EnvironmentReconciler::new(Arc::new(WaitingDockerRuntime));
+    let error = ResourceError::other("failed to parse provisioned mount metadata: corrupt label");
+
+    let patch = reconciler
+        .finalizer_error_patch(&environment, &error)
+        .expect("environment finalizer errors should produce a visible failed status");
+    let mut status = EnvironmentStatus::default();
+    patch.apply(&mut status);
+
+    assert_eq!(status.phase, EnvironmentPhase::Failed);
+    assert_eq!(status.message.as_deref(), Some("environment teardown failed: failed to parse provisioned mount metadata: corrupt label"));
 }

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -577,6 +577,10 @@ mod tests {
         async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
             Ok(vec![])
         }
+
+        async fn destroy(&self, _container_id: &str) -> Result<(), String> {
+            Err("unused in test".to_string())
+        }
     }
 
     fn mock_handle(

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -3502,6 +3502,9 @@ impl EnvironmentProvider for MockEnvironmentProvider {
     async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
         Ok(vec![])
     }
+    async fn destroy(&self, _container_id: &str) -> Result<(), String> {
+        Err("unused in test".to_string())
+    }
 }
 
 struct MockProvisionedEnvironment {

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -223,6 +223,10 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
 
         Ok(handles)
     }
+
+    async fn destroy(&self, container_id: &str) -> Result<(), String> {
+        self.inner.destroy(container_id).await
+    }
 }
 
 fn dockerfile_image_tag(spec_path: &Path, abs_path: &Path) -> Result<String, String> {

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -154,12 +154,14 @@ impl From<flotilla_resources::DockerImagePullPolicy> for ImagePullPolicy {
 pub struct ProvisionedMount {
     pub host_path: DaemonHostPath,
     pub environment_path: ExecutionEnvironmentPath,
+    #[serde(default)]
     pub mode: ProvisionedMountMode,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ProvisionedMountMode {
+    #[default]
     Ro,
     Rw,
 }
@@ -179,6 +181,11 @@ pub trait EnvironmentProvider: Send + Sync {
     async fn ensure_image(&self, spec: &EnvironmentSpec, repo_root: &Path) -> Result<ImageId, String>;
     async fn create(&self, id: EnvironmentId, image: &ImageId, opts: CreateOpts) -> Result<EnvironmentHandle, String>;
     async fn list(&self) -> Result<Vec<EnvironmentHandle>, String>;
+    /// Destroy an environment using only its stable provider identity.
+    ///
+    /// Teardown must not depend on parsing mutable actuated-object metadata:
+    /// that metadata can outlive the daemon version which wrote it.
+    async fn destroy(&self, container_id: &str) -> Result<(), String>;
 }
 
 /// A handle to a single provisioned sandbox environment instance.

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -601,6 +601,22 @@ async fn list_preserves_provisioned_mount_metadata() {
 }
 
 #[tokio::test]
+async fn list_defaults_mount_mode_from_pre_mode_metadata() {
+    let runner = Arc::new(RecordingRunner::new_ok(
+        "container-1\ttest-env-list\tubuntu:22.04\t[{\"host_path\":\"/host/reference-repo\",\"environment_path\":\"/ref/repo\"}]\n",
+    ));
+    let provider = DockerEnvironmentProvider::new(runner);
+
+    let handles = provider.list().await.expect("pre-mode mount metadata should remain readable");
+
+    assert_eq!(
+        handles[0].provisioned_mounts(),
+        vec![ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro)],
+        "mounts written before mode existed were mounted read-only",
+    );
+}
+
+#[tokio::test]
 async fn list_fails_on_malformed_reference_repo_mount_metadata() {
     use flotilla_protocol::ImageId;
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1874,8 +1874,8 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
 
     async fn destroy(&self, environment_ref: &str, container_id: &str) -> Result<(), String> {
         let active = self.state.provisioned_environments.lock().await.remove(container_id);
-        let handle = match active {
-            Some(active) => Some(active.handle),
+        match active {
+            Some(active) => active.handle.destroy().await?,
             None => {
                 let (_, provider) = self
                     .state
@@ -1884,11 +1884,8 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
                     .get("docker")
                     .or_else(|| self.state.local_registry.environment_providers.preferred_with_desc())
                     .ok_or_else(|| "docker environment provider unavailable during teardown".to_string())?;
-                provider.list().await?.into_iter().find(|handle| handle.container_name() == Some(container_id))
+                provider.destroy(container_id).await?;
             }
-        };
-        if let Some(handle) = handle {
-            handle.destroy().await?;
         }
         let _ = self.state.daemon.remove_provisioned_environment(&EnvironmentId::new(environment_ref));
         let cleanup_errors =
@@ -3200,6 +3197,10 @@ mod tests {
         async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
             Ok(Vec::new())
         }
+
+        async fn destroy(&self, _container_id: &str) -> Result<(), String> {
+            Err("not used".to_string())
+        }
     }
 
     struct CapturingFailingEnvironmentProvider {
@@ -3218,6 +3219,10 @@ mod tests {
         }
 
         async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
+            Err("not used".to_string())
+        }
+
+        async fn destroy(&self, _container_id: &str) -> Result<(), String> {
             Err("not used".to_string())
         }
     }
@@ -3271,7 +3276,14 @@ mod tests {
         }
 
         async fn list(&self) -> Result<Vec<EnvironmentHandle>, String> {
-            Ok(vec![Arc::clone(&self.handle)])
+            Err("failed to parse provisioned mount metadata: corrupt label".to_string())
+        }
+
+        async fn destroy(&self, container_id: &str) -> Result<(), String> {
+            if self.handle.container_name() != Some(container_id) {
+                return Err(format!("container {container_id} not found"));
+            }
+            self.handle.destroy().await
         }
     }
 
@@ -3578,7 +3590,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_teardown_after_restart_destroys_the_container_before_releasing_runtime_state() {
+    async fn docker_teardown_after_restart_does_not_parse_corrupt_mount_metadata() {
         let temp = TempDir::new().expect("tempdir");
         let config_base = temp.path().join("config");
         fs::create_dir_all(&config_base).expect("config directory");


### PR DESCRIPTION
Closes #1310

## What changed

- add an environment-provider teardown operation that accepts the stable container identity directly
- use that operation after daemon restart instead of listing and fully parsing container mount metadata
- default mount metadata written before the `mode` field existed to its historical read-only behavior
- surface environment finalizer failures through the resource's failed status and message

## Root cause

Restart teardown rediscovered a container through `EnvironmentProvider::list()`. That path deserialized the full `flotilla.provisioned_mounts` label before returning a handle, so a required-field schema change made the container impossible to reclaim.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- focused legacy-label, restart-teardown, and finalizer-status regression tests