### PR TITLE
refactor: leave checkout cleanup to convoy teardown

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -1051,7 +1051,8 @@ impl Reconciler for VesselReconciler {
         let selector = BTreeMap::from([(VESSEL_REF_LABEL.to_string(), obj.metadata.name.clone())]);
 
         delete_lifecycle_owned_matching(&self.terminal_sessions, &selector).await?;
-        delete_lifecycle_owned_matching(&self.checkouts, &selector).await?;
+        // Checkouts are convoy-owned and are removed by the convoy finalizer's
+        // ownership cascade, independently of vessel teardown.
         delete_lifecycle_owned_matching(&self.environments, &selector).await?;
 
         Ok(())

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -818,7 +818,7 @@ async fn presentation_controller_marks_presentation_active_for_live_convoy_sessi
 }
 
 #[tokio::test]
-async fn vessel_controller_finalizer_deletes_labeled_children_on_delete() {
+async fn vessel_controller_finalizer_deletes_vessel_owned_children_but_preserves_checkout() {
     let backend = ResourceBackend::InMemory(Default::default());
     create_workspace(
         &backend,
@@ -926,7 +926,7 @@ async fn vessel_controller_finalizer_deletes_labeled_children_on_delete() {
             async move {
                 matches!(workspaces.get("workspace-delete").await, Err(ResourceError::NotFound { .. }))
                     && matches!(environments.get("env-workspace-delete").await, Err(ResourceError::NotFound { .. }))
-                    && matches!(checkouts.get("checkout-workspace-delete").await, Err(ResourceError::NotFound { .. }))
+                    && checkouts.get("checkout-workspace-delete").await.is_ok()
                     && matches!(terminals.get("terminal-workspace-delete-coder").await, Err(ResourceError::NotFound { .. }))
             }
         })

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -1928,7 +1928,7 @@ async fn observed_checkout_at_managed_name_marks_workspace_failed() {
 }
 
 #[tokio::test]
-async fn run_finalizer_deletes_all_labeled_children() {
+async fn run_finalizer_deletes_vessel_owned_children_but_preserves_checkout() {
     let backend = ResourceBackend::InMemory(Default::default());
     let workspace = create_workspace(&backend, NAMESPACE, "workspace-finalize", "convoy-a", "implement", "policy-a", REPO_URL).await;
 
@@ -1943,10 +1943,7 @@ async fn run_finalizer_deletes_all_labeled_children() {
         backend.clone().using::<Environment>(NAMESPACE).get("env-workspace-finalize").await,
         Err(ResourceError::NotFound { .. })
     ));
-    assert!(matches!(
-        backend.clone().using::<Checkout>(NAMESPACE).get("checkout-workspace-finalize").await,
-        Err(ResourceError::NotFound { .. })
-    ));
+    backend.clone().using::<Checkout>(NAMESPACE).get("checkout-workspace-finalize").await.expect("convoy cascade owns checkout cleanup");
     assert!(matches!(
         backend.clone().using::<TerminalSession>(NAMESPACE).get("terminal-workspace-finalize-coder").await,
         Err(ResourceError::NotFound { .. })


### PR DESCRIPTION
Closes #1337

Removes the stale vessel-finalizer checkout deletion path now that every managed checkout is convoy-owned. The finalizer comment and lifecycle tests now make the ownership boundary explicit: vessel teardown cleans terminal sessions and environments, while the convoy cascade cleans checkouts.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`