### PR TITLE
feat: observe change requests for leaf waits

### DIFF
--- a/crates/flotilla-core/src/change_request_observer.rs
+++ b/crates/flotilla-core/src/change_request_observer.rs
@@ -1,0 +1,295 @@
+use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use flotilla_protocol::LeafAddress;
+use flotilla_resources::{
+    change_request_record_name, ChangeRequest, ChangeRequestReviewObservation, ChangeRequestSpec, ChangeRequestStatus, InputMeta,
+    Observation, ObservedChangeRequestState, ObservedChecks, ObservedMergeability, ResourceBackend, ResourceProvenance,
+};
+use tokio::{sync::Mutex, task::JoinHandle};
+
+use crate::providers::{run, CommandRunner};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChangeRequestRef {
+    pub namespace: String,
+    pub service: String,
+    pub scope: String,
+    pub number: u64,
+}
+
+impl ChangeRequestRef {
+    pub fn from_address(namespace: &str, address: &LeafAddress) -> Option<Self> {
+        let LeafAddress::ChangeRequest { service, scope, number } = address else { return None };
+        Some(Self { namespace: namespace.to_string(), service: service.clone(), scope: scope.clone(), number: *number })
+    }
+
+    fn record_name(&self) -> String {
+        change_request_record_name(&self.service, &self.scope, self.number)
+    }
+}
+
+#[async_trait]
+pub trait ChangeRequestObservationSource: Send + Sync {
+    async fn observe(&self, subject: &ChangeRequestRef) -> Result<ChangeRequestStatus, String>;
+}
+
+pub struct GhChangeRequestObservationSource {
+    runner: Arc<dyn CommandRunner>,
+}
+
+impl GhChangeRequestObservationSource {
+    pub fn new(runner: Arc<dyn CommandRunner>) -> Self {
+        Self { runner }
+    }
+}
+
+#[async_trait]
+impl ChangeRequestObservationSource for GhChangeRequestObservationSource {
+    async fn observe(&self, subject: &ChangeRequestRef) -> Result<ChangeRequestStatus, String> {
+        if subject.service != "github.com" {
+            return Err(format!("change request observation service `{}` is not available on this host", subject.service));
+        }
+        let number = subject.number.to_string();
+        let output = run!(
+            self.runner,
+            "gh",
+            &["pr", "view", &number, "--repo", &subject.scope, "--json", "state,headRefOid,statusCheckRollup,reviewDecision,mergeable",],
+            Path::new("/"),
+        )?;
+        parse_gh_observation(&output, Utc::now())
+    }
+}
+
+fn parse_gh_observation(json: &str, observed_at: DateTime<Utc>) -> Result<ChangeRequestStatus, String> {
+    let value: serde_json::Value = serde_json::from_str(json).map_err(|error| format!("decode gh pr observation: {error}"))?;
+    let state = match value["state"].as_str() {
+        Some("OPEN") => Some(ObservedChangeRequestState::Open),
+        Some("MERGED") => Some(ObservedChangeRequestState::Merged),
+        Some("CLOSED") => Some(ObservedChangeRequestState::Closed),
+        _ => None,
+    };
+    let head_sha = value["headRefOid"].as_str().map(str::to_string);
+    let checks = value["statusCheckRollup"].as_array().map(|checks| {
+        if checks.iter().any(check_failed) {
+            ObservedChecks::Fail
+        } else if checks.iter().any(check_pending) {
+            ObservedChecks::Pending
+        } else {
+            ObservedChecks::Pass
+        }
+    });
+    let actionable_at_head = value["reviewDecision"].as_str().map(|decision| decision == "CHANGES_REQUESTED");
+    let mergeable = match value["mergeable"].as_str() {
+        Some("MERGEABLE") => Some(ObservedMergeability::Mergeable),
+        Some("CONFLICTING") => Some(ObservedMergeability::Conflicting),
+        _ => None,
+    };
+    Ok(ChangeRequestStatus {
+        state: Observation { value: state, observed_at },
+        head_sha: Observation { value: head_sha, observed_at },
+        checks: Observation { value: checks, observed_at },
+        review: ChangeRequestReviewObservation { actionable_at_head: Observation { value: actionable_at_head, observed_at } },
+        mergeable: Observation { value: mergeable, observed_at },
+    })
+}
+
+fn check_failed(check: &serde_json::Value) -> bool {
+    matches!(check["conclusion"].as_str(), Some("FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE"))
+        || matches!(check["state"].as_str(), Some("FAILURE" | "ERROR"))
+}
+
+fn check_pending(check: &serde_json::Value) -> bool {
+    check["conclusion"].is_null()
+        || matches!(check["status"].as_str(), Some("QUEUED" | "IN_PROGRESS" | "WAITING" | "PENDING"))
+        || matches!(check["state"].as_str(), Some("PENDING" | "EXPECTED"))
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ChangeRequestRefreshCadence {
+    pub state: Duration,
+    pub checks_pending: Duration,
+    pub freshness_demanded: Duration,
+    pub stale_after: Duration,
+}
+
+impl Default for ChangeRequestRefreshCadence {
+    fn default() -> Self {
+        Self {
+            state: Duration::from_secs(90),
+            checks_pending: Duration::from_secs(15),
+            freshness_demanded: Duration::from_secs(10),
+            stale_after: Duration::from_secs(180),
+        }
+    }
+}
+
+struct ActiveRefresh {
+    demands: HashMap<uuid::Uuid, Option<DateTime<Utc>>>,
+    task: JoinHandle<()>,
+}
+
+#[derive(Clone)]
+pub struct ChangeRequestRefresher {
+    inner: Arc<ChangeRequestRefresherInner>,
+}
+
+struct ChangeRequestRefresherInner {
+    backend: ResourceBackend,
+    authority: String,
+    source: Arc<dyn ChangeRequestObservationSource>,
+    cadence: ChangeRequestRefreshCadence,
+    active: Mutex<HashMap<ChangeRequestRef, ActiveRefresh>>,
+}
+
+impl ChangeRequestRefresher {
+    pub fn new(
+        backend: ResourceBackend,
+        authority: String,
+        source: Arc<dyn ChangeRequestObservationSource>,
+        cadence: ChangeRequestRefreshCadence,
+    ) -> Self {
+        Self { inner: Arc::new(ChangeRequestRefresherInner { backend, authority, source, cadence, active: Mutex::new(HashMap::new()) }) }
+    }
+
+    pub fn stale_after(&self) -> Duration {
+        self.inner.cadence.stale_after
+    }
+
+    pub async fn demand(
+        &self,
+        subscription_id: uuid::Uuid,
+        subject: ChangeRequestRef,
+        freshness: Option<DateTime<Utc>>,
+    ) -> Result<(), String> {
+        let records =
+            self.inner.backend.including_replicas::<ChangeRequest>(&subject.namespace).list().await.map_err(|error| error.to_string())?;
+        let name = subject.record_name();
+        if records
+            .items
+            .iter()
+            .any(|item| item.object.metadata.name == name && matches!(item.provenance, ResourceProvenance::Replica { .. }))
+        {
+            return Ok(());
+        }
+        self.ensure_record(&subject, &name).await?;
+
+        let mut active = self.inner.active.lock().await;
+        if let Some(refresh) = active.get_mut(&subject) {
+            refresh.demands.insert(subscription_id, freshness);
+            return Ok(());
+        }
+        let this = self.clone();
+        let task_subject = subject.clone();
+        let task = tokio::spawn(async move { this.refresh_loop(task_subject).await });
+        active.insert(subject, ActiveRefresh { demands: HashMap::from([(subscription_id, freshness)]), task });
+        Ok(())
+    }
+
+    pub async fn release(&self, subscription_id: uuid::Uuid) {
+        let mut active = self.inner.active.lock().await;
+        let empty = active
+            .iter_mut()
+            .filter_map(|(subject, refresh)| {
+                refresh.demands.remove(&subscription_id);
+                refresh.demands.is_empty().then_some(subject.clone())
+            })
+            .collect::<Vec<_>>();
+        for subject in empty {
+            if let Some(refresh) = active.remove(&subject) {
+                refresh.task.abort();
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub async fn active_demands(&self) -> usize {
+        self.inner.active.lock().await.values().map(|refresh| refresh.demands.len()).sum()
+    }
+
+    async fn refresh_loop(&self, subject: ChangeRequestRef) {
+        let record_name = subject.record_name();
+        loop {
+            match self.inner.source.observe(&subject).await {
+                Ok(status) => {
+                    if let Err(error) = self.publish(&subject, &record_name, status.clone()).await {
+                        tracing::warn!(service = %subject.service, scope = %subject.scope, number = subject.number, %error, "publish change request observation failed");
+                    }
+                    let demanded =
+                        self.inner.active.lock().await.get(&subject).is_some_and(|refresh| refresh.demands.values().any(Option::is_some));
+                    let delay = if demanded {
+                        self.inner.cadence.freshness_demanded
+                    } else if status.checks.value == Some(ObservedChecks::Pending) {
+                        self.inner.cadence.checks_pending
+                    } else {
+                        self.inner.cadence.state
+                    };
+                    tokio::time::sleep(delay).await;
+                }
+                Err(error) => {
+                    tracing::warn!(service = %subject.service, scope = %subject.scope, number = subject.number, %error, "change request observation failed");
+                    tokio::time::sleep(self.inner.cadence.checks_pending).await;
+                }
+            }
+        }
+    }
+
+    async fn publish(&self, subject: &ChangeRequestRef, name: &str, status: ChangeRequestStatus) -> Result<(), String> {
+        let records = self.inner.backend.using::<ChangeRequest>(&subject.namespace);
+        let current = match records.get(name).await {
+            Ok(current) => current,
+            Err(flotilla_resources::ResourceError::NotFound { .. }) => {
+                let spec = ChangeRequestSpec::builder()
+                    .service(subject.service.clone())
+                    .scope(subject.scope.clone())
+                    .number(subject.number)
+                    .observing_authority(self.inner.authority.clone())
+                    .build();
+                records.create(&InputMeta::builder().name(name.to_string()).build(), &spec).await.map_err(|error| error.to_string())?
+            }
+            Err(error) => return Err(error.to_string()),
+        };
+        records.update_status(name, &current.metadata.resource_version, &status).await.map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    async fn ensure_record(&self, subject: &ChangeRequestRef, name: &str) -> Result<(), String> {
+        let records = self.inner.backend.using::<ChangeRequest>(&subject.namespace);
+        match records.get(name).await {
+            Ok(_) => Ok(()),
+            Err(flotilla_resources::ResourceError::NotFound { .. }) => {
+                let spec = ChangeRequestSpec::builder()
+                    .service(subject.service.clone())
+                    .scope(subject.scope.clone())
+                    .number(subject.number)
+                    .observing_authority(self.inner.authority.clone())
+                    .build();
+                records
+                    .create(&InputMeta::builder().name(name.to_string()).build(), &spec)
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| error.to_string())
+            }
+            Err(error) => Err(error.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_gh_observation_vocabulary() {
+        let status = parse_gh_observation(
+            r#"{"state":"MERGED","headRefOid":"abc","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}],"reviewDecision":"CHANGES_REQUESTED","mergeable":"CONFLICTING"}"#,
+            "2026-08-03T20:00:00Z".parse().expect("time"),
+        )
+        .expect("parse");
+        assert_eq!(status.state.value, Some(ObservedChangeRequestState::Merged));
+        assert_eq!(status.checks.value, Some(ObservedChecks::Pass));
+        assert_eq!(status.review.actionable_at_head.value, Some(true));
+        assert_eq!(status.mergeable.value, Some(ObservedMergeability::Conflicting));
+    }
+}

--- a/crates/flotilla-core/src/change_request_observer.rs
+++ b/crates/flotilla-core/src/change_request_observer.rs
@@ -7,7 +7,10 @@ use flotilla_resources::{
     change_request_record_name, ChangeRequest, ChangeRequestReviewObservation, ChangeRequestSpec, ChangeRequestStatus, InputMeta,
     Observation, ObservedChangeRequestState, ObservedChecks, ObservedMergeability, ResourceBackend, ResourceProvenance,
 };
-use tokio::{sync::Mutex, task::JoinHandle};
+use tokio::{
+    sync::{Mutex, Notify},
+    task::JoinHandle,
+};
 
 use crate::providers::{run, CommandRunner};
 
@@ -127,6 +130,7 @@ impl Default for ChangeRequestRefreshCadence {
 
 struct ActiveRefresh {
     demands: HashMap<uuid::Uuid, Option<DateTime<Utc>>>,
+    wake: Arc<Notify>,
     task: JoinHandle<()>,
 }
 
@@ -178,12 +182,19 @@ impl ChangeRequestRefresher {
         let mut active = self.inner.active.lock().await;
         if let Some(refresh) = active.get_mut(&subject) {
             refresh.demands.insert(subscription_id, freshness);
+            if freshness.is_some() {
+                refresh.wake.notify_one();
+            }
             return Ok(());
         }
         let this = self.clone();
         let task_subject = subject.clone();
         let task = tokio::spawn(async move { this.refresh_loop(task_subject).await });
-        active.insert(subject, ActiveRefresh { demands: HashMap::from([(subscription_id, freshness)]), task });
+        active.insert(subject, ActiveRefresh {
+            demands: HashMap::from([(subscription_id, freshness)]),
+            wake: Arc::new(Notify::new()),
+            task,
+        });
         Ok(())
     }
 
@@ -225,45 +236,50 @@ impl ChangeRequestRefresher {
                     } else {
                         self.inner.cadence.state
                     };
-                    tokio::time::sleep(delay).await;
+                    if !self.wait_for_next(&subject, delay).await {
+                        break;
+                    }
                 }
                 Err(error) => {
                     tracing::warn!(service = %subject.service, scope = %subject.scope, number = subject.number, %error, "change request observation failed");
-                    tokio::time::sleep(self.inner.cadence.checks_pending).await;
+                    if !self.wait_for_next(&subject, self.inner.cadence.checks_pending).await {
+                        break;
+                    }
                 }
             }
         }
     }
 
+    async fn wait_for_next(&self, subject: &ChangeRequestRef, delay: Duration) -> bool {
+        let Some(wake) = self.inner.active.lock().await.get(subject).map(|refresh| Arc::clone(&refresh.wake)) else {
+            return false;
+        };
+        tokio::select! {
+            () = tokio::time::sleep(delay) => {}
+            () = wake.notified() => {}
+        }
+        true
+    }
+
     async fn publish(&self, subject: &ChangeRequestRef, name: &str, status: ChangeRequestStatus) -> Result<(), String> {
         let records = self.inner.backend.using::<ChangeRequest>(&subject.namespace);
-        let current = match records.get(name).await {
-            Ok(current) => current,
-            Err(flotilla_resources::ResourceError::NotFound { .. }) => {
-                let spec = ChangeRequestSpec::builder()
-                    .service(subject.service.clone())
-                    .scope(subject.scope.clone())
-                    .number(subject.number)
-                    .observing_authority(self.inner.authority.clone())
-                    .build();
-                match records.create(&InputMeta::builder().name(name.to_string()).build(), &spec).await {
-                    Ok(created) => created,
-                    Err(flotilla_resources::ResourceError::Conflict { .. }) => {
-                        records.get(name).await.map_err(|error| error.to_string())?
-                    }
-                    Err(error) => return Err(error.to_string()),
-                }
-            }
-            Err(error) => return Err(error.to_string()),
-        };
+        let current = self.get_or_create_record(subject, name).await?;
         records.update_status(name, &current.metadata.resource_version, &status).await.map_err(|error| error.to_string())?;
         Ok(())
     }
 
     async fn ensure_record(&self, subject: &ChangeRequestRef, name: &str) -> Result<(), String> {
+        self.get_or_create_record(subject, name).await.map(|_| ())
+    }
+
+    async fn get_or_create_record(
+        &self,
+        subject: &ChangeRequestRef,
+        name: &str,
+    ) -> Result<flotilla_resources::ResourceObject<ChangeRequest>, String> {
         let records = self.inner.backend.using::<ChangeRequest>(&subject.namespace);
         match records.get(name).await {
-            Ok(_) => Ok(()),
+            Ok(current) => Ok(current),
             Err(flotilla_resources::ResourceError::NotFound { .. }) => {
                 let spec = ChangeRequestSpec::builder()
                     .service(subject.service.clone())
@@ -272,10 +288,8 @@ impl ChangeRequestRefresher {
                     .observing_authority(self.inner.authority.clone())
                     .build();
                 match records.create(&InputMeta::builder().name(name.to_string()).build(), &spec).await {
-                    Ok(_) => Ok(()),
-                    Err(flotilla_resources::ResourceError::Conflict { .. }) => {
-                        records.get(name).await.map(|_| ()).map_err(|error| error.to_string())
-                    }
+                    Ok(created) => Ok(created),
+                    Err(flotilla_resources::ResourceError::Conflict { .. }) => records.get(name).await.map_err(|error| error.to_string()),
                     Err(error) => Err(error.to_string()),
                 }
             }
@@ -286,7 +300,10 @@ impl ChangeRequestRefresher {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     use async_trait::async_trait;
     use flotilla_resources::{InMemoryBackend, ResourceBackend};
@@ -299,6 +316,23 @@ mod tests {
     impl ChangeRequestObservationSource for UnavailableSource {
         async fn observe(&self, _subject: &ChangeRequestRef) -> Result<ChangeRequestStatus, String> {
             Err("unavailable".to_string())
+        }
+    }
+
+    struct CountingSource(Arc<AtomicUsize>);
+
+    #[async_trait]
+    impl ChangeRequestObservationSource for CountingSource {
+        async fn observe(&self, _subject: &ChangeRequestRef) -> Result<ChangeRequestStatus, String> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            let observed_at = Utc::now();
+            Ok(ChangeRequestStatus {
+                state: Observation::known(ObservedChangeRequestState::Open, observed_at),
+                head_sha: Observation::known("abc".to_string(), observed_at),
+                checks: Observation::known(ObservedChecks::Pass, observed_at),
+                review: ChangeRequestReviewObservation { actionable_at_head: Observation::known(false, observed_at) },
+                mergeable: Observation::known(ObservedMergeability::Mergeable, observed_at),
+            })
         }
     }
 
@@ -358,5 +392,40 @@ mod tests {
         second.expect("concurrent demand");
         assert_eq!(backend.using::<ChangeRequest>("flotilla").list().await.expect("list CRs").items.len(), 1);
         assert_eq!(refresher.active_demands().await, 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn late_freshness_demand_preempts_existing_state_cadence_sleep() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let refresher = ChangeRequestRefresher::new(
+            backend,
+            "authority".to_string(),
+            Arc::new(CountingSource(Arc::clone(&calls))),
+            ChangeRequestRefreshCadence {
+                state: Duration::from_secs(90),
+                checks_pending: Duration::from_secs(15),
+                freshness_demanded: Duration::from_secs(10),
+                stale_after: Duration::from_secs(180),
+            },
+        );
+        let subject = ChangeRequestRef {
+            namespace: "flotilla".to_string(),
+            service: "github.com".to_string(),
+            scope: "flotilla-org/flotilla".to_string(),
+            number: 1366,
+        };
+        refresher.demand(uuid::Uuid::new_v4(), subject.clone(), None).await.expect("initial demand");
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        refresher.demand(uuid::Uuid::new_v4(), subject, Some(Utc::now())).await.expect("late freshness demand");
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "freshness demand must preempt the remaining 85-second sleep");
     }
 }

--- a/crates/flotilla-core/src/change_request_observer.rs
+++ b/crates/flotilla-core/src/change_request_observer.rs
@@ -101,7 +101,7 @@ fn check_failed(check: &serde_json::Value) -> bool {
 }
 
 fn check_pending(check: &serde_json::Value) -> bool {
-    check["conclusion"].is_null()
+    check.get("conclusion").is_some_and(serde_json::Value::is_null)
         || matches!(check["status"].as_str(), Some("QUEUED" | "IN_PROGRESS" | "WAITING" | "PENDING"))
         || matches!(check["state"].as_str(), Some("PENDING" | "EXPECTED"))
 }
@@ -291,5 +291,15 @@ mod tests {
         assert_eq!(status.checks.value, Some(ObservedChecks::Pass));
         assert_eq!(status.review.actionable_at_head.value, Some(true));
         assert_eq!(status.mergeable.value, Some(ObservedMergeability::Conflicting));
+    }
+
+    #[test]
+    fn classic_success_status_without_check_run_fields_passes() {
+        let status = parse_gh_observation(
+            r#"{"state":"OPEN","headRefOid":"abc","statusCheckRollup":[{"state":"SUCCESS"}],"reviewDecision":"APPROVED","mergeable":"MERGEABLE"}"#,
+            "2026-08-03T20:00:00Z".parse().expect("time"),
+        )
+        .expect("parse");
+        assert_eq!(status.checks.value, Some(ObservedChecks::Pass));
     }
 }

--- a/crates/flotilla-core/src/change_request_observer.rs
+++ b/crates/flotilla-core/src/change_request_observer.rs
@@ -207,11 +207,35 @@ impl ChangeRequestRefresher {
                 refresh.demands.is_empty().then_some(subject.clone())
             })
             .collect::<Vec<_>>();
-        for subject in empty {
-            if let Some(refresh) = active.remove(&subject) {
-                refresh.task.abort();
+        let stopped =
+            empty.into_iter().filter_map(|subject| active.remove(&subject).map(|refresh| (subject, refresh.task))).collect::<Vec<_>>();
+        drop(active);
+
+        for (subject, task) in stopped {
+            task.abort();
+            let _ = task.await;
+            let active = self.inner.active.lock().await;
+            if active.contains_key(&subject) {
+                continue;
             }
+            let result = self.inner.backend.using::<ChangeRequest>(&subject.namespace).delete(&subject.record_name()).await;
+            if let Err(error) = result {
+                if !matches!(error, flotilla_resources::ResourceError::NotFound { .. }) {
+                    tracing::warn!(service = %subject.service, scope = %subject.scope, number = subject.number, %error, "garbage collect undemanded change request failed");
+                }
+            }
+            drop(active);
         }
+    }
+
+    /// A daemon restart has no surviving leaf subscriptions, so locally
+    /// authoritative observations from the previous process are all orphans.
+    pub async fn garbage_collect_orphans(&self) -> Result<(), String> {
+        let records = self.inner.backend.using::<ChangeRequest>("flotilla");
+        for record in records.list().await.map_err(|error| error.to_string())?.items {
+            records.delete(&record.metadata.name).await.map_err(|error| error.to_string())?;
+        }
+        Ok(())
     }
 
     #[cfg(test)]
@@ -264,6 +288,9 @@ impl ChangeRequestRefresher {
     async fn publish(&self, subject: &ChangeRequestRef, name: &str, status: ChangeRequestStatus) -> Result<(), String> {
         let records = self.inner.backend.using::<ChangeRequest>(&subject.namespace);
         let current = self.get_or_create_record(subject, name).await?;
+        if current.status.as_ref().is_some_and(|current| observed_values_equal(current, &status)) {
+            return Ok(());
+        }
         records.update_status(name, &current.metadata.resource_version, &status).await.map_err(|error| error.to_string())?;
         Ok(())
     }
@@ -296,6 +323,14 @@ impl ChangeRequestRefresher {
             Err(error) => Err(error.to_string()),
         }
     }
+}
+
+fn observed_values_equal(left: &ChangeRequestStatus, right: &ChangeRequestStatus) -> bool {
+    left.state.value == right.state.value
+        && left.head_sha.value == right.head_sha.value
+        && left.checks.value == right.checks.value
+        && left.review.actionable_at_head.value == right.review.actionable_at_head.value
+        && left.mergeable.value == right.mergeable.value
 }
 
 #[cfg(test)]
@@ -392,6 +427,71 @@ mod tests {
         second.expect("concurrent demand");
         assert_eq!(backend.using::<ChangeRequest>("flotilla").list().await.expect("list CRs").items.len(), 1);
         assert_eq!(refresher.active_demands().await, 2);
+    }
+
+    #[tokio::test]
+    async fn last_released_demand_garbage_collects_observed_record() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let refresher = ChangeRequestRefresher::new(
+            backend.clone(),
+            "authority".to_string(),
+            Arc::new(UnavailableSource),
+            ChangeRequestRefreshCadence::default(),
+        );
+        let subject = ChangeRequestRef {
+            namespace: "flotilla".to_string(),
+            service: "github.com".to_string(),
+            scope: "flotilla-org/flotilla".to_string(),
+            number: 1366,
+        };
+        let first = uuid::Uuid::new_v4();
+        let last = uuid::Uuid::new_v4();
+        refresher.demand(first, subject.clone(), None).await.expect("first demand");
+        refresher.demand(last, subject.clone(), None).await.expect("last demand");
+        assert_eq!(backend.using::<ChangeRequest>("flotilla").list().await.expect("list CRs").items.len(), 1);
+
+        refresher.release(first).await;
+        assert_eq!(backend.using::<ChangeRequest>("flotilla").list().await.expect("list CRs").items.len(), 1);
+
+        refresher.release(last).await;
+        assert!(backend.using::<ChangeRequest>("flotilla").list().await.expect("list CRs").items.is_empty());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn identical_polls_do_not_write_status() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let refresher = ChangeRequestRefresher::new(
+            backend.clone(),
+            "authority".to_string(),
+            Arc::new(CountingSource(Arc::clone(&calls))),
+            ChangeRequestRefreshCadence::default(),
+        );
+        let subject = ChangeRequestRef {
+            namespace: "flotilla".to_string(),
+            service: "github.com".to_string(),
+            scope: "flotilla-org/flotilla".to_string(),
+            number: 1366,
+        };
+        refresher.demand(uuid::Uuid::new_v4(), subject.clone(), None).await.expect("demand");
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+        let records = backend.using::<ChangeRequest>("flotilla");
+        let first = records.get(&subject.record_name()).await.expect("first observation");
+
+        const IDENTICAL_POLLS: usize = 4;
+        for _ in 0..IDENTICAL_POLLS {
+            tokio::time::advance(Duration::from_secs(90)).await;
+            for _ in 0..5 {
+                tokio::task::yield_now().await;
+            }
+        }
+
+        let after = records.get(&subject.record_name()).await.expect("observation after identical polls");
+        assert_eq!(calls.load(Ordering::SeqCst), IDENTICAL_POLLS + 1);
+        assert_eq!(after.metadata.resource_version, first.metadata.resource_version, "identical observed values must produce no writes");
+        assert_eq!(after.status, first.status, "poll timestamps are not persisted unless an observed value changes");
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/flotilla-core/src/change_request_observer.rs
+++ b/crates/flotilla-core/src/change_request_observer.rs
@@ -231,9 +231,12 @@ impl ChangeRequestRefresher {
     /// A daemon restart has no surviving leaf subscriptions, so locally
     /// authoritative observations from the previous process are all orphans.
     pub async fn garbage_collect_orphans(&self) -> Result<(), String> {
-        let records = self.inner.backend.using::<ChangeRequest>("flotilla");
-        for record in records.list().await.map_err(|error| error.to_string())?.items {
-            records.delete(&record.metadata.name).await.map_err(|error| error.to_string())?;
+        let namespaces = self.inner.backend.local_namespaces::<ChangeRequest>().await.map_err(|error| error.to_string())?;
+        for namespace in namespaces {
+            let records = self.inner.backend.using::<ChangeRequest>(&namespace);
+            for record in records.list().await.map_err(|error| error.to_string())?.items {
+                records.delete(&record.metadata.name).await.map_err(|error| error.to_string())?;
+            }
         }
         Ok(())
     }
@@ -455,6 +458,30 @@ mod tests {
 
         refresher.release(last).await;
         assert!(backend.using::<ChangeRequest>("flotilla").list().await.expect("list CRs").items.is_empty());
+    }
+
+    #[tokio::test]
+    async fn startup_garbage_collection_covers_non_default_namespaces() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let refresher = ChangeRequestRefresher::new(
+            backend.clone(),
+            "authority".to_string(),
+            Arc::new(UnavailableSource),
+            ChangeRequestRefreshCadence::default(),
+        );
+        let subject = ChangeRequestRef {
+            namespace: "ops".to_string(),
+            service: "github.com".to_string(),
+            scope: "flotilla-org/flotilla".to_string(),
+            number: 1366,
+        };
+        refresher.demand(uuid::Uuid::new_v4(), subject, None).await.expect("non-default namespace demand");
+        assert_eq!(backend.local_namespaces::<ChangeRequest>().await.expect("local namespaces"), vec!["ops"]);
+
+        refresher.garbage_collect_orphans().await.expect("startup garbage collection");
+
+        assert!(backend.using::<ChangeRequest>("ops").list().await.expect("list ops CRs").items.is_empty());
+        assert!(backend.local_namespaces::<ChangeRequest>().await.expect("local namespaces after GC").is_empty());
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/flotilla-core/src/change_request_observer.rs
+++ b/crates/flotilla-core/src/change_request_observer.rs
@@ -80,7 +80,7 @@ fn parse_gh_observation(json: &str, observed_at: DateTime<Utc>) -> Result<Change
             ObservedChecks::Pass
         }
     });
-    let actionable_at_head = value["reviewDecision"].as_str().map(|decision| decision == "CHANGES_REQUESTED");
+    let actionable_at_head = value.get("reviewDecision").map(|decision| decision.as_str() == Some("CHANGES_REQUESTED"));
     let mergeable = match value["mergeable"].as_str() {
         Some("MERGEABLE") => Some(ObservedMergeability::Mergeable),
         Some("CONFLICTING") => Some(ObservedMergeability::Conflicting),
@@ -246,7 +246,13 @@ impl ChangeRequestRefresher {
                     .number(subject.number)
                     .observing_authority(self.inner.authority.clone())
                     .build();
-                records.create(&InputMeta::builder().name(name.to_string()).build(), &spec).await.map_err(|error| error.to_string())?
+                match records.create(&InputMeta::builder().name(name.to_string()).build(), &spec).await {
+                    Ok(created) => created,
+                    Err(flotilla_resources::ResourceError::Conflict { .. }) => {
+                        records.get(name).await.map_err(|error| error.to_string())?
+                    }
+                    Err(error) => return Err(error.to_string()),
+                }
             }
             Err(error) => return Err(error.to_string()),
         };
@@ -265,11 +271,13 @@ impl ChangeRequestRefresher {
                     .number(subject.number)
                     .observing_authority(self.inner.authority.clone())
                     .build();
-                records
-                    .create(&InputMeta::builder().name(name.to_string()).build(), &spec)
-                    .await
-                    .map(|_| ())
-                    .map_err(|error| error.to_string())
+                match records.create(&InputMeta::builder().name(name.to_string()).build(), &spec).await {
+                    Ok(_) => Ok(()),
+                    Err(flotilla_resources::ResourceError::Conflict { .. }) => {
+                        records.get(name).await.map(|_| ()).map_err(|error| error.to_string())
+                    }
+                    Err(error) => Err(error.to_string()),
+                }
             }
             Err(error) => Err(error.to_string()),
         }
@@ -278,7 +286,21 @@ impl ChangeRequestRefresher {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use flotilla_resources::{InMemoryBackend, ResourceBackend};
+
     use super::*;
+
+    struct UnavailableSource;
+
+    #[async_trait]
+    impl ChangeRequestObservationSource for UnavailableSource {
+        async fn observe(&self, _subject: &ChangeRequestRef) -> Result<ChangeRequestStatus, String> {
+            Err("unavailable".to_string())
+        }
+    }
 
     #[test]
     fn parses_gh_observation_vocabulary() {
@@ -301,5 +323,40 @@ mod tests {
         )
         .expect("parse");
         assert_eq!(status.checks.value, Some(ObservedChecks::Pass));
+    }
+
+    #[test]
+    fn explicit_null_review_decision_is_not_actionable() {
+        let status = parse_gh_observation(
+            r#"{"state":"OPEN","headRefOid":"abc","statusCheckRollup":[],"reviewDecision":null,"mergeable":"MERGEABLE"}"#,
+            "2026-08-03T20:00:00Z".parse().expect("time"),
+        )
+        .expect("parse");
+        assert_eq!(status.review.actionable_at_head.value, Some(false));
+    }
+
+    #[tokio::test]
+    async fn concurrent_first_demands_converge_on_one_authority_record() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let refresher = ChangeRequestRefresher::new(
+            backend.clone(),
+            "authority".to_string(),
+            Arc::new(UnavailableSource),
+            ChangeRequestRefreshCadence::default(),
+        );
+        let subject = ChangeRequestRef {
+            namespace: "flotilla".to_string(),
+            service: "github.com".to_string(),
+            scope: "flotilla-org/flotilla".to_string(),
+            number: 1366,
+        };
+        let (first, second) = tokio::join!(
+            refresher.demand(uuid::Uuid::new_v4(), subject.clone(), None),
+            refresher.demand(uuid::Uuid::new_v4(), subject, None),
+        );
+        first.expect("first demand");
+        second.expect("concurrent demand");
+        assert_eq!(backend.using::<ChangeRequest>("flotilla").list().await.expect("list CRs").items.len(), 1);
+        assert_eq!(refresher.active_demands().await, 2);
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2014,7 +2014,13 @@ impl InProcessDaemon {
         .await;
 
         let (fleet_replica_tx, _) = broadcast::channel(32);
-        let leaf_subscriptions = LeafSubscriptionTable::new(resource_backend.clone(), event_tx.clone());
+        let change_request_refresher = crate::change_request_observer::ChangeRequestRefresher::new(
+            resource_backend.clone(),
+            local_node_id.to_string(),
+            Arc::new(crate::change_request_observer::GhChangeRequestObservationSource::new(discovery.runner.clone())),
+            crate::change_request_observer::ChangeRequestRefreshCadence::default(),
+        );
+        let leaf_subscriptions = LeafSubscriptionTable::new(resource_backend.clone(), event_tx.clone(), change_request_refresher);
         let daemon = Arc::new_cyclic(|self_weak| Self {
             repos: RwLock::new(repos),
             repo_order: RwLock::new(order),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2020,6 +2020,9 @@ impl InProcessDaemon {
             Arc::new(crate::change_request_observer::GhChangeRequestObservationSource::new(discovery.runner.clone())),
             crate::change_request_observer::ChangeRequestRefreshCadence::default(),
         );
+        if let Err(error) = change_request_refresher.garbage_collect_orphans().await {
+            tracing::warn!(%error, "garbage collect orphaned change request observations at startup failed");
+        }
         let leaf_subscriptions = LeafSubscriptionTable::new(resource_backend.clone(), event_tx.clone(), change_request_refresher);
         let daemon = Arc::new_cyclic(|self_weak| Self {
             repos: RwLock::new(repos),

--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -3,14 +3,16 @@ use std::{collections::HashMap, sync::Arc};
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{DaemonEvent, Leaf, LeafAddress, LeafFire, WaitSubscriptionRequest};
 use flotilla_resources::{
-    admit_leaf, evaluate_leaf, Convoy, ConvoyLeafSubject, ResourceBackend, ResourceObject, ThreeValue, Vessel, VesselLeafSubject,
-    WorkLeafSubject,
+    admit_leaf, evaluate_leaf, ChangeRequest, ChangeRequestLeafSubject, Convoy, ConvoyLeafSubject, ResourceBackend, ResourceObject,
+    ThreeValue, Vessel, VesselLeafSubject, WorkLeafSubject,
 };
 use futures::StreamExt;
 use tokio::{
     sync::{broadcast, Mutex},
     task::JoinHandle,
 };
+
+use crate::change_request_observer::{ChangeRequestRef, ChangeRequestRefresher};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LeafWatcher {
@@ -46,16 +48,18 @@ struct LeafSubscriptionTableInner {
     event_tx: broadcast::Sender<DaemonEvent>,
     rows: Mutex<HashMap<uuid::Uuid, LeafSubscriptionRow>>,
     tasks: Mutex<HashMap<uuid::Uuid, JoinHandle<()>>>,
+    change_requests: ChangeRequestRefresher,
 }
 
 impl LeafSubscriptionTable {
-    pub fn new(backend: ResourceBackend, event_tx: broadcast::Sender<DaemonEvent>) -> Self {
+    pub fn new(backend: ResourceBackend, event_tx: broadcast::Sender<DaemonEvent>, change_requests: ChangeRequestRefresher) -> Self {
         Self {
             inner: Arc::new(LeafSubscriptionTableInner {
                 backend,
                 event_tx,
                 rows: Mutex::new(HashMap::new()),
                 tasks: Mutex::new(HashMap::new()),
+                change_requests,
             }),
         }
     }
@@ -82,6 +86,13 @@ impl LeafSubscriptionTable {
             episode_key: EpisodeKeyFields::default(),
         };
         self.inner.rows.lock().await.insert(id, row.clone());
+        for subject in row.leaves.iter().filter_map(|leaf| ChangeRequestRef::from_address(&row.namespace, &leaf.address)) {
+            if let Err(error) = self.inner.change_requests.demand(id, subject, row.freshness_demand).await {
+                self.inner.rows.lock().await.remove(&id);
+                self.inner.change_requests.release(id).await;
+                return Err(error);
+            }
+        }
         let table = self.clone();
         let task = tokio::spawn(async move {
             if let Err(error) = table.watch_row(row).await {
@@ -110,6 +121,7 @@ impl LeafSubscriptionTable {
             if let Some(task) = self.inner.tasks.lock().await.remove(&id) {
                 task.abort();
             }
+            self.inner.change_requests.release(id).await;
         }
     }
 
@@ -121,18 +133,22 @@ impl LeafSubscriptionTable {
     async fn finish(&self, id: uuid::Uuid) {
         self.inner.rows.lock().await.remove(&id);
         self.inner.tasks.lock().await.remove(&id);
+        self.inner.change_requests.release(id).await;
     }
 
     async fn watch_row(&self, row: LeafSubscriptionRow) -> Result<(), String> {
         let convoys = self.inner.backend.including_replicas::<Convoy>(&row.namespace);
         let vessels = self.inner.backend.including_replicas::<Vessel>(&row.namespace);
+        let change_requests = self.inner.backend.including_replicas::<ChangeRequest>(&row.namespace);
         // Open watches before taking the level-triggered snapshots. Writes
         // racing the lists are then buffered by the streams and replayed by
         // the loop instead of falling through a list-then-watch gap.
         let mut convoy_watch = convoys.watch().await.map_err(|error| error.to_string())?;
         let mut vessel_watch = vessels.watch().await.map_err(|error| error.to_string())?;
+        let mut change_request_watch = change_requests.watch().await.map_err(|error| error.to_string())?;
         let convoy_list = convoys.list().await.map_err(|error| error.to_string())?;
         let vessel_list = vessels.list().await.map_err(|error| error.to_string())?;
+        let change_request_list = change_requests.list().await.map_err(|error| error.to_string())?;
         let mut convoy_objects = convoy_list.items.into_iter().fold(HashMap::new(), |mut objects, item| {
             objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
             objects
@@ -141,8 +157,14 @@ impl LeafSubscriptionTable {
             objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
             objects
         });
+        let mut change_request_objects = change_request_list.items.into_iter().fold(HashMap::new(), |mut objects, item| {
+            objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
+            objects
+        });
 
-        if let Some(fire) = evaluate_row(&row, &convoy_objects, &vessel_objects)? {
+        if let Some(fire) =
+            evaluate_row(&row, &convoy_objects, &vessel_objects, &change_request_objects, self.inner.change_requests.stale_after())?
+        {
             self.fire(row.id, fire).await;
             return Ok(());
         }
@@ -157,8 +179,14 @@ impl LeafSubscriptionTable {
                     let event = event.ok_or_else(|| "vessel resource watch closed".to_string())?.map_err(|error| error.to_string())?;
                     apply_read_event(event, &mut vessel_objects);
                 }
+                event = change_request_watch.next() => {
+                    let event = event.ok_or_else(|| "change request resource watch closed".to_string())?.map_err(|error| error.to_string())?;
+                    apply_read_event(event, &mut change_request_objects);
+                }
             }
-            if let Some(fire) = evaluate_row(&row, &convoy_objects, &vessel_objects)? {
+            if let Some(fire) =
+                evaluate_row(&row, &convoy_objects, &vessel_objects, &change_request_objects, self.inner.change_requests.stale_after())?
+            {
                 self.fire(row.id, fire).await;
                 return Ok(());
             }
@@ -196,6 +224,8 @@ fn evaluate_row(
     row: &LeafSubscriptionRow,
     convoys: &HashMap<String, ResourceObject<Convoy>>,
     vessels: &HashMap<String, ResourceObject<Vessel>>,
+    change_requests: &HashMap<String, ResourceObject<ChangeRequest>>,
+    change_request_stale_after: std::time::Duration,
 ) -> Result<Option<LeafFire>, String> {
     for leaf in &row.leaves {
         let evaluation = match &leaf.address {
@@ -210,6 +240,15 @@ fn evaluate_row(
             LeafAddress::Work { convoy, work } => {
                 let subject = convoys.get(convoy).and_then(|convoy| convoy.status.as_ref()).and_then(|status| {
                     status.work.get(work).map(|work_state| WorkLeafSubject { work: work_state, crew: status.crew_work.get(work) })
+                });
+                evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
+            }
+            LeafAddress::ChangeRequest { service, scope, number } => {
+                let name = flotilla_resources::change_request_record_name(service, scope, *number);
+                let subject = change_requests.get(&name).map(|change_request| ChangeRequestLeafSubject {
+                    change_request,
+                    now: Utc::now(),
+                    stale_after: change_request_stale_after,
                 });
                 evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
             }
@@ -228,8 +267,13 @@ fn evaluate_row(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeMap, time::Duration};
+    use std::{
+        collections::BTreeMap,
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
 
+    use async_trait::async_trait;
     use flotilla_protocol::{LeafAddress, LeafOperator};
     use flotilla_resources::{
         ConvoyPhase, ConvoySpec, ConvoyStatus, CrewWorkPhase, CrewWorkState, InMemoryBackend, InputMeta, SqliteBackend, WorkPhase,
@@ -237,6 +281,42 @@ mod tests {
     };
 
     use super::*;
+
+    struct UnavailableChangeRequests;
+
+    #[async_trait]
+    impl crate::change_request_observer::ChangeRequestObservationSource for UnavailableChangeRequests {
+        async fn observe(
+            &self,
+            _subject: &crate::change_request_observer::ChangeRequestRef,
+        ) -> Result<flotilla_resources::ChangeRequestStatus, String> {
+            Err("unavailable in non-CR leaf contract".to_string())
+        }
+    }
+
+    struct CountingChangeRequests {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl crate::change_request_observer::ChangeRequestObservationSource for CountingChangeRequests {
+        async fn observe(
+            &self,
+            _subject: &crate::change_request_observer::ChangeRequestRef,
+        ) -> Result<flotilla_resources::ChangeRequestStatus, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let observed_at = Utc::now();
+            Ok(flotilla_resources::ChangeRequestStatus {
+                state: flotilla_resources::Observation::known(flotilla_resources::ObservedChangeRequestState::Open, observed_at),
+                head_sha: flotilla_resources::Observation::known("abc".to_string(), observed_at),
+                checks: flotilla_resources::Observation::known(flotilla_resources::ObservedChecks::Pass, observed_at),
+                review: flotilla_resources::ChangeRequestReviewObservation {
+                    actionable_at_head: flotilla_resources::Observation::known(false, observed_at),
+                },
+                mergeable: flotilla_resources::Observation::known(flotilla_resources::ObservedMergeability::Mergeable, observed_at),
+            })
+        }
+    }
 
     fn convoy_spec() -> ConvoySpec {
         ConvoySpec::builder().workflow_ref("workflow".to_string()).build()
@@ -276,7 +356,13 @@ mod tests {
 
     async fn assert_leaf_subscription_contract(backend: ResourceBackend) {
         let (event_tx, _) = broadcast::channel(16);
-        let table = LeafSubscriptionTable::new(backend.clone(), event_tx.clone());
+        let refresher = ChangeRequestRefresher::new(
+            backend.clone(),
+            "test-host".to_string(),
+            Arc::new(UnavailableChangeRequests),
+            crate::change_request_observer::ChangeRequestRefreshCadence::default(),
+        );
+        let table = LeafSubscriptionTable::new(backend.clone(), event_tx.clone(), refresher);
         let connection_id = uuid::Uuid::new_v4();
         let mut events = event_tx.subscribe();
 
@@ -360,5 +446,147 @@ mod tests {
     #[tokio::test]
     async fn sqlite_leaf_subscription_contract() {
         assert_leaf_subscription_contract(ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("open sqlite"))).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replayed_real_merge_observation_unblocks_wait_and_releases_demand() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let (event_tx, _) = broadcast::channel(16);
+        let fixture = crate::providers::testing::fixture_path("change_request", "cr_observation_merge.yaml");
+        let session = crate::providers::replay::Session::replaying(fixture, crate::providers::replay::Masks::new());
+        let source = Arc::new(crate::change_request_observer::GhChangeRequestObservationSource::new(
+            crate::providers::replay::test_runner(&session),
+        ));
+        let cadence = crate::change_request_observer::ChangeRequestRefreshCadence {
+            state: Duration::from_secs(60),
+            checks_pending: Duration::from_secs(5),
+            freshness_demanded: Duration::from_secs(2),
+            stale_after: Duration::from_secs(120),
+        };
+        let refresher = ChangeRequestRefresher::new(backend.clone(), "authority".to_string(), source, cadence);
+        let table = LeafSubscriptionTable::new(backend.clone(), event_tx.clone(), refresher.clone());
+        let connection_id = uuid::Uuid::new_v4();
+        let mut events = event_tx.subscribe();
+        let request = WaitSubscriptionRequest {
+            namespace: "flotilla".to_string(),
+            leaves: vec![leaf(
+                LeafAddress::ChangeRequest { service: "github.com".to_string(), scope: "flotilla-org/flotilla".to_string(), number: 1363 },
+                ".state",
+                "merged",
+            )],
+            freshness_demand: None,
+        };
+        let subscription_id = table.subscribe_wait(connection_id, request).await.expect("subscribe CR wait");
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(Duration::from_secs(60)).await;
+        let fire = receive_fire(&mut events, subscription_id).await;
+        assert_eq!(fire.value, "merged");
+        assert_eq!(refresher.active_demands().await, 0, "fired wait must stop polling");
+        session.finish();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unsubscribe_stops_change_request_observation_and_freshness_tightens_cadence() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let (event_tx, _) = broadcast::channel(16);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let source = Arc::new(CountingChangeRequests { calls: Arc::clone(&calls) });
+        let cadence = crate::change_request_observer::ChangeRequestRefreshCadence {
+            state: Duration::from_secs(60),
+            checks_pending: Duration::from_secs(20),
+            freshness_demanded: Duration::from_secs(5),
+            stale_after: Duration::from_secs(120),
+        };
+        let refresher = ChangeRequestRefresher::new(backend.clone(), "authority".to_string(), source, cadence);
+        let table = LeafSubscriptionTable::new(backend, event_tx, refresher.clone());
+        let connection_id = uuid::Uuid::new_v4();
+        let request = WaitSubscriptionRequest {
+            namespace: "flotilla".to_string(),
+            leaves: vec![leaf(
+                LeafAddress::ChangeRequest { service: "github.com".to_string(), scope: "flotilla-org/flotilla".to_string(), number: 1364 },
+                ".state",
+                "merged",
+            )],
+            freshness_demand: Some(Utc::now()),
+        };
+        table.subscribe_wait(connection_id, request).await.expect("subscribe CR wait");
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        tokio::time::advance(Duration::from_secs(5)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "freshness demand must use tighter cadence");
+
+        table.unsubscribe_connection(connection_id).await;
+        assert_eq!(refresher.active_demands().await, 0);
+        let stopped_at = calls.load(Ordering::SeqCst);
+        tokio::time::advance(Duration::from_secs(300)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(calls.load(Ordering::SeqCst), stopped_at, "no subscribers means no polling");
+    }
+
+    #[tokio::test]
+    async fn replica_reading_evaluator_fires_from_authority_change_request_record() {
+        let authority = ResourceBackend::InMemory(InMemoryBackend::default());
+        let subject =
+            LeafAddress::ChangeRequest { service: "github.com".to_string(), scope: "flotilla-org/flotilla".to_string(), number: 1365 };
+        let name = flotilla_resources::change_request_record_name("github.com", "flotilla-org/flotilla", 1365);
+        let records = authority.using::<ChangeRequest>("flotilla");
+        let created = records
+            .create(
+                &InputMeta::builder().name(name).build(),
+                &flotilla_resources::ChangeRequestSpec::builder()
+                    .service("github.com".to_string())
+                    .scope("flotilla-org/flotilla".to_string())
+                    .number(1365)
+                    .observing_authority("feta".to_string())
+                    .build(),
+            )
+            .await
+            .expect("create authority CR");
+        let observed_at = Utc::now();
+        records
+            .update_status(&created.metadata.name, &created.metadata.resource_version, &flotilla_resources::ChangeRequestStatus {
+                state: flotilla_resources::Observation::known(flotilla_resources::ObservedChangeRequestState::Merged, observed_at),
+                head_sha: flotilla_resources::Observation::known("abc".to_string(), observed_at),
+                checks: flotilla_resources::Observation::known(flotilla_resources::ObservedChecks::Pass, observed_at),
+                review: flotilla_resources::ChangeRequestReviewObservation {
+                    actionable_at_head: flotilla_resources::Observation::known(false, observed_at),
+                },
+                mergeable: flotilla_resources::Observation::known(flotilla_resources::ObservedMergeability::Mergeable, observed_at),
+            })
+            .await
+            .expect("publish authority CR");
+
+        let reader = ResourceBackend::InMemory(InMemoryBackend::default());
+        let authority_list = records.list().await.expect("list authority CR");
+        reader
+            .replica_writer::<ChangeRequest>(flotilla_protocol::NodeId::new("feta-root"), "flotilla")
+            .replace(&authority_list, Utc::now())
+            .await
+            .expect("replicate authority CR");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let refresher = ChangeRequestRefresher::new(
+            reader.clone(),
+            "kiwi".to_string(),
+            Arc::new(CountingChangeRequests { calls: Arc::clone(&calls) }),
+            crate::change_request_observer::ChangeRequestRefreshCadence::default(),
+        );
+        let (event_tx, _) = broadcast::channel(16);
+        let table = LeafSubscriptionTable::new(reader, event_tx.clone(), refresher);
+        let mut events = event_tx.subscribe();
+        let subscription_id = table
+            .subscribe_wait(uuid::Uuid::new_v4(), WaitSubscriptionRequest {
+                namespace: "flotilla".to_string(),
+                leaves: vec![leaf(subject, ".state", "merged")],
+                freshness_demand: None,
+            })
+            .await
+            .expect("subscribe replica CR");
+        assert_eq!(receive_fire(&mut events, subscription_id).await.value, "merged");
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "replica reader must not become a second observing authority");
     }
 }

--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -500,7 +500,7 @@ mod tests {
             stale_after: Duration::from_secs(120),
         };
         let refresher = ChangeRequestRefresher::new(backend.clone(), "authority".to_string(), source, cadence);
-        let table = LeafSubscriptionTable::new(backend, event_tx, refresher.clone());
+        let table = LeafSubscriptionTable::new(backend.clone(), event_tx, refresher.clone());
         let connection_id = uuid::Uuid::new_v4();
         let request = WaitSubscriptionRequest {
             namespace: "flotilla".to_string(),
@@ -516,12 +516,21 @@ mod tests {
             tokio::task::yield_now().await;
         }
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            backend.using::<ChangeRequest>("flotilla").list().await.expect("list demanded CR").items.len(),
+            1,
+            "subscription must materialize its individually bound subject"
+        );
         tokio::time::advance(Duration::from_secs(5)).await;
         tokio::task::yield_now().await;
         assert_eq!(calls.load(Ordering::SeqCst), 2, "freshness demand must use tighter cadence");
 
         table.unsubscribe_connection(connection_id).await;
         assert_eq!(refresher.active_demands().await, 0);
+        assert!(
+            backend.using::<ChangeRequest>("flotilla").list().await.expect("list released CRs").items.is_empty(),
+            "last unsubscribe must garbage collect the observed record"
+        );
         let stopped_at = calls.load(Ordering::SeqCst);
         tokio::time::advance(Duration::from_secs(300)).await;
         tokio::task::yield_now().await;

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod agents;
 pub mod aggregator_projection;
 pub mod attachable;
 pub mod awareness_projection;
+pub mod change_request_observer;
 pub mod checkout_integration;
 pub mod config;
 pub mod convert;

--- a/crates/flotilla-core/src/providers/change_request/fixtures/cr_observation_merge.yaml
+++ b/crates/flotilla-core/src/providers/change_request/fixtures/cr_observation_merge.yaml
@@ -1,0 +1,13 @@
+interactions:
+- channel: command
+  cmd: gh
+  args: [pr, view, '1363', --repo, flotilla-org/flotilla, --json, 'state,headRefOid,statusCheckRollup,reviewDecision,mergeable']
+  cwd: /
+  stdout: '{"state":"OPEN","headRefOid":"abc123","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}],"reviewDecision":"APPROVED","mergeable":"MERGEABLE"}'
+  exit_code: 0
+- channel: command
+  cmd: gh
+  args: [pr, view, '1363', --repo, flotilla-org/flotilla, --json, 'state,headRefOid,statusCheckRollup,reviewDecision,mergeable']
+  cwd: /
+  stdout: '{"state":"MERGED","headRefOid":"abc123","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}],"reviewDecision":"APPROVED","mergeable":"UNKNOWN"}'
+  exit_code: 0

--- a/crates/flotilla-protocol/src/leaf.rs
+++ b/crates/flotilla-protocol/src/leaf.rs
@@ -48,6 +48,7 @@ pub enum LeafAddress {
     Convoy { name: String },
     Vessel { name: String },
     Work { convoy: String, work: String },
+    ChangeRequest { service: String, scope: String, number: u64 },
 }
 
 impl LeafAddress {
@@ -56,6 +57,7 @@ impl LeafAddress {
             Self::Convoy { .. } => LeafKind::Convoy,
             Self::Vessel { .. } => LeafKind::Vessel,
             Self::Work { .. } => LeafKind::Work,
+            Self::ChangeRequest { .. } => LeafKind::ChangeRequest,
         }
     }
 }
@@ -71,7 +73,13 @@ impl FromStr for LeafAddress {
             ["work", convoy, work] if !convoy.is_empty() && !work.is_empty() => {
                 Ok(Self::Work { convoy: (*convoy).to_string(), work: (*work).to_string() })
             }
-            _ => Err(format!("invalid leaf address `{value}`; expected convoy/<name>, vessel/<name>, or work/<convoy>/<work>")),
+            ["cr", service, scope @ .., number] if !service.is_empty() && !scope.is_empty() => {
+                let number = number.parse().map_err(|_| format!("invalid change request number `{number}` in leaf address `{value}`"))?;
+                Ok(Self::ChangeRequest { service: (*service).to_string(), scope: scope.join("/"), number })
+            }
+            _ => Err(format!(
+                "invalid leaf address `{value}`; expected convoy/<name>, vessel/<name>, work/<convoy>/<work>, or cr/<service>/<scope>/<number>"
+            )),
         }
     }
 }
@@ -82,6 +90,7 @@ impl fmt::Display for LeafAddress {
             Self::Convoy { name } => write!(f, "convoy/{name}"),
             Self::Vessel { name } => write!(f, "vessel/{name}"),
             Self::Work { convoy, work } => write!(f, "work/{convoy}/{work}"),
+            Self::ChangeRequest { service, scope, number } => write!(f, "cr/{service}/{scope}/{number}"),
         }
     }
 }
@@ -92,6 +101,7 @@ pub enum LeafKind {
     Convoy,
     Vessel,
     Work,
+    ChangeRequest,
 }
 
 impl fmt::Display for LeafKind {
@@ -100,6 +110,7 @@ impl fmt::Display for LeafKind {
             Self::Convoy => "convoy",
             Self::Vessel => "vessel",
             Self::Work => "work",
+            Self::ChangeRequest => "cr",
         })
     }
 }
@@ -186,5 +197,16 @@ mod tests {
         let leaf: Leaf = "work/demo/implement .latest-claim.disposition == 'changes pushed'".parse().expect("parse claim leaf");
         assert_eq!(leaf.address, LeafAddress::Work { convoy: "demo".to_string(), work: "implement".to_string() });
         assert_eq!(leaf.literal, "changes pushed");
+    }
+
+    #[test]
+    fn parses_subject_keyed_change_request_address() {
+        let leaf: Leaf = "cr/github.com/flotilla-org/flotilla/1363 .state == merged".parse().expect("parse CR leaf");
+        assert_eq!(leaf.address, LeafAddress::ChangeRequest {
+            service: "github.com".to_string(),
+            scope: "flotilla-org/flotilla".to_string(),
+            number: 1363,
+        });
+        assert_eq!(leaf.to_string(), "cr/github.com/flotilla-org/flotilla/1363 .state == merged");
     }
 }

--- a/crates/flotilla-protocol/src/leaf.rs
+++ b/crates/flotilla-protocol/src/leaf.rs
@@ -209,4 +209,15 @@ mod tests {
         });
         assert_eq!(leaf.to_string(), "cr/github.com/flotilla-org/flotilla/1363 .state == merged");
     }
+
+    #[test]
+    fn rejects_change_request_collection_and_query_addresses() {
+        for address in [
+            "cr/github.com/flotilla-org/flotilla",
+            "cr/github.com/flotilla-org/flotilla/*",
+            "cr/github.com/flotilla-org/flotilla?state=open",
+        ] {
+            assert!(address.parse::<LeafAddress>().is_err(), "collection or query address must be rejected: {address}");
+        }
+    }
 }

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -56,6 +56,15 @@ impl ResourceBackend {
         TypedResolver { backend: self.clone(), namespace: namespace.to_string(), _marker: PhantomData }
     }
 
+    /// Namespaces containing locally-authored objects of this kind.
+    pub async fn local_namespaces<T: Resource>(&self) -> Result<Vec<String>, ResourceError> {
+        match self {
+            Self::InMemory(backend) => backend.local_namespaces_typed::<T>().await,
+            Self::Sqlite(backend) => backend.local_namespaces_typed::<T>().await,
+            Self::Http(_) => Err(ResourceError::invalid("HTTP backends cannot enumerate local resource namespaces")),
+        }
+    }
+
     pub fn definitions<T: Resource>(&self, namespace: &str) -> DefinitionResolver<T> {
         DefinitionResolver::new(self.clone(), namespace.to_string())
     }

--- a/crates/flotilla-resources/src/change_request.rs
+++ b/crates/flotilla-resources/src/change_request.rs
@@ -1,0 +1,106 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::{ApiPaths, ReplicationClass, Resource, ResourceError, StatusPatch};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChangeRequest;
+
+impl Resource for ChangeRequest {
+    type Spec = ChangeRequestSpec;
+    type Status = ChangeRequestStatus;
+    type StatusPatch = ChangeRequestStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "changerequests", kind: "ChangeRequest" };
+    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
+
+    fn validate_spec_update(current: &Self::Spec, requested: &Self::Spec) -> Result<(), ResourceError> {
+        if current == requested {
+            Ok(())
+        } else {
+            Err(ResourceError::invalid("ChangeRequest subject and observing authority are immutable"))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct ChangeRequestSpec {
+    pub service: String,
+    pub scope: String,
+    pub number: u64,
+    pub observing_authority: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Observation<T> {
+    /// `None` is the structural Unknown value.
+    pub value: Option<T>,
+    pub observed_at: DateTime<Utc>,
+}
+
+impl<T> Observation<T> {
+    pub fn known(value: T, observed_at: DateTime<Utc>) -> Self {
+        Self { value: Some(value), observed_at }
+    }
+
+    pub fn unknown(observed_at: DateTime<Utc>) -> Self {
+        Self { value: None, observed_at }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservedChangeRequestState {
+    Open,
+    Merged,
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservedChecks {
+    Pass,
+    Fail,
+    Pending,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservedMergeability {
+    Mergeable,
+    Conflicting,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeRequestReviewObservation {
+    pub actionable_at_head: Observation<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeRequestStatus {
+    pub state: Observation<ObservedChangeRequestState>,
+    pub head_sha: Observation<String>,
+    pub checks: Observation<ObservedChecks>,
+    pub review: ChangeRequestReviewObservation,
+    pub mergeable: Observation<ObservedMergeability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChangeRequestStatusPatch {
+    Observed(ChangeRequestStatus),
+}
+
+impl StatusPatch<ChangeRequestStatus> for ChangeRequestStatusPatch {
+    fn apply(&self, status: &mut ChangeRequestStatus) {
+        match self {
+            Self::Observed(observation) => *status = observation.clone(),
+        }
+    }
+}
+
+pub fn change_request_record_name(service: &str, scope: &str, number: u64) -> String {
+    fn hex(value: &str) -> String {
+        value.as_bytes().iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+    format!("cr-{}-{}-{number}", hex(service), hex(scope))
+}

--- a/crates/flotilla-resources/src/change_request.rs
+++ b/crates/flotilla-resources/src/change_request.rs
@@ -150,6 +150,23 @@ mod tests {
         assert_eq!(diagnostics.event_count, 1, "observations retain only the latest watch handoff event");
     }
 
+    async fn assert_local_namespace_enumeration(backend: ResourceBackend) {
+        let spec = ChangeRequestSpec::builder()
+            .service("github.com".to_string())
+            .scope("flotilla-org/flotilla".to_string())
+            .number(1366)
+            .observing_authority("authority".to_string())
+            .build();
+        for namespace in ["flotilla", "ops"] {
+            backend
+                .using::<ChangeRequest>(namespace)
+                .create(&InputMeta::builder().name("cr".to_string()).build(), &spec)
+                .await
+                .expect("create namespaced observation");
+        }
+        assert_eq!(backend.local_namespaces::<ChangeRequest>().await.expect("local namespaces"), vec!["flotilla", "ops"]);
+    }
+
     #[tokio::test]
     async fn in_memory_observation_history_is_thin() {
         assert_observation_history_is_thin(ResourceBackend::InMemory(InMemoryBackend::default())).await;
@@ -158,5 +175,15 @@ mod tests {
     #[tokio::test]
     async fn sqlite_observation_history_is_thin() {
         assert_observation_history_is_thin(ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend"))).await;
+    }
+
+    #[tokio::test]
+    async fn in_memory_enumerates_local_observation_namespaces() {
+        assert_local_namespace_enumeration(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_enumerates_local_observation_namespaces() {
+        assert_local_namespace_enumeration(ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend"))).await;
     }
 }

--- a/crates/flotilla-resources/src/change_request.rs
+++ b/crates/flotilla-resources/src/change_request.rs
@@ -12,7 +12,7 @@ impl Resource for ChangeRequest {
     type StatusPatch = ChangeRequestStatusPatch;
 
     const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "changerequests", kind: "ChangeRequest" };
-    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::HomeBoundRuntime;
+    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::Observations;
 
     fn validate_spec_update(current: &Self::Spec, requested: &Self::Spec) -> Result<(), ResourceError> {
         if current == requested {
@@ -103,4 +103,60 @@ pub fn change_request_record_name(service: &str, scope: &str, number: u64) -> St
         value.as_bytes().iter().map(|byte| format!("{byte:02x}")).collect()
     }
     format!("cr-{}-{}-{number}", hex(service), hex(scope))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{InMemoryBackend, InputMeta, ResourceBackend, SqliteBackend};
+
+    fn status(state: ObservedChangeRequestState, observed_at: DateTime<Utc>) -> ChangeRequestStatus {
+        ChangeRequestStatus {
+            state: Observation::known(state, observed_at),
+            head_sha: Observation::known("abc".to_string(), observed_at),
+            checks: Observation::known(ObservedChecks::Pass, observed_at),
+            review: ChangeRequestReviewObservation { actionable_at_head: Observation::known(false, observed_at) },
+            mergeable: Observation::known(ObservedMergeability::Mergeable, observed_at),
+        }
+    }
+
+    async fn assert_observation_history_is_thin(backend: ResourceBackend) {
+        let records = backend.using::<ChangeRequest>("flotilla");
+        let spec = ChangeRequestSpec::builder()
+            .service("github.com".to_string())
+            .scope("flotilla-org/flotilla".to_string())
+            .number(1366)
+            .observing_authority("authority".to_string())
+            .build();
+        let created = records.create(&InputMeta::builder().name("cr".to_string()).build(), &spec).await.expect("create observation");
+        let opened = records
+            .update_status(
+                "cr",
+                &created.metadata.resource_version,
+                &status(ObservedChangeRequestState::Open, "2026-08-03T20:00:00Z".parse().expect("time")),
+            )
+            .await
+            .expect("publish open observation");
+        records
+            .update_status(
+                "cr",
+                &opened.metadata.resource_version,
+                &status(ObservedChangeRequestState::Merged, "2026-08-03T20:01:00Z".parse().expect("time")),
+            )
+            .await
+            .expect("publish merged observation");
+
+        let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded store diagnostics");
+        assert_eq!(diagnostics.event_count, 1, "observations retain only the latest watch handoff event");
+    }
+
+    #[tokio::test]
+    async fn in_memory_observation_history_is_thin() {
+        assert_observation_history_is_thin(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_observation_history_is_thin() {
+        assert_observation_history_is_thin(ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend"))).await;
+    }
 }

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -82,8 +82,8 @@ impl ResourceStore {
         version
     }
 
-    fn push_event(&mut self, event: StoredEvent, retention: EventRetention) {
-        let excess = self.event_log.len().saturating_add(1).saturating_sub(retention.max_events_per_resource_stream());
+    fn push_event(&mut self, event: StoredEvent, max_events: usize) {
+        let excess = self.event_log.len().saturating_add(1).saturating_sub(max_events);
         if excess > 0 {
             if let Some(last_removed) = self.event_log.get(excess - 1) {
                 self.compacted_through = last_removed.version;
@@ -479,7 +479,10 @@ impl InMemoryBackend {
 
             let encoded = Self::encode_object(&object)?;
             store.objects.insert(meta.name.clone(), encoded.clone());
-            store.push_event(StoredEvent { version, kind: StoredEventKind::Added, object: encoded }, self.event_retention);
+            store.push_event(
+                StoredEvent { version, kind: StoredEventKind::Added, object: encoded },
+                T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
+            );
             Ok(object)
         })
         .await
@@ -545,10 +548,16 @@ impl InMemoryBackend {
                 && object.metadata.finalizers.is_empty()
             {
                 store.objects.remove(&meta.name);
-                store.push_event(StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded }, self.event_retention);
+                store.push_event(
+                    StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded },
+                    T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
+                );
             } else {
                 store.objects.insert(meta.name.clone(), encoded.clone());
-                store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded }, self.event_retention);
+                store.push_event(
+                    StoredEvent { version, kind: StoredEventKind::Modified, object: encoded },
+                    T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
+                );
             }
             Ok(object)
         })
@@ -578,7 +587,10 @@ impl InMemoryBackend {
 
             let encoded = Self::encode_object(&object)?;
             store.objects.insert(name.to_string(), encoded.clone());
-            store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded }, self.event_retention);
+            store.push_event(
+                StoredEvent { version, kind: StoredEventKind::Modified, object: encoded },
+                T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
+            );
             Ok(object)
         })
         .await
@@ -597,13 +609,19 @@ impl InMemoryBackend {
                 object.metadata.deletion_timestamp = Some(Utc::now());
                 let encoded = Self::encode_object(&object)?;
                 store.objects.insert(name.to_string(), encoded.clone());
-                store.push_event(StoredEvent { version, kind: StoredEventKind::Modified, object: encoded }, self.event_retention);
+                store.push_event(
+                    StoredEvent { version, kind: StoredEventKind::Modified, object: encoded },
+                    T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
+                );
                 return Ok(());
             }
 
             let encoded = Self::encode_object(&object)?;
             store.objects.remove(name);
-            store.push_event(StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded }, self.event_retention);
+            store.push_event(
+                StoredEvent { version, kind: StoredEventKind::Deleted, object: encoded },
+                T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
+            );
             Ok(())
         })
         .await

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -167,6 +167,19 @@ impl InMemoryBackend {
         (T::API_PATHS.group.to_string(), T::API_PATHS.version.to_string(), T::API_PATHS.plural.to_string(), namespace.to_string())
     }
 
+    pub(crate) async fn local_namespaces_typed<T: Resource>(&self) -> Result<Vec<String>, ResourceError> {
+        let stores = self.stores.lock().await;
+        let mut namespaces = stores
+            .iter()
+            .filter(|(key, store)| {
+                key.0 == T::API_PATHS.group && key.1 == T::API_PATHS.version && key.2 == T::API_PATHS.plural && !store.objects.is_empty()
+            })
+            .map(|(key, _)| key.3.clone())
+            .collect::<Vec<_>>();
+        namespaces.sort();
+        Ok(namespaces)
+    }
+
     fn clone_through_serde<T>(value: &T) -> Result<T, ResourceError>
     where
         T: serde::Serialize + serde::de::DeserializeOwned,

--- a/crates/flotilla-resources/src/leaf.rs
+++ b/crates/flotilla-resources/src/leaf.rs
@@ -1,9 +1,9 @@
-use std::cmp::Ordering;
+use std::{cmp::Ordering, time::Duration};
 
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{Leaf, LeafKind, LeafOperator};
 
-use crate::{Convoy, CrewWorkPhase, CrewWorkState, ResourceObject, Vessel, WorkState};
+use crate::{ChangeRequest, Convoy, CrewWorkPhase, CrewWorkState, ResourceObject, Vessel, WorkState};
 
 pub const ADMITTED_LEAF_VOCABULARY: &[(&str, &str)] = &[
     ("convoy", ".status.phase"),
@@ -11,6 +11,11 @@ pub const ADMITTED_LEAF_VOCABULARY: &[(&str, &str)] = &[
     ("work", ".status.phase"),
     ("work", ".latest-claim.disposition"),
     ("work", ".latest-claim.claimed-at"),
+    ("cr", ".state"),
+    ("cr", ".head-sha"),
+    ("cr", ".checks"),
+    ("cr", ".review.actionable-at-head"),
+    ("cr", ".mergeable"),
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,7 +53,7 @@ pub struct LeafEvaluation {
 pub trait LeafSubject {
     fn kind(&self) -> LeafKind;
     fn value(&self, field_path: &str) -> Option<LeafValue>;
-    fn observed_at(&self) -> Option<DateTime<Utc>> {
+    fn observed_at(&self, _field_path: &str) -> Option<DateTime<Utc>> {
         None
     }
 }
@@ -84,7 +89,7 @@ pub fn evaluate_leaf(
     if subject.kind() != leaf.address.kind() {
         return Err(format!("leaf addresses {} but subject is {}", leaf.address.kind(), subject.kind()));
     }
-    if freshness_demand.is_some_and(|demand| subject.observed_at().is_none_or(|observed_at| observed_at < demand)) {
+    if freshness_demand.is_some_and(|demand| subject.observed_at(&leaf.field_path).is_none_or(|observed_at| observed_at < demand)) {
         return Ok(LeafEvaluation { result: ThreeValue::Unknown, value: None });
     }
     let Some(value) = subject.value(&leaf.field_path) else {
@@ -180,8 +185,71 @@ impl LeafSubject for WorkLeafSubject<'_> {
         }
     }
 
-    fn observed_at(&self) -> Option<DateTime<Utc>> {
+    fn observed_at(&self, _field_path: &str) -> Option<DateTime<Utc>> {
         self.latest_claim()?.finished_at
+    }
+}
+
+pub struct ChangeRequestLeafSubject<'a> {
+    pub change_request: &'a ResourceObject<ChangeRequest>,
+    pub now: DateTime<Utc>,
+    pub stale_after: Duration,
+}
+
+impl ChangeRequestLeafSubject<'_> {
+    fn field_observed_at(&self, field_path: &str) -> Option<DateTime<Utc>> {
+        let status = self.change_request.status.as_ref()?;
+        Some(match field_path {
+            ".state" => status.state.observed_at,
+            ".head-sha" => status.head_sha.observed_at,
+            ".checks" => status.checks.observed_at,
+            ".review.actionable-at-head" => status.review.actionable_at_head.observed_at,
+            ".mergeable" => status.mergeable.observed_at,
+            _ => return None,
+        })
+    }
+
+    fn is_fresh(&self, field_path: &str) -> bool {
+        self.field_observed_at(field_path)
+            .and_then(|observed_at| self.now.signed_duration_since(observed_at).to_std().ok())
+            .is_some_and(|age| age <= self.stale_after)
+    }
+}
+
+impl LeafSubject for ChangeRequestLeafSubject<'_> {
+    fn kind(&self) -> LeafKind {
+        LeafKind::ChangeRequest
+    }
+
+    fn value(&self, field_path: &str) -> Option<LeafValue> {
+        if !self.is_fresh(field_path) {
+            return None;
+        }
+        let status = self.change_request.status.as_ref()?;
+        let value = match field_path {
+            ".state" => match status.state.value? {
+                crate::ObservedChangeRequestState::Open => "open".to_string(),
+                crate::ObservedChangeRequestState::Merged => "merged".to_string(),
+                crate::ObservedChangeRequestState::Closed => "closed".to_string(),
+            },
+            ".head-sha" => status.head_sha.value.clone()?,
+            ".checks" => match status.checks.value? {
+                crate::ObservedChecks::Pass => "pass".to_string(),
+                crate::ObservedChecks::Fail => "fail".to_string(),
+                crate::ObservedChecks::Pending => "pending".to_string(),
+            },
+            ".review.actionable-at-head" => status.review.actionable_at_head.value?.to_string(),
+            ".mergeable" => match status.mergeable.value? {
+                crate::ObservedMergeability::Mergeable => "mergeable".to_string(),
+                crate::ObservedMergeability::Conflicting => "conflicting".to_string(),
+            },
+            _ => return None,
+        };
+        Some(LeafValue::Text(value))
+    }
+
+    fn observed_at(&self, field_path: &str) -> Option<DateTime<Utc>> {
+        self.field_observed_at(field_path)
     }
 }
 
@@ -204,7 +272,7 @@ mod tests {
             Some(LeafValue::Text("Landed".to_string()))
         }
 
-        fn observed_at(&self) -> Option<DateTime<Utc>> {
+        fn observed_at(&self, _field_path: &str) -> Option<DateTime<Utc>> {
             self.observed_at
         }
     }
@@ -241,5 +309,53 @@ mod tests {
         let error = admit_leaf(&leaf).expect_err("text ordering should be rejected");
         assert!(error.contains("operator `>` is not admitted"));
         assert!(error.contains("use `==` or `!=`"));
+    }
+
+    #[test]
+    fn stale_change_request_field_is_structurally_unknown() {
+        let observed_at = "2026-08-03T20:00:00Z".parse().expect("time");
+        let object = ResourceObject::<ChangeRequest> {
+            metadata: crate::ObjectMeta {
+                name: "cr".to_string(),
+                namespace: "flotilla".to_string(),
+                resource_version: "1".to_string(),
+                labels: Default::default(),
+                annotations: Default::default(),
+                owner_references: Vec::new(),
+                finalizers: Vec::new(),
+                deletion_timestamp: None,
+                creation_timestamp: observed_at,
+                merge: None,
+            },
+            spec: crate::ChangeRequestSpec::builder()
+                .service("github.com".to_string())
+                .scope("flotilla-org/flotilla".to_string())
+                .number(1363)
+                .observing_authority("feta".to_string())
+                .build(),
+            status: Some(crate::ChangeRequestStatus {
+                state: crate::Observation::known(crate::ObservedChangeRequestState::Merged, observed_at),
+                head_sha: crate::Observation::known("abc".to_string(), observed_at),
+                checks: crate::Observation::known(crate::ObservedChecks::Pass, observed_at),
+                review: crate::ChangeRequestReviewObservation { actionable_at_head: crate::Observation::known(false, observed_at) },
+                mergeable: crate::Observation::known(crate::ObservedMergeability::Mergeable, observed_at),
+            }),
+        };
+        let subject = ChangeRequestLeafSubject {
+            change_request: &object,
+            now: "2026-08-03T20:03:01Z".parse().expect("time"),
+            stale_after: Duration::from_secs(180),
+        };
+        let leaf = Leaf {
+            address: LeafAddress::ChangeRequest {
+                service: "github.com".to_string(),
+                scope: "flotilla-org/flotilla".to_string(),
+                number: 1363,
+            },
+            field_path: ".state".to_string(),
+            operator: LeafOperator::Equal,
+            literal: "merged".to_string(),
+        };
+        assert_eq!(evaluate_leaf(&leaf, Some(&subject), None).expect("evaluate").result, ThreeValue::Unknown);
     }
 }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -1,4 +1,5 @@
 mod backend;
+mod change_request;
 mod checkout;
 mod clock;
 mod clone;
@@ -37,6 +38,10 @@ mod watch;
 mod workflow_template;
 
 pub use backend::{ReplicaReadResolver, ReplicaWriter, ResourceBackend, TypedResolver};
+pub use change_request::{
+    change_request_record_name, ChangeRequest, ChangeRequestReviewObservation, ChangeRequestSpec, ChangeRequestStatus,
+    ChangeRequestStatusPatch, Observation, ObservedChangeRequestState, ObservedChecks, ObservedMergeability,
+};
 pub use checkout::{
     ChangeRequestMergeability, ChangeRequestObservation, ChangeRequestState, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus,
     CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec,
@@ -77,8 +82,8 @@ pub use labels::{
     REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 pub use leaf::{
-    admit_leaf, evaluate_leaf, ConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue, VesselLeafSubject, WorkLeafSubject,
-    ADMITTED_LEAF_VOCABULARY,
+    admit_leaf, evaluate_leaf, ChangeRequestLeafSubject, ConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue,
+    VesselLeafSubject, WorkLeafSubject, ADMITTED_LEAF_VOCABULARY,
 };
 pub use material_pool::{
     MaterialPool, MaterialPoolLease, MaterialPoolSpec, MaterialPoolStatus, MaterialPoolStatusPatch, MaterialPoolUnitSpec,
@@ -139,6 +144,7 @@ pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
 macro_rules! for_each_registered_resource {
     ($callback:ident, $($argument:expr),* $(,)?) => {{
         $callback::<$crate::Checkout>($($argument),*);
+        $callback::<$crate::ChangeRequest>($($argument),*);
         $callback::<$crate::Clone>($($argument),*);
         $callback::<$crate::Convoy>($($argument),*);
         $callback::<$crate::CredentialGrant>($($argument),*);

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -10,9 +10,9 @@ use crate::{
     field_ownership::merge_owned_spec,
     host::HostStatus,
     replica::{LAST_SYNCED_AT_ANNOTATION, ORIGIN_ROOT_ANNOTATION},
-    Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, Environment, FieldOwnedResource, Host, InputMeta,
-    MaterialPool, ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project, ReadResourceList, ReadWatchEvent, Regard,
-    ReplicaCursor, ReplicationClass, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject,
+    ChangeRequest, Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, Environment, FieldOwnedResource,
+    Host, InputMeta, MaterialPool, ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project, ReadResourceList, ReadWatchEvent,
+    Regard, ReplicaCursor, ReplicationClass, Repository, Resource, ResourceBackend, ResourceError, ResourceList, ResourceObject,
     ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate, WriterIdentity,
 };
 
@@ -27,6 +27,7 @@ pub struct RegisteredResourceKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RegisteredResource {
+    ChangeRequest,
     Checkout,
     Clone,
     Convoy,
@@ -74,6 +75,7 @@ pub struct DynamicResourceWatch {
 }
 
 pub const REGISTERED_RESOURCE_KINDS: &[RegisteredResourceKind] = &[
+    kind::<ChangeRequest>(RegisteredResource::ChangeRequest, &["cr", "change_request", "change-request"]),
     kind::<Checkout>(RegisteredResource::Checkout, &[]),
     kind::<CloneResource>(RegisteredResource::Clone, &[]),
     kind::<Convoy>(RegisteredResource::Convoy, &[]),
@@ -142,6 +144,7 @@ const fn kind<T: Resource>(resource: RegisteredResource, aliases: &'static [&'st
 macro_rules! dispatch_resource_kind {
     ($resource:expr, $body:ident($($arg:expr),*).await) => {
         match $resource {
+            RegisteredResource::ChangeRequest => $body::<ChangeRequest>($($arg),*).await,
             RegisteredResource::Checkout => $body::<Checkout>($($arg),*).await,
             RegisteredResource::Clone => $body::<CloneResource>($($arg),*).await,
             RegisteredResource::Convoy => $body::<Convoy>($($arg),*).await,
@@ -163,6 +166,7 @@ macro_rules! dispatch_resource_kind {
     };
     ($resource:expr, $body:ident()) => {
         match $resource {
+            RegisteredResource::ChangeRequest => $body::<ChangeRequest>(),
             RegisteredResource::Checkout => $body::<Checkout>(),
             RegisteredResource::Clone => $body::<CloneResource>(),
             RegisteredResource::Convoy => $body::<Convoy>(),
@@ -184,6 +188,7 @@ macro_rules! dispatch_resource_kind {
     };
     ($resource:expr, $body:ident($($arg:expr),*)) => {
         match $resource {
+            RegisteredResource::ChangeRequest => $body::<ChangeRequest>($($arg),*),
             RegisteredResource::Checkout => $body::<Checkout>($($arg),*),
             RegisteredResource::Clone => $body::<CloneResource>($($arg),*),
             RegisteredResource::Convoy => $body::<Convoy>($($arg),*),

--- a/crates/flotilla-resources/src/replica.rs
+++ b/crates/flotilla-resources/src/replica.rs
@@ -16,6 +16,19 @@ pub enum ReplicationClass {
     None,
     Definitions,
     HomeBoundRuntime,
+    /// Demand-scoped observed state. Retain only the latest watch handoff
+    /// event so lagging peers relist current state instead of replaying history.
+    Observations,
+}
+
+impl ReplicationClass {
+    pub(crate) fn event_retention(self, configured: usize) -> usize {
+        if self == Self::Observations {
+            1
+        } else {
+            configured
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -526,6 +526,7 @@ impl SqliteBackend {
         kind: StoredEventKind,
         body_json: &str,
         event_retention: EventRetention,
+        replication_class: crate::ReplicationClass,
     ) -> Result<(), ResourceError> {
         tx.execute(
             r#"
@@ -535,7 +536,12 @@ impl SqliteBackend {
             params![key.0, key.1, key.2, key.3, event_version, kind.as_str(), body_json],
         )
         .map_err(|err| Self::map_sqlite(err, "insert sqlite resource event"))?;
-        Self::compact_events(tx, key, event_version, event_retention)?;
+        Self::compact_events_to_limit(
+            tx,
+            key,
+            event_version,
+            replication_class.event_retention(event_retention.max_events_per_resource_stream()),
+        )?;
         Ok(())
     }
 
@@ -545,7 +551,16 @@ impl SqliteBackend {
         current_version: u64,
         event_retention: EventRetention,
     ) -> Result<(), ResourceError> {
-        let compacted_through = current_version.saturating_sub(event_retention.max_events_per_resource_stream() as u64);
+        Self::compact_events_to_limit(tx, key, current_version, event_retention.max_events_per_resource_stream())
+    }
+
+    fn compact_events_to_limit(
+        tx: &rusqlite::Transaction<'_>,
+        key: &StoreKey,
+        current_version: u64,
+        max_events: usize,
+    ) -> Result<(), ResourceError> {
+        let compacted_through = current_version.saturating_sub(max_events as u64);
         if compacted_through == 0 {
             return Ok(());
         }
@@ -1183,7 +1198,7 @@ impl SqliteBackend {
             )
             .map_err(|err| Self::map_sqlite(err, "insert sqlite resource object"))?;
             Self::clear_decode_quarantine(&tx, &key, &meta.name)?;
-            Self::insert_event(&tx, &key, version, StoredEventKind::Added, &body_json, event_retention)?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Added, &body_json, event_retention, T::REPLICATION_CLASS)?;
             tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource create"))?;
             Self::notify_watchers(&watchers, &key, StoredEvent { kind: StoredEventKind::Added, object: encoded });
             Ok(object)
@@ -1271,7 +1286,7 @@ impl SqliteBackend {
                 Self::upsert_object(&tx, &key, &meta.name, version, &body_json)?;
                 StoredEventKind::Modified
             };
-            Self::insert_event(&tx, &key, version, event_kind, &body_json, event_retention)?;
+            Self::insert_event(&tx, &key, version, event_kind, &body_json, event_retention, T::REPLICATION_CLASS)?;
             tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource update"))?;
             Self::notify_watchers(&watchers, &key, StoredEvent { kind: event_kind, object: encoded });
             Ok(object)
@@ -1310,7 +1325,7 @@ impl SqliteBackend {
             let encoded = Self::encode_object(&object)?;
             let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
             Self::upsert_object(&tx, &key, &name, version, &body_json)?;
-            Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, event_retention)?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, event_retention, T::REPLICATION_CLASS)?;
             tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource status update"))?;
             Self::notify_watchers(&watchers, &key, StoredEvent { kind: StoredEventKind::Modified, object: encoded });
             Ok(object)
@@ -1339,7 +1354,7 @@ impl SqliteBackend {
                 let body_json =
                     serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
                 Self::upsert_object(&tx, &key, &name, version, &body_json)?;
-                Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, event_retention)?;
+                Self::insert_event(&tx, &key, version, StoredEventKind::Modified, &body_json, event_retention, T::REPLICATION_CLASS)?;
                 (StoredEventKind::Modified, encoded)
             } else {
                 let encoded = Self::encode_object(&object)?;
@@ -1353,7 +1368,7 @@ impl SqliteBackend {
                     params![key.0, key.1, key.2, key.3, name],
                 )
                 .map_err(|err| Self::map_sqlite(err, "delete sqlite resource object"))?;
-                Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json, event_retention)?;
+                Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json, event_retention, T::REPLICATION_CLASS)?;
                 (StoredEventKind::Deleted, encoded)
             };
             tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource delete"))?;

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -86,6 +86,24 @@ impl StoredEventKind {
 }
 
 impl SqliteBackend {
+    pub(crate) async fn local_namespaces_typed<T: Resource>(&self) -> Result<Vec<String>, ResourceError> {
+        let group = T::API_PATHS.group.to_string();
+        let version = T::API_PATHS.version.to_string();
+        let kind = T::API_PATHS.kind.to_string();
+        self.call(move |connection| {
+            let mut statement = connection
+                .prepare(
+                    "SELECT DISTINCT namespace FROM resource_objects WHERE group_name = ?1 AND version = ?2 AND kind = ?3 ORDER BY namespace",
+                )
+                .map_err(|error| Self::map_sqlite(error, "prepare sqlite local namespace list"))?;
+            let rows = statement
+                .query_map(params![group, version, kind], |row| row.get::<_, String>(0))
+                .map_err(|error| Self::map_sqlite(error, "query sqlite local namespace list"))?;
+            rows.collect::<Result<Vec<_>, _>>().map_err(|error| Self::map_sqlite(error, "read sqlite local namespace list"))
+        })
+        .await
+    }
+
     pub fn open(path: impl AsRef<Path>) -> Result<Self, ResourceError> {
         Self::open_with_event_retention(path, EventRetention::default())
     }

--- a/scripts/demo-cr-wait-bosun.sh
+++ b/scripts/demo-cr-wait-bosun.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run-3-lite of the #1321 Bosun decision table. The driver blocks only in the
+# leaf engine: there is no shell sleep loop and therefore no repeated gh read.
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 cr/<service>/<scope>/<number>" >&2
+  exit 2
+fi
+
+subject=$1
+case "$subject" in
+  cr/*/*/*) ;;
+  *) echo "expected a cr/<service>/<scope>/<number> address" >&2; exit 2 ;;
+esac
+
+while true; do
+  fired=$(flotilla --json wait \
+    --for "$subject .state == merged" \
+    --for "$subject .state == closed" \
+    --for "$subject .checks == fail" \
+    --for "$subject .review.actionable-at-head == true" \
+    --for "$subject .mergeable == conflicting")
+  path=$(jq -r '.leaf.field_path' <<<"$fired")
+  value=$(jq -r '.value' <<<"$fired")
+
+  case "$path:$value" in
+    .state:merged)
+      echo "DISPOSITION: merged"
+      exit 0
+      ;;
+    .state:closed)
+      echo "DISPOSITION: blocked (change request closed without merge)"
+      exit 1
+      ;;
+    .checks:fail)
+      echo "WAKE: coder — checks failed at the observed head"
+      ;;
+    .review.actionable-at-head:true)
+      echo "WAKE: coder — actionable review exists at the observed head"
+      ;;
+    .mergeable:conflicting)
+      echo "WAKE: coder — change request conflicts"
+      ;;
+    *)
+      echo "unexpected leaf result: $fired" >&2
+      exit 2
+      ;;
+  esac
+done

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,8 @@ enum SubCommand {
         namespace: String,
         /// Require claim evidence observed at or after this RFC3339 instant
         ///
-        /// This slice has observation timestamps for work claim leaves only;
-        /// other leaves remain Unknown when a freshness demand is present.
+        /// Observation and claim leaves remain Unknown until their evidence
+        /// is at least this fresh.
         #[arg(long)]
         fresher_than: Option<chrono::DateTime<chrono::Utc>>,
         /// Maximum seconds to block


### PR DESCRIPTION
Closes #1363.

## Summary

- add replicated, subject-keyed observed `ChangeRequest` resources with per-field observation timestamps and structural Unknown values
- admit and evaluate `.state`, `.head-sha`, `.checks`, `.review.actionable-at-head`, and `.mergeable` leaves
- start GitHub observation on first CR-leaf demand, tighten cadence for pending checks/freshness demand, and stop polling after the last subscription ends
- garbage-collect the observed record after its last demand is released (and clear orphaned local observations on daemon startup)
- coalesce observations by field value before persistence, so identical polls do not write status or advance observation timestamps
- keep evaluation store-only and let replica-reading hosts consume the observing authority record without becoming a second authority
- add the #1321 Bosun decision-table run-3-lite script using `flotilla wait` instead of sleeps

## Design-round riders

**Thin history:** `ChangeRequest` uses the new `ReplicationClass::Observations`. Embedded stores retain only the latest watch-handoff event for an observation stream while still notifying live watchers. A peer behind that one-event window receives watch expiry and relists the current snapshot instead of paying to replay observation history.

**Bound subjects only:** CR leaves accept only an exact `cr/<service>/<scope>/<number>` subject. Collection, wildcard, and query-shaped CR addresses are rejected; browsing remains an Aggregator concern and cannot materialize observed records.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Focused coverage includes replayed GitHub OPEN→MERGED observation, subscribe/materialize → last-unsubscribe/delete, N identical polls → zero status writes, one-event observation-history bounds in both embedded stores, exact-subject address admission, freshness cadence tightening, stale-as-Unknown, and replica-reading evaluation.