### PR TITLE
fix: require federated checkout settlement evidence

### DIFF
--- a/crates/flotilla-controllers/tests/liveness_contract.rs
+++ b/crates/flotilla-controllers/tests/liveness_contract.rs
@@ -277,7 +277,11 @@ impl ConvoyTeardownRuntime for LandingRuntime {
         Ok(!self.contradictory)
     }
 
-    async fn verify_reclaim(&self, _convoy: &ResourceObject<Convoy>) -> Result<(), String> {
+    async fn verify_reclaim(
+        &self,
+        _convoy: &ResourceObject<Convoy>,
+        _checkouts: &[ResourceObject<flotilla_resources::Checkout>],
+    ) -> Result<(), String> {
         Err("not terminal".to_string())
     }
 }

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -38,7 +38,11 @@ struct AlwaysEligible;
 
 #[async_trait]
 impl ConvoyTeardownRuntime for AlwaysEligible {
-    async fn verify_reclaim(&self, _convoy: &flotilla_resources::ResourceObject<Convoy>) -> Result<(), String> {
+    async fn verify_reclaim(
+        &self,
+        _convoy: &flotilla_resources::ResourceObject<Convoy>,
+        _checkouts: &[flotilla_resources::ResourceObject<flotilla_resources::Checkout>],
+    ) -> Result<(), String> {
         Ok(())
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6132,18 +6132,22 @@ impl InProcessDaemon {
             .await
             .map_err(|err| err.to_string())?
             .items;
-        self.convoy_change_requests_settled_for_checkouts(&checkout_list).await
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
+        let convoy = convoys.get(name).await.map_err(|err| err.to_string())?;
+        self.convoy_change_requests_settled_for_checkouts(&convoy, &checkout_list).await
     }
 
     pub async fn convoy_change_requests_settled_for_checkouts(
         &self,
+        convoy: &ResourceObject<ResourceConvoy>,
         checkout_list: &[ResourceObject<ResourceCheckout>],
     ) -> Result<bool, String> {
-        let Some(first_checkout) = checkout_list.first() else {
-            return Ok(false);
-        };
-        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(&first_checkout.metadata.namespace);
-        for checkout in checkout_list {
+        let expected = flotilla_resources::expected_checkout_refs(convoy)?;
+        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(&convoy.metadata.namespace);
+        for checkout_name in expected {
+            let Some(checkout) = checkout_list.iter().find(|checkout| checkout.metadata.name == checkout_name) else {
+                return Ok(false);
+            };
             if let Some(landed) = checkout.status.as_ref().map(|status| &status.integration.landed) {
                 let recent = landed
                     .observed_at
@@ -6223,14 +6227,26 @@ impl InProcessDaemon {
         if convoy.status.as_ref().is_some_and(|status| status.phase == flotilla_resources::ConvoyPhase::Abandoned) {
             return Ok(());
         }
-        if checkout_list.is_empty() {
-            return Err(format!("convoy {namespace}/{name} is not safe to delete: no checkout integration evidence"));
+        let expected = flotilla_resources::expected_checkout_refs(convoy)?;
+        if expected.is_empty() {
+            return Ok(());
+        }
+        let missing = expected
+            .iter()
+            .filter(|checkout_name| !checkout_list.iter().any(|checkout| &checkout.metadata.name == *checkout_name))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing.is_empty() {
+            return Err(format!(
+                "convoy {namespace}/{name} is not safe to delete: missing checkout integration evidence for {}",
+                missing.join(", ")
+            ));
         }
 
         let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(namespace);
         let mut refusals = Vec::new();
         let mut verified = false;
-        for checkout in checkout_list {
+        for checkout in checkout_list.iter().filter(|checkout| expected.contains(&checkout.metadata.name)) {
             let is_adopted = checkout.metadata.lifecycle_authority().map_err(|err| err.to_string())? == Some(LifecycleAuthority::Adopted);
             if let Some(env_ref) = checkout.spec.env_ref() {
                 if self.checkout_environment_is_destroyed(namespace, env_ref).await? {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6120,20 +6120,30 @@ impl InProcessDaemon {
     /// anything unknown or unprobeable holds Landing — absence of evidence
     /// never releases the gate. Recent observations are trusted as-is, which
     /// bounds forge lookups and keeps the persist from re-triggering the
-    /// reconcile in a loop. Adopted checkouts are exempt, exactly as they are
-    /// from teardown deletion: the convoy does not own their integration
-    /// lifecycle.
+    /// reconcile in a loop. Adopted checkouts participate because an adopted
+    /// open change request is still outstanding, even though its checkout is
+    /// exempt from deletion.
     pub async fn convoy_change_requests_settled(&self, namespace: &str, name: &str) -> Result<bool, String> {
-        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(namespace);
-        let checkout_list = checkouts
+        let checkout_list = self
+            .resource_backend
+            .clone()
+            .using::<ResourceCheckout>(namespace)
             .list_matching_labels(&BTreeMap::from([(CONVOY_LABEL.to_string(), name.to_string())]))
             .await
             .map_err(|err| err.to_string())?
             .items;
+        self.convoy_change_requests_settled_for_checkouts(&checkout_list).await
+    }
+
+    pub async fn convoy_change_requests_settled_for_checkouts(
+        &self,
+        checkout_list: &[ResourceObject<ResourceCheckout>],
+    ) -> Result<bool, String> {
+        let Some(first_checkout) = checkout_list.first() else {
+            return Ok(false);
+        };
+        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(&first_checkout.metadata.namespace);
         for checkout in checkout_list {
-            if checkout.metadata.lifecycle_authority().map_err(|err| err.to_string())? == Some(LifecycleAuthority::Adopted) {
-                continue;
-            }
             if let Some(landed) = checkout.status.as_ref().map(|status| &status.integration.landed) {
                 let recent = landed
                     .observed_at
@@ -6147,10 +6157,10 @@ impl InProcessDaemon {
                     return Ok(false);
                 }
             }
-            let Some(path) = checkout_path(&checkout).map(|path| Path::new(path).to_path_buf()) else {
+            let Some(path) = checkout_path(checkout).map(|path| Path::new(path).to_path_buf()) else {
                 return Ok(false);
             };
-            let runner = match self.runner_for_resource_checkout(&checkout).await {
+            let runner = match self.runner_for_resource_checkout(checkout).await {
                 Ok(runner) => runner,
                 Err(_) => return Ok(false),
             };
@@ -6196,7 +6206,30 @@ impl InProcessDaemon {
             .await
             .map_err(|err| err.to_string())?
             .items;
+        self.verify_convoy_teardown_gate_for_checkouts(&convoy, &checkout_list, false).await
+    }
+
+    pub async fn verify_convoy_teardown_gate_for_checkouts(
+        &self,
+        convoy: &ResourceObject<ResourceConvoy>,
+        checkout_list: &[ResourceObject<ResourceCheckout>],
+        force: bool,
+    ) -> Result<(), String> {
+        if force {
+            return Ok(());
+        }
+        let namespace = &convoy.metadata.namespace;
+        let name = &convoy.metadata.name;
+        if convoy.status.as_ref().is_some_and(|status| status.phase == flotilla_resources::ConvoyPhase::Abandoned) {
+            return Ok(());
+        }
+        if checkout_list.is_empty() {
+            return Err(format!("convoy {namespace}/{name} is not safe to delete: no checkout integration evidence"));
+        }
+
+        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(namespace);
         let mut refusals = Vec::new();
+        let mut verified = false;
         for checkout in checkout_list {
             let is_adopted = checkout.metadata.lifecycle_authority().map_err(|err| err.to_string())? == Some(LifecycleAuthority::Adopted);
             if let Some(env_ref) = checkout.spec.env_ref() {
@@ -6209,7 +6242,7 @@ impl InProcessDaemon {
                     continue;
                 }
             }
-            let path = match checkout_path(&checkout) {
+            let path = match checkout_path(checkout) {
                 Some(path) => Path::new(path).to_path_buf(),
                 None => {
                     if is_adopted {
@@ -6220,7 +6253,7 @@ impl InProcessDaemon {
                     continue;
                 }
             };
-            let runner = match self.runner_for_resource_checkout(&checkout).await {
+            let runner = match self.runner_for_resource_checkout(checkout).await {
                 Ok(runner) => runner,
                 Err(error) => {
                     if is_adopted {
@@ -6261,6 +6294,7 @@ impl InProcessDaemon {
                 checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
             )
             .await;
+            verified = true;
             if let Some(existing) = checkout.status.as_ref() {
                 latch_evidence_backed_integration(&existing.integration, &mut integration);
             }
@@ -6280,19 +6314,24 @@ impl InProcessDaemon {
                 }
             }
             if is_adopted {
-                if let Some(summary) = checkout_integration_summary(&checkout, &integration) {
-                    warn!(checkout = %checkout.metadata.name, summary = %summary, "adopted checkout has integration dirt; releasing without deletion");
+                if !condition_is_true(&integration.landed) {
+                    refusals.push(
+                        checkout_integration_summary(checkout, &integration)
+                            .unwrap_or_else(|| format!("{}: Landed is not verified", checkout.metadata.name)),
+                    );
                 }
                 continue;
             }
             if !(condition_is_true(&integration.clean) && condition_is_true(&integration.pushed) && condition_is_true(&integration.landed))
             {
-                if let Some(summary) = checkout_integration_summary(&checkout, &integration) {
+                if let Some(summary) = checkout_integration_summary(checkout, &integration) {
                     refusals.push(summary);
                 }
             }
         }
-        if refusals.is_empty() {
+        if !verified {
+            Err(format!("convoy {namespace}/{name} is not safe to delete: no checkout integration evidence"))
+        } else if refusals.is_empty() {
             Ok(())
         } else {
             refusals.sort();

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -6437,6 +6437,88 @@ async fn adopted_checkout_with_open_change_request_holds_settlement() {
 }
 
 #[tokio::test]
+async fn adopted_checkout_with_unlanded_change_request_refuses_reclaim_gate() {
+    // Gate-side twin of the settle-condition test above: the reclaim gate's
+    // adopted branch must refuse while an Adopted checkout's landed condition
+    // is not True, rather than the old warn-and-release semantics.
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/adopted-gate\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/adopted-gate..HEAD"], Ok("0\n".into()))
+        .on_run(
+            "gh",
+            &[
+                "pr",
+                "list",
+                "--head",
+                "feature/adopted-gate",
+                "--state",
+                "all",
+                "--json",
+                "number,state,mergedAt,baseRefName,mergeable",
+                "--limit",
+                "1",
+            ],
+            Ok("[]".into()),
+        )
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("1\n".into()))
+        .build();
+    let mut discovery = fake_discovery(false);
+    discovery.runner = Arc::new(runner);
+    let daemon = InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), discovery, HostName::local()).await;
+    daemon
+        .resource_backend()
+        .using::<Convoy>("flotilla")
+        .create(&empty_input_meta("adopted-gate-convoy"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+        .await
+        .expect("convoy create should succeed");
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let created = checkouts
+        .create(
+            &InputMeta::builder()
+                .name("adopted-gate-open".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "adopted-gate-convoy".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+                r#ref: "feature/adopted-gate".to_string(),
+                path: "/repo".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
+                host_ref: "host-01".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("create adopted checkout");
+    checkouts
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            path: Some("/repo".to_string()),
+            commit: None,
+            branch_provenance: Default::default(),
+            integration: Default::default(),
+            message: None,
+        })
+        .await
+        .expect("adopted checkout should be ready");
+    record_expected_checkout_for_convoy(&daemon, "flotilla", "adopted-gate-convoy", "adopted-gate-open").await;
+
+    let error = daemon
+        .verify_convoy_teardown_gate("flotilla", "adopted-gate-convoy", false)
+        .await
+        .expect_err("unlanded adopted checkout must refuse reclaim");
+    assert!(error.contains("adopted-gate-open"), "refusal should name the adopted checkout: {error}");
+    assert!(error.contains("Landed=False"), "refusal should identify the landed condition: {error}");
+}
+
+#[tokio::test]
 async fn landing_holds_when_fresh_probe_contradicts_stale_vacuous_landed() {
     // #1163 replay: a checkout's landed condition was recorded True while the
     // branch was untouched ("nothing to land"), the crew then pushed and

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4994,7 +4994,7 @@ async fn convoy_delete_command_targets_requested_namespace_or_configured_default
             node_id: None,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::ConvoyDelete { namespace: None, name: "failed-convoy".to_string(), force: false },
+            action: CommandAction::ConvoyDelete { namespace: None, name: "failed-convoy".to_string(), force: true },
         })
         .await
         .expect("execute should return a command id");
@@ -5012,7 +5012,7 @@ async fn convoy_delete_command_targets_requested_namespace_or_configured_default
             action: CommandAction::ConvoyDelete {
                 namespace: Some("explicit-ns".to_string()),
                 name: "completed-convoy".to_string(),
-                force: false,
+                force: true,
             },
         })
         .await
@@ -5394,7 +5394,7 @@ async fn landing_settlement_uses_latched_terminal_change_request_after_stale_rep
 }
 
 #[tokio::test]
-async fn convoy_reclaim_allows_managed_checkout_whose_path_is_already_gone() {
+async fn convoy_reclaim_refuses_when_missing_path_leaves_no_integration_evidence() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -5418,10 +5418,11 @@ async fn convoy_reclaim_allows_managed_checkout_whose_path_is_already_gone() {
     )
     .await;
 
-    daemon
+    let refusal = daemon
         .verify_convoy_teardown_gate("flotilla", "half-reclaimed", false)
         .await
-        .expect("a missing checkout path has no integration work left to protect");
+        .expect_err("a missing checkout path alone is not positive integration evidence");
+    assert!(refusal.contains("no checkout integration evidence"), "unexpected refusal: {refusal}");
 }
 
 #[tokio::test]
@@ -5607,7 +5608,7 @@ async fn convoy_delete_refuses_ignored_embedded_repository_with_local_commits() 
 }
 
 #[tokio::test]
-async fn convoy_delete_allows_env_scoped_checkout_when_environment_is_destroyed() {
+async fn convoy_delete_refuses_when_destroyed_environment_leaves_no_integration_evidence() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -5656,8 +5657,12 @@ async fn convoy_delete_allows_env_scoped_checkout_when_environment_is_destroyed(
         .await
         .expect("execute should return a command id");
 
-    assert_eq!(wait_for_command_result(&mut events, command_id).await, CommandValue::Ok);
-    assert!(matches!(convoys.get("corpse-convoy").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
+    let result = wait_for_command_result(&mut events, command_id).await;
+    assert!(
+        matches!(&result, CommandValue::Error { message } if message.contains("no checkout integration evidence")),
+        "unexpected delete result: {result:?}"
+    );
+    convoys.get("corpse-convoy").await.expect("refused convoy should remain");
 }
 
 #[tokio::test]
@@ -6295,6 +6300,74 @@ async fn local_convoy_admission_pins_the_grant_resolved_workflow() {
         .await
         .expect("get standalone resolved workflow snapshot");
     assert_eq!(snapshot.spec.vessels[0].credential_refs, BTreeSet::from(["model-api".to_string()]));
+}
+
+#[tokio::test]
+async fn empty_checkout_evidence_neither_settles_nor_allows_reclaim() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    daemon
+        .resource_backend()
+        .using::<Convoy>("flotilla")
+        .create(&empty_input_meta("empty-convoy"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+        .await
+        .expect("create convoy");
+
+    assert!(!daemon.convoy_change_requests_settled("flotilla", "empty-convoy").await.expect("evaluate settlement"));
+    let refusal = daemon
+        .verify_convoy_teardown_gate("flotilla", "empty-convoy", false)
+        .await
+        .expect_err("empty checkout evidence must refuse reclaim");
+    assert!(refusal.contains("no checkout integration evidence"), "unexpected refusal: {refusal}");
+}
+
+#[tokio::test]
+async fn adopted_checkout_with_open_change_request_holds_settlement() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let created = checkouts
+        .create(
+            &InputMeta::builder()
+                .name("adopted-open".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "adopted-convoy".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+                r#ref: "feature/adopted-open".to_string(),
+                path: "/adopted".to_string(),
+                repo_ref: flotilla_resources::RepositoryKey("repo".to_string()),
+                host_ref: "host-01".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("create adopted checkout");
+    let observed_at = chrono::Utc::now().to_rfc3339();
+    checkouts
+        .update_status(&created.metadata.name, &created.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            path: Some("/adopted".to_string()),
+            commit: None,
+            branch_provenance: Default::default(),
+            integration: CheckoutIntegrationStatus {
+                landed: IntegrationCondition::builder().value(ConditionValue::False).observed_at(observed_at).build(),
+                ..Default::default()
+            },
+            message: None,
+        })
+        .await
+        .expect("record open adopted change request");
+
+    assert!(!daemon.convoy_change_requests_settled("flotilla", "adopted-convoy").await.expect("evaluate adopted settlement"));
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -26,8 +26,8 @@ use flotilla_resources::{
     CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec, CrewWorkPhase,
     CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost, HostCondition,
     HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta,
-    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
-    ProjectRepositorySpec, ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus, Selector, Stance,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, PlacementStatus,
+    Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus, Selector, Stance,
     TerminalBrief, TerminalCrewContext, TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase,
     TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus,
     Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
@@ -1077,6 +1077,47 @@ async fn create_ready_observed_checkout_for_convoy(
         })
         .await
         .expect("checkout should be ready");
+    record_expected_checkout_for_convoy(daemon, namespace, convoy, checkout_name).await;
+}
+
+async fn record_expected_checkout_for_convoy(daemon: &InProcessDaemon, namespace: &str, convoy_name: &str, checkout_name: &str) {
+    let convoys = daemon.resource_backend().using::<Convoy>(namespace);
+    let convoy = match convoys.get(convoy_name).await {
+        Ok(convoy) => convoy,
+        Err(flotilla_resources::ResourceError::NotFound { .. }) => convoys
+            .create(&empty_input_meta(convoy_name), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
+            .await
+            .expect("expected-checkout convoy should be created"),
+        Err(error) => panic!("expected-checkout convoy should resolve: {error}"),
+    };
+    let mut status = convoy.status.clone().unwrap_or_default();
+    let placement = status
+        .work
+        .entry("__test_checkout_expectations".to_string())
+        .or_insert(WorkState {
+            phase: WorkPhase::Pending,
+            completion_authority: WorkCompletionAuthority::CrewRollup,
+            ready_at: None,
+            started_at: None,
+            finished_at: None,
+            message: None,
+            placement: None,
+        })
+        .placement
+        .get_or_insert_with(PlacementStatus::default);
+    let mut checkout_refs = placement
+        .fields
+        .get("checkout_refs")
+        .map(|value| serde_json::from_value::<BTreeMap<flotilla_resources::RepositoryKey, String>>(value.clone()))
+        .transpose()
+        .expect("test checkout refs should deserialize")
+        .unwrap_or_default();
+    checkout_refs.insert(flotilla_resources::RepositoryKey(format!("test:{checkout_name}")), checkout_name.to_string());
+    placement.fields.insert("checkout_refs".to_string(), serde_json::json!(checkout_refs));
+    convoys
+        .update_status(convoy_name, &convoy.metadata.resource_version, &status)
+        .await
+        .expect("expected checkout should be recorded on convoy work");
 }
 
 #[builder]
@@ -5645,6 +5686,7 @@ async fn convoy_delete_refuses_when_destroyed_environment_leaves_no_integration_
         })
         .await
         .expect("checkout status should update");
+    record_expected_checkout_for_convoy(&daemon, "flotilla", "corpse-convoy", "checkout-corpse").await;
 
     let mut events = daemon.subscribe();
     let command_id = daemon
@@ -6303,7 +6345,7 @@ async fn local_convoy_admission_pins_the_grant_resolved_workflow() {
 }
 
 #[tokio::test]
-async fn empty_checkout_evidence_neither_settles_nor_allows_reclaim() {
+async fn expected_but_unobserved_checkout_neither_settles_nor_allows_reclaim() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -6316,13 +6358,36 @@ async fn empty_checkout_evidence_neither_settles_nor_allows_reclaim() {
         .create(&empty_input_meta("empty-convoy"), &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build())
         .await
         .expect("create convoy");
+    record_expected_checkout_for_convoy(&daemon, "flotilla", "empty-convoy", "missing-checkout").await;
 
     assert!(!daemon.convoy_change_requests_settled("flotilla", "empty-convoy").await.expect("evaluate settlement"));
     let refusal = daemon
         .verify_convoy_teardown_gate("flotilla", "empty-convoy", false)
         .await
         .expect_err("empty checkout evidence must refuse reclaim");
-    assert!(refusal.contains("no checkout integration evidence"), "unexpected refusal: {refusal}");
+    assert!(refusal.contains("missing checkout integration evidence for missing-checkout"), "unexpected refusal: {refusal}");
+}
+
+#[tokio::test]
+async fn artifactless_convoy_settles_and_allows_reclaim_on_claims() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let daemon =
+        InProcessDaemon::new(vec![], Arc::new(ConfigStore::with_base(&config_base)), fake_discovery(false), HostName::local()).await;
+    daemon
+        .resource_backend()
+        .using::<Convoy>("flotilla")
+        .create(&empty_input_meta("artifactless-convoy"), &ConvoySpec::builder().workflow_ref("tool-only".to_string()).build())
+        .await
+        .expect("create artifactless convoy");
+
+    assert!(daemon.convoy_change_requests_settled("flotilla", "artifactless-convoy").await.expect("evaluate settlement"));
+    daemon
+        .verify_convoy_teardown_gate("flotilla", "artifactless-convoy", false)
+        .await
+        .expect("artifactless convoy should pass reclaim gate");
 }
 
 #[tokio::test]
@@ -6366,6 +6431,7 @@ async fn adopted_checkout_with_open_change_request_holds_settlement() {
         })
         .await
         .expect("record open adopted change request");
+    record_expected_checkout_for_convoy(&daemon, "flotilla", "adopted-convoy", "adopted-open").await;
 
     assert!(!daemon.convoy_change_requests_settled("flotilla", "adopted-convoy").await.expect("evaluate adopted settlement"));
 }
@@ -6453,6 +6519,7 @@ async fn landing_holds_when_fresh_probe_contradicts_stale_vacuous_landed() {
         })
         .await
         .expect("checkout status should update");
+    record_expected_checkout_for_convoy(&daemon, "flotilla", "split-convoy", "checkout-split").await;
 
     // First pass: the stale True is re-probed; the open change request holds
     // Landing and the fresh False observation is persisted un-latched.

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -49,7 +49,7 @@ use flotilla_resources::{
     apply_status_patch, controller_patches as convoy_controller_patches, implement_review_workflow_spec,
     single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase,
     CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy as ResourceConvoy, ConvoyPhase,
-    DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
+    ConvoySpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
     HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta, IntegrationCondition, LifecycleAuthority, ObservedCheckoutSpec,
     PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource,
     Repository, RepositoryKey, RepositoryRelation, RepositorySpec, Stance, TypedResolver, VirtualClock, WorkPhase, WorkState,
@@ -6796,6 +6796,18 @@ async fn convoy_landing_reprobes_after_injected_clock_crosses_evidence_ttl() {
         clock.clone() as Arc<dyn flotilla_resources::Clock>,
     )
     .await;
+    backend
+        .clone()
+        .using::<ResourceConvoy>("flotilla")
+        .create(
+            &InputMeta::builder().name("convoy-a".to_string()).build(),
+            &ConvoySpec::builder()
+                .workflow_ref("review-and-fix".to_string())
+                .adopted_checkout_refs(BTreeMap::from([(RepositoryKey("repo-a".to_string()), "checkout-a".to_string())]))
+                .build(),
+        )
+        .await
+        .expect("create convoy with expected checkout");
     let checkouts = backend.using::<ResourceCheckout>("flotilla");
     let checkout = checkouts
         .create(

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -87,14 +87,14 @@ impl DaemonConvoyTeardownRuntime {
 impl ConvoyTeardownRuntime for DaemonConvoyTeardownRuntime {
     async fn no_change_request_outstanding(
         &self,
-        convoy: &ResourceObject<Convoy>,
-        _checkouts: &[ResourceObject<Checkout>],
+        _convoy: &ResourceObject<Convoy>,
+        checkouts: &[ResourceObject<Checkout>],
     ) -> Result<bool, String> {
-        self.daemon.convoy_change_requests_settled(&convoy.metadata.namespace, &convoy.metadata.name).await
+        self.daemon.convoy_change_requests_settled_for_checkouts(checkouts).await
     }
 
-    async fn verify_reclaim(&self, convoy: &ResourceObject<Convoy>) -> Result<(), String> {
-        let result = self.daemon.verify_convoy_teardown_gate(&convoy.metadata.namespace, &convoy.metadata.name, false).await;
+    async fn verify_reclaim(&self, convoy: &ResourceObject<Convoy>, checkouts: &[ResourceObject<Checkout>]) -> Result<(), String> {
+        let result = self.daemon.verify_convoy_teardown_gate_for_checkouts(convoy, checkouts, false).await;
         let key = format!("{}/{}", convoy.metadata.namespace, convoy.metadata.name);
         match &result {
             Err(error) => {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -87,10 +87,10 @@ impl DaemonConvoyTeardownRuntime {
 impl ConvoyTeardownRuntime for DaemonConvoyTeardownRuntime {
     async fn no_change_request_outstanding(
         &self,
-        _convoy: &ResourceObject<Convoy>,
+        convoy: &ResourceObject<Convoy>,
         checkouts: &[ResourceObject<Checkout>],
     ) -> Result<bool, String> {
-        self.daemon.convoy_change_requests_settled_for_checkouts(checkouts).await
+        self.daemon.convoy_change_requests_settled_for_checkouts(convoy, checkouts).await
     }
 
     async fn verify_reclaim(&self, convoy: &ResourceObject<Convoy>, checkouts: &[ResourceObject<Checkout>]) -> Result<(), String> {

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -61,6 +61,29 @@ impl ConvoySpec {
     }
 }
 
+/// Checkout object names durably recorded as provisioned for this convoy.
+///
+/// Placements are copied onto work state before vessels can disappear, so the
+/// expected set remains available while federated checkout observations lag.
+/// Adopted refs are also declarations on the convoy itself and therefore count
+/// as expected even before a placement has repeated them.
+pub fn expected_checkout_refs(convoy: &crate::ResourceObject<Convoy>) -> Result<BTreeSet<String>, String> {
+    let mut expected = convoy.spec.adopted_checkout_refs.values().cloned().collect::<BTreeSet<_>>();
+    let Some(status) = &convoy.status else {
+        return Ok(expected);
+    };
+    for (work_name, work) in &status.work {
+        let Some(checkout_refs) = work.placement.as_ref().and_then(|placement| placement.fields.get("checkout_refs")) else {
+            continue;
+        };
+        let checkout_refs = serde_json::from_value::<BTreeMap<RepositoryKey, String>>(checkout_refs.clone()).map_err(|error| {
+            format!("convoy {}/{} has invalid checkout_refs in work {work_name}: {error}", convoy.metadata.namespace, convoy.metadata.name)
+        })?;
+        expected.extend(checkout_refs.into_values());
+    }
+    Ok(expected)
+}
+
 pub fn pinned_workflow_ref(convoy: &crate::ResourceObject<Convoy>) -> &str {
     convoy.metadata.annotations.get(WORKFLOW_SNAPSHOT_ANNOTATION).map(String::as_str).unwrap_or(&convoy.spec.workflow_ref)
 }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -350,18 +350,26 @@ impl Reconciler for ConvoyReconciler {
     }
 }
 
+/// Test-support reconcile entry that carries no vessel, presentation, or
+/// checkout state. Settlement can therefore only be judged from the convoy
+/// record itself: a convoy expecting no checkouts (no placement
+/// `checkout_refs`, no adoptions) settles on claims alone, and any expected
+/// checkout holds settlement here because this path has no integration
+/// evidence to offer. Production callers go through `ConvoyReconciler`,
+/// which supplies the federated checkout list.
 pub fn reconcile(
     convoy: &ResourceObject<Convoy>,
     template: Option<&ResourceObject<WorkflowTemplate>>,
     now: DateTime<Utc>,
 ) -> ReconcileOutcome {
+    let no_change_request_outstanding = expected_checkout_refs(convoy).is_ok_and(|expected| expected.is_empty());
     let outcome = reconcile_internal(
         convoy,
         template,
         &BTreeMap::new(),
         &BTreeMap::new(),
         &BTreeMap::new(),
-        LifecycleConditions { no_change_request_outstanding: true, reclaim_eligible: false },
+        LifecycleConditions { no_change_request_outstanding, reclaim_eligible: false },
         now,
     );
     ReconcileOutcome { patch: outcome.patch, events: outcome.events }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -40,13 +40,14 @@ pub trait ConvoyTeardownRuntime: Send + Sync {
         _convoy: &ResourceObject<Convoy>,
         checkouts: &[ResourceObject<Checkout>],
     ) -> Result<bool, String> {
-        Ok(checkouts
-            .iter()
-            .all(|checkout| checkout.status.as_ref().is_some_and(|status| status.integration.landed.value == crate::ConditionValue::True)))
+        Ok(!checkouts.is_empty()
+            && checkouts.iter().all(|checkout| {
+                checkout.status.as_ref().is_some_and(|status| status.integration.landed.value == crate::ConditionValue::True)
+            }))
     }
 
     /// Re-verify ADR 0017 teardown eligibility at the execution edge.
-    async fn verify_reclaim(&self, convoy: &ResourceObject<Convoy>) -> Result<(), String>;
+    async fn verify_reclaim(&self, convoy: &ResourceObject<Convoy>, checkouts: &[ResourceObject<Checkout>]) -> Result<(), String>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -271,16 +272,22 @@ impl Reconciler for ConvoyReconciler {
                     let checkout_list = checkouts.values().cloned().collect::<Vec<_>>();
                     runtime.no_change_request_outstanding(obj, &checkout_list).await.unwrap_or(false)
                 }
-                None => checkouts.values().all(|checkout| {
-                    checkout.status.as_ref().is_some_and(|status| status.integration.landed.value == crate::ConditionValue::True)
-                }),
+                None => {
+                    !checkouts.is_empty()
+                        && checkouts.values().all(|checkout| {
+                            checkout.status.as_ref().is_some_and(|status| status.integration.landed.value == crate::ConditionValue::True)
+                        })
+                }
             }
         } else {
             false
         };
         let reclaim_eligible = if obj.status.as_ref().is_some_and(|status| status.phase.is_terminal()) {
             match &self.teardown_runtime {
-                Some(runtime) => runtime.verify_reclaim(obj).await.is_ok(),
+                Some(runtime) => {
+                    let checkout_list = checkouts.values().cloned().collect::<Vec<_>>();
+                    runtime.verify_reclaim(obj, &checkout_list).await.is_ok()
+                }
                 None => false,
             }
         } else {

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -9,8 +9,8 @@ use chrono::{DateTime, Utc};
 use serde_json::json;
 
 use super::{
-    controller_patches, provisioning_patches, Convoy, ConvoyPhase, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, VesselRequirement,
-    WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    controller_patches, expected_checkout_refs, provisioning_patches, Convoy, ConvoyPhase, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState,
+    VesselRequirement, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
 };
 use crate::{
     checkout::Checkout,
@@ -37,13 +37,15 @@ pub trait ConvoyTeardownRuntime: Send + Sync {
     /// before answering; the default keeps in-memory reconcilers deterministic.
     async fn no_change_request_outstanding(
         &self,
-        _convoy: &ResourceObject<Convoy>,
+        convoy: &ResourceObject<Convoy>,
         checkouts: &[ResourceObject<Checkout>],
     ) -> Result<bool, String> {
-        Ok(!checkouts.is_empty()
-            && checkouts.iter().all(|checkout| {
+        let expected = expected_checkout_refs(convoy)?;
+        Ok(expected.iter().all(|name| {
+            checkouts.iter().find(|checkout| &checkout.metadata.name == name).is_some_and(|checkout| {
                 checkout.status.as_ref().is_some_and(|status| status.integration.landed.value == crate::ConditionValue::True)
-            }))
+            })
+        }))
     }
 
     /// Re-verify ADR 0017 teardown eligibility at the execution edge.
@@ -272,12 +274,13 @@ impl Reconciler for ConvoyReconciler {
                     let checkout_list = checkouts.values().cloned().collect::<Vec<_>>();
                     runtime.no_change_request_outstanding(obj, &checkout_list).await.unwrap_or(false)
                 }
-                None => {
-                    !checkouts.is_empty()
-                        && checkouts.values().all(|checkout| {
+                None => expected_checkout_refs(obj).is_ok_and(|expected| {
+                    expected.iter().all(|name| {
+                        checkouts.get(name).is_some_and(|checkout| {
                             checkout.status.as_ref().is_some_and(|status| status.integration.landed.value == crate::ConditionValue::True)
                         })
-                }
+                    })
+                }),
             }
         } else {
             false

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -46,11 +46,11 @@ pub use clock::VirtualClock;
 pub use clock::{Clock, SystemClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
-    controller_patches, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches,
-    reconcile, BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec,
-    ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot, PlacementStatus,
-    ReconcileOutcome, TargetMismatch, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION,
-    PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
+    controller_patches, expected_checkout_refs, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending,
+    provisioning_patches, reconcile, BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue,
+    IssueSnapshot, PlacementStatus, ReconcileOutcome, TargetMismatch, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use credential::{
     CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -1,6 +1,12 @@
 mod common;
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use async_trait::async_trait;
 use common::{
@@ -23,7 +29,35 @@ struct AlwaysEligible;
 
 #[async_trait]
 impl ConvoyTeardownRuntime for AlwaysEligible {
-    async fn verify_reclaim(&self, _convoy: &flotilla_resources::ResourceObject<Convoy>) -> Result<(), String> {
+    async fn verify_reclaim(
+        &self,
+        _convoy: &flotilla_resources::ResourceObject<Convoy>,
+        _checkouts: &[flotilla_resources::ResourceObject<Checkout>],
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+struct RecordingUnsettledRuntime {
+    checkout_count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl ConvoyTeardownRuntime for RecordingUnsettledRuntime {
+    async fn no_change_request_outstanding(
+        &self,
+        _convoy: &flotilla_resources::ResourceObject<Convoy>,
+        checkouts: &[flotilla_resources::ResourceObject<Checkout>],
+    ) -> Result<bool, String> {
+        self.checkout_count.store(checkouts.len(), Ordering::SeqCst);
+        Ok(false)
+    }
+
+    async fn verify_reclaim(
+        &self,
+        _convoy: &flotilla_resources::ResourceObject<Convoy>,
+        _checkouts: &[flotilla_resources::ResourceObject<Checkout>],
+    ) -> Result<(), String> {
         Ok(())
     }
 }
@@ -646,10 +680,89 @@ async fn landing_on_a_different_target_records_a_fact_and_still_becomes_landed()
 }
 
 #[tokio::test]
-async fn landing_without_a_change_request_becomes_landed_on_first_evaluation() {
+async fn landing_without_checkout_evidence_stays_landing() {
     let outcome = reconcile_landing_with_observed_change_request(None, None).await;
 
-    assert_eq!(outcome.patch, Some(controller_patches::settle(Vec::new(), timestamp(40))));
+    assert_eq!(outcome.patch, None);
+}
+
+#[tokio::test]
+async fn teardown_runtime_default_rejects_empty_checkout_evidence() {
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
+
+    assert!(!AlwaysEligible.no_change_request_outstanding(&convoy, &[]).await.expect("default settlement condition should evaluate"));
+}
+
+#[tokio::test]
+async fn federated_open_checkout_holds_landing_on_authority_host() {
+    let authority = ResourceBackend::InMemory(InMemoryBackend::default());
+    let remote = ResourceBackend::InMemory(InMemoryBackend::default());
+    let convoys = authority.clone().using::<Convoy>("flotilla");
+    let remote_checkouts = remote.clone().using::<Checkout>("flotilla");
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Landing;
+    for work in status.work.values_mut() {
+        work.phase = WorkPhase::Complete;
+    }
+    for crew in status.crew_work.values_mut() {
+        for member in crew.values_mut() {
+            member.phase = CrewWorkPhase::Done;
+        }
+    }
+    let source = convoy_object("cross-host", valid_convoy_spec(), Some(status));
+    let created = convoys.create(&convoy_meta("cross-host"), &source.spec).await.expect("create authority convoy");
+    convoys
+        .update_status("cross-host", &created.metadata.resource_version, source.status.as_ref().expect("convoy status"))
+        .await
+        .expect("set landing status");
+
+    let checkout = remote_checkouts
+        .create(
+            &InputMeta::builder()
+                .name("remote-checkout".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "cross-host".to_string())]))
+                .build(),
+            &CheckoutSpec::Observed(ObservedCheckoutSpec {
+                r#ref: "feature/open-pr".to_string(),
+                path: "/remote/worktree".to_string(),
+                repo_ref: RepositoryKey("repo-a".to_string()),
+                host_ref: "feta".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("create remote checkout");
+    remote_checkouts
+        .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &CheckoutStatus {
+            phase: CheckoutPhase::Ready,
+            path: Some("/remote/worktree".to_string()),
+            commit: None,
+            branch_provenance: Default::default(),
+            integration: CheckoutIntegrationStatus {
+                landed: IntegrationCondition::builder().value(ConditionValue::False).build(),
+                ..Default::default()
+            },
+            message: None,
+        })
+        .await
+        .expect("record open change request");
+    authority
+        .replica_writer::<Checkout>(flotilla_protocol::NodeId::new("feta"), "flotilla")
+        .replace(&remote_checkouts.list().await.expect("list remote checkouts"), chrono::Utc::now())
+        .await
+        .expect("replicate remote checkout");
+
+    let checkout_count = Arc::new(AtomicUsize::new(0));
+    let runtime = Arc::new(RecordingUnsettledRuntime { checkout_count: checkout_count.clone() });
+    let current = convoys.get("cross-host").await.expect("get authority convoy");
+    let reconciler = ConvoyReconciler::new(authority.clone().using::<WorkflowTemplate>("flotilla"))
+        .with_federated_checkouts(authority.including_replicas::<Checkout>("flotilla"))
+        .with_teardown_runtime(runtime);
+    let deps = reconciler.fetch_dependencies(&current).await.expect("resolve federated dependencies");
+    let outcome = reconciler.reconcile(&current, &deps, timestamp(40));
+
+    assert_eq!(checkout_count.load(Ordering::SeqCst), 1, "runtime must receive the federated checkout");
+    assert_eq!(outcome.patch, None, "an open remote change request must hold Landing");
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -143,6 +143,12 @@ async fn reconcile_landing_with_observed_change_request(
             member.phase = CrewWorkPhase::Done;
         }
     }
+    status.work.get_mut("implement").expect("implement work").placement = Some(flotilla_resources::PlacementStatus {
+        fields: BTreeMap::from([(
+            "checkout_refs".to_string(),
+            serde_json::json!(BTreeMap::from([(RepositoryKey("repo-a".to_string()), "checkout-a".to_string())])),
+        )]),
+    });
     let mut spec = valid_convoy_spec();
     spec.repositories = vec![flotilla_resources::ConvoyRepositorySpec::builder()
         .url("https://example.com/repo-a".to_string())
@@ -687,8 +693,22 @@ async fn landing_without_checkout_evidence_stays_landing() {
 }
 
 #[tokio::test]
-async fn teardown_runtime_default_rejects_empty_checkout_evidence() {
+async fn teardown_runtime_default_accepts_artifactless_convoy() {
     let convoy = convoy_object("convoy-a", valid_convoy_spec(), None);
+
+    assert!(AlwaysEligible.no_change_request_outstanding(&convoy, &[]).await.expect("default settlement condition should evaluate"));
+}
+
+#[tokio::test]
+async fn teardown_runtime_default_rejects_unobserved_expected_checkout() {
+    let mut status = bootstrapped_convoy_status();
+    status.work.get_mut("implement").expect("implement work").placement = Some(flotilla_resources::PlacementStatus {
+        fields: BTreeMap::from([(
+            "checkout_refs".to_string(),
+            serde_json::json!(BTreeMap::from([(RepositoryKey("repo-a".to_string()), "checkout-a".to_string())])),
+        )]),
+    });
+    let convoy = convoy_object("convoy-a", valid_convoy_spec(), Some(status));
 
     assert!(!AlwaysEligible.no_change_request_outstanding(&convoy, &[]).await.expect("default settlement condition should evaluate"));
 }
@@ -709,6 +729,12 @@ async fn federated_open_checkout_holds_landing_on_authority_host() {
             member.phase = CrewWorkPhase::Done;
         }
     }
+    status.work.get_mut("implement").expect("implement work").placement = Some(flotilla_resources::PlacementStatus {
+        fields: BTreeMap::from([(
+            "checkout_refs".to_string(),
+            serde_json::json!(BTreeMap::from([(RepositoryKey("repo-a".to_string()), "remote-checkout".to_string())])),
+        )]),
+    });
     let source = convoy_object("cross-host", valid_convoy_spec(), Some(status));
     let created = convoys.create(&convoy_meta("cross-host"), &source.spec).await.expect("create authority convoy");
     convoys

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -46,7 +46,11 @@ struct AlwaysEligible;
 
 #[async_trait]
 impl ConvoyTeardownRuntime for AlwaysEligible {
-    async fn verify_reclaim(&self, _convoy: &flotilla_resources::ResourceObject<Convoy>) -> Result<(), String> {
+    async fn verify_reclaim(
+        &self,
+        _convoy: &flotilla_resources::ResourceObject<Convoy>,
+        _checkouts: &[flotilla_resources::ResourceObject<flotilla_resources::Checkout>],
+    ) -> Result<(), String> {
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #1341.

Crew-authored fix (convoy `landing-vacuous-settle`, contained on feta), delivered by hand: the vessel had no working GitHub auth — second occurrence of #1335, this time in a fresh vessel created after host resume — so the branch was pushed from the host and this PR opened by the governor. Crew's claim message: implementation committed as 90bd3edc with fmt, clippy, and the focused regression suites passing.

Makes convoy settlement and the teardown gate consume the federated checkout list the reconciler already resolved, and bans vacuous truth: an empty effective checkout list no longer evaluates as settled/reclaimable.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp
