### PR TITLE
fix: fail loudly when daemon logging init fails

### DIFF
--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -44,7 +44,12 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
     // structured stream into that file.
     let stderr_layer = std::io::stderr().is_terminal().then(|| tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
     let file_layer = tracing_subscriber::fmt::layer().json().with_ansi(false).with_writer(file_appender);
-    tracing_subscriber::registry().with(filter).with(stderr_layer).with(file_layer).try_init().ok();
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(stderr_layer)
+        .with(file_layer)
+        .try_init()
+        .map_err(|error| format!("initialize daemon logging: {error}"))?;
     raise_file_descriptor_limit();
 
     let timeout = if timeout_secs == 0 { Duration::from_secs(u64::MAX) } else { Duration::from_secs(timeout_secs) };
@@ -86,9 +91,11 @@ fn stable_socket_discovery_path() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::os::fd::AsRawFd;
+    use std::{fs, os::fd::AsRawFd};
 
-    use tempfile::TempDir;
+    use flotilla_core::log_file::{rotating_log_writer, DAEMON_LOG_FILE};
+    use tempfile::{tempdir, TempDir};
+    use tracing_subscriber::{layer::SubscriberExt, Registry};
 
     use super::*;
 
@@ -112,5 +119,21 @@ mod tests {
 
         assert!(error.contains("another flotillad process holds the lifecycle lock"), "unexpected error: {error}");
         assert_eq!(std::fs::read_to_string(&socket_path).expect("live socket stand-in survives"), "owned by live daemon");
+    }
+
+    #[test]
+    fn structured_file_layer_writes_boot_record() {
+        let log_dir = tempdir().expect("log directory");
+        let writer = rotating_log_writer(log_dir.path(), DAEMON_LOG_FILE, 1024 * 1024, 1).expect("rotating log writer");
+        let file_layer = tracing_subscriber::fmt::layer().json().with_ansi(false).with_writer(writer);
+        let subscriber = Registry::default().with(file_layer);
+
+        tracing::subscriber::with_default(subscriber, || tracing::info!(repo_count = 0, "starting daemon"));
+
+        let contents = fs::read_to_string(log_dir.path().join(DAEMON_LOG_FILE)).expect("structured daemon log");
+        let record: serde_json::Value = serde_json::from_str(contents.trim()).expect("JSON log record");
+        assert_eq!(record["level"], "INFO");
+        assert_eq!(record["fields"]["message"], "starting daemon");
+        assert_eq!(record["fields"]["repo_count"], 0);
     }
 }

--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -12,7 +12,7 @@ use flotilla_core::{
     path_policy::PathPolicy,
     providers::discovery::DiscoveryRuntime,
 };
-use tracing::info;
+use tracing::{info, Subscriber};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::{
@@ -44,12 +44,7 @@ pub async fn run(socket_path: &Path, config_dir: &Path, state_dir: &Path, timeou
     // structured stream into that file.
     let stderr_layer = std::io::stderr().is_terminal().then(|| tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
     let file_layer = tracing_subscriber::fmt::layer().json().with_ansi(false).with_writer(file_appender);
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(stderr_layer)
-        .with(file_layer)
-        .try_init()
-        .map_err(|error| format!("initialize daemon logging: {error}"))?;
+    init_daemon_tracing(tracing_subscriber::registry().with(filter).with(stderr_layer).with(file_layer))?;
     raise_file_descriptor_limit();
 
     let timeout = if timeout_secs == 0 { Duration::from_secs(u64::MAX) } else { Duration::from_secs(timeout_secs) };
@@ -89,15 +84,28 @@ fn stable_socket_discovery_path() -> PathBuf {
     home_policy.config_dir.into_path_buf().join(DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH)
 }
 
+fn init_daemon_tracing(subscriber: impl Subscriber + Send + Sync) -> Result<(), String> {
+    subscriber.try_init().map_err(|error| format!("initialize daemon logging: {error}"))
+}
+
 #[cfg(test)]
 mod tests {
     use std::{fs, os::fd::AsRawFd};
 
     use flotilla_core::log_file::{rotating_log_writer, DAEMON_LOG_FILE};
     use tempfile::{tempdir, TempDir};
-    use tracing_subscriber::{layer::SubscriberExt, Registry};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Registry};
 
     use super::*;
+
+    #[test]
+    fn tracing_init_failure_is_returned_with_operator_context() {
+        tracing_subscriber::registry().try_init().expect("install first global tracing subscriber");
+
+        let error = init_daemon_tracing(tracing_subscriber::registry()).expect_err("second global subscriber must be rejected");
+
+        assert_eq!(error, "initialize daemon logging: a global default trace dispatcher has already been set");
+    }
 
     #[tokio::test]
     async fn lifecycle_loser_never_removes_live_daemon_socket() {

--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -100,6 +100,7 @@ mod tests {
 
     #[test]
     fn tracing_init_failure_is_returned_with_operator_context() {
+        // This must remain the only test in this binary that installs a global tracing subscriber; another would make ordering matter.
         tracing_subscriber::registry().try_init().expect("install first global tracing subscriber");
 
         let error = init_daemon_tracing(tracing_subscriber::registry()).expect_err("second global subscriber must be rejected");

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,15 @@
 # Development
 
+## Daemon logs
+
+The daemon's canonical structured log is
+`$XDG_STATE_HOME/flotilla/log/flotillad.jsonl`, or
+`~/.local/state/flotilla/log/flotillad.jsonl` when `XDG_STATE_HOME` is unset.
+Older size-rotated generations use numeric suffixes such as
+`flotillad.jsonl.1`. Detached daemons write their normal tracing output only
+to this JSON-lines log; `daemon-panic.log` under the configuration directory
+is reserved for panics and errors that occur before tracing initializes.
+
 ## Cargo target cache policy
 
 A checkout's `target/` is managed cache state. The fleet uses two complementary controls: a daily, per-host mtime-based sweep for old Cargo artifact families and a per-checkout size-cap backstop for unusually large targets.


### PR DESCRIPTION
Closes #1356

## What changed

- propagate tracing subscriber initialization failures instead of silently discarding them
- cover the rotating JSON file layer with a boot-record regression test
- document the canonical daemon log and rotated generation paths in `docs/development.md`

## Root cause and impact

The daemon used `try_init().ok()`, so a subscriber or logger initialization conflict was silently ignored. Detached daemons have no terminal stderr layer and consequently continued running without their structured file subscriber. Startup now returns an explicit error, which reaches the daemon's redirected pre-init stderr/panic log, rather than running silently.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- focused `flotilla-daemon` structured file-layer test
- detached `flotillad` binary probe confirmed immediate JSON boot records in `$XDG_STATE_HOME/flotilla/log/flotillad.jsonl`

The sandbox-safe workspace suite encountered one unrelated ambient-environment failure: `replica_snapshot_does_not_spawn_daemon_when_socket_is_missing` connected to the live fleet daemon exposed in the crew vessel.