### PR TITLE
ci: path-filter and cache Compose integration builds

### DIFF
--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -6,7 +6,13 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - .github/workflows/compose-integration.yml
+      - ".github/workflows/compose-integration.yml"
+      - ".dockerignore"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "src/**"
+      - "crates/**"
+      - "tests/integration/**"
 
 permissions:
   contents: read
@@ -17,7 +23,27 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+      - name: Build integration base image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: tests/integration/docker/base/Dockerfile
+          target: full
+          tags: flotilla-base
+          load: true
+          cache-from: type=gha,scope=compose-integration-base
+          cache-to: type=gha,mode=max,scope=compose-integration-base
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -39,8 +65,29 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
-      # The fixture builds flotilla-base into the host image store before the
-      # role images; a container-driver buildx builder cannot resolve it.
+      - uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+      # Keep the docker driver: the fixture builds flotilla-base into the host
+      # image store before the role images, which resolve it by image name.
+      - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+      - name: Build integration base image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: tests/integration/docker/base/Dockerfile
+          target: full
+          tags: flotilla-base
+          load: true
+          cache-from: type=gha,scope=compose-integration-base
+          cache-to: type=gha,mode=max,scope=compose-integration-base
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -42,8 +42,8 @@ jobs:
           target: full
           tags: flotilla-base
           load: true
-          cache-from: type=gha,scope=compose-integration-base
-          cache-to: type=gha,mode=max,scope=compose-integration-base
+          cache-from: type=gha,scope=compose-integration-wedge
+          cache-to: type=gha,mode=max,scope=compose-integration-wedge
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -86,8 +86,8 @@ jobs:
           target: full
           tags: flotilla-base
           load: true
-          cache-from: type=gha,scope=compose-integration-base
-          cache-to: type=gha,mode=max,scope=compose-integration-base
+          cache-from: type=gha,scope=compose-integration-hub-spoke
+          cache-to: type=gha,mode=max,scope=compose-integration-hub-spoke
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -10,6 +10,7 @@ on:
       - ".dockerignore"
       - "Cargo.lock"
       - "Cargo.toml"
+      - "assets/**"
       - "src/**"
       - "crates/**"
       - "tests/integration/**"

--- a/tests/integration/docker/base/Dockerfile
+++ b/tests/integration/docker/base/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 
 FROM chef AS planner
 COPY Cargo.toml Cargo.lock ./
+COPY assets/ assets/
 COPY src/ src/
 COPY crates/ crates/
 RUN cargo chef prepare --recipe-path recipe.json

--- a/tests/integration/docker/base/Dockerfile
+++ b/tests/integration/docker/base/Dockerfile
@@ -14,7 +14,9 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
-COPY . .
+COPY Cargo.toml Cargo.lock ./
+COPY src/ src/
+COPY crates/ crates/
 RUN cargo build --release
 
 # === Shared runtime base (used by both full and dev) ===

--- a/tests/integration/docker/base/Dockerfile
+++ b/tests/integration/docker/base/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /app
 
 FROM chef AS planner
 COPY Cargo.toml Cargo.lock ./
-COPY assets/ assets/
 COPY src/ src/
 COPY crates/ crates/
 RUN cargo chef prepare --recipe-path recipe.json
@@ -16,6 +15,7 @@ FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY Cargo.toml Cargo.lock ./
+COPY assets/ assets/
 COPY src/ src/
 COPY crates/ crates/
 RUN cargo build --release


### PR DESCRIPTION
Closes #1330.

## What changed

- Restricts the Compose integration `pull_request` trigger to build inputs: the workflow and Docker context controls (`.dockerignore`), root manifests and binary sources (`Cargo.toml`, `Cargo.lock`, `src/**`, `assets/**`), every workspace crate (`crates/**`), and the complete integration harness (`tests/integration/**`). A docs-only change matches none of these paths; a daemon change matches `crates/**`. The daily schedule and manual dispatch remain unfiltered.
- Prebuilds `flotilla-base` with `docker/build-push-action`, importing and exporting job-specific `type=gha` caches in `mode=max` so intermediate Cargo dependency layers survive ephemeral runners without concurrent jobs overwriting one cache scope.
- Enables Docker's containerd image store and keeps the local `docker` buildx driver, preserving the hub-spoke fixture's requirement that role Dockerfiles resolve the locally loaded `flotilla-base` image.
- Makes the post-`cargo chef cook` source layer explicit: manifests, embedded assets, `src/`, and `crates/` are copied only after dependencies are cooked.

The integration pytest selections and Compose topologies are unchanged.

## Timing

Measured on PR workflow run 26, comparing the successful cold attempt with successful job reruns on the same commit:

| Job | Cold | Warm GHA cache |
| --- | ---: | ---: |
| hub-spoke | 20m10s | 5m41s |
| wedge-regressions | 21m07s | 6m37s |

Both warm runs are single-digit minutes. The GHA cache removes the Rust/image build from the critical path; the remaining time is primarily the unchanged topology and wedge regression coverage.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `git diff --check`
- Compose integration: cold run and warm reruns green for both jobs
- Repository CI: green
- Claude Code Review: green

Container execution was unavailable in the vessel, so the PR workflow provided the end-to-end Docker and integration validation.