### PR TITLE
fix: derive remote peer socket path

### DIFF
--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -292,7 +292,6 @@ pub struct RemoteHostConfig {
     #[serde(default)]
     pub expected_node_id: Option<NodeId>,
     pub user: Option<String>,
-    pub daemon_socket: String,
     pub ssh_multiplex: Option<bool>,
 }
 
@@ -311,7 +310,6 @@ struct RawRemoteHostConfig {
     #[serde(default)]
     expected_node_id: Option<NodeId>,
     user: Option<String>,
-    daemon_socket: String,
     ssh_multiplex: Option<bool>,
 }
 
@@ -332,7 +330,6 @@ impl<'de> Deserialize<'de> for HostsConfig {
                     expected_host_name,
                     expected_node_id: host.expected_node_id,
                     user: host.user,
-                    daemon_socket: host.daemon_socket,
                     ssh_multiplex: host.ssh_multiplex,
                 })
             })

--- a/crates/flotilla-core/src/config/tests.rs
+++ b/crates/flotilla-core/src/config/tests.rs
@@ -489,12 +489,10 @@ hostname = "desktop.local"
 expected_host_name = "desktop"
 expected_node_id = "1b4d1d6b-f7b5-4c1c-8f61-6f2d8e4c91ab"
 user = "robert"
-daemon_socket = "/run/user/1000/flotilla/daemon.sock"
 
 [hosts.cloud]
 hostname = "10.0.1.50"
 expected_host_name = "cloud"
-daemon_socket = "/home/robert/.config/flotilla/daemon.sock"
 "#;
     let config: HostsConfig = toml::from_str(toml).unwrap();
     assert_eq!(config.hosts.len(), 2);
@@ -511,7 +509,6 @@ fn parse_hosts_config_defaults_expected_host_name_to_table_key() {
     let toml = r#"
 [hosts.desktop]
 hostname = "desktop.local"
-daemon_socket = "/run/user/1000/flotilla/daemon.sock"
 "#;
     let config: HostsConfig = toml::from_str(toml).unwrap();
     assert_eq!(config.hosts.len(), 1);
@@ -594,7 +591,7 @@ fn load_hosts_from_file() {
     let base = dir.path();
     std::fs::write(
         base.join("hosts.toml"),
-        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\nexpected_node_id = \"1b4d1d6b-f7b5-4c1c-8f61-6f2d8e4c91ab\"\ndaemon_socket = \"/tmp/d.sock\"\n",
+        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\nexpected_node_id = \"1b4d1d6b-f7b5-4c1c-8f61-6f2d8e4c91ab\"\n",
     )
     .unwrap();
     let store = ConfigStore::with_base(base);
@@ -609,11 +606,7 @@ fn load_hosts_from_file() {
 fn load_hosts_invalid_file_returns_error() {
     let dir = tempdir().unwrap();
     let base = dir.path();
-    std::fs::write(
-        base.join("hosts.toml"),
-        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = [\ndaemon_socket = \"/tmp/d.sock\"\n",
-    )
-    .unwrap();
+    std::fs::write(base.join("hosts.toml"), "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = [\n").unwrap();
     let store = ConfigStore::with_base(base);
     let err = store.load_hosts().expect_err("invalid hosts config should error");
     assert!(err.contains("failed to parse"));
@@ -686,8 +679,8 @@ fn load_hosts_with_ssh_config() {
         base.join("hosts.toml"),
         "\
 [ssh]\nmultiplex = false\n\n\
-[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\ndaemon_socket = \"/tmp/d.sock\"\n\n\
-[hosts.feta]\nhostname = \"feta.local\"\nexpected_host_name = \"feta\"\ndaemon_socket = \"/tmp/f.sock\"\nssh_multiplex = true\n",
+[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\n\n\
+[hosts.feta]\nhostname = \"feta.local\"\nexpected_host_name = \"feta\"\nssh_multiplex = true\n",
     )
     .unwrap();
     let store = ConfigStore::with_base(base);
@@ -706,11 +699,7 @@ fn load_hosts_with_ssh_config() {
 fn load_hosts_ssh_defaults_to_multiplex_true() {
     let dir = tempdir().unwrap();
     let base = dir.path();
-    std::fs::write(
-        base.join("hosts.toml"),
-        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\ndaemon_socket = \"/tmp/d.sock\"\n",
-    )
-    .unwrap();
+    std::fs::write(base.join("hosts.toml"), "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\n").unwrap();
     let store = ConfigStore::with_base(base);
     let config = store.load_hosts().unwrap();
     // No [ssh] section — defaults to multiplex=true

--- a/crates/flotilla-core/src/executor/tests.rs
+++ b/crates/flotilla-core/src/executor/tests.rs
@@ -768,11 +768,8 @@ async fn create_workspace_from_prepared_terminal_wraps_remote_commands_in_ssh() 
     let attachable_store = test_attachable_store(&DaemonHostPath::new(temp.path()));
     let repo_root = temp.path().join("repo");
     std::fs::create_dir_all(&repo_root).expect("create repo root");
-    std::fs::write(
-        temp.path().join("hosts.toml"),
-        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\ndaemon_socket = \"/tmp/flotilla.sock\"\n",
-    )
-    .expect("write hosts config");
+    std::fs::write(temp.path().join("hosts.toml"), "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\n")
+        .expect("write hosts config");
     let attachable_set_id = {
         let mut store = attachable_store.lock().expect("store lock");
         store.ensure_terminal_set(Some(HostName::new("desktop")), Some(HostPath::new(HostName::new("desktop"), "/remote/feat").into()))
@@ -819,11 +816,8 @@ async fn create_workspace_from_prepared_terminal_prefixes_name_with_host() {
     let attachable_store = test_attachable_store(&DaemonHostPath::new(temp.path()));
     let repo_root = temp.path().join("repo");
     std::fs::create_dir_all(&repo_root).expect("create repo root");
-    std::fs::write(
-        temp.path().join("hosts.toml"),
-        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\ndaemon_socket = \"/tmp/flotilla.sock\"\n",
-    )
-    .expect("write hosts config");
+    std::fs::write(temp.path().join("hosts.toml"), "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\n")
+        .expect("write hosts config");
     let attachable_set_id = {
         let mut store = attachable_store.lock().expect("store lock");
         store.ensure_terminal_set(Some(HostName::new("desktop")), Some(HostPath::new(HostName::new("desktop"), "/remote/feat").into()))
@@ -862,11 +856,8 @@ async fn create_workspace_from_prepared_terminal_persists_remote_attachable_set_
     let attachable_store = test_attachable_store(&DaemonHostPath::new(temp.path()));
     let repo_root = temp.path().join("repo");
     std::fs::create_dir_all(&repo_root).expect("create repo root");
-    std::fs::write(
-        temp.path().join("hosts.toml"),
-        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\ndaemon_socket = \"/tmp/flotilla.sock\"\n",
-    )
-    .expect("write hosts config");
+    std::fs::write(temp.path().join("hosts.toml"), "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\n")
+        .expect("write hosts config");
 
     let set_id = {
         let mut store = attachable_store.lock().expect("store lock");
@@ -990,11 +981,8 @@ async fn create_workspace_from_prepared_terminal_uses_local_fallback_for_remote_
     let runner = runner_ok();
     let temp = tempfile::tempdir().expect("tempdir");
     let attachable_store = test_attachable_store(&DaemonHostPath::new(temp.path()));
-    std::fs::write(
-        temp.path().join("hosts.toml"),
-        "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\ndaemon_socket = \"/tmp/flotilla.sock\"\n",
-    )
-    .expect("write hosts config");
+    std::fs::write(temp.path().join("hosts.toml"), "[hosts.desktop]\nhostname = \"desktop.local\"\nexpected_host_name = \"desktop\"\n")
+        .expect("write hosts config");
     let attachable_set_id = {
         let mut store = attachable_store.lock().expect("store lock");
         store.ensure_terminal_set(Some(HostName::new("desktop")), Some(HostPath::new(HostName::new("desktop"), "/remote/feat").into()))

--- a/crates/flotilla-core/src/hop_chain/tests.rs
+++ b/crates/flotilla-core/src/hop_chain/tests.rs
@@ -124,7 +124,6 @@ fn test_hosts_config() -> HostsConfig {
         expected_host_name: "feta".into(),
         expected_node_id: None,
         user: Some("alice".into()),
-        daemon_socket: "/tmp/flotilla.sock".into(),
         ssh_multiplex: None,
     });
     hosts.insert("gouda".into(), RemoteHostConfig {
@@ -132,7 +131,6 @@ fn test_hosts_config() -> HostsConfig {
         expected_host_name: "gouda".into(),
         expected_node_id: None,
         user: None,
-        daemon_socket: "/tmp/flotilla.sock".into(),
         ssh_multiplex: Some(false),
     });
     HostsConfig { ssh: SshConfig::default(), hosts }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -739,8 +739,6 @@ fn fleet_replica_ssh_args(remote: &RemoteHostConfig, multiplex: bool) -> Vec<Str
         Arg::Literal("&&".to_string()),
         Arg::Literal("exec".to_string()),
         Arg::Literal("flotilla".to_string()),
-        Arg::Literal("--socket".to_string()),
-        Arg::Quoted(remote.daemon_socket.clone()),
         Arg::Literal("--json".to_string()),
         Arg::Quoted("replica-snapshot".to_string()),
     ];

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -918,9 +918,7 @@ async fn create_remote_attach_environment(daemon: &InProcessDaemon, host: &str) 
 fn write_attach_hosts_config(config_base: &Path, hosts: &[(&str, &str, Option<&str>)]) {
     let mut toml = "[ssh]\nmultiplex = false\n".to_string();
     for (label, hostname, user) in hosts {
-        toml.push_str(&format!(
-            "\n[hosts.{label}]\nhostname = \"{hostname}\"\nexpected_host_name = \"{label}\"\ndaemon_socket = \"/tmp/flotilla.sock\"\n"
-        ));
+        toml.push_str(&format!("\n[hosts.{label}]\nhostname = \"{hostname}\"\nexpected_host_name = \"{label}\"\n"));
         if let Some(user) = user {
             toml.push_str(&format!("user = \"{user}\"\n"));
         }
@@ -1925,7 +1923,6 @@ fn fleet_replica_ssh_args_wraps_snapshot_command_in_remote_login_shell() {
         expected_host_name: "feta".to_string(),
         expected_node_id: None,
         user: Some("alice".to_string()),
-        daemon_socket: "/tmp/flotilla.sock".to_string(),
         ssh_multiplex: None,
     };
 
@@ -1939,8 +1936,8 @@ fn fleet_replica_ssh_args_wraps_snapshot_command_in_remote_login_shell() {
 
     let remote_command = args.last().expect("remote command arg");
     assert!(remote_command.starts_with("${SHELL:-/bin/sh} -l -c "), "remote command should start with login shell: {remote_command}");
-    assert!(remote_command.contains("exec flotilla --socket"), "remote command should execute flotilla: {remote_command}");
-    assert!(remote_command.contains("/tmp/flotilla.sock"), "remote command should include socket: {remote_command}");
+    assert!(remote_command.contains("exec flotilla --json"), "remote command should execute flotilla: {remote_command}");
+    assert!(!remote_command.contains("--socket"), "remote command should derive the daemon socket: {remote_command}");
     assert!(remote_command.contains("replica-snapshot"), "remote command should include hidden subcommand: {remote_command}");
     assert!(!args.iter().any(|arg| arg == "&&"), "shell operators must not be separate SSH argv elements: {args:?}");
 }
@@ -1952,7 +1949,6 @@ fn fleet_replica_ssh_args_preserves_multiplex_options() {
         expected_host_name: "feta".to_string(),
         expected_node_id: None,
         user: None,
-        daemon_socket: "/tmp/flotilla.sock".to_string(),
         ssh_multiplex: None,
     };
 

--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -15,7 +15,10 @@ use flotilla_core::{
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use crate::{resource_limits::raise_file_descriptor_limit, restart_history::DaemonLifecycle, runtime::DaemonRuntime, server::DaemonServer};
+use crate::{
+    resource_limits::raise_file_descriptor_limit, restart_history::DaemonLifecycle, runtime::DaemonRuntime, server::DaemonServer,
+    DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH,
+};
 
 pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeout_secs: u64) -> Result<(), String> {
     let lifecycle = DaemonLifecycle::begin(state_dir)?;
@@ -75,6 +78,8 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
 }
 
 fn stable_socket_discovery_path() -> PathBuf {
+    // This path is a dialer-facing contract derived from the remote user's
+    // home, so deliberately do not inherit config-directory overrides.
     let home_policy = PathPolicy::from_env(|key| if key == "HOME" { std::env::var_os(key) } else { None });
-    home_policy.config_dir.into_path_buf().join("run/socket-path")
+    home_policy.config_dir.into_path_buf().join(DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH)
 }

--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -1,9 +1,15 @@
-use std::{io::IsTerminal, path::Path, sync::Arc, time::Duration};
+use std::{
+    io::IsTerminal,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use flotilla_core::{
     config::ConfigStore,
     log_file::{rotating_log_writer, DAEMON_LOG_DIRECTORY, DAEMON_LOG_FILE},
     path_context::DaemonHostPath,
+    path_policy::PathPolicy,
     providers::discovery::DiscoveryRuntime,
 };
 use tracing::info;
@@ -45,7 +51,15 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
 
     let discovery = DiscoveryRuntime::for_process(daemon_config.follower);
     let repo_root_paths = repo_roots.into_iter().map(|p| p.into_path_buf()).collect();
-    let server = DaemonServer::new(repo_root_paths, Arc::clone(&config), discovery, socket_path.to_path_buf(), timeout).await?;
+    let server = DaemonServer::new_with_socket_discovery_path(
+        repo_root_paths,
+        Arc::clone(&config),
+        discovery,
+        socket_path.to_path_buf(),
+        stable_socket_discovery_path(),
+        timeout,
+    )
+    .await?;
     let daemon = server.daemon();
     let runtime = DaemonRuntime::start(daemon, Arc::clone(&config), Some(socket_path.to_path_buf())).await?;
 
@@ -58,4 +72,9 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
         lifecycle.finish()?;
     }
     result
+}
+
+fn stable_socket_discovery_path() -> PathBuf {
+    let home_policy = PathPolicy::from_env(|key| if key == "HOME" { std::env::var_os(key) } else { None });
+    home_policy.config_dir.into_path_buf().join("run/socket-path")
 }

--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -15,3 +15,5 @@ pub mod peer;
 pub mod runtime;
 pub mod server;
 pub mod supervisor;
+
+pub(crate) const DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH: &str = "run/socket-path";

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -28,6 +28,11 @@ const SOCKET_POLL_TIMEOUT: Duration = Duration::from_secs(10);
 /// Interval between polls when waiting for the socket to appear.
 const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Remote command that reads the accepting daemon's published socket path.
+/// The discovery file is stable dialer-facing configuration; its contents are
+/// owned by the remote daemon and may change between connection attempts.
+const REMOTE_SOCKET_PATH_COMMAND: &str = "cat \"${XDG_CONFIG_HOME:-$HOME/.config}/flotilla/run/socket-path\"";
+
 /// Channel buffer size for inbound and outbound peer data messages.
 const CHANNEL_BUFFER: usize = 256;
 
@@ -100,7 +105,8 @@ pub struct SshTransport {
     expected_node_id: Option<NodeId>,
     local_socket_path: PathBuf,
     local_daemon_socket_path: PathBuf,
-    remote_resource_socket_path: PathBuf,
+    remote_daemon_socket_path: Option<PathBuf>,
+    remote_resource_socket_path: Option<PathBuf>,
     ssh_binary: PathBuf,
     ssh_process: Option<tokio::process::Child>,
     status: PeerConnectionStatus,
@@ -134,7 +140,6 @@ impl SshTransport {
         paths: SshTransportPaths<'_>,
     ) -> Result<Self, String> {
         let local_socket_path = peer_resource_socket_path(&paths.state_dir.join("peers"), &config_label)?;
-        let remote_resource_socket_path = reverse_peer_resource_socket_path(Path::new(&config.daemon_socket), &local_node_id)?;
         let expected_host_name = HostName::new(&config.expected_host_name);
 
         Ok(Self {
@@ -146,7 +151,8 @@ impl SshTransport {
             expected_node_id,
             local_socket_path,
             local_daemon_socket_path: paths.daemon_socket.to_path_buf(),
-            remote_resource_socket_path,
+            remote_daemon_socket_path: None,
+            remote_resource_socket_path: None,
             ssh_binary: PathBuf::from("ssh"),
             ssh_process: None,
             status: PeerConnectionStatus::Disconnected,
@@ -163,6 +169,10 @@ impl SshTransport {
     async fn spawn_ssh(&mut self) -> Result<(), String> {
         // Clean up any stale local socket before spawning
         self.cleanup_socket();
+
+        let remote_daemon_socket = self.resolve_remote_daemon_socket().await?;
+        self.remote_resource_socket_path = Some(reverse_peer_resource_socket_path(&remote_daemon_socket, &self.local_node_id)?);
+        self.remote_daemon_socket_path = Some(remote_daemon_socket);
 
         // OpenSSH's client-side StreamLocalBindUnlink option only applies to
         // the local (-L) socket. The reverse (-R) socket is bound by sshd and
@@ -222,9 +232,36 @@ impl SshTransport {
         }
     }
 
+    async fn resolve_remote_daemon_socket(&self) -> Result<PathBuf, String> {
+        let destination = self.destination();
+        let output = tokio::process::Command::new(&self.ssh_binary)
+            .arg(&destination)
+            .arg(REMOTE_SOCKET_PATH_COMMAND)
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output();
+        let output = tokio::time::timeout(SOCKET_POLL_TIMEOUT, output)
+            .await
+            .map_err(|_| format!("timed out resolving remote daemon socket path on {destination}"))?
+            .map_err(|error| format!("failed to resolve remote daemon socket path on {destination}: {error}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "failed to resolve remote daemon socket path on {destination}: ssh exited with {}{}",
+                output.status,
+                if stderr.trim().is_empty() { String::new() } else { format!(": {}", stderr.trim()) }
+            ));
+        }
+
+        parse_remote_socket_path(&output.stdout).map_err(|error| format!("invalid remote daemon socket path from {destination}: {error}"))
+    }
+
     async fn cleanup_remote_socket(&self) -> Result<(), String> {
         let destination = self.destination();
-        let path = self.remote_resource_socket_path.to_string_lossy();
+        let path = self.remote_resource_socket_path()?.to_string_lossy();
         let command = self.remote_cleanup_command();
         debug!(%destination, remote_socket = %path, "removing stale reverse peer socket before SSH tunnel dial");
 
@@ -254,14 +291,26 @@ impl SshTransport {
     }
 
     fn remote_cleanup_command(&self) -> String {
-        format!("rm -f -- {}", shell_quote(&self.remote_resource_socket_path.to_string_lossy()))
+        self.remote_resource_socket_path()
+            .map(|path| format!("rm -f -- {}", shell_quote(&path.to_string_lossy())))
+            .expect("remote resource socket path is resolved before cleanup")
     }
 
     fn resource_forward_specs(&self) -> (String, String) {
+        let remote_daemon_socket = self.remote_daemon_socket_path().expect("remote daemon socket path is resolved before forwarding");
+        let remote_resource_socket = self.remote_resource_socket_path().expect("remote resource socket path is resolved before forwarding");
         (
-            format!("{}:{}", self.local_socket_path.display(), self.config.daemon_socket),
-            format!("{}:{}", self.remote_resource_socket_path.display(), self.local_daemon_socket_path.display()),
+            format!("{}:{}", self.local_socket_path.display(), remote_daemon_socket.display()),
+            format!("{}:{}", remote_resource_socket.display(), self.local_daemon_socket_path.display()),
         )
+    }
+
+    fn remote_daemon_socket_path(&self) -> Result<&Path, String> {
+        self.remote_daemon_socket_path.as_deref().ok_or_else(|| "remote daemon socket path has not been resolved".to_string())
+    }
+
+    fn remote_resource_socket_path(&self) -> Result<&Path, String> {
+        self.remote_resource_socket_path.as_deref().ok_or_else(|| "remote resource socket path has not been resolved".to_string())
     }
 
     /// Wait for the forwarded local socket file to appear on disk.
@@ -403,6 +452,31 @@ impl SshTransport {
         Ok(inbound_rx)
     }
 
+    async fn diagnose_pre_hello_close(&self) -> Option<String> {
+        let remote_socket = self.remote_daemon_socket_path().ok()?;
+        let destination = self.destination();
+        let quoted_path = shell_quote(&remote_socket.to_string_lossy());
+        let command =
+            format!("test -S {quoted_path} && {{ ! command -v ss >/dev/null 2>&1 || ss -xlH | grep -F -- {quoted_path} >/dev/null; }}");
+        let output = tokio::process::Command::new(&self.ssh_binary)
+            .arg(&destination)
+            .arg(command)
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output();
+        let output = tokio::time::timeout(SOCKET_POLL_TIMEOUT, output).await.ok()?.ok()?;
+
+        match output.status.code() {
+            Some(0) | Some(255) | None => None,
+            Some(_) => Some(format!(
+                "remote daemon not listening at derived path {} on {destination} (peer closed before sending hello)",
+                remote_socket.display()
+            )),
+        }
+    }
+
     /// Remove the local forwarded socket file if it exists.
     fn cleanup_socket(&self) {
         if self.local_socket_path.exists() {
@@ -473,6 +547,23 @@ impl SshTransport {
     }
 }
 
+fn parse_remote_socket_path(stdout: &[u8]) -> Result<PathBuf, String> {
+    let stdout = std::str::from_utf8(stdout).map_err(|error| format!("not UTF-8: {error}"))?;
+    let mut lines = stdout.lines();
+    let path = lines.next().unwrap_or_default().trim();
+    if path.is_empty() {
+        return Err("discovery file was empty".to_string());
+    }
+    if lines.any(|line| !line.trim().is_empty()) {
+        return Err("discovery command returned more than one path".to_string());
+    }
+    let path = PathBuf::from(path);
+    if !path.is_absolute() {
+        return Err(format!("path is not absolute: {}", path.display()));
+    }
+    Ok(path)
+}
+
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
@@ -486,9 +577,16 @@ impl PeerTransport for SshTransport {
         self.wait_for_socket().await.inspect_err(|_| {
             self.cleanup_socket();
         })?;
-        let rx = self.connect_socket().await.inspect_err(|_| {
-            self.cleanup_socket();
-        })?;
+        let rx = match self.connect_socket().await {
+            Ok(rx) => rx,
+            Err(error) => {
+                self.cleanup_socket();
+                if error == "peer closed before sending hello" {
+                    return Err(self.diagnose_pre_hello_close().await.unwrap_or(error));
+                }
+                return Err(error);
+            }
+        };
 
         // Store the inbound receiver for subscribe() to return
         self.inbound_rx = Some(rx);
@@ -591,13 +689,76 @@ mod tests {
     }
 
     #[test]
+    fn remote_socket_path_parser_requires_one_absolute_path() {
+        assert_eq!(parse_remote_socket_path(b"/tmp/flotilla.sock\n").expect("absolute path"), PathBuf::from("/tmp/flotilla.sock"));
+        assert!(parse_remote_socket_path(b"relative.sock\n").expect_err("relative path").contains("not absolute"));
+        assert!(parse_remote_socket_path(b"\n").expect_err("empty path").contains("empty"));
+        assert!(parse_remote_socket_path(b"/one.sock\n/two.sock\n").expect_err("multiple paths").contains("more than one"));
+    }
+
+    #[tokio::test]
+    async fn remote_socket_path_is_resolved_again_after_it_moves() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let published_path = tmp.path().join("published-path");
+        std::fs::write(&published_path, "/run/first.sock\n").expect("write first path");
+        let fake_ssh = tmp.path().join("ssh");
+        std::fs::write(&fake_ssh, format!("#!/bin/sh\ncat {}\n", shell_quote(&published_path.to_string_lossy()))).expect("write fake ssh");
+        let mut permissions = std::fs::metadata(&fake_ssh).expect("fake ssh metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
+
+        let mut transport = test_transport();
+        transport.ssh_binary = fake_ssh;
+        assert_eq!(transport.resolve_remote_daemon_socket().await.expect("first resolution"), PathBuf::from("/run/first.sock"));
+
+        std::fs::write(&published_path, "/run/moved.sock\n").expect("move published path");
+        assert_eq!(transport.resolve_remote_daemon_socket().await.expect("second resolution"), PathBuf::from("/run/moved.sock"));
+    }
+
+    #[tokio::test]
+    async fn pre_hello_close_names_remote_daemon_not_listening() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fake_ssh = tmp.path().join("ssh");
+        std::fs::write(&fake_ssh, "#!/bin/sh\nexit 1\n").expect("write fake ssh");
+        let mut permissions = std::fs::metadata(&fake_ssh).expect("fake ssh metadata").permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
+
+        let mut transport = test_transport();
+        transport.ssh_binary = fake_ssh;
+        transport.remote_daemon_socket_path = Some(PathBuf::from("/remote/run/flotilla.sock"));
+
+        let diagnosis = transport.diagnose_pre_hello_close().await.expect("probable cause");
+        assert!(diagnosis.contains("remote daemon not listening at derived path /remote/run/flotilla.sock"));
+        assert!(diagnosis.contains("peer closed before sending hello"));
+    }
+
+    fn test_transport() -> SshTransport {
+        SshTransport::new(
+            NodeId::new("local"),
+            "local-display".into(),
+            ConfigLabel("remote".into()),
+            RemoteHostConfig {
+                hostname: "remote.example.invalid".into(),
+                expected_host_name: "remote".into(),
+                expected_node_id: None,
+                user: None,
+                ssh_multiplex: None,
+            },
+            None,
+            uuid::Uuid::nil(),
+            SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
+        )
+        .expect("test transport")
+    }
+
+    #[test]
     fn local_socket_path_uses_host_name() {
         let config = RemoteHostConfig {
             hostname: "10.0.0.5".to_string(),
             expected_host_name: "my-server".to_string(),
             expected_node_id: None,
             user: Some("dev".to_string()),
-            daemon_socket: "/run/user/1000/flotilla.sock".to_string(),
             ssh_multiplex: None,
         };
         let transport = SshTransport::new(
@@ -620,11 +781,10 @@ mod tests {
             expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
             user: Some("test-user".to_string()),
-            daemon_socket: "/home/test-remote/.config/flotilla/flotilla.sock".to_string(),
             ssh_multiplex: None,
         };
         let local_node = NodeId::new("local-node");
-        let transport = SshTransport::new(
+        let mut transport = SshTransport::new(
             local_node.clone(),
             "local-host".into(),
             ConfigLabel("peer-a".to_string()),
@@ -637,18 +797,23 @@ mod tests {
             },
         )
         .expect("valid transport");
+        transport.remote_daemon_socket_path = Some(PathBuf::from("/home/test-remote/.config/flotilla/run/flotilla.sock"));
+        transport.remote_resource_socket_path = Some(
+            reverse_peer_resource_socket_path(transport.remote_daemon_socket_path.as_deref().expect("remote daemon socket"), &local_node)
+                .expect("reverse path"),
+        );
 
         let (local_forward, reverse_forward) = transport.resource_forward_specs();
 
         assert_eq!(
             local_forward,
-            "/home/test-local/.local/state/flotilla/peers/peer-a.sock:/home/test-remote/.config/flotilla/flotilla.sock"
+            "/home/test-local/.local/state/flotilla/peers/peer-a.sock:/home/test-remote/.config/flotilla/run/flotilla.sock"
         );
         assert_eq!(
             reverse_forward,
             format!(
                 "{}:/home/test-local/.config/flotilla/flotilla.sock",
-                reverse_peer_resource_socket_path(Path::new("/home/test-remote/.config/flotilla/flotilla.sock"), &local_node)
+                reverse_peer_resource_socket_path(Path::new("/home/test-remote/.config/flotilla/run/flotilla.sock"), &local_node)
                     .expect("reverse path")
                     .display()
             )
@@ -662,10 +827,9 @@ mod tests {
             expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
             user: Some("test-user".to_string()),
-            daemon_socket: "/home/O'Brien/.config/flotilla/flotilla.sock".to_string(),
             ssh_multiplex: None,
         };
-        let transport = SshTransport::new(
+        let mut transport = SshTransport::new(
             NodeId::new("local-node"),
             "local-host".into(),
             ConfigLabel("peer-a".into()),
@@ -675,12 +839,21 @@ mod tests {
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid transport");
+        transport.remote_resource_socket_path = Some(
+            reverse_peer_resource_socket_path(Path::new("/home/O'Brien/.config/flotilla/run/flotilla.sock"), &NodeId::new("local-node"))
+                .expect("reverse path"),
+        );
 
         assert_eq!(
             transport.remote_cleanup_command(),
             format!(
-                "rm -f -- '/home/O'\"'\"'Brien/.config/flotilla/{}'",
-                transport.remote_resource_socket_path.file_name().expect("socket file name").to_string_lossy()
+                "rm -f -- '/home/O'\"'\"'Brien/.config/flotilla/run/{}'",
+                transport
+                    .remote_resource_socket_path()
+                    .expect("remote resource socket")
+                    .file_name()
+                    .expect("socket file name")
+                    .to_string_lossy()
             )
         );
     }
@@ -694,7 +867,6 @@ mod tests {
             expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: daemon_socket.to_string_lossy().into_owned(),
             ssh_multiplex: None,
         };
         let mut transport = SshTransport::new(
@@ -707,10 +879,17 @@ mod tests {
             SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
         )
         .expect("valid transport");
-        std::fs::write(&transport.remote_resource_socket_path, []).expect("create stale reverse socket stand-in");
-
+        let stale_reverse_socket = reverse_peer_resource_socket_path(&daemon_socket, &NodeId::new("local-node")).expect("reverse socket");
+        std::fs::write(&stale_reverse_socket, []).expect("create stale reverse socket stand-in");
         let fake_ssh = tmp.path().join("ssh");
-        std::fs::write(&fake_ssh, "#!/bin/sh\nif [ \"$#\" -eq 2 ]; then exec /bin/sh -c \"$2\"; fi\nexit 0\n").expect("write fake ssh");
+        std::fs::write(
+            &fake_ssh,
+            format!(
+                "#!/bin/sh\n[ \"$#\" -ne 2 ] && exit 0\ncase \"$2\" in\n  *socket-path*) printf '%s\\n' '{}' ;;\n  *) exec /bin/sh -c \"$2\" ;;\nesac\n",
+                daemon_socket.display()
+            ),
+        )
+        .expect("write fake ssh");
         let mut permissions = std::fs::metadata(&fake_ssh).expect("fake ssh metadata").permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
@@ -718,7 +897,7 @@ mod tests {
 
         transport.spawn_ssh().await.expect("stale cleanup and tunnel spawn should succeed");
 
-        assert!(!transport.remote_resource_socket_path.exists(), "stale reverse socket must be removed before the tunnel is spawned");
+        assert!(!transport.remote_resource_socket_path().expect("resolved reverse socket").exists());
         let status = transport.ssh_process.as_mut().expect("tunnel child").wait().await.expect("wait for fake tunnel");
         assert!(status.success());
     }
@@ -732,7 +911,6 @@ mod tests {
             expected_host_name: "peer-a".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: daemon_socket.to_string_lossy().into_owned(),
             ssh_multiplex: None,
         };
         let mut transport = SshTransport::new(
@@ -746,7 +924,14 @@ mod tests {
         )
         .expect("valid transport");
         let fake_ssh = tmp.path().join("ssh");
-        std::fs::write(&fake_ssh, "#!/bin/sh\necho cleanup-denied >&2\nexit 23\n").expect("write failing fake ssh");
+        std::fs::write(
+            &fake_ssh,
+            format!(
+                "#!/bin/sh\n[ \"$#\" -ne 2 ] && exit 0\ncase \"$2\" in\n  *socket-path*) printf '%s\\n' '{}' ;;\n  *) echo cleanup-denied >&2; exit 23 ;;\nesac\n",
+                daemon_socket.display()
+            ),
+        )
+        .expect("write failing fake ssh");
         let mut permissions = std::fs::metadata(&fake_ssh).expect("fake ssh metadata").permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
@@ -755,7 +940,7 @@ mod tests {
         let error = transport.spawn_ssh().await.expect_err("cleanup failure must stop the tunnel dial");
 
         assert!(error.contains("failed to remove stale reverse peer socket"), "unexpected error: {error}");
-        assert!(error.contains(&transport.remote_resource_socket_path.to_string_lossy().into_owned()), "unexpected error: {error}");
+        assert!(error.contains(&transport.remote_resource_socket_path().expect("resolved reverse socket").to_string_lossy().into_owned()));
         assert!(error.contains("cleanup-denied"), "unexpected error: {error}");
         assert!(transport.ssh_process.is_none(), "tunnel must not spawn after cleanup failure");
     }
@@ -767,7 +952,6 @@ mod tests {
             expected_host_name: "remote".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: "/tmp/daemon.sock".to_string(),
             ssh_multiplex: None,
         };
         match SshTransport::new(
@@ -791,7 +975,6 @@ mod tests {
             expected_host_name: "remote".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: "/tmp/daemon.sock".to_string(),
             ssh_multiplex: None,
         };
         let transport = SshTransport::new(
@@ -895,7 +1078,6 @@ mod tests {
             expected_host_name: "remote".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: "/tmp/daemon.sock".to_string(),
             ssh_multiplex: None,
         };
         let transport = SshTransport::new(
@@ -918,7 +1100,6 @@ mod tests {
             expected_host_name: "remote".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: "/tmp/daemon.sock".to_string(),
             ssh_multiplex: None,
         };
         let mut transport = SshTransport::new(
@@ -949,7 +1130,6 @@ mod tests {
             expected_host_name: "remote".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: "/tmp/daemon.sock".to_string(),
             ssh_multiplex: None,
         };
         let mut transport = SshTransport::new(
@@ -1021,7 +1201,6 @@ mod tests {
             expected_host_name: "localhost-test".to_string(),
             expected_node_id: None,
             user: None,
-            daemon_socket: "/tmp/flotilla-test-daemon.sock".to_string(),
             ssh_multiplex: None,
         };
         let mut transport = SshTransport::new(

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -23,7 +23,10 @@ const MAX_BACKOFF: Duration = Duration::from_secs(60);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 
 /// How long to wait for the forwarded socket to appear after spawning SSH.
-const SOCKET_POLL_TIMEOUT: Duration = Duration::from_secs(10);
+const FORWARDED_SOCKET_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long to wait for an SSH discovery, cleanup, or diagnostic command.
+const REMOTE_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Interval between polls when waiting for the socket to appear.
 const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -244,7 +247,7 @@ impl SshTransport {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .output();
-        let output = tokio::time::timeout(SOCKET_POLL_TIMEOUT, output)
+        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, output)
             .await
             .map_err(|_| format!("timed out resolving remote daemon socket path on {destination}"))?
             .map_err(|error| format!("failed to resolve remote daemon socket path on {destination}: {error}"))?;
@@ -275,7 +278,7 @@ impl SshTransport {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
             .output();
-        let output = tokio::time::timeout(SOCKET_POLL_TIMEOUT, output)
+        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, output)
             .await
             .map_err(|_| format!("timed out removing stale reverse peer socket at {path} on {destination}"))?
             .map_err(|e| format!("failed to run remote stale peer socket cleanup at {path} on {destination}: {e}"))?;
@@ -321,7 +324,7 @@ impl SshTransport {
     /// unreachable host, etc.) to fail fast instead of waiting the
     /// full timeout.
     async fn wait_for_socket(&mut self) -> Result<(), String> {
-        let deadline = tokio::time::Instant::now() + SOCKET_POLL_TIMEOUT;
+        let deadline = tokio::time::Instant::now() + FORWARDED_SOCKET_TIMEOUT;
 
         loop {
             if self.local_socket_path.exists() {
@@ -468,7 +471,7 @@ impl SshTransport {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .output();
-        let output = tokio::time::timeout(SOCKET_POLL_TIMEOUT, output).await.ok()?.ok()?;
+        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, output).await.ok()?.ok()?;
 
         match output.status.code() {
             Some(0) | Some(255) | None => None,

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -15,6 +15,7 @@ use tokio::{
 use tracing::{debug, error, info, warn};
 
 use super::transport::{PeerConnectionStatus, PeerSender, PeerTransport};
+use crate::DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH;
 
 /// Maximum backoff delay between reconnection attempts.
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
@@ -31,10 +32,7 @@ const REMOTE_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 /// Interval between polls when waiting for the socket to appear.
 const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Remote command that reads the accepting daemon's published socket path.
-/// The discovery file is stable dialer-facing configuration; its contents are
-/// owned by the remote daemon and may change between connection attempts.
-const REMOTE_SOCKET_PATH_COMMAND: &str = "cat \"$HOME/.config/flotilla/run/socket-path\"";
+const REMOTE_SOCKET_PATH_PREFIX: &str = "FLOTILLA_DAEMON_SOCKET_PATH=";
 
 const PRE_HELLO_CLOSE_ERROR: &str = "peer closed before sending hello";
 
@@ -239,9 +237,13 @@ impl SshTransport {
 
     async fn resolve_remote_daemon_socket(&self) -> Result<PathBuf, String> {
         let destination = self.destination();
+        let command = remote_socket_path_command();
         let output = tokio::process::Command::new(&self.ssh_binary)
+            .arg("-T")
+            .arg("-o")
+            .arg("BatchMode=yes")
             .arg(&destination)
-            .arg(REMOTE_SOCKET_PATH_COMMAND)
+            .arg(&command)
             .kill_on_drop(true)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -271,6 +273,9 @@ impl SshTransport {
         debug!(%destination, remote_socket = %path, "removing stale reverse peer socket before SSH tunnel dial");
 
         let output = tokio::process::Command::new(&self.ssh_binary)
+            .arg("-T")
+            .arg("-o")
+            .arg("BatchMode=yes")
             .arg(&destination)
             .arg(&command)
             .kill_on_drop(true)
@@ -464,6 +469,9 @@ impl SshTransport {
         let command =
             format!("test -S {quoted_path} && {{ ! command -v ss >/dev/null 2>&1 || ss -xlH | grep -F -- {quoted_path} >/dev/null; }}");
         let output = tokio::process::Command::new(&self.ssh_binary)
+            .arg("-T")
+            .arg("-o")
+            .arg("BatchMode=yes")
             .arg(&destination)
             .arg(command)
             .kill_on_drop(true)
@@ -554,19 +562,25 @@ impl SshTransport {
 
 fn parse_remote_socket_path(stdout: &[u8]) -> Result<PathBuf, String> {
     let stdout = std::str::from_utf8(stdout).map_err(|error| format!("not UTF-8: {error}"))?;
-    let mut lines = stdout.lines();
-    let path = lines.next().unwrap_or_default().trim();
+    let mut paths = stdout.lines().filter_map(|line| line.strip_prefix(REMOTE_SOCKET_PATH_PREFIX));
+    let path = paths.next().ok_or_else(|| "discovery command returned no tagged path".to_string())?.trim();
     if path.is_empty() {
-        return Err("discovery file was empty".to_string());
+        return Err("discovery command returned an empty tagged path".to_string());
     }
-    if lines.any(|line| !line.trim().is_empty()) {
-        return Err("discovery command returned more than one path".to_string());
+    if paths.next().is_some() {
+        return Err("discovery command returned more than one tagged path".to_string());
     }
     let path = PathBuf::from(path);
     if !path.is_absolute() {
         return Err(format!("path is not absolute: {}", path.display()));
     }
     Ok(path)
+}
+
+fn remote_socket_path_command() -> String {
+    format!(
+        "path=$(cat \"$HOME/.config/flotilla/{DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH}\") || exit; printf '{REMOTE_SOCKET_PATH_PREFIX}%s\\n' \"$path\""
+    )
 }
 
 fn shell_quote(value: &str) -> String {
@@ -695,10 +709,25 @@ mod tests {
 
     #[test]
     fn remote_socket_path_parser_requires_one_absolute_path() {
-        assert_eq!(parse_remote_socket_path(b"/tmp/flotilla.sock\n").expect("absolute path"), PathBuf::from("/tmp/flotilla.sock"));
-        assert!(parse_remote_socket_path(b"relative.sock\n").expect_err("relative path").contains("not absolute"));
-        assert!(parse_remote_socket_path(b"\n").expect_err("empty path").contains("empty"));
-        assert!(parse_remote_socket_path(b"/one.sock\n/two.sock\n").expect_err("multiple paths").contains("more than one"));
+        assert_eq!(
+            parse_remote_socket_path(b"login banner\nFLOTILLA_DAEMON_SOCKET_PATH=/tmp/flotilla.sock\nmotd\n").expect("absolute path"),
+            PathBuf::from("/tmp/flotilla.sock")
+        );
+        assert!(parse_remote_socket_path(b"relative.sock\n").expect_err("untagged path").contains("no tagged path"));
+        assert!(parse_remote_socket_path(b"FLOTILLA_DAEMON_SOCKET_PATH=relative.sock\n")
+            .expect_err("relative path")
+            .contains("not absolute"));
+        assert!(parse_remote_socket_path(b"FLOTILLA_DAEMON_SOCKET_PATH=\n").expect_err("empty path").contains("empty"));
+        assert!(parse_remote_socket_path(b"FLOTILLA_DAEMON_SOCKET_PATH=/one.sock\nFLOTILLA_DAEMON_SOCKET_PATH=/two.sock\n")
+            .expect_err("multiple paths")
+            .contains("more than one"));
+    }
+
+    #[test]
+    fn remote_socket_path_command_uses_shared_discovery_contract() {
+        let command = remote_socket_path_command();
+        assert!(command.contains("$HOME/.config/flotilla/run/socket-path"));
+        assert!(command.contains(REMOTE_SOCKET_PATH_PREFIX));
     }
 
     #[tokio::test]
@@ -707,7 +736,14 @@ mod tests {
         let published_path = tmp.path().join("published-path");
         std::fs::write(&published_path, "/run/first.sock\n").expect("write first path");
         let fake_ssh = tmp.path().join("ssh");
-        std::fs::write(&fake_ssh, format!("#!/bin/sh\ncat {}\n", shell_quote(&published_path.to_string_lossy()))).expect("write fake ssh");
+        std::fs::write(
+            &fake_ssh,
+            format!(
+                "#!/bin/sh\nprintf 'login banner\\n{REMOTE_SOCKET_PATH_PREFIX}'; cat {}\nprintf 'motd\\n'\n",
+                shell_quote(&published_path.to_string_lossy())
+            ),
+        )
+        .expect("write fake ssh");
         let mut permissions = std::fs::metadata(&fake_ssh).expect("fake ssh metadata").permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&fake_ssh, permissions).expect("make fake ssh executable");
@@ -890,7 +926,7 @@ mod tests {
         std::fs::write(
             &fake_ssh,
             format!(
-                "#!/bin/sh\n[ \"$#\" -ne 2 ] && exit 0\ncase \"$2\" in\n  *socket-path*) printf '%s\\n' '{}' ;;\n  *) exec /bin/sh -c \"$2\" ;;\nesac\n",
+                "#!/bin/sh\n[ \"$1\" = \"-N\" ] && exit 0\nfor command do :; done\ncase \"$command\" in\n  *socket-path*) printf '{REMOTE_SOCKET_PATH_PREFIX}%s\\n' '{}' ;;\n  *) exec /bin/sh -c \"$command\" ;;\nesac\n",
                 daemon_socket.display()
             ),
         )
@@ -932,7 +968,7 @@ mod tests {
         std::fs::write(
             &fake_ssh,
             format!(
-                "#!/bin/sh\n[ \"$#\" -ne 2 ] && exit 0\ncase \"$2\" in\n  *socket-path*) printf '%s\\n' '{}' ;;\n  *) echo cleanup-denied >&2; exit 23 ;;\nesac\n",
+                "#!/bin/sh\n[ \"$1\" = \"-N\" ] && exit 0\nfor command do :; done\ncase \"$command\" in\n  *socket-path*) printf '{REMOTE_SOCKET_PATH_PREFIX}%s\\n' '{}' ;;\n  *) echo cleanup-denied >&2; exit 23 ;;\nesac\n",
                 daemon_socket.display()
             ),
         )

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -31,7 +31,9 @@ const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Remote command that reads the accepting daemon's published socket path.
 /// The discovery file is stable dialer-facing configuration; its contents are
 /// owned by the remote daemon and may change between connection attempts.
-const REMOTE_SOCKET_PATH_COMMAND: &str = "cat \"${XDG_CONFIG_HOME:-$HOME/.config}/flotilla/run/socket-path\"";
+const REMOTE_SOCKET_PATH_COMMAND: &str = "cat \"$HOME/.config/flotilla/run/socket-path\"";
+
+const PRE_HELLO_CLOSE_ERROR: &str = "peer closed before sending hello";
 
 /// Channel buffer size for inbound and outbound peer data messages.
 const CHANNEL_BUFFER: usize = 256;
@@ -368,7 +370,7 @@ impl SshTransport {
             .next_line()
             .await
             .map_err(|e| format!("failed to read peer hello: {e}"))?
-            .ok_or_else(|| "peer closed before sending hello".to_string())?;
+            .ok_or_else(|| PRE_HELLO_CLOSE_ERROR.to_string())?;
         let hello = serde_json::from_str(&line).map_err(|e| format!("failed to parse peer hello: {e}"))?;
         let (remote_node_info, remote_session_id) =
             Self::validate_remote_hello(&self.expected_host_name, self.expected_node_id.as_ref(), hello)?;
@@ -581,7 +583,7 @@ impl PeerTransport for SshTransport {
             Ok(rx) => rx,
             Err(error) => {
                 self.cleanup_socket();
-                if error == "peer closed before sending hello" {
+                if error == PRE_HELLO_CLOSE_ERROR {
                     return Err(self.diagnose_pre_hello_close().await.unwrap_or(error));
                 }
                 return Err(error);

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -41,7 +41,10 @@ use self::{
     remote_commands::{ForwardedCommandMap, PendingRemoteCancelMap, PendingRemoteCommandMap, RemoteCommandRouter},
     shared::{sync_peer_query_state, SocketPeerSender},
 };
-use crate::peer::{ConnectionDirection, ConnectionMeta, InboundPeerEnvelope, PeerManager, SshTransport, SshTransportPaths};
+use crate::{
+    peer::{ConnectionDirection, ConnectionMeta, InboundPeerEnvelope, PeerManager, SshTransport, SshTransportPaths},
+    DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH,
+};
 
 const CONNECTION_PREFACE_TIMEOUT: Duration = Duration::from_secs(10);
 const HELLO_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -306,7 +309,7 @@ impl DaemonServer {
         socket_path: PathBuf,
         idle_timeout: Duration,
     ) -> Result<Self, String> {
-        let socket_discovery_path = config.base_path().as_path().join("run/socket-path");
+        let socket_discovery_path = config.base_path().as_path().join(DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH);
         Self::new_with_socket_discovery_path(repo_paths, config, discovery, socket_path, socket_discovery_path, idle_timeout).await
     }
 

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -306,6 +306,18 @@ impl DaemonServer {
         socket_path: PathBuf,
         idle_timeout: Duration,
     ) -> Result<Self, String> {
+        let socket_discovery_path = config.base_path().as_path().join("run/socket-path");
+        Self::new_with_socket_discovery_path(repo_paths, config, discovery, socket_path, socket_discovery_path, idle_timeout).await
+    }
+
+    pub async fn new_with_socket_discovery_path(
+        repo_paths: Vec<PathBuf>,
+        config: Arc<ConfigStore>,
+        discovery: DiscoveryRuntime,
+        socket_path: PathBuf,
+        socket_discovery_path: PathBuf,
+        idle_timeout: Duration,
+    ) -> Result<Self, String> {
         let daemon_config = config.load_daemon_config()?;
         let host_name = daemon_config.host_name.map(HostName::new).unwrap_or_else(HostName::local);
         let resource_backend = build_embedded_resource_backend(&config).await?;
@@ -320,8 +332,6 @@ impl DaemonServer {
         let agent_state_store = Arc::clone(daemon.agent_state_store());
         let remote_command_router = build_remote_command_router(&daemon, &peer_manager);
         let peer_resource_socket_dir = config.state_dir().as_path().join("peers");
-        let socket_discovery_path = config.base_path().as_path().join("run/socket-path");
-
         Ok(Self {
             daemon,
             socket_path,
@@ -536,8 +546,14 @@ fn publish_socket_path(discovery_path: &Path, socket_path: &Path) -> Result<(), 
     let parent =
         discovery_path.parent().ok_or_else(|| format!("daemon socket discovery path has no parent: {}", discovery_path.display()))?;
     std::fs::create_dir_all(parent).map_err(|error| format!("failed to create daemon socket discovery directory: {error}"))?;
-    std::fs::write(discovery_path, format!("{}\n", socket_path.display()))
-        .map_err(|error| format!("failed to publish daemon socket path at {}: {error}", discovery_path.display()))
+    let temporary_path = parent.join(format!(".socket-path-{}.tmp", uuid::Uuid::new_v4()));
+    std::fs::write(&temporary_path, format!("{}\n", socket_path.display()))
+        .map_err(|error| format!("failed to write daemon socket discovery file at {}: {error}", temporary_path.display()))?;
+    if let Err(error) = std::fs::rename(&temporary_path, discovery_path) {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(format!("failed to publish daemon socket path at {}: {error}", discovery_path.display()));
+    }
+    Ok(())
 }
 
 fn spawn_peer_networking_runtime(

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -271,6 +271,7 @@ pub fn spawn_test_peer_networking(
 pub struct DaemonServer {
     daemon: Arc<InProcessDaemon>,
     socket_path: PathBuf,
+    socket_discovery_path: PathBuf,
     idle_timeout: Duration,
     follower: bool,
     client_count: Arc<AtomicUsize>,
@@ -319,10 +320,12 @@ impl DaemonServer {
         let agent_state_store = Arc::clone(daemon.agent_state_store());
         let remote_command_router = build_remote_command_router(&daemon, &peer_manager);
         let peer_resource_socket_dir = config.state_dir().as_path().join("peers");
+        let socket_discovery_path = config.base_path().as_path().join("run/socket-path");
 
         Ok(Self {
             daemon,
             socket_path,
+            socket_discovery_path,
             idle_timeout,
             follower: daemon_config.follower,
             client_count: Arc::new(AtomicUsize::new(0)),
@@ -368,6 +371,8 @@ impl DaemonServer {
         }
 
         let listener = UnixListener::bind(&self.socket_path).map_err(|e| format!("failed to bind socket: {e}"))?;
+
+        publish_socket_path(&self.socket_discovery_path, &self.socket_path)?;
 
         info!(path = %self.socket_path.display(), "daemon listening");
 
@@ -525,6 +530,14 @@ impl DaemonServer {
         info!("daemon server stopped");
         Ok(())
     }
+}
+
+fn publish_socket_path(discovery_path: &Path, socket_path: &Path) -> Result<(), String> {
+    let parent =
+        discovery_path.parent().ok_or_else(|| format!("daemon socket discovery path has no parent: {}", discovery_path.display()))?;
+    std::fs::create_dir_all(parent).map_err(|error| format!("failed to create daemon socket discovery directory: {error}"))?;
+    std::fs::write(discovery_path, format!("{}\n", socket_path.display()))
+        .map_err(|error| format!("failed to publish daemon socket path at {}: {error}", discovery_path.display()))
 }
 
 fn spawn_peer_networking_runtime(

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -79,6 +79,29 @@ fn daemon_publishes_its_actual_socket_path_for_remote_dialers() {
     publish_socket_path(&discovery_path, &socket_path).expect("publish socket path");
 
     assert_eq!(std::fs::read_to_string(discovery_path).expect("read discovery file"), format!("{}\n", socket_path.display()));
+    assert_eq!(std::fs::read_dir(tmp.path().join("config/run")).expect("read discovery directory").count(), 1);
+}
+
+#[tokio::test]
+async fn daemon_discovery_path_is_independent_of_its_config_and_socket_paths() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = test_config_store(tmp.path().join("custom-config"));
+    let socket_path = tmp.path().join("custom-runtime/daemon.sock");
+    let discovery_path = tmp.path().join("remote-home/.config/flotilla/run/socket-path");
+
+    let server = DaemonServer::new_with_socket_discovery_path(
+        Vec::new(),
+        config,
+        fake_discovery(false),
+        socket_path.clone(),
+        discovery_path.clone(),
+        StdDuration::from_secs(30),
+    )
+    .await
+    .expect("server");
+
+    assert_eq!(server.socket_path, socket_path);
+    assert_eq!(server.socket_discovery_path, discovery_path);
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -56,6 +56,7 @@ use super::{
         disconnect_peer_and_rebuild, forward_with_keepalive_for_test, handle_remote_restart_if_needed, relay_peer_data, send_local_to_peer,
         should_send_local_version, ForwardResult,
     },
+    publish_socket_path,
     remote_commands::{
         extract_command_repo_identity, ForwardedCommand, ForwardedCommandMap, ForwardedCommandState, PendingRemoteCancelMap,
         PendingRemoteCommand, PendingRemoteCommandMap, RemoteCommandRouter,
@@ -68,6 +69,17 @@ use super::{
     AcceptErrorBackoff, DaemonServer, PeerConnectionEvent, ACCEPT_ERROR_INITIAL_BACKOFF, ACCEPT_ERROR_MAX_BACKOFF,
     CONNECTION_PREFACE_TIMEOUT, HELLO_HANDSHAKE_TIMEOUT,
 };
+
+#[test]
+fn daemon_publishes_its_actual_socket_path_for_remote_dialers() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let discovery_path = tmp.path().join("config/run/socket-path");
+    let socket_path = tmp.path().join("custom/location/flotilla.sock");
+
+    publish_socket_path(&discovery_path, &socket_path).expect("publish socket path");
+
+    assert_eq!(std::fs::read_to_string(discovery_path).expect("read discovery file"), format!("{}\n", socket_path.display()));
+}
 
 #[tokio::test]
 async fn resource_http_lists_and_watches_over_a_unix_socket() {
@@ -1780,7 +1792,6 @@ async fn remote_convoy_started_event_routes_auto_attach_back_through_the_target_
         r#"[hosts.feta]
 hostname = "feta.example"
 expected_host_name = "feta"
-daemon_socket = "/run/user/1000/flotilla.sock"
 "#,
     )
     .expect("write peer config");
@@ -3279,10 +3290,7 @@ async fn daemon_server_does_not_replay_configured_peers_without_host_environment
     let base = tmp.path().join("config");
     std::fs::create_dir_all(&base).expect("create config directory");
     std::fs::write(base.join("daemon.toml"), "machine_id = \"test-machine\"\nhost_name = \"local\"\n").expect("write daemon config");
-    std::fs::write(
-            base.join("hosts.toml"),
-            "[hosts.udder]\nhostname = \"udder\"\ndaemon_socket = \"/tmp/udder.sock\"\n\n[hosts.feta]\nhostname = \"feta\"\ndaemon_socket = \"/tmp/feta.sock\"\n",
-        )
+    std::fs::write(base.join("hosts.toml"), "[hosts.udder]\nhostname = \"udder\"\n\n[hosts.feta]\nhostname = \"feta\"\n")
         .expect("write hosts config");
 
     let config = Arc::new(ConfigStore::with_base(&base));
@@ -4370,11 +4378,8 @@ async fn peer_manager_initialized_from_config() {
     std::fs::write(base.join("daemon.toml"), "machine_id = \"test-machine\"\nhost_name = \"test-host\"\n").expect("write daemon config");
 
     // Write hosts config with one peer
-    std::fs::write(
-        base.join("hosts.toml"),
-        "[hosts.remote]\nhostname = \"10.0.0.5\"\nexpected_host_name = \"remote\"\ndaemon_socket = \"/tmp/daemon.sock\"\n",
-    )
-    .expect("write hosts config");
+    std::fs::write(base.join("hosts.toml"), "[hosts.remote]\nhostname = \"10.0.0.5\"\nexpected_host_name = \"remote\"\n")
+        .expect("write hosts config");
 
     let config = Arc::new(ConfigStore::with_base(&base));
     let server = DaemonServer::new(vec![], config, fake_discovery(false), tmp.path().join("test.sock"), Duration::from_secs(60))
@@ -4406,11 +4411,8 @@ async fn daemon_server_new_returns_error_for_invalid_hosts_config() {
     let base = tmp.path().join("config");
     std::fs::create_dir_all(&base).expect("create config directory");
     std::fs::write(base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
-    std::fs::write(
-        base.join("hosts.toml"),
-        "[hosts.remote]\nhostname = \"10.0.0.5\"\nexpected_host_name = [\ndaemon_socket = \"/tmp/daemon.sock\"\n",
-    )
-    .expect("write invalid hosts config");
+    std::fs::write(base.join("hosts.toml"), "[hosts.remote]\nhostname = \"10.0.0.5\"\nexpected_host_name = [\n")
+        .expect("write invalid hosts config");
 
     let config = Arc::new(ConfigStore::with_base(&base));
     let result = DaemonServer::new(vec![], config, fake_discovery(false), tmp.path().join("test.sock"), Duration::from_secs(60)).await;

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -190,7 +190,6 @@ def topology():
                     "[hosts.node-b]",
                     'hostname = "node-b"',
                     'expected_host_name = "node-b"',
-                    'daemon_socket = "/home/flotilla/.config/flotilla/flotilla.sock"',
                     "TOML",
                 ]
             ),

--- a/tests/integration/test_hub_spoke_topology.py
+++ b/tests/integration/test_hub_spoke_topology.py
@@ -144,12 +144,10 @@ def hub_spoke_topology():
                     "[hosts.homelab-1]",
                     'hostname = "homelab-1"',
                     'expected_host_name = "homelab-1"',
-                    'daemon_socket = "/home/flotilla/.config/flotilla/flotilla.sock"',
                     "",
                     "[hosts.homelab-2]",
                     'hostname = "homelab-2"',
                     'expected_host_name = "homelab-2"',
-                    'daemon_socket = "/home/flotilla/.config/flotilla/flotilla.sock"',
                     "TOML",
                 ]
             ),


### PR DESCRIPTION
Closes #1315

## Summary

- remove daemon socket paths from `hosts.toml` peer configuration
- publish each daemon’s actual socket path and resolve it over SSH on every tunnel attempt
- probe the remote listener after a pre-hello close and report when the daemon is not listening at the derived path
- let fleet replica snapshots use the remote CLI’s own socket resolution

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`