### PR TITLE
fix: consult forge before checkout settlement

### DIFF
--- a/crates/flotilla-core/src/checkout_integration.rs
+++ b/crates/flotilla-core/src/checkout_integration.rs
@@ -246,24 +246,11 @@ async fn inspect_landed(
     change_request_id: Option<&str>,
     observed_at: &str,
 ) -> (IntegrationCondition, Option<LandedEvidence>, Option<ChangeRequestObservation>) {
-    // Git evidence first: a branch with no commits beyond its base has
-    // nothing to land, so it counts as landed without consulting the forge at
-    // all. This keeps untouched checkouts landable in environments where `gh`
-    // is absent or unauthenticated.
+    // Git evidence alone cannot prove that no change request remains
+    // outstanding. In particular, a crew may publish its work from a branch
+    // other than the checkout's provisioned ref. Always consult the forge;
+    // failure to do so leaves the condition unknown.
     let comparison = compare_branch_to_base(runner, checkout_path, base_ref).await;
-    if change_request_id.is_none() {
-        if let BaseComparison::Counted { base_ref, count: 0 } = &comparison {
-            return (
-                IntegrationCondition::builder()
-                    .value(ConditionValue::True)
-                    .details(vec![format!("branch has no commits beyond {base_ref}")])
-                    .observed_at(observed_at.to_string())
-                    .build(),
-                None,
-                None,
-            );
-        }
-    }
     let args = match change_request_id {
         Some(id) => vec!["pr", "view", id, "--json", "number,state,mergedAt,baseRefName,mergeable"],
         None => {
@@ -406,9 +393,15 @@ async fn compare_branch_to_base(runner: &dyn CommandRunner, checkout_path: &Path
 /// no commits beyond its base: "work exists but no change request is visible
 /// yet" is not landed — the observation may simply predate the change request
 /// (absence of evidence, not evidence of absence). The nothing-beyond-base
-/// case is answered before the forge lookup and never reaches here.
+/// case is true only after the forge lookup has also found no associated
+/// change request.
 fn landed_without_change_request(comparison: &BaseComparison, observed_at: &str) -> IntegrationCondition {
     match comparison {
+        BaseComparison::Counted { base_ref, count: 0 } => IntegrationCondition::builder()
+            .value(ConditionValue::True)
+            .details(vec![format!("no change request exists; branch has no commits beyond {base_ref}")])
+            .observed_at(observed_at.to_string())
+            .build(),
         BaseComparison::Counted { base_ref, count } => IntegrationCondition::builder()
             .value(ConditionValue::False)
             .details(vec![format!("no change request exists; {count} commit{} beyond {base_ref}", if *count == 1 { "" } else { "s" })])
@@ -443,13 +436,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn untouched_branch_is_landed_without_consulting_the_forge() {
-        // One response only: the MockRunner panics on extra calls, so this
-        // also asserts gh is never invoked for a branch with nothing beyond
-        // its base — landing must not depend on forge availability when there
-        // is nothing to land.
-        let landed = landed_with_responses(vec![Ok("0".into())]).await;
+    async fn untouched_branch_is_landed_after_forge_reports_no_change_request() {
+        let runner = MockRunner::new(vec![Ok("0".into()), Ok("[]".into())]);
+        let (landed, _, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
+
         assert_eq!(landed.value, ConditionValue::True);
+        assert_eq!(runner.calls()[1].0, "gh");
+    }
+
+    #[tokio::test]
+    async fn open_associated_change_request_from_another_branch_holds_landing_when_spec_ref_is_at_base() {
+        let runner =
+            MockRunner::new(vec![Ok("0".into()), Ok(r#"{"number":1338,"state":"OPEN","mergedAt":null,"baseRefName":"main"}"#.into())]);
+        let (landed, _, change_request) =
+            inspect_landed(&runner, Path::new("/checkout"), "provisioned-ref", Some("main"), Some("1338"), "2026-07-27T00:00:00Z").await;
+
+        assert_eq!(landed.value, ConditionValue::False);
+        assert_eq!(change_request.expect("associated change request should be observed").state, ChangeRequestState::Open);
+        assert_eq!(runner.calls()[1].1[2], "1338");
+    }
+
+    #[tokio::test]
+    async fn untouched_branch_is_unknown_when_forge_cannot_be_consulted() {
+        let landed = landed_with_responses(vec![Ok("0".into()), Err("authentication unavailable".into())]).await;
+        assert_eq!(landed.value, ConditionValue::Unknown);
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/checkout_integration.rs
+++ b/crates/flotilla-core/src/checkout_integration.rs
@@ -57,6 +57,8 @@ pub fn checkout_path_from_status_and_spec<'a>(status: Option<&'a CheckoutStatus>
     })
 }
 
+/// Inspect a checkout without claiming that a checkout-ref lookup covers its
+/// owning convoy. An absent change request therefore cannot produce Landed.
 pub async fn inspect_checkout_integration(
     runner: &dyn CommandRunner,
     checkout_path: &Path,
@@ -66,6 +68,8 @@ pub async fn inspect_checkout_integration(
     inspect_checkout_integration_with_association(runner, checkout_path, spec, change_request_id, change_request_id.is_some()).await
 }
 
+/// Inspect a checkout for settlement after the caller has resolved the
+/// convoy's associated change request, if any.
 pub async fn inspect_convoy_checkout_integration(
     runner: &dyn CommandRunner,
     checkout_path: &Path,

--- a/crates/flotilla-core/src/checkout_integration.rs
+++ b/crates/flotilla-core/src/checkout_integration.rs
@@ -63,6 +63,25 @@ pub async fn inspect_checkout_integration(
     spec: &CheckoutSpec,
     change_request_id: Option<&str>,
 ) -> CheckoutIntegrationStatus {
+    inspect_checkout_integration_with_association(runner, checkout_path, spec, change_request_id, change_request_id.is_some()).await
+}
+
+pub async fn inspect_convoy_checkout_integration(
+    runner: &dyn CommandRunner,
+    checkout_path: &Path,
+    spec: &CheckoutSpec,
+    change_request_id: Option<&str>,
+) -> CheckoutIntegrationStatus {
+    inspect_checkout_integration_with_association(runner, checkout_path, spec, change_request_id, true).await
+}
+
+async fn inspect_checkout_integration_with_association(
+    runner: &dyn CommandRunner,
+    checkout_path: &Path,
+    spec: &CheckoutSpec,
+    change_request_id: Option<&str>,
+    convoy_association_complete: bool,
+) -> CheckoutIntegrationStatus {
     let observed_at = Utc::now().to_rfc3339();
     let clean = inspect_clean(runner, checkout_path, &observed_at).await;
     let pushed = inspect_pushed(runner, checkout_path, &observed_at).await;
@@ -72,6 +91,7 @@ pub async fn inspect_checkout_integration(
         checkout_branch_from_spec(spec),
         checkout_base_ref_from_spec(spec),
         change_request_id,
+        convoy_association_complete,
         &observed_at,
     )
     .await;
@@ -244,6 +264,7 @@ async fn inspect_landed(
     branch: &str,
     base_ref: Option<&str>,
     change_request_id: Option<&str>,
+    convoy_association_complete: bool,
     observed_at: &str,
 ) -> (IntegrationCondition, Option<LandedEvidence>, Option<ChangeRequestObservation>) {
     // Git evidence alone cannot prove that no change request remains
@@ -320,7 +341,7 @@ async fn inspect_landed(
                             )
                         }
                     }
-                    None => (landed_without_change_request(&comparison, observed_at), None, None),
+                    None => (landed_without_change_request(&comparison, convoy_association_complete, observed_at), None, None),
                 }
             }
             Err(_) => (
@@ -395,7 +416,18 @@ async fn compare_branch_to_base(runner: &dyn CommandRunner, checkout_path: &Path
 /// (absence of evidence, not evidence of absence). The nothing-beyond-base
 /// case is true only after the forge lookup has also found no associated
 /// change request.
-fn landed_without_change_request(comparison: &BaseComparison, observed_at: &str) -> IntegrationCondition {
+fn landed_without_change_request(
+    comparison: &BaseComparison,
+    convoy_association_complete: bool,
+    observed_at: &str,
+) -> IntegrationCondition {
+    if !convoy_association_complete {
+        return IntegrationCondition::builder()
+            .value(ConditionValue::Unknown)
+            .details(vec!["no change request exists for the checkout ref, but convoy association was not available".to_string()])
+            .observed_at(observed_at.to_string())
+            .build();
+    }
     match comparison {
         BaseComparison::Counted { base_ref, count: 0 } => IntegrationCondition::builder()
             .value(ConditionValue::True)
@@ -431,14 +463,16 @@ mod tests {
 
     async fn landed_with_responses(responses: Vec<Result<String, String>>) -> IntegrationCondition {
         let runner = MockRunner::new(responses);
-        let (landed, _, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
+        let (landed, _, _) =
+            inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, true, "2026-07-27T00:00:00Z").await;
         landed
     }
 
     #[tokio::test]
     async fn untouched_branch_is_landed_after_forge_reports_no_change_request() {
         let runner = MockRunner::new(vec![Ok("0".into()), Ok("[]".into())]);
-        let (landed, _, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
+        let (landed, _, _) =
+            inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, true, "2026-07-27T00:00:00Z").await;
 
         assert_eq!(landed.value, ConditionValue::True);
         assert_eq!(runner.calls()[1].0, "gh");
@@ -449,7 +483,8 @@ mod tests {
         let runner =
             MockRunner::new(vec![Ok("0".into()), Ok(r#"{"number":1338,"state":"OPEN","mergedAt":null,"baseRefName":"main"}"#.into())]);
         let (landed, _, change_request) =
-            inspect_landed(&runner, Path::new("/checkout"), "provisioned-ref", Some("main"), Some("1338"), "2026-07-27T00:00:00Z").await;
+            inspect_landed(&runner, Path::new("/checkout"), "provisioned-ref", Some("main"), Some("1338"), true, "2026-07-27T00:00:00Z")
+                .await;
 
         assert_eq!(landed.value, ConditionValue::False);
         assert_eq!(change_request.expect("associated change request should be observed").state, ChangeRequestState::Open);
@@ -459,6 +494,15 @@ mod tests {
     #[tokio::test]
     async fn untouched_branch_is_unknown_when_forge_cannot_be_consulted() {
         let landed = landed_with_responses(vec![Ok("0".into()), Err("authentication unavailable".into())]).await;
+        assert_eq!(landed.value, ConditionValue::Unknown);
+    }
+
+    #[tokio::test]
+    async fn checkout_only_lookup_cannot_prove_that_the_convoy_has_no_change_request() {
+        let runner = MockRunner::new(vec![Ok("0".into()), Ok("[]".into())]);
+        let (landed, _, _) =
+            inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, false, "2026-07-27T00:00:00Z").await;
+
         assert_eq!(landed.value, ConditionValue::Unknown);
     }
 
@@ -489,7 +533,7 @@ mod tests {
             Ok(r#"{"number":1071,"state":"MERGED","mergedAt":"2026-07-27T12:00:00Z","baseRefName":"main"}"#.into()),
         ]);
         let (landed, evidence, change_request) =
-            inspect_landed(&runner, Path::new("/checkout"), "renamed-head", Some("main"), Some("1071"), "2026-07-27T00:00:00Z").await;
+            inspect_landed(&runner, Path::new("/checkout"), "renamed-head", Some("main"), Some("1071"), true, "2026-07-27T00:00:00Z").await;
 
         assert_eq!(landed.value, ConditionValue::True);
         assert_eq!(evidence.as_ref().map(|evidence| evidence.change_request_id.as_str()), Some("1071"));
@@ -515,7 +559,7 @@ mod tests {
         ]);
 
         let (_, _, change_request) =
-            inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, "2026-07-27T00:00:00Z").await;
+            inspect_landed(&runner, Path::new("/checkout"), "feature/x", Some("main"), None, true, "2026-07-27T00:00:00Z").await;
 
         assert_eq!(change_request.expect("open change request should be observed").mergeability, ChangeRequestMergeability::Conflicting);
     }
@@ -533,7 +577,7 @@ mod tests {
     #[tokio::test]
     async fn indeterminate_base_without_change_request_is_unknown() {
         let runner = MockRunner::new(vec![Err("fatal: ambiguous argument".into()), Ok("[]".into())]);
-        let (landed, _, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", None, None, "2026-07-27T00:00:00Z").await;
+        let (landed, _, _) = inspect_landed(&runner, Path::new("/checkout"), "feature/x", None, None, true, "2026-07-27T00:00:00Z").await;
         assert_eq!(landed.value, ConditionValue::Unknown);
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -61,7 +61,7 @@ use tracing::{debug, info, warn};
 use crate::{
     agent_adapter::CapabilityTable,
     aggregator_projection::AggregatorProjectionState,
-    checkout_integration::{checkout_path_from_status_and_spec, inspect_checkout_integration},
+    checkout_integration::{checkout_path_from_status_and_spec, inspect_checkout_integration, inspect_convoy_checkout_integration},
     config::{ConfigStore, RemoteHostConfig, StaticEnvironmentConfig},
     convert::snapshot_to_proto,
     daemon::{DaemonHandle, QuerySubscription},
@@ -1695,13 +1695,13 @@ fn convoy_change_request_id_for_checkout(
 }
 
 fn change_request_id_from_completion_message(message: &str, repository_url: &str) -> Option<String> {
-    let message = message.trim().trim_end_matches(['/', '.', ',', ')', ']']);
     let repository_url = repository_url.trim().trim_end_matches('/').trim_end_matches(".git");
     ["pull", "pulls"].into_iter().find_map(|segment| {
-        message
-            .strip_prefix(&format!("{repository_url}/{segment}/"))
-            .filter(|id| !id.is_empty() && id.chars().all(|character| character.is_ascii_digit()))
-            .map(str::to_string)
+        let prefix = format!("{repository_url}/{segment}/");
+        message.match_indices(&prefix).find_map(|(start, _)| {
+            let id = message[start + prefix.len()..].chars().take_while(char::is_ascii_digit).collect::<String>();
+            (!id.is_empty()).then_some(id)
+        })
     })
 }
 
@@ -6195,10 +6195,11 @@ impl InProcessDaemon {
                     .and_then(|observed_at| chrono::DateTime::parse_from_rfc3339(observed_at).ok())
                     .is_some_and(|observed_at| self.clock.now().signed_duration_since(observed_at) < LANDING_EVIDENCE_TTL);
                 if recent {
-                    if condition_is_true(landed) {
-                        continue;
+                    match landed.value {
+                        ConditionValue::True => continue,
+                        ConditionValue::False => return Ok(false),
+                        ConditionValue::Unknown => {}
                     }
-                    return Ok(false);
                 }
             }
             let Some(path) = checkout_path(checkout).map(|path| Path::new(path).to_path_buf()) else {
@@ -6209,7 +6210,7 @@ impl InProcessDaemon {
                 Err(_) => return Ok(false),
             };
             let change_request_id = convoy_change_request_id_for_checkout(convoy, checkout);
-            let mut integration = inspect_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
+            let mut integration = inspect_convoy_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
             if let Some(existing) = checkout.status.as_ref() {
                 latch_evidence_backed_integration(&existing.integration, &mut integration);
             }
@@ -6339,7 +6340,7 @@ impl InProcessDaemon {
                 }
             }
             let change_request_id = convoy_change_request_id_for_checkout(convoy, checkout);
-            let mut integration = inspect_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
+            let mut integration = inspect_convoy_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
             verified = true;
             if let Some(existing) = checkout.status.as_ref() {
                 latch_evidence_backed_integration(&existing.integration, &mut integration);

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -7873,6 +7873,12 @@ impl InProcessDaemon {
             } else if let Some(url) = direct_repository_url {
                 let resolved = async {
                     let repository_spec = self.resolve_repository_remote(&url).await?;
+                    let canonical_url = match repository_spec.identity() {
+                        flotilla_resources::RepositoryIdentity::Remote { canonical_remote } => canonical_remote.clone(),
+                        flotilla_resources::RepositoryIdentity::Local { .. } => {
+                            return Err(format!("repository {url} did not resolve to a remote identity"));
+                        }
+                    };
                     let repo_ref = repository_spec.key();
                     let repository = flotilla_resources::ensure_repository(
                         &self.resource_backend.clone().using::<Repository>(&namespace),
@@ -7891,7 +7897,7 @@ impl InProcessDaemon {
                         .remove(&repo_ref)
                         .expect("repository slug should resolve");
                     Ok::<_, String>(vec![ConvoyRepositorySpec {
-                        url,
+                        url: canonical_url,
                         repo_ref,
                         source_ref: default_ref.clone(),
                         target_ref: default_ref,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -41,16 +41,16 @@ use flotilla_resources::{
     watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
     CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
-    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment,
-    EnvironmentPhase, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec,
-    HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution,
-    IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec,
-    Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
-    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
-    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL,
-    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, CrewWorkPhase,
+    Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
+    IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
+    PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource,
+    ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext,
+    TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
+    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent,
+    WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL,
+    HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -1663,6 +1663,46 @@ fn convoy_start_failure(convoy: &ResourceObject<ResourceConvoy>) -> Option<Strin
 
 fn checkout_path(checkout: &ResourceObject<ResourceCheckout>) -> Option<&str> {
     checkout_path_from_status_and_spec(checkout.status.as_ref(), &checkout.spec)
+}
+
+fn convoy_change_request_id_for_checkout(
+    convoy: &ResourceObject<ResourceConvoy>,
+    checkout: &ResourceObject<ResourceCheckout>,
+) -> Option<String> {
+    if let Some(id) = checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL) {
+        return Some(id.clone());
+    }
+    if let Some(change_request) =
+        convoy.spec.change_request.as_ref().filter(|change_request| change_request.repository_ref == *checkout.spec.repo_ref())
+    {
+        return Some(change_request.id.clone());
+    }
+
+    let repository = convoy.spec.repositories.iter().find(|repository| repository.repo_ref == *checkout.spec.repo_ref())?;
+    convoy
+        .status
+        .as_ref()?
+        .crew_work
+        .values()
+        .flat_map(BTreeMap::values)
+        .filter(|work| work.phase == CrewWorkPhase::Done)
+        .filter_map(|work| {
+            let id = change_request_id_from_completion_message(work.message.as_deref()?, &repository.url)?;
+            Some((work.finished_at, id))
+        })
+        .max_by_key(|(finished_at, _)| *finished_at)
+        .map(|(_, id)| id)
+}
+
+fn change_request_id_from_completion_message(message: &str, repository_url: &str) -> Option<String> {
+    let message = message.trim().trim_end_matches(['/', '.', ',', ')', ']']);
+    let repository_url = repository_url.trim().trim_end_matches('/').trim_end_matches(".git");
+    ["pull", "pulls"].into_iter().find_map(|segment| {
+        message
+            .strip_prefix(&format!("{repository_url}/{segment}/"))
+            .filter(|id| !id.is_empty() && id.chars().all(|character| character.is_ascii_digit()))
+            .map(str::to_string)
+    })
 }
 
 fn condition_is_true(condition: &IntegrationCondition) -> bool {
@@ -6168,13 +6208,8 @@ impl InProcessDaemon {
                 Ok(runner) => runner,
                 Err(_) => return Ok(false),
             };
-            let mut integration = inspect_checkout_integration(
-                &*runner,
-                &path,
-                &checkout.spec,
-                checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
-            )
-            .await;
+            let change_request_id = convoy_change_request_id_for_checkout(convoy, checkout);
+            let mut integration = inspect_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
             if let Some(existing) = checkout.status.as_ref() {
                 latch_evidence_backed_integration(&existing.integration, &mut integration);
             }
@@ -6303,13 +6338,8 @@ impl InProcessDaemon {
                     continue;
                 }
             }
-            let mut integration = inspect_checkout_integration(
-                &*runner,
-                &path,
-                &checkout.spec,
-                checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
-            )
-            .await;
+            let change_request_id = convoy_change_request_id_for_checkout(convoy, checkout);
+            let mut integration = inspect_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
             verified = true;
             if let Some(existing) = checkout.status.as_ref() {
                 latch_evidence_backed_integration(&existing.integration, &mut integration);

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -5435,6 +5435,81 @@ async fn landing_settlement_uses_latched_terminal_change_request_after_stale_rep
 }
 
 #[tokio::test]
+async fn completion_pr_from_another_branch_holds_landing_when_checkout_spec_ref_is_at_base() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/provisioned-ref\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/provisioned-ref..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("0\n".into()))
+        .on_run(
+            "gh",
+            &["pr", "view", "1338", "--json", "number,state,mergedAt,baseRefName,mergeable"],
+            Ok(r#"{"number":1338,"state":"OPEN","mergedAt":null,"baseRefName":"main"}"#.into()),
+        )
+        .build();
+    let daemon = InProcessDaemon::new(
+        vec![],
+        Arc::new(ConfigStore::with_base(&config_base)),
+        fake_discovery_with_runner(false, Arc::new(runner)),
+        HostName::local(),
+    )
+    .await;
+    let convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    let convoy = convoys
+        .create(
+            &empty_input_meta("different-pr-branch"),
+            &ConvoySpec::builder()
+                .workflow_ref("review-and-fix".to_string())
+                .repositories(vec![ConvoyRepositorySpec::builder()
+                    .url("https://github.com/flotilla-org/flotilla".to_string())
+                    .repo_ref(flotilla_resources::RepositoryKey("repo".to_string()))
+                    .source_ref("main".to_string())
+                    .target_ref("main".to_string())
+                    .workspace_slug("flotilla".to_string())
+                    .subpaths(Vec::new())
+                    .build()])
+                .build(),
+        )
+        .await
+        .expect("create convoy");
+    let finished_at = chrono::Utc::now();
+    let mut status = ConvoyStatus::default();
+    status.crew_work.insert(
+        "work".to_string(),
+        BTreeMap::from([(
+            "coder".to_string(),
+            CrewWorkState::builder()
+                .phase(CrewWorkPhase::Done)
+                .finished_at(finished_at)
+                .message("https://github.com/flotilla-org/flotilla/pull/1338".to_string())
+                .build(),
+        )]),
+    );
+    convoys.update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &status).await.expect("record completion PR");
+    create_ready_observed_checkout_for_convoy(
+        &daemon,
+        "flotilla",
+        "different-pr-branch",
+        "checkout-different-pr-branch",
+        "/repo",
+        "provisioned-ref",
+    )
+    .await;
+
+    assert!(
+        !daemon.convoy_change_requests_settled("flotilla", "different-pr-branch").await.expect("evaluate settlement"),
+        "the open completion PR must hold Landing even though its head differs from the checkout spec ref"
+    );
+}
+
+#[tokio::test]
 async fn convoy_reclaim_refuses_when_missing_path_leaves_no_integration_evidence() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4684,7 +4684,7 @@ async fn direct_repository_admission_snapshots_its_resolved_default_branch() {
                 name: "direct-repository".to_string(),
                 workflow_ref: "scratch".to_string(),
                 inputs: Vec::new(),
-                repository_url: Some("https://github.com/flotilla-org/flotilla".to_string()),
+                repository_url: Some("https://GitHub.com/flotilla-org/flotilla.git".to_string()),
                 r#ref: Some("feature/direct".to_string()),
                 project_ref: None,
                 placement_policy: None,
@@ -4698,6 +4698,7 @@ async fn direct_repository_admission_snapshots_its_resolved_default_branch() {
         name: "direct-repository".to_string()
     });
     let convoy = daemon.resource_backend().using::<Convoy>("flotilla").get("direct-repository").await.expect("convoy");
+    assert_eq!(convoy.spec.repositories[0].url, "https://github.com/flotilla-org/flotilla");
     assert_eq!(convoy.spec.repositories[0].source_ref, "main");
     assert_eq!(convoy.spec.repositories[0].target_ref, "main");
 }
@@ -4795,7 +4796,7 @@ async fn convoy_create_with_adopted_checkout_creates_adopted_checkout_resource()
 
     assert_eq!(fixture.create_convoy().await, CommandValue::ConvoyCreated { name: "convoy-adopted".to_string() });
     let convoy = daemon.resource_backend().using::<Convoy>("flotilla").get("convoy-adopted").await.expect("convoy should exist");
-    assert_eq!(convoy.spec.repositories.first().map(|repo| repo.url.as_str()), Some(ADOPTED_CHECKOUT_REMOTE));
+    assert_eq!(convoy.spec.repositories.first().map(|repo| repo.url.as_str()), Some("https://github.com/flotilla-org/flotilla"));
     assert_eq!(convoy.spec.r#ref.as_deref(), Some("main"));
     assert_eq!(convoy.spec.adopted_checkout_refs.values().next().map(String::as_str), Some("adopted-checkout-convoy-adopted"));
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -57,6 +57,37 @@ use crate::{
 
 const TEST_LOCAL_ATTACH_HOST: &str = "local";
 
+#[test]
+fn completion_message_extracts_github_and_forgejo_change_request_urls_from_prose() {
+    assert_eq!(
+        change_request_id_from_completion_message(
+            "Opened [PR #1338](https://github.com/flotilla-org/flotilla/pull/1338); checks are green.",
+            "https://github.com/flotilla-org/flotilla.git",
+        )
+        .as_deref(),
+        Some("1338")
+    );
+    assert_eq!(
+        change_request_id_from_completion_message(
+            "Ready: https://forgejo.lab/fork-issues/zellij/pulls/9 (reviewed)",
+            "https://forgejo.lab/fork-issues/zellij",
+        )
+        .as_deref(),
+        Some("9")
+    );
+}
+
+#[test]
+fn completion_message_ignores_change_request_urls_for_other_repositories() {
+    assert_eq!(
+        change_request_id_from_completion_message(
+            "https://github.com/flotilla-org/other/pull/42",
+            "https://github.com/flotilla-org/flotilla",
+        ),
+        None
+    );
+}
+
 fn attach_plan_text(plan: &flotilla_protocol::ResolvedAttachPlan) -> String {
     plan.0
         .iter()


### PR DESCRIPTION
## Summary

- require a successful forge lookup before a zero-commit checkout can count as landed
- associate crew completion PR URLs with their convoy repository so PRs opened from a different head branch are queried by ID
- preserve Unknown when the forge is unavailable and retain no-CR checkout settlement after the forge confirms absence

## Root cause

Checkout integration returned Landed before contacting the forge whenever HEAD had no commits beyond the base. It also searched by the checkout's provisioned ref when no change request was bound, so a crew-delivered PR from another branch was invisible to settlement.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1342
