### PR TITLE
feat: add leaf evaluator core and blocking wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ name = "flotilla"
 version = "0.1.0"
 dependencies = [
  "bon",
+ "chrono",
  "clap",
  "color-eyre",
  "flotilla-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ serde_yml = "0.0.12"
 libc = "0.2"
 uuid = { version = "1", features = ["v4"] }
 humantime = "2"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -11,8 +11,8 @@ use std::{
 use async_trait::async_trait;
 use flotilla_core::daemon::DaemonHandle;
 use flotilla_protocol::{
-    Command, ConnectionRole, DaemonEvent, Message, NodeId, QueryCursor, QueryId, ReplayCursor, RepoIdentity, RepoInfo, RepoSnapshot,
-    Request, Response, ResponseResult, StatusResponse, StreamKey, SurfaceDeclaration, TopologyResponse, PROTOCOL_VERSION,
+    Command, ConnectionRole, DaemonEvent, LeafFire, Message, NodeId, QueryCursor, QueryId, ReplayCursor, RepoIdentity, RepoInfo,
+    RepoSnapshot, Request, Response, ResponseResult, StatusResponse, StreamKey, SurfaceDeclaration, TopologyResponse, PROTOCOL_VERSION,
 };
 use flotilla_transport::message::{connect_unix_message_session, MessageSession};
 use tokio::sync::{broadcast, oneshot, Mutex};
@@ -115,6 +115,7 @@ pub struct SocketDaemon {
     session: Arc<MessageSession>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<ResponseResult>>>>,
     event_tx: broadcast::WeakSender<DaemonEvent>,
+    wait_event_tx: broadcast::WeakSender<LeafFire>,
     next_id: Arc<AtomicU64>,
     reader_task: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Local snapshot seq per repo, for gap detection.
@@ -164,6 +165,10 @@ impl SocketDaemon {
 
         let (event_tx, _) = broadcast::channel(256);
         let event_tx_weak = event_tx.downgrade();
+        // Wait fires are one-shot and must not be displaced by unrelated
+        // daemon traffic on the general event fan-out.
+        let (wait_event_tx, _) = broadcast::channel(256);
+        let wait_event_tx_weak = wait_event_tx.downgrade();
         let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<ResponseResult>>>> = Arc::new(Mutex::new(HashMap::new()));
         let next_id = Arc::new(AtomicU64::new(1));
         let local_seqs: Arc<SeqMap> = Arc::new(std::sync::RwLock::new(HashMap::new()));
@@ -178,6 +183,7 @@ impl SocketDaemon {
             .subscribed_queries(Arc::clone(&subscribed_queries))
             .recovering(recovering)
             .event_tx(event_tx_weak.clone())
+            .wait_event_tx(wait_event_tx_weak.clone())
             .session(Arc::clone(&session))
             .pending(Arc::clone(&pending))
             .next_id(Arc::clone(&next_id))
@@ -185,6 +191,7 @@ impl SocketDaemon {
             .build();
         let reader_task = tokio::spawn(async move {
             let _event_channel_guard = event_tx;
+            let _wait_event_channel_guard = wait_event_tx;
             loop {
                 match reader_session.read().await {
                     Ok(Some(msg)) => match msg {
@@ -234,6 +241,7 @@ impl SocketDaemon {
             session,
             pending: Arc::clone(&pending),
             event_tx: event_tx_weak,
+            wait_event_tx: wait_event_tx_weak,
             next_id: Arc::clone(&next_id),
             reader_task: std::sync::Mutex::new(Some(reader_task)),
             local_seqs: Arc::clone(&local_seqs),
@@ -252,6 +260,26 @@ impl SocketDaemon {
         match into_success_response(result)? {
             Response::AgentHook => Ok(()),
             other => Err(format!("unexpected agent hook response: {other:?}")),
+        }
+    }
+
+    /// Register a connection-owned wait and return a receiver that was opened
+    /// before admission, so an immediately true leaf cannot race delivery.
+    pub async fn subscribe_wait(
+        &self,
+        subscription: flotilla_protocol::WaitSubscriptionRequest,
+    ) -> Result<(uuid::Uuid, broadcast::Receiver<LeafFire>), String> {
+        let events = match self.wait_event_tx.upgrade() {
+            Some(event_tx) => event_tx.subscribe(),
+            None => {
+                let (event_tx, receiver) = broadcast::channel(1);
+                drop(event_tx);
+                receiver
+            }
+        };
+        match into_success_response(self.request(Request::SubscribeWait { subscription }).await?)? {
+            Response::WaitSubscribed { subscription_id } => Ok((subscription_id, events)),
+            other => Err(format!("unexpected response for wait subscription: {other:?}")),
         }
     }
 
@@ -690,6 +718,7 @@ struct EventContext {
     subscribed_queries: Arc<QuerySet>,
     recovering: Arc<std::sync::Mutex<HashMap<RepoIdentity, Vec<DaemonEvent>>>>,
     event_tx: broadcast::WeakSender<DaemonEvent>,
+    wait_event_tx: broadcast::WeakSender<LeafFire>,
     session: Arc<MessageSession>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<ResponseResult>>>>,
     next_id: Arc<AtomicU64>,
@@ -718,6 +747,12 @@ fn send_event(event_tx: &broadcast::WeakSender<DaemonEvent>, event: DaemonEvent)
     }
 }
 
+fn send_wait_event(event_tx: &broadcast::WeakSender<LeafFire>, event: LeafFire) {
+    if let Some(event_tx) = event_tx.upgrade() {
+        let _ = event_tx.send(event);
+    }
+}
+
 /// Handle a daemon event in the background reader: update local seq tracking,
 /// forward to TUI subscribers, and spawn gap recovery if needed.
 ///
@@ -725,7 +760,7 @@ fn send_event(event_tx: &broadcast::WeakSender<DaemonEvent>, event: DaemonEvent)
 /// is spawned on a separate task to avoid deadlocking the reader (which must
 /// remain free to route the recovery response).
 fn handle_event(event: DaemonEvent, ctx: &EventContext) {
-    let EventContext { local_seqs, recovering, event_tx, .. } = ctx;
+    let EventContext { local_seqs, recovering, event_tx, wait_event_tx, .. } = ctx;
     match &event {
         DaemonEvent::RepoSnapshot(snap) => {
             debug!(repo_identity = %snap.repo_identity, repo = ?snap.repo, seq = snap.seq, "received full snapshot");
@@ -860,6 +895,10 @@ fn handle_event(event: DaemonEvent, ctx: &EventContext) {
         | DaemonEvent::PeerStatusChanged { .. } => {
             send_event(event_tx, event);
         }
+        DaemonEvent::LeafFired(fire) => {
+            send_wait_event(wait_event_tx, fire.clone());
+            send_event(event_tx, event);
+        }
     }
 }
 
@@ -921,7 +960,8 @@ async fn recover_from_gap(ctx: &EventContext) {
                             | DaemonEvent::CommandStepUpdate { .. }
                             | DaemonEvent::PeerStatusChanged { .. }
                             | DaemonEvent::ResultSet(_)
-                            | DaemonEvent::ResultDelta(_) => {}
+                            | DaemonEvent::ResultDelta(_)
+                            | DaemonEvent::LeafFired(_) => {}
                         }
                     }
                 }
@@ -1124,7 +1164,8 @@ impl DaemonHandle for SocketDaemon {
                     | DaemonEvent::CommandStepUpdate { .. }
                     | DaemonEvent::PeerStatusChanged { .. }
                     | DaemonEvent::ResultSet(_)
-                    | DaemonEvent::ResultDelta(_) => continue,
+                    | DaemonEvent::ResultDelta(_)
+                    | DaemonEvent::LeafFired(_) => continue,
                 };
                 seqs.entry(stream_key).and_modify(|s| *s = (*s).max(seq)).or_insert(seq);
             }

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -56,11 +56,13 @@ fn test_context(
     pending: &SharedPending,
     next_id: &Arc<AtomicU64>,
 ) -> EventContext {
+    let (wait_event_tx, _) = broadcast::channel(1);
     EventContext::builder()
         .local_seqs(Arc::clone(local_seqs))
         .subscribed_queries(Arc::clone(subscribed_queries))
         .recovering(Arc::clone(recovering))
         .event_tx(event_tx.downgrade())
+        .wait_event_tx(wait_event_tx.downgrade())
         .session(Arc::clone(session))
         .pending(Arc::clone(pending))
         .next_id(Arc::clone(next_id))

--- a/crates/flotilla-commands/src/commands/crew.rs
+++ b/crates/flotilla-commands/src/commands/crew.rs
@@ -30,6 +30,9 @@ pub struct CrewNoun {
     /// Completion or failure message
     #[arg(long)]
     pub message: Option<String>,
+    /// Machine-readable settlement answer declared by the brief
+    #[arg(long)]
+    pub disposition: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
@@ -52,11 +55,18 @@ impl CrewNoun {
             .build();
         let subject = self.subjects.resolve()?.ok_or_else(|| "crew command requires a command or target subject".to_string())?;
         let action = match (subject.value.as_str(), subject.interpretation, self.verb) {
-            ("list", SubjectInterpretation::Ordinary, None) if self.message.is_none() => CommandAction::QueryCrewList { context },
-            ("list", SubjectInterpretation::Ordinary, None) => {
-                return Err("`flotilla crew list` does not accept --message".to_string());
+            ("list", SubjectInterpretation::Ordinary, None) if self.message.is_none() && self.disposition.is_none() => {
+                CommandAction::QueryCrewList { context }
             }
-            ("complete", SubjectInterpretation::Ordinary, None) => CommandAction::CrewComplete { context, message: self.message },
+            ("list", SubjectInterpretation::Ordinary, None) => {
+                return Err("`flotilla crew list` does not accept --message or --disposition".to_string());
+            }
+            ("complete", SubjectInterpretation::Ordinary, None) => {
+                CommandAction::CrewComplete { context, message: self.message, disposition: self.disposition }
+            }
+            ("fail", SubjectInterpretation::Ordinary, None) if self.disposition.is_some() => {
+                return Err("`flotilla crew fail` does not accept --disposition".to_string());
+            }
             ("fail", SubjectInterpretation::Ordinary, None) => CommandAction::CrewFail {
                 context,
                 message: self.message.ok_or_else(|| "`flotilla crew fail` requires --message".to_string())?,
@@ -96,6 +106,9 @@ impl std::fmt::Display for CrewNoun {
         }
         if let Some(message) = &self.message {
             write!(f, " --message {}", quote_value(message))?;
+        }
+        if let Some(disposition) = &self.disposition {
+            write!(f, " --disposition {}", quote_value(disposition))?;
         }
         if let Some(CrewVerb::Handoff { message }) = &self.verb {
             write!(f, " handoff --message {}", quote_value(message))?;
@@ -184,6 +197,18 @@ mod tests {
         assert_eq!(action(noun, Some("crew-123")), CommandAction::CrewComplete {
             context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
             message: Some("ready for review".into()),
+            disposition: None,
+        });
+    }
+
+    #[test]
+    fn complete_preserves_declared_disposition() {
+        let noun = CrewNoun::try_parse_from(["crew", "complete", "--message", "ready for review", "--disposition", "changes-pushed"])
+            .expect("parse complete disposition");
+        assert_eq!(action(noun, Some("crew-123")), CommandAction::CrewComplete {
+            context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
+            message: Some("ready for review".into()),
+            disposition: Some("changes-pushed".into()),
         });
     }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -80,6 +80,7 @@ use crate::{
         resolve_or_create_remote_environment_id, resolve_or_create_remote_host_id,
     },
     host_registry::HostCounts,
+    leaf_engine::LeafSubscriptionTable,
     model::{provider_names_from_registry, repo_name, RepoModel},
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     placement_policy::reconcile_registered_policy,
@@ -1848,6 +1849,7 @@ pub struct InProcessDaemon {
     resource_replication_failures: RwLock<HashMap<NodeId, BTreeMap<String, String>>>,
     repository_inspector: RwLock<Option<Arc<dyn RepositoryInspector>>>,
     local_placement_provider_statuses: RwLock<Vec<HostProviderStatus>>,
+    leaf_subscriptions: LeafSubscriptionTable,
 }
 
 /// Default provisioning namespace used until [`InProcessDaemon::set_provisioning_namespace`]
@@ -2012,10 +2014,11 @@ impl InProcessDaemon {
         .await;
 
         let (fleet_replica_tx, _) = broadcast::channel(32);
+        let leaf_subscriptions = LeafSubscriptionTable::new(resource_backend.clone(), event_tx.clone());
         let daemon = Arc::new_cyclic(|self_weak| Self {
             repos: RwLock::new(repos),
             repo_order: RwLock::new(order),
-            event_tx,
+            event_tx: event_tx.clone(),
             config,
             next_command_id: AtomicU64::new(1),
             node_id: local_node_id.clone(),
@@ -2050,6 +2053,7 @@ impl InProcessDaemon {
             resource_replication_failures: RwLock::new(HashMap::new()),
             repository_inspector: RwLock::new(None),
             local_placement_provider_statuses: RwLock::new(Vec::new()),
+            leaf_subscriptions: leaf_subscriptions.clone(),
         });
 
         // Spawn self-driving poll loop with a Weak reference.
@@ -2365,6 +2369,18 @@ impl InProcessDaemon {
 
     pub fn resource_backend(&self) -> ResourceBackend {
         self.resource_backend.clone()
+    }
+
+    pub async fn subscribe_wait(
+        &self,
+        connection_id: uuid::Uuid,
+        request: flotilla_protocol::WaitSubscriptionRequest,
+    ) -> Result<uuid::Uuid, String> {
+        self.leaf_subscriptions.subscribe_wait(connection_id, request).await
+    }
+
+    pub async fn unsubscribe_waits(&self, connection_id: uuid::Uuid) {
+        self.leaf_subscriptions.unsubscribe_connection(connection_id).await;
     }
 
     pub fn connect_surface(&self, surface_id: uuid::Uuid, declaration: SurfaceDeclaration) {
@@ -6128,9 +6144,24 @@ impl InProcessDaemon {
     }
 
     pub async fn crew_complete_internal(&self, requested: &CrewCommandContext, message: Option<String>) -> Result<(), String> {
+        self.crew_complete_with_disposition_internal(requested, message, None).await
+    }
+
+    pub async fn crew_complete_with_disposition_internal(
+        &self,
+        requested: &CrewCommandContext,
+        message: Option<String>,
+        disposition: Option<String>,
+    ) -> Result<(), String> {
         let routing = self.resolve_crew_routing_context(requested).await?;
         self.apply_crew_work_patch(requested, |context| {
-            convoy_external_patches::mark_crew_completed(context.vessel.clone(), context.caller_role.clone(), chrono::Utc::now(), message)
+            convoy_external_patches::mark_crew_completed(
+                context.vessel.clone(),
+                context.caller_role.clone(),
+                chrono::Utc::now(),
+                message,
+                disposition,
+            )
         })
         .await?;
         if let Some(session_name) = routing.session_name {
@@ -7574,9 +7605,9 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::CrewComplete { context, message } = &command.action {
+        if let flotilla_protocol::CommandAction::CrewComplete { context, message, disposition } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
-            let result = match self.crew_complete_internal(context, message.clone()).await {
+            let result = match self.crew_complete_with_disposition_internal(context, message.clone(), disposition.clone()).await {
                 Ok(()) => flotilla_protocol::CommandValue::Ok,
                 Err(message) => flotilla_protocol::CommandValue::Error { message },
             };

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1513,6 +1513,7 @@ async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
     daemon
         .mark_crew_completion_pending("flotilla", "terminal-demo-implement-coder", CrewCompletionPending {
             message: Some("ready for review".into()),
+            disposition: None,
             attempted_at: chrono::Utc::now(),
             authority: "remote-before-failover".into(),
             last_error: "authority unreachable".into(),
@@ -1529,6 +1530,7 @@ async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
             action: CommandAction::CrewComplete {
                 context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
                 message: Some("ready for review".into()),
+                disposition: Some("changes-pushed".into()),
             },
         })
         .await
@@ -1539,6 +1541,7 @@ async fn crew_complete_uses_ambient_identity_to_complete_callers_work() {
     let coder = &convoy.status.expect("convoy status").crew_work["implement"]["coder"];
     assert_eq!(coder.phase, CrewWorkPhase::Done);
     assert_eq!(coder.message.as_deref(), Some("ready for review"));
+    assert_eq!(coder.disposition.as_deref(), Some("changes-pushed"));
     assert!(
         daemon
             .resource_backend()
@@ -1869,7 +1872,11 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
             node_id: None,
             provisioning_target: None,
             context_repo: None,
-            action: CommandAction::CrewComplete { context: context.clone(), message: Some("implementation ready".into()) },
+            action: CommandAction::CrewComplete {
+                context: context.clone(),
+                message: Some("implementation ready".into()),
+                disposition: None,
+            },
         })
         .await
         .expect("complete coder work");

--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -1,0 +1,364 @@
+use std::{collections::HashMap, sync::Arc};
+
+use chrono::{DateTime, Utc};
+use flotilla_protocol::{DaemonEvent, Leaf, LeafAddress, LeafFire, WaitSubscriptionRequest};
+use flotilla_resources::{
+    admit_leaf, evaluate_leaf, Convoy, ConvoyLeafSubject, ResourceBackend, ResourceObject, ThreeValue, Vessel, VesselLeafSubject,
+    WorkLeafSubject,
+};
+use futures::StreamExt;
+use tokio::{
+    sync::{broadcast, Mutex},
+    task::JoinHandle,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LeafWatcher {
+    WaitCaller { connection_id: uuid::Uuid },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EpisodeKeyFields {
+    pub source: Option<String>,
+    pub convoy: Option<String>,
+    pub vessel: Option<String>,
+    pub role: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeafSubscriptionRow {
+    pub id: uuid::Uuid,
+    pub namespace: String,
+    pub leaves: Vec<Leaf>,
+    pub watcher: LeafWatcher,
+    pub freshness_demand: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub episode_key: EpisodeKeyFields,
+}
+
+#[derive(Clone)]
+pub struct LeafSubscriptionTable {
+    inner: Arc<LeafSubscriptionTableInner>,
+}
+
+struct LeafSubscriptionTableInner {
+    backend: ResourceBackend,
+    event_tx: broadcast::Sender<DaemonEvent>,
+    rows: Mutex<HashMap<uuid::Uuid, LeafSubscriptionRow>>,
+    tasks: Mutex<HashMap<uuid::Uuid, JoinHandle<()>>>,
+}
+
+impl LeafSubscriptionTable {
+    pub fn new(backend: ResourceBackend, event_tx: broadcast::Sender<DaemonEvent>) -> Self {
+        Self {
+            inner: Arc::new(LeafSubscriptionTableInner {
+                backend,
+                event_tx,
+                rows: Mutex::new(HashMap::new()),
+                tasks: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    pub async fn subscribe_wait(&self, connection_id: uuid::Uuid, request: WaitSubscriptionRequest) -> Result<uuid::Uuid, String> {
+        if request.leaves.is_empty() {
+            return Err("wait requires at least one --for leaf".to_string());
+        }
+        let mut leaves = Vec::with_capacity(request.leaves.len());
+        for leaf in request.leaves {
+            admit_leaf(&leaf)?;
+            if !leaves.contains(&leaf) {
+                leaves.push(leaf);
+            }
+        }
+        let id = uuid::Uuid::new_v4();
+        let row = LeafSubscriptionRow {
+            id,
+            namespace: request.namespace,
+            leaves,
+            watcher: LeafWatcher::WaitCaller { connection_id },
+            freshness_demand: request.freshness_demand,
+            created_at: Utc::now(),
+            episode_key: EpisodeKeyFields::default(),
+        };
+        self.inner.rows.lock().await.insert(id, row.clone());
+        let table = self.clone();
+        let task = tokio::spawn(async move {
+            if let Err(error) = table.watch_row(row).await {
+                tracing::warn!(subscription_id = %id, %error, "leaf subscription watch ended");
+                table.finish(id).await;
+            }
+        });
+        self.inner.tasks.lock().await.insert(id, task);
+        Ok(id)
+    }
+
+    pub async fn unsubscribe_connection(&self, connection_id: uuid::Uuid) {
+        let ids = self
+            .inner
+            .rows
+            .lock()
+            .await
+            .values()
+            .filter_map(|row| match row.watcher {
+                LeafWatcher::WaitCaller { connection_id: owner } if owner == connection_id => Some(row.id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        for id in ids {
+            self.inner.rows.lock().await.remove(&id);
+            if let Some(task) = self.inner.tasks.lock().await.remove(&id) {
+                task.abort();
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub async fn rows(&self) -> Vec<LeafSubscriptionRow> {
+        self.inner.rows.lock().await.values().cloned().collect()
+    }
+
+    async fn finish(&self, id: uuid::Uuid) {
+        self.inner.rows.lock().await.remove(&id);
+        self.inner.tasks.lock().await.remove(&id);
+    }
+
+    async fn watch_row(&self, row: LeafSubscriptionRow) -> Result<(), String> {
+        let convoys = self.inner.backend.including_replicas::<Convoy>(&row.namespace);
+        let vessels = self.inner.backend.including_replicas::<Vessel>(&row.namespace);
+        // Open watches before taking the level-triggered snapshots. Writes
+        // racing the lists are then buffered by the streams and replayed by
+        // the loop instead of falling through a list-then-watch gap.
+        let mut convoy_watch = convoys.watch().await.map_err(|error| error.to_string())?;
+        let mut vessel_watch = vessels.watch().await.map_err(|error| error.to_string())?;
+        let convoy_list = convoys.list().await.map_err(|error| error.to_string())?;
+        let vessel_list = vessels.list().await.map_err(|error| error.to_string())?;
+        let mut convoy_objects = convoy_list.items.into_iter().fold(HashMap::new(), |mut objects, item| {
+            objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
+            objects
+        });
+        let mut vessel_objects = vessel_list.items.into_iter().fold(HashMap::new(), |mut objects, item| {
+            objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
+            objects
+        });
+
+        if let Some(fire) = evaluate_row(&row, &convoy_objects, &vessel_objects)? {
+            self.fire(row.id, fire).await;
+            return Ok(());
+        }
+
+        loop {
+            tokio::select! {
+                event = convoy_watch.next() => {
+                    let event = event.ok_or_else(|| "convoy resource watch closed".to_string())?.map_err(|error| error.to_string())?;
+                    apply_read_event(event, &mut convoy_objects);
+                }
+                event = vessel_watch.next() => {
+                    let event = event.ok_or_else(|| "vessel resource watch closed".to_string())?.map_err(|error| error.to_string())?;
+                    apply_read_event(event, &mut vessel_objects);
+                }
+            }
+            if let Some(fire) = evaluate_row(&row, &convoy_objects, &vessel_objects)? {
+                self.fire(row.id, fire).await;
+                return Ok(());
+            }
+        }
+    }
+
+    async fn fire(&self, subscription_id: uuid::Uuid, mut fire: LeafFire) {
+        fire.subscription_id = subscription_id;
+        let Some(LeafWatcher::WaitCaller { connection_id }) =
+            self.inner.rows.lock().await.get(&subscription_id).map(|row| row.watcher.clone())
+        else {
+            return;
+        };
+        fire.watcher_id = connection_id;
+        let _ = self.inner.event_tx.send(DaemonEvent::LeafFired(fire));
+        self.finish(subscription_id).await;
+    }
+}
+
+fn apply_read_event<T: flotilla_resources::Resource>(
+    event: flotilla_resources::ReadWatchEvent<T>,
+    objects: &mut HashMap<String, ResourceObject<T>>,
+) {
+    match event {
+        flotilla_resources::ReadWatchEvent::Added(item) | flotilla_resources::ReadWatchEvent::Modified(item) => {
+            objects.insert(item.object.metadata.name.clone(), item.object);
+        }
+        flotilla_resources::ReadWatchEvent::Deleted(item) => {
+            objects.remove(&item.object.metadata.name);
+        }
+    }
+}
+
+fn evaluate_row(
+    row: &LeafSubscriptionRow,
+    convoys: &HashMap<String, ResourceObject<Convoy>>,
+    vessels: &HashMap<String, ResourceObject<Vessel>>,
+) -> Result<Option<LeafFire>, String> {
+    for leaf in &row.leaves {
+        let evaluation = match &leaf.address {
+            LeafAddress::Convoy { name } => {
+                let subject = convoys.get(name).map(ConvoyLeafSubject);
+                evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
+            }
+            LeafAddress::Vessel { name } => {
+                let subject = vessels.get(name).map(VesselLeafSubject);
+                evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
+            }
+            LeafAddress::Work { convoy, work } => {
+                let subject = convoys.get(convoy).and_then(|convoy| convoy.status.as_ref()).and_then(|status| {
+                    status.work.get(work).map(|work_state| WorkLeafSubject { work: work_state, crew: status.crew_work.get(work) })
+                });
+                evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
+            }
+        };
+        if evaluation.result == ThreeValue::True {
+            return Ok(Some(LeafFire {
+                subscription_id: row.id,
+                watcher_id: uuid::Uuid::nil(),
+                leaf: leaf.clone(),
+                value: evaluation.value.expect("true leaf has a value").to_string(),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, time::Duration};
+
+    use flotilla_protocol::{LeafAddress, LeafOperator};
+    use flotilla_resources::{
+        ConvoyPhase, ConvoySpec, ConvoyStatus, CrewWorkPhase, CrewWorkState, InMemoryBackend, InputMeta, SqliteBackend, WorkPhase,
+        WorkState,
+    };
+
+    use super::*;
+
+    fn convoy_spec() -> ConvoySpec {
+        ConvoySpec::builder().workflow_ref("workflow".to_string()).build()
+    }
+
+    fn leaf(address: LeafAddress, field_path: &str, literal: &str) -> Leaf {
+        Leaf { address, field_path: field_path.to_string(), operator: LeafOperator::Equal, literal: literal.to_string() }
+    }
+
+    async fn create_convoy(backend: &ResourceBackend, name: &str, status: ConvoyStatus) {
+        let convoys = backend.using::<Convoy>("flotilla");
+        let created = convoys.create(&InputMeta::builder().name(name.to_string()).build(), &convoy_spec()).await.expect("create convoy");
+        convoys.update_status(name, &created.metadata.resource_version, &status).await.expect("write convoy status");
+    }
+
+    async fn update_convoy(backend: &ResourceBackend, name: &str, update: impl FnOnce(&mut ConvoyStatus)) {
+        let convoys = backend.using::<Convoy>("flotilla");
+        let current = convoys.get(name).await.expect("get convoy");
+        let mut status = current.status.expect("convoy status");
+        update(&mut status);
+        convoys.update_status(name, &current.metadata.resource_version, &status).await.expect("update convoy status");
+    }
+
+    async fn receive_fire(events: &mut broadcast::Receiver<DaemonEvent>, subscription_id: uuid::Uuid) -> LeafFire {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let DaemonEvent::LeafFired(fire) = events.recv().await.expect("leaf event stream") {
+                    if fire.subscription_id == subscription_id {
+                        return fire;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("leaf should fire")
+    }
+
+    async fn assert_leaf_subscription_contract(backend: ResourceBackend) {
+        let (event_tx, _) = broadcast::channel(16);
+        let table = LeafSubscriptionTable::new(backend.clone(), event_tx.clone());
+        let connection_id = uuid::Uuid::new_v4();
+        let mut events = event_tx.subscribe();
+
+        let unknown = WaitSubscriptionRequest {
+            namespace: "flotilla".to_string(),
+            leaves: vec![leaf(LeafAddress::Convoy { name: "demo".to_string() }, ".status.typo", "Landed")],
+            freshness_demand: None,
+        };
+        let error = table.subscribe_wait(connection_id, unknown).await.expect_err("unknown path admission");
+        assert!(error.contains("admitted vocabulary"));
+        assert!(error.contains("work.latest-claim.disposition"));
+
+        let absent = WaitSubscriptionRequest {
+            namespace: "flotilla".to_string(),
+            leaves: vec![leaf(LeafAddress::Convoy { name: "demo".to_string() }, ".status.phase", "Landed")],
+            freshness_demand: None,
+        };
+        let absent_id = table.subscribe_wait(connection_id, absent).await.expect("subscribe absent leaf");
+        assert!(tokio::time::timeout(Duration::from_millis(40), events.recv()).await.is_err(), "absent record must remain unknown");
+
+        create_convoy(&backend, "demo", ConvoyStatus { phase: ConvoyPhase::Active, ..Default::default() }).await;
+        assert!(tokio::time::timeout(Duration::from_millis(40), events.recv()).await.is_err(), "false leaf must not fire");
+        update_convoy(&backend, "demo", |status| status.phase = ConvoyPhase::Landed).await;
+        let fire = receive_fire(&mut events, absent_id).await;
+        assert_eq!(fire.leaf.address, LeafAddress::Convoy { name: "demo".to_string() });
+        assert_eq!(fire.value, "Landed");
+
+        let immediate = WaitSubscriptionRequest {
+            namespace: "flotilla".to_string(),
+            leaves: vec![
+                leaf(LeafAddress::Vessel { name: "missing".to_string() }, ".status.phase", "Ready"),
+                leaf(LeafAddress::Convoy { name: "demo".to_string() }, ".status.phase", "Landed"),
+            ],
+            freshness_demand: None,
+        };
+        let immediate_id = table.subscribe_wait(connection_id, immediate).await.expect("subscribe immediate OR-set");
+        assert_eq!(receive_fire(&mut events, immediate_id).await.leaf.address, LeafAddress::Convoy { name: "demo".to_string() });
+
+        let claimed_at = "2026-08-03T20:00:00Z".parse().expect("claim timestamp");
+        let work = WorkState::builder().phase(WorkPhase::Complete).build();
+        let crew =
+            CrewWorkState::builder().phase(CrewWorkPhase::Done).finished_at(claimed_at).disposition("changes-pushed".to_string()).build();
+        update_convoy(&backend, "demo", |status| {
+            status.work = BTreeMap::from([("implement".to_string(), work)]);
+            status.crew_work = BTreeMap::from([("implement".to_string(), BTreeMap::from([("coder".to_string(), crew)]))]);
+        })
+        .await;
+        let claim = WaitSubscriptionRequest {
+            namespace: "flotilla".to_string(),
+            leaves: vec![leaf(
+                LeafAddress::Work { convoy: "demo".to_string(), work: "implement".to_string() },
+                ".latest-claim.disposition",
+                "changes-pushed",
+            )],
+            freshness_demand: None,
+        };
+        let claim_id = table.subscribe_wait(connection_id, claim).await.expect("subscribe claim leaf");
+        assert_eq!(receive_fire(&mut events, claim_id).await.value, "changes-pushed");
+
+        let stale = WaitSubscriptionRequest {
+            namespace: "flotilla".to_string(),
+            leaves: vec![leaf(
+                LeafAddress::Work { convoy: "demo".to_string(), work: "implement".to_string() },
+                ".latest-claim.disposition",
+                "changes-pushed",
+            )],
+            freshness_demand: Some("2026-08-03T21:00:00Z".parse().expect("freshness timestamp")),
+        };
+        let stale_id = table.subscribe_wait(connection_id, stale).await.expect("subscribe stale claim leaf");
+        assert!(tokio::time::timeout(Duration::from_millis(40), events.recv()).await.is_err(), "stale evidence must remain unknown");
+        assert!(table.rows().await.iter().any(|row| row.id == stale_id));
+        table.unsubscribe_connection(connection_id).await;
+        assert!(table.rows().await.is_empty(), "connection teardown must remove WaitCaller rows");
+    }
+
+    #[tokio::test]
+    async fn in_memory_leaf_subscription_contract() {
+        assert_leaf_subscription_contract(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_leaf_subscription_contract() {
+        assert_leaf_subscription_contract(ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("open sqlite"))).await;
+    }
+}

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod host_identity;
 pub(crate) mod host_registry;
 pub mod host_summary;
 pub mod in_process;
+pub mod leaf_engine;
 pub mod log_file;
 pub mod merge;
 pub mod model;

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -2106,6 +2106,7 @@ mod tests {
             BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string()), (VESSEL_LABEL.to_string(), "implement".to_string())]);
         session.status.as_mut().expect("running status").completion_pending = Some(flotilla_resources::CrewCompletionPending {
             message: Some("https://github.com/flotilla-org/flotilla/pull/1300".into()),
+            disposition: None,
             attempted_at: Utc::now(),
             authority: "kiwi".into(),
             last_error: "authority unreachable for convoy-a".into(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -6758,7 +6758,11 @@ mod tests {
                 node_id: None,
                 provisioning_target: None,
                 context_repo: None,
-                action: CommandAction::CrewComplete { context: crew_context.clone(), message: Some("implementation ready".to_string()) },
+                action: CommandAction::CrewComplete {
+                    context: crew_context.clone(),
+                    message: Some("implementation ready".to_string()),
+                    disposition: None,
+                },
             })
             .await
             .expect("coder complete");
@@ -6950,6 +6954,7 @@ mod tests {
                 action: CommandAction::CrewComplete {
                     context: CrewCommandContext { crew_id: Some(revived_coder_id.clone()), ..Default::default() },
                     message: Some("review findings addressed".to_string()),
+                    disposition: None,
                 },
             })
             .await
@@ -6996,6 +7001,7 @@ mod tests {
                 action: CommandAction::CrewComplete {
                     context: CrewCommandContext { crew_id: Some(reviewer_id), ..Default::default() },
                     message: Some("changes accepted".to_string()),
+                    disposition: None,
                 },
             })
             .await

--- a/crates/flotilla-daemon/src/server/client_connection.rs
+++ b/crates/flotilla-daemon/src/server/client_connection.rs
@@ -18,10 +18,11 @@ use super::{attach_excursions::AttachExcursions, remote_commands::RemoteCommandR
 /// for other queries are not relayed to the connection.
 pub(super) type QuerySubscriptions = Arc<RwLock<HashSet<QueryId>>>;
 
-fn event_subscribed(event: &DaemonEvent, subscriptions: &QuerySubscriptions) -> bool {
+fn event_subscribed(event: &DaemonEvent, subscriptions: &QuerySubscriptions, session_id: uuid::Uuid) -> bool {
     let query = match event {
         DaemonEvent::ResultSet(result_set) => result_set.query(),
         DaemonEvent::ResultDelta(delta) => delta.query(),
+        DaemonEvent::LeafFired(fire) => return fire.watcher_id == session_id,
         _ => return true,
     };
     subscriptions.read().expect("query subscriptions lock poisoned").contains(&query)
@@ -91,7 +92,7 @@ impl ClientConnection {
             loop {
                 match event_rx.recv().await {
                     Ok(event) => {
-                        if !event_subscribed(&event, &event_subscriptions) {
+                        if !event_subscribed(&event, &event_subscriptions, session_id) {
                             continue;
                         }
                         let msg = Message::Event { event: Box::new(event) };
@@ -123,6 +124,7 @@ impl ClientConnection {
         event_task.abort();
         self.attach_excursions.finish_all().await;
         self.daemon.unsubscribe_queries(session_id).await;
+        self.daemon.unsubscribe_waits(session_id).await;
         if let Err(error) = self.daemon.disconnect_surface(session_id).await {
             warn!(%error, "failed to disconnect client surface");
         }

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -46,6 +46,7 @@ pub(super) struct PendingCrewCompletionRoute {
     session_name: String,
     context: CrewCommandContext,
     message: Option<String>,
+    disposition: Option<String>,
     authority: Option<HostName>,
 }
 
@@ -968,8 +969,8 @@ impl RemoteStepExecutor for RemoteCommandRouter {
 
 impl RemoteCommandRouter {
     async fn resolve_crew_command_routing(&self, action: &mut CommandAction) -> Result<Option<PendingCrewCompletionRoute>, String> {
-        let (context, completion_message) = match action {
-            CommandAction::CrewComplete { context, message } => (context, Some(message.clone())),
+        let (context, completion) = match action {
+            CommandAction::CrewComplete { context, message, disposition } => (context, Some((message.clone(), disposition.clone()))),
             CommandAction::CrewFail { context, .. }
             | CommandAction::CrewHandoff { context, .. }
             | CommandAction::QueryCrewList { context } => (context, None),
@@ -977,7 +978,7 @@ impl RemoteCommandRouter {
         };
         let routing = self.daemon.resolve_crew_routing_context(context).await?;
         *context = routing.command_context.clone();
-        let Some(message) = completion_message else { return Ok(None) };
+        let Some((message, disposition)) = completion else { return Ok(None) };
         let Some(session_name) = routing.session_name else { return Ok(None) };
         Ok(Some(PendingCrewCompletionRoute {
             namespace: context.namespace.clone().expect("resolved crew context has namespace"),
@@ -985,6 +986,7 @@ impl RemoteCommandRouter {
             session_name,
             context: context.clone(),
             message,
+            disposition,
             authority: None,
         }))
     }
@@ -996,6 +998,7 @@ impl RemoteCommandRouter {
     async fn persist_crew_completion(&self, completion: &PendingCrewCompletionRoute, authority: &HostName, last_error: &str) {
         let pending = CrewCompletionPending {
             message: completion.message.clone(),
+            disposition: completion.disposition.clone(),
             attempted_at: chrono::Utc::now(),
             authority: authority.to_string(),
             last_error: last_error.to_string(),
@@ -1043,6 +1046,7 @@ impl RemoteCommandRouter {
                     action: CommandAction::CrewComplete {
                         context: state.completion.context.clone(),
                         message: state.completion.message.clone(),
+                        disposition: state.completion.disposition.clone(),
                     },
                 };
                 if router.dispatch_execute_for_principal(command, None).await.is_ok() {
@@ -1073,6 +1077,7 @@ impl RemoteCommandRouter {
                 session_name,
                 context,
                 message: pending.message,
+                disposition: pending.disposition,
                 authority: Some(HostName::new(pending.authority)),
             });
         }

--- a/crates/flotilla-daemon/src/server/request_dispatch.rs
+++ b/crates/flotilla-daemon/src/server/request_dispatch.rs
@@ -162,6 +162,11 @@ impl<'a> RequestDispatcher<'a> {
                 Err(error) => Message::error_response(id, error),
             },
 
+            Request::SubscribeWait { subscription } => match self.daemon.subscribe_wait(self.session_id, subscription).await {
+                Ok(subscription_id) => Message::ok_response(id, Response::WaitSubscribed { subscription_id }),
+                Err(error) => Message::error_response(id, error),
+            },
+
             Request::BeginAttachExcursion { excursion_id, cleanup_actions } => {
                 match self.attach_excursions.begin(excursion_id, cleanup_actions).await {
                     Ok(()) => Message::ok_response(id, Response::BeginAttachExcursion),

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1557,6 +1557,7 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
             action: CommandAction::CrewComplete {
                 context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
                 message: Some("https://github.com/flotilla-org/flotilla/pull/1300".into()),
+                disposition: None,
             },
         })
         .await
@@ -1579,6 +1580,7 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
             action: CommandAction::CrewComplete {
                 context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
                 message: Some("https://github.com/flotilla-org/flotilla/pull/1301".into()),
+                disposition: None,
             },
         })
         .await
@@ -1640,6 +1642,7 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
             action: CommandAction::CrewComplete {
                 context: CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() },
                 message: Some("https://github.com/flotilla-org/flotilla/pull/1302".into()),
+                disposition: None,
             },
         })
         .await

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -447,6 +447,8 @@ pub enum CommandAction {
         context: CrewCommandContext,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         message: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        disposition: Option<String>,
     },
     CrewFail {
         context: CrewCommandContext,
@@ -1045,6 +1047,7 @@ mod tests {
                 action: CommandAction::CrewComplete {
                     context: CrewCommandContext { crew_id: Some("crew-123".into()), ..Default::default() },
                     message: Some("ready for review".into()),
+                    disposition: Some("changes-pushed".into()),
                 },
             },
             Command {

--- a/crates/flotilla-protocol/src/leaf.rs
+++ b/crates/flotilla-protocol/src/leaf.rs
@@ -1,0 +1,190 @@
+use std::{fmt, str::FromStr};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Leaf {
+    pub address: LeafAddress,
+    pub field_path: String,
+    pub operator: LeafOperator,
+    pub literal: String,
+}
+
+impl FromStr for Leaf {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut parts = input.split_whitespace();
+        let address = parts.next().ok_or_else(|| leaf_syntax_error(input))?.parse()?;
+        let field_path = parts.next().ok_or_else(|| leaf_syntax_error(input))?.to_string();
+        let operator = parts.next().ok_or_else(|| leaf_syntax_error(input))?.parse()?;
+        let literal = parts.collect::<Vec<_>>().join(" ");
+        if literal.is_empty() {
+            return Err(leaf_syntax_error(input));
+        }
+        let literal = literal
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .or_else(|| literal.strip_prefix('\'').and_then(|value| value.strip_suffix('\'')))
+            .unwrap_or(&literal)
+            .to_string();
+        Ok(Self { address, field_path, operator, literal })
+    }
+}
+
+fn leaf_syntax_error(input: &str) -> String {
+    format!("invalid leaf `{input}`; expected `<kind>/<name> <field-path> <operator> <literal>`")
+}
+
+impl fmt::Display for Leaf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} {} {} {}", self.address, self.field_path, self.operator, self.literal)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LeafAddress {
+    Convoy { name: String },
+    Vessel { name: String },
+    Work { convoy: String, work: String },
+}
+
+impl LeafAddress {
+    pub fn kind(&self) -> LeafKind {
+        match self {
+            Self::Convoy { .. } => LeafKind::Convoy,
+            Self::Vessel { .. } => LeafKind::Vessel,
+            Self::Work { .. } => LeafKind::Work,
+        }
+    }
+}
+
+impl FromStr for LeafAddress {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let parts = value.split('/').collect::<Vec<_>>();
+        match parts.as_slice() {
+            ["convoy", name] if !name.is_empty() => Ok(Self::Convoy { name: (*name).to_string() }),
+            ["vessel", name] if !name.is_empty() => Ok(Self::Vessel { name: (*name).to_string() }),
+            ["work", convoy, work] if !convoy.is_empty() && !work.is_empty() => {
+                Ok(Self::Work { convoy: (*convoy).to_string(), work: (*work).to_string() })
+            }
+            _ => Err(format!("invalid leaf address `{value}`; expected convoy/<name>, vessel/<name>, or work/<convoy>/<work>")),
+        }
+    }
+}
+
+impl fmt::Display for LeafAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Convoy { name } => write!(f, "convoy/{name}"),
+            Self::Vessel { name } => write!(f, "vessel/{name}"),
+            Self::Work { convoy, work } => write!(f, "work/{convoy}/{work}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LeafKind {
+    Convoy,
+    Vessel,
+    Work,
+}
+
+impl fmt::Display for LeafKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Convoy => "convoy",
+            Self::Vessel => "vessel",
+            Self::Work => "work",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum LeafOperator {
+    #[serde(rename = "==")]
+    Equal,
+    #[serde(rename = "!=")]
+    NotEqual,
+    #[serde(rename = "<")]
+    LessThan,
+    #[serde(rename = "<=")]
+    LessThanOrEqual,
+    #[serde(rename = ">")]
+    GreaterThan,
+    #[serde(rename = ">=")]
+    GreaterThanOrEqual,
+}
+
+impl FromStr for LeafOperator {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "==" => Ok(Self::Equal),
+            "!=" => Ok(Self::NotEqual),
+            "<" => Ok(Self::LessThan),
+            "<=" => Ok(Self::LessThanOrEqual),
+            ">" => Ok(Self::GreaterThan),
+            ">=" => Ok(Self::GreaterThanOrEqual),
+            _ => Err(format!("unknown leaf operator `{value}`; admitted operators: ==, !=, <, <=, >, >=")),
+        }
+    }
+}
+
+impl fmt::Display for LeafOperator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Equal => "==",
+            Self::NotEqual => "!=",
+            Self::LessThan => "<",
+            Self::LessThanOrEqual => "<=",
+            Self::GreaterThan => ">",
+            Self::GreaterThanOrEqual => ">=",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WaitSubscriptionRequest {
+    pub namespace: String,
+    pub leaves: Vec<Leaf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub freshness_demand: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LeafFire {
+    pub subscription_id: uuid::Uuid,
+    /// Daemon-internal delivery address; never crosses the wire.
+    #[serde(skip)]
+    pub watcher_id: uuid::Uuid,
+    pub leaf: Leaf,
+    pub value: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_and_formats_wait_leaf() {
+        let leaf: Leaf = "convoy/demo .status.phase == Landed".parse().expect("parse leaf");
+        assert_eq!(leaf.address, LeafAddress::Convoy { name: "demo".to_string() });
+        assert_eq!(leaf.field_path, ".status.phase");
+        assert_eq!(leaf.operator, LeafOperator::Equal);
+        assert_eq!(leaf.literal, "Landed");
+        assert_eq!(leaf.to_string(), "convoy/demo .status.phase == Landed");
+    }
+
+    #[test]
+    fn parses_work_claim_address_and_quoted_literal() {
+        let leaf: Leaf = "work/demo/implement .latest-claim.disposition == 'changes pushed'".parse().expect("parse claim leaf");
+        assert_eq!(leaf.address, LeafAddress::Work { convoy: "demo".to_string(), work: "implement".to_string() });
+        assert_eq!(leaf.literal, "changes pushed");
+    }
+}

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -7,6 +7,7 @@ pub mod framing;
 mod host;
 mod host_summary;
 pub mod issue_query;
+pub mod leaf;
 mod lifecycle;
 pub mod output;
 pub mod path_context;
@@ -35,6 +36,7 @@ pub use host_summary::{
     DiscoveryFact, HostEnvironment, HostProviderStatus, HostSnapshot, HostSummary, NodeInfo, SystemInfo, ToolInventory,
     AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
+pub use leaf::{Leaf, LeafAddress, LeafFire, LeafKind, LeafOperator, WaitSubscriptionRequest};
 pub use lifecycle::LifecycleAuthority;
 pub use path_context::{DaemonHostPath, ExecutionEnvironmentPath};
 pub use peer::{CommandPeerEvent, GoodbyeReason, PeerDataKind, PeerDataMessage, PeerWireMessage, RoutedPeerMessage, VectorClock};
@@ -276,6 +278,10 @@ pub enum Request {
     ObserveFocus {
         targets: Vec<ResourceRef>,
     },
+    /// Register an ephemeral, connection-owned OR-set of condition leaves.
+    SubscribeWait {
+        subscription: WaitSubscriptionRequest,
+    },
     /// Register teardown for an interactive attach before launching it. The
     /// actions are ordered innermost-to-outermost and belong to this socket
     /// connection until finished.
@@ -316,6 +322,9 @@ pub enum Response {
     SubscribeQueries(Vec<DaemonEvent>),
     FetchMore,
     ObserveFocus,
+    WaitSubscribed {
+        subscription_id: uuid::Uuid,
+    },
     BeginAttachExcursion,
     FinishAttachExcursion,
     GetStatus(StatusResponse),
@@ -449,6 +458,9 @@ pub enum DaemonEvent {
     /// Incremental result-set update for a subscribed named query.
     #[serde(rename = "result_delta")]
     ResultDelta(Box<ResultDelta>),
+    /// One leaf in a connection-owned wait subscription evaluated true.
+    #[serde(rename = "leaf_fired")]
+    LeafFired(LeafFire),
 }
 
 /// Peer connection state as seen by the TUI.

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -271,6 +271,8 @@ pub struct CrewWorkState {
     pub finished_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -371,6 +373,7 @@ pub enum ConvoyStatusPatch {
         role: String,
         finished_at: DateTime<Utc>,
         message: Option<String>,
+        disposition: Option<String>,
     },
     MarkCrewFailed {
         vessel: String,
@@ -563,15 +566,20 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                     state.message = Some(reason.clone());
                 }
             }
-            Self::MarkCrewCompleted { vessel, role, finished_at, message } => {
+            Self::MarkCrewCompleted { vessel, role, finished_at, message, disposition } => {
                 if let Some(state) = status.crew_work.get_mut(vessel).and_then(|crew| crew.get_mut(role)) {
                     // Duplicate settlement is sticky; changing the settled outcome records its own time.
-                    if state.phase != CrewWorkPhase::Done {
+                    if state.phase != CrewWorkPhase::Done
+                        || disposition.as_ref().is_some_and(|disposition| state.disposition.as_ref() != Some(disposition))
+                    {
                         state.finished_at = None;
                     }
                     state.phase = CrewWorkPhase::Done;
                     state.finished_at.get_or_insert(*finished_at);
                     state.message = message.clone();
+                    if disposition.is_some() {
+                        state.disposition = disposition.clone();
+                    }
                 }
                 enter_landing_if_completion_claims_settled(status);
             }
@@ -753,8 +761,14 @@ pub mod external_patches {
         ConvoyStatusPatch::MarkConvoyAbandoned { finished_at, authority, reason }
     }
 
-    pub fn mark_crew_completed(vessel: String, role: String, finished_at: DateTime<Utc>, message: Option<String>) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::MarkCrewCompleted { vessel, role, finished_at, message }
+    pub fn mark_crew_completed(
+        vessel: String,
+        role: String,
+        finished_at: DateTime<Utc>,
+        message: Option<String>,
+        disposition: Option<String>,
+    ) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::MarkCrewCompleted { vessel, role, finished_at, message, disposition }
     }
 
     pub fn mark_crew_failed(vessel: String, role: String, finished_at: DateTime<Utc>, message: String) -> ConvoyStatusPatch {

--- a/crates/flotilla-resources/src/leaf.rs
+++ b/crates/flotilla-resources/src/leaf.rs
@@ -1,0 +1,245 @@
+use std::cmp::Ordering;
+
+use chrono::{DateTime, Utc};
+use flotilla_protocol::{Leaf, LeafKind, LeafOperator};
+
+use crate::{Convoy, CrewWorkPhase, CrewWorkState, ResourceObject, Vessel, WorkState};
+
+pub const ADMITTED_LEAF_VOCABULARY: &[(&str, &str)] = &[
+    ("convoy", ".status.phase"),
+    ("vessel", ".status.phase"),
+    ("work", ".status.phase"),
+    ("work", ".latest-claim.disposition"),
+    ("work", ".latest-claim.claimed-at"),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThreeValue {
+    True,
+    False,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LeafValue {
+    Text(String),
+    Timestamp(DateTime<Utc>),
+}
+
+impl std::fmt::Display for LeafValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text(value) => f.write_str(value),
+            Self::Timestamp(value) => write!(f, "{}", value.to_rfc3339()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeafEvaluation {
+    pub result: ThreeValue,
+    pub value: Option<LeafValue>,
+}
+
+/// Typed seam between the expression evaluator and a stored resource shape.
+///
+/// A descriptor-backed implementation can replace the handwritten subjects
+/// without changing admission, comparison, or subscription machinery.
+pub trait LeafSubject {
+    fn kind(&self) -> LeafKind;
+    fn value(&self, field_path: &str) -> Option<LeafValue>;
+    fn observed_at(&self) -> Option<DateTime<Utc>> {
+        None
+    }
+}
+
+pub fn admit_leaf(leaf: &Leaf) -> Result<(), String> {
+    let kind = leaf.address.kind();
+    let admitted =
+        ADMITTED_LEAF_VOCABULARY.iter().any(|(candidate_kind, path)| *candidate_kind == kind.to_string() && *path == leaf.field_path);
+    if !admitted {
+        let vocabulary = ADMITTED_LEAF_VOCABULARY.iter().map(|(kind, path)| format!("{kind}{path}")).collect::<Vec<_>>().join(", ");
+        return Err(format!("leaf path `{kind}{}` is not admitted; admitted vocabulary: {vocabulary}", leaf.field_path));
+    }
+    if leaf.field_path != ".latest-claim.claimed-at" && !matches!(leaf.operator, LeafOperator::Equal | LeafOperator::NotEqual) {
+        return Err(format!("operator `{}` is not admitted for text leaf `{kind}{}`; use `==` or `!=`", leaf.operator, leaf.field_path));
+    }
+    if leaf.field_path == ".latest-claim.claimed-at" {
+        leaf.literal
+            .parse::<DateTime<Utc>>()
+            .map_err(|error| format!("invalid timestamp literal `{}` for work.latest-claim.claimed-at: {error}", leaf.literal))?;
+    }
+    Ok(())
+}
+
+pub fn evaluate_leaf(
+    leaf: &Leaf,
+    subject: Option<&dyn LeafSubject>,
+    freshness_demand: Option<DateTime<Utc>>,
+) -> Result<LeafEvaluation, String> {
+    admit_leaf(leaf)?;
+    let Some(subject) = subject else {
+        return Ok(LeafEvaluation { result: ThreeValue::Unknown, value: None });
+    };
+    if subject.kind() != leaf.address.kind() {
+        return Err(format!("leaf addresses {} but subject is {}", leaf.address.kind(), subject.kind()));
+    }
+    if freshness_demand.is_some_and(|demand| subject.observed_at().is_none_or(|observed_at| observed_at < demand)) {
+        return Ok(LeafEvaluation { result: ThreeValue::Unknown, value: None });
+    }
+    let Some(value) = subject.value(&leaf.field_path) else {
+        return Ok(LeafEvaluation { result: ThreeValue::Unknown, value: None });
+    };
+    let literal = bind_literal(&leaf.field_path, &leaf.literal)?;
+    let ordering = compare_values(&value, &literal)?;
+    let fired = match leaf.operator {
+        LeafOperator::Equal => ordering == Ordering::Equal,
+        LeafOperator::NotEqual => ordering != Ordering::Equal,
+        LeafOperator::LessThan => ordering == Ordering::Less,
+        LeafOperator::LessThanOrEqual => ordering != Ordering::Greater,
+        LeafOperator::GreaterThan => ordering == Ordering::Greater,
+        LeafOperator::GreaterThanOrEqual => ordering != Ordering::Less,
+    };
+    Ok(LeafEvaluation { result: if fired { ThreeValue::True } else { ThreeValue::False }, value: Some(value) })
+}
+
+fn bind_literal(path: &str, literal: &str) -> Result<LeafValue, String> {
+    if path == ".latest-claim.claimed-at" {
+        return literal
+            .parse::<DateTime<Utc>>()
+            .map(LeafValue::Timestamp)
+            .map_err(|error| format!("invalid timestamp literal `{literal}`: {error}"));
+    }
+    Ok(LeafValue::Text(literal.to_string()))
+}
+
+fn compare_values(left: &LeafValue, right: &LeafValue) -> Result<Ordering, String> {
+    match (left, right) {
+        (LeafValue::Text(left), LeafValue::Text(right)) => Ok(left.cmp(right)),
+        (LeafValue::Timestamp(left), LeafValue::Timestamp(right)) => Ok(left.cmp(right)),
+        _ => Err("leaf value and bound literal have different types".to_string()),
+    }
+}
+
+pub struct ConvoyLeafSubject<'a>(pub &'a ResourceObject<Convoy>);
+
+impl LeafSubject for ConvoyLeafSubject<'_> {
+    fn kind(&self) -> LeafKind {
+        LeafKind::Convoy
+    }
+
+    fn value(&self, field_path: &str) -> Option<LeafValue> {
+        match field_path {
+            ".status.phase" => self.0.status.as_ref().map(|status| LeafValue::Text(format!("{:?}", status.phase))),
+            _ => None,
+        }
+    }
+}
+
+pub struct VesselLeafSubject<'a>(pub &'a ResourceObject<Vessel>);
+
+impl LeafSubject for VesselLeafSubject<'_> {
+    fn kind(&self) -> LeafKind {
+        LeafKind::Vessel
+    }
+
+    fn value(&self, field_path: &str) -> Option<LeafValue> {
+        match field_path {
+            ".status.phase" => self.0.status.as_ref().map(|status| LeafValue::Text(format!("{:?}", status.phase))),
+            _ => None,
+        }
+    }
+}
+
+pub struct WorkLeafSubject<'a> {
+    pub work: &'a WorkState,
+    pub crew: Option<&'a std::collections::BTreeMap<String, CrewWorkState>>,
+}
+
+impl WorkLeafSubject<'_> {
+    fn latest_claim(&self) -> Option<&CrewWorkState> {
+        self.crew?
+            .values()
+            .filter(|state| state.phase == CrewWorkPhase::Done)
+            .filter(|state| state.finished_at.is_some())
+            .max_by_key(|state| state.finished_at)
+    }
+}
+
+impl LeafSubject for WorkLeafSubject<'_> {
+    fn kind(&self) -> LeafKind {
+        LeafKind::Work
+    }
+
+    fn value(&self, field_path: &str) -> Option<LeafValue> {
+        match field_path {
+            ".status.phase" => Some(LeafValue::Text(format!("{:?}", self.work.phase))),
+            ".latest-claim.disposition" => self.latest_claim()?.disposition.clone().map(LeafValue::Text),
+            ".latest-claim.claimed-at" => self.latest_claim()?.finished_at.map(LeafValue::Timestamp),
+            _ => None,
+        }
+    }
+
+    fn observed_at(&self) -> Option<DateTime<Utc>> {
+        self.latest_claim()?.finished_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use flotilla_protocol::LeafAddress;
+
+    use super::*;
+
+    struct FakeSubject {
+        observed_at: Option<DateTime<Utc>>,
+    }
+
+    impl LeafSubject for FakeSubject {
+        fn kind(&self) -> LeafKind {
+            LeafKind::Convoy
+        }
+
+        fn value(&self, _field_path: &str) -> Option<LeafValue> {
+            Some(LeafValue::Text("Landed".to_string()))
+        }
+
+        fn observed_at(&self) -> Option<DateTime<Utc>> {
+            self.observed_at
+        }
+    }
+
+    fn leaf(path: &str) -> Leaf {
+        Leaf {
+            address: LeafAddress::Convoy { name: "demo".to_string() },
+            field_path: path.to_string(),
+            operator: LeafOperator::Equal,
+            literal: "Landed".to_string(),
+        }
+    }
+
+    #[test]
+    fn absent_and_stale_subjects_are_unknown() {
+        assert_eq!(evaluate_leaf(&leaf(".status.phase"), None, None).expect("evaluate").result, ThreeValue::Unknown);
+        let demand = "2026-08-03T20:00:00Z".parse().expect("timestamp");
+        let stale = FakeSubject { observed_at: Some("2026-08-03T19:00:00Z".parse().expect("timestamp")) };
+        assert_eq!(evaluate_leaf(&leaf(".status.phase"), Some(&stale), Some(demand)).expect("evaluate").result, ThreeValue::Unknown);
+    }
+
+    #[test]
+    fn unknown_path_names_the_closed_vocabulary() {
+        let error = admit_leaf(&leaf(".status.nope")).expect_err("path should be rejected");
+        assert!(error.contains("admitted vocabulary"));
+        assert!(error.contains("convoy.status.phase"));
+        assert!(error.contains("work.latest-claim.disposition"));
+    }
+
+    #[test]
+    fn text_leaf_rejects_order_operators_at_admission() {
+        let mut leaf = leaf(".status.phase");
+        leaf.operator = LeafOperator::GreaterThan;
+        let error = admit_leaf(&leaf).expect_err("text ordering should be rejected");
+        assert!(error.contains("operator `>` is not admitted"));
+        assert!(error.contains("use `==` or `!=`"));
+    }
+}

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -13,6 +13,7 @@ mod host;
 mod http;
 mod in_memory;
 mod labels;
+mod leaf;
 mod material_pool;
 mod placement_policy;
 mod prepared_snapshot;
@@ -74,6 +75,10 @@ pub use in_memory::InMemoryBackend;
 pub use labels::{
     LifecycleAuthority, AUTHORITY_LABEL, CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL, CREW_ORDINAL_LABEL, MANAGED_BY_LABEL, REPO_KEY_LABEL,
     REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+};
+pub use leaf::{
+    admit_leaf, evaluate_leaf, ConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue, VesselLeafSubject, WorkLeafSubject,
+    ADMITTED_LEAF_VOCABULARY,
 };
 pub use material_pool::{
     MaterialPool, MaterialPoolLease, MaterialPoolSpec, MaterialPoolStatus, MaterialPoolStatusPatch, MaterialPoolUnitSpec,

--- a/crates/flotilla-resources/src/terminal_session.rs
+++ b/crates/flotilla-resources/src/terminal_session.rs
@@ -186,6 +186,8 @@ pub struct TerminalSessionStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CrewCompletionPending {
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<String>,
     pub attempted_at: DateTime<Utc>,
     pub authority: String,
     pub last_error: String,
@@ -458,6 +460,7 @@ mod tests {
     fn pending_completion_survives_terminal_restart_until_acknowledged() {
         let pending = CrewCompletionPending {
             message: Some("https://github.com/flotilla-org/flotilla/pull/1300".into()),
+            disposition: None,
             attempted_at: Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).single().expect("valid timestamp"),
             authority: "kiwi".into(),
             last_error: "authority unreachable for convoy-a".into(),

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -163,14 +163,21 @@ fn crew_completion_updates_only_the_calling_agent() {
         target_mismatches: Vec::new(),
     };
 
-    external_patches::mark_crew_completed("implement".to_string(), "coder".to_string(), ts(20), Some("ready for review".to_string()))
-        .apply(&mut status);
-    external_patches::mark_crew_completed("implement".to_string(), "coder".to_string(), ts(30), Some("still ready".to_string()))
+    external_patches::mark_crew_completed(
+        "implement".to_string(),
+        "coder".to_string(),
+        ts(20),
+        Some("ready for review".to_string()),
+        Some("changes-pushed".to_string()),
+    )
+    .apply(&mut status);
+    external_patches::mark_crew_completed("implement".to_string(), "coder".to_string(), ts(30), Some("still ready".to_string()), None)
         .apply(&mut status);
 
     assert_eq!(status.crew_work["implement"]["coder"].phase, CrewWorkPhase::Done);
     assert_eq!(status.crew_work["implement"]["coder"].finished_at, Some(ts(20)));
     assert_eq!(status.crew_work["implement"]["coder"].message.as_deref(), Some("still ready"));
+    assert_eq!(status.crew_work["implement"]["coder"].disposition.as_deref(), Some("changes-pushed"));
     assert_eq!(status.crew_work["implement"]["reviewer"].phase, CrewWorkPhase::Working);
     assert_eq!(status.work["implement"].phase, WorkPhase::Running);
     assert_eq!(status.phase, ConvoyPhase::Active);
@@ -200,7 +207,8 @@ fn final_crew_completion_claim_enters_landing_idempotently() {
         target_mismatches: Vec::new(),
     };
 
-    let patch = external_patches::mark_crew_completed("implement".to_string(), "coder".to_string(), ts(20), Some("ready".to_string()));
+    let patch =
+        external_patches::mark_crew_completed("implement".to_string(), "coder".to_string(), ts(20), Some("ready".to_string()), None);
     patch.apply(&mut status);
     patch.apply(&mut status);
 
@@ -224,7 +232,7 @@ fn crew_failure_records_terminal_state_and_message() {
         target_mismatches: Vec::new(),
     };
 
-    external_patches::mark_crew_completed("implement".to_string(), "coder".to_string(), ts(15), Some("initially done".to_string()))
+    external_patches::mark_crew_completed("implement".to_string(), "coder".to_string(), ts(15), Some("initially done".to_string()), None)
         .apply(&mut status);
     external_patches::mark_crew_failed("implement".to_string(), "coder".to_string(), ts(20), "blocked by missing credentials".to_string())
         .apply(&mut status);

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -190,7 +190,7 @@ fn work_state(phase: WorkPhase, started_at: Option<DateTime<Utc>>, finished_at: 
 }
 
 fn crew_state(phase: CrewWorkPhase, started_at: Option<DateTime<Utc>>, finished_at: Option<DateTime<Utc>>) -> CrewWorkState {
-    CrewWorkState { phase, started_at, finished_at, message: None }
+    CrewWorkState { phase, started_at, finished_at, message: None, disposition: None }
 }
 
 fn active_convoy_status() -> ConvoyStatus {
@@ -511,6 +511,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                     role: "coder".to_string(),
                     finished_at: ts(30),
                     message: Some("still complete".to_string()),
+                    disposition: None,
                 };
                 apply_and_replay(&mut status, &patch);
                 (before, crew_timestamps(&status))
@@ -903,6 +904,7 @@ fn settling_again_after_a_continuation_records_the_new_outcome_time() {
                     role: "coder".to_string(),
                     finished_at: ts(30),
                     message: Some("addressed".to_string()),
+                    disposition: None,
                 };
                 apply_and_replay(&mut status, &resettle);
                 (before, crew_timestamps(&status))

--- a/crates/flotilla-tui/src/app/mod.rs
+++ b/crates/flotilla-tui/src/app/mod.rs
@@ -1860,6 +1860,7 @@ impl App {
                     }
                 }
             }
+            DaemonEvent::LeafFired(_) => {}
         }
     }
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -690,6 +690,7 @@ pub(crate) fn format_event_human(event: &flotilla_protocol::DaemonEvent) -> Stri
                 delta.changes.removed_len()
             )
         }
+        DaemonEvent::LeafFired(fire) => format!("[leaf]      {} fired (value: {})", fire.leaf, fire.value),
     }
 }
 
@@ -708,7 +709,8 @@ fn event_stream_seq(event: &DaemonEvent) -> Option<(StreamKey, u64)> {
         | DaemonEvent::CommandStarted { .. }
         | DaemonEvent::CommandFinished { .. }
         | DaemonEvent::CommandStepUpdate { .. }
-        | DaemonEvent::PeerStatusChanged { .. } => None,
+        | DaemonEvent::PeerStatusChanged { .. }
+        | DaemonEvent::LeafFired(_) => None,
     }
 }
 

--- a/crates/flotilla-tui/tests/support/high_fidelity.rs
+++ b/crates/flotilla-tui/tests/support/high_fidelity.rs
@@ -348,6 +348,7 @@ impl HighFidelityHarness {
             DaemonEvent::HostRemoved { environment_id, .. } => format!("host_removed {environment_id}"),
             DaemonEvent::ResultSet(result_set) => format!("result_set query={} seq={}", result_set.query(), result_set.seq),
             DaemonEvent::ResultDelta(delta) => format!("result_delta query={} seq={}", delta.query(), delta.seq),
+            DaemonEvent::LeafFired(fire) => format!("leaf_fired subscription={}", fire.subscription_id),
         };
         self.recent_events.push(summary);
         if self.recent_events.len() > 20 {
@@ -458,6 +459,7 @@ fn record_recent_event(recent: &mut Vec<String>, source: &str, event: &DaemonEve
         DaemonEvent::HostRemoved { environment_id, .. } => format!("{source}: host_removed {environment_id}"),
         DaemonEvent::ResultSet(result_set) => format!("{source}: result_set query={} seq={}", result_set.query(), result_set.seq),
         DaemonEvent::ResultDelta(delta) => format!("{source}: result_delta query={} seq={}", delta.query(), delta.seq),
+        DaemonEvent::LeafFired(fire) => format!("{source}: leaf_fired subscription={}", fire.subscription_id),
     };
     recent.push(summary);
     if recent.len() > 20 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,24 @@ enum SubCommand {
     Status,
     /// Stream daemon events to stdout
     Watch,
+    /// Block until one condition leaf becomes true
+    Wait {
+        /// Condition leaf; repeat to wait for any leaf (OR)
+        #[arg(long = "for", required = true)]
+        leaves: Vec<flotilla_protocol::Leaf>,
+        /// Resource namespace
+        #[arg(long, default_value = "flotilla")]
+        namespace: String,
+        /// Require claim evidence observed at or after this RFC3339 instant
+        ///
+        /// This slice has observation timestamps for work claim leaves only;
+        /// other leaves remain Unknown when a freshness demand is present.
+        #[arg(long)]
+        fresher_than: Option<chrono::DateTime<chrono::Utc>>,
+        /// Maximum seconds to block
+        #[arg(long)]
+        timeout: Option<u64>,
+    },
     /// Show the daemon's current multi-host routing view
     Topology,
     /// Read structured daemon logs from this host or a peer
@@ -397,6 +415,9 @@ async fn main() -> Result<()> {
         Some(SubCommand::Daemon { timeout }) => run_daemon(&cli, timeout).await,
         Some(SubCommand::Status) => run_status(&cli, format).await,
         Some(SubCommand::Watch) => run_watch(&cli, format).await,
+        Some(SubCommand::Wait { leaves, namespace, fresher_than, timeout }) => {
+            run_wait(&cli, leaves, namespace, fresher_than, timeout, format).await
+        }
         Some(SubCommand::Topology) => run_topology_command(&cli, format).await,
         Some(SubCommand::Logs { host, since, level, target }) => run_logs(&cli, host.as_deref(), since, level, target).await,
         Some(SubCommand::Fleet) => run_fleet_health(&cli, format).await,
@@ -827,6 +848,57 @@ async fn run_pm_command(cli: &Cli, command: PmSubCommand) -> Result<()> {
 async fn run_watch(cli: &Cli, format: OutputFormat) -> Result<()> {
     reset_sigpipe();
     flotilla_tui::cli::run_watch(&cli.socket_path(), format).await.map_err(|e| color_eyre::eyre::eyre!(e))
+}
+
+async fn run_wait(
+    cli: &Cli,
+    leaves: Vec<flotilla_protocol::Leaf>,
+    namespace: String,
+    freshness_demand: Option<chrono::DateTime<chrono::Utc>>,
+    timeout_seconds: Option<u64>,
+    format: OutputFormat,
+) -> Result<()> {
+    reset_sigpipe();
+    let socket_path = cli.socket_path();
+    let config_dir = cli.config_dir();
+    let paths = PathPolicy::from_process_env();
+    let daemon = connect_cli_socket(
+        &socket_path,
+        &config_dir,
+        paths.state_dir.as_path(),
+        cli.config_dir.as_deref(),
+        cli.socket.as_deref(),
+        host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref()),
+    )
+    .await
+    .map_err(|error| color_eyre::eyre::eyre!(error))?;
+    let request = flotilla_protocol::WaitSubscriptionRequest { namespace, leaves, freshness_demand };
+    let (subscription_id, mut events) = daemon.subscribe_wait(request).await.map_err(|error| color_eyre::eyre::eyre!(error))?;
+    let wait = async move {
+        loop {
+            match events.recv().await {
+                Ok(fire) if fire.subscription_id == subscription_id => break Ok(fire),
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    break Err(color_eyre::eyre::eyre!("wait event stream lagged by {skipped} event(s); condition may have fired"));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    break Err(color_eyre::eyre::eyre!("daemon restarted"));
+                }
+            }
+        }
+    };
+    let fire = match timeout_seconds {
+        Some(seconds) => tokio::time::timeout(Duration::from_secs(seconds), wait)
+            .await
+            .map_err(|_| color_eyre::eyre::eyre!("timed out waiting for condition after {seconds}s"))??,
+        None => wait.await?,
+    };
+    match format {
+        OutputFormat::Json => println!("{}", serde_json::to_string(&fire)?),
+        OutputFormat::Human => println!("condition fired: {} (value: {})", fire.leaf, fire.value),
+    }
+    Ok(())
 }
 
 async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
@@ -1806,6 +1878,24 @@ mod tests {
             provider_health: Default::default(),
             loading: false,
         }
+    }
+
+    #[test]
+    fn wait_cli_accepts_an_or_set_and_timeout() {
+        let cli = Cli::try_parse_from([
+            "flotilla",
+            "wait",
+            "--for",
+            "convoy/demo .status.phase == Landed",
+            "--for",
+            "work/demo/implement .latest-claim.disposition == changes-pushed",
+            "--timeout",
+            "30",
+        ])
+        .expect("parse wait command");
+        let Some(SubCommand::Wait { leaves, timeout, .. }) = cli.command else { panic!("expected wait command") };
+        assert_eq!(leaves.len(), 2);
+        assert_eq!(timeout, Some(30));
     }
 
     fn landing_project(name: &str, repositories: &[(&str, Option<&str>)]) -> ProjectListEntry {


### PR DESCRIPTION
## Summary

- add the typed `LeafSubject` seam and closed leaf vocabulary for convoy, vessel, and work state
- add an ephemeral, event-driven subscription table with shared in-memory and SQLite backend contract tests
- add `flotilla wait --for ...`, including OR conditions, freshness constraints, timeouts, and clean daemon-restart errors
- preserve and expose crew completion dispositions for work claim leaves

## Testing

- `cargo +nightly-2026-03-12 fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked --features flotilla-daemon/skip-no-sandbox-tests -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1362
