### PR TITLE
fix: quarantine undecodable replay events

### DIFF
--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1224,26 +1224,60 @@ async fn resource_replication_content_condition(daemon: &Arc<InProcessDaemon>, n
 }
 
 fn resource_decode_quarantine_condition(diagnostics: Option<&flotilla_resources::ResourceStoreDiagnostics>) -> Option<HostCondition> {
-    let quarantines = &diagnostics?.decode_quarantines;
-    if quarantines.is_empty() {
+    let diagnostics = diagnostics?;
+    let object_quarantines = &diagnostics.decode_quarantines;
+    let event_quarantines = &diagnostics.event_decode_quarantines;
+    if object_quarantines.is_empty() && event_quarantines.is_empty() {
         return None;
     }
-    let identities = quarantines
+    let identities = object_quarantines
         .iter()
         .map(|quarantine| format!("{}/{}: {}", quarantine.kind, quarantine.name, quarantine.error))
+        .chain(
+            event_quarantines
+                .iter()
+                .map(|quarantine| format!("{}/{}@{}: {}", quarantine.kind, quarantine.name, quarantine.event_version, quarantine.error)),
+        )
         .collect::<Vec<_>>()
         .join("; ");
+    let (reason, message) = if event_quarantines.is_empty() {
+        (
+            "StoredObjectDecodeFailed",
+            format!(
+                "{} stored resource object{} quarantined after typed decode failure{}: {identities}",
+                object_quarantines.len(),
+                if object_quarantines.len() == 1 { "" } else { "s" },
+                if object_quarantines.len() == 1 { "" } else { "s" },
+            ),
+        )
+    } else if object_quarantines.is_empty() {
+        (
+            "StoredEventDecodeFailed",
+            format!(
+                "{} stored resource event{} quarantined after typed decode failure{}: {identities}",
+                event_quarantines.len(),
+                if event_quarantines.len() == 1 { "" } else { "s" },
+                if event_quarantines.len() == 1 { "" } else { "s" },
+            ),
+        )
+    } else {
+        (
+            "StoredResourceDecodeFailed",
+            format!(
+                "{} stored resource object{} and {} event{} quarantined after typed decode failures: {identities}",
+                object_quarantines.len(),
+                if object_quarantines.len() == 1 { "" } else { "s" },
+                event_quarantines.len(),
+                if event_quarantines.len() == 1 { "" } else { "s" },
+            ),
+        )
+    };
     Some(
         HostCondition::builder()
             .condition_type("ResourceStore/DecodeQuarantine")
             .value(ConditionValue::False)
-            .reason("StoredObjectDecodeFailed")
-            .message(format!(
-                "{} stored resource object{} quarantined after typed decode failure{}: {identities}",
-                quarantines.len(),
-                if quarantines.len() == 1 { "" } else { "s" },
-                if quarantines.len() == 1 { "" } else { "s" },
-            ))
+            .reason(reason)
+            .message(message)
             .observed_at(Utc::now())
             .build(),
     )
@@ -5383,6 +5417,27 @@ mod tests {
             "startup recovery must retain leases until an environment's finalizer removes it from the store"
         );
         world.runtime.take().expect("sequence restarted daemon runtime").shutdown();
+    }
+
+    #[test]
+    fn fleet_diagnosis_surfaces_event_decode_quarantines() {
+        let mut diagnostics = flotilla_resources::ResourceStoreDiagnostics::default();
+        diagnostics.event_decode_quarantines.push(
+            flotilla_resources::ResourceEventDecodeQuarantine::builder()
+                .kind("CredentialSpec".to_string())
+                .namespace("flotilla".to_string())
+                .name("forgejo-token".to_string())
+                .event_version(17)
+                .error("missing field `username`".to_string())
+                .quarantined_at(Utc::now())
+                .build(),
+        );
+
+        let condition = resource_decode_quarantine_condition(Some(&diagnostics)).expect("quarantine should degrade fleet health");
+        assert_eq!(condition.condition_type, "ResourceStore/DecodeQuarantine");
+        assert_eq!(condition.reason, "StoredEventDecodeFailed");
+        assert!(condition.message.contains("CredentialSpec/forgejo-token@17"), "unexpected diagnosis: {}", condition.message);
+        assert!(condition.message.contains("missing field `username`"), "unexpected diagnosis: {}", condition.message);
     }
 
     fn insert_undecodable_resource<T: Resource>(connection: &rusqlite::Connection, name: &str) {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -33,9 +33,9 @@ use flotilla_protocol::{
 use flotilla_resources::{
     list_resource_kind, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, CrewSessionStatus,
     HttpBackend, InMemoryBackend, InputMeta, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend,
-    ResourceError, ResourceProvenance, Selector, Stance, StatusPatch, TerminalAttentionState, TerminalBrief, TerminalCrewContext,
-    TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, WatchEvent, WatchStart,
-    WorkflowTemplate,
+    ResourceError, ResourceList, ResourceProvenance, Selector, SqliteBackend, Stance, StatusPatch, TerminalAttentionState, TerminalBrief,
+    TerminalCrewContext, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
+    WatchEvent, WatchStart, WorkflowTemplate,
 };
 use flotilla_test_support::TestSocketDir;
 use flotilla_transport::message::{message_session_pair, MessageSession};
@@ -142,6 +142,120 @@ async fn resource_http_lists_and_watches_over_a_unix_socket() {
     ));
 
     server.await.expect("resource HTTP server task");
+    std::fs::remove_file(&socket_path).expect("remove resource HTTP socket");
+}
+
+#[tokio::test]
+async fn http_replication_skips_an_old_schema_event_and_reaches_unrelated_resources() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let origin_path = temp.path().join("origin.sqlite");
+    let origin = ResourceBackend::Sqlite(SqliteBackend::open(&origin_path).expect("open origin store"));
+    let origin_convoys = origin.using::<Convoy>("flotilla");
+    let first = origin_convoys
+        .create(
+            &InputMeta::builder().name("superseded".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("old-workflow".to_string()).build(),
+        )
+        .await
+        .expect("create event that predates the schema change");
+    origin_convoys
+        .update(
+            &InputMeta::builder().name("superseded".to_string()).build(),
+            &first.metadata.resource_version,
+            &ConvoySpec::builder().workflow_ref("current-workflow".to_string()).build(),
+        )
+        .await
+        .expect("write a full superseding event");
+    origin_convoys
+        .create(
+            &InputMeta::builder().name("unrelated".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("healthy-workflow".to_string()).build(),
+        )
+        .await
+        .expect("write an unrelated later event");
+    drop(origin_convoys);
+    drop(origin);
+
+    let connection = rusqlite::Connection::open(&origin_path).expect("open raw origin store");
+    let body: String = connection
+        .query_row("SELECT body_json FROM resource_events WHERE event_version = 1", [], |row| row.get(0))
+        .expect("read historical event");
+    let mut body: serde_json::Value = serde_json::from_str(&body).expect("decode historical event");
+    body.pointer_mut("/spec")
+        .expect("historical event should contain a spec")
+        .as_object_mut()
+        .expect("historical spec should be an object")
+        .remove("workflow_ref");
+    connection
+        .execute("UPDATE resource_events SET body_json = ?1 WHERE event_version = 1", [
+            serde_json::to_string(&body).expect("encode old-schema event")
+        ])
+        .expect("remove a now-required field from the historical event");
+    drop(connection);
+    let origin = ResourceBackend::Sqlite(SqliteBackend::open(&origin_path).expect("reopen origin after schema upgrade"));
+
+    let holder_backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let origin_root = NodeId::new("origin-root");
+    holder_backend
+        .replica_writer::<Convoy>(origin_root.clone(), "flotilla")
+        .replace(&ResourceList { items: Vec::new(), resource_version: "0".to_string(), generation: None }, chrono::Utc::now())
+        .await
+        .expect("seed a pre-upgrade replica cursor");
+    let holder = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        test_config_store(temp.path().join("holder")),
+        fake_discovery(false),
+        HostName::new("holder"),
+        holder_backend.clone(),
+    )
+    .await;
+
+    let socket_path = PathBuf::from(format!("/tmp/flotilla-event-quarantine-http-{}.sock", uuid::Uuid::new_v4()));
+    let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind origin resource HTTP socket");
+    let server_backend = origin.clone();
+    let server = tokio::spawn(async move {
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().await.expect("accept resource HTTP request");
+            let first_byte = tokio::io::AsyncReadExt::read_u8(&mut stream).await.expect("read HTTP preface");
+            let backend = server_backend.clone();
+            tokio::spawn(async move {
+                serve_resource_http(stream, first_byte, backend).await.expect("serve resource HTTP request");
+            });
+        }
+    });
+
+    let http = HttpBackend::from_unix_socket(&socket_path).expect("build resource HTTP client");
+    let holder_for_replication = Arc::clone(&holder);
+    let origin_for_replication = origin_root.clone();
+    let replicator =
+        tokio::spawn(async move { replicate_kind_over_http::<Convoy>(http, &holder_for_replication, &origin_for_replication).await });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let replicas = holder_backend.including_replicas::<Convoy>("flotilla").list().await.expect("list replicated convoys");
+            let names = replicas.items.iter().map(|item| item.object.metadata.name.as_str()).collect::<Vec<_>>();
+            if names.contains(&"superseded") && names.contains(&"unrelated") {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("replication should advance past the quarantined event");
+
+    let diagnostics = origin.diagnostics().await.expect("read origin diagnostics").expect("sqlite diagnostics");
+    let [quarantine] = diagnostics.event_decode_quarantines.as_slice() else {
+        panic!("expected one visible event quarantine, got {:?}", diagnostics.event_decode_quarantines)
+    };
+    assert_eq!(quarantine.kind, "Convoy");
+    assert_eq!(quarantine.name, "superseded");
+    assert_eq!(quarantine.event_version, 1);
+    assert!(quarantine.error.contains("workflow_ref"), "unexpected quarantine error: {}", quarantine.error);
+
+    replicator.abort();
+    server.abort();
+    let _ = replicator.await;
+    let _ = server.await;
     std::fs::remove_file(&socket_path).expect("remove resource HTTP socket");
 }
 

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -113,7 +113,9 @@ pub use resource::{
     api_version, ApiPaths, CausalDot, FieldMergeMetadata, InputMeta, K8sListMeta, K8sObjectMeta, K8sResourceList, K8sResourceObject,
     K8sWatchEvent, MergeConflictSibling, MergeMetadata, ObjectMeta, OwnerReference, Resource, ResourceObject,
 };
-pub use retention::{EventRetention, ResourceDecodeQuarantine, ResourceStoreDiagnostics, ResourceStoreWarning};
+pub use retention::{
+    EventRetention, ResourceDecodeQuarantine, ResourceEventDecodeQuarantine, ResourceStoreDiagnostics, ResourceStoreWarning,
+};
 pub use sqlite::SqliteBackend;
 pub use status_patch::{apply_status_patch, apply_status_patch_checked, NoStatusPatch, StatusPatch};
 pub use terminal_session::{

--- a/crates/flotilla-resources/src/retention.rs
+++ b/crates/flotilla-resources/src/retention.rs
@@ -47,6 +47,16 @@ pub struct ResourceDecodeQuarantine {
     pub quarantined_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct ResourceEventDecodeQuarantine {
+    pub kind: String,
+    pub namespace: String,
+    pub name: String,
+    pub event_version: u64,
+    pub error: String,
+    pub quarantined_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ResourceStoreDiagnostics {
     pub object_count: u64,
@@ -57,6 +67,8 @@ pub struct ResourceStoreDiagnostics {
     pub warnings: Vec<ResourceStoreWarning>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub decode_quarantines: Vec<ResourceDecodeQuarantine>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub event_decode_quarantines: Vec<ResourceEventDecodeQuarantine>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub field_ownership_violations: Vec<FieldOwnershipViolation>,
 }
@@ -81,6 +93,7 @@ impl ResourceStoreDiagnostics {
             max_retained_events,
             warnings,
             decode_quarantines: Vec::new(),
+            event_decode_quarantines: Vec::new(),
             field_ownership_violations: Vec::new(),
         }
     }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -17,7 +17,9 @@ use crate::{
     error::ResourceError,
     replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
     resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
-    retention::{EventRetention, ResourceDecodeQuarantine, ResourceStoreDiagnostics, MAX_FIELD_OWNERSHIP_VIOLATIONS},
+    retention::{
+        EventRetention, ResourceDecodeQuarantine, ResourceEventDecodeQuarantine, ResourceStoreDiagnostics, MAX_FIELD_OWNERSHIP_VIOLATIONS,
+    },
     watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
     FieldOwnershipViolation,
 };
@@ -44,6 +46,17 @@ pub struct SqliteBackend {
 struct StoredEvent {
     kind: StoredEventKind,
     object: Value,
+}
+
+struct ReplayedEvents<T: Resource> {
+    events: Vec<WatchEvent<T>>,
+    quarantines: Vec<EventDecodeWarning>,
+}
+
+struct EventDecodeWarning {
+    event_version: u64,
+    name: String,
+    error: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -192,6 +205,19 @@ impl SqliteBackend {
                     namespace TEXT NOT NULL,
                     compacted_through INTEGER NOT NULL,
                     PRIMARY KEY (group_name, version, kind, namespace)
+                );
+
+                CREATE TABLE IF NOT EXISTS resource_event_decode_quarantine (
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    event_version INTEGER NOT NULL,
+                    name TEXT NOT NULL,
+                    body_json TEXT NOT NULL,
+                    error TEXT NOT NULL,
+                    quarantined_at TEXT NOT NULL,
+                    PRIMARY KEY (group_name, version, kind, namespace, event_version)
                 );
 
                 CREATE TABLE IF NOT EXISTS field_ownership_violations (
@@ -358,6 +384,36 @@ impl SqliteBackend {
         let mut diagnostics = ResourceStoreDiagnostics::new(object_count, event_count, resource_stream_count, event_retention);
         diagnostics.decode_quarantines = decode_quarantines;
         let mut statement = connection
+            .prepare(
+                r#"
+                SELECT kind, namespace, name, event_version, error, quarantined_at
+                FROM resource_event_decode_quarantine
+                ORDER BY kind, namespace, event_version
+                "#,
+            )
+            .map_err(|err| Self::map_sqlite(err, "prepare sqlite resource event decode quarantine diagnostics"))?;
+        diagnostics.event_decode_quarantines = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, u64>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                ))
+            })
+            .map_err(|err| Self::map_sqlite(err, "query sqlite resource event decode quarantine diagnostics"))?
+            .map(|row| {
+                let (kind, namespace, name, event_version, error, quarantined_at) =
+                    row.map_err(|err| Self::map_sqlite(err, "read sqlite resource event decode quarantine diagnostic"))?;
+                let quarantined_at = DateTime::parse_from_rfc3339(&quarantined_at)
+                    .map_err(|err| ResourceError::decode(format!("decode resource event quarantine timestamp: {err}")))?
+                    .with_timezone(&Utc);
+                Ok(ResourceEventDecodeQuarantine { kind, namespace, name, event_version, error, quarantined_at })
+            })
+            .collect::<Result<Vec<_>, ResourceError>>()?;
+        let mut statement = connection
             .prepare("SELECT body_json FROM field_ownership_violations ORDER BY id")
             .map_err(|err| Self::map_sqlite(err, "prepare field ownership violation diagnostics"))?;
         diagnostics.field_ownership_violations = statement
@@ -501,6 +557,14 @@ impl SqliteBackend {
             params![key.0, key.1, key.2, key.3, compacted_through],
         )
         .map_err(|err| Self::map_sqlite(err, "compact sqlite resource events"))?;
+        tx.execute(
+            r#"
+            DELETE FROM resource_event_decode_quarantine
+            WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND event_version <= ?5
+            "#,
+            params![key.0, key.1, key.2, key.3, compacted_through],
+        )
+        .map_err(|err| Self::map_sqlite(err, "compact sqlite resource event decode quarantine"))?;
         tx.execute(
             r#"
             INSERT INTO resource_event_compaction (group_name, version, kind, namespace, compacted_through)
@@ -1315,15 +1379,26 @@ impl SqliteBackend {
         let replay = self
             .call(move |connection| {
                 let replay = match replay_from {
-                    Some(version) => Self::replay_events(connection, &key, version)?,
-                    None => Vec::new(),
+                    Some(version) => Self::replay_events::<T>(connection, &key, version)?,
+                    None => ReplayedEvents { events: Vec::new(), quarantines: Vec::new() },
                 };
                 Self::lock_watchers(&watchers)?.entry(key).or_default().push(sender);
                 Ok(replay)
             })
             .await?;
 
-        let replay_stream = stream::iter(replay.into_iter().map(Self::decode_event::<T>));
+        for warning in replay.quarantines {
+            tracing::warn!(
+                kind = T::API_PATHS.kind,
+                namespace,
+                name = %warning.name,
+                event_version = warning.event_version,
+                error = %warning.error,
+                "quarantined undecodable stored resource event"
+            );
+        }
+
+        let replay_stream = stream::iter(replay.events.into_iter().map(Ok));
         let live_stream = stream::unfold(receiver, |mut receiver| async {
             receiver.recv().await.map(|event| (Self::decode_event::<T>(event), receiver))
         });
@@ -1386,7 +1461,11 @@ impl SqliteBackend {
         Ok(())
     }
 
-    fn replay_events(conn: &RusqliteConnection, key: &StoreKey, replay_from: u64) -> Result<Vec<StoredEvent>, ResourceError> {
+    fn replay_events<T: Resource>(
+        conn: &mut RusqliteConnection,
+        key: &StoreKey,
+        replay_from: u64,
+    ) -> Result<ReplayedEvents<T>, ResourceError> {
         let compacted_through = conn
             .query_row(
                 r#"
@@ -1408,22 +1487,62 @@ impl SqliteBackend {
         let mut statement = conn
             .prepare(
                 r#"
-                SELECT event_type, body_json FROM resource_events
+                SELECT event_version, event_type, body_json FROM resource_events
                 WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND event_version > ?5
                 ORDER BY event_version
                 "#,
             )
             .map_err(|err| Self::map_sqlite(err, "prepare sqlite resource event replay"))?;
         let rows = statement
-            .query_map(params![key.0, key.1, key.2, key.3, replay_from], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+            .query_map(params![key.0, key.1, key.2, key.3, replay_from], |row| {
+                Ok((row.get::<_, u64>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+            })
             .map_err(|err| Self::map_sqlite(err, "query sqlite resource event replay"))?;
+        let rows = rows.collect::<Result<Vec<_>, _>>().map_err(|err| Self::map_sqlite(err, "read sqlite resource event replay row"))?;
+        drop(statement);
         let mut events = Vec::new();
-        for row in rows {
-            let (event_type, body_json) = row.map_err(|err| Self::map_sqlite(err, "read sqlite resource event replay row"))?;
-            let object =
-                serde_json::from_str(&body_json).map_err(|err| ResourceError::decode(format!("decode stored event JSON: {err}")))?;
-            events.push(StoredEvent { kind: StoredEventKind::from_str(&event_type)?, object });
+        let mut failures = Vec::new();
+        for (event_version, event_type, body_json) in rows {
+            let value =
+                serde_json::from_str::<Value>(&body_json).map_err(|err| ResourceError::decode(format!("decode stored event JSON: {err}")));
+            let name = value
+                .as_ref()
+                .ok()
+                .and_then(|value| value.pointer("/metadata/name"))
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>")
+                .to_string();
+            let decoded = value
+                .and_then(|object| Ok(StoredEvent { kind: StoredEventKind::from_str(&event_type)?, object }))
+                .and_then(Self::decode_event::<T>);
+            match decoded {
+                Ok(event) => events.push(event),
+                Err(error) => failures.push((event_version, name, body_json, error.to_string())),
+            }
         }
-        Ok(events)
+        if !failures.is_empty() {
+            let quarantined_at = Utc::now().to_rfc3339();
+            let tx = conn.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource event decode quarantine"))?;
+            for (event_version, name, body_json, error) in &failures {
+                tx.execute(
+                    r#"
+                    INSERT INTO resource_event_decode_quarantine
+                        (group_name, version, kind, namespace, event_version, name, body_json, error, quarantined_at)
+                    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                    ON CONFLICT(group_name, version, kind, namespace, event_version)
+                    DO UPDATE SET name = excluded.name,
+                                  body_json = excluded.body_json,
+                                  error = excluded.error,
+                                  quarantined_at = excluded.quarantined_at
+                    "#,
+                    params![key.0, key.1, key.2, key.3, event_version, name, body_json, error, quarantined_at],
+                )
+                .map_err(|err| Self::map_sqlite(err, "persist sqlite resource event decode quarantine"))?;
+            }
+            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource event decode quarantine"))?;
+        }
+        let quarantines =
+            failures.into_iter().map(|(event_version, name, _, error)| EventDecodeWarning { event_version, name, error }).collect();
+        Ok(ReplayedEvents { events, quarantines })
     }
 }

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -81,6 +81,39 @@ impl Resource for SlowResource {
     const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.test", version: "v1", plural: "slowresources", kind: "SlowResource" };
 }
 
+#[derive(Debug, Clone, Copy)]
+struct LegacyReplayCredential;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LegacyReplayCredentialSpec {
+    service: String,
+}
+
+impl Resource for LegacyReplayCredential {
+    type Spec = LegacyReplayCredentialSpec;
+    type Status = ();
+    type StatusPatch = NoStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.test", version: "v1", plural: "replaycredentials", kind: "ReplayCredential" };
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CurrentReplayCredential;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CurrentReplayCredentialSpec {
+    service: String,
+    username: String,
+}
+
+impl Resource for CurrentReplayCredential {
+    type Spec = CurrentReplayCredentialSpec;
+    type Status = ();
+    type StatusPatch = NoStatusPatch;
+
+    const API_PATHS: ApiPaths = LegacyReplayCredential::API_PATHS;
+}
+
 macro_rules! resource_contract_tests {
     ($module:ident, $fixture:ty) => {
         mod $module {
@@ -670,6 +703,126 @@ async fn watch_from_version_replays_events_persisted_before_restart() {
         WatchEvent::Modified(object) => assert_eq!(object.metadata.resource_version, updated.metadata.resource_version),
         other => panic!("expected modified event, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn watch_replay_skips_an_undecodable_historical_event_and_reaches_later_resources() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should open"));
+    backend
+        .using::<LegacyReplayCredential>("flotilla")
+        .create(&resource_meta().name("superseded").call(), &LegacyReplayCredentialSpec { service: "forgejo".to_string() })
+        .await
+        .expect("create old-schema event");
+    drop(backend);
+
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("sqlite backend should reopen after schema upgrade"));
+    backend
+        .using::<CurrentReplayCredential>("flotilla")
+        .create(&resource_meta().name("healthy").call(), &CurrentReplayCredentialSpec {
+            service: "forgejo".to_string(),
+            username: "robert".to_string(),
+        })
+        .await
+        .expect("create current-schema event");
+
+    let mut watch = backend
+        .using::<CurrentReplayCredential>("flotilla")
+        .watch(WatchStart::FromVersion("0".to_string()))
+        .await
+        .expect("watch should start");
+    let event = timeout(Duration::from_secs(1), watch.next())
+        .await
+        .expect("watch replay should remain live past the poison event")
+        .expect("later event should be delivered")
+        .expect("later event should decode");
+
+    let WatchEvent::Added(object) = event else { panic!("expected added event") };
+    assert_eq!(object.metadata.name, "healthy");
+
+    let diagnostics = backend.diagnostics().await.expect("read quarantine diagnostics").expect("sqlite diagnostics");
+    let [quarantine] = diagnostics.event_decode_quarantines.as_slice() else {
+        panic!("expected one event quarantine, got {:?}", diagnostics.event_decode_quarantines)
+    };
+    assert_eq!(quarantine.kind, "ReplayCredential");
+    assert_eq!(quarantine.namespace, "flotilla");
+    assert_eq!(quarantine.name, "superseded");
+    assert_eq!(quarantine.event_version, 1);
+    assert!(quarantine.error.contains("missing field `username`"), "unexpected quarantine error: {}", quarantine.error);
+}
+
+#[tokio::test]
+async fn compaction_removes_a_superseded_event_quarantine_with_its_event() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("resources.sqlite");
+    let retention = EventRetention::new(2).expect("valid retention");
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open_with_event_retention(&path, retention).expect("sqlite backend should open"));
+    let resolver = backend.using::<CurrentReplayCredential>("flotilla");
+    let first = resolver
+        .create(&resource_meta().name("superseded").call(), &CurrentReplayCredentialSpec {
+            service: "forgejo".to_string(),
+            username: "old".to_string(),
+        })
+        .await
+        .expect("create first event");
+    resolver
+        .update(&resource_meta().name("superseded").call(), &first.metadata.resource_version, &CurrentReplayCredentialSpec {
+            service: "forgejo".to_string(),
+            username: "current".to_string(),
+        })
+        .await
+        .expect("replace resource with a superseding event");
+    drop(resolver);
+    drop(backend);
+
+    let connection = rusqlite::Connection::open(&path).expect("open raw sqlite connection");
+    let body: String = connection
+        .query_row("SELECT body_json FROM resource_events WHERE event_version = 1", [], |row| row.get(0))
+        .expect("read first event body");
+    let mut body: serde_json::Value = serde_json::from_str(&body).expect("decode first event body");
+    body.pointer_mut("/spec")
+        .expect("event body should contain spec")
+        .as_object_mut()
+        .expect("spec should be an object")
+        .remove("username");
+    connection
+        .execute("UPDATE resource_events SET body_json = ?1 WHERE event_version = 1", [
+            serde_json::to_string(&body).expect("encode old-schema body")
+        ])
+        .expect("downgrade first event body");
+    drop(connection);
+
+    let backend =
+        ResourceBackend::Sqlite(SqliteBackend::open_with_event_retention(&path, retention).expect("sqlite backend should reopen"));
+    let resolver = backend.using::<CurrentReplayCredential>("flotilla");
+    let mut watch = resolver.watch(WatchStart::FromVersion("0".to_string())).await.expect("watch should start");
+    let replayed = watch.next().await.expect("superseding event should replay").expect("superseding event should decode");
+    let WatchEvent::Modified(object) = replayed else { panic!("expected modified event") };
+    assert_eq!(object.spec.username, "current");
+    assert_eq!(
+        backend.diagnostics().await.expect("read quarantine diagnostics").expect("sqlite diagnostics").event_decode_quarantines.len(),
+        1
+    );
+
+    resolver
+        .create(&resource_meta().name("compaction-trigger").call(), &CurrentReplayCredentialSpec {
+            service: "forgejo".to_string(),
+            username: "healthy".to_string(),
+        })
+        .await
+        .expect("create event that advances the compaction floor");
+    assert!(
+        backend
+            .diagnostics()
+            .await
+            .expect("read post-compaction diagnostics")
+            .expect("sqlite diagnostics")
+            .event_decode_quarantines
+            .is_empty(),
+        "compaction should retire the quarantine when it removes the superseded event"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1309.

## What changed

- Decode historical SQLite watch events at replay time and skip individual events that no longer match the current resource schema.
- Persist event quarantine diagnostics with kind, namespace, name, event version, error, body, and timestamp.
- Surface event quarantines through the existing fleet `ResourceStore/DecodeQuarantine` condition.
- Remove event quarantine records when retention compaction removes their corresponding historical rows.

## Root cause and impact

Stored event JSON was parsed during replay, but typed resource decoding happened later as each watch item was consumed. One old-schema item therefore reached the resource HTTP handler as an error, closed the entire watch connection, and permanently blocked every later event in that resource stream. Typed decoding now happens at the SQLite replay boundary, where one bad row can be recorded and omitted without terminating the stream.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Regression coverage includes Unix-socket HTTP replication from a pre-upgrade cursor, an unrelated resource behind the poison event, fleet diagnosis visibility, and quarantine retirement through compaction.