### PR TITLE
fix: guard daemon socket ownership

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -365,20 +365,22 @@ fn spawn_daemon(config_dir: &Path, config_dir_override: Option<&Path>, socket_ov
 pub async fn connect_or_spawn(
     socket_path: &Path,
     config_dir: &Path,
+    state_dir: &Path,
     config_dir_override: Option<&Path>,
     socket_override: Option<&Path>,
 ) -> Result<Arc<SocketDaemon>, String> {
-    connect_or_spawn_with_optional_surface(socket_path, config_dir, config_dir_override, socket_override, None).await
+    connect_or_spawn_with_optional_surface(socket_path, config_dir, state_dir, config_dir_override, socket_override, None).await
 }
 
 pub async fn connect_or_spawn_with_surface(
     socket_path: &Path,
     config_dir: &Path,
+    state_dir: &Path,
     config_dir_override: Option<&Path>,
     socket_override: Option<&Path>,
     surface: SurfaceDeclaration,
 ) -> Result<Arc<SocketDaemon>, String> {
-    connect_or_spawn_with_optional_surface(socket_path, config_dir, config_dir_override, socket_override, Some(surface)).await
+    connect_or_spawn_with_optional_surface(socket_path, config_dir, state_dir, config_dir_override, socket_override, Some(surface)).await
 }
 
 /// Connect to the host daemon exposed inside a contained environment.
@@ -413,6 +415,7 @@ async fn connect_required_host_daemon_with_optional_surface(
 async fn connect_or_spawn_with_optional_surface(
     socket_path: &Path,
     config_dir: &Path,
+    state_dir: &Path,
     config_dir_override: Option<&Path>,
     socket_override: Option<&Path>,
     surface: Option<SurfaceDeclaration>,
@@ -431,6 +434,8 @@ async fn connect_or_spawn_with_optional_surface(
     if let Some(daemon) = connect_existing_stateful(socket_path, surface.as_ref()).await? {
         return Ok(daemon);
     }
+
+    ensure_no_live_daemon_without_socket(state_dir, socket_path)?;
 
     // Acquire spawn lock (tmux-style flock). The loser blocks until the
     // winner's daemon is ready, then retries connect.
@@ -521,6 +526,8 @@ async fn connect_or_spawn_with_optional_surface(
         }
     }
 
+    ensure_no_live_daemon_without_socket(state_dir, socket_path)?;
+
     {
         // Clean up stale socket
         let _ = std::fs::remove_file(socket_path);
@@ -552,6 +559,33 @@ async fn connect_or_spawn_with_optional_surface(
             });
         }
     }
+}
+
+fn ensure_no_live_daemon_without_socket(state_dir: &Path, socket_path: &Path) -> Result<(), String> {
+    use std::os::fd::AsRawFd;
+
+    let lock_path = state_dir.join(flotilla_core::DAEMON_LIFECYCLE_LOCK_FILE);
+    let file = match std::fs::OpenOptions::new().read(true).write(true).open(&lock_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("failed to inspect daemon lifecycle lock {}: {error}", lock_path.display())),
+    };
+    // SAFETY: `file` owns this descriptor for the duration of the flock calls.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        // SAFETY: the descriptor is still valid, and explicitly unlocking keeps
+        // this read-only health probe from retaining daemon lifecycle authority.
+        let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+        return Ok(());
+    }
+    let error = std::io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::EWOULDBLOCK) || error.raw_os_error() == Some(libc::EAGAIN) {
+        return Err(format!(
+            "daemon process is alive (lifecycle lock {} is held), but its socket is missing or unreachable at {}; refusing to spawn a competing daemon — restart the existing daemon",
+            lock_path.display(),
+            socket_path.display()
+        ));
+    }
+    Err(format!("failed to inspect daemon lifecycle lock {}: {error}", lock_path.display()))
 }
 
 /// Deadline for a listening daemon to complete the Hello handshake. Generous

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -162,7 +162,8 @@ async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_con
 
     let client_socket = socket_path.clone();
     let client_dir = dir.path().to_path_buf();
-    let client_task = tokio::spawn(async move { connect_or_spawn(&client_socket, &client_dir, None, Some(&client_socket)).await });
+    let client_task =
+        tokio::spawn(async move { connect_or_spawn(&client_socket, &client_dir, &client_dir, None, Some(&client_socket)).await });
 
     // Give A time to run its first probe (nothing listening) and block on the lock.
     tokio::time::sleep(Duration::from_millis(250)).await;
@@ -227,6 +228,28 @@ async fn required_host_daemon_connection_never_enters_the_spawn_path() {
 }
 
 #[tokio::test]
+async fn connect_or_spawn_reports_live_daemon_with_missing_socket() {
+    use std::os::fd::AsRawFd;
+
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("missing-daemon.sock");
+    let lifecycle_path = dir.path().join(flotilla_core::DAEMON_LIFECYCLE_LOCK_FILE);
+    let lifecycle =
+        std::fs::OpenOptions::new().create(true).truncate(false).read(true).write(true).open(&lifecycle_path).expect("open lifecycle lock");
+    // SAFETY: the file owns this descriptor for the rest of the test.
+    assert_eq!(unsafe { libc::flock(lifecycle.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) }, 0, "hold lifecycle lock");
+
+    let error = connect_or_spawn(&socket_path, dir.path(), dir.path(), None, Some(&socket_path))
+        .await
+        .err()
+        .expect("a live daemon with no socket should be diagnosed");
+
+    assert!(error.contains("daemon process is alive"), "unexpected error: {error}");
+    assert!(error.contains("socket is missing or unreachable"), "unexpected error: {error}");
+    assert!(!socket_path.exists(), "the client must not spawn a competing daemon");
+}
+
+#[tokio::test]
 async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning() {
     let dir = TestSocketDir::new();
     let socket_path = dir.socket_path("daemon.sock");
@@ -248,7 +271,7 @@ async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning
         std::future::pending::<()>().await;
     });
 
-    let error = match connect_or_spawn(&socket_path, dir.path(), None, Some(&socket_path)).await {
+    let error = match connect_or_spawn(&socket_path, dir.path(), dir.path(), None, Some(&socket_path)).await {
         Ok(_) => panic!("a wedged daemon must surface an error, not hang or be replaced"),
         Err(error) => error,
     };
@@ -395,7 +418,7 @@ async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
             .expect("write stale daemon hello");
     });
 
-    let result = connect_or_spawn(&socket_path, dir.path(), None, Some(&socket_path)).await;
+    let result = connect_or_spawn(&socket_path, dir.path(), dir.path(), None, Some(&socket_path)).await;
     server_task.await.expect("join server task");
 
     let error = match result {

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -38,6 +38,8 @@ pub mod step;
 pub mod template;
 pub mod terminal_manager;
 
+pub const DAEMON_LIFECYCLE_LOCK_FILE: &str = "flotillad-lifecycle.lock";
+
 // Re-export shared infrastructure and host types for convenience.
 pub use admission::measure_available_space;
 pub use flotilla_protocol::HostName;

--- a/crates/flotilla-daemon/src/cli.rs
+++ b/crates/flotilla-daemon/src/cli.rs
@@ -83,3 +83,34 @@ fn stable_socket_discovery_path() -> PathBuf {
     let home_policy = PathPolicy::from_env(|key| if key == "HOME" { std::env::var_os(key) } else { None });
     home_policy.config_dir.into_path_buf().join(DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::fd::AsRawFd;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn lifecycle_loser_never_removes_live_daemon_socket() {
+        let temp = TempDir::new().expect("tempdir");
+        let state_dir = temp.path().join("state");
+        let config_dir = temp.path().join("config");
+        let socket_path = config_dir.join("run/flotilla.sock");
+        std::fs::create_dir_all(socket_path.parent().expect("socket parent")).expect("create socket parent");
+        std::fs::write(&socket_path, "owned by live daemon").expect("create live socket stand-in");
+
+        std::fs::create_dir_all(&state_dir).expect("create state dir");
+        let lock_path = state_dir.join(flotilla_core::DAEMON_LIFECYCLE_LOCK_FILE);
+        let lifecycle =
+            std::fs::OpenOptions::new().create(true).truncate(false).read(true).write(true).open(&lock_path).expect("open lifecycle lock");
+        // SAFETY: the file owns this descriptor for the rest of the test.
+        assert_eq!(unsafe { libc::flock(lifecycle.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) }, 0, "hold lifecycle lock");
+
+        let error = run(&socket_path, &config_dir, &state_dir, 0).await.expect_err("competing daemon must lose lifecycle lock");
+
+        assert!(error.contains("another flotillad process holds the lifecycle lock"), "unexpected error: {error}");
+        assert_eq!(std::fs::read_to_string(&socket_path).expect("live socket stand-in survives"), "owned by live daemon");
+    }
+}

--- a/crates/flotilla-daemon/src/restart_history.rs
+++ b/crates/flotilla-daemon/src/restart_history.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use chrono::{DateTime, Utc};
+use flotilla_core::DAEMON_LIFECYCLE_LOCK_FILE;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 const ACTIVE_RUN_FILE: &str = "flotillad-active-run.json";
 const HISTORY_FILE: &str = "flotillad-abnormal-exits.json";
-const LOCK_FILE: &str = "flotillad-lifecycle.lock";
 pub(crate) const ABNORMAL_RESTART_WINDOW: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -48,7 +48,7 @@ impl DaemonLifecycle {
 
     fn begin_at(state_dir: &Path, now: DateTime<Utc>) -> Result<Self, String> {
         fs::create_dir_all(state_dir).map_err(|error| format!("create daemon state directory {}: {error}", state_dir.display()))?;
-        let lock_path = state_dir.join(LOCK_FILE);
+        let lock_path = state_dir.join(DAEMON_LIFECYCLE_LOCK_FILE);
         let lock = OpenOptions::new()
             .create(true)
             .truncate(false)

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -13,6 +13,7 @@ pub mod test_support;
 
 use std::{
     collections::HashMap,
+    os::unix::fs::MetadataExt,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -50,6 +51,35 @@ const CONNECTION_PREFACE_TIMEOUT: Duration = Duration::from_secs(10);
 const HELLO_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 const ACCEPT_ERROR_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
 const ACCEPT_ERROR_MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+struct BoundSocketGuard {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+impl BoundSocketGuard {
+    fn new(path: PathBuf) -> Result<Self, String> {
+        let metadata =
+            std::fs::symlink_metadata(&path).map_err(|error| format!("failed to identify bound socket {}: {error}", path.display()))?;
+        Ok(Self { path, device: metadata.dev(), inode: metadata.ino() })
+    }
+}
+
+impl Drop for BoundSocketGuard {
+    fn drop(&mut self) {
+        let still_owned = std::fs::symlink_metadata(&self.path)
+            .map(|metadata| metadata.dev() == self.device && metadata.ino() == self.inode)
+            .unwrap_or(false);
+        if still_owned {
+            if let Err(error) = std::fs::remove_file(&self.path) {
+                warn!(path = %self.path.display(), %error, "failed to remove owned socket file on shutdown");
+            }
+        } else {
+            warn!(path = %self.path.display(), "daemon socket path no longer names this server's socket; leaving it untouched");
+        }
+    }
+}
 
 fn is_reverse_peer_resource_socket_name(name: &str) -> bool {
     name.strip_prefix(".peer-").is_some_and(|hash| hash.len() == 16 && hash.bytes().all(|byte| byte.is_ascii_hexdigit()))
@@ -386,6 +416,7 @@ impl DaemonServer {
         }
 
         let listener = UnixListener::bind(&self.socket_path).map_err(|e| format!("failed to bind socket: {e}"))?;
+        let _socket_guard = BoundSocketGuard::new(self.socket_path.clone())?;
 
         publish_socket_path(&self.socket_discovery_path, &self.socket_path)?;
 
@@ -403,7 +434,6 @@ impl DaemonServer {
         let shutdown_tx = self.shutdown_tx;
         let mut shutdown_rx = self.shutdown_rx;
         let idle_timeout = self.idle_timeout;
-        let socket_path = self.socket_path.clone();
         let client_notify = self.client_notify;
         let peer_data_tx = self.peer_data_tx;
         let agent_state_store = self.agent_state_store;
@@ -535,11 +565,6 @@ impl DaemonServer {
                     break;
                 }
             }
-        }
-
-        // Clean up socket file on shutdown
-        if let Err(e) = std::fs::remove_file(&socket_path) {
-            warn!(err = %e, "failed to remove socket file on shutdown");
         }
 
         info!("daemon server stopped");

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -66,9 +66,32 @@ use super::{
     resource_http::serve_resource_http,
     shared::{sync_peer_query_state, write_message, SocketPeerSender},
     test_support::{apply_convoy_replica_feed, seed_trusted_remote_convoy_project},
-    AcceptErrorBackoff, DaemonServer, PeerConnectionEvent, ACCEPT_ERROR_INITIAL_BACKOFF, ACCEPT_ERROR_MAX_BACKOFF,
+    AcceptErrorBackoff, BoundSocketGuard, DaemonServer, PeerConnectionEvent, ACCEPT_ERROR_INITIAL_BACKOFF, ACCEPT_ERROR_MAX_BACKOFF,
     CONNECTION_PREFACE_TIMEOUT, HELLO_HANDSHAKE_TIMEOUT,
 };
+
+#[tokio::test]
+async fn socket_guard_does_not_unlink_replacement_listener() {
+    let dir = TestSocketDir::new();
+    let socket_path = dir.socket_path("daemon.sock");
+    let first_listener = match tokio::net::UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => {
+            eprintln!("skipping socket_guard_does_not_unlink_replacement_listener: unix socket bind not permitted: {error}");
+            return;
+        }
+        Err(error) => panic!("bind first listener: {error}"),
+    };
+    let guard = BoundSocketGuard::new(socket_path.clone()).expect("guard first listener");
+
+    std::fs::remove_file(&socket_path).expect("unlink first listener path");
+    let replacement_listener = tokio::net::UnixListener::bind(&socket_path).expect("bind replacement listener");
+    drop(guard);
+
+    assert!(socket_path.exists(), "old listener cleanup must preserve the replacement socket");
+    drop(replacement_listener);
+    drop(first_listener);
+}
 
 #[test]
 fn daemon_publishes_its_actual_socket_path_for_remote_dialers() {

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -328,7 +328,16 @@ pub async fn run(
             if require_host_daemon {
                 crate::socket::connect_required_host_daemon_with_surface(socket_path, surface).await
             } else {
-                crate::socket::connect_or_spawn_with_surface(socket_path, config_dir, config_dir_override, socket_override, surface).await
+                let state_dir = flotilla_core::path_policy::PathPolicy::from_process_env().state_dir;
+                crate::socket::connect_or_spawn_with_surface(
+                    socket_path,
+                    config_dir,
+                    state_dir.as_path(),
+                    config_dir_override,
+                    socket_override,
+                    surface,
+                )
+                .await
             }
             .map(|daemon| daemon as Arc<dyn DaemonHandle>)
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,7 @@ fn host_daemon_socket_required(contained_marker: Option<&std::ffi::OsStr>) -> bo
 async fn connect_cli_socket(
     socket_path: &Path,
     config_dir: &Path,
+    state_dir: &Path,
     config_dir_override: Option<&Path>,
     socket_override: Option<&Path>,
     require_host_daemon: bool,
@@ -368,7 +369,7 @@ async fn connect_cli_socket(
     if require_host_daemon {
         flotilla_tui::socket::connect_required_host_daemon(socket_path).await
     } else {
-        flotilla_tui::socket::connect_or_spawn(socket_path, config_dir, config_dir_override, socket_override).await
+        flotilla_tui::socket::connect_or_spawn(socket_path, config_dir, state_dir, config_dir_override, socket_override).await
     }
 }
 
@@ -577,12 +578,14 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     let daemon_panic_log_path = resolved_config_dir.join("daemon-panic.log");
     let initial_socket_path = socket_path.clone();
     let initial_config_dir = resolved_config_dir.clone();
+    let initial_state_dir = paths.state_dir.clone();
     let initial_config_override = config_dir_override.clone();
     let initial_socket_override = socket_override.clone();
     let daemon_task = tokio::spawn(async move {
         connect_cli_socket(
             &initial_socket_path,
             &initial_config_dir,
+            initial_state_dir.as_path(),
             initial_config_override.as_deref(),
             initial_socket_override.as_deref(),
             require_host_daemon,
@@ -675,6 +678,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
                 connect_cli_socket(
                     &socket_path,
                     &resolved_config_dir,
+                    paths.state_dir.as_path(),
                     config_dir_override.as_deref(),
                     socket_override.as_deref(),
                     require_host_daemon,
@@ -828,9 +832,11 @@ async fn run_watch(cli: &Cli, format: OutputFormat) -> Result<()> {
 async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
     let socket_path = cli.socket_path();
     let config_dir = cli.config_dir();
+    let paths = PathPolicy::from_process_env();
     let daemon = connect_cli_socket(
         &socket_path,
         &config_dir,
+        paths.state_dir.as_path(),
         cli.config_dir.as_deref(),
         cli.socket.as_deref(),
         host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref()),


### PR DESCRIPTION
Closes #1357

## Summary

- refuse client-side daemon spawning when the lifecycle lock proves an existing daemon is alive but its socket is missing
- make server shutdown unlink only the exact socket inode the server bound
- cover lifecycle lock loss and the restart/replacement socket race with regressions

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`