### PR TITLE
fix: keep contained daemon sockets live across restarts

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -404,7 +404,7 @@ async fn connect_required_host_daemon_with_optional_surface(
 ) -> Result<Arc<SocketDaemon>, String> {
     connect_existing_stateful(socket_path, surface.as_ref()).await?.ok_or_else(|| {
         format!(
-            "host daemon socket stale or unreachable at {}; FLOTILLA_DAEMON_SOCKET is set, so a local daemon will not be spawned",
+            "host daemon socket stale or unreachable at {}; this contained environment requires the host daemon, so a local daemon will not be spawned",
             socket_path.display()
         )
     })

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -381,6 +381,35 @@ pub async fn connect_or_spawn_with_surface(
     connect_or_spawn_with_optional_surface(socket_path, config_dir, config_dir_override, socket_override, Some(surface)).await
 }
 
+/// Connect to the host daemon exposed inside a contained environment.
+///
+/// Unlike [`connect_or_spawn`], this never acquires a spawn lock, removes a
+/// stale socket, or starts a daemon. A missing listener means the host-owned
+/// control-plane mount is stale or unreachable and must be repaired outside
+/// the contained environment.
+pub async fn connect_required_host_daemon(socket_path: &Path) -> Result<Arc<SocketDaemon>, String> {
+    connect_required_host_daemon_with_optional_surface(socket_path, None).await
+}
+
+pub async fn connect_required_host_daemon_with_surface(
+    socket_path: &Path,
+    surface: SurfaceDeclaration,
+) -> Result<Arc<SocketDaemon>, String> {
+    connect_required_host_daemon_with_optional_surface(socket_path, Some(surface)).await
+}
+
+async fn connect_required_host_daemon_with_optional_surface(
+    socket_path: &Path,
+    surface: Option<SurfaceDeclaration>,
+) -> Result<Arc<SocketDaemon>, String> {
+    connect_existing_stateful(socket_path, surface.as_ref()).await?.ok_or_else(|| {
+        format!(
+            "host daemon socket stale or unreachable at {}; FLOTILLA_DAEMON_SOCKET is set, so a local daemon will not be spawned",
+            socket_path.display()
+        )
+    })
+}
+
 async fn connect_or_spawn_with_optional_surface(
     socket_path: &Path,
     config_dir: &Path,

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -214,6 +214,19 @@ async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_con
 }
 
 #[tokio::test]
+async fn required_host_daemon_connection_never_enters_the_spawn_path() {
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("missing-host-daemon.sock");
+    let lock_path = std::path::PathBuf::from(format!("{}.lock", socket_path.display()));
+
+    let error = connect_required_host_daemon(&socket_path).await.err().expect("a missing host daemon socket should fail");
+
+    assert!(error.contains("host daemon socket stale or unreachable"), "unexpected error: {error}");
+    assert!(error.contains("a local daemon will not be spawned"), "unexpected error: {error}");
+    assert!(!lock_path.exists(), "connect-only mode must not create a daemon spawn lock");
+}
+
+#[tokio::test]
 async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning() {
     let dir = TestSocketDir::new();
     let socket_path = dir.socket_path("daemon.sock");

--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -4,8 +4,8 @@ use flotilla_core::{
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     providers::{
         environment::{
-            CreateOpts, EnvironmentProvider, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind,
-            EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
+            contained_daemon_socket_path, CreateOpts, EnvironmentProvider, EnvironmentTool, EnvironmentToolAsset,
+            EnvironmentToolAssetAccess, EnvironmentToolAssetKind, EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
         },
         terminal::TerminalPool,
         vcs::{CloneInspection, CloneProvisioner},
@@ -46,6 +46,7 @@ impl DockerEnvironmentActuator {
     }
 
     pub fn build_create_opts(&self, spec: &DockerEnvironmentSpec) -> CreateOpts {
+        let environment_socket_path = contained_daemon_socket_path(self.daemon_socket_path.as_path());
         CreateOpts {
             tokens: self.tokens.clone(),
             working_directory: None,
@@ -55,12 +56,16 @@ impl DockerEnvironmentActuator {
             tools: vec![EnvironmentTool::new("flotilla-daemon-access", "/usr/local/bin/flotilla")
                 .with_asset(EnvironmentToolAsset::new(
                     self.daemon_socket_path.as_path().to_path_buf(),
-                    "/run/flotilla.sock",
+                    environment_socket_path.clone(),
                     EnvironmentToolAssetKind::UnixSocket,
                     EnvironmentToolAssetAccess::SharedWritable,
                     "the daemon socket",
                 ))
-                .with_environment(EnvironmentVariableUpdate::set("FLOTILLA_DAEMON_SOCKET", "/run/flotilla.sock", "the daemon socket"))],
+                .with_environment(EnvironmentVariableUpdate::set(
+                    "FLOTILLA_DAEMON_SOCKET",
+                    environment_socket_path.to_string_lossy(),
+                    "the daemon socket",
+                ))],
         }
     }
 }

--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -6,6 +6,7 @@ use flotilla_core::{
         environment::{
             contained_daemon_socket_path, CreateOpts, EnvironmentProvider, EnvironmentTool, EnvironmentToolAsset,
             EnvironmentToolAssetAccess, EnvironmentToolAssetKind, EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
+            CONTAINED_DAEMON_REQUIRED_ENV,
         },
         terminal::TerminalPool,
         vcs::{CloneInspection, CloneProvisioner},
@@ -65,6 +66,11 @@ impl DockerEnvironmentActuator {
                     "FLOTILLA_DAEMON_SOCKET",
                     environment_socket_path.to_string_lossy(),
                     "the daemon socket",
+                ))
+                .with_environment(EnvironmentVariableUpdate::set(
+                    CONTAINED_DAEMON_REQUIRED_ENV,
+                    "1",
+                    "the contained host-daemon requirement",
                 ))],
         }
     }

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -18,8 +18,8 @@ use crate::{
             FactoryRegistry,
         },
         environment::{
-            CreateOpts, EnvironmentHandle, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind,
-            EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
+            contained_daemon_socket_path, CreateOpts, EnvironmentHandle, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess,
+            EnvironmentToolAssetKind, EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
         },
         registry::ProviderRegistry,
         CommandRunner,
@@ -273,6 +273,7 @@ impl EnvironmentManager {
             .as_ref()
             .map(|repo| vec![ProvisionedMount::new(repo.as_path().to_path_buf(), PathBuf::from("/ref/repo"), ProvisionedMountMode::Ro)])
             .unwrap_or_default();
+        let environment_socket_path = contained_daemon_socket_path(daemon_socket_path.as_path());
         let opts = CreateOpts {
             tokens,
             working_directory: None,
@@ -280,12 +281,16 @@ impl EnvironmentManager {
             tools: vec![EnvironmentTool::new("flotilla-daemon-access", "/usr/local/bin/flotilla")
                 .with_asset(EnvironmentToolAsset::new(
                     daemon_socket_path.as_path().to_path_buf(),
-                    "/run/flotilla.sock",
+                    environment_socket_path.clone(),
                     EnvironmentToolAssetKind::UnixSocket,
                     EnvironmentToolAssetAccess::SharedWritable,
                     "the daemon socket",
                 ))
-                .with_environment(EnvironmentVariableUpdate::set("FLOTILLA_DAEMON_SOCKET", "/run/flotilla.sock", "the daemon socket"))],
+                .with_environment(EnvironmentVariableUpdate::set(
+                    "FLOTILLA_DAEMON_SOCKET",
+                    environment_socket_path.to_string_lossy(),
+                    "the daemon socket",
+                ))],
             image_pull_policy: Default::default(),
             docker_config_dir: None,
         };

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         environment::{
             contained_daemon_socket_path, CreateOpts, EnvironmentHandle, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess,
-            EnvironmentToolAssetKind, EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode,
+            EnvironmentToolAssetKind, EnvironmentVariableUpdate, ProvisionedMount, ProvisionedMountMode, CONTAINED_DAEMON_REQUIRED_ENV,
         },
         registry::ProviderRegistry,
         CommandRunner,
@@ -290,6 +290,11 @@ impl EnvironmentManager {
                     "FLOTILLA_DAEMON_SOCKET",
                     environment_socket_path.to_string_lossy(),
                     "the daemon socket",
+                ))
+                .with_environment(EnvironmentVariableUpdate::set(
+                    CONTAINED_DAEMON_REQUIRED_ENV,
+                    "1",
+                    "the contained host-daemon requirement",
                 ))],
             image_pull_policy: Default::default(),
             docker_config_dir: None,

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 
 use super::{
     runner::DockerEnvironmentRunner, CreateOpts, EnvironmentHandle, EnvironmentProvider, EnvironmentToolAssetAccess,
-    EnvironmentVariableUpdate, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode,
+    EnvironmentToolAssetKind, EnvironmentVariableUpdate, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode,
 };
 use crate::providers::{ChannelLabel, CommandRunner};
 
@@ -82,11 +82,24 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
                     EnvironmentToolAssetAccess::ReadOnly => ProvisionedMountMode::Ro,
                     EnvironmentToolAssetAccess::SharedWritable => ProvisionedMountMode::Rw,
                 };
-                provisioned_mounts.push(ProvisionedMount::new(
-                    asset.host_path.as_path().to_path_buf(),
-                    asset.environment_path.as_path().to_path_buf(),
-                    mode,
-                ));
+                let (host_path, environment_path) = match asset.kind {
+                    EnvironmentToolAssetKind::UnixSocket => {
+                        let host_parent = asset
+                            .host_path
+                            .as_path()
+                            .parent()
+                            .ok_or_else(|| format!("Unix socket asset {} has no host parent directory", asset.host_path))?;
+                        let environment_parent =
+                            asset.environment_path.as_path().parent().ok_or_else(|| {
+                                format!("Unix socket asset {} has no environment parent directory", asset.environment_path)
+                            })?;
+                        (host_parent.to_path_buf(), environment_parent.to_path_buf())
+                    }
+                    EnvironmentToolAssetKind::File | EnvironmentToolAssetKind::Directory => {
+                        (asset.host_path.as_path().to_path_buf(), asset.environment_path.as_path().to_path_buf())
+                    }
+                };
+                provisioned_mounts.push(ProvisionedMount::new(host_path, environment_path, mode));
             }
             for update in &tool.environment {
                 match update {

--- a/crates/flotilla-core/src/providers/environment/docker.rs
+++ b/crates/flotilla-core/src/providers/environment/docker.rs
@@ -75,9 +75,6 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
         let mut tokens = opts.tokens;
         for tool in &opts.tools {
             for asset in &tool.assets {
-                if requested_mounts.iter().chain(&provisioned_mounts).any(|mount| mount.environment_path == asset.environment_path) {
-                    return Err(format!("mount target {} is reserved for {}", asset.environment_path, asset.purpose));
-                }
                 let mode = match asset.access {
                     EnvironmentToolAssetAccess::ReadOnly => ProvisionedMountMode::Ro,
                     EnvironmentToolAssetAccess::SharedWritable => ProvisionedMountMode::Rw,
@@ -99,6 +96,9 @@ impl EnvironmentProvider for DockerEnvironmentProvider {
                         (asset.host_path.as_path().to_path_buf(), asset.environment_path.as_path().to_path_buf())
                     }
                 };
+                if requested_mounts.iter().chain(&provisioned_mounts).any(|mount| mount.environment_path.as_path() == environment_path) {
+                    return Err(format!("mount target {} is reserved for {}", environment_path.display(), asset.purpose));
+                }
                 provisioned_mounts.push(ProvisionedMount::new(host_path, environment_path, mode));
             }
             for update in &tool.environment {

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -109,6 +109,7 @@ pub enum EnvironmentToolAssetAccess {
 /// so a daemon restart can replace the socket inode without breaking the
 /// container's view of it.
 pub const CONTAINED_DAEMON_SOCKET_DIRECTORY: &str = "/run/flotilla-daemon";
+pub const CONTAINED_DAEMON_REQUIRED_ENV: &str = "FLOTILLA_CONTAINED_HOST_DAEMON";
 
 pub fn contained_daemon_socket_path(host_socket_path: &Path) -> PathBuf {
     let file_name = host_socket_path.file_name().expect("daemon socket path must name a socket file");

--- a/crates/flotilla-core/src/providers/environment/mod.rs
+++ b/crates/flotilla-core/src/providers/environment/mod.rs
@@ -104,6 +104,17 @@ pub enum EnvironmentToolAssetAccess {
     SharedWritable,
 }
 
+/// Stable directory used for the host daemon socket inside contained
+/// environments. Docker bind-mounts the host socket's parent directory here
+/// so a daemon restart can replace the socket inode without breaking the
+/// container's view of it.
+pub const CONTAINED_DAEMON_SOCKET_DIRECTORY: &str = "/run/flotilla-daemon";
+
+pub fn contained_daemon_socket_path(host_socket_path: &Path) -> PathBuf {
+    let file_name = host_socket_path.file_name().expect("daemon socket path must name a socket file");
+    Path::new(CONTAINED_DAEMON_SOCKET_DIRECTORY).join(file_name)
+}
+
 /// A tool's requested mutation to the environment it runs in.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnvironmentVariableUpdate {

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -8,22 +8,28 @@ use async_trait::async_trait;
 use flotilla_protocol::{DaemonHostPath, EnvironmentId, EnvironmentSpec, EnvironmentStatus, HostName, ImageSource};
 
 use super::{
-    docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider, EnvironmentTool,
-    EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind, EnvironmentVariableUpdate, ImagePullPolicy,
-    ProvisionedMount, ProvisionedMountMode,
+    contained_daemon_socket_path, docker::DockerEnvironmentProvider, runner::DockerEnvironmentRunner, CreateOpts, EnvironmentProvider,
+    EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind, EnvironmentVariableUpdate,
+    ImagePullPolicy, ProvisionedMount, ProvisionedMountMode,
 };
 use crate::providers::{ChannelLabel, CommandOutput, CommandRunner};
 
 fn test_daemon_tool(socket_path: impl Into<PathBuf>) -> EnvironmentTool {
+    let socket_path = socket_path.into();
+    let environment_socket_path = contained_daemon_socket_path(&socket_path);
     EnvironmentTool::new("flotilla", "/usr/local/bin/flotilla")
         .with_asset(EnvironmentToolAsset::new(
             socket_path,
-            "/run/flotilla.sock",
+            environment_socket_path.clone(),
             EnvironmentToolAssetKind::UnixSocket,
             EnvironmentToolAssetAccess::SharedWritable,
             "the daemon socket",
         ))
-        .with_environment(EnvironmentVariableUpdate::set("FLOTILLA_DAEMON_SOCKET", "/run/flotilla.sock", "the daemon socket"))
+        .with_environment(EnvironmentVariableUpdate::set(
+            "FLOTILLA_DAEMON_SOCKET",
+            environment_socket_path.to_string_lossy(),
+            "the daemon socket",
+        ))
 }
 
 /// A mock CommandRunner that records all (cmd, args, cwd) tuples passed to run/run_output.
@@ -432,7 +438,7 @@ async fn create_reports_infrastructure_and_requested_mount_metadata() {
     let reference_repo = DaemonHostPath::new("/host/reference-repo");
     let opts = CreateOpts {
         tokens: vec![],
-        tools: vec![test_daemon_tool("/run/flotilla.sock")],
+        tools: vec![test_daemon_tool("/host/daemon/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo", ProvisionedMountMode::Ro)],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -445,13 +451,13 @@ async fn create_reports_infrastructure_and_requested_mount_metadata() {
     let calls = runner.calls();
     let (_, args, _) = &calls[0];
     assert!(
-        args.windows(2).any(|pair| pair == ["-v", "/run/flotilla.sock:/run/flotilla.sock:rw"]),
-        "daemon socket should be mounted read-write; args: {args:?}",
+        args.windows(2).any(|pair| pair == ["-v", "/host/daemon:/run/flotilla-daemon:rw"]),
+        "daemon socket parent directory should be mounted read-write; args: {args:?}",
     );
     assert_eq!(
         handle.provisioned_mounts(),
         vec![
-            ProvisionedMount::new("/run/flotilla.sock", "/run/flotilla.sock", ProvisionedMountMode::Rw),
+            ProvisionedMount::new("/host/daemon", "/run/flotilla-daemon", ProvisionedMountMode::Rw),
             ProvisionedMount::new(reference_repo.as_path().to_path_buf(), "/ref/repo", ProvisionedMountMode::Ro),
         ],
         "docker provisioned environments should report infrastructure and requested bind mount metadata",
@@ -469,7 +475,11 @@ async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_path() {
         tokens: vec![],
         tools: vec![test_daemon_tool("/host/flotilla.sock")],
         working_directory: None,
-        provisioned_mounts: vec![ProvisionedMount::new("/host/replacement.sock", "/run/flotilla.sock", ProvisionedMountMode::Rw)],
+        provisioned_mounts: vec![ProvisionedMount::new(
+            "/host/replacement.sock",
+            "/run/flotilla-daemon/flotilla.sock",
+            ProvisionedMountMode::Rw,
+        )],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
         docker_config_dir: None,
     };
@@ -480,7 +490,7 @@ async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_path() {
         .err()
         .expect("reserved socket mount should be rejected");
 
-    assert_eq!(error, "mount target /run/flotilla.sock is reserved for the daemon socket");
+    assert_eq!(error, "mount target /run/flotilla-daemon/flotilla.sock is reserved for the daemon socket");
     assert!(runner.calls().is_empty(), "reserved mount collisions should fail before invoking docker");
 }
 
@@ -569,7 +579,7 @@ async fn list_preserves_provisioned_mount_metadata() {
         Ok(format!(
             "container-1\ttest-env-list\tubuntu:22.04\t{}\n",
             serde_json::to_string(&vec![
-                ProvisionedMount::new("/run/flotilla.sock", "/run/flotilla.sock", ProvisionedMountMode::Rw),
+                ProvisionedMount::new("/run", "/run/flotilla-daemon", ProvisionedMountMode::Rw),
                 ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro),
             ])
             .expect("serialize mount metadata")
@@ -593,7 +603,7 @@ async fn list_preserves_provisioned_mount_metadata() {
     assert_eq!(
         handles[0].provisioned_mounts(),
         vec![
-            ProvisionedMount::new("/run/flotilla.sock", "/run/flotilla.sock", ProvisionedMountMode::Rw),
+            ProvisionedMount::new("/run", "/run/flotilla-daemon", ProvisionedMountMode::Rw),
             ProvisionedMount::new("/host/reference-repo", "/ref/repo", ProvisionedMountMode::Ro),
         ],
         "docker list should preserve flotilla-managed bind mount metadata",

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -465,7 +465,7 @@ async fn create_reports_infrastructure_and_requested_mount_metadata() {
 }
 
 #[tokio::test]
-async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_path() {
+async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_directory() {
     use flotilla_protocol::ImageId;
 
     let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
@@ -476,8 +476,8 @@ async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_path() {
         tools: vec![test_daemon_tool("/host/flotilla.sock")],
         working_directory: None,
         provisioned_mounts: vec![ProvisionedMount::new(
-            "/host/replacement.sock",
-            "/run/flotilla-daemon/flotilla.sock",
+            "/host/replacement-socket-directory",
+            "/run/flotilla-daemon",
             ProvisionedMountMode::Rw,
         )],
         image_pull_policy: ImagePullPolicy::IfNotPresent,
@@ -490,7 +490,7 @@ async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_path() {
         .err()
         .expect("reserved socket mount should be rejected");
 
-    assert_eq!(error, "mount target /run/flotilla-daemon/flotilla.sock is reserved for the daemon socket");
+    assert_eq!(error, "mount target /run/flotilla-daemon is reserved for the daemon socket");
     assert!(runner.calls().is_empty(), "reserved mount collisions should fail before invoking docker");
 }
 

--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -495,6 +495,39 @@ async fn create_rejects_a_mount_targeting_the_reserved_daemon_socket_directory()
 }
 
 #[tokio::test]
+async fn create_rejects_a_mount_targeting_a_reserved_tool_file() {
+    use flotilla_protocol::ImageId;
+
+    let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
+    let provider = DockerEnvironmentProvider::new(runner.clone());
+    let image = ImageId::new("ubuntu:22.04");
+    let tool = EnvironmentTool::new("flotilla", "/usr/local/bin/flotilla").with_asset(EnvironmentToolAsset::new(
+        "/host/flotilla",
+        "/usr/local/bin/flotilla",
+        EnvironmentToolAssetKind::File,
+        EnvironmentToolAssetAccess::ReadOnly,
+        "the flotilla CLI",
+    ));
+    let opts = CreateOpts {
+        tokens: vec![],
+        tools: vec![tool],
+        working_directory: None,
+        provisioned_mounts: vec![ProvisionedMount::new("/host/replacement-flotilla", "/usr/local/bin/flotilla", ProvisionedMountMode::Ro)],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
+        docker_config_dir: None,
+    };
+
+    let error = provider
+        .create(EnvironmentId::new("test-env-reserved-cli"), &image, opts)
+        .await
+        .err()
+        .expect("reserved CLI mount should be rejected");
+
+    assert_eq!(error, "mount target /usr/local/bin/flotilla is reserved for the flotilla CLI");
+    assert!(runner.calls().is_empty(), "reserved mount collisions should fail before invoking docker");
+}
+
+#[tokio::test]
 async fn create_delivers_tool_assets_and_applies_tool_environment() {
     use flotilla_protocol::ImageId;
 

--- a/crates/flotilla-daemon/src/environment_tools.rs
+++ b/crates/flotilla-daemon/src/environment_tools.rs
@@ -11,7 +11,8 @@ use flotilla_core::{
     path_context::DaemonHostPath,
     providers::{
         environment::{
-            EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind, EnvironmentVariableUpdate,
+            contained_daemon_socket_path, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind,
+            EnvironmentVariableUpdate,
         },
         ChannelLabel, CommandRunner,
     },
@@ -19,7 +20,8 @@ use flotilla_core::{
 use tokio::sync::OnceCell;
 
 pub(crate) const ENVIRONMENT_FLOTILLA_PATH: &str = "/usr/local/bin/flotilla";
-pub(crate) const ENVIRONMENT_DAEMON_SOCKET_PATH: &str = "/run/flotilla.sock";
+#[cfg(test)]
+pub(crate) const ENVIRONMENT_DAEMON_SOCKET_PATH: &str = "/run/flotilla-daemon/flotilla.sock";
 pub(crate) const ENVIRONMENT_CLEAT_PATH: &str = "/usr/local/bin/cleat";
 pub(crate) const ENVIRONMENT_CLEAT_LIBRARY_DIR: &str = "/usr/local/lib/flotilla";
 pub(crate) const ENVIRONMENT_CLEAT_GHOSTTY_LIBRARY_PATH: &str = "/usr/local/lib/flotilla/libghostty-vt.so.0";
@@ -123,6 +125,7 @@ impl EnvironmentToolFactory for FlotillaCliTool {
             self.binary_path.as_ref().map_err(|error| format!("flotilla CLI unavailable for environment provisioning: {error}"))?;
         let daemon_socket_path =
             self.daemon_socket_path.as_ref().map_err(|error| format!("flotilla CLI unavailable for environment provisioning: {error}"))?;
+        let environment_socket_path = contained_daemon_socket_path(daemon_socket_path.as_path());
         Ok(EnvironmentTool::new("flotilla", ENVIRONMENT_FLOTILLA_PATH)
             .with_asset(EnvironmentToolAsset::new(
                 binary_path.as_path().to_path_buf(),
@@ -133,14 +136,14 @@ impl EnvironmentToolFactory for FlotillaCliTool {
             ))
             .with_asset(EnvironmentToolAsset::new(
                 daemon_socket_path.as_path().to_path_buf(),
-                ENVIRONMENT_DAEMON_SOCKET_PATH,
+                environment_socket_path.clone(),
                 EnvironmentToolAssetKind::UnixSocket,
                 EnvironmentToolAssetAccess::SharedWritable,
                 "the daemon socket",
             ))
             .with_environment(EnvironmentVariableUpdate::set(
                 "FLOTILLA_DAEMON_SOCKET",
-                ENVIRONMENT_DAEMON_SOCKET_PATH,
+                environment_socket_path.to_string_lossy(),
                 "the daemon socket",
             )))
     }

--- a/crates/flotilla-daemon/src/environment_tools.rs
+++ b/crates/flotilla-daemon/src/environment_tools.rs
@@ -12,7 +12,7 @@ use flotilla_core::{
     providers::{
         environment::{
             contained_daemon_socket_path, EnvironmentTool, EnvironmentToolAsset, EnvironmentToolAssetAccess, EnvironmentToolAssetKind,
-            EnvironmentVariableUpdate,
+            EnvironmentVariableUpdate, CONTAINED_DAEMON_REQUIRED_ENV,
         },
         ChannelLabel, CommandRunner,
     },
@@ -145,7 +145,8 @@ impl EnvironmentToolFactory for FlotillaCliTool {
                 "FLOTILLA_DAEMON_SOCKET",
                 environment_socket_path.to_string_lossy(),
                 "the daemon socket",
-            )))
+            ))
+            .with_environment(EnvironmentVariableUpdate::set(CONTAINED_DAEMON_REQUIRED_ENV, "1", "the contained host-daemon requirement")))
     }
 }
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -3336,6 +3336,10 @@ mod tests {
         assert_eq!(opts.tools.iter().map(|tool| tool.name.as_str()).collect::<Vec<_>>(), vec!["flotilla", "cleat"]);
         assert_eq!(opts.tools[0].executable.as_path(), Path::new(ENVIRONMENT_FLOTILLA_PATH));
         assert_eq!(opts.tools[0].assets[1].environment_path.as_path(), Path::new(ENVIRONMENT_DAEMON_SOCKET_PATH));
+        assert_eq!(
+            opts.tools[0].environment[1],
+            EnvironmentVariableUpdate::set("FLOTILLA_CONTAINED_HOST_DAEMON", "1", "the contained host-daemon requirement",),
+        );
         assert_eq!(opts.tools[1].executable.as_path(), Path::new(ENVIRONMENT_CLEAT_PATH));
         assert_eq!(opts.tools[1].assets[1].environment_path.as_path(), Path::new(ENVIRONMENT_CLEAT_GHOSTTY_LIBRARY_PATH));
         assert_eq!(opts.tools[1].assets[2].host_path.as_path(), cleat_state.as_path());

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -25,7 +25,7 @@ use flotilla_core::{
     placement_policy::reconcile_registered_policy,
     providers::{
         discovery::{run_provisioned_host_detectors, EnvironmentBag},
-        environment::{CreateOpts, EnvironmentHandle, EnvironmentVariableUpdate},
+        environment::{CreateOpts, EnvironmentHandle, EnvironmentToolAssetKind, EnvironmentVariableUpdate},
         registry::ProviderRegistry,
         terminal::{ScreenActivity, TerminalPool},
         vcs::{CloneInspection, CloneProvisioner, GitCloneProvisioner},
@@ -1656,10 +1656,17 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
         let tools = self.state.environment_tools.prepare(name).await?;
         for tool in &tools {
             for asset in &tool.assets {
-                if spec.mounts.iter().any(|mount| Path::new(&mount.target_path) == asset.environment_path.as_path()) {
+                let reserved_path = match asset.kind {
+                    EnvironmentToolAssetKind::UnixSocket => asset.environment_path.as_path().parent().ok_or_else(|| {
+                        DockerProvisioningError::Failed(format!("Unix socket asset {} has no parent directory", asset.environment_path))
+                    })?,
+                    EnvironmentToolAssetKind::File | EnvironmentToolAssetKind::Directory => asset.environment_path.as_path(),
+                };
+                if spec.mounts.iter().any(|mount| Path::new(&mount.target_path) == reserved_path) {
                     return Err(DockerProvisioningError::Failed(format!(
                         "mount target {} is reserved for {}",
-                        asset.environment_path, asset.purpose
+                        reserved_path.display(),
+                        asset.purpose
                     )));
                 }
             }
@@ -3659,7 +3666,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_provisioning_rejects_a_mount_targeting_the_reserved_cli_path() {
+    async fn docker_provisioning_rejects_a_mount_targeting_the_reserved_socket_directory() {
         let temp = TempDir::new().expect("tempdir");
         let config_base = temp.path().join("config");
         fs::create_dir_all(&config_base).expect("config directory");
@@ -3696,8 +3703,8 @@ mod tests {
             required_agent_adapters: BTreeSet::new(),
             pull_policy: Default::default(),
             mounts: vec![flotilla_resources::EnvironmentMount {
-                source_path: "/host/replacement-flotilla".to_string(),
-                target_path: "/usr/local/bin/flotilla".to_string(),
+                source_path: "/host/replacement-socket-directory".to_string(),
+                target_path: "/run/flotilla-daemon".to_string(),
                 mode: flotilla_resources::EnvironmentMountMode::Ro,
             }],
             env: BTreeMap::new(),
@@ -3706,9 +3713,9 @@ mod tests {
         let error = DockerControllerRuntime { state }
             .provision("contained-work", &spec)
             .await
-            .expect_err("reserved CLI mount should fail provision");
+            .expect_err("reserved socket directory mount should fail provision");
 
-        assert_eq!(error.to_string(), "mount target /usr/local/bin/flotilla is reserved for the flotilla CLI");
+        assert_eq!(error.to_string(), "mount target /run/flotilla-daemon is reserved for the daemon socket");
         assert!(provider.create_opts.lock().await.is_none(), "reserved mount collisions should fail before invoking the provider");
     }
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -3670,7 +3670,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn docker_provisioning_rejects_a_mount_targeting_the_reserved_socket_directory() {
+    async fn docker_provisioning_rejects_mounts_targeting_reserved_tool_assets() {
         let temp = TempDir::new().expect("tempdir");
         let config_base = temp.path().join("config");
         fs::create_dir_all(&config_base).expect("config directory");
@@ -3714,12 +3714,28 @@ mod tests {
             env: BTreeMap::new(),
         };
 
-        let error = DockerControllerRuntime { state }
+        let error = DockerControllerRuntime { state: Arc::clone(&state) }
             .provision("contained-work", &spec)
             .await
             .expect_err("reserved socket directory mount should fail provision");
 
         assert_eq!(error.to_string(), "mount target /run/flotilla-daemon is reserved for the daemon socket");
+        assert!(provider.create_opts.lock().await.is_none(), "reserved mount collisions should fail before invoking the provider");
+
+        let cli_collision_spec = flotilla_resources::DockerEnvironmentSpec {
+            mounts: vec![flotilla_resources::EnvironmentMount {
+                source_path: "/host/replacement-flotilla".to_string(),
+                target_path: "/usr/local/bin/flotilla".to_string(),
+                mode: flotilla_resources::EnvironmentMountMode::Ro,
+            }],
+            ..spec
+        };
+        let error = DockerControllerRuntime { state }
+            .provision("contained-work", &cli_collision_spec)
+            .await
+            .expect_err("reserved CLI mount should fail provision");
+
+        assert_eq!(error.to_string(), "mount target /usr/local/bin/flotilla is reserved for the flotilla CLI");
         assert!(provider.create_opts.lock().await.is_none(), "reserved mount collisions should fail before invoking the provider");
     }
 

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -213,7 +213,7 @@ async fn build_embedded_resource_backend(config: &ConfigStore) -> Result<Resourc
 }
 
 pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &ConfigStore) -> Result<tokio::task::JoinHandle<()>, String> {
-    let local_daemon_socket_path = config.base_path().join("flotilla.sock");
+    let local_daemon_socket_path = config.base_path().join("run/flotilla.sock");
     let peer_manager = build_peer_manager(&daemon, config, local_daemon_socket_path.as_path())?;
     {
         let daemon = Arc::clone(&daemon);

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -310,6 +310,7 @@ pub async fn run(
     config_dir: &Path,
     config_dir_override: Option<&Path>,
     socket_override: Option<&Path>,
+    require_host_daemon: bool,
     options: PmConnectOptions,
 ) -> Result<(), String> {
     // The connector runs headless in a PM pane: structured logs to stderr.
@@ -323,14 +324,12 @@ pub async fn run(
     let mint: Arc<dyn RecipeMint> = Arc::new(FlotillaRecipes::new(options.flotilla_bin.clone()));
     run_reconnecting(
         || async {
-            crate::socket::connect_or_spawn_with_surface(
-                socket_path,
-                config_dir,
-                config_dir_override,
-                socket_override,
-                flotilla_protocol::SurfaceDeclaration::ambient_for_namespace("flotilla"),
-            )
-            .await
+            let surface = flotilla_protocol::SurfaceDeclaration::ambient_for_namespace("flotilla");
+            if require_host_daemon {
+                crate::socket::connect_required_host_daemon_with_surface(socket_path, surface).await
+            } else {
+                crate::socket::connect_or_spawn_with_surface(socket_path, config_dir, config_dir_override, socket_override, surface).await
+            }
             .map(|daemon| daemon as Arc<dyn DaemonHandle>)
         },
         |daemon| run_connector(daemon, sink.clone(), mint.clone(), Duration::from_millis(REASSERT_INTERVAL_MS)),

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -30,9 +30,11 @@ records sessions by default, so recordings remain on the host after container
 teardown. A future image release should bake cleat into the image; the shared
 runtime root remains the durability boundary either way.
 
-The mounted Flotilla CLI connects back to the host daemon through the mounted
-socket named by `FLOTILLA_DAEMON_SOCKET`; normal CLI commands honor that
-variable, not only agent-hook delivery.
+The mounted Flotilla CLI connects back to the host daemon through the socket
+named by `FLOTILLA_DAEMON_SOCKET`. Docker mounts the socket's parent directory,
+so replacing the socket inode during a host daemon restart remains visible
+inside the environment. Normal CLI commands honor that variable, not only
+agent-hook delivery, and never try to spawn a local daemon when it is set.
 
 This document is curation advice for the Flotilla project. It is not a schema
 or a contract that Flotilla validates. Flotilla's contract stays deliberately

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -34,7 +34,10 @@ The mounted Flotilla CLI connects back to the host daemon through the socket
 named by `FLOTILLA_DAEMON_SOCKET`. Docker mounts the socket's parent directory,
 so replacing the socket inode during a host daemon restart remains visible
 inside the environment. Normal CLI commands honor that variable, not only
-agent-hook delivery, and never try to spawn a local daemon when it is set.
+agent-hook delivery. Contained delivery also sets a dedicated marker that
+prevents the CLI from trying to spawn a local daemon if the host socket is
+unreachable; host-side managed terminals retain their normal self-healing
+spawn behavior.
 
 This document is curation advice for the Flotilla project. It is not a schema
 or a contract that Flotilla validates. Flotilla's contract stays deliberately

--- a/src/bin/flotillad.rs
+++ b/src/bin/flotillad.rs
@@ -11,7 +11,7 @@ struct Cli {
     #[arg(long)]
     config_dir: Option<PathBuf>,
 
-    /// Socket path (default: ${config_dir}/flotilla.sock)
+    /// Socket path (default: ${config_dir}/run/flotilla.sock)
     #[arg(long)]
     socket: Option<PathBuf>,
 
@@ -31,7 +31,7 @@ impl Cli {
     }
 
     fn socket_path(&self) -> PathBuf {
-        self.socket.clone().unwrap_or_else(|| self.config_dir().join("flotilla.sock"))
+        self.socket.clone().unwrap_or_else(|| self.config_dir().join("run/flotilla.sock"))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ struct Cli {
     #[arg(long)]
     config_dir: Option<PathBuf>,
 
-    /// Socket path (default: ${config_dir}/flotilla.sock)
+    /// Socket path (default: ${config_dir}/run/flotilla.sock)
     #[arg(long)]
     socket: Option<PathBuf>,
 
@@ -351,11 +351,11 @@ impl Cli {
 }
 
 fn socket_path_from(explicit: Option<&Path>, config_dir: &Path, environment: Option<&std::ffi::OsStr>) -> PathBuf {
-    environment.map(PathBuf::from).or_else(|| explicit.map(PathBuf::from)).unwrap_or_else(|| config_dir.join("flotilla.sock"))
+    environment.map(PathBuf::from).or_else(|| explicit.map(PathBuf::from)).unwrap_or_else(|| config_dir.join("run/flotilla.sock"))
 }
 
-fn host_daemon_socket_required(environment: Option<&std::ffi::OsStr>) -> bool {
-    environment.is_some()
+fn host_daemon_socket_required(contained_marker: Option<&std::ffi::OsStr>) -> bool {
+    contained_marker.is_some()
 }
 
 async fn connect_cli_socket(
@@ -567,7 +567,8 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     let socket_path = cli.socket_path();
     let config_dir_override = cli.config_dir.clone();
     let socket_override = cli.socket.clone();
-    let require_host_daemon = host_daemon_socket_required(std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref());
+    let require_host_daemon =
+        host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref());
 
     // Spawn daemon init on a separate task so full-app startup can run it
     // concurrently with the splash (which uses blocking event polling).
@@ -808,7 +809,9 @@ async fn run_pm_command(cli: &Cli, command: PmSubCommand) -> Result<()> {
                 &cli.config_dir(),
                 cli.config_dir.as_deref(),
                 cli.socket.as_deref(),
-                host_daemon_socket_required(std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref()),
+                host_daemon_socket_required(
+                    std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref(),
+                ),
                 options,
             )
             .await
@@ -830,7 +833,7 @@ async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
         &config_dir,
         cli.config_dir.as_deref(),
         cli.socket.as_deref(),
-        host_daemon_socket_required(std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref()),
+        host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref()),
     )
     .await
     .map_err(|e| color_eyre::eyre::eyre!(e))?;
@@ -2141,8 +2144,13 @@ mod tests {
     }
 
     #[test]
+    fn default_socket_uses_a_dedicated_runtime_directory() {
+        assert_eq!(socket_path_from(None, Path::new("/config"), None), PathBuf::from("/config/run/flotilla.sock"));
+    }
+
+    #[test]
     fn contained_cli_socket_environment_requires_the_host_daemon() {
-        assert!(host_daemon_socket_required(Some(std::ffi::OsStr::new("/run/flotilla-daemon/flotilla.sock"))));
+        assert!(host_daemon_socket_required(Some(std::ffi::OsStr::new("1"))));
         assert!(!host_daemon_socket_required(None));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,6 +354,24 @@ fn socket_path_from(explicit: Option<&Path>, config_dir: &Path, environment: Opt
     environment.map(PathBuf::from).or_else(|| explicit.map(PathBuf::from)).unwrap_or_else(|| config_dir.join("flotilla.sock"))
 }
 
+fn host_daemon_socket_required(environment: Option<&std::ffi::OsStr>) -> bool {
+    environment.is_some()
+}
+
+async fn connect_cli_socket(
+    socket_path: &Path,
+    config_dir: &Path,
+    config_dir_override: Option<&Path>,
+    socket_override: Option<&Path>,
+    require_host_daemon: bool,
+) -> Result<Arc<flotilla_tui::socket::SocketDaemon>, String> {
+    if require_host_daemon {
+        flotilla_tui::socket::connect_required_host_daemon(socket_path).await
+    } else {
+        flotilla_tui::socket::connect_or_spawn(socket_path, config_dir, config_dir_override, socket_override).await
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     flotilla_core::tls::install_default_provider();
@@ -549,6 +567,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     let socket_path = cli.socket_path();
     let config_dir_override = cli.config_dir.clone();
     let socket_override = cli.socket.clone();
+    let require_host_daemon = host_daemon_socket_required(std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref());
 
     // Spawn daemon init on a separate task so full-app startup can run it
     // concurrently with the splash (which uses blocking event polling).
@@ -560,11 +579,12 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     let initial_config_override = config_dir_override.clone();
     let initial_socket_override = socket_override.clone();
     let daemon_task = tokio::spawn(async move {
-        flotilla_tui::socket::connect_or_spawn(
+        connect_cli_socket(
             &initial_socket_path,
             &initial_config_dir,
             initial_config_override.as_deref(),
             initial_socket_override.as_deref(),
+            require_host_daemon,
         )
         .await
         .map(|d| d as Arc<dyn DaemonHandle>)
@@ -651,11 +671,12 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
         terminal = ratatui::init();
         let connected = match flotilla_tui::socket::reconnect::connect_with_retry(
             || {
-                flotilla_tui::socket::connect_or_spawn(
+                connect_cli_socket(
                     &socket_path,
                     &resolved_config_dir,
                     config_dir_override.as_deref(),
                     socket_override.as_deref(),
+                    require_host_daemon,
                 )
             },
             |notice| {
@@ -782,9 +803,16 @@ async fn run_pm_command(cli: &Cli, command: PmSubCommand) -> Result<()> {
                 .maybe_wheelhouse_socket(wheelhouse_socket)
                 .flotilla_bin(flotilla_bin)
                 .build();
-            flotilla_tui::pm_connect::run(&cli.socket_path(), &cli.config_dir(), cli.config_dir.as_deref(), cli.socket.as_deref(), options)
-                .await
-                .map_err(|e| color_eyre::eyre::eyre!(e))
+            flotilla_tui::pm_connect::run(
+                &cli.socket_path(),
+                &cli.config_dir(),
+                cli.config_dir.as_deref(),
+                cli.socket.as_deref(),
+                host_daemon_socket_required(std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref()),
+                options,
+            )
+            .await
+            .map_err(|e| color_eyre::eyre::eyre!(e))
         }
     }
 }
@@ -797,9 +825,15 @@ async fn run_watch(cli: &Cli, format: OutputFormat) -> Result<()> {
 async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
     let socket_path = cli.socket_path();
     let config_dir = cli.config_dir();
-    let daemon = flotilla_tui::socket::connect_or_spawn(&socket_path, &config_dir, cli.config_dir.as_deref(), cli.socket.as_deref())
-        .await
-        .map_err(|e| color_eyre::eyre::eyre!(e))?;
+    let daemon = connect_cli_socket(
+        &socket_path,
+        &config_dir,
+        cli.config_dir.as_deref(),
+        cli.socket.as_deref(),
+        host_daemon_socket_required(std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref()),
+    )
+    .await
+    .map_err(|e| color_eyre::eyre::eyre!(e))?;
     Ok(daemon as Arc<dyn DaemonHandle>)
 }
 
@@ -1746,7 +1780,7 @@ mod tests {
     };
 
     use super::{
-        attach_exit_disposition, confirm_command, default_project_landing, format_human_resource_value,
+        attach_exit_disposition, confirm_command, default_project_landing, format_human_resource_value, host_daemon_socket_required,
         provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target, select_startup_repo_roots,
         should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from, AttachExitDisposition, Cli, CommandValue,
         ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, ResourceWatchArgs, SubCommand,
@@ -2104,6 +2138,12 @@ mod tests {
             ),
             PathBuf::from("/run/flotilla.sock"),
         );
+    }
+
+    #[test]
+    fn contained_cli_socket_environment_requires_the_host_daemon() {
+        assert!(host_daemon_socket_required(Some(std::ffi::OsStr::new("/run/flotilla-daemon/flotilla.sock"))));
+        assert!(!host_daemon_socket_required(None));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1308

## Summary

- lower Unix socket tool assets to parent-directory bind mounts so socket inode replacement remains visible inside contained environments
- expose the mounted socket under a dedicated `/run/flotilla-daemon` directory while preserving custom socket filenames
- require an existing host daemon whenever `FLOTILLA_DAEMON_SOCKET` is set, with no spawn-lock or local-daemon fallback
- document the contained socket lifecycle and add regressions for mount lowering and connect-only behavior

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`