### PR TITLE
fix: cascade convoy checkout cleanup

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -15,6 +15,7 @@ const CHECKOUT_PROVISIONING_REQUEUE_AFTER: Duration = Duration::from_secs(1);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CheckoutRemoval {
     Worktree { clone_path: String, branch: String, target_path: String },
+    OrphanedWorktree { target_path: String },
     FreshClone { target_path: String },
 }
 
@@ -209,10 +210,15 @@ where
 
     async fn run_finalizer(&self, obj: &ResourceObject<Self::Resource>) -> Result<(), ResourceError> {
         let removal = match &obj.spec {
-            CheckoutSpec::Worktree(spec) => {
-                let clone = self.clones.get(&spec.clone_ref).await?;
-                CheckoutRemoval::Worktree { clone_path: clone.spec.path, branch: spec.r#ref.clone(), target_path: spec.target_path.clone() }
-            }
+            CheckoutSpec::Worktree(spec) => match self.clones.get(&spec.clone_ref).await {
+                Ok(clone) => CheckoutRemoval::Worktree {
+                    clone_path: clone.spec.path,
+                    branch: spec.r#ref.clone(),
+                    target_path: spec.target_path.clone(),
+                },
+                Err(ResourceError::NotFound { .. }) => CheckoutRemoval::OrphanedWorktree { target_path: spec.target_path.clone() },
+                Err(err) => return Err(err),
+            },
             CheckoutSpec::FreshClone(spec) => CheckoutRemoval::FreshClone { target_path: spec.target_path.clone() },
             CheckoutSpec::Observed(_) => return Ok(()),
         };

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -662,12 +662,7 @@ impl Reconciler for VesselReconciler {
                     {
                         labels.insert(CHANGE_REQUEST_ID_LABEL.to_string(), change_request.id.clone());
                     }
-                    let meta = match &strategy {
-                        PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
-                            convoy_owned_child_meta(&checkout_name, &convoy, obj, labels)
-                        }
-                        PlacementStrategy::DockerFreshCloneInContainer { .. } => owned_child_meta(&checkout_name, obj, labels),
-                    };
+                    let meta = convoy_owned_child_meta(&checkout_name, &convoy, obj, labels);
                     actuations.push(Actuation::CreateCheckout { meta, spec });
                     waiting_for_checkouts.push(checkout_name);
                 }

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -72,7 +72,9 @@ impl CheckoutRuntime for RecordingCheckoutRuntime {
     async fn remove_checkout(&self, removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String> {
         self.removals.lock().expect("removals lock").push(removal.clone());
         let target_path = match removal {
-            CheckoutRemoval::Worktree { target_path, .. } | CheckoutRemoval::FreshClone { target_path } => target_path,
+            CheckoutRemoval::Worktree { target_path, .. }
+            | CheckoutRemoval::OrphanedWorktree { target_path }
+            | CheckoutRemoval::FreshClone { target_path } => target_path,
         };
         if self.failed_removal_target.as_deref() == Some(target_path) {
             return Err("permission denied removing root-owned debris".to_string());
@@ -231,6 +233,34 @@ async fn worktree_finalizer_supplies_clone_branch_and_target_to_runtime() {
     assert_eq!(runtime.removals.lock().expect("removals lock").as_slice(), &[CheckoutRemoval::Worktree {
         clone_path: "/checkouts/repo".to_string(),
         branch: "feature/cleanup".to_string(),
+        target_path: "/checkouts/convoy-a/repo.feature-cleanup".to_string(),
+    }]);
+}
+
+#[tokio::test]
+async fn worktree_finalizer_removes_checkout_when_clone_resource_is_already_gone() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    let created = checkouts
+        .create(
+            &meta("checkout-a"),
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                env_ref: "host-direct-a".to_string(),
+                r#ref: "feature/cleanup".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/convoy-a/repo.feature-cleanup".to_string(),
+                clone_ref: "missing-clone".to_string(),
+            }),
+        )
+        .await
+        .expect("checkout create should succeed");
+    let runtime = Arc::new(RecordingCheckoutRuntime::default());
+    let reconciler = CheckoutReconciler::new(Arc::clone(&runtime), backend, NAMESPACE);
+
+    reconciler.run_finalizer(&created).await.expect("missing clone must not wedge checkout deletion");
+
+    assert_eq!(runtime.removals.lock().expect("removals lock").as_slice(), &[CheckoutRemoval::OrphanedWorktree {
         target_path: "/checkouts/convoy-a/repo.feature-cleanup".to_string(),
     }]);
 }

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -859,6 +859,15 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
         })
         .collect::<Vec<_>>();
     assert_eq!(checkout_paths, ["/workspace/flotilla", "/workspace/cleat"]);
+    for actuation in &outcome.actuations {
+        let Actuation::CreateCheckout { meta, spec: CheckoutSpec::FreshClone(_) } = actuation else {
+            continue;
+        };
+        assert_eq!(meta.labels.get(CONVOY_LABEL).map(String::as_str), Some("convoy-multi-fresh"));
+        assert_eq!(meta.owner_references.len(), 1);
+        assert_eq!(meta.owner_references[0].kind, "Convoy");
+        assert_eq!(meta.owner_references[0].name, "convoy-multi-fresh");
+    }
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2318,6 +2318,10 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
                 remove_checkout_path(&*runner, &clone_staging_path(target_path)).await?;
                 Ok(CheckoutRemovalOutcome::Removed)
             }
+            CheckoutRemoval::OrphanedWorktree { target_path } => {
+                remove_checkout_path(&*runner, utf8_path(target_path)?).await?;
+                Ok(CheckoutRemovalOutcome::Removed)
+            }
             CheckoutRemoval::Worktree { clone_path, branch, target_path } => {
                 let clone_path = utf8_path(clone_path)?;
                 let target_path = utf8_path(target_path)?;
@@ -4392,6 +4396,20 @@ mod tests {
 
         assert_eq!(outcome, CheckoutRemovalOutcome::Removed);
         assert!(!Path::new(&staging_path).exists());
+    }
+
+    #[tokio::test]
+    async fn checkout_runtime_treats_an_already_missing_orphaned_worktree_as_removed() {
+        let temp = TempDir::new().expect("tempdir");
+        let target = temp.path().join("already-removed-worktree");
+        let runtime = CheckoutControllerRuntime { runner: Arc::new(ProcessCommandRunner) };
+
+        let outcome = runtime
+            .remove_checkout(&CheckoutRemoval::OrphanedWorktree { target_path: target.to_str().expect("utf-8 target path").to_string() })
+            .await
+            .expect("an absent checkout directory should not wedge finalization");
+
+        assert_eq!(outcome, CheckoutRemovalOutcome::Removed);
     }
 
     #[tokio::test]

--- a/crates/flotilla-resources/tests/convoy_in_memory.rs
+++ b/crates/flotilla-resources/tests/convoy_in_memory.rs
@@ -6,11 +6,11 @@ use common::{
 };
 use flotilla_protocol::{IssueRef, IssueSource, IssueState};
 use flotilla_resources::{
-    apply_status_patch, controller::ControllerLoop, external_patches, reconcile, Convoy, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
-    InMemoryBackend, InputMeta, IssueSnapshot, LifecycleAuthority, PlacementPolicy, PlacementPolicySpec, PreparedSnapshotGarbageCollector,
-    Presentation, PresentationSpec, RepositorySpec, ResourceBackend, ResourceError, Vessel, VesselPhase, VesselStatus, WorkflowTemplate,
-    WorkflowTemplateSpec, CONVOY_LABEL, PLACEMENT_SNAPSHOT_ANNOTATION, PLACEMENT_SNAPSHOT_KIND, PREPARED_SNAPSHOT_LABEL, VESSEL_LABEL,
-    WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
+    apply_status_patch, controller::ControllerLoop, external_patches, reconcile, Checkout, CheckoutSpec, Convoy, ConvoyIssue, ConvoyPhase,
+    ConvoyReconciler, FreshCloneCheckoutSpec, InMemoryBackend, InputMeta, IssueSnapshot, LifecycleAuthority, PlacementPolicy,
+    PlacementPolicySpec, PreparedSnapshotGarbageCollector, Presentation, PresentationSpec, RepositoryKey, RepositorySpec, ResourceBackend,
+    ResourceError, Vessel, VesselPhase, VesselStatus, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, PLACEMENT_SNAPSHOT_ANNOTATION,
+    PLACEMENT_SNAPSHOT_KIND, PREPARED_SNAPSHOT_LABEL, VESSEL_LABEL, WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
 };
 use tokio::time::{timeout, Duration};
 
@@ -293,6 +293,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
     let convoys = backend.clone().using::<Convoy>("flotilla");
     let workspaces = backend.clone().using::<Vessel>("flotilla");
     let presentations = backend.clone().using::<Presentation>("flotilla");
+    let checkouts = backend.clone().using::<Checkout>("flotilla");
     let workflow_snapshot_name = "workflow-snapshot-012345abcdef";
     let placement_snapshot_name = "placement-snapshot-012345abcdef";
     let snapshot_labels = |kind: &str| [(PREPARED_SNAPSHOT_LABEL.to_string(), kind.to_string())].into_iter().collect();
@@ -369,6 +370,23 @@ async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
         )
         .await
         .expect("presentation create should succeed");
+    checkouts
+        .create(
+            &InputMeta::builder()
+                .name("checkout-convoy-delete".to_string())
+                .labels([(CONVOY_LABEL.to_string(), "convoy-delete".to_string())].into_iter().collect())
+                .build(),
+            &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                repo_ref: RepositoryKey("repo-a".to_string()),
+                env_ref: "env-convoy-delete".to_string(),
+                r#ref: "feature/delete".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/convoy-delete".to_string(),
+                url: "https://github.com/flotilla-org/flotilla".to_string(),
+            }),
+        )
+        .await
+        .expect("checkout create should succeed");
     workspaces
         .create(
             &InputMeta::builder()
@@ -467,6 +485,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
             reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla"))
                 .with_vessels(workspaces.clone())
                 .with_presentations(presentations.clone())
+                .with_checkouts(checkouts.clone())
                 .with_prepared_snapshot_gc(PreparedSnapshotGarbageCollector::new(backend.clone(), "flotilla")),
             resync_interval: Duration::from_millis(50),
             backend: backend.clone(),
@@ -493,6 +512,7 @@ async fn controller_loop_finalizer_deletes_presentations_and_vessels() {
             if matches!(convoys.get("convoy-delete").await, Err(ResourceError::NotFound { .. }))
                 && matches!(workspaces.get("convoy-delete-implement").await, Err(ResourceError::NotFound { .. }))
                 && matches!(presentations.get("convoy-delete-implement").await, Err(ResourceError::NotFound { .. }))
+                && matches!(checkouts.get("checkout-convoy-delete").await, Err(ResourceError::NotFound { .. }))
                 && matches!(
                     backend.clone().using::<WorkflowTemplate>("flotilla").get(workflow_snapshot_name).await,
                     Err(ResourceError::NotFound { .. })


### PR DESCRIPTION
Fixes #1332.

Crew-authored fix (convoy checkout-cascade) salvaged by the governor: the implementation completed in the vessel as commit 536edb88, but delivery failed — the contained vessel reported `gh` unauthenticated at push time (feta suspended mid-run; possible credential-lease expiry after resume, under investigation separately). Branch pushed from the host; the commit is the crew's, unmodified.

Makes convoy teardown cascade to the convoy's Checkout resources so their `checkout-cleanup` finalizers actually fire, covering both the delete-after-landed and abandon exits, with missing-directory checkouts deleting cleanly.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp