### PR TITLE
fix: surface sleep inhibition failure as host condition

### DIFF
--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -41,7 +41,7 @@ use flotilla_resources::{
     InputDefinition, InputMeta, PlacementPolicySpec, Presentation, Project, Regard, ReplicationClass, Repository, ResourceBackend,
     ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate,
     WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY,
-    MANAGED_BY_LABEL, REGISTERED_RESOURCE_KINDS,
+    MANAGED_BY_LABEL, REGISTERED_RESOURCE_KINDS, SLEEP_INHIBITION_CONDITION_TYPE,
 };
 use serde_json::json;
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -1159,6 +1159,13 @@ async fn apply_host_heartbeat_with_credentials(
     }
     if let Some(condition) = resource_replication_content_condition(daemon, namespace).await? {
         conditions.push(condition);
+    }
+    if let Some(condition) = host
+        .status
+        .as_ref()
+        .and_then(|status| status.conditions.iter().find(|condition| condition.condition_type == SLEEP_INHIBITION_CONDITION_TYPE))
+    {
+        conditions.push(condition.clone());
     }
     let status = HostStatus {
         capabilities: host_capabilities(&summary, profile, &held_credentials),
@@ -5914,6 +5921,7 @@ mod tests {
         let hosts = daemon.resource_backend().using::<Host>(NAMESPACE);
         flotilla_resources::apply_status_patch(&hosts, &host_id, &flotilla_resources::HostStatusPatch::SleepInhibition {
             health: flotilla_protocol::SleepInhibitionHealth::Failed { consecutive_failures: 3, message: "polkit denied".to_string() },
+            observed_at: Utc::now(),
         })
         .await
         .expect("seed sleep inhibition health");
@@ -5923,11 +5931,11 @@ mod tests {
         wait_until_with_timeout(Duration::from_secs(30), || {
             let hosts = hosts.clone();
             let host_id = host_id.clone();
-            async move { hosts.get(&host_id).await.ok().and_then(|host| host.status).is_some_and(|status| status.ready) }
+            async move { hosts.get(&host_id).await.ok().and_then(|host| host.status).is_some_and(|status| status.heartbeat_at.is_some()) }
         })
         .await;
         let status = hosts.get(&host_id).await.expect("get host").status.expect("host status");
-        assert!(status.ready, "heartbeat should mark host ready");
+        assert!(!status.ready, "sleep inhibition failure should keep the host degraded");
         assert_eq!(status.agent_adapters().expect("valid agent adapter capability"), BTreeSet::new());
         assert_eq!(status.capabilities.get("docker"), Some(&json!(false)));
         assert_eq!(status.capabilities.get("terminal_pools"), Some(&json!(["passthrough"])));
@@ -5936,9 +5944,19 @@ mod tests {
         assert!(status.daemon_started_at.is_some());
         assert!(status.disk_free_bytes.is_some());
         assert!(matches!(status.sleep_inhibition, flotilla_protocol::SleepInhibitionHealth::Failed { consecutive_failures: 3, .. }));
+        assert_eq!(status.conditions.len(), 1);
+        assert_eq!(status.conditions[0].condition_type, SLEEP_INHIBITION_CONDITION_TYPE);
+        assert!(status.conditions[0].message.contains("polkit denied"));
         assert!(
             status.resource_store.expect("heartbeat should publish resource store diagnostics").event_log_within_retention(),
             "heartbeat should report a bounded resource event log"
+        );
+        let fleet = daemon.fleet_health_internal().await.expect("query fleet health");
+        let local = fleet.hosts.iter().find(|host| host.is_local).expect("local fleet-health row");
+        assert!(
+            local.degraded_conditions.iter().any(|condition| condition.contains("SleepInhibition") && condition.contains("polkit denied")),
+            "fleet health should expose the sleep-inhibition condition: {:?}",
+            local.degraded_conditions
         );
 
         heartbeat.abort();

--- a/crates/flotilla-daemon/src/sleep_inhibitor.rs
+++ b/crates/flotilla-daemon/src/sleep_inhibitor.rs
@@ -175,7 +175,7 @@ async fn maintain_and_publish(
         ),
     }
     if let Some(health) = observation.changed {
-        apply_status_patch(hosts, host_id, &HostStatusPatch::SleepInhibition { health }).await?;
+        apply_status_patch(hosts, host_id, &HostStatusPatch::SleepInhibition { health, observed_at: chrono::Utc::now() }).await?;
     }
     Ok(())
 }
@@ -468,7 +468,7 @@ fn platform_inhibitor_commands(_daemon_pid: u32) -> Result<Vec<InhibitorCommand>
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, VecDeque};
 
     use chrono::Utc;
     use flotilla_protocol::{NodeId, PlacementDecision, PlacementTargetHost, PrincipalRef};
@@ -483,7 +483,9 @@ mod tests {
         states: mpsc::UnboundedSender<bool>,
     }
 
-    struct FailingInhibitor;
+    struct ScriptedInhibitor {
+        results: VecDeque<Result<SleepInhibitionHealth, String>>,
+    }
 
     #[async_trait]
     impl SleepInhibitor for RecordingInhibitor {
@@ -494,9 +496,9 @@ mod tests {
     }
 
     #[async_trait]
-    impl SleepInhibitor for FailingInhibitor {
+    impl SleepInhibitor for ScriptedInhibitor {
         async fn maintain(&mut self, _required: bool) -> Result<SleepInhibitionHealth, String> {
-            Err("polkit denied".to_string())
+            self.results.pop_front().expect("scripted inhibitor result")
         }
     }
 
@@ -751,21 +753,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn three_consecutive_failures_publish_a_failed_host_condition() {
+    async fn persistent_failure_publishes_a_host_condition_that_recovery_clears() {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
         let hosts = backend.using::<Host>(NAMESPACE);
         create_host(&hosts).await;
-        let mut inhibitor = FailingInhibitor;
+        let mut inhibitor = ScriptedInhibitor {
+            results: VecDeque::from([
+                Err("polkit denied".to_string()),
+                Err("polkit denied".to_string()),
+                Err("polkit denied".to_string()),
+                Ok(SleepInhibitionHealth::Held),
+            ]),
+        };
         let mut tracker = InhibitionHealthTracker::default();
 
         for _ in 0..FAILURE_THRESHOLD {
             maintain_and_publish(&mut inhibitor, true, &mut tracker, &hosts, "test-host").await.expect("publish sleep inhibition health");
         }
 
-        assert_eq!(
-            hosts.get("test-host").await.expect("get host").status.expect("host status").sleep_inhibition,
-            SleepInhibitionHealth::Failed { consecutive_failures: FAILURE_THRESHOLD, message: "polkit denied".to_string() }
-        );
+        let failed = hosts.get("test-host").await.expect("get failed host").status.expect("failed host status");
+        assert_eq!(failed.sleep_inhibition, SleepInhibitionHealth::Failed {
+            consecutive_failures: FAILURE_THRESHOLD,
+            message: "polkit denied".to_string()
+        });
+        assert_eq!(failed.conditions.len(), 1);
+        assert_eq!(failed.conditions[0].condition_type, "SleepInhibition");
+        assert_eq!(failed.conditions[0].reason, "InhibitorNotHeld");
+        assert!(failed.conditions[0].message.contains("sleep inhibition required but not held"));
+        assert!(failed.conditions[0].message.contains("polkit denied"));
+
+        maintain_and_publish(&mut inhibitor, true, &mut tracker, &hosts, "test-host").await.expect("publish sleep inhibition recovery");
+
+        let recovered = hosts.get("test-host").await.expect("get recovered host").status.expect("recovered host status");
+        assert_eq!(recovered.sleep_inhibition, SleepInhibitionHealth::Held);
+        assert!(recovered.conditions.iter().all(|condition| condition.condition_type != "SleepInhibition"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -14,6 +14,7 @@ pub const AGENT_ADAPTERS_CAPABILITY: &str = "agent_adapters";
 pub const HELD_CREDENTIALS_CAPABILITY: &str = "held_credentials";
 pub const TERMINAL_POOLS_CAPABILITY: &str = "terminal_pools";
 pub const HEARTBEAT_READY_TTL_SECS: i64 = 60;
+pub const SLEEP_INHIBITION_CONDITION_TYPE: &str = "SleepInhibition";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HostSpec {
@@ -102,6 +103,7 @@ pub enum HostStatusPatch {
     },
     SleepInhibition {
         health: SleepInhibitionHealth,
+        observed_at: DateTime<Utc>,
     },
 }
 
@@ -125,7 +127,27 @@ impl StatusPatch<HostStatus> for HostStatusPatch {
                 status.daemon_started_at = *daemon_started_at;
                 status.disk_free_bytes = *disk_free_bytes;
             }
-            Self::SleepInhibition { health } => status.sleep_inhibition.clone_from(health),
+            Self::SleepInhibition { health, observed_at } => {
+                status.sleep_inhibition.clone_from(health);
+                match health {
+                    SleepInhibitionHealth::Failed { message, .. } => {
+                        status.conditions.retain(|condition| condition.condition_type != SLEEP_INHIBITION_CONDITION_TYPE);
+                        status.conditions.push(
+                            HostCondition::builder()
+                                .condition_type(SLEEP_INHIBITION_CONDITION_TYPE)
+                                .value(ConditionValue::False)
+                                .reason("InhibitorNotHeld")
+                                .message(format!("sleep inhibition required but not held ({message})"))
+                                .observed_at(*observed_at)
+                                .build(),
+                        );
+                    }
+                    SleepInhibitionHealth::Held | SleepInhibitionHealth::NotRequired => {
+                        status.conditions.retain(|condition| condition.condition_type != SLEEP_INHIBITION_CONDITION_TYPE);
+                    }
+                    SleepInhibitionHealth::Acquiring { .. } => {}
+                }
+            }
         }
     }
 }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -67,7 +67,7 @@ pub use field_ownership::{FieldOwnedResource, FieldOwnership, FieldOwnershipViol
 pub use flotilla_protocol::{PrincipalRef, ResourceRef};
 pub use host::{
     Host, HostCondition, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY, HEARTBEAT_READY_TTL_SECS,
-    HELD_CREDENTIALS_CAPABILITY, TERMINAL_POOLS_CAPABILITY,
+    HELD_CREDENTIALS_CAPABILITY, SLEEP_INHIBITION_CONDITION_TYPE, TERMINAL_POOLS_CAPABILITY,
 };
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -10,6 +10,7 @@ use flotilla_resources::{
 #[test]
 fn host_status_patch_updates_heartbeat_snapshot() {
     let mut status = HostStatus::default();
+    let observed_at = Utc.with_ymd_and_hms(2026, 8, 3, 12, 40, 0).single().expect("valid timestamp");
     HostStatusPatch::Heartbeat {
         capabilities: [("docker".to_string(), serde_json::Value::Bool(true))].into_iter().collect(),
         heartbeat_at: Utc::now(),
@@ -27,10 +28,27 @@ fn host_status_patch_updates_heartbeat_snapshot() {
 
     HostStatusPatch::SleepInhibition {
         health: SleepInhibitionHealth::Failed { consecutive_failures: 3, message: "polkit denied".to_string() },
+        observed_at,
     }
     .apply(&mut status);
 
     assert_eq!(status.sleep_inhibition, SleepInhibitionHealth::Failed { consecutive_failures: 3, message: "polkit denied".to_string() });
+    assert_eq!(status.conditions.len(), 1);
+    assert_eq!(status.conditions[0].condition_type, "SleepInhibition");
+    assert_eq!(status.conditions[0].reason, "InhibitorNotHeld");
+    assert_eq!(status.conditions[0].observed_at, observed_at);
+    assert!(status.conditions[0].message.contains("polkit denied"));
+
+    HostStatusPatch::SleepInhibition {
+        health: SleepInhibitionHealth::Acquiring { consecutive_failures: 1, message: "polkit denied again".to_string() },
+        observed_at: observed_at + chrono::Duration::minutes(1),
+    }
+    .apply(&mut status);
+    assert_eq!(status.conditions.len(), 1, "a retry alone must not clear a persisted failure");
+
+    HostStatusPatch::SleepInhibition { health: SleepInhibitionHealth::Held, observed_at: observed_at + chrono::Duration::minutes(2) }
+        .apply(&mut status);
+    assert!(status.conditions.is_empty(), "successful acquisition should clear the condition");
 }
 
 #[test]


### PR DESCRIPTION
Closes #1347.

## Summary

- publish persistent sleep-inhibitor acquisition failure as a degrading `SleepInhibition` host condition
- preserve that condition across heartbeat status refreshes and clear it only after acquisition succeeds
- carry inhibitor stderr into fleet-health diagnosis and cover fail-loop, recovery, heartbeat persistence, and fleet projection

## Tests

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
