### PR TITLE
docs: sharpen Condition Leaf to the ruled evaluable form

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -501,11 +501,19 @@ claims.
 _Avoid_: Fact (histories are evidence — ADR 0023), event.
 
 **Condition Leaf**:
-One atomic predicate over the machine, **Settlement Claims**, or
-**Observations** — a
-single comparison, no connectives. `wait` ORs leaves; all other composition
-(AND, loops, budgets) lives in the caller's own language. Named definitions
-are layered data, not new objects.
+One serializable, three-valued comparison against one stored record:
+`(record address, field path, operator, bound literal)` evaluating to
+True, False, or Unknown — over the machine, **Settlement Claims**, or
+**Observations**. Unknown is structural (absent record, Unknown
+observation, or staler than the demanded freshness) and triggers nothing.
+Cross-record references (a claim's timestamp for postdating, a prior head
+SHA) are **bound at subscription time** and frozen into the row as
+literals — evaluation stays single-record and pure. The admitted path
+vocabulary is closed: an unknown path is a loud admission error, never
+Unknown-forever. No connectives; `wait` ORs leaves; all other composition
+(AND, loops, budgets) lives in the caller's own language. Named
+definitions are layered data, not new objects. (Ruled in the #1322 grill,
+2026-08-03.)
 _Avoid_: Rule (that is a leaf bound to a wake or crew turn), expression
 language.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -501,10 +501,10 @@ claims.
 _Avoid_: Fact (histories are evidence — ADR 0023), event.
 
 **Condition Leaf**:
-One serializable, three-valued comparison against one stored record:
+One serializable, three-valued comparison against one stored record of
+the machine, a **Settlement Claim**, or an **Observation**:
 `(record address, field path, operator, bound literal)` evaluating to
-True, False, or Unknown — over the machine, **Settlement Claims**, or
-**Observations**. Unknown is structural (absent record, Unknown
+True, False, or Unknown. Unknown is structural (absent record, Unknown
 observation, or staler than the demanded freshness) and triggers nothing.
 Cross-record references (a claim's timestamp for postdating, a prior head
 SHA) are **bound at subscription time** and frozen into the row as


### PR DESCRIPTION
Glossary carry from the #1322 leaf-engine grill (rulings recorded on the issue): leaf = one serializable three-valued comparison against one stored record, literals bound at subscription time, closed admitted vocabulary with loud admission errors. No code changes.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp