### PR TITLE
fix: inject ssh transport processes

### DIFF
--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -684,6 +684,63 @@ pub(crate) mod testing {
 
         assert_eq!(output.len(), 131_072);
     }
+
+    #[tokio::test]
+    async fn process_runner_long_lived_process_supports_lifecycle_contract() {
+        let runner = super::ProcessCommandRunner;
+        let mut process = runner.spawn_long_lived("sleep", &["30"], Path::new("/"), &ChannelLabel::Noop).await.expect("spawn sleep");
+
+        assert!(process.try_wait().expect("poll running child").is_none());
+        process.kill().await.expect("kill child");
+        let status = process.wait().await.expect("reap killed child");
+        assert!(!status.success());
+        assert!(process.try_wait().expect("poll reaped child").is_some());
+    }
+
+    #[tokio::test]
+    async fn process_runner_long_lived_process_drop_does_not_leak_child() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join("child.pid");
+        let pid_path_arg = pid_path.to_string_lossy();
+        let runner = super::ProcessCommandRunner;
+        let process = runner
+            .spawn_long_lived("sh", &["-c", "echo $$ > \"$1\"; exec sleep 30", "sh", &pid_path_arg], Path::new("/"), &ChannelLabel::Noop)
+            .await
+            .expect("spawn tracked sleep");
+
+        let pid = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Ok(contents) = tokio::fs::read_to_string(&pid_path).await {
+                    let pid = contents.trim();
+                    if !pid.is_empty() {
+                        break pid.to_string();
+                    }
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("child should publish pid");
+
+        drop(process);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let status = tokio::process::Command::new("kill")
+                    .args(["-0", &pid])
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .await
+                    .expect("poll child pid");
+                if !status.success() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped process must terminate its child");
+    }
 }
 
 #[cfg(test)]

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -150,6 +150,19 @@ pub struct CommandOutput {
     pub success: bool,
 }
 
+/// Handle to a supervised long-lived command spawned by a [`CommandRunner`].
+#[async_trait]
+pub trait CommandProcess: Send + Sync {
+    /// Return the exit status when the command has exited, without waiting.
+    fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>, String>;
+
+    /// Request termination of the command.
+    async fn kill(&mut self) -> Result<(), String>;
+
+    /// Wait for the command to exit.
+    async fn wait(&mut self) -> Result<std::process::ExitStatus, String>;
+}
+
 pub(crate) fn helper_exec_script(helper_path: &str, subcommand: &str, args: &[&str]) -> Result<String, String> {
     let helper_dir = Path::new(helper_path).parent().ok_or_else(|| format!("installed helper path has no parent: {helper_path}"))?;
     let mut parts = vec![
@@ -214,6 +227,20 @@ pub trait CommandRunner: Send + Sync {
     /// `Err` only if the process could not be spawned at all.
     async fn run_output(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<CommandOutput, String>;
 
+    /// Spawn a supervised command that is expected to outlive this call.
+    ///
+    /// Implementations should ensure dropping the returned handle terminates
+    /// the command so cancellation cannot orphan a child process.
+    async fn spawn_long_lived(
+        &self,
+        _cmd: &str,
+        _args: &[&str],
+        _cwd: &Path,
+        _label: &ChannelLabel,
+    ) -> Result<Box<dyn CommandProcess>, String> {
+        Err("command runner does not support long-lived processes".to_string())
+    }
+
     /// Run a command with bytes supplied on stdin. The input is deliberately
     /// separate from argv so sensitive content cannot leak into process lists
     /// or recorded command transcripts.
@@ -256,6 +283,25 @@ pub trait CommandRunner: Send + Sync {
 /// Production implementation that delegates to `tokio::process::Command`.
 pub struct ProcessCommandRunner;
 
+struct TokioCommandProcess {
+    child: tokio::process::Child,
+}
+
+#[async_trait]
+impl CommandProcess for TokioCommandProcess {
+    fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>, String> {
+        self.child.try_wait().map_err(|error| error.to_string())
+    }
+
+    async fn kill(&mut self) -> Result<(), String> {
+        self.child.kill().await.map_err(|error| error.to_string())
+    }
+
+    async fn wait(&mut self) -> Result<std::process::ExitStatus, String> {
+        self.child.wait().await.map_err(|error| error.to_string())
+    }
+}
+
 #[async_trait]
 impl CommandRunner for ProcessCommandRunner {
     async fn run(&self, cmd: &str, args: &[&str], cwd: &Path, _label: &ChannelLabel) -> Result<String, String> {
@@ -277,6 +323,7 @@ impl CommandRunner for ProcessCommandRunner {
         let output = tokio::process::Command::new(cmd)
             .args(args)
             .current_dir(cwd)
+            .kill_on_drop(true)
             .stdin(std::process::Stdio::null())
             .output()
             .await
@@ -286,6 +333,25 @@ impl CommandRunner for ProcessCommandRunner {
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
             success: output.status.success(),
         })
+    }
+
+    async fn spawn_long_lived(
+        &self,
+        cmd: &str,
+        args: &[&str],
+        cwd: &Path,
+        _label: &ChannelLabel,
+    ) -> Result<Box<dyn CommandProcess>, String> {
+        let child = tokio::process::Command::new(cmd)
+            .args(args)
+            .current_dir(cwd)
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|error| error.to_string())?;
+        Ok(Box::new(TokioCommandProcess { child }))
     }
 
     async fn run_with_input(&self, cmd: &str, args: &[&str], cwd: &Path, _label: &ChannelLabel, input: &[u8]) -> Result<String, String> {

--- a/crates/flotilla-core/src/providers/replay.rs
+++ b/crates/flotilla-core/src/providers/replay.rs
@@ -748,6 +748,19 @@ impl CommandRunner for RecordingRunner {
         result
     }
 
+    async fn spawn_long_lived(
+        &self,
+        cmd: &str,
+        args: &[&str],
+        cwd: &Path,
+        label: &ChannelLabel,
+    ) -> Result<Box<dyn super::CommandProcess>, String> {
+        // Lifecycle recording needs distinct spawn/kill/wait interactions.
+        // Until that fixture shape is introduced, preserve the shared runner
+        // boundary by delegating rather than bypassing the wrapped runner.
+        self.inner.spawn_long_lived(cmd, args, cwd, label).await
+    }
+
     async fn run_with_input(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel, input: &[u8]) -> Result<String, String> {
         let result = self.inner.run_with_input(cmd, args, cwd, label, input).await;
 

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use async_trait::async_trait;
-use flotilla_core::config::RemoteHostConfig;
+use flotilla_core::{
+    config::RemoteHostConfig,
+    providers::{ChannelLabel, CommandOutput, CommandProcess, CommandRunner, ProcessCommandRunner},
+};
 use flotilla_protocol::{ConfigLabel, GoodbyeReason, HostName, Message, NodeId, NodeInfo, PeerWireMessage, PROTOCOL_VERSION};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -35,6 +38,8 @@ const SOCKET_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const REMOTE_SOCKET_PATH_PREFIX: &str = "FLOTILLA_DAEMON_SOCKET_PATH=";
 
 const PRE_HELLO_CLOSE_ERROR: &str = "peer closed before sending hello";
+
+const REMOTE_DAEMON_NOT_LISTENING: &str = "FLOTILLA_DAEMON_NOT_LISTENING";
 
 /// Channel buffer size for inbound and outbound peer data messages.
 const CHANNEL_BUFFER: usize = 256;
@@ -111,9 +116,8 @@ pub struct SshTransport {
     remote_daemon_socket_path: Option<PathBuf>,
     remote_resource_socket_path: Option<PathBuf>,
     ssh_binary: PathBuf,
-    #[cfg(test)]
-    ssh_args_prefix: Vec<PathBuf>,
-    ssh_process: Option<tokio::process::Child>,
+    command_runner: Arc<dyn CommandRunner>,
+    ssh_process: Option<Box<dyn CommandProcess>>,
     status: PeerConnectionStatus,
     /// Receiver for inbound peer data, produced by `connect_socket()` and
     /// returned once via `subscribe()`.
@@ -159,8 +163,7 @@ impl SshTransport {
             remote_daemon_socket_path: None,
             remote_resource_socket_path: None,
             ssh_binary: PathBuf::from("ssh"),
-            #[cfg(test)]
-            ssh_args_prefix: Vec::new(),
+            command_runner: Arc::new(ProcessCommandRunner),
             ssh_process: None,
             status: PeerConnectionStatus::Disconnected,
             inbound_rx: None,
@@ -170,17 +173,6 @@ impl SshTransport {
             remote_session_id: None,
             remote_node_info: None,
         })
-    }
-
-    fn ssh_command(&self) -> tokio::process::Command {
-        let command = tokio::process::Command::new(&self.ssh_binary);
-        #[cfg(test)]
-        let command = {
-            let mut command = command;
-            command.args(&self.ssh_args_prefix);
-            command
-        };
-        command
     }
 
     /// Spawn the SSH child process that forwards the remote socket locally.
@@ -217,28 +209,29 @@ impl SshTransport {
             "spawning SSH tunnel"
         );
 
+        let args = vec![
+            "-N".to_string(),
+            "-L".to_string(),
+            forward_spec,
+            "-R".to_string(),
+            reverse_forward_spec,
+            "-o".to_string(),
+            "ExitOnForwardFailure=yes".to_string(),
+            "-o".to_string(),
+            "StreamLocalBindUnlink=yes".to_string(),
+            "-o".to_string(),
+            "ServerAliveInterval=15".to_string(),
+            "-o".to_string(),
+            "ServerAliveCountMax=3".to_string(),
+            destination,
+        ];
+        let binary = self.ssh_binary.to_string_lossy();
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
         let child = self
-            .ssh_command()
-            .arg("-N") // no remote command
-            .arg("-L")
-            .arg(&forward_spec)
-            .arg("-R")
-            .arg(&reverse_forward_spec)
-            .arg("-o")
-            .arg("ExitOnForwardFailure=yes")
-            .arg("-o")
-            .arg("StreamLocalBindUnlink=yes")
-            .arg("-o")
-            .arg("ServerAliveInterval=15")
-            .arg("-o")
-            .arg("ServerAliveCountMax=3")
-            .arg(&destination)
-            .kill_on_drop(true)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .map_err(|e| format!("failed to spawn ssh: {e}"))?;
+            .command_runner
+            .spawn_long_lived(&binary, &arg_refs, Path::new("/"), &ChannelLabel::Noop)
+            .await
+            .map_err(|error| format!("failed to spawn ssh: {error}"))?;
 
         self.ssh_process = Some(child);
         Ok(())
@@ -254,33 +247,20 @@ impl SshTransport {
     async fn resolve_remote_daemon_socket(&self) -> Result<PathBuf, String> {
         let destination = self.destination();
         let command = remote_socket_path_command();
-        let output = self
-            .ssh_command()
-            .arg("-T")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(&destination)
-            .arg(&command)
-            .kill_on_drop(true)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output();
-        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, output)
+        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, self.run_ssh_output(&destination, command))
             .await
             .map_err(|_| format!("timed out resolving remote daemon socket path on {destination}"))?
             .map_err(|error| format!("failed to resolve remote daemon socket path on {destination}: {error}"))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+        if !output.success {
             return Err(format!(
-                "failed to resolve remote daemon socket path on {destination}: ssh exited with {}{}",
-                output.status,
-                if stderr.trim().is_empty() { String::new() } else { format!(": {}", stderr.trim()) }
+                "failed to resolve remote daemon socket path on {destination}: ssh exited unsuccessfully{}",
+                if output.stderr.trim().is_empty() { String::new() } else { format!(": {}", output.stderr.trim()) }
             ));
         }
 
-        parse_remote_socket_path(&output.stdout).map_err(|error| format!("invalid remote daemon socket path from {destination}: {error}"))
+        parse_remote_socket_path(output.stdout.as_bytes())
+            .map_err(|error| format!("invalid remote daemon socket path from {destination}: {error}"))
     }
 
     async fn cleanup_remote_socket(&self) -> Result<(), String> {
@@ -289,33 +269,26 @@ impl SshTransport {
         let command = self.remote_cleanup_command();
         debug!(%destination, remote_socket = %path, "removing stale reverse peer socket before SSH tunnel dial");
 
-        let output = self
-            .ssh_command()
-            .arg("-T")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(&destination)
-            .arg(&command)
-            .kill_on_drop(true)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::piped())
-            .output();
-        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, output)
+        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, self.run_ssh_output(&destination, command))
             .await
             .map_err(|_| format!("timed out removing stale reverse peer socket at {path} on {destination}"))?
             .map_err(|e| format!("failed to run remote stale peer socket cleanup at {path} on {destination}: {e}"))?;
 
-        if output.status.success() {
+        if output.success {
             return Ok(());
         }
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
         Err(format!(
-            "failed to remove stale reverse peer socket at {path} on {destination}: ssh exited with {}{}",
-            output.status,
-            if stderr.trim().is_empty() { String::new() } else { format!(": {}", stderr.trim()) }
+            "failed to remove stale reverse peer socket at {path} on {destination}: ssh exited unsuccessfully{}",
+            if output.stderr.trim().is_empty() { String::new() } else { format!(": {}", output.stderr.trim()) }
         ))
+    }
+
+    async fn run_ssh_output(&self, destination: &str, command: String) -> Result<CommandOutput, String> {
+        let binary = self.ssh_binary.to_string_lossy();
+        self.command_runner
+            .run_output(&binary, &["-T", "-o", "BatchMode=yes", destination, &command], Path::new("/"), &ChannelLabel::Noop)
+            .await
     }
 
     fn remote_cleanup_command(&self) -> String {
@@ -484,28 +457,18 @@ impl SshTransport {
         let remote_socket = self.remote_daemon_socket_path().ok()?;
         let destination = self.destination();
         let quoted_path = shell_quote(&remote_socket.to_string_lossy());
-        let command =
-            format!("test -S {quoted_path} && {{ ! command -v ss >/dev/null 2>&1 || ss -xlH | grep -F -- {quoted_path} >/dev/null; }}");
-        let output = self
-            .ssh_command()
-            .arg("-T")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(&destination)
-            .arg(command)
-            .kill_on_drop(true)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .output();
-        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, output).await.ok()?.ok()?;
+        let command = format!(
+            "test -S {quoted_path} && {{ ! command -v ss >/dev/null 2>&1 || ss -xlH | grep -F -- {quoted_path} >/dev/null; }} || printf '%s\\n' {REMOTE_DAEMON_NOT_LISTENING}"
+        );
+        let output = tokio::time::timeout(REMOTE_COMMAND_TIMEOUT, self.run_ssh_output(&destination, command)).await.ok()?.ok()?;
 
-        match output.status.code() {
-            Some(0) | Some(255) | None => None,
-            Some(_) => Some(format!(
+        if output.success && output.stdout.lines().any(|line| line.trim() == REMOTE_DAEMON_NOT_LISTENING) {
+            Some(format!(
                 "remote daemon not listening at derived path {} on {destination} (peer closed before sending hello)",
                 remote_socket.display()
-            )),
+            ))
+        } else {
+            None
         }
     }
 
@@ -706,10 +669,102 @@ impl Drop for SshTransport {
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::VecDeque, sync::Mutex as StdMutex};
+
     use flotilla_protocol::PeerDataMessage;
     use tokio::io::AsyncWriteExt;
 
     use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedCommand {
+        binary: String,
+        args: Vec<String>,
+    }
+
+    struct FakeCommandRunner {
+        outputs: StdMutex<VecDeque<Result<CommandOutput, String>>>,
+        commands: StdMutex<Vec<RecordedCommand>>,
+        spawns: StdMutex<Vec<RecordedCommand>>,
+        events: Arc<StdMutex<Vec<&'static str>>>,
+    }
+
+    impl FakeCommandRunner {
+        fn new(outputs: Vec<Result<CommandOutput, String>>, events: Arc<StdMutex<Vec<&'static str>>>) -> Self {
+            Self { outputs: StdMutex::new(outputs.into()), commands: StdMutex::new(Vec::new()), spawns: StdMutex::new(Vec::new()), events }
+        }
+
+        fn commands(&self) -> Vec<RecordedCommand> {
+            self.commands.lock().expect("command lock").clone()
+        }
+
+        fn spawns(&self) -> Vec<RecordedCommand> {
+            self.spawns.lock().expect("spawn lock").clone()
+        }
+    }
+
+    #[async_trait]
+    impl CommandRunner for FakeCommandRunner {
+        async fn run(&self, _cmd: &str, _args: &[&str], _cwd: &Path, _label: &ChannelLabel) -> Result<String, String> {
+            panic!("ssh transport only uses run_output")
+        }
+
+        async fn run_output(&self, cmd: &str, args: &[&str], _cwd: &Path, _label: &ChannelLabel) -> Result<CommandOutput, String> {
+            self.events.lock().expect("event lock").push("command");
+            self.commands
+                .lock()
+                .expect("command lock")
+                .push(RecordedCommand { binary: cmd.to_string(), args: args.iter().map(|arg| (*arg).to_string()).collect() });
+            self.outputs.lock().expect("output lock").pop_front().expect("queued command output")
+        }
+
+        async fn spawn_long_lived(
+            &self,
+            cmd: &str,
+            args: &[&str],
+            _cwd: &Path,
+            _label: &ChannelLabel,
+        ) -> Result<Box<dyn CommandProcess>, String> {
+            self.events.lock().expect("event lock").push("spawn");
+            self.spawns
+                .lock()
+                .expect("spawn lock")
+                .push(RecordedCommand { binary: cmd.to_string(), args: args.iter().map(|arg| (*arg).to_string()).collect() });
+            let local_forward =
+                args.windows(2).find_map(|pair| (pair[0] == "-L").then_some(pair[1])).expect("tunnel spawn has a local forward");
+            let (local_socket, _) = local_forward.split_once(':').expect("local forward spec");
+            std::fs::write(local_socket, []).expect("simulate forwarded socket");
+            Ok(Box::new(FakeCommandProcess))
+        }
+
+        async fn exists(&self, _cmd: &str, _args: &[&str]) -> bool {
+            false
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeCommandProcess;
+
+    #[async_trait]
+    impl CommandProcess for FakeCommandProcess {
+        fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>, String> {
+            Ok(None)
+        }
+
+        async fn kill(&mut self) -> Result<(), String> {
+            Ok(())
+        }
+
+        async fn wait(&mut self) -> Result<std::process::ExitStatus, String> {
+            use std::os::unix::process::ExitStatusExt;
+
+            Ok(std::process::ExitStatus::from_raw(0))
+        }
+    }
+
+    fn successful_output(stdout: impl Into<String>) -> Result<CommandOutput, String> {
+        Ok(CommandOutput { stdout: stdout.into(), stderr: String::new(), success: true })
+    }
 
     #[test]
     fn backoff_delay_exponential_with_cap() {
@@ -749,36 +804,41 @@ mod tests {
 
     #[tokio::test]
     async fn remote_socket_path_is_resolved_again_after_it_moves() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let published_path = tmp.path().join("published-path");
-        std::fs::write(&published_path, "/run/first.sock\n").expect("write first path");
-        let fake_ssh = tmp.path().join("ssh");
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let runner = Arc::new(FakeCommandRunner::new(
+            vec![
+                successful_output(format!("login banner\n{REMOTE_SOCKET_PATH_PREFIX}/run/first.sock\nmotd\n")),
+                successful_output(format!("login banner\n{REMOTE_SOCKET_PATH_PREFIX}/run/moved.sock\nmotd\n")),
+            ],
+            events,
+        ));
         let mut transport = test_transport();
-        install_fake_ssh(
-            &mut transport,
-            &fake_ssh,
-            format!(
-                "#!/bin/sh\nprintf 'login banner\\n{REMOTE_SOCKET_PATH_PREFIX}'; cat {}\nprintf 'motd\\n'\n",
-                shell_quote(&published_path.to_string_lossy())
-            ),
-        );
+        transport.command_runner = runner.clone();
         assert_eq!(transport.resolve_remote_daemon_socket().await.expect("first resolution"), PathBuf::from("/run/first.sock"));
-
-        std::fs::write(&published_path, "/run/moved.sock\n").expect("move published path");
         assert_eq!(transport.resolve_remote_daemon_socket().await.expect("second resolution"), PathBuf::from("/run/moved.sock"));
+
+        let commands = runner.commands();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0], commands[1]);
+        assert_eq!(commands[0].binary, "ssh");
+        assert_eq!(&commands[0].args[..4], ["-T", "-o", "BatchMode=yes", "remote.example.invalid"]);
+        assert_eq!(commands[0].args[4], remote_socket_path_command());
     }
 
     #[tokio::test]
     async fn pre_hello_close_names_remote_daemon_not_listening() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let fake_ssh = tmp.path().join("ssh");
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let runner = Arc::new(FakeCommandRunner::new(vec![successful_output(format!("{REMOTE_DAEMON_NOT_LISTENING}\n"))], events));
         let mut transport = test_transport();
-        install_fake_ssh(&mut transport, &fake_ssh, "#!/bin/sh\nexit 1\n");
+        transport.command_runner = runner.clone();
         transport.remote_daemon_socket_path = Some(PathBuf::from("/remote/run/flotilla.sock"));
 
         let diagnosis = transport.diagnose_pre_hello_close().await.expect("probable cause");
         assert!(diagnosis.contains("remote daemon not listening at derived path /remote/run/flotilla.sock"));
         assert!(diagnosis.contains("peer closed before sending hello"));
+        let command = runner.commands().pop().expect("diagnostic command");
+        assert_eq!(&command.args[..4], ["-T", "-o", "BatchMode=yes", "remote.example.invalid"]);
+        assert!(command.args[4].contains("test -S '/remote/run/flotilla.sock'"));
     }
 
     fn test_transport() -> SshTransport {
@@ -798,16 +858,6 @@ mod tests {
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("test transport")
-    }
-
-    fn install_fake_ssh(transport: &mut SshTransport, path: &Path, script: impl AsRef<[u8]>) {
-        std::fs::write(path, script).expect("write fake ssh");
-
-        // Execute the freshly written stub as data through sh instead of exec-ing it
-        // directly. On Linux, another test spawning during our write can inherit the
-        // write fd in the fork/exec CLOEXEC window, making direct exec fail with ETXTBSY.
-        transport.ssh_binary = PathBuf::from("/bin/sh");
-        transport.ssh_args_prefix = vec![path.to_path_buf()];
     }
 
     #[test]
@@ -937,23 +987,41 @@ mod tests {
             SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
         )
         .expect("valid transport");
-        let stale_reverse_socket = reverse_peer_resource_socket_path(&daemon_socket, &NodeId::new("local-node")).expect("reverse socket");
-        std::fs::write(&stale_reverse_socket, []).expect("create stale reverse socket stand-in");
-        let fake_ssh = tmp.path().join("ssh");
-        install_fake_ssh(
-            &mut transport,
-            &fake_ssh,
-            format!(
-                "#!/bin/sh\n[ \"$1\" = \"-N\" ] && exit 0\nfor command do :; done\ncase \"$command\" in\n  *socket-path*) printf '{REMOTE_SOCKET_PATH_PREFIX}%s\\n' '{}' ;;\n  *) exec /bin/sh -c \"$command\" ;;\nesac\n",
-                daemon_socket.display()
-            ),
-        );
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let runner = Arc::new(FakeCommandRunner::new(
+            vec![successful_output(format!("{REMOTE_SOCKET_PATH_PREFIX}{}\n", daemon_socket.display())), successful_output("")],
+            events.clone(),
+        ));
+        transport.command_runner = runner.clone();
 
         transport.spawn_ssh().await.expect("stale cleanup and tunnel spawn should succeed");
+        transport.wait_for_socket().await.expect("fake tunnel creates forwarded socket");
 
-        assert!(!transport.remote_resource_socket_path().expect("resolved reverse socket").exists());
-        let status = transport.ssh_process.as_mut().expect("tunnel child").wait().await.expect("wait for fake tunnel");
-        assert!(status.success());
+        assert_eq!(*events.lock().expect("event lock"), ["command", "command", "spawn"]);
+        let commands = runner.commands();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[1].args[4], transport.remote_cleanup_command());
+        let tunnel = runner.spawns().pop().expect("tunnel invocation");
+        let (forward, reverse) = transport.resource_forward_specs();
+        assert_eq!(tunnel, RecordedCommand {
+            binary: "ssh".into(),
+            args: vec![
+                "-N".into(),
+                "-L".into(),
+                forward,
+                "-R".into(),
+                reverse,
+                "-o".into(),
+                "ExitOnForwardFailure=yes".into(),
+                "-o".into(),
+                "StreamLocalBindUnlink=yes".into(),
+                "-o".into(),
+                "ServerAliveInterval=15".into(),
+                "-o".into(),
+                "ServerAliveCountMax=3".into(),
+                "peer-a.example.invalid".into(),
+            ],
+        });
     }
 
     #[tokio::test]
@@ -977,15 +1045,15 @@ mod tests {
             SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
         )
         .expect("valid transport");
-        let fake_ssh = tmp.path().join("ssh");
-        install_fake_ssh(
-            &mut transport,
-            &fake_ssh,
-            format!(
-                "#!/bin/sh\n[ \"$1\" = \"-N\" ] && exit 0\nfor command do :; done\ncase \"$command\" in\n  *socket-path*) printf '{REMOTE_SOCKET_PATH_PREFIX}%s\\n' '{}' ;;\n  *) echo cleanup-denied >&2; exit 23 ;;\nesac\n",
-                daemon_socket.display()
-            ),
-        );
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let runner = Arc::new(FakeCommandRunner::new(
+            vec![
+                successful_output(format!("{REMOTE_SOCKET_PATH_PREFIX}{}\n", daemon_socket.display())),
+                Ok(CommandOutput { stdout: String::new(), stderr: "cleanup-denied".into(), success: false }),
+            ],
+            events.clone(),
+        ));
+        transport.command_runner = runner.clone();
 
         let error = transport.spawn_ssh().await.expect_err("cleanup failure must stop the tunnel dial");
 
@@ -993,6 +1061,8 @@ mod tests {
         assert!(error.contains(&transport.remote_resource_socket_path().expect("resolved reverse socket").to_string_lossy().into_owned()));
         assert!(error.contains("cleanup-denied"), "unexpected error: {error}");
         assert!(transport.ssh_process.is_none(), "tunnel must not spawn after cleanup failure");
+        assert!(runner.spawns().is_empty(), "tunnel must not be invoked after cleanup failure");
+        assert_eq!(*events.lock().expect("event lock"), ["command", "command"]);
     }
 
     #[test]

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -7,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use flotilla_core::{
     config::RemoteHostConfig,
-    providers::{ChannelLabel, CommandOutput, CommandProcess, CommandRunner, ProcessCommandRunner},
+    providers::{ChannelLabel, CommandOutput, CommandProcess, CommandRunner},
 };
 use flotilla_protocol::{ConfigLabel, GoodbyeReason, HostName, Message, NodeId, NodeInfo, PeerWireMessage, PROTOCOL_VERSION};
 use tokio::{
@@ -139,6 +139,7 @@ impl SshTransport {
     ///
     /// The local forwarded socket will be placed at
     /// `~/.config/flotilla/peers/<host-name>.sock`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         local_node_id: NodeId,
         local_display_name: String,
@@ -146,6 +147,7 @@ impl SshTransport {
         config: RemoteHostConfig,
         expected_node_id: Option<NodeId>,
         local_session_id: uuid::Uuid,
+        command_runner: Arc<dyn CommandRunner>,
         paths: SshTransportPaths<'_>,
     ) -> Result<Self, String> {
         let local_socket_path = peer_resource_socket_path(&paths.state_dir.join("peers"), &config_label)?;
@@ -163,7 +165,7 @@ impl SshTransport {
             remote_daemon_socket_path: None,
             remote_resource_socket_path: None,
             ssh_binary: PathBuf::from("ssh"),
-            command_runner: Arc::new(ProcessCommandRunner),
+            command_runner,
             ssh_process: None,
             status: PeerConnectionStatus::Disconnected,
             inbound_rx: None,
@@ -812,8 +814,7 @@ mod tests {
             ],
             events,
         ));
-        let mut transport = test_transport();
-        transport.command_runner = runner.clone();
+        let transport = test_transport(runner.clone());
         assert_eq!(transport.resolve_remote_daemon_socket().await.expect("first resolution"), PathBuf::from("/run/first.sock"));
         assert_eq!(transport.resolve_remote_daemon_socket().await.expect("second resolution"), PathBuf::from("/run/moved.sock"));
 
@@ -829,8 +830,7 @@ mod tests {
     async fn pre_hello_close_names_remote_daemon_not_listening() {
         let events = Arc::new(StdMutex::new(Vec::new()));
         let runner = Arc::new(FakeCommandRunner::new(vec![successful_output(format!("{REMOTE_DAEMON_NOT_LISTENING}\n"))], events));
-        let mut transport = test_transport();
-        transport.command_runner = runner.clone();
+        let mut transport = test_transport(runner.clone());
         transport.remote_daemon_socket_path = Some(PathBuf::from("/remote/run/flotilla.sock"));
 
         let diagnosis = transport.diagnose_pre_hello_close().await.expect("probable cause");
@@ -841,7 +841,7 @@ mod tests {
         assert!(command.args[4].contains("test -S '/remote/run/flotilla.sock'"));
     }
 
-    fn test_transport() -> SshTransport {
+    fn test_transport(command_runner: Arc<dyn CommandRunner>) -> SshTransport {
         SshTransport::new(
             NodeId::new("local"),
             "local-display".into(),
@@ -855,6 +855,7 @@ mod tests {
             },
             None,
             uuid::Uuid::nil(),
+            command_runner,
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("test transport")
@@ -876,6 +877,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
@@ -899,6 +901,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths {
                 state_dir: Path::new("/home/test-local/.local/state/flotilla"),
                 daemon_socket: Path::new("/home/test-local/.config/flotilla/flotilla.sock"),
@@ -944,6 +947,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid transport");
@@ -977,6 +981,11 @@ mod tests {
             user: None,
             ssh_multiplex: None,
         };
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let runner = Arc::new(FakeCommandRunner::new(
+            vec![successful_output(format!("{REMOTE_SOCKET_PATH_PREFIX}{}\n", daemon_socket.display())), successful_output("")],
+            events.clone(),
+        ));
         let mut transport = SshTransport::new(
             NodeId::new("local-node"),
             "local-host".into(),
@@ -984,15 +993,10 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            runner.clone(),
             SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
         )
         .expect("valid transport");
-        let events = Arc::new(StdMutex::new(Vec::new()));
-        let runner = Arc::new(FakeCommandRunner::new(
-            vec![successful_output(format!("{REMOTE_SOCKET_PATH_PREFIX}{}\n", daemon_socket.display())), successful_output("")],
-            events.clone(),
-        ));
-        transport.command_runner = runner.clone();
 
         transport.spawn_ssh().await.expect("stale cleanup and tunnel spawn should succeed");
         transport.wait_for_socket().await.expect("fake tunnel creates forwarded socket");
@@ -1035,16 +1039,6 @@ mod tests {
             user: None,
             ssh_multiplex: None,
         };
-        let mut transport = SshTransport::new(
-            NodeId::new("local-node"),
-            "local-host".into(),
-            ConfigLabel("peer-a".into()),
-            config,
-            None,
-            uuid::Uuid::nil(),
-            SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
-        )
-        .expect("valid transport");
         let events = Arc::new(StdMutex::new(Vec::new()));
         let runner = Arc::new(FakeCommandRunner::new(
             vec![
@@ -1053,7 +1047,17 @@ mod tests {
             ],
             events.clone(),
         ));
-        transport.command_runner = runner.clone();
+        let mut transport = SshTransport::new(
+            NodeId::new("local-node"),
+            "local-host".into(),
+            ConfigLabel("peer-a".into()),
+            config,
+            None,
+            uuid::Uuid::nil(),
+            runner.clone(),
+            SshTransportPaths { state_dir: tmp.path(), daemon_socket: &daemon_socket },
+        )
+        .expect("valid transport");
 
         let error = transport.spawn_ssh().await.expect_err("cleanup failure must stop the tunnel dial");
 
@@ -1081,6 +1085,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         ) {
             Err(e) => assert!(e.contains("path separators"), "unexpected error: {e}"),
@@ -1104,6 +1109,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
@@ -1207,6 +1213,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
@@ -1229,6 +1236,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
@@ -1259,6 +1267,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");
@@ -1330,6 +1339,7 @@ mod tests {
             config,
             None,
             uuid::Uuid::nil(),
+            Arc::new(flotilla_core::providers::ProcessCommandRunner),
             SshTransportPaths { state_dir: Path::new("/tmp/flotilla-test"), daemon_socket: Path::new("/tmp/flotilla.sock") },
         )
         .expect("valid host name");

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -176,6 +176,7 @@ fn build_peer_manager(
 
     let peer_count = hosts_config.hosts.len();
     let mut peer_manager = PeerManager::new(local_node_id.clone());
+    let command_runner = daemon.local_command_runner().ok_or_else(|| "local command runner unavailable".to_string())?;
     for (name, host_config) in hosts_config.hosts {
         let expected_host_name = HostName::new(&host_config.expected_host_name);
         let expected_node_id = host_config.expected_node_id.clone();
@@ -186,6 +187,7 @@ fn build_peer_manager(
             host_config,
             expected_node_id.clone(),
             daemon.session_id(),
+            Arc::clone(&command_runner),
             SshTransportPaths { state_dir: config.state_dir().as_path(), daemon_socket: local_daemon_socket_path },
         ) {
             Ok(transport) => {


### PR DESCRIPTION
## Summary

- extend the shared `CommandRunner` family with supervised long-lived process spawning and a `CommandProcess` lifecycle handle
- route SSH discovery, cleanup, diagnostics, and tunnel spawning through the injected runner
- replace the executable stub-script harness with a recording fake that asserts exact argv and simulates the forwarded socket

## Seam choice

This reuses and extends `flotilla_core::CommandRunner` rather than adding a daemon-local process trait. The three finite SSH commands already fit `run_output`; the tunnel now uses `spawn_long_lived`, whose handle exposes the existing `try_wait`, `kill`, and `wait` lifecycle. `ProcessCommandRunner` owns the Tokio implementation and `RecordingRunner` delegates the new capability, keeping all process execution behind the replay-family boundary and leaving a single home for future lifecycle recording/replay.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p flotilla-daemon --locked peer::ssh_transport::tests` (20 passed, 1 ignored)
- sandbox-safe workspace run reached an unrelated live-daemon-sensitive root test failure
- core/daemon package run executed 1,218 core tests before two unrelated host-environment failures (machine identity and real-git fixture availability)

Closes #1327