### PR TITLE
fix: use local Docker builder for hub-spoke Compose

### DIFF
--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -27,7 +27,7 @@ jobs:
         run: python -m pip install ./tests/integration
       - name: Run real-boundary topology and wedge regressions
         run: >-
-          python -m pytest -v --timeout=900
+          python -m pytest -v --timeout=1800
           tests/integration/test_minimal_topology.py
           tests/integration/test_wedge_regressions.py
       - name: Print compose logs

--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/compose-integration.yml
 
 permissions:
   contents: read

--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -27,7 +27,7 @@ jobs:
         run: python -m pip install ./tests/integration
       - name: Run real-boundary topology and wedge regressions
         run: >-
-          python -m pytest -v
+          python -m pytest -v --timeout=900
           tests/integration/test_minimal_topology.py
           tests/integration/test_wedge_regressions.py
       - name: Print compose logs

--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -36,7 +36,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      # The fixture builds flotilla-base into the host image store before the
+      # role images; a container-driver buildx builder cannot resolve it.
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -219,10 +219,19 @@ def topology():
             )
             start_daemon(node)
 
+        def daemon_ready(node):
+            result = docker_exec(node, "flotilla status --json")
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"flotilla status failed on {node} (rc={result.returncode}): "
+                    f"{result.stderr.strip()}"
+                )
+            return True
+
         # Wait for daemon readiness on each node
         for node in ("node-a", "node-b"):
             wait_for(
-                lambda n=node: docker_exec(n, "flotilla status --json").returncode == 0,
+                lambda n=node: daemon_ready(n),
                 f"daemon ready on {node}",
                 timeout=30,
             )
@@ -236,7 +245,7 @@ def topology():
         def peers_connected():
             result = flotilla_json("node-a", "host list")
             return any(
-                h["host_name"] == "node-b" and h["connection_status"] == "Connected"
+                h["host"] == "node-b" and h["link"] == "Connected"
                 for h in result.get("hosts", [])
             )
 

--- a/tests/integration/docker/base/Dockerfile
+++ b/tests/integration/docker/base/Dockerfile
@@ -1,5 +1,7 @@
 # === Cargo build stages (only executed when building 'full' target) ===
 FROM rust:slim-trixie AS chef
+ARG FLOTILLA_BUILD_ID=compose-integration
+ENV FLOTILLA_BUILD_ID=$FLOTILLA_BUILD_ID
 RUN cargo install cargo-chef
 WORKDIR /app
 

--- a/tests/integration/test_hub_spoke_topology.py
+++ b/tests/integration/test_hub_spoke_topology.py
@@ -69,8 +69,8 @@ def wait_for_follower(follower: str):
             next(
                 host
                 for host in hub_json("workstation", "host list")["hosts"]
-                if host["host_name"] == follower
-            )["connection_status"]
+                if host["host"] == follower
+            )["link"]
             == "Connected"
         ),
         f"{follower} connected to workstation",
@@ -177,9 +177,18 @@ def hub_spoke_topology():
             )
             hub_start_daemon(node)
 
+        def daemon_ready(node):
+            result = hub_exec(node, "flotilla status --json")
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"flotilla status failed on {node} (rc={result.returncode}): "
+                    f"{result.stderr.strip()}"
+                )
+            return True
+
         for node in NODES:
             wait_for(
-                lambda n=node: hub_exec(n, "flotilla status --json").returncode == 0,
+                lambda n=node: daemon_ready(n),
                 f"daemon ready on {node}",
                 timeout=30,
                 interval=0.5,

--- a/tests/integration/test_hub_spoke_topology.py
+++ b/tests/integration/test_hub_spoke_topology.py
@@ -26,7 +26,7 @@ HUB_SPOKE_COMPOSE = str(COMPOSE_DIR / "docker-compose.hub-spoke.yml")
 
 NODES = ("workstation", "homelab-1", "homelab-2")
 FOLLOWERS = ("homelab-1", "homelab-2")
-pytestmark = pytest.mark.timeout(900)
+pytestmark = pytest.mark.timeout(1800)
 
 
 def hub_exec(service: str, cmd: str, timeout: int = 30):
@@ -105,7 +105,7 @@ def hub_spoke_topology():
         "-d",
         "--build",
         "--force-recreate",
-        timeout=900,
+        timeout=1800,
     )
     assert result.returncode == 0, (
         f"compose up failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"

--- a/tests/integration/test_minimal_topology.py
+++ b/tests/integration/test_minimal_topology.py
@@ -22,9 +22,9 @@ def test_host_list_shows_peer(topology):
     # Should see at least local host + node-b
     assert len(hosts) >= 2
 
-    peer = next((h for h in hosts if h["host_name"] == "node-b"), None)
+    peer = next((h for h in hosts if h["host"] == "node-b"), None)
     assert peer is not None, f"node-b not in host list: {hosts}"
-    assert peer["connection_status"] == "Connected"
+    assert peer["link"] == "Connected"
     assert not peer["is_local"]
     assert peer["configured"]
 
@@ -34,7 +34,7 @@ def test_host_list_shows_local(topology):
     result = flotilla_json(topology["node-a"], "host list")
     local = next((h for h in result["hosts"] if h["is_local"]), None)
     assert local is not None, "no local host in host list"
-    assert local["host_name"] == "node-a"
+    assert local["host"] == "node-a"
 
 
 def test_topology_shows_direct_route(topology):

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -34,9 +34,9 @@ def peer_status():
     return flotilla_json("node-a", "host node-b status")
 
 
-def daemon_events(service: str) -> list[dict]:
+def daemon_events(service: str, offset: int = 0) -> list[dict]:
     events = []
-    for line in daemon_log(service).splitlines():
+    for line in daemon_log(service)[offset:].splitlines():
         try:
             events.append(json.loads(line))
         except json.JSONDecodeError:
@@ -48,7 +48,10 @@ def peer_generations() -> list[int]:
     return [
         int(event["fields"]["generation"])
         for event in daemon_events("node-a")
-        if event.get("fields", {}).get("message") == "reconnected successfully"
+        if (
+            "connected successfully"
+            in event.get("fields", {}).get("message", "")
+        )
         and "generation" in event["fields"]
     ]
 
@@ -247,13 +250,14 @@ def test_03_idle_link_survives_three_ping_windows(topology):
 def test_04_long_transport_outage_recovers_with_capped_backoff(topology):
     """#1045: prolonged transport failure cannot strand a recovered peer."""
     initial_generation = max(peer_generations())
+    log_offset = len(daemon_log("node-a"))
 
     stop_daemon("node-b")
 
     def capped_attempt_observed():
         attempts = [
             (int(event["fields"]["attempt"]), int(event["fields"]["delay_secs"]))
-            for event in daemon_events("node-a")
+            for event in daemon_events("node-a", log_offset)
             if event.get("fields", {}).get("message") == "reconnecting after backoff"
             and "attempt" in event["fields"]
             and "delay_secs" in event["fields"]

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -25,7 +25,7 @@ RECONNECT_MESSAGES = (
 def peer_entry():
     return next(
         host
-        for host in flotilla_json("node-a", "host list")
+        for host in flotilla_json("node-a", "host list")["hosts"]
         if host["host"] == "node-b"
     )
 

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -1,7 +1,6 @@
 """Real-boundary regressions for the multi-host wedge family."""
 
 import json
-import re
 import time
 
 import pytest
@@ -29,15 +28,31 @@ def peer_entry():
     return flotilla_json("node-a", "host node-b status")
 
 
-def peer_generations() -> list[int]:
-    generations = []
-    for line in daemon_log("node-a").splitlines():
-        if "connected successfully" not in line:
+def daemon_events(service: str) -> list[dict]:
+    events = []
+    for line in daemon_log(service).splitlines():
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
             continue
-        match = GENERATION_RE.search(line)
-        if match:
-            generations.append(int(match.group(1)))
-    return generations
+    return events
+
+
+def peer_generations() -> list[int]:
+    return [
+        int(event["fields"]["generation"])
+        for event in daemon_events("node-a")
+        if event.get("fields", {}).get("message") == "reconnected successfully"
+        and "generation" in event["fields"]
+    ]
+
+
+def listed_objects(response: dict) -> list[dict]:
+    return [
+        record["object"]
+        for record in response["records"]
+        if record.get("object") is not None
+    ]
 
 
 def replicated_peer_host() -> dict:
@@ -47,7 +62,7 @@ def replicated_peer_host() -> dict:
     listed = flotilla_json(
         "node-a", "resource list hosts --include-replicas"
     )
-    for item in listed["items"]:
+    for item in listed_objects(listed):
         annotations = item["metadata"].get("annotations", {})
         if (
             item["metadata"]["name"] == peer_host_id
@@ -64,7 +79,7 @@ def replicated_host_by_identity(name: str, origin: str) -> dict:
     listed = flotilla_json(
         "node-a", "resource list hosts --include-replicas"
     )
-    for item in listed["items"]:
+    for item in listed_objects(listed):
         annotations = item["metadata"].get("annotations", {})
         if (
             item["metadata"]["name"] == name
@@ -192,7 +207,7 @@ def test_02_transport_death_re_resolves_forwarded_socket(topology):
         )
         return any(
             item["metadata"]["name"] == "transport-recovery"
-            for item in listed["items"]
+            for item in listed_objects(listed)
         )
 
     wait_for(
@@ -226,15 +241,15 @@ def test_03_idle_link_survives_three_ping_windows(topology):
 def test_04_long_transport_outage_recovers_with_capped_backoff(topology):
     """#1045: prolonged transport failure cannot strand a recovered peer."""
     initial_generation = max(peer_generations())
-    initial_log = daemon_log("node-a")
-
     stop_daemon("node-b")
 
     def capped_attempt_observed():
-        recovery_log = daemon_log("node-a")[len(initial_log):]
         attempts = [
-            (int(attempt), int(delay))
-            for attempt, delay in BACKOFF_RE.findall(recovery_log)
+            (int(event["fields"]["attempt"]), int(event["fields"]["delay_secs"]))
+            for event in daemon_events("node-a")
+            if event.get("fields", {}).get("message") == "reconnecting after backoff"
+            and "attempt" in event["fields"]
+            and "delay_secs" in event["fields"]
         ]
         assert all(delay <= 60 for _, delay in attempts), (
             f"redial delay exceeded its 60-second cap: {attempts}"

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -23,6 +23,14 @@ RECONNECT_MESSAGES = (
 
 
 def peer_entry():
+    return next(
+        host
+        for host in flotilla_json("node-a", "host list")
+        if host["host"] == "node-b"
+    )
+
+
+def peer_status():
     return flotilla_json("node-a", "host node-b status")
 
 
@@ -54,7 +62,7 @@ def listed_objects(response: dict) -> list[dict]:
 
 
 def replicated_peer_host() -> dict:
-    peer = peer_entry()
+    peer = peer_status()
     peer_node_id = peer["node"]["node_id"]
     peer_host_id = peer["environment_id"].removeprefix("host:")
     listed = flotilla_json(
@@ -96,7 +104,7 @@ def heartbeat_at() -> str:
 
 def wait_connected():
     wait_for(
-        lambda: peer_entry()["connection_status"] == "Connected",
+        lambda: peer_entry()["link"] == "Connected",
         "node-a reports node-b connected",
         timeout=30,
         interval=0.5,
@@ -226,7 +234,7 @@ def test_03_idle_link_survives_three_ping_windows(topology):
 
     time.sleep(95)
 
-    assert peer_entry()["connection_status"] == "Connected"
+    assert peer_entry()["link"] == "Connected"
     assert replicated_peer_host()["status"]["ready"] is True
     assert max(peer_generations()) == generation
     final_log = daemon_log("node-a")

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -241,6 +241,7 @@ def test_03_idle_link_survives_three_ping_windows(topology):
 def test_04_long_transport_outage_recovers_with_capped_backoff(topology):
     """#1045: prolonged transport failure cannot strand a recovered peer."""
     initial_generation = max(peer_generations())
+
     stop_daemon("node-b")
 
     def capped_attempt_observed():

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -15,8 +15,6 @@ from conftest import (
     wait_for,
 )
 
-GENERATION_RE = re.compile(r"\bgeneration=(\d+)\b")
-BACKOFF_RE = re.compile(r"\battempt=(\d+)\b.*\bdelay_secs=(\d+)\b")
 RECONNECT_MESSAGES = (
     "SSH connection dropped, will reconnect",
     "reconnecting after backoff",

--- a/tests/integration/test_wedge_regressions.py
+++ b/tests/integration/test_wedge_regressions.py
@@ -26,8 +26,7 @@ RECONNECT_MESSAGES = (
 
 
 def peer_entry():
-    hosts = flotilla_json("node-a", "host list")["hosts"]
-    return next(host for host in hosts if host["host_name"] == "node-b")
+    return flotilla_json("node-a", "host node-b status")
 
 
 def peer_generations() -> list[int]:


### PR DESCRIPTION
## Summary

- keep the hub-spoke fixture on Docker's default builder so its local `flotilla-base` image remains resolvable
- budget CI for cold Compose and role-image builds
- stamp integration CLI/daemon binaries with a shared, known wire generation
- update topology tests to the current fleet-health `host list` JSON shape
- preserve failing CLI stderr in daemon-readiness timeout diagnostics
- run this workflow on PRs that change the workflow itself

## Root causes

`docker/setup-buildx-action` selects a docker-container builder. The fixture first builds `flotilla-base:latest`, then the role Dockerfiles use `FROM flotilla-base`. The isolated builder cannot resolve the image from the host Docker image store and attempts to pull `docker.io/library/flotilla-base:latest` instead.

Live validation exposed three independent failures, each filed with logs: #1324 (cold builds exceeded pytest's setup budget), #1325 (`.dockerignore` produced deliberately incompatible `unknown` wire stamps), and #1326 (tests still parsed the pre-fleet-health host-list shape). This PR fixes all three and improves readiness diagnostics.

## Validation

- `git diff --check`
- `docker compose v2.39.1 -f tests/integration/docker-compose.hub-spoke.yml config --quiet`
- CI run 30752076630: format, Clippy, and workspace tests green
- Compose integration run 30752076675: hub-spoke and all 14 minimal/wedge regressions green
- Claude Code Review run 30752076637 green; no unresolved review threads

Closes #1320
Closes #1324
Closes #1325
Closes #1326